### PR TITLE
Tool hardening, command modules, test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
         run: make lint-lua
 
       - name: Install Biome
-        run: npm install -g @biomejs/biome
+        run: npm install -g @biomejs/biome@1.9.4
 
       - name: JS lint
         run: make lint-js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
         run: make lint-lua
 
       - name: Install Biome
-        run: curl -fsSL https://biomejs.dev/install.sh | sh && echo "$HOME/.biome/bin" >> $GITHUB_PATH
+        run: npm install -g @biomejs/biome
 
       - name: JS lint
         run: make lint-js

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,4 +1,4 @@
-globals = { "app", "db", "time", "json", "crypto", "log", "env" }
+globals = { "app", "db", "time", "json", "crypto", "log", "env", "tool" }
 std = "lua54"
 exclude_files = { "stdlib/lua/vendor/", "vendor/" }
 max_line_length = false

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,4 +1,4 @@
-globals = { "app", "db", "time", "json", "crypto", "log", "env", "tool" }
+globals = { "app", "db", "time", "json", "crypto", "log", "env", "tool", "__hull_exe" }
 std = "lua54"
 exclude_files = { "stdlib/lua/vendor/", "vendor/" }
 max_line_length = false

--- a/Makefile
+++ b/Makefile
@@ -448,6 +448,7 @@ $(TWEETNACL_OBJ): $(TWEETNACL_DIR)/tweetnacl.c | $(BUILDDIR)
 # jart/pledge polyfill (vendored, Linux only, relaxed warnings)
 # Flatten libc/calls/pledge.c → build/pledge_libc_calls_pledge.o
 $(BUILDDIR)/pledge_%.o: $(PLEDGE_DIR)/%.c | $(BUILDDIR)
+	@mkdir -p $(dir $@)
 	$(CC) $(PLEDGE_CFLAGS) -c -o $@ $<
 
 $(BUILDDIR):

--- a/Makefile
+++ b/Makefile
@@ -165,10 +165,11 @@ PLEDGE_OBJS ?=
 
 # ── Hull source files ───────────────────────────────────────────────
 
-# Capability sources (always compiled, except cap/tool.c which needs Lua)
-CAP_SRCS := $(filter-out $(SRCDIR)/hull/cap/tool.c,$(wildcard $(SRCDIR)/hull/cap/*.c))
+# Capability sources (always compiled, except cap/tool.c and cap/test.c which need runtimes)
+CAP_SRCS := $(filter-out $(SRCDIR)/hull/cap/tool.c $(SRCDIR)/hull/cap/test.c,$(wildcard $(SRCDIR)/hull/cap/*.c))
 CAP_OBJS := $(patsubst $(SRCDIR)/hull/cap/%.c,$(BUILDDIR)/cap_%.o,$(CAP_SRCS))
 CAP_TOOL_OBJ := $(BUILDDIR)/cap_tool.o
+CAP_TEST_OBJ := $(BUILDDIR)/cap_test.o
 
 # JS runtime sources
 JS_RT_SRCS := $(wildcard $(SRCDIR)/hull/runtime/js/*.c)
@@ -177,6 +178,10 @@ JS_RT_OBJS := $(patsubst $(SRCDIR)/hull/runtime/js/%.c,$(BUILDDIR)/js_%.o,$(JS_R
 # Lua runtime sources
 LUA_RT_SRCS := $(wildcard $(SRCDIR)/hull/runtime/lua/*.c)
 LUA_RT_OBJS := $(patsubst $(SRCDIR)/hull/runtime/lua/%.c,$(BUILDDIR)/lua_rt_%.o,$(LUA_RT_SRCS))
+
+# Command module sources
+CMD_SRCS := $(wildcard $(SRCDIR)/hull/commands/*.c)
+CMD_OBJS := $(patsubst $(SRCDIR)/hull/commands/%.c,$(BUILDDIR)/cmd_%.o,$(CMD_SRCS))
 
 # Select which runtimes to build
 ifeq ($(RUNTIME),js)
@@ -320,7 +325,7 @@ all: $(BUILDDIR)/hull
 # Platform static library — everything except entry.o and build_assets.o
 # Used by `hull build` to produce standalone app binaries.
 # Exports hull_main() (subcommand dispatch + server logic).
-PLATFORM_OBJS := $(CAP_OBJS) $(CAP_TOOL_OBJ) $(RT_OBJS) $(ALLOC_OBJ) $(MANIFEST_OBJ) $(SANDBOX_OBJ) $(MAIN_OBJ) $(TOOL_OBJ) $(VEND_OBJS) \
+PLATFORM_OBJS := $(CAP_OBJS) $(CAP_TOOL_OBJ) $(CAP_TEST_OBJ) $(CMD_OBJS) $(RT_OBJS) $(ALLOC_OBJ) $(MANIFEST_OBJ) $(SANDBOX_OBJ) $(MAIN_OBJ) $(TOOL_OBJ) $(VEND_OBJS) \
 	$(SQLITE_OBJ) $(LOG_OBJ) $(SH_ARENA_OBJ) $(TWEETNACL_OBJ) $(PLEDGE_OBJS)
 
 PLATFORM_LIB := $(BUILDDIR)/libhull_platform.a
@@ -360,12 +365,16 @@ $(BUILD_ASSET_OBJ): $(EMBEDDED_PLATFORM_H) $(EMBEDDED_TEMPLATES_H)
 endif
 
 # Hull binary
-$(BUILDDIR)/hull: $(CAP_OBJS) $(CAP_TOOL_OBJ) $(RT_OBJS) $(ALLOC_OBJ) $(MANIFEST_OBJ) $(SANDBOX_OBJ) $(TOOL_OBJ) $(BUILD_ASSET_OBJ) $(MAIN_OBJ) $(ENTRY_OBJ) $(APP_EXTRA_OBJS) $(VEND_OBJS) $(SQLITE_OBJ) $(LOG_OBJ) $(SH_ARENA_OBJ) $(TWEETNACL_OBJ) $(PLEDGE_OBJS) $(KEEL_LIB)
-	$(CC) $(LDFLAGS) -o $@ $(CAP_OBJS) $(CAP_TOOL_OBJ) $(RT_OBJS) $(ALLOC_OBJ) $(MANIFEST_OBJ) $(SANDBOX_OBJ) $(TOOL_OBJ) $(BUILD_ASSET_OBJ) $(MAIN_OBJ) $(ENTRY_OBJ) $(APP_EXTRA_OBJS) $(VEND_OBJS) \
+$(BUILDDIR)/hull: $(CAP_OBJS) $(CAP_TOOL_OBJ) $(CAP_TEST_OBJ) $(CMD_OBJS) $(RT_OBJS) $(ALLOC_OBJ) $(MANIFEST_OBJ) $(SANDBOX_OBJ) $(TOOL_OBJ) $(BUILD_ASSET_OBJ) $(MAIN_OBJ) $(ENTRY_OBJ) $(APP_EXTRA_OBJS) $(VEND_OBJS) $(SQLITE_OBJ) $(LOG_OBJ) $(SH_ARENA_OBJ) $(TWEETNACL_OBJ) $(PLEDGE_OBJS) $(KEEL_LIB)
+	$(CC) $(LDFLAGS) -o $@ $(CAP_OBJS) $(CAP_TOOL_OBJ) $(CAP_TEST_OBJ) $(CMD_OBJS) $(RT_OBJS) $(ALLOC_OBJ) $(MANIFEST_OBJ) $(SANDBOX_OBJ) $(TOOL_OBJ) $(BUILD_ASSET_OBJ) $(MAIN_OBJ) $(ENTRY_OBJ) $(APP_EXTRA_OBJS) $(VEND_OBJS) \
 		$(SQLITE_OBJ) $(LOG_OBJ) $(SH_ARENA_OBJ) $(TWEETNACL_OBJ) $(PLEDGE_OBJS) $(KEEL_LIB) -lm -lpthread
 
 # Capability sources
 $(BUILDDIR)/cap_%.o: $(SRCDIR)/hull/cap/%.c | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
+
+# Command module sources
+$(BUILDDIR)/cmd_%.o: $(SRCDIR)/hull/commands/%.c | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
 
 # JS runtime sources
@@ -492,6 +501,21 @@ $(BUILDDIR)/test_lua: $(TESTDIR)/hull/runtime/lua/test_lua.c $(TEST_COMMON_DEPS)
 		$(TEST_CAP_OBJS) $(CAP_TOOL_OBJ) $(LUA_RT_OBJS) $(MANIFEST_LUA_OBJ) $(APP_ENTRIES_DEFAULT_OBJ) $(ALLOC_OBJ) $(LUA_OBJS) \
 		$(KEEL_LIB) $(SQLITE_OBJ) $(LOG_OBJ) $(SH_ARENA_OBJ) $(TWEETNACL_OBJ) -lm -lpthread
 
+# Tool hardening test — cap/tool.c compiled without runtime flags (self-contained C functions)
+CAP_TOOL_NONE_OBJ := $(BUILDDIR)/cap_tool_none.o
+$(CAP_TOOL_NONE_OBJ): $(SRCDIR)/hull/cap/tool.c | $(BUILDDIR)
+	$(CC) $(filter-out -DHL_ENABLE_LUA -DHL_ENABLE_JS,$(CFLAGS)) $(INCLUDES) -c -o $@ $<
+
+$(BUILDDIR)/test_tool: $(TESTDIR)/hull/cap/test_tool.c $(CAP_TOOL_NONE_OBJ) | $(BUILDDIR)
+	$(CC) $(filter-out -DHL_ENABLE_LUA -DHL_ENABLE_JS,$(CFLAGS)) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(CAP_TOOL_NONE_OBJ)
+
+# Command dispatcher test — needs full command set (symbol resolution for command table)
+$(BUILDDIR)/test_dispatch: $(TESTDIR)/hull/commands/test_dispatch.c $(CMD_OBJS) $(CAP_TOOL_OBJ) $(CAP_TEST_OBJ) $(TOOL_OBJ) $(SANDBOX_OBJ) $(TEST_COMMON_DEPS) $(RT_OBJS) $(VEND_OBJS) $(MANIFEST_OBJ) $(BUILD_ASSET_OBJ) $(APP_ENTRIES_DEFAULT_OBJ) $(PLEDGE_OBJS) $(STDLIB_LUA_HDRS) | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< \
+		$(CMD_OBJS) $(CAP_TOOL_OBJ) $(CAP_TEST_OBJ) $(TOOL_OBJ) $(SANDBOX_OBJ) \
+		$(TEST_CAP_OBJS) $(RT_OBJS) $(MANIFEST_OBJ) $(BUILD_ASSET_OBJ) $(APP_ENTRIES_DEFAULT_OBJ) $(ALLOC_OBJ) $(VEND_OBJS) \
+		$(KEEL_LIB) $(SQLITE_OBJ) $(LOG_OBJ) $(SH_ARENA_OBJ) $(TWEETNACL_OBJ) $(PLEDGE_OBJS) -lm -lpthread
+
 test: $(TEST_BINS)
 	@echo "Running tests..."
 	@pass=0; fail=0; total=0; \
@@ -571,7 +595,7 @@ check:
 analyze:
 	$(MAKE) clean
 	$(MAKE) $(VEND_OBJS) $(SQLITE_OBJ) $(LOG_OBJ) $(KEEL_LIB)
-	scan-build --status-bugs $(MAKE) $(CAP_OBJS) $(RT_OBJS) $(MAIN_OBJ) $(BUILDDIR)/hull
+	scan-build --status-bugs $(MAKE) $(CAP_OBJS) $(CAP_TEST_OBJ) $(CMD_OBJS) $(RT_OBJS) $(MAIN_OBJ) $(BUILDDIR)/hull
 
 cppcheck:
 	cppcheck --enable=all --inline-suppr \
@@ -593,6 +617,7 @@ cppcheck:
 		--error-exitcode=1 \
 		-I$(INCDIR) -I$(QJS_DIR) -I$(LUA_DIR) -I$(SQLITE_DIR) -I$(KEEL_INC) \
 		$(SRCDIR)/hull/main.c $(SRCDIR)/hull/alloc.c $(SRCDIR)/hull/cap/*.c \
+		$(SRCDIR)/hull/commands/*.c \
 		$(SRCDIR)/hull/runtime/js/*.c $(SRCDIR)/hull/runtime/lua/*.c
 
 # ── Benchmark ──────────────────────────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -604,7 +604,7 @@ check:
 analyze:
 	$(MAKE) clean
 	$(MAKE) $(VEND_OBJS) $(SQLITE_OBJ) $(LOG_OBJ) $(KEEL_LIB)
-	scan-build --status-bugs $(MAKE) $(CAP_OBJS) $(CAP_TEST_OBJ) $(CMD_OBJS) $(RT_OBJS) $(MAIN_OBJ) $(BUILDDIR)/hull
+	scan-build --status-bugs -disable-checker alpha.unix.Stream $(MAKE) $(CAP_OBJS) $(CAP_TEST_OBJ) $(CMD_OBJS) $(RT_OBJS) $(MAIN_OBJ) $(BUILDDIR)/hull
 
 cppcheck:
 	cppcheck --enable=all --inline-suppr \

--- a/Makefile
+++ b/Makefile
@@ -553,6 +553,14 @@ SQLITE_CFLAGS := -std=c11 -O1 -w -fsanitize=memory,undefined -fno-omit-frame-poi
                  -DSQLITE_THREADSAFE=1
 LOG_CFLAGS := -std=c11 -O1 -w -fsanitize=memory,undefined -fno-omit-frame-pointer \
               -DLOG_USE_COLOR
+# Re-add runtime defines (the := above clobbers earlier += additions)
+ifeq ($(RUNTIME),js)
+  CFLAGS += -DHL_ENABLE_JS
+else ifeq ($(RUNTIME),lua)
+  CFLAGS += -DHL_ENABLE_LUA
+else
+  CFLAGS += -DHL_ENABLE_JS -DHL_ENABLE_LUA
+endif
 endif
 
 msan:

--- a/Makefile
+++ b/Makefile
@@ -611,6 +611,7 @@ analyze:
 cppcheck:
 	cppcheck --enable=all --inline-suppr \
 		--suppress=missingIncludeSystem \
+		--suppress=missingInclude \
 		--suppress=unusedFunction \
 		--suppress=checkersReport \
 		--suppress=toomanyconfigs \
@@ -620,6 +621,7 @@ cppcheck:
 		--suppress=constVariablePointer \
 		--suppress=staticFunction \
 		--suppress=uninitvar:$(SRCDIR)/hull/runtime/lua/bindings.c \
+		--suppress=unusedLabelConfiguration:$(SRCDIR)/hull/main.c \
 		--suppress=unmatchedSuppression \
 		--suppress='*:$(QJS_DIR)/*' \
 		--suppress='*:$(LUA_DIR)/*' \

--- a/Makefile
+++ b/Makefile
@@ -553,6 +553,8 @@ SQLITE_CFLAGS := -std=c11 -O1 -w -fsanitize=memory,undefined -fno-omit-frame-poi
                  -DSQLITE_THREADSAFE=1
 LOG_CFLAGS := -std=c11 -O1 -w -fsanitize=memory,undefined -fno-omit-frame-pointer \
               -DLOG_USE_COLOR
+SH_ARENA_CFLAGS := -std=c11 -O1 -w -fsanitize=memory,undefined -fno-omit-frame-pointer
+TWEETNACL_CFLAGS := -std=c11 -O1 -w -fsanitize=memory,undefined -fno-omit-frame-pointer
 # Re-add runtime defines (the := above clobbers earlier += additions)
 ifeq ($(RUNTIME),js)
   CFLAGS += -DHL_ENABLE_JS
@@ -603,7 +605,7 @@ check:
 
 analyze:
 	$(MAKE) clean
-	$(MAKE) $(VEND_OBJS) $(SQLITE_OBJ) $(LOG_OBJ) $(KEEL_LIB)
+	$(MAKE) $(VEND_OBJS) $(SQLITE_OBJ) $(LOG_OBJ) $(SH_ARENA_OBJ) $(TWEETNACL_OBJ) $(PLEDGE_OBJS) $(KEEL_LIB)
 	scan-build --status-bugs -disable-checker alpha.unix.Stream $(MAKE) $(CAP_OBJS) $(CAP_TEST_OBJ) $(CMD_OBJS) $(RT_OBJS) $(MAIN_OBJ) $(BUILDDIR)/hull
 
 cppcheck:

--- a/examples/hello/app.js
+++ b/examples/hello/app.js
@@ -5,24 +5,24 @@
 
 import { app } from "hull:app";
 import { db } from "hull:db";
-import { time } from "hull:time";
 import { log } from "hull:log";
+import { time } from "hull:time";
 
 // Initialize database
 db.exec("CREATE TABLE IF NOT EXISTS visits (id INTEGER PRIMARY KEY AUTOINCREMENT, path TEXT, ts INTEGER)");
 
 // Routes
-app.get("/", (req, res) => {
+app.get("/", (_req, res) => {
     db.exec("INSERT INTO visits (path, ts) VALUES (?, ?)", ["/", time.now()]);
     res.json({ message: "Hello from Hull + QuickJS!", time: time.datetime() });
 });
 
-app.get("/visits", (req, res) => {
+app.get("/visits", (_req, res) => {
     const visits = db.query("SELECT * FROM visits ORDER BY id DESC LIMIT 20");
     res.json(visits);
 });
 
-app.get("/health", (req, res) => {
+app.get("/health", (_req, res) => {
     res.json({ status: "ok", runtime: "quickjs", uptime: time.clock() });
 });
 
@@ -33,12 +33,12 @@ app.post("/echo", (req, res) => {
 
 // Greet by route param
 app.get("/greet/:name", (req, res) => {
-    res.json({ greeting: "Hello, " + req.params.name + "!" });
+    res.json({ greeting: `Hello, ${req.params.name}!` });
 });
 
 // Greet with body
 app.post("/greet/:name", (req, res) => {
-    res.json({ greeting: "Hello, " + req.params.name + "!", body: req.body });
+    res.json({ greeting: `Hello, ${req.params.name}!`, body: req.body });
 });
 
 log.info("Hello app loaded — routes registered");

--- a/examples/hello/app.lua
+++ b/examples/hello/app.lua
@@ -7,17 +7,17 @@
 db.exec("CREATE TABLE IF NOT EXISTS visits (id INTEGER PRIMARY KEY AUTOINCREMENT, path TEXT, ts INTEGER)")
 
 -- Routes
-app.get("/", function(req, res)
+app.get("/", function(_req, res)
     db.exec("INSERT INTO visits (path, ts) VALUES (?, ?)", {"/", time.now()})
     res:json({ message = "Hello from Hull + Lua!", time = time.datetime() })
 end)
 
-app.get("/visits", function(req, res)
+app.get("/visits", function(_req, res)
     local visits = db.query("SELECT * FROM visits ORDER BY id DESC LIMIT 20")
     res:json(visits)
 end)
 
-app.get("/health", function(req, res)
+app.get("/health", function(_req, res)
     res:json({ status = "ok", runtime = "lua", uptime = time.clock() })
 end)
 

--- a/examples/rest_api/app.js
+++ b/examples/rest_api/app.js
@@ -6,7 +6,6 @@
 import { app } from "hull:app";
 import { db } from "hull:db";
 import { time } from "hull:time";
-import { crypto } from "hull:crypto";
 
 // Initialize database
 db.exec(`CREATE TABLE IF NOT EXISTS tasks (
@@ -17,7 +16,7 @@ db.exec(`CREATE TABLE IF NOT EXISTS tasks (
 )`);
 
 // List all tasks
-app.get("/tasks", (req, res) => {
+app.get("/tasks", (_req, res) => {
     const tasks = db.query("SELECT * FROM tasks ORDER BY created_at DESC");
     res.json(tasks);
 });

--- a/include/hull/cap/test.h
+++ b/include/hull/cap/test.h
@@ -1,0 +1,55 @@
+/*
+ * cap/test.h — In-process test module for hull test
+ *
+ * Provides:
+ *   - test("desc", fn)       — register a test case
+ *   - test.get/post/...      — HTTP dispatch without TCP
+ *   - test.eq/ok/err         — assertions
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef HL_CAP_TEST_H
+#define HL_CAP_TEST_H
+
+/* Forward declarations */
+typedef struct lua_State lua_State;
+typedef struct JSContext JSContext;
+typedef struct KlRouter KlRouter;
+typedef struct HlLua HlLua;
+typedef struct HlJS HlJS;
+
+/* ── Lua bindings ──────────────────────────────────────────────────── */
+
+#ifdef HL_ENABLE_LUA
+
+/*
+ * Register the `test` global in the Lua state.
+ * test is a callable table (via __call metamethod) for registering tests,
+ * and also has methods: get, post, put, delete, patch, eq, ok, err.
+ */
+void hl_cap_test_register_lua(lua_State *L, KlRouter *router, HlLua *lua);
+
+/*
+ * Clear registered test cases (between files).
+ */
+void hl_cap_test_clear_lua(lua_State *L);
+
+/*
+ * Run all registered test cases and report results.
+ */
+void hl_cap_test_run_lua(lua_State *L, int *total, int *passed, int *failed);
+
+#endif /* HL_ENABLE_LUA */
+
+/* ── JS bindings ───────────────────────────────────────────────────── */
+
+#ifdef HL_ENABLE_JS
+
+void hl_cap_test_register_js(JSContext *ctx, KlRouter *router, HlJS *js);
+void hl_cap_test_clear_js(JSContext *ctx);
+void hl_cap_test_run_js(JSContext *ctx, int *total, int *passed, int *failed);
+
+#endif /* HL_ENABLE_JS */
+
+#endif /* HL_CAP_TEST_H */

--- a/include/hull/cap/tool.h
+++ b/include/hull/cap/tool.h
@@ -2,7 +2,8 @@
  * cap/tool.h — Controlled process/filesystem access for tool scripts
  *
  * Provides the `tool` global table in Lua tool mode.
- * Replaces raw os/io access with an explicit, auditable interface.
+ * All process execution goes through an allowlisted fork/execvp path.
+ * All filesystem operations validate paths against unveiled directories.
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -10,23 +11,124 @@
 #ifndef HL_CAP_TOOL_H
 #define HL_CAP_TOOL_H
 
+#include <stddef.h>
+
+#ifdef HL_ENABLE_LUA
 /* Forward declaration */
 typedef struct lua_State lua_State;
+#endif
+
+/* ── Unveil path table ─────────────────────────────────────────────── */
+
+#define HL_TOOL_MAX_UNVEILED 16
+
+typedef struct {
+    const char *path;
+    const char *perms;   /* "r", "rw", "rwc", "rx" etc. */
+} HlToolUnveilEntry;
+
+typedef struct HlToolUnveilCtx {
+    HlToolUnveilEntry entries[HL_TOOL_MAX_UNVEILED];
+    int count;
+    int sealed;
+} HlToolUnveilCtx;
+
+/*
+ * Initialize the tool unveil context (empty, unsealed).
+ */
+void hl_tool_unveil_init(HlToolUnveilCtx *ctx);
+
+/*
+ * Add a path to the unveil table. The path is resolved via realpath()
+ * (or used as-is if it doesn't exist yet). Returns 0 on success, -1 if full.
+ */
+int hl_tool_unveil_add(HlToolUnveilCtx *ctx, const char *path, const char *perms);
+
+/*
+ * Seal the unveil table — no more entries can be added.
+ */
+void hl_tool_unveil_seal(HlToolUnveilCtx *ctx);
+
+/*
+ * Check if a path is allowed under the unveil table.
+ * `needed` is a single char: 'r' for read, 'w' for write, 'x' for execute.
+ * Returns 0 if allowed, -1 if denied.
+ */
+int hl_tool_unveil_check(const HlToolUnveilCtx *ctx, const char *path, char needed);
+
+/* ── C-level tool functions (callable from test runner etc.) ──────── */
+
+/*
+ * Spawn a process from an argv array (no shell).
+ * Validates argv[0] against the compiler allowlist.
+ * Returns the child exit code, or -1 on fork/exec error.
+ */
+int hl_tool_spawn(const char *const argv[]);
+
+/*
+ * Spawn a process and capture its stdout.
+ * Returns a malloc'd string (caller frees), or NULL on error.
+ * If out_len is non-NULL, the output length is stored there.
+ */
+char *hl_tool_spawn_read(const char *const argv[], size_t *out_len);
+
+/*
+ * Check if a binary name is in the compiler allowlist.
+ * Accepts: cc, gcc, clang, cosmocc, cosmoar, ar (and versioned variants).
+ * Returns 0 if allowed, -1 if rejected.
+ */
+int hl_tool_check_allowlist(const char *binary);
+
+/*
+ * Recursively find files matching a glob pattern.
+ * Skips dotfiles/dirs, node_modules, vendor.
+ * Returns a NULL-terminated array of strdup'd paths (caller frees each + array).
+ * Validates dir against unveil context if ctx is non-NULL.
+ */
+char **hl_tool_find_files(const char *dir, const char *pattern,
+                          const HlToolUnveilCtx *ctx);
+
+/*
+ * Copy a file (binary-safe).
+ * Returns 0 on success, -1 on error.
+ */
+int hl_tool_copy(const char *src, const char *dst,
+                 const HlToolUnveilCtx *ctx);
+
+/*
+ * Recursively remove a directory tree.
+ * Uses lstat (no symlink following). Validates path against unveil context.
+ * Returns 0 on success, -1 on error.
+ */
+int hl_tool_rmdir(const char *path, const HlToolUnveilCtx *ctx);
+
+/* ── Lua registration ──────────────────────────────────────────────── */
+
+#ifdef HL_ENABLE_LUA
 
 /*
  * Register the `tool` global table in the Lua state.
  *
  * Provides:
- *   tool.exec(cmd)             — execute shell command, return bool
- *   tool.read(cmd)             — execute and capture stdout, return string
- *   tool.tmpdir()              — create temp directory, return path
- *   tool.exit(code)            — exit process
- *   tool.read_file(path)       — read file, return string or nil
- *   tool.write_file(path,data) — write file, return bool
- *   tool.file_exists(path)     — check existence, return bool
- *   tool.stderr(msg)           — write to stderr
- *   tool.loadfile(path)        — load Lua chunk, return function or nil+err
+ *   tool.spawn(argv_table)        — fork/execvp with allowlist, return (bool, int)
+ *   tool.spawn_read(argv_table)   — spawn and capture stdout, return string|nil
+ *   tool.find_files(dir, pattern) — recursive file search, return table
+ *   tool.copy(src, dst)           — copy file, return bool
+ *   tool.rmdir(path)              — recursive remove, return bool
+ *   tool.tmpdir()                 — create temp directory, return path
+ *   tool.exit(code)               — exit process
+ *   tool.read_file(path)          — read file, return string or nil
+ *   tool.write_file(path, data)   — write file, return bool
+ *   tool.file_exists(path)        — check existence, return bool
+ *   tool.stderr(msg)              — write to stderr
+ *   tool.loadfile(path)           — load Lua chunk, return function or nil+err
+ *   tool.cc                       — configured compiler (string field)
+ *
+ * The unveil context pointer is stored in the Lua registry for
+ * path validation by filesystem functions.
  */
-void hl_cap_tool_register(lua_State *L);
+void hl_cap_tool_register(lua_State *L, HlToolUnveilCtx *ctx);
+
+#endif /* HL_ENABLE_LUA */
 
 #endif /* HL_CAP_TOOL_H */

--- a/include/hull/cap/tool.h
+++ b/include/hull/cap/tool.h
@@ -45,6 +45,11 @@ void hl_tool_unveil_init(HlToolUnveilCtx *ctx);
 int hl_tool_unveil_add(HlToolUnveilCtx *ctx, const char *path, const char *perms);
 
 /*
+ * Free all strdup'd paths in the unveil context and reset to empty.
+ */
+void hl_tool_unveil_free(HlToolUnveilCtx *ctx);
+
+/*
  * Seal the unveil table — no more entries can be added.
  */
 void hl_tool_unveil_seal(HlToolUnveilCtx *ctx);

--- a/include/hull/commands/build.h
+++ b/include/hull/commands/build.h
@@ -1,0 +1,12 @@
+/*
+ * commands/build.h — hull build subcommand
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef HL_COMMANDS_BUILD_H
+#define HL_COMMANDS_BUILD_H
+
+int hl_cmd_build(int argc, char **argv, const char *hull_exe);
+
+#endif /* HL_COMMANDS_BUILD_H */

--- a/include/hull/commands/dispatch.h
+++ b/include/hull/commands/dispatch.h
@@ -1,0 +1,33 @@
+/*
+ * commands/dispatch.h — Table-driven subcommand dispatcher
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef HL_COMMANDS_DISPATCH_H
+#define HL_COMMANDS_DISPATCH_H
+
+/*
+ * Command handler signature.
+ *   argc/argv — subcommand args (argv[0] is the subcommand name)
+ *   hull_exe  — path to the hull binary (original argv[0])
+ *
+ * Returns process exit code (0 = success).
+ */
+typedef int (*HlCommandFn)(int argc, char **argv, const char *hull_exe);
+
+typedef struct {
+    const char  *name;       /* "build", "test", "keygen", etc. */
+    HlCommandFn  handler;    /* C handler function */
+} HlCommand;
+
+/*
+ * Dispatch a subcommand from the command table.
+ *
+ *   argc/argv — full program args (argv[1] is the subcommand)
+ *
+ * Returns the handler's exit code, or -1 if no subcommand matched.
+ */
+int hl_command_dispatch(int argc, char **argv);
+
+#endif /* HL_COMMANDS_DISPATCH_H */

--- a/include/hull/commands/inspect.h
+++ b/include/hull/commands/inspect.h
@@ -1,0 +1,12 @@
+/*
+ * commands/inspect.h — hull inspect subcommand
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef HL_COMMANDS_INSPECT_H
+#define HL_COMMANDS_INSPECT_H
+
+int hl_cmd_inspect(int argc, char **argv, const char *hull_exe);
+
+#endif /* HL_COMMANDS_INSPECT_H */

--- a/include/hull/commands/keygen.h
+++ b/include/hull/commands/keygen.h
@@ -1,0 +1,12 @@
+/*
+ * commands/keygen.h — hull keygen subcommand
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef HL_COMMANDS_KEYGEN_H
+#define HL_COMMANDS_KEYGEN_H
+
+int hl_cmd_keygen(int argc, char **argv, const char *hull_exe);
+
+#endif /* HL_COMMANDS_KEYGEN_H */

--- a/include/hull/commands/manifest.h
+++ b/include/hull/commands/manifest.h
@@ -1,0 +1,12 @@
+/*
+ * commands/manifest.h — hull manifest subcommand
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef HL_COMMANDS_MANIFEST_H
+#define HL_COMMANDS_MANIFEST_H
+
+int hl_cmd_manifest(int argc, char **argv, const char *hull_exe);
+
+#endif /* HL_COMMANDS_MANIFEST_H */

--- a/include/hull/commands/test.h
+++ b/include/hull/commands/test.h
@@ -1,0 +1,12 @@
+/*
+ * commands/test.h — hull test subcommand
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef HL_COMMANDS_TEST_H
+#define HL_COMMANDS_TEST_H
+
+int hl_cmd_test(int argc, char **argv, const char *hull_exe);
+
+#endif /* HL_COMMANDS_TEST_H */

--- a/include/hull/commands/verify.h
+++ b/include/hull/commands/verify.h
@@ -1,0 +1,12 @@
+/*
+ * commands/verify.h — hull verify subcommand
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef HL_COMMANDS_VERIFY_H
+#define HL_COMMANDS_VERIFY_H
+
+int hl_cmd_verify(int argc, char **argv, const char *hull_exe);
+
+#endif /* HL_COMMANDS_VERIFY_H */

--- a/include/hull/runtime/js.h
+++ b/include/hull/runtime/js.h
@@ -19,6 +19,7 @@ typedef struct JSRuntime JSRuntime;
 typedef struct JSContext JSContext;
 typedef struct KlRequest KlRequest;
 typedef struct KlResponse KlResponse;
+typedef struct KlRouter KlRouter;
 typedef struct SHArena SHArena;
 typedef struct HlAllocator HlAllocator;
 typedef struct sqlite3 sqlite3;
@@ -145,5 +146,26 @@ int hl_js_register_modules(HlJS *js);
  * Call after any JS_IsException() check.
  */
 void hl_js_dump_error(HlJS *js);
+
+/* ── Route wiring ──────────────────────────────────────────────────── */
+
+/*
+ * Per-route context: associates a Keel route with a JS handler.
+ */
+typedef struct {
+    HlJS *js;
+    int    handler_id;
+} HlJSRoute;
+
+/*
+ * Keel handler bridge: dispatches a request to the JS handler.
+ */
+void hl_js_keel_handler(KlRequest *req, KlResponse *res, void *user_data);
+
+/*
+ * Wire JS routes from __hull_route_defs into a KlRouter.
+ * Returns 0 on success, -1 on error.
+ */
+int hl_js_wire_routes(HlJS *js, KlRouter *router);
 
 #endif /* HL_RUNTIME_JS_H */

--- a/include/hull/sandbox.h
+++ b/include/hull/sandbox.h
@@ -18,6 +18,7 @@
 #define HL_SANDBOX_H
 
 #include "hull/manifest.h"
+#include "hull/cap/tool.h"
 
 /*
  * Apply kernel sandbox based on manifest capabilities.
@@ -29,5 +30,22 @@
  * Returns 0 on success, -1 on error (logged).
  */
 int hl_sandbox_apply(const HlManifest *manifest, const char *db_path);
+
+/*
+ * Initialize tool-mode unveil context for `hull build`.
+ * Populates the HlToolUnveilCtx with allowed paths for build operations.
+ * Also calls kernel-level unveil() on supported platforms.
+ *
+ *   ctx           — tool unveil context to populate
+ *   app_dir       — application source directory (read)
+ *   output_dir    — directory for output binary (write/create)
+ *   platform_dir  — directory containing libhull_platform.a (read)
+ *
+ * Returns 0 on success, -1 on error.
+ */
+int hl_tool_sandbox_init(HlToolUnveilCtx *ctx,
+                         const char *app_dir,
+                         const char *output_dir,
+                         const char *platform_dir);
 
 #endif /* HL_SANDBOX_H */

--- a/src/hull/alloc.c
+++ b/src/hull/alloc.c
@@ -6,6 +6,7 @@
 
 #include "hull/alloc.h"
 #include <sh_arena.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 /* ── Tracked allocation functions ──────────────────────────────────── */

--- a/src/hull/cap/test.c
+++ b/src/hull/cap/test.c
@@ -545,7 +545,9 @@ static JSValue js_test_http(JSContext *ctx, const char *method,
                            header_names, header_values, num_headers, &result);
 
     /* Free C strings */
+    // cppcheck-suppress knownConditionTrueFalse
     if (body_str) JS_FreeCString(ctx, body_str);
+    // cppcheck-suppress knownConditionTrueFalse
     for (int i = 0; i < num_headers; i++) {
         if (header_names[i]) JS_FreeCString(ctx, header_names[i]);
         if (header_values[i]) JS_FreeCString(ctx, header_values[i]);

--- a/src/hull/cap/test.c
+++ b/src/hull/cap/test.c
@@ -1,0 +1,826 @@
+/*
+ * cap/test.c — In-process test module for hull test
+ *
+ * Provides HTTP dispatch (no TCP) and assertions for testing Hull apps.
+ * Routes are matched via kl_router_match, handlers called in-process,
+ * and KlResponse fields inspected directly.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "hull/cap/test.h"
+
+#include <keel/router.h>
+#include <keel/request.h>
+#include <keel/response.h>
+#include <keel/allocator.h>
+#include <keel/body_reader.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Registry keys for stored state */
+#define TEST_ROUTER_KEY   "__hull_test_router"
+#define TEST_CASES_KEY    "__hull_test_cases"
+
+/* ── Shared C dispatch logic ───────────────────────────────────────── */
+
+/*
+ * Build a KlRequest on the stack, match a route, dispatch the handler,
+ * and return response info. Used by both Lua and JS bindings.
+ */
+typedef struct {
+    int status;
+    const char *body;
+    size_t body_len;
+    const char *hdr_buf;
+    size_t hdr_len;
+} HlTestResult;
+
+static int test_dispatch(KlRouter *router, const char *method,
+                         const char *path, const char *body_data,
+                         size_t body_len, const char **header_names,
+                         const char **header_values, int num_headers,
+                         HlTestResult *result)
+{
+    if (!router || !method || !path || !result) return -1;
+
+    memset(result, 0, sizeof(*result));
+
+    /* Split path at '?' for query string */
+    const char *query = NULL;
+    size_t path_len = strlen(path);
+    size_t query_len = 0;
+    const char *qmark = strchr(path, '?');
+    if (qmark) {
+        path_len = (size_t)(qmark - path);
+        query = qmark + 1;
+        query_len = strlen(query);
+    }
+
+    /* Match route */
+    KlRoute *matched = NULL;
+    KlParam params[KL_MAX_PARAMS];
+    int num_params = 0;
+
+    int match_status = kl_router_match(router, method, strlen(method),
+                                        path, path_len,
+                                        &matched, params, &num_params);
+
+    if (match_status != 200 || !matched) {
+        result->status = match_status;
+        return 0;
+    }
+
+    /* Build request */
+    KlRequest req;
+    memset(&req, 0, sizeof(req));
+    req.method = method;
+    req.method_len = strlen(method);
+    req.path = path;
+    req.path_len = path_len;
+    req.query = query;
+    req.query_len = query_len;
+    req.version_major = 1;
+    req.version_minor = 1;
+    req.keep_alive = 0;
+
+    /* Copy matched params */
+    req.num_params = num_params;
+    for (int i = 0; i < num_params && i < KL_MAX_PARAMS; i++)
+        req.params[i] = params[i];
+
+    /* Set headers */
+    for (int i = 0; i < num_headers && i < KL_MAX_HEADERS; i++) {
+        req.headers[i].name = header_names[i];
+        req.headers[i].name_len = strlen(header_names[i]);
+        req.headers[i].value = header_values[i];
+        req.headers[i].value_len = strlen(header_values[i]);
+    }
+    req.num_headers = num_headers;
+
+    /* Fake body reader if body provided */
+    KlBodyReader fake_body;
+    memset(&fake_body, 0, sizeof(fake_body));
+    if (body_data && body_len > 0) {
+        req.body_reader = &fake_body;
+        req.content_length = body_len;
+    }
+
+    /* Build response */
+    KlAllocator alloc = kl_allocator_default();
+    KlResponse res;
+    if (kl_response_init(&res, &alloc) != 0) return -1;
+    res.conn_fd = -1; /* no actual connection */
+
+    /* Dispatch handler */
+    matched->handler(&req, &res, matched->user_data);
+
+    /* Extract results */
+    result->status = res.status;
+    result->body = res.body;
+    result->body_len = res.body_len;
+    result->hdr_buf = res.hdr_buf;
+    result->hdr_len = res.hdr_len;
+
+    /* Don't free response yet — caller reads the body pointer.
+     * Caller is responsible for cleanup. We copy what we need. */
+    /* Actually, body points into runtime-managed memory, so we copy it. */
+    if (res.body && res.body_len > 0) {
+        char *body_copy = malloc(res.body_len + 1);
+        if (body_copy) {
+            memcpy(body_copy, res.body, res.body_len);
+            body_copy[res.body_len] = '\0';
+            result->body = body_copy;
+        }
+    }
+
+    kl_response_free(&res);
+    return 0;
+}
+
+/* ══════════════════════════════════════════════════════════════════════
+ *  Lua bindings
+ * ══════════════════════════════════════════════════════════════════════ */
+
+#ifdef HL_ENABLE_LUA
+
+#include "hull/runtime/lua.h"
+#include "lua.h"
+#include "lauxlib.h"
+
+static KlRouter *get_test_router(lua_State *L)
+{
+    lua_getfield(L, LUA_REGISTRYINDEX, TEST_ROUTER_KEY);
+    KlRouter *r = (KlRouter *)lua_touserdata(L, -1);
+    lua_pop(L, 1);
+    return r;
+}
+
+static HlLua *get_test_lua(lua_State *L)
+{
+    lua_getfield(L, LUA_REGISTRYINDEX, "__hull_test_lua");
+    HlLua *lua = (HlLua *)lua_touserdata(L, -1);
+    lua_pop(L, 1);
+    return lua;
+}
+
+/* ── test(...) — register a test case ──────────────────────────────── */
+
+static int l_test_call(lua_State *L)
+{
+    /* Called as test("desc", fn) — first arg is the test table (self) */
+    const char *desc = luaL_checkstring(L, 2);
+    luaL_checktype(L, 3, LUA_TFUNCTION);
+
+    /* Get test cases table */
+    lua_getfield(L, LUA_REGISTRYINDEX, TEST_CASES_KEY);
+    int idx = (int)luaL_len(L, -1) + 1;
+
+    /* Store { desc = desc, fn = fn } */
+    lua_newtable(L);
+    lua_pushstring(L, desc);
+    lua_setfield(L, -2, "desc");
+    lua_pushvalue(L, 3);
+    lua_setfield(L, -2, "fn");
+
+    lua_rawseti(L, -2, idx);
+    lua_pop(L, 1); /* pop test cases table */
+    return 0;
+}
+
+/* ── test.get/post/put/delete/patch ────────────────────────────────── */
+
+static int l_test_http(lua_State *L, const char *method)
+{
+    const char *path = luaL_checkstring(L, 1);
+    KlRouter *router = get_test_router(L);
+    HlLua *lua = get_test_lua(L);
+
+    if (!router || !lua) {
+        return luaL_error(L, "test module not initialized");
+    }
+
+    /* Parse optional opts table (arg 2) */
+    const char *body_str = NULL;
+    size_t body_len = 0;
+    const char *header_names[KL_MAX_HEADERS];
+    const char *header_values[KL_MAX_HEADERS];
+    int num_headers = 0;
+
+    if (lua_istable(L, 2)) {
+        /* opts.body */
+        lua_getfield(L, 2, "body");
+        if (lua_isstring(L, -1))
+            body_str = lua_tolstring(L, -1, &body_len);
+        lua_pop(L, 1);
+
+        /* opts.headers */
+        lua_getfield(L, 2, "headers");
+        if (lua_istable(L, -1)) {
+            lua_pushnil(L);
+            while (lua_next(L, -2) != 0 && num_headers < KL_MAX_HEADERS) {
+                if (lua_isstring(L, -2) && lua_isstring(L, -1)) {
+                    header_names[num_headers] = lua_tostring(L, -2);
+                    header_values[num_headers] = lua_tostring(L, -1);
+                    num_headers++;
+                }
+                lua_pop(L, 1);
+            }
+        }
+        lua_pop(L, 1);
+    }
+
+    HlTestResult result;
+    if (test_dispatch(router, method, path, body_str, body_len,
+                      header_names, header_values, num_headers,
+                      &result) != 0) {
+        return luaL_error(L, "test dispatch failed");
+    }
+
+    /* Build result table */
+    lua_newtable(L);
+
+    lua_pushinteger(L, result.status);
+    lua_setfield(L, -2, "status");
+
+    if (result.body && result.body_len > 0) {
+        lua_pushlstring(L, result.body, result.body_len);
+        lua_setfield(L, -2, "body");
+
+        /* Auto-decode JSON if body looks like JSON */
+        if (result.body[0] == '{' || result.body[0] == '[') {
+            /* Try json.decode via hull.json module */
+            lua_getglobal(L, "require");
+            lua_pushstring(L, "hull.json");
+            if (lua_pcall(L, 1, 1, 0) == LUA_OK && lua_istable(L, -1)) {
+                lua_getfield(L, -1, "decode");
+                lua_pushlstring(L, result.body, result.body_len);
+                if (lua_pcall(L, 1, 1, 0) == LUA_OK) {
+                    lua_setfield(L, -3, "json");
+                } else {
+                    lua_pop(L, 1); /* pop error */
+                }
+                lua_pop(L, 1); /* pop json module */
+            } else {
+                lua_pop(L, 1);
+            }
+        }
+
+        free((void *)result.body);
+    }
+
+    return 1;
+}
+
+static int l_test_get(lua_State *L)    { return l_test_http(L, "GET"); }
+static int l_test_post(lua_State *L)   { return l_test_http(L, "POST"); }
+static int l_test_put(lua_State *L)    { return l_test_http(L, "PUT"); }
+static int l_test_delete(lua_State *L) { return l_test_http(L, "DELETE"); }
+static int l_test_patch(lua_State *L)  { return l_test_http(L, "PATCH"); }
+
+/* ── test.eq(a, b, msg?) ──────────────────────────────────────────── */
+
+static int l_test_eq(lua_State *L)
+{
+    int equal = 0;
+
+    if (lua_type(L, 1) == lua_type(L, 2)) {
+        if (lua_isstring(L, 1) && lua_isstring(L, 2)) {
+            equal = (strcmp(lua_tostring(L, 1), lua_tostring(L, 2)) == 0);
+        } else if (lua_isnumber(L, 1) && lua_isnumber(L, 2)) {
+            equal = (lua_tonumber(L, 1) == lua_tonumber(L, 2));
+        } else if (lua_isboolean(L, 1) && lua_isboolean(L, 2)) {
+            equal = (lua_toboolean(L, 1) == lua_toboolean(L, 2));
+        } else if (lua_isnil(L, 1) && lua_isnil(L, 2)) {
+            equal = 1;
+        } else {
+            /* For tables/userdata, compare by reference */
+            equal = lua_rawequal(L, 1, 2);
+        }
+    }
+
+    if (!equal) {
+        const char *msg = lua_isstring(L, 3) ? lua_tostring(L, 3) : NULL;
+        const char *a_str = luaL_tolstring(L, 1, NULL);
+        const char *b_str = luaL_tolstring(L, 2, NULL);
+        if (msg)
+            return luaL_error(L, "test.eq failed: %s\n  expected: %s\n  actual:   %s",
+                              msg, b_str, a_str);
+        else
+            return luaL_error(L, "test.eq failed\n  expected: %s\n  actual:   %s",
+                              b_str, a_str);
+    }
+
+    return 0;
+}
+
+/* ── test.ok(val, msg?) ───────────────────────────────────────────── */
+
+static int l_test_ok(lua_State *L)
+{
+    if (!lua_toboolean(L, 1)) {
+        const char *msg = lua_isstring(L, 2) ? lua_tostring(L, 2) : "test.ok failed";
+        return luaL_error(L, "%s", msg);
+    }
+    return 0;
+}
+
+/* ── test.err(fn, pattern?) ───────────────────────────────────────── */
+
+static int l_test_err(lua_State *L)
+{
+    luaL_checktype(L, 1, LUA_TFUNCTION);
+    const char *pattern = lua_isstring(L, 2) ? lua_tostring(L, 2) : NULL;
+
+    lua_pushvalue(L, 1);
+    int rc = lua_pcall(L, 0, 0, 0);
+
+    if (rc == LUA_OK)
+        return luaL_error(L, "test.err: expected error but function succeeded");
+
+    if (pattern) {
+        const char *err = lua_tostring(L, -1);
+        if (!err || strstr(err, pattern) == NULL) {
+            return luaL_error(L, "test.err: error '%s' does not match pattern '%s'",
+                              err ? err : "(nil)", pattern);
+        }
+    }
+
+    lua_pop(L, 1); /* pop error message */
+    return 0;
+}
+
+/* ── Registration ──────────────────────────────────────────────────── */
+
+static const luaL_Reg test_methods[] = {
+    { "get",    l_test_get },
+    { "post",   l_test_post },
+    { "put",    l_test_put },
+    { "delete", l_test_delete },
+    { "patch",  l_test_patch },
+    { "eq",     l_test_eq },
+    { "ok",     l_test_ok },
+    { "err",    l_test_err },
+    { NULL, NULL }
+};
+
+void hl_cap_test_register_lua(lua_State *L, KlRouter *router, HlLua *lua)
+{
+    /* Store router and lua context in registry */
+    lua_pushlightuserdata(L, router);
+    lua_setfield(L, LUA_REGISTRYINDEX, TEST_ROUTER_KEY);
+
+    lua_pushlightuserdata(L, lua);
+    lua_setfield(L, LUA_REGISTRYINDEX, "__hull_test_lua");
+
+    /* Create test cases table */
+    lua_newtable(L);
+    lua_setfield(L, LUA_REGISTRYINDEX, TEST_CASES_KEY);
+
+    /* Create the test table with methods */
+    luaL_newlib(L, test_methods);
+
+    /* Create metatable with __call for test("desc", fn) */
+    lua_newtable(L); /* metatable */
+    lua_pushcfunction(L, l_test_call);
+    lua_setfield(L, -2, "__call");
+    lua_setmetatable(L, -2);
+
+    lua_setglobal(L, "test");
+}
+
+void hl_cap_test_clear_lua(lua_State *L)
+{
+    lua_newtable(L);
+    lua_setfield(L, LUA_REGISTRYINDEX, TEST_CASES_KEY);
+}
+
+void hl_cap_test_run_lua(lua_State *L, int *total, int *passed, int *failed)
+{
+    *total = 0;
+    *passed = 0;
+    *failed = 0;
+
+    lua_getfield(L, LUA_REGISTRYINDEX, TEST_CASES_KEY);
+    if (!lua_istable(L, -1)) {
+        lua_pop(L, 1);
+        return;
+    }
+
+    int count = (int)luaL_len(L, -1);
+    for (int i = 1; i <= count; i++) {
+        lua_rawgeti(L, -1, i);
+
+        lua_getfield(L, -1, "desc");
+        const char *desc = lua_tostring(L, -1);
+        lua_pop(L, 1);
+
+        lua_getfield(L, -1, "fn");
+
+        (*total)++;
+        int rc = lua_pcall(L, 0, 0, 0);
+        if (rc == LUA_OK) {
+            printf("  PASS  %s\n", desc ? desc : "(unnamed)");
+            (*passed)++;
+        } else {
+            const char *err = lua_tostring(L, -1);
+            printf("  FAIL  %s\n    %s\n", desc ? desc : "(unnamed)",
+                   err ? err : "unknown error");
+            lua_pop(L, 1); /* pop error */
+            (*failed)++;
+        }
+
+        lua_pop(L, 1); /* pop test case table */
+    }
+
+    lua_pop(L, 1); /* pop test cases table */
+}
+
+#endif /* HL_ENABLE_LUA */
+
+/* ══════════════════════════════════════════════════════════════════════
+ *  JS bindings
+ * ══════════════════════════════════════════════════════════════════════ */
+
+#ifdef HL_ENABLE_JS
+
+#include "hull/runtime/js.h"
+#include "quickjs.h"
+
+/* JS test state stored as opaque pointer on globalThis.__hull_test_state */
+
+typedef struct {
+    KlRouter *router;
+    HlJS *js;
+    JSValue cases; /* Array of { desc: string, fn: function } */
+} HlJSTestState;
+
+static HlJSTestState *get_js_test_state(JSContext *ctx)
+{
+    JSValue global = JS_GetGlobalObject(ctx);
+    JSValue state_val = JS_GetPropertyStr(ctx, global, "__hull_test_state");
+    HlJSTestState *state = NULL;
+    if (!JS_IsUndefined(state_val)) {
+        state = JS_GetOpaque(state_val, 0);
+    }
+    JS_FreeValue(ctx, state_val);
+    JS_FreeValue(ctx, global);
+    return state;
+}
+
+/* test("desc", fn) — callable */
+static JSValue js_test_call(JSContext *ctx, JSValueConst this_val,
+                            int argc, JSValueConst *argv)
+{
+    (void)this_val;
+    if (argc < 2) return JS_UNDEFINED;
+
+    HlJSTestState *state = get_js_test_state(ctx);
+    if (!state) return JS_ThrowInternalError(ctx, "test not initialized");
+
+    JSValue len_val = JS_GetPropertyStr(ctx, state->cases, "length");
+    int32_t idx = 0;
+    JS_ToInt32(ctx, &idx, len_val);
+    JS_FreeValue(ctx, len_val);
+
+    JSValue entry = JS_NewObject(ctx);
+    JS_SetPropertyStr(ctx, entry, "desc", JS_DupValue(ctx, argv[0]));
+    JS_SetPropertyStr(ctx, entry, "fn", JS_DupValue(ctx, argv[1]));
+    JS_SetPropertyUint32(ctx, state->cases, (uint32_t)idx, entry);
+
+    return JS_UNDEFINED;
+}
+
+/* test.get/post/put/delete/patch */
+static JSValue js_test_http(JSContext *ctx, const char *method,
+                            int argc, JSValueConst *argv)
+{
+    if (argc < 1) return JS_ThrowTypeError(ctx, "path required");
+
+    HlJSTestState *state = get_js_test_state(ctx);
+    if (!state) return JS_ThrowInternalError(ctx, "test not initialized");
+
+    const char *path = JS_ToCString(ctx, argv[0]);
+    if (!path) return JS_EXCEPTION;
+
+    const char *body_str = NULL;
+    size_t body_len = 0;
+    const char *header_names[KL_MAX_HEADERS];
+    const char *header_values[KL_MAX_HEADERS];
+    int num_headers = 0;
+
+    /* Parse opts (arg 1) */
+    if (argc >= 2 && JS_IsObject(argv[1])) {
+        JSValue body_val = JS_GetPropertyStr(ctx, argv[1], "body");
+        if (JS_IsString(body_val))
+            body_str = JS_ToCStringLen(ctx, &body_len, body_val);
+        JS_FreeValue(ctx, body_val);
+
+        JSValue hdrs_val = JS_GetPropertyStr(ctx, argv[1], "headers");
+        if (JS_IsObject(hdrs_val)) {
+            JSPropertyEnum *props = NULL;
+            uint32_t prop_count = 0;
+            if (JS_GetOwnPropertyNames(ctx, &props, &prop_count, hdrs_val,
+                                        JS_GPN_STRING_MASK | JS_GPN_ENUM_ONLY) == 0) {
+                for (uint32_t i = 0; i < prop_count && num_headers < KL_MAX_HEADERS; i++) {
+                    header_names[num_headers] = JS_AtomToCString(ctx, props[i].atom);
+                    JSValue val = JS_GetProperty(ctx, hdrs_val, props[i].atom);
+                    header_values[num_headers] = JS_ToCString(ctx, val);
+                    JS_FreeValue(ctx, val);
+                    if (header_names[num_headers] && header_values[num_headers])
+                        num_headers++;
+                }
+                for (uint32_t i = 0; i < prop_count; i++)
+                    JS_FreeAtom(ctx, props[i].atom);
+                js_free(ctx, props);
+            }
+        }
+        JS_FreeValue(ctx, hdrs_val);
+    }
+
+    HlTestResult result;
+    int rc = test_dispatch(state->router, method, path, body_str, body_len,
+                           header_names, header_values, num_headers, &result);
+
+    /* Free C strings */
+    if (body_str) JS_FreeCString(ctx, body_str);
+    for (int i = 0; i < num_headers; i++) {
+        if (header_names[i]) JS_FreeCString(ctx, header_names[i]);
+        if (header_values[i]) JS_FreeCString(ctx, header_values[i]);
+    }
+    JS_FreeCString(ctx, path);
+
+    if (rc != 0)
+        return JS_ThrowInternalError(ctx, "test dispatch failed");
+
+    /* Build result object */
+    JSValue obj = JS_NewObject(ctx);
+    JS_SetPropertyStr(ctx, obj, "status", JS_NewInt32(ctx, result.status));
+
+    if (result.body && result.body_len > 0) {
+        JS_SetPropertyStr(ctx, obj, "body",
+                          JS_NewStringLen(ctx, result.body, result.body_len));
+
+        /* Auto-decode JSON */
+        if (result.body[0] == '{' || result.body[0] == '[') {
+            JSValue json_str = JS_NewStringLen(ctx, result.body, result.body_len);
+            JSValue parsed = JS_ParseJSON(ctx, result.body, result.body_len, "<test>");
+            if (!JS_IsException(parsed))
+                JS_SetPropertyStr(ctx, obj, "json", parsed);
+            else
+                JS_FreeValue(ctx, JS_GetException(ctx));
+            JS_FreeValue(ctx, json_str);
+        }
+
+        free((void *)result.body);
+    }
+
+    return obj;
+}
+
+static JSValue js_test_get(JSContext *ctx, JSValueConst this_val,
+                           int argc, JSValueConst *argv)
+{
+    (void)this_val;
+    return js_test_http(ctx, "GET", argc, argv);
+}
+
+static JSValue js_test_post(JSContext *ctx, JSValueConst this_val,
+                            int argc, JSValueConst *argv)
+{
+    (void)this_val;
+    return js_test_http(ctx, "POST", argc, argv);
+}
+
+static JSValue js_test_put(JSContext *ctx, JSValueConst this_val,
+                           int argc, JSValueConst *argv)
+{
+    (void)this_val;
+    return js_test_http(ctx, "PUT", argc, argv);
+}
+
+static JSValue js_test_del(JSContext *ctx, JSValueConst this_val,
+                           int argc, JSValueConst *argv)
+{
+    (void)this_val;
+    return js_test_http(ctx, "DELETE", argc, argv);
+}
+
+static JSValue js_test_patch(JSContext *ctx, JSValueConst this_val,
+                             int argc, JSValueConst *argv)
+{
+    (void)this_val;
+    return js_test_http(ctx, "PATCH", argc, argv);
+}
+
+/* test.eq(a, b, msg?) */
+static JSValue js_test_eq(JSContext *ctx, JSValueConst this_val,
+                          int argc, JSValueConst *argv)
+{
+    (void)this_val;
+    if (argc < 2) return JS_ThrowTypeError(ctx, "test.eq requires 2 arguments");
+
+    int equal = 0;
+
+    /* Use strict equality for primitives */
+    if (JS_IsNumber(argv[0]) && JS_IsNumber(argv[1])) {
+        double a, b;
+        JS_ToFloat64(ctx, &a, argv[0]);
+        JS_ToFloat64(ctx, &b, argv[1]);
+        equal = (a == b);
+    } else if (JS_IsString(argv[0]) && JS_IsString(argv[1])) {
+        const char *a = JS_ToCString(ctx, argv[0]);
+        const char *b = JS_ToCString(ctx, argv[1]);
+        equal = (a && b && strcmp(a, b) == 0);
+        if (a) JS_FreeCString(ctx, a);
+        if (b) JS_FreeCString(ctx, b);
+    } else if (JS_IsBool(argv[0]) && JS_IsBool(argv[1])) {
+        equal = (JS_ToBool(ctx, argv[0]) == JS_ToBool(ctx, argv[1]));
+    } else if (JS_IsNull(argv[0]) && JS_IsNull(argv[1])) {
+        equal = 1;
+    } else if (JS_IsUndefined(argv[0]) && JS_IsUndefined(argv[1])) {
+        equal = 1;
+    } else {
+        /* Reference equality for objects */
+        equal = (JS_VALUE_GET_PTR(argv[0]) == JS_VALUE_GET_PTR(argv[1]));
+    }
+
+    if (!equal) {
+        const char *msg = (argc >= 3 && JS_IsString(argv[2]))
+                          ? JS_ToCString(ctx, argv[2]) : NULL;
+        JSValue a_str = JS_JSONStringify(ctx, argv[0], JS_UNDEFINED, JS_UNDEFINED);
+        JSValue b_str = JS_JSONStringify(ctx, argv[1], JS_UNDEFINED, JS_UNDEFINED);
+        const char *a = JS_ToCString(ctx, a_str);
+        const char *b = JS_ToCString(ctx, b_str);
+
+        JSValue err;
+        if (msg)
+            err = JS_ThrowTypeError(ctx, "test.eq failed: %s\n  expected: %s\n  actual:   %s",
+                                    msg, b ? b : "?", a ? a : "?");
+        else
+            err = JS_ThrowTypeError(ctx, "test.eq failed\n  expected: %s\n  actual:   %s",
+                                    b ? b : "?", a ? a : "?");
+
+        if (a) JS_FreeCString(ctx, a);
+        if (b) JS_FreeCString(ctx, b);
+        JS_FreeValue(ctx, a_str);
+        JS_FreeValue(ctx, b_str);
+        if (msg) JS_FreeCString(ctx, msg);
+        return err;
+    }
+
+    return JS_UNDEFINED;
+}
+
+/* test.ok(val, msg?) */
+static JSValue js_test_ok(JSContext *ctx, JSValueConst this_val,
+                          int argc, JSValueConst *argv)
+{
+    (void)this_val;
+    if (argc < 1 || !JS_ToBool(ctx, argv[0])) {
+        const char *msg = (argc >= 2 && JS_IsString(argv[1]))
+                          ? JS_ToCString(ctx, argv[1]) : "test.ok failed";
+        JSValue err = JS_ThrowTypeError(ctx, "%s", msg);
+        if (argc >= 2 && JS_IsString(argv[1]))
+            JS_FreeCString(ctx, msg);
+        return err;
+    }
+    return JS_UNDEFINED;
+}
+
+/* test.err(fn, pattern?) */
+static JSValue js_test_err(JSContext *ctx, JSValueConst this_val,
+                           int argc, JSValueConst *argv)
+{
+    (void)this_val;
+    if (argc < 1 || !JS_IsFunction(ctx, argv[0]))
+        return JS_ThrowTypeError(ctx, "test.err requires a function");
+
+    JSValue ret = JS_Call(ctx, argv[0], JS_UNDEFINED, 0, NULL);
+    if (!JS_IsException(ret)) {
+        JS_FreeValue(ctx, ret);
+        return JS_ThrowTypeError(ctx, "test.err: expected error but function succeeded");
+    }
+
+    JSValue exc = JS_GetException(ctx);
+    if (argc >= 2 && JS_IsString(argv[1])) {
+        const char *pattern = JS_ToCString(ctx, argv[1]);
+        JSValue msg_val = JS_GetPropertyStr(ctx, exc, "message");
+        const char *msg = JS_ToCString(ctx, msg_val);
+
+        int matches = (msg && pattern && strstr(msg, pattern) != NULL);
+
+        if (msg) JS_FreeCString(ctx, msg);
+        JS_FreeValue(ctx, msg_val);
+        JS_FreeCString(ctx, pattern);
+
+        if (!matches) {
+            JS_FreeValue(ctx, exc);
+            return JS_ThrowTypeError(ctx, "test.err: error does not match pattern");
+        }
+    }
+
+    JS_FreeValue(ctx, exc);
+    return JS_UNDEFINED;
+}
+
+void hl_cap_test_register_js(JSContext *ctx, KlRouter *router, HlJS *js)
+{
+    HlJSTestState *state = js_malloc(ctx, sizeof(HlJSTestState));
+    if (!state) return;
+
+    state->router = router;
+    state->js = js;
+    state->cases = JS_NewArray(ctx);
+
+    /* Store state on global */
+    JSValue global = JS_GetGlobalObject(ctx);
+
+    JSValue state_obj = JS_NewObjectClass(ctx, 0);
+    JS_SetOpaque(state_obj, state);
+    JS_SetPropertyStr(ctx, global, "__hull_test_state", state_obj);
+
+    /* Create test function (callable + has properties) */
+    JSValue test_fn = JS_NewCFunction(ctx, js_test_call, "test", 2);
+
+    /* Add methods */
+    JS_SetPropertyStr(ctx, test_fn, "get",
+                      JS_NewCFunction(ctx, js_test_get, "get", 2));
+    JS_SetPropertyStr(ctx, test_fn, "post",
+                      JS_NewCFunction(ctx, js_test_post, "post", 2));
+    JS_SetPropertyStr(ctx, test_fn, "put",
+                      JS_NewCFunction(ctx, js_test_put, "put", 2));
+    JS_SetPropertyStr(ctx, test_fn, "delete",
+                      JS_NewCFunction(ctx, js_test_del, "delete", 2));
+    JS_SetPropertyStr(ctx, test_fn, "patch",
+                      JS_NewCFunction(ctx, js_test_patch, "patch", 2));
+    JS_SetPropertyStr(ctx, test_fn, "eq",
+                      JS_NewCFunction(ctx, js_test_eq, "eq", 3));
+    JS_SetPropertyStr(ctx, test_fn, "ok",
+                      JS_NewCFunction(ctx, js_test_ok, "ok", 2));
+    JS_SetPropertyStr(ctx, test_fn, "err",
+                      JS_NewCFunction(ctx, js_test_err, "err", 2));
+
+    JS_SetPropertyStr(ctx, global, "test", test_fn);
+    JS_FreeValue(ctx, global);
+}
+
+void hl_cap_test_clear_js(JSContext *ctx)
+{
+    HlJSTestState *state = get_js_test_state(ctx);
+    if (!state) return;
+
+    JS_FreeValue(ctx, state->cases);
+    state->cases = JS_NewArray(ctx);
+}
+
+void hl_cap_test_run_js(JSContext *ctx, int *total, int *passed, int *failed)
+{
+    *total = 0;
+    *passed = 0;
+    *failed = 0;
+
+    HlJSTestState *state = get_js_test_state(ctx);
+    if (!state) return;
+
+    JSValue len_val = JS_GetPropertyStr(ctx, state->cases, "length");
+    int32_t count = 0;
+    JS_ToInt32(ctx, &count, len_val);
+    JS_FreeValue(ctx, len_val);
+
+    for (int32_t i = 0; i < count; i++) {
+        JSValue entry = JS_GetPropertyUint32(ctx, state->cases, (uint32_t)i);
+        JSValue desc_val = JS_GetPropertyStr(ctx, entry, "desc");
+        JSValue fn = JS_GetPropertyStr(ctx, entry, "fn");
+
+        const char *desc = JS_ToCString(ctx, desc_val);
+
+        (*total)++;
+        JSValue ret = JS_Call(ctx, fn, JS_UNDEFINED, 0, NULL);
+
+        if (JS_IsException(ret)) {
+            JSValue exc = JS_GetException(ctx);
+            JSValue msg_val = JS_GetPropertyStr(ctx, exc, "message");
+            const char *msg = JS_ToCString(ctx, msg_val);
+            printf("  FAIL  %s\n    %s\n", desc ? desc : "(unnamed)",
+                   msg ? msg : "unknown error");
+            if (msg) JS_FreeCString(ctx, msg);
+            JS_FreeValue(ctx, msg_val);
+            JS_FreeValue(ctx, exc);
+            (*failed)++;
+        } else {
+            printf("  PASS  %s\n", desc ? desc : "(unnamed)");
+            (*passed)++;
+        }
+
+        JS_FreeValue(ctx, ret);
+        if (desc) JS_FreeCString(ctx, desc);
+        JS_FreeValue(ctx, fn);
+        JS_FreeValue(ctx, desc_val);
+        JS_FreeValue(ctx, entry);
+    }
+}
+
+#endif /* HL_ENABLE_JS */

--- a/src/hull/cap/tool.c
+++ b/src/hull/cap/tool.c
@@ -350,6 +350,7 @@ int hl_tool_copy(const char *src, const char *dst,
     while ((n = fread(buf, 1, sizeof(buf), in)) > 0) {
         if (fwrite(buf, 1, n, out) != n) { ok = -1; break; }
     }
+    if (ferror(in)) ok = -1;
 
     fclose(in);
     fclose(out);
@@ -591,7 +592,12 @@ static int l_tool_read_file(lua_State *L)
     size_t n;
     while ((n = fread(buf, 1, sizeof(buf), f)) > 0)
         luaL_addlstring(&b, buf, n);
+    int read_err = ferror(f);
     fclose(f);
+    if (read_err) {
+        lua_pushnil(L);
+        return 1;
+    }
     luaL_pushresult(&b);
     return 1;
 }

--- a/src/hull/cap/tool.c
+++ b/src/hull/cap/tool.c
@@ -1,51 +1,537 @@
 /*
  * cap/tool.c — Controlled process/filesystem access for tool scripts
  *
- * Replaces raw os/io in tool mode with an explicit, auditable C module.
- * Each function is a Lua C function registered in the `tool` global table.
+ * All process execution uses fork/execvp with an allowlisted set of
+ * compiler binaries. All filesystem operations validate paths against
+ * an unveil table. No shell invocation (system/popen) anywhere.
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 #include "hull/cap/tool.h"
 
+#ifdef HL_ENABLE_LUA
 #include "lua.h"
 #include "lauxlib.h"
+#endif
 
+#include <dirent.h>
+#include <errno.h>
+#include <fnmatch.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
-/* ── tool.exec(cmd) ────────────────────────────────────────────────── */
+#ifdef HL_ENABLE_LUA
+/* Registry key for the unveil context pointer */
+#define TOOL_UNVEIL_KEY "__hull_tool_unveil"
+#endif
 
-static int l_tool_exec(lua_State *L)
+/* ── Unveil path table ─────────────────────────────────────────────── */
+
+void hl_tool_unveil_init(HlToolUnveilCtx *ctx)
 {
-    const char *cmd = luaL_checkstring(L, 1);
-    int rc = system(cmd);
-    lua_pushboolean(L, rc == 0);
-    return 1;
+    if (!ctx) return;
+    memset(ctx, 0, sizeof(*ctx));
 }
 
-/* ── tool.read(cmd) ────────────────────────────────────────────────── */
-
-static int l_tool_read(lua_State *L)
+int hl_tool_unveil_add(HlToolUnveilCtx *ctx, const char *path, const char *perms)
 {
-    const char *cmd = luaL_checkstring(L, 1);
-    FILE *f = popen(cmd, "r");
-    if (!f) {
+    if (!ctx || !path || !perms) return -1;
+    if (ctx->sealed) return -1;
+    if (ctx->count >= HL_TOOL_MAX_UNVEILED) return -1;
+
+    /* Resolve to absolute path if possible */
+    char resolved[PATH_MAX];
+    const char *use_path = path;
+    int resolved_differs = 0;
+    if (realpath(path, resolved) != NULL) {
+        if (strcmp(resolved, path) != 0)
+            resolved_differs = 1;
+        use_path = resolved;
+    }
+
+    /* Store the resolved copy */
+    char *dup = strdup(use_path);
+    if (!dup) return -1;
+
+    ctx->entries[ctx->count].path = dup;
+    ctx->entries[ctx->count].perms = perms;
+    ctx->count++;
+
+    /* If resolved path differs (e.g. /tmp → /private/tmp on macOS),
+     * also store the original path for prefix matching */
+    if (resolved_differs && ctx->count < HL_TOOL_MAX_UNVEILED) {
+        char *dup_orig = strdup(path);
+        if (dup_orig) {
+            ctx->entries[ctx->count].path = dup_orig;
+            ctx->entries[ctx->count].perms = perms;
+            ctx->count++;
+        }
+    }
+
+    return 0;
+}
+
+void hl_tool_unveil_seal(HlToolUnveilCtx *ctx)
+{
+    if (ctx) ctx->sealed = 1;
+}
+
+int hl_tool_unveil_check(const HlToolUnveilCtx *ctx, const char *path, char needed)
+{
+    if (!ctx || !path) return -1;
+
+    /* Resolve the path being checked */
+    char resolved[PATH_MAX];
+    const char *check_path = path;
+    if (realpath(path, resolved) != NULL)
+        check_path = resolved;
+
+    for (int i = 0; i < ctx->count; i++) {
+        const char *unveiled = ctx->entries[i].path;
+        size_t ulen = strlen(unveiled);
+
+        /* Check if path is under unveiled prefix */
+        if (strncmp(check_path, unveiled, ulen) != 0)
+            continue;
+
+        /* Must be exact match or have a / separator */
+        if (check_path[ulen] != '\0' && check_path[ulen] != '/')
+            continue;
+
+        /* Check permission */
+        if (strchr(ctx->entries[i].perms, needed) != NULL)
+            return 0;
+    }
+
+    return -1;
+}
+
+/* ── Compiler allowlist ────────────────────────────────────────────── */
+
+static const char *allowed_prefixes[] = {
+    "cc", "gcc", "clang", "cosmocc", "cosmoar", "ar", NULL
+};
+
+int hl_tool_check_allowlist(const char *binary)
+{
+    if (!binary) return -1;
+
+    /* Extract basename */
+    const char *base = strrchr(binary, '/');
+    base = base ? base + 1 : binary;
+
+    for (const char **p = allowed_prefixes; *p; p++) {
+        size_t plen = strlen(*p);
+        if (strncmp(base, *p, plen) == 0) {
+            /* Exact match or versioned variant (e.g. clang-18, gcc-12) */
+            char next = base[plen];
+            if (next == '\0' || next == '-')
+                return 0;
+        }
+    }
+
+    return -1;
+}
+
+/* ── Process spawning ──────────────────────────────────────────────── */
+
+int hl_tool_spawn(const char *const argv[])
+{
+    if (!argv || !argv[0]) return -1;
+    if (hl_tool_check_allowlist(argv[0]) != 0) return -1;
+
+    pid_t pid = fork();
+    if (pid < 0) return -1;
+
+    if (pid == 0) {
+        /* Child: exec */
+        execvp(argv[0], (char *const *)argv);
+        _exit(127);
+    }
+
+    /* Parent: wait */
+    int status;
+    if (waitpid(pid, &status, 0) < 0) return -1;
+
+    if (WIFEXITED(status))
+        return WEXITSTATUS(status);
+    return -1;
+}
+
+char *hl_tool_spawn_read(const char *const argv[], size_t *out_len)
+{
+    if (!argv || !argv[0]) return NULL;
+    if (hl_tool_check_allowlist(argv[0]) != 0) return NULL;
+
+    int pipefd[2];
+    if (pipe(pipefd) < 0) return NULL;
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        close(pipefd[0]);
+        close(pipefd[1]);
+        return NULL;
+    }
+
+    if (pid == 0) {
+        /* Child: redirect stdout to pipe */
+        close(pipefd[0]);
+        dup2(pipefd[1], STDOUT_FILENO);
+        close(pipefd[1]);
+        execvp(argv[0], (char *const *)argv);
+        _exit(127);
+    }
+
+    /* Parent: read from pipe */
+    close(pipefd[1]);
+
+    size_t cap = 4096, len = 0;
+    char *buf = malloc(cap);
+    if (!buf) {
+        close(pipefd[0]);
+        waitpid(pid, NULL, 0);
+        return NULL;
+    }
+
+    ssize_t n;
+    while ((n = read(pipefd[0], buf + len, cap - len)) > 0) {
+        len += (size_t)n;
+        if (len >= cap) {
+            if (cap > SIZE_MAX / 2) { free(buf); close(pipefd[0]); waitpid(pid, NULL, 0); return NULL; }
+            cap *= 2;
+            char *nb = realloc(buf, cap);
+            if (!nb) { free(buf); close(pipefd[0]); waitpid(pid, NULL, 0); return NULL; }
+            buf = nb;
+        }
+    }
+    close(pipefd[0]);
+
+    int status;
+    waitpid(pid, &status, 0);
+
+    /* Null-terminate */
+    char *result = realloc(buf, len + 1);
+    if (!result) result = buf;
+    result[len] = '\0';
+
+    if (out_len) *out_len = len;
+    return result;
+}
+
+/* ── File discovery ────────────────────────────────────────────────── */
+
+/* Skip list for directory names */
+static int should_skip_dir(const char *name)
+{
+    if (name[0] == '.') return 1;
+    if (strcmp(name, "node_modules") == 0) return 1;
+    if (strcmp(name, "vendor") == 0) return 1;
+    return 0;
+}
+
+/* Recursive helper for find_files */
+static int find_files_recurse(const char *dir, const char *pattern,
+                               char ***results, size_t *count, size_t *cap)
+{
+    DIR *d = opendir(dir);
+    if (!d) return 0; /* skip unreadable dirs */
+
+    struct dirent *ent;
+    while ((ent = readdir(d)) != NULL) {
+        if (ent->d_name[0] == '.') continue;
+        if (strcmp(ent->d_name, "node_modules") == 0) continue;
+        if (strcmp(ent->d_name, "vendor") == 0) continue;
+
+        /* Build full path */
+        size_t dlen = strlen(dir);
+        size_t nlen = strlen(ent->d_name);
+        if (dlen + 1 + nlen + 1 > PATH_MAX) continue;
+
+        char path[PATH_MAX];
+        snprintf(path, sizeof(path), "%s/%s", dir, ent->d_name);
+
+        struct stat st;
+        if (lstat(path, &st) != 0) continue;
+
+        if (S_ISDIR(st.st_mode)) {
+            if (!should_skip_dir(ent->d_name))
+                find_files_recurse(path, pattern, results, count, cap);
+        } else if (S_ISREG(st.st_mode)) {
+            if (fnmatch(pattern, ent->d_name, 0) == 0) {
+                /* Add to results */
+                if (*count >= *cap) {
+                    if (*cap > SIZE_MAX / (2 * sizeof(char *))) { closedir(d); return -1; }
+                    size_t newcap = *cap * 2;
+                    char **nr = realloc(*results, newcap * sizeof(char *));
+                    if (!nr) { closedir(d); return -1; }
+                    *results = nr;
+                    *cap = newcap;
+                }
+                (*results)[*count] = strdup(path);
+                if ((*results)[*count])
+                    (*count)++;
+            }
+        }
+    }
+
+    closedir(d);
+    return 0;
+}
+
+/* String comparison for qsort */
+static int str_compare(const void *a, const void *b)
+{
+    return strcmp(*(const char **)a, *(const char **)b);
+}
+
+char **hl_tool_find_files(const char *dir, const char *pattern,
+                          const HlToolUnveilCtx *ctx)
+{
+    if (!dir || !pattern) return NULL;
+
+    /* Validate path against unveil if context provided */
+    if (ctx && hl_tool_unveil_check(ctx, dir, 'r') != 0)
+        return NULL;
+
+    size_t cap = 64, count = 0;
+    char **results = malloc(cap * sizeof(char *));
+    if (!results) return NULL;
+
+    find_files_recurse(dir, pattern, &results, &count, &cap);
+
+    /* Sort alphabetically for deterministic ordering */
+    if (count > 1)
+        qsort(results, count, sizeof(char *), str_compare);
+
+    /* NULL-terminate */
+    char **final = realloc(results, (count + 1) * sizeof(char *));
+    if (!final) final = results;
+    final[count] = NULL;
+
+    return final;
+}
+
+/* ── File copy ─────────────────────────────────────────────────────── */
+
+int hl_tool_copy(const char *src, const char *dst,
+                 const HlToolUnveilCtx *ctx)
+{
+    if (!src || !dst) return -1;
+
+    if (ctx) {
+        if (hl_tool_unveil_check(ctx, src, 'r') != 0) return -1;
+        if (hl_tool_unveil_check(ctx, dst, 'w') != 0) return -1;
+    }
+
+    FILE *in = fopen(src, "rb");
+    if (!in) return -1;
+
+    FILE *out = fopen(dst, "wb");
+    if (!out) { fclose(in); return -1; }
+
+    char buf[8192];
+    size_t n;
+    int ok = 0;
+    while ((n = fread(buf, 1, sizeof(buf), in)) > 0) {
+        if (fwrite(buf, 1, n, out) != n) { ok = -1; break; }
+    }
+
+    fclose(in);
+    fclose(out);
+    return ok;
+}
+
+/* ── Recursive directory removal ───────────────────────────────────── */
+
+static int rmdir_recurse(const char *path)
+{
+    DIR *d = opendir(path);
+    if (!d) return -1;
+
+    struct dirent *ent;
+    int ret = 0;
+    while ((ent = readdir(d)) != NULL) {
+        if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0)
+            continue;
+
+        size_t plen = strlen(path);
+        size_t nlen = strlen(ent->d_name);
+        if (plen + 1 + nlen + 1 > PATH_MAX) { ret = -1; continue; }
+
+        char child[PATH_MAX];
+        snprintf(child, sizeof(child), "%s/%s", path, ent->d_name);
+
+        struct stat st;
+        if (lstat(child, &st) != 0) { ret = -1; continue; }
+
+        if (S_ISDIR(st.st_mode)) {
+            if (rmdir_recurse(child) != 0) ret = -1;
+        } else {
+            if (unlink(child) != 0) ret = -1;
+        }
+    }
+
+    closedir(d);
+    if (rmdir(path) != 0) ret = -1;
+    return ret;
+}
+
+int hl_tool_rmdir(const char *path, const HlToolUnveilCtx *ctx)
+{
+    if (!path) return -1;
+
+    if (ctx && hl_tool_unveil_check(ctx, path, 'w') != 0)
+        return -1;
+
+    return rmdir_recurse(path);
+}
+
+#ifdef HL_ENABLE_LUA
+
+/* ── Lua helper: get unveil context from registry ──────────────────── */
+
+static HlToolUnveilCtx *get_unveil_ctx(lua_State *L)
+{
+    lua_getfield(L, LUA_REGISTRYINDEX, TOOL_UNVEIL_KEY);
+    HlToolUnveilCtx *ctx = (HlToolUnveilCtx *)lua_touserdata(L, -1);
+    lua_pop(L, 1);
+    return ctx;
+}
+
+/* ── tool.spawn(argv_table) → (bool, int) ─────────────────────────── */
+
+static int l_tool_spawn(lua_State *L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+
+    /* Count elements */
+    int n = (int)luaL_len(L, 1);
+    if (n <= 0) {
+        lua_pushboolean(L, 0);
+        lua_pushinteger(L, -1);
+        return 2;
+    }
+
+    /* Build argv array */
+    const char **argv = malloc(((size_t)n + 1) * sizeof(const char *));
+    if (!argv) {
+        lua_pushboolean(L, 0);
+        lua_pushinteger(L, -1);
+        return 2;
+    }
+
+    for (int i = 1; i <= n; i++) {
+        lua_rawgeti(L, 1, i);
+        argv[i - 1] = lua_tostring(L, -1);
+        lua_pop(L, 1);
+    }
+    argv[n] = NULL;
+
+    int rc = hl_tool_spawn(argv);
+    free(argv);
+
+    if (rc == 0) {
+        lua_pushboolean(L, 1);
+        lua_pushinteger(L, 0);
+    } else {
+        lua_pushboolean(L, 0);
+        lua_pushinteger(L, rc);
+    }
+    return 2;
+}
+
+/* ── tool.spawn_read(argv_table) → string | nil ──────────────────── */
+
+static int l_tool_spawn_read(lua_State *L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+
+    int n = (int)luaL_len(L, 1);
+    if (n <= 0) {
         lua_pushnil(L);
         return 1;
     }
 
-    luaL_Buffer b;
-    luaL_buffinit(L, &b);
-    char buf[4096];
-    size_t n;
-    while ((n = fread(buf, 1, sizeof(buf), f)) > 0)
-        luaL_addlstring(&b, buf, n);
-    pclose(f);
-    luaL_pushresult(&b);
+    const char **argv = malloc(((size_t)n + 1) * sizeof(const char *));
+    if (!argv) {
+        lua_pushnil(L);
+        return 1;
+    }
+
+    for (int i = 1; i <= n; i++) {
+        lua_rawgeti(L, 1, i);
+        argv[i - 1] = lua_tostring(L, -1);
+        lua_pop(L, 1);
+    }
+    argv[n] = NULL;
+
+    size_t out_len = 0;
+    char *output = hl_tool_spawn_read(argv, &out_len);
+    free(argv);
+
+    if (output) {
+        lua_pushlstring(L, output, out_len);
+        free(output);
+    } else {
+        lua_pushnil(L);
+    }
+    return 1;
+}
+
+/* ── tool.find_files(dir, pattern) → table ────────────────────────── */
+
+static int l_tool_find_files(lua_State *L)
+{
+    const char *dir = luaL_checkstring(L, 1);
+    const char *pattern = luaL_checkstring(L, 2);
+    HlToolUnveilCtx *ctx = get_unveil_ctx(L);
+
+    char **files = hl_tool_find_files(dir, pattern, ctx);
+    if (!files) {
+        lua_newtable(L);
+        return 1;
+    }
+
+    lua_newtable(L);
+    int idx = 1;
+    for (char **p = files; *p; p++) {
+        lua_pushstring(L, *p);
+        lua_rawseti(L, -2, idx++);
+        free(*p);
+    }
+    free(files);
+
+    return 1;
+}
+
+/* ── tool.copy(src, dst) → bool ───────────────────────────────────── */
+
+static int l_tool_copy(lua_State *L)
+{
+    const char *src = luaL_checkstring(L, 1);
+    const char *dst = luaL_checkstring(L, 2);
+    HlToolUnveilCtx *ctx = get_unveil_ctx(L);
+
+    int rc = hl_tool_copy(src, dst, ctx);
+    lua_pushboolean(L, rc == 0);
+    return 1;
+}
+
+/* ── tool.rmdir(path) → bool ──────────────────────────────────────── */
+
+static int l_tool_rmdir(lua_State *L)
+{
+    const char *path = luaL_checkstring(L, 1);
+    HlToolUnveilCtx *ctx = get_unveil_ctx(L);
+
+    int rc = hl_tool_rmdir(path, ctx);
+    lua_pushboolean(L, rc == 0);
     return 1;
 }
 
@@ -77,6 +563,13 @@ static int l_tool_exit(lua_State *L)
 static int l_tool_read_file(lua_State *L)
 {
     const char *path = luaL_checkstring(L, 1);
+    HlToolUnveilCtx *ctx = get_unveil_ctx(L);
+
+    if (ctx && hl_tool_unveil_check(ctx, path, 'r') != 0) {
+        lua_pushnil(L);
+        return 1;
+    }
+
     FILE *f = fopen(path, "rb");
     if (!f) {
         lua_pushnil(L);
@@ -101,6 +594,12 @@ static int l_tool_write_file(lua_State *L)
     const char *path = luaL_checkstring(L, 1);
     size_t len;
     const char *data = luaL_checklstring(L, 2, &len);
+    HlToolUnveilCtx *ctx = get_unveil_ctx(L);
+
+    if (ctx && hl_tool_unveil_check(ctx, path, 'w') != 0) {
+        lua_pushboolean(L, 0);
+        return 1;
+    }
 
     FILE *f = fopen(path, "wb");
     if (!f) {
@@ -118,6 +617,13 @@ static int l_tool_write_file(lua_State *L)
 static int l_tool_file_exists(lua_State *L)
 {
     const char *path = luaL_checkstring(L, 1);
+    HlToolUnveilCtx *ctx = get_unveil_ctx(L);
+
+    if (ctx && hl_tool_unveil_check(ctx, path, 'r') != 0) {
+        lua_pushboolean(L, 0);
+        return 1;
+    }
+
     lua_pushboolean(L, access(path, F_OK) == 0);
     return 1;
 }
@@ -149,8 +655,11 @@ static int l_tool_loadfile(lua_State *L)
 /* ── Registration ──────────────────────────────────────────────────── */
 
 static const luaL_Reg tool_funcs[] = {
-    { "exec",        l_tool_exec },
-    { "read",        l_tool_read },
+    { "spawn",       l_tool_spawn },
+    { "spawn_read",  l_tool_spawn_read },
+    { "find_files",  l_tool_find_files },
+    { "copy",        l_tool_copy },
+    { "rmdir",       l_tool_rmdir },
     { "tmpdir",      l_tool_tmpdir },
     { "exit",        l_tool_exit },
     { "read_file",   l_tool_read_file },
@@ -161,8 +670,18 @@ static const luaL_Reg tool_funcs[] = {
     { NULL, NULL }
 };
 
-void hl_cap_tool_register(lua_State *L)
+void hl_cap_tool_register(lua_State *L, HlToolUnveilCtx *ctx)
 {
+    /* Store unveil context in registry */
+    if (ctx)
+        lua_pushlightuserdata(L, ctx);
+    else
+        lua_pushnil(L);
+    lua_setfield(L, LUA_REGISTRYINDEX, TOOL_UNVEIL_KEY);
+
+    /* Register tool table */
     luaL_newlib(L, tool_funcs);
     lua_setglobal(L, "tool");
 }
+
+#endif /* HL_ENABLE_LUA */

--- a/src/hull/cap/tool.c
+++ b/src/hull/cap/tool.c
@@ -19,6 +19,7 @@
 #include <errno.h>
 #include <fnmatch.h>
 #include <limits.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/hull/cap/tool.c
+++ b/src/hull/cap/tool.c
@@ -78,6 +78,14 @@ int hl_tool_unveil_add(HlToolUnveilCtx *ctx, const char *path, const char *perms
     return 0;
 }
 
+void hl_tool_unveil_free(HlToolUnveilCtx *ctx)
+{
+    if (!ctx) return;
+    for (int i = 0; i < ctx->count; i++)
+        free((void *)ctx->entries[i].path);
+    memset(ctx, 0, sizeof(*ctx));
+}
+
 void hl_tool_unveil_seal(HlToolUnveilCtx *ctx)
 {
     if (ctx) ctx->sealed = 1;

--- a/src/hull/commands/build.c
+++ b/src/hull/commands/build.c
@@ -1,0 +1,15 @@
+/*
+ * commands/build.c — hull build subcommand
+ *
+ * Thin wrapper: launches the Lua tool VM with hull.build module.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "hull/commands/build.h"
+#include "hull/tool.h"
+
+int hl_cmd_build(int argc, char **argv, const char *hull_exe)
+{
+    return hull_tool("hull.build", argc, argv, hull_exe);
+}

--- a/src/hull/commands/dispatch.c
+++ b/src/hull/commands/dispatch.c
@@ -1,0 +1,46 @@
+/*
+ * commands/dispatch.c — Table-driven subcommand dispatcher
+ *
+ * Central command table + dispatch function. Adding a new subcommand
+ * means adding one line to the table and one .c/.h file.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "hull/commands/dispatch.h"
+#include "hull/commands/keygen.h"
+#include "hull/commands/build.h"
+#include "hull/commands/verify.h"
+#include "hull/commands/inspect.h"
+#include "hull/commands/manifest.h"
+#include "hull/commands/test.h"
+
+#include <string.h>
+
+/* ── Command table ─────────────────────────────────────────────────── */
+
+static const HlCommand commands[] = {
+    { "keygen",   hl_cmd_keygen },
+    { "build",    hl_cmd_build },
+    { "verify",   hl_cmd_verify },
+    { "inspect",  hl_cmd_inspect },
+    { "manifest", hl_cmd_manifest },
+    { "test",     hl_cmd_test },
+    { NULL, NULL }  /* sentinel */
+};
+
+/* ── Public API ────────────────────────────────────────────────────── */
+
+int hl_command_dispatch(int argc, char **argv)
+{
+    if (argc < 2)
+        return -1;
+
+    const char *name = argv[1];
+    for (const HlCommand *cmd = commands; cmd->name; cmd++) {
+        if (strcmp(name, cmd->name) == 0)
+            return cmd->handler(argc - 1, argv + 1, argv[0]);
+    }
+
+    return -1;
+}

--- a/src/hull/commands/inspect.c
+++ b/src/hull/commands/inspect.c
@@ -1,0 +1,15 @@
+/*
+ * commands/inspect.c — hull inspect subcommand
+ *
+ * Thin wrapper: launches the Lua tool VM with hull.inspect module.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "hull/commands/inspect.h"
+#include "hull/tool.h"
+
+int hl_cmd_inspect(int argc, char **argv, const char *hull_exe)
+{
+    return hull_tool("hull.inspect", argc, argv, hull_exe);
+}

--- a/src/hull/commands/keygen.c
+++ b/src/hull/commands/keygen.c
@@ -1,0 +1,16 @@
+/*
+ * commands/keygen.c — hull keygen subcommand
+ *
+ * Pure C implementation — generates Ed25519 keypair.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "hull/commands/keygen.h"
+#include "hull/tool.h"
+
+int hl_cmd_keygen(int argc, char **argv, const char *hull_exe)
+{
+    (void)hull_exe;
+    return hull_keygen(argc, argv);
+}

--- a/src/hull/commands/manifest.c
+++ b/src/hull/commands/manifest.c
@@ -1,0 +1,15 @@
+/*
+ * commands/manifest.c — hull manifest subcommand
+ *
+ * Thin wrapper: launches the Lua tool VM with hull.manifest module.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "hull/commands/manifest.h"
+#include "hull/tool.h"
+
+int hl_cmd_manifest(int argc, char **argv, const char *hull_exe)
+{
+    return hull_tool("hull.manifest", argc, argv, hull_exe);
+}

--- a/src/hull/commands/test.c
+++ b/src/hull/commands/test.c
@@ -258,10 +258,13 @@ static int run_js_tests(const char *app_dir, const char *entry)
         }
         fseek(f, 0, SEEK_END);
         long flen = ftell(f);
+        if (flen < 0) { fclose(f); free(*fp); continue; }
         fseek(f, 0, SEEK_SET);
         char *src = malloc((size_t)flen + 1);
         if (!src) { fclose(f); free(*fp); continue; }
-        fread(src, 1, (size_t)flen, f);
+        if (fread(src, 1, (size_t)flen, f) != (size_t)flen) {
+            free(src); fclose(f); free(*fp); continue;
+        }
         src[flen] = '\0';
         fclose(f);
 

--- a/src/hull/commands/test.c
+++ b/src/hull/commands/test.c
@@ -1,0 +1,340 @@
+/*
+ * commands/test.c — hull test subcommand
+ *
+ * In-process test runner: discovers test files, loads app,
+ * wires routes, executes tests with assertions.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "hull/commands/test.h"
+#include "hull/cap/tool.h"
+
+#ifdef HL_ENABLE_LUA
+#include "hull/runtime/lua.h"
+#include "hull/cap/test.h"
+#include "lua.h"
+#include "lauxlib.h"
+#endif
+
+#ifdef HL_ENABLE_JS
+#include "hull/runtime/js.h"
+#include "hull/cap/test.h"
+#include "quickjs.h"
+#endif
+
+#include <keel/router.h>
+#include <keel/allocator.h>
+
+#include <sqlite3.h>
+#include <sh_arena.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* ── Usage ─────────────────────────────────────────────────────────── */
+
+static void test_usage(void)
+{
+    fprintf(stderr, "Usage: hull test [app_dir]\n"
+            "\n"
+            "Discovers and runs test_*.[lua|js] files.\n");
+}
+
+/* ── Detect entry point ────────────────────────────────────────────── */
+
+static const char *detect_entry(const char *app_dir)
+{
+    static char buf[4096];
+
+    snprintf(buf, sizeof(buf), "%s/app.js", app_dir);
+    if (access(buf, F_OK) == 0) return buf;
+
+    snprintf(buf, sizeof(buf), "%s/app.lua", app_dir);
+    if (access(buf, F_OK) == 0) return buf;
+
+    return NULL;
+}
+
+static int is_js_entry(const char *entry)
+{
+    const char *ext = strrchr(entry, '.');
+    return ext && strcmp(ext, ".js") == 0;
+}
+
+#ifdef HL_ENABLE_LUA
+
+/* ── Lua test runner ───────────────────────────────────────────────── */
+
+static int run_lua_tests(const char *app_dir, const char *entry)
+{
+    /* Init Lua VM (sandboxed — tests run in app context) */
+    HlLuaConfig cfg = HL_LUA_CONFIG_DEFAULT;
+    cfg.sandbox = 1;
+
+    HlLua lua;
+    memset(&lua, 0, sizeof(lua));
+
+    /* Open :memory: SQLite for test isolation */
+    sqlite3 *db = NULL;
+    if (sqlite3_open(":memory:", &db) != SQLITE_OK) {
+        fprintf(stderr, "hull test: cannot open :memory: database\n");
+        return 1;
+    }
+    sqlite3_exec(db, "PRAGMA journal_mode=WAL", NULL, NULL, NULL);
+    sqlite3_exec(db, "PRAGMA foreign_keys=ON", NULL, NULL, NULL);
+    lua.db = db;
+
+    if (hl_lua_init(&lua, &cfg) != 0) {
+        fprintf(stderr, "hull test: Lua init failed\n");
+        sqlite3_close(db);
+        return 1;
+    }
+
+    /* Load app entry point → routes registered */
+    if (hl_lua_load_app(&lua, entry) != 0) {
+        fprintf(stderr, "hull test: failed to load %s\n", entry);
+        hl_lua_free(&lua);
+        sqlite3_close(db);
+        return 1;
+    }
+
+    /* Wire routes into a standalone KlRouter */
+    KlAllocator alloc = kl_allocator_default();
+    KlRouter router;
+    kl_router_init(&router, &alloc);
+
+    if (hl_lua_wire_routes(&lua, &router) != 0) {
+        fprintf(stderr, "hull test: no routes registered\n");
+        kl_router_free(&router);
+        hl_lua_free(&lua);
+        sqlite3_close(db);
+        return 1;
+    }
+
+    /* Register test module */
+    hl_cap_test_register_lua(lua.L, &router, &lua);
+
+    /* Discover test files */
+    char **test_files = hl_tool_find_files(app_dir, "test_*.lua", NULL);
+    if (!test_files || !test_files[0]) {
+        fprintf(stderr, "hull test: no test files found in %s\n", app_dir);
+        if (test_files) free(test_files);
+        kl_router_free(&router);
+        hl_lua_free(&lua);
+        sqlite3_close(db);
+        return 1;
+    }
+
+    /* Run each test file */
+    int total = 0, passed = 0, failed = 0;
+
+    for (char **fp = test_files; *fp; fp++) {
+        const char *file = *fp;
+        const char *basename = strrchr(file, '/');
+        basename = basename ? basename + 1 : file;
+
+        printf("\n--- %s ---\n", basename);
+
+        /* Clear test cases from previous file */
+        hl_cap_test_clear_lua(lua.L);
+
+        /* Load and execute the test file → registers test cases */
+        if (luaL_dofile(lua.L, file) != LUA_OK) {
+            const char *err = lua_tostring(lua.L, -1);
+            fprintf(stderr, "  ERROR: %s\n", err ? err : "unknown");
+            lua_pop(lua.L, 1);
+            failed++;
+            total++;
+            free(*fp);
+            continue;
+        }
+
+        /* Execute registered test cases */
+        int file_total = 0, file_passed = 0, file_failed = 0;
+        hl_cap_test_run_lua(lua.L, &file_total, &file_passed, &file_failed);
+
+        total += file_total;
+        passed += file_passed;
+        failed += file_failed;
+
+        free(*fp);
+    }
+    free(test_files);
+
+    /* Report */
+    printf("\n%d/%d tests passed", passed, total);
+    if (failed > 0)
+        printf(", %d failed", failed);
+    printf("\n");
+
+    /* Cleanup */
+    kl_router_free(&router);
+    hl_lua_free(&lua);
+    sqlite3_close(db);
+
+    return failed > 0 ? 1 : 0;
+}
+
+#endif /* HL_ENABLE_LUA */
+
+#ifdef HL_ENABLE_JS
+
+/* ── JS test runner ────────────────────────────────────────────────── */
+
+static int run_js_tests(const char *app_dir, const char *entry)
+{
+    HlJSConfig cfg = HL_JS_CONFIG_DEFAULT;
+    HlJS js;
+    memset(&js, 0, sizeof(js));
+
+    sqlite3 *db = NULL;
+    if (sqlite3_open(":memory:", &db) != SQLITE_OK) {
+        fprintf(stderr, "hull test: cannot open :memory: database\n");
+        return 1;
+    }
+    sqlite3_exec(db, "PRAGMA journal_mode=WAL", NULL, NULL, NULL);
+    sqlite3_exec(db, "PRAGMA foreign_keys=ON", NULL, NULL, NULL);
+    js.db = db;
+
+    if (hl_js_init(&js, &cfg) != 0) {
+        fprintf(stderr, "hull test: QuickJS init failed\n");
+        sqlite3_close(db);
+        return 1;
+    }
+
+    if (hl_js_load_app(&js, entry) != 0) {
+        fprintf(stderr, "hull test: failed to load %s\n", entry);
+        hl_js_free(&js);
+        sqlite3_close(db);
+        return 1;
+    }
+
+    KlAllocator alloc = kl_allocator_default();
+    KlRouter router;
+    kl_router_init(&router, &alloc);
+
+    if (hl_js_wire_routes(&js, &router) != 0) {
+        fprintf(stderr, "hull test: no routes registered\n");
+        kl_router_free(&router);
+        hl_js_free(&js);
+        sqlite3_close(db);
+        return 1;
+    }
+
+    hl_cap_test_register_js(js.ctx, &router, &js);
+
+    char **test_files = hl_tool_find_files(app_dir, "test_*.js", NULL);
+    if (!test_files || !test_files[0]) {
+        fprintf(stderr, "hull test: no test files found in %s\n", app_dir);
+        if (test_files) free(test_files);
+        kl_router_free(&router);
+        hl_js_free(&js);
+        sqlite3_close(db);
+        return 1;
+    }
+
+    int total = 0, passed = 0, failed = 0;
+
+    for (char **fp = test_files; *fp; fp++) {
+        const char *file = *fp;
+        const char *basename = strrchr(file, '/');
+        basename = basename ? basename + 1 : file;
+
+        printf("\n--- %s ---\n", basename);
+
+        hl_cap_test_clear_js(js.ctx);
+
+        /* Read and evaluate the test file */
+        FILE *f = fopen(file, "r");
+        if (!f) {
+            fprintf(stderr, "  ERROR: cannot open %s\n", file);
+            failed++;
+            total++;
+            free(*fp);
+            continue;
+        }
+        fseek(f, 0, SEEK_END);
+        long flen = ftell(f);
+        fseek(f, 0, SEEK_SET);
+        char *src = malloc((size_t)flen + 1);
+        if (!src) { fclose(f); free(*fp); continue; }
+        fread(src, 1, (size_t)flen, f);
+        src[flen] = '\0';
+        fclose(f);
+
+        JSValue result = JS_Eval(js.ctx, src, (size_t)flen, file,
+                                 JS_EVAL_TYPE_MODULE);
+        free(src);
+
+        if (JS_IsException(result)) {
+            hl_js_dump_error(&js);
+            JS_FreeValue(js.ctx, result);
+            failed++;
+            total++;
+            free(*fp);
+            continue;
+        }
+        JS_FreeValue(js.ctx, result);
+
+        int file_total = 0, file_passed = 0, file_failed = 0;
+        hl_cap_test_run_js(js.ctx, &file_total, &file_passed, &file_failed);
+
+        total += file_total;
+        passed += file_passed;
+        failed += file_failed;
+
+        free(*fp);
+    }
+    free(test_files);
+
+    printf("\n%d/%d tests passed", passed, total);
+    if (failed > 0)
+        printf(", %d failed", failed);
+    printf("\n");
+
+    kl_router_free(&router);
+    hl_js_free(&js);
+    sqlite3_close(db);
+
+    return failed > 0 ? 1 : 0;
+}
+
+#endif /* HL_ENABLE_JS */
+
+/* ── Command entry point ───────────────────────────────────────────── */
+
+int hl_cmd_test(int argc, char **argv, const char *hull_exe)
+{
+    (void)hull_exe;
+
+    const char *app_dir = ".";
+    if (argc >= 2 && argv[1][0] != '-')
+        app_dir = argv[1];
+
+    /* Detect entry point */
+    const char *entry = detect_entry(app_dir);
+    if (!entry) {
+        fprintf(stderr, "hull test: no entry point found (app.js or app.lua) in %s\n",
+                app_dir);
+        test_usage();
+        return 1;
+    }
+
+    int is_js = is_js_entry(entry);
+
+#ifdef HL_ENABLE_JS
+    if (is_js)
+        return run_js_tests(app_dir, entry);
+#endif
+
+#ifdef HL_ENABLE_LUA
+    if (!is_js)
+        return run_lua_tests(app_dir, entry);
+#endif
+
+    fprintf(stderr, "hull test: runtime for %s not enabled in this build\n", entry);
+    return 1;
+}

--- a/src/hull/commands/test.c
+++ b/src/hull/commands/test.c
@@ -327,6 +327,7 @@ int hl_cmd_test(int argc, char **argv, const char *hull_exe)
     }
 
     int is_js = is_js_entry(entry);
+    (void)is_js; /* may be unused if runtime not compiled in */
 
 #ifdef HL_ENABLE_JS
     if (is_js)

--- a/src/hull/commands/verify.c
+++ b/src/hull/commands/verify.c
@@ -1,0 +1,15 @@
+/*
+ * commands/verify.c — hull verify subcommand
+ *
+ * Thin wrapper: launches the Lua tool VM with hull.verify module.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "hull/commands/verify.h"
+#include "hull/tool.h"
+
+int hl_cmd_verify(int argc, char **argv, const char *hull_exe)
+{
+    return hull_tool("hull.verify", argc, argv, hull_exe);
+}

--- a/src/hull/runtime/lua/modules.c
+++ b/src/hull/runtime/lua/modules.c
@@ -590,6 +590,16 @@ static int lua_crypto_hash_password(lua_State *L)
     return 1;
 }
 
+/* ── Hex nibble helper (no sscanf — Cosmopolitan compat) ──────────── */
+
+static int hex_nibble(unsigned char c)
+{
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
+    if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
+    return -1;
+}
+
 /* crypto.verify_password(password, hash_string) → boolean */
 static int lua_crypto_verify_password(lua_State *L)
 {
@@ -633,12 +643,13 @@ static int lua_crypto_verify_password(lua_State *L)
     memcpy(hash_hex, p, 64);
     hash_hex[64] = '\0';
 
-    /* Decode hex salt */
+    /* Decode hex salt (manual — sscanf %x broken on Cosmopolitan) */
     uint8_t salt[16];
     for (int i = 0; i < 16; i++) {
-        unsigned int byte;
-        sscanf(salt_hex + i * 2, "%2x", &byte);
-        salt[i] = (uint8_t)byte;
+        int hi = hex_nibble((unsigned char)salt_hex[i * 2]);
+        int lo = hex_nibble((unsigned char)salt_hex[i * 2 + 1]);
+        if (hi < 0 || lo < 0) { lua_pushboolean(L, 0); return 1; }
+        salt[i] = (uint8_t)((hi << 4) | lo);
     }
 
     /* Recompute hash */
@@ -652,9 +663,10 @@ static int lua_crypto_verify_password(lua_State *L)
     /* Decode stored hash and compare (constant-time) */
     uint8_t stored_hash[32];
     for (int i = 0; i < 32; i++) {
-        unsigned int byte;
-        sscanf(hash_hex + i * 2, "%2x", &byte);
-        stored_hash[i] = (uint8_t)byte;
+        int hi = hex_nibble((unsigned char)hash_hex[i * 2]);
+        int lo = hex_nibble((unsigned char)hash_hex[i * 2 + 1]);
+        if (hi < 0 || lo < 0) { lua_pushboolean(L, 0); return 1; }
+        stored_hash[i] = (uint8_t)((hi << 4) | lo);
     }
 
     /* Constant-time comparison */
@@ -666,17 +678,18 @@ static int lua_crypto_verify_password(lua_State *L)
     return 1;
 }
 
-/* ── Hex decode helper ─────────────────────────────────────────────── */
+/* ── Hex decode helper (no sscanf — Cosmopolitan compat) ──────────── */
 
 static int hex_decode(const char *hex, size_t hex_len, uint8_t *out, size_t out_len)
 {
     if (hex_len != out_len * 2)
         return -1;
     for (size_t i = 0; i < out_len; i++) {
-        unsigned int byte;
-        if (sscanf(hex + i * 2, "%2x", &byte) != 1)
+        int hi = hex_nibble((unsigned char)hex[i * 2]);
+        int lo = hex_nibble((unsigned char)hex[i * 2 + 1]);
+        if (hi < 0 || lo < 0)
             return -1;
-        out[i] = (uint8_t)byte;
+        out[i] = (uint8_t)((hi << 4) | lo);
     }
     return 0;
 }

--- a/src/hull/sandbox.c
+++ b/src/hull/sandbox.c
@@ -25,7 +25,8 @@
 #if defined(__COSMOPOLITAN__)
 
 /* Cosmopolitan libc provides pledge() and unveil() natively. */
-#include <libc/calls/pledge.h>
+extern int pledge(const char *promises, const char *execpromises);
+extern int unveil(const char *path, const char *permissions);
 
 static int sb_supported(void) { return 1; }
 

--- a/src/hull/tool.c
+++ b/src/hull/tool.c
@@ -91,6 +91,7 @@ static const char *parse_cc_option(int argc, char **argv)
 static const char *parse_app_dir(int argc, char **argv)
 {
     for (int i = 0; i < argc; i++) {
+        if (!argv[i]) continue;
         if (argv[i][0] != '-')
             return argv[i];
         /* Skip --flag value pairs */

--- a/src/hull/tool.c
+++ b/src/hull/tool.c
@@ -1,14 +1,16 @@
 /*
  * tool.c — Tool mode: unsandboxed Lua VM for hull build tools
  *
- * Provides hull_tool() for running Lua stdlib modules with full
- * filesystem access, and hull_keygen() for Ed25519 key generation.
+ * Provides hull_tool() for running Lua stdlib modules with controlled
+ * process/filesystem access, and hull_keygen() for Ed25519 key generation.
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 #include "hull/tool.h"
 #include "hull/cap/crypto.h"
+#include "hull/cap/tool.h"
+#include "hull/sandbox.h"
 
 #ifdef HL_ENABLE_LUA
 #include "hull/runtime/lua.h"
@@ -69,6 +71,40 @@ int hull_keygen(int argc, char **argv)
 
 #ifdef HL_ENABLE_LUA
 
+/*
+ * Parse --cc option from argv, return compiler name (or NULL for default).
+ * Scans for "--cc" followed by a value.
+ */
+static const char *parse_cc_option(int argc, char **argv)
+{
+    for (int i = 0; i < argc; i++) {
+        if (strcmp(argv[i], "--cc") == 0 && i + 1 < argc)
+            return argv[i + 1];
+    }
+    return NULL;
+}
+
+/*
+ * Extract app_dir from argv (first positional arg not starting with '-').
+ * Returns "." if not found.
+ */
+static const char *parse_app_dir(int argc, char **argv)
+{
+    for (int i = 0; i < argc; i++) {
+        if (argv[i][0] != '-')
+            return argv[i];
+        /* Skip --flag value pairs */
+        if (strcmp(argv[i], "--cc") == 0 ||
+            strcmp(argv[i], "--sign") == 0 ||
+            strcmp(argv[i], "--runtime") == 0 ||
+            strcmp(argv[i], "--output") == 0 ||
+            strcmp(argv[i], "-o") == 0) {
+            i++; /* skip value */
+        }
+    }
+    return ".";
+}
+
 int hull_tool(const char *module, int argc, char **argv, const char *hull_exe)
 {
     if (!module) {
@@ -76,19 +112,60 @@ int hull_tool(const char *module, int argc, char **argv, const char *hull_exe)
         return 1;
     }
 
-    /* Init unsandboxed Lua VM */
+    /* Parse --cc option for configurable compiler */
+    const char *cc = parse_cc_option(argc, argv);
+    if (!cc) cc = "cosmocc";
+
+    /* Validate compiler against allowlist */
+    if (hl_tool_check_allowlist(cc) != 0) {
+        fprintf(stderr, "hull: compiler '%s' not in allowlist\n", cc);
+        return 1;
+    }
+
+    /* Set up tool-mode unveil context */
+    const char *app_dir = parse_app_dir(argc, argv);
+    HlToolUnveilCtx unveil_ctx;
+
+    /* Derive platform directory from hull binary path */
+    const char *platform_dir = NULL;
+    char platform_buf[4096];
+    if (hull_exe) {
+        const char *slash = strrchr(hull_exe, '/');
+        if (slash) {
+            size_t len = (size_t)(slash - hull_exe + 1);
+            if (len < sizeof(platform_buf)) {
+                memcpy(platform_buf, hull_exe, len);
+                platform_buf[len] = '\0';
+                platform_dir = platform_buf;
+            }
+        }
+    }
+
+    hl_tool_sandbox_init(&unveil_ctx, app_dir, ".", platform_dir);
+
+    /* Init unsandboxed Lua VM with tool unveil context */
     HlLuaConfig cfg = HL_LUA_CONFIG_DEFAULT;
     cfg.sandbox = 0;
 
     HlLua lua;
     memset(&lua, 0, sizeof(lua));
+    lua.tool_unveil_ctx = &unveil_ctx;
+
     if (hl_lua_init(&lua, &cfg) != 0) {
         fprintf(stderr, "hull: Lua init failed\n");
         return 1;
     }
 
-    /* Pass CLI args as global `arg` table */
+    /* Set tool.cc in the tool global table */
     lua_State *L = lua.L;
+    lua_getglobal(L, "tool");
+    if (lua_istable(L, -1)) {
+        lua_pushstring(L, cc);
+        lua_setfield(L, -2, "cc");
+    }
+    lua_pop(L, 1);
+
+    /* Pass CLI args as global `arg` table */
     lua_newtable(L);
     for (int i = 0; i < argc; i++) {
         lua_pushstring(L, argv[i]);

--- a/tests/e2e_sandbox.sh
+++ b/tests/e2e_sandbox.sh
@@ -316,7 +316,7 @@ else
         fi
     else
         # Native Linux: link against pledge polyfill objects
-        PLEDGE_OBJS=$(find "$BUILDDIR" -name 'pledge_*.o' 2>/dev/null | tr '\n' ' ')
+        PLEDGE_OBJS=$(find "$BUILDDIR" -path '*/pledge*' -name '*.o' 2>/dev/null | tr '\n' ' ')
 
         if [ -z "$PLEDGE_OBJS" ]; then
             fail "pledge polyfill objects not found in $BUILDDIR"

--- a/tests/hull/cap/test_time.c
+++ b/tests/hull/cap/test_time.c
@@ -30,9 +30,9 @@ UTEST(hl_cap_time, clock_monotonic)
 {
     int64_t t1 = hl_cap_time_clock();
     /* Spin briefly */
-    volatile int x = 0;
+    volatile unsigned x = 0;
     for (int i = 0; i < 100000; i++)
-        x += i;
+        x += (unsigned)i;
     (void)x;
     int64_t t2 = hl_cap_time_clock();
     ASSERT_GE(t2, t1);

--- a/tests/hull/cap/test_tool.c
+++ b/tests/hull/cap/test_tool.c
@@ -1,0 +1,456 @@
+/*
+ * test_tool.c — Tests for tool hardening (spawn, find_files, copy, rmdir, unveil)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "utest.h"
+#include "hull/cap/tool.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+/* ── Helper: create a temp directory ──────────────────────────────── */
+
+static char *make_tmpdir(void)
+{
+    char tmpl[] = "/tmp/hull_test_XXXXXX";
+    char *dir = mkdtemp(tmpl);
+    if (!dir) return NULL;
+    return strdup(dir);
+}
+
+/* Helper: write a file */
+static int write_test_file(const char *path, const char *content)
+{
+    FILE *f = fopen(path, "w");
+    if (!f) return -1;
+    fputs(content, f);
+    fclose(f);
+    return 0;
+}
+
+/* ── Allowlist tests ──────────────────────────────────────────────── */
+
+UTEST(tool, allowlist_accept_cc)
+{
+    ASSERT_EQ(hl_tool_check_allowlist("cc"), 0);
+}
+
+UTEST(tool, allowlist_accept_gcc)
+{
+    ASSERT_EQ(hl_tool_check_allowlist("gcc"), 0);
+}
+
+UTEST(tool, allowlist_accept_clang)
+{
+    ASSERT_EQ(hl_tool_check_allowlist("clang"), 0);
+}
+
+UTEST(tool, allowlist_accept_cosmocc)
+{
+    ASSERT_EQ(hl_tool_check_allowlist("cosmocc"), 0);
+}
+
+UTEST(tool, allowlist_accept_ar)
+{
+    ASSERT_EQ(hl_tool_check_allowlist("ar"), 0);
+}
+
+UTEST(tool, allowlist_accept_cosmoar)
+{
+    ASSERT_EQ(hl_tool_check_allowlist("cosmoar"), 0);
+}
+
+UTEST(tool, allowlist_versioned_clang)
+{
+    ASSERT_EQ(hl_tool_check_allowlist("clang-18"), 0);
+}
+
+UTEST(tool, allowlist_versioned_gcc)
+{
+    ASSERT_EQ(hl_tool_check_allowlist("gcc-12"), 0);
+}
+
+UTEST(tool, allowlist_with_path)
+{
+    ASSERT_EQ(hl_tool_check_allowlist("/usr/bin/cc"), 0);
+    ASSERT_EQ(hl_tool_check_allowlist("/usr/bin/clang-18"), 0);
+}
+
+UTEST(tool, allowlist_reject_sh)
+{
+    ASSERT_NE(hl_tool_check_allowlist("sh"), 0);
+}
+
+UTEST(tool, allowlist_reject_bash)
+{
+    ASSERT_NE(hl_tool_check_allowlist("bash"), 0);
+}
+
+UTEST(tool, allowlist_reject_rm)
+{
+    ASSERT_NE(hl_tool_check_allowlist("rm"), 0);
+}
+
+UTEST(tool, allowlist_reject_curl)
+{
+    ASSERT_NE(hl_tool_check_allowlist("curl"), 0);
+}
+
+UTEST(tool, allowlist_reject_null)
+{
+    ASSERT_NE(hl_tool_check_allowlist(NULL), 0);
+}
+
+UTEST(tool, allowlist_reject_empty)
+{
+    ASSERT_NE(hl_tool_check_allowlist(""), 0);
+}
+
+/* ── Spawn tests ──────────────────────────────────────────────────── */
+
+UTEST(tool, spawn_reject_disallowed)
+{
+    const char *argv[] = { "ls", "-la", NULL };
+    int rc = hl_tool_spawn(argv);
+    ASSERT_EQ(rc, -1);
+}
+
+UTEST(tool, spawn_null_argv)
+{
+    ASSERT_EQ(hl_tool_spawn(NULL), -1);
+}
+
+UTEST(tool, spawn_read_reject_disallowed)
+{
+    const char *argv[] = { "echo", "hello", NULL };
+    char *out = hl_tool_spawn_read(argv, NULL);
+    ASSERT_TRUE(out == NULL);
+}
+
+/* ── find_files tests ─────────────────────────────────────────────── */
+
+UTEST(tool, find_files_basic)
+{
+    char *tmpdir = make_tmpdir();
+    ASSERT_TRUE(tmpdir != NULL);
+
+    /* Create test files */
+    char path[512];
+    snprintf(path, sizeof(path), "%s/test_one.lua", tmpdir);
+    write_test_file(path, "-- test");
+    snprintf(path, sizeof(path), "%s/test_two.lua", tmpdir);
+    write_test_file(path, "-- test");
+    snprintf(path, sizeof(path), "%s/other.txt", tmpdir);
+    write_test_file(path, "not a lua file");
+
+    char **files = hl_tool_find_files(tmpdir, "*.lua", NULL);
+    ASSERT_TRUE(files != NULL);
+
+    int count = 0;
+    for (char **p = files; *p; p++) count++;
+    ASSERT_EQ(count, 2);
+
+    /* Cleanup */
+    for (char **p = files; *p; p++) free(*p);
+    free(files);
+    hl_tool_rmdir(tmpdir, NULL);
+    free(tmpdir);
+}
+
+UTEST(tool, find_files_recursive)
+{
+    char *tmpdir = make_tmpdir();
+    ASSERT_TRUE(tmpdir != NULL);
+
+    /* Create subdirectory */
+    char subdir[512];
+    snprintf(subdir, sizeof(subdir), "%s/sub", tmpdir);
+    mkdir(subdir, 0755);
+
+    char path[512];
+    snprintf(path, sizeof(path), "%s/test_a.lua", tmpdir);
+    write_test_file(path, "-- test");
+    snprintf(path, sizeof(path), "%s/test_b.lua", subdir);
+    write_test_file(path, "-- test");
+
+    char **files = hl_tool_find_files(tmpdir, "*.lua", NULL);
+    ASSERT_TRUE(files != NULL);
+
+    int count = 0;
+    for (char **p = files; *p; p++) count++;
+    ASSERT_EQ(count, 2);
+
+    for (char **p = files; *p; p++) free(*p);
+    free(files);
+    hl_tool_rmdir(tmpdir, NULL);
+    free(tmpdir);
+}
+
+UTEST(tool, find_files_skips_dotdirs)
+{
+    char *tmpdir = make_tmpdir();
+    ASSERT_TRUE(tmpdir != NULL);
+
+    char dotdir[512];
+    snprintf(dotdir, sizeof(dotdir), "%s/.hidden", tmpdir);
+    mkdir(dotdir, 0755);
+
+    char path[512];
+    snprintf(path, sizeof(path), "%s/test_a.lua", tmpdir);
+    write_test_file(path, "-- visible");
+    snprintf(path, sizeof(path), "%s/.hidden/test_b.lua", tmpdir);
+    write_test_file(path, "-- hidden");
+
+    char **files = hl_tool_find_files(tmpdir, "*.lua", NULL);
+    ASSERT_TRUE(files != NULL);
+
+    int count = 0;
+    for (char **p = files; *p; p++) count++;
+    ASSERT_EQ(count, 1);
+
+    for (char **p = files; *p; p++) free(*p);
+    free(files);
+    hl_tool_rmdir(tmpdir, NULL);
+    free(tmpdir);
+}
+
+UTEST(tool, find_files_skips_vendor)
+{
+    char *tmpdir = make_tmpdir();
+    ASSERT_TRUE(tmpdir != NULL);
+
+    char vendordir[512];
+    snprintf(vendordir, sizeof(vendordir), "%s/vendor", tmpdir);
+    mkdir(vendordir, 0755);
+    char nodedir[512];
+    snprintf(nodedir, sizeof(nodedir), "%s/node_modules", tmpdir);
+    mkdir(nodedir, 0755);
+
+    char path[512];
+    snprintf(path, sizeof(path), "%s/test_a.lua", tmpdir);
+    write_test_file(path, "-- visible");
+    snprintf(path, sizeof(path), "%s/vendor/test_b.lua", tmpdir);
+    write_test_file(path, "-- skipped");
+    snprintf(path, sizeof(path), "%s/node_modules/test_c.lua", tmpdir);
+    write_test_file(path, "-- skipped");
+
+    char **files = hl_tool_find_files(tmpdir, "*.lua", NULL);
+    ASSERT_TRUE(files != NULL);
+
+    int count = 0;
+    for (char **p = files; *p; p++) count++;
+    ASSERT_EQ(count, 1);
+
+    for (char **p = files; *p; p++) free(*p);
+    free(files);
+    hl_tool_rmdir(tmpdir, NULL);
+    free(tmpdir);
+}
+
+UTEST(tool, find_files_pattern_match)
+{
+    char *tmpdir = make_tmpdir();
+    ASSERT_TRUE(tmpdir != NULL);
+
+    char path[512];
+    snprintf(path, sizeof(path), "%s/test_foo.lua", tmpdir);
+    write_test_file(path, "-- test");
+    snprintf(path, sizeof(path), "%s/helper.lua", tmpdir);
+    write_test_file(path, "-- helper");
+
+    char **files = hl_tool_find_files(tmpdir, "test_*.lua", NULL);
+    ASSERT_TRUE(files != NULL);
+
+    int count = 0;
+    for (char **p = files; *p; p++) count++;
+    ASSERT_EQ(count, 1);
+
+    for (char **p = files; *p; p++) free(*p);
+    free(files);
+    hl_tool_rmdir(tmpdir, NULL);
+    free(tmpdir);
+}
+
+/* ── copy tests ───────────────────────────────────────────────────── */
+
+UTEST(tool, copy_basic)
+{
+    char *tmpdir = make_tmpdir();
+    ASSERT_TRUE(tmpdir != NULL);
+
+    char src[512], dst[512];
+    snprintf(src, sizeof(src), "%s/original.txt", tmpdir);
+    snprintf(dst, sizeof(dst), "%s/copied.txt", tmpdir);
+
+    write_test_file(src, "hello world");
+
+    int rc = hl_tool_copy(src, dst, NULL);
+    ASSERT_EQ(rc, 0);
+
+    /* Verify content */
+    FILE *f = fopen(dst, "r");
+    ASSERT_TRUE(f != NULL);
+    char buf[64];
+    size_t n = fread(buf, 1, sizeof(buf), f);
+    fclose(f);
+    buf[n] = '\0';
+    ASSERT_STREQ(buf, "hello world");
+
+    hl_tool_rmdir(tmpdir, NULL);
+    free(tmpdir);
+}
+
+UTEST(tool, copy_path_validation)
+{
+    HlToolUnveilCtx ctx;
+    hl_tool_unveil_init(&ctx);
+    hl_tool_unveil_add(&ctx, "/tmp", "rwc");
+    hl_tool_unveil_seal(&ctx);
+
+    /* Copy within /tmp should work */
+    char *tmpdir = make_tmpdir();
+    ASSERT_TRUE(tmpdir != NULL);
+
+    char src[512], dst[512];
+    snprintf(src, sizeof(src), "%s/src.txt", tmpdir);
+    snprintf(dst, sizeof(dst), "%s/dst.txt", tmpdir);
+    write_test_file(src, "test data");
+
+    ASSERT_EQ(hl_tool_copy(src, dst, &ctx), 0);
+
+    hl_tool_rmdir(tmpdir, NULL);
+    free(tmpdir);
+}
+
+/* ── rmdir tests ──────────────────────────────────────────────────── */
+
+UTEST(tool, rmdir_basic)
+{
+    char *tmpdir = make_tmpdir();
+    ASSERT_TRUE(tmpdir != NULL);
+
+    /* Create files in it */
+    char path[512];
+    snprintf(path, sizeof(path), "%s/file.txt", tmpdir);
+    write_test_file(path, "data");
+
+    /* Create subdirectory with file */
+    char sub[512];
+    snprintf(sub, sizeof(sub), "%s/subdir", tmpdir);
+    mkdir(sub, 0755);
+    snprintf(path, sizeof(path), "%s/subdir/nested.txt", tmpdir);
+    write_test_file(path, "nested");
+
+    int rc = hl_tool_rmdir(tmpdir, NULL);
+    ASSERT_EQ(rc, 0);
+
+    /* Verify it's gone */
+    ASSERT_NE(access(tmpdir, F_OK), 0);
+
+    free(tmpdir);
+}
+
+UTEST(tool, rmdir_path_validation)
+{
+    HlToolUnveilCtx ctx;
+    hl_tool_unveil_init(&ctx);
+    hl_tool_unveil_add(&ctx, "/tmp", "rwc");
+    hl_tool_unveil_seal(&ctx);
+
+    char *tmpdir = make_tmpdir();
+    ASSERT_TRUE(tmpdir != NULL);
+
+    /* Should succeed — /tmp is unveiled for write */
+    ASSERT_EQ(hl_tool_rmdir(tmpdir, &ctx), 0);
+
+    free(tmpdir);
+}
+
+/* ── Unveil context tests ─────────────────────────────────────────── */
+
+UTEST(tool, unveil_init_and_add)
+{
+    HlToolUnveilCtx ctx;
+    hl_tool_unveil_init(&ctx);
+    ASSERT_EQ(ctx.count, 0);
+    ASSERT_EQ(ctx.sealed, 0);
+
+    ASSERT_EQ(hl_tool_unveil_add(&ctx, "/tmp", "rwc"), 0);
+    /* On macOS /tmp → /private/tmp, so both paths are stored (count=2).
+     * On Linux /tmp is real, so only one entry (count=1). */
+    ASSERT_TRUE(ctx.count >= 1);
+}
+
+UTEST(tool, unveil_seal_prevents_add)
+{
+    HlToolUnveilCtx ctx;
+    hl_tool_unveil_init(&ctx);
+    hl_tool_unveil_add(&ctx, "/tmp", "rwc");
+    hl_tool_unveil_seal(&ctx);
+    ASSERT_EQ(ctx.sealed, 1);
+
+    /* Adding after seal should fail */
+    ASSERT_EQ(hl_tool_unveil_add(&ctx, "/usr", "r"), -1);
+}
+
+UTEST(tool, unveil_check_allowed)
+{
+    HlToolUnveilCtx ctx;
+    hl_tool_unveil_init(&ctx);
+    hl_tool_unveil_add(&ctx, "/tmp", "rwc");
+    hl_tool_unveil_seal(&ctx);
+
+    ASSERT_EQ(hl_tool_unveil_check(&ctx, "/tmp/foo/bar", 'r'), 0);
+    ASSERT_EQ(hl_tool_unveil_check(&ctx, "/tmp/foo/bar", 'w'), 0);
+}
+
+UTEST(tool, unveil_check_denied)
+{
+    HlToolUnveilCtx ctx;
+    hl_tool_unveil_init(&ctx);
+    hl_tool_unveil_add(&ctx, "/tmp", "r");
+    hl_tool_unveil_seal(&ctx);
+
+    /* Read allowed, write denied */
+    ASSERT_EQ(hl_tool_unveil_check(&ctx, "/tmp/foo", 'r'), 0);
+    ASSERT_NE(hl_tool_unveil_check(&ctx, "/tmp/foo", 'w'), 0);
+
+    /* Path outside unveiled dirs denied */
+    ASSERT_NE(hl_tool_unveil_check(&ctx, "/etc/passwd", 'r'), 0);
+}
+
+UTEST(tool, unveil_enforcement_find_files)
+{
+    HlToolUnveilCtx ctx;
+    hl_tool_unveil_init(&ctx);
+    hl_tool_unveil_add(&ctx, "/tmp", "r");
+    hl_tool_unveil_seal(&ctx);
+
+    /* Should fail — /etc is not unveiled */
+    char **files = hl_tool_find_files("/etc", "*.conf", &ctx);
+    ASSERT_TRUE(files == NULL);
+}
+
+UTEST(tool, find_files_null_args)
+{
+    ASSERT_TRUE(hl_tool_find_files(NULL, "*.lua", NULL) == NULL);
+    ASSERT_TRUE(hl_tool_find_files("/tmp", NULL, NULL) == NULL);
+}
+
+UTEST(tool, copy_null_args)
+{
+    ASSERT_EQ(hl_tool_copy(NULL, "/tmp/dst", NULL), -1);
+    ASSERT_EQ(hl_tool_copy("/tmp/src", NULL, NULL), -1);
+}
+
+UTEST(tool, rmdir_null_args)
+{
+    ASSERT_EQ(hl_tool_rmdir(NULL, NULL), -1);
+}
+
+UTEST_MAIN();

--- a/tests/hull/cap/test_tool.c
+++ b/tests/hull/cap/test_tool.c
@@ -325,6 +325,7 @@ UTEST(tool, copy_path_validation)
 
     hl_tool_rmdir(tmpdir, NULL);
     free(tmpdir);
+    hl_tool_unveil_free(&ctx);
 }
 
 /* ── rmdir tests ──────────────────────────────────────────────────── */
@@ -369,6 +370,7 @@ UTEST(tool, rmdir_path_validation)
     ASSERT_EQ(hl_tool_rmdir(tmpdir, &ctx), 0);
 
     free(tmpdir);
+    hl_tool_unveil_free(&ctx);
 }
 
 /* ── Unveil context tests ─────────────────────────────────────────── */
@@ -384,6 +386,7 @@ UTEST(tool, unveil_init_and_add)
     /* On macOS /tmp → /private/tmp, so both paths are stored (count=2).
      * On Linux /tmp is real, so only one entry (count=1). */
     ASSERT_TRUE(ctx.count >= 1);
+    hl_tool_unveil_free(&ctx);
 }
 
 UTEST(tool, unveil_seal_prevents_add)
@@ -396,6 +399,7 @@ UTEST(tool, unveil_seal_prevents_add)
 
     /* Adding after seal should fail */
     ASSERT_EQ(hl_tool_unveil_add(&ctx, "/usr", "r"), -1);
+    hl_tool_unveil_free(&ctx);
 }
 
 UTEST(tool, unveil_check_allowed)
@@ -407,6 +411,7 @@ UTEST(tool, unveil_check_allowed)
 
     ASSERT_EQ(hl_tool_unveil_check(&ctx, "/tmp/foo/bar", 'r'), 0);
     ASSERT_EQ(hl_tool_unveil_check(&ctx, "/tmp/foo/bar", 'w'), 0);
+    hl_tool_unveil_free(&ctx);
 }
 
 UTEST(tool, unveil_check_denied)
@@ -422,6 +427,7 @@ UTEST(tool, unveil_check_denied)
 
     /* Path outside unveiled dirs denied */
     ASSERT_NE(hl_tool_unveil_check(&ctx, "/etc/passwd", 'r'), 0);
+    hl_tool_unveil_free(&ctx);
 }
 
 UTEST(tool, unveil_enforcement_find_files)
@@ -434,6 +440,7 @@ UTEST(tool, unveil_enforcement_find_files)
     /* Should fail — /etc is not unveiled */
     char **files = hl_tool_find_files("/etc", "*.conf", &ctx);
     ASSERT_TRUE(files == NULL);
+    hl_tool_unveil_free(&ctx);
 }
 
 UTEST(tool, find_files_null_args)

--- a/tests/hull/commands/test_dispatch.c
+++ b/tests/hull/commands/test_dispatch.c
@@ -1,0 +1,48 @@
+/*
+ * test_dispatch.c — Tests for subcommand dispatcher
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "utest.h"
+#include "hull/commands/dispatch.h"
+
+/* ── Dispatch tests ───────────────────────────────────────────────── */
+
+UTEST(dispatch, no_args_returns_neg1)
+{
+    char *argv[] = { "hull" };
+    int rc = hl_command_dispatch(1, argv);
+    ASSERT_EQ(rc, -1);
+}
+
+UTEST(dispatch, unknown_command_returns_neg1)
+{
+    char *argv[] = { "hull", "nonexistent" };
+    int rc = hl_command_dispatch(2, argv);
+    ASSERT_EQ(rc, -1);
+}
+
+UTEST(dispatch, server_args_return_neg1)
+{
+    /* Server flags like -p 3000 should not match any command */
+    char *argv[] = { "hull", "-p", "3000" };
+    int rc = hl_command_dispatch(3, argv);
+    ASSERT_EQ(rc, -1);
+}
+
+UTEST(dispatch, entry_point_returns_neg1)
+{
+    /* A .lua or .js file should not match a command */
+    char *argv[] = { "hull", "app.lua" };
+    int rc = hl_command_dispatch(2, argv);
+    ASSERT_EQ(rc, -1);
+}
+
+/*
+ * We can't easily test that known commands dispatch correctly without
+ * side effects, but we can verify the negative cases above which confirm
+ * the dispatcher correctly falls through for non-command args.
+ */
+
+UTEST_MAIN();

--- a/tests/hull/runtime/lua/test_lua.c
+++ b/tests/hull/runtime/lua/test_lua.c
@@ -801,7 +801,7 @@ UTEST(lua_require_fs, too_large)
     char path[1024];
     snprintf(path, sizeof(path), "%s/big.lua", tmpdir);
     FILE *f = fopen(path, "w");
-    ASSERT_NE(f, NULL);
+    ASSERT_TRUE(f != NULL);
     /* Write just past the limit — use fseek to create a sparse file */
     fseek(f, HL_MODULE_MAX_SIZE + 1, SEEK_SET);
     fputc('x', f);

--- a/tests/sandbox_violation.c
+++ b/tests/sandbox_violation.c
@@ -29,7 +29,9 @@
 #if defined(__COSMOPOLITAN__)
 #define SANDBOX_SUPPORTED 1
 #define HAS_PLEDGE_MODE   0
-#include <libc/calls/pledge.h>
+/* Cosmopolitan libc provides pledge() and unveil() natively. */
+extern int pledge(const char *promises, const char *execpromises);
+extern int unveil(const char *path, const char *permissions);
 
 #elif defined(__linux__)
 #define SANDBOX_SUPPORTED 1

--- a/vendor/pledge/libc/intrin/likely.h
+++ b/vendor/pledge/libc/intrin/likely.h
@@ -5,8 +5,8 @@
 #define LIKELY(x)   __builtin_expect(!!(x), 1)
 #define UNLIKELY(x) __builtin_expect(!!(x), 0)
 #else
-#define LIKELY(x)
-#define UNLIKELY(x)
+#define LIKELY(x)   (x)
+#define UNLIKELY(x) (x)
 #endif
 
 #endif


### PR DESCRIPTION
## Summary
- **Phase 1: Tool Hardening** — Replace shell-based `tool.exec()`/`tool.read()` with shell-free `tool.spawn()` (fork/execvp with compiler allowlist), `tool.find_files()`, `tool.copy()`, `tool.rmdir()`. All filesystem ops validate paths against unveil context. Configurable compiler via `tool.cc`.
- **Phase 2: Command Modules** — Replace hardcoded if-else chain in `hull_main()` with table-driven dispatcher. Each subcommand (build, verify, inspect, manifest, keygen, test) in its own compilation unit under `src/hull/commands/`.
- **Phase 3: `hull test`** — In-process test runner with `test()` registration, HTTP dispatch (`test.get()`, `test.post()`, etc.), and assertions (`test.eq()`, `test.ok()`, `test.err()`). Discovers `test_*.[lua|js]` recursively. No TCP/HTTP parsing — dispatches directly through KlRouter.
- **CI fixes** — Add missing `#include <stdint.h>` in alloc.c, fix Cosmopolitan unveil declaration, add `tool` to luacheckrc globals.

## Test plan
- [x] All 11 test suites pass locally (191 tests)
- [x] `make clean && make` succeeds
- [ ] CI passes (Linux, macOS, ASan, MSan, Cosmo, Lint, Static Analysis, Coverage, Benchmark)