### PR TITLE
Wire Lua/JS middleware to Keel router

### DIFF
--- a/include/hull/runtime/js.h
+++ b/include/hull/runtime/js.h
@@ -176,4 +176,17 @@ int hl_js_wire_routes(HlJS *js, KlRouter *router);
 int hl_js_wire_routes_server(HlJS *js, KlServer *server,
                               void *(*alloc_fn)(size_t));
 
+/*
+ * Dispatch a middleware call to the JS handler.
+ * Returns 0 (continue), positive (short-circuit), or -1 (error).
+ */
+int hl_js_dispatch_middleware(HlJS *js, int handler_id,
+                              KlRequest *req, KlResponse *res);
+
+/*
+ * Keel middleware bridge: dispatches a request to the JS middleware.
+ * Returns 0 (continue) or non-zero (short-circuit).
+ */
+int hl_js_keel_middleware(KlRequest *req, KlResponse *res, void *user_data);
+
 #endif /* HL_RUNTIME_JS_H */

--- a/include/hull/runtime/lua.h
+++ b/include/hull/runtime/lua.h
@@ -167,4 +167,17 @@ int hl_lua_wire_routes(HlLua *lua, KlRouter *router);
 int hl_lua_wire_routes_server(HlLua *lua, KlServer *server,
                                void *(*alloc_fn)(size_t));
 
+/*
+ * Dispatch a middleware call to the Lua handler.
+ * Returns 0 (continue), positive (short-circuit), or -1 (error).
+ */
+int hl_lua_dispatch_middleware(HlLua *lua, int handler_id,
+                               KlRequest *req, KlResponse *res);
+
+/*
+ * Keel middleware bridge: dispatches a request to the Lua middleware.
+ * Returns 0 (continue) or non-zero (short-circuit).
+ */
+int hl_lua_keel_middleware(KlRequest *req, KlResponse *res, void *user_data);
+
 #endif /* HL_RUNTIME_LUA_H */

--- a/src/hull/runtime/lua/modules.c
+++ b/src/hull/runtime/lua/modules.c
@@ -115,6 +115,21 @@ static int lua_app_use(lua_State *L)
     const char *pattern = luaL_checkstring(L, 2);
     luaL_checktype(L, 3, LUA_TFUNCTION);
 
+    /* Store handler in __hull_routes (same array as route handlers) */
+    lua_getfield(L, LUA_REGISTRYINDEX, "__hull_routes");
+    if (lua_isnil(L, -1)) {
+        lua_pop(L, 1);
+        lua_newtable(L);
+        lua_pushvalue(L, -1);
+        lua_setfield(L, LUA_REGISTRYINDEX, "__hull_routes");
+    }
+
+    lua_Integer handler_id = (lua_Integer)luaL_len(L, -1) + 1;
+    lua_pushvalue(L, 3);
+    lua_rawseti(L, -2, handler_id);
+    lua_pop(L, 1); /* pop routes table */
+
+    /* Store middleware entry with handler_id */
     lua_getfield(L, LUA_REGISTRYINDEX, "__hull_middleware");
     if (lua_isnil(L, -1)) {
         lua_pop(L, 1);
@@ -130,8 +145,8 @@ static int lua_app_use(lua_State *L)
     lua_setfield(L, -2, "method");
     lua_pushstring(L, pattern);
     lua_setfield(L, -2, "pattern");
-    lua_pushvalue(L, 3);
-    lua_setfield(L, -2, "handler");
+    lua_pushinteger(L, handler_id);
+    lua_setfield(L, -2, "handler_id");
     lua_rawseti(L, -2, idx);
 
     lua_pop(L, 1); /* pop middleware table */


### PR DESCRIPTION
## Summary
- `app.use()` stored middleware metadata in `__hull_middleware` but never registered it with `kl_server_use()` — middleware was silently ignored
- Add `hl_lua_dispatch_middleware()` / `hl_js_dispatch_middleware()` that capture the int return value (0=continue, non-zero=short-circuit)
- Add `hl_lua_keel_middleware()` / `hl_js_keel_middleware()` C bridge functions matching `KlMiddleware` signature
- Add middleware wiring loops in `hl_lua_wire_routes_server()` / `hl_js_wire_routes_server()`
- 12 new tests (6 Lua, 6 JS): registration, ID isolation, dispatch continue/short-circuit, server wiring, order preservation

## Test plan
- [x] `make clean && make` builds cleanly
- [x] `make test` — 13/13 test suites pass
- [x] `make cppcheck` — no warnings