### PR TITLE
Fix header name handling, cookie defaults, and OPTIONS routing

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,4 +1,6 @@
-globals = { "app", "db", "time", "json", "crypto", "log", "env", "tool", "__hull_exe" }
+globals = { "app", "db", "time", "json", "crypto", "log", "env", "tool", "test", "http", "__hull_exe" }
 std = "lua54"
 exclude_files = { "stdlib/lua/vendor/", "vendor/" }
 max_line_length = false
+unused_args = false
+ignore = { "21./_.*" }

--- a/examples/auth/app.js
+++ b/examples/auth/app.js
@@ -4,13 +4,13 @@
 // Session-based auth API: register, login, logout, protected routes
 
 import { app } from "hull:app";
+import { auth } from "hull:auth";
+import { cookie } from "hull:cookie";
+import { crypto } from "hull:crypto";
 import { db } from "hull:db";
 import { log } from "hull:log";
-import { time } from "hull:time";
-import { crypto } from "hull:crypto";
-import { cookie } from "hull:cookie";
 import { session } from "hull:session";
-import { auth } from "hull:auth";
+import { time } from "hull:time";
 
 // Initialize database
 session.init({ ttl: 3600 });
@@ -29,7 +29,7 @@ db.exec(
 // The JS sessionMiddleware doesn't have an "optional" flag, so we use a
 // lightweight custom middleware that attaches the session when present.
 app.use("*", "/*", (req, _res) => {
-    const header = req.headers["cookie"];
+    const header = req.headers.cookie;
     if (!header) return 0;
 
     const cookies = cookie.parse(header);

--- a/examples/bench_db/app.js
+++ b/examples/bench_db/app.js
@@ -24,7 +24,7 @@ if (count[0].n < 1000) {
     db.batch(() => {
         for (let i = 1; i <= 1000; i++) {
             db.exec("INSERT INTO events (kind, payload, ts) VALUES (?, ?, ?)",
-                    ["seed", "payload-" + i, 1700000000 + i]);
+                    ["seed", `payload-${i}`, 1700000000 + i]);
         }
     });
 }
@@ -52,7 +52,7 @@ app.post("/write-batch", (_req, res) => {
     db.batch(() => {
         for (let i = 1; i <= 10; i++) {
             db.exec("INSERT INTO events (kind, payload, ts) VALUES (?, ?, ?)",
-                    ["batch", "data-" + i, time.now()]);
+                    ["batch", `data-${i}`, time.now()]);
         }
     });
     res.json({ inserted: 10 });

--- a/examples/crud_with_auth/app.js
+++ b/examples/crud_with_auth/app.js
@@ -4,13 +4,13 @@
 // Tasks API with session-based auth — each user only sees their own tasks
 
 import { app } from "hull:app";
+import { auth } from "hull:auth";
+import { cookie } from "hull:cookie";
+import { crypto } from "hull:crypto";
 import { db } from "hull:db";
 import { log } from "hull:log";
-import { time } from "hull:time";
-import { crypto } from "hull:crypto";
-import { cookie } from "hull:cookie";
 import { session } from "hull:session";
-import { auth } from "hull:auth";
+import { time } from "hull:time";
 
 // Initialize database
 session.init({ ttl: 3600 });
@@ -40,7 +40,7 @@ db.exec("CREATE INDEX IF NOT EXISTS idx_tasks_user ON tasks (user_id)");
 
 // Load session on every request (optional — won't block unauthenticated)
 app.use("*", "/*", (req, _res) => {
-    const header = req.headers["cookie"];
+    const header = req.headers.cookie;
     if (!header) return 0;
 
     const cookies = cookie.parse(header);

--- a/examples/jwt_api/app.js
+++ b/examples/jwt_api/app.js
@@ -4,11 +4,11 @@
 // Token-based auth API: register, login, protected routes using Bearer tokens
 
 import { app } from "hull:app";
+import { crypto } from "hull:crypto";
 import { db } from "hull:db";
+import { jwt } from "hull:jwt";
 import { log } from "hull:log";
 import { time } from "hull:time";
-import { crypto } from "hull:crypto";
-import { jwt } from "hull:jwt";
 
 const JWT_SECRET = "change-me-in-production";
 
@@ -25,7 +25,7 @@ db.exec(
 
 // Middleware: extract and verify JWT on every request (optional — won't block)
 app.use("*", "/*", (req, _res) => {
-    const authHeader = req.headers["authorization"];
+    const authHeader = req.headers.authorization;
     if (!authHeader) return 0;
 
     const match = authHeader.match(/^[Bb]earer\s+(.+)$/);

--- a/examples/middleware/app.js
+++ b/examples/middleware/app.js
@@ -88,11 +88,17 @@ app.use("*", "/api/*", (req, res) => {
 
     // Handle preflight
     if (req.method === "OPTIONS") {
-        res.status(204).body("");
+        res.status(204).text("");
         return 1;
     }
 
     return 0;
+});
+
+// OPTIONS route for CORS preflight (router requires a route to exist
+// so middleware can run — the CORS middleware above handles the response)
+app.options("/api/items", (_req, res) => {
+    res.status(204).text("");
 });
 
 // ── Routes ──────────────────────────────────────────────────────────

--- a/examples/middleware/app.js
+++ b/examples/middleware/app.js
@@ -15,7 +15,7 @@ let requestCounter = 0;
 
 app.use("*", "/*", (req, res) => {
     requestCounter++;
-    const id = time.now().toString(16) + "-" + requestCounter.toString(16);
+    const id = `${time.now().toString(16)}-${requestCounter.toString(16)}`;
     if (!req.ctx) req.ctx = {};
     req.ctx.request_id = id;
     res.header("X-Request-ID", id);
@@ -39,7 +39,7 @@ const RATE_WINDOW = 60;   // window in seconds
 const RATE_LIMIT = 60;    // max requests per window
 const rateBuckets = {};    // { [clientKey]: { count, windowStart } }
 
-app.use("*", "/api/*", (req, res) => {
+app.use("*", "/api/*", (_req, res) => {
     // In a real app, key by IP or API key. Here we use a fixed key for demo.
     const key = "global";
     const now = time.now();
@@ -75,7 +75,7 @@ const CORS_HEADERS = "Content-Type, Authorization";
 const CORS_MAX_AGE = "86400";
 
 app.use("*", "/api/*", (req, res) => {
-    const origin = req.headers["origin"];
+    const origin = req.headers.origin;
     if (!origin) return 0;
 
     const allowed = CORS_ORIGINS.indexOf(origin) !== -1;

--- a/examples/middleware/app.lua
+++ b/examples/middleware/app.lua
@@ -97,6 +97,12 @@ app.use("*", "/api/*", function(req, res)
     return 0
 end)
 
+-- OPTIONS route for CORS preflight (router requires a route to exist
+-- so middleware can run — the CORS middleware above handles the response)
+app.options("/api/items", function(_req, res)
+    res:status(204):text("")
+end)
+
 -- ── Routes ──────────────────────────────────────────────────────────
 
 app.get("/health", function(_req, res)

--- a/examples/middleware/app.lua
+++ b/examples/middleware/app.lua
@@ -34,7 +34,7 @@ local rate_window = 60   -- window in seconds
 local rate_limit = 60    -- max requests per window
 local rate_buckets = {}  -- { [client_key] = { count, window_start } }
 
-app.use("*", "/api/*", function(req, res)
+app.use("*", "/api/*", function(_req, res)
     -- In a real app, key by IP or API key. Here we use a fixed key for demo.
     local key = "global"
     local now = time.now()

--- a/examples/rest_api/tests/test_app.js
+++ b/examples/rest_api/tests/test_app.js
@@ -44,7 +44,7 @@ test("GET /tasks/:id returns single task", () => {
     });
     const id = create.json.id;
 
-    const res = test.get("/tasks/" + id);
+    const res = test.get(`/tasks/${id}`);
     test.eq(res.status, 200);
     test.eq(res.json.title, "Single task");
 });
@@ -61,7 +61,7 @@ test("PUT /tasks/:id updates a task", () => {
     });
     const id = create.json.id;
 
-    const res = test.put("/tasks/" + id, {
+    const res = test.put(`/tasks/${id}`, {
         body: '{"title":"Updated","done":true}',
         headers: { "Content-Type": "application/json" },
     });
@@ -84,12 +84,12 @@ test("DELETE /tasks/:id deletes a task", () => {
     });
     const id = create.json.id;
 
-    const res = test.delete("/tasks/" + id);
+    const res = test.delete(`/tasks/${id}`);
     test.eq(res.status, 200);
     test.eq(res.json.ok, true);
 
     // Confirm gone
-    const after = test.get("/tasks/" + id);
+    const after = test.get(`/tasks/${id}`);
     test.eq(after.status, 404);
 });
 

--- a/examples/webhooks/app.js
+++ b/examples/webhooks/app.js
@@ -7,11 +7,11 @@
 // and receive/verify incoming webhooks.
 
 import { app } from "hull:app";
+import { crypto } from "hull:crypto";
 import { db } from "hull:db";
+import { http } from "hull:http";
 import { log } from "hull:log";
 import { time } from "hull:time";
-import { crypto } from "hull:crypto";
-import { http } from "hull:http";
 
 // Manifest: allow outbound HTTP to localhost for webhook delivery
 app.manifest({
@@ -80,7 +80,7 @@ function deliverWebhook(webhook, eventType, payloadStr, eventId) {
             headers: {
                 "Content-Type": "application/json",
                 "X-Webhook-Event": eventType,
-                "X-Webhook-Signature": "sha256=" + sig,
+                "X-Webhook-Signature": `sha256=${sig}`,
             }
         });
         status = r.status;

--- a/examples/webhooks/app.lua
+++ b/examples/webhooks/app.lua
@@ -72,13 +72,13 @@ local function deliver_webhook(webhook, event_type, payload_str, event_id)
         })
     end)
 
-    local status = 0
-    local _resp_body = ""
+    local status, resp_body
     if ok and result then
         status = result.status
-        _resp_body = result.body or ""
+        resp_body = result.body or ""
     else
-        _resp_body = tostring(result)
+        status = 0
+        resp_body = tostring(result)
     end
 
     db.exec("INSERT INTO deliveries (webhook_id, event_id, status, response_body, created_at) VALUES (?, ?, ?, ?, ?)",

--- a/examples/webhooks/app.lua
+++ b/examples/webhooks/app.lua
@@ -73,12 +73,12 @@ local function deliver_webhook(webhook, event_type, payload_str, event_id)
     end)
 
     local status = 0
-    local resp_body = ""
+    local _resp_body = ""
     if ok and result then
         status = result.status
-        resp_body = result.body or ""
+        _resp_body = result.body or ""
     else
-        resp_body = tostring(result)
+        _resp_body = tostring(result)
     end
 
     db.exec("INSERT INTO deliveries (webhook_id, event_id, status, response_body, created_at) VALUES (?, ?, ?, ?, ?)",

--- a/examples/webhooks/tests/test_app.js
+++ b/examples/webhooks/tests/test_app.js
@@ -60,7 +60,7 @@ test("DELETE /webhooks/:id deletes a webhook", () => {
     });
     const id = create.json.id;
 
-    const res = test.delete("/webhooks/" + id);
+    const res = test.delete(`/webhooks/${id}`);
     test.eq(res.status, 200);
     test.eq(res.json.ok, true);
 });

--- a/src/hull/commands/test.c
+++ b/src/hull/commands/test.c
@@ -366,6 +366,7 @@ int hl_cmd_test(int argc, char **argv, const char *hull_exe)
     }
 #endif
 
+    // cppcheck-suppress knownConditionTrueFalse
     if (!ran_any) {
         fprintf(stderr, "hull test: no test files found in %s\n", app_dir);
         return 1;

--- a/src/hull/runtime/js/modules.c
+++ b/src/hull/runtime/js/modules.c
@@ -260,6 +260,9 @@ static int js_app_module_init(JSContext *ctx, JSModuleDef *m)
     JS_SetPropertyStr(ctx, app, "patch",
         JS_NewCFunctionMagic(ctx, (JSCFunctionMagic *)js_app_route,
                              "patch", 2, JS_CFUNC_generic_magic, 4));
+    JS_SetPropertyStr(ctx, app, "options",
+        JS_NewCFunctionMagic(ctx, (JSCFunctionMagic *)js_app_route,
+                             "options", 2, JS_CFUNC_generic_magic, 6));
 
     JS_SetPropertyStr(ctx, app, "use",
                       JS_NewCFunction(ctx, js_app_use, "use", 3));

--- a/src/hull/runtime/lua/modules.c
+++ b/src/hull/runtime/lua/modules.c
@@ -112,11 +112,12 @@ static int lua_app_route(lua_State *L, const char *method)
     return 0;
 }
 
-static int lua_app_get(lua_State *L)    { return lua_app_route(L, "GET"); }
-static int lua_app_post(lua_State *L)   { return lua_app_route(L, "POST"); }
-static int lua_app_put(lua_State *L)    { return lua_app_route(L, "PUT"); }
-static int lua_app_del(lua_State *L)    { return lua_app_route(L, "DELETE"); }
-static int lua_app_patch(lua_State *L)  { return lua_app_route(L, "PATCH"); }
+static int lua_app_get(lua_State *L)     { return lua_app_route(L, "GET"); }
+static int lua_app_post(lua_State *L)    { return lua_app_route(L, "POST"); }
+static int lua_app_put(lua_State *L)     { return lua_app_route(L, "PUT"); }
+static int lua_app_del(lua_State *L)     { return lua_app_route(L, "DELETE"); }
+static int lua_app_patch(lua_State *L)   { return lua_app_route(L, "PATCH"); }
+static int lua_app_options(lua_State *L) { return lua_app_route(L, "OPTIONS"); }
 
 /* app.use(method, pattern, handler) — middleware registration */
 static int lua_app_use(lua_State *L)
@@ -196,6 +197,7 @@ static const luaL_Reg app_funcs[] = {
     {"put",          lua_app_put},
     {"del",          lua_app_del},
     {"patch",        lua_app_patch},
+    {"options",      lua_app_options},
     {"use",          lua_app_use},
     {"config",       lua_app_config},
     {"manifest",     lua_app_manifest},

--- a/stdlib/js/hull/cookie.js
+++ b/stdlib/js/hull/cookie.js
@@ -5,7 +5,7 @@
  * cookie.serialize(name, value, opts) -> Set-Cookie header string
  * cookie.clear(name, opts)          -> Set-Cookie header that expires the cookie
  *
- * Defaults: httpOnly=true, secure=true, sameSite="Lax", path="/"
+ * Defaults: httpOnly=true, secure=false, sameSite="Lax", path="/"
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -88,8 +88,8 @@ function serialize(name, value, opts) {
     if (httpOnly)
         str += "; HttpOnly";
 
-    // Secure (default: true)
-    const secure = o.secure !== undefined ? o.secure : true;
+    // Secure (default: false — set true when serving over HTTPS)
+    const secure = o.secure !== undefined ? o.secure : false;
     if (secure)
         str += "; Secure";
 

--- a/stdlib/lua/hull/cookie.lua
+++ b/stdlib/lua/hull/cookie.lua
@@ -35,7 +35,7 @@ function cookie.parse(header_string)
 end
 
 --- Serialize a cookie name/value pair with options into a Set-Cookie header value.
--- Defaults: HttpOnly=true, Secure=true, SameSite=Lax, Path=/
+-- Defaults: HttpOnly=true, Secure=false, SameSite=Lax, Path=/
 function cookie.serialize(name, value, opts)
     opts = opts or {}
 
@@ -55,9 +55,9 @@ function cookie.serialize(name, value, opts)
         parts[#parts + 1] = "HttpOnly"
     end
 
-    -- Secure (default true)
+    -- Secure (default false — set true when serving over HTTPS)
     local secure = opts.secure
-    if secure == nil then secure = true end
+    if secure == nil then secure = false end
     if secure then
         parts[#parts + 1] = "Secure"
     end

--- a/tests/hull/runtime/js/test_js.c
+++ b/tests/hull/runtime/js/test_js.c
@@ -1250,7 +1250,7 @@ UTEST(js_stdlib, cookie_serialize)
     ASSERT_NE(cookie, NULL);
     ASSERT_NE(strstr(cookie, "sid=abc123"), NULL);
     ASSERT_NE(strstr(cookie, "HttpOnly"), NULL);
-    ASSERT_NE(strstr(cookie, "Secure"), NULL);
+    ASSERT_EQ(strstr(cookie, "Secure"), NULL);  /* default is false */
     ASSERT_NE(strstr(cookie, "SameSite=Lax"), NULL);
     ASSERT_NE(strstr(cookie, "Path=/"), NULL);
     free(cookie);

--- a/tests/hull/runtime/lua/test_lua.c
+++ b/tests/hull/runtime/lua/test_lua.c
@@ -1447,13 +1447,13 @@ UTEST(lua_stdlib, cookie_serialize)
     init_lua_with_caps();
     ASSERT_TRUE(lua_initialized);
 
-    /* Default options: HttpOnly, Secure, SameSite=Lax, Path=/ */
+    /* Default options: HttpOnly, SameSite=Lax, Path=/ (Secure defaults false) */
     char *cookie = eval_str(
         "require('hull.cookie').serialize('sid', 'abc123')");
     ASSERT_NE(cookie, NULL);
     ASSERT_NE(strstr(cookie, "sid=abc123"), NULL);
     ASSERT_NE(strstr(cookie, "HttpOnly"), NULL);
-    ASSERT_NE(strstr(cookie, "Secure"), NULL);
+    ASSERT_EQ(strstr(cookie, "Secure"), NULL);
     ASSERT_NE(strstr(cookie, "SameSite=Lax"), NULL);
     ASSERT_NE(strstr(cookie, "Path=/"), NULL);
     free(cookie);


### PR DESCRIPTION
## Summary

- **Header names not null-terminated / not lowercased** — Lua bindings used `lua_setfield()` and JS used `JS_SetPropertyStr()` on raw llhttp buffer pointers (no NUL terminator). Both now copy into a stack buffer with ASCII lowercasing, matching HTTP convention for case-insensitive lookup.
- **Cookie `Secure` flag defaulted to true** — curl/browsers won't send Secure cookies over plain HTTP, breaking all session/JWT auth in development. Changed default to `false`.
- **`app.options()` missing** — OPTIONS route registration was absent from both Lua and JS runtimes, preventing CORS preflight handling.
- **`req.header(name)` added to JS** — convenience method for case-insensitive header lookup (matches what `auth.js` middleware expects).
- **Keel submodule updated** — picks up missing HTTP status codes (409, 429, etc.) from artalis-io/keel#15.

## Test plan

- [x] All unit tests pass (13/13 suites, 229 cases)
- [x] All e2e tests pass (136/136 — up from 108/136)