### PR TITLE
Add multi-arch platform archives for cosmo fat binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,9 +120,6 @@ jobs:
         timeout-minutes: 5
         run: make test CC=cosmocc
 
-      - name: Self-build test
-        run: make self-build CC=cosmocc
-
       - name: E2E smoke test
         run: |
           ./build/hull -p 19852 -d /tmp/cosmo_e2e.db examples/hello/app.lua &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,12 +110,18 @@ jobs:
           rm /tmp/cosmocc.zip
           echo "/opt/cosmo/bin" >> $GITHUB_PATH
 
-      - name: Build
+      - name: Build platform (multi-arch)
+        run: make platform-cosmo
+
+      - name: Build hull
         run: make CC=cosmocc
 
       - name: Unit tests
         timeout-minutes: 5
         run: make test CC=cosmocc
+
+      - name: Self-build test
+        run: make self-build CC=cosmocc
 
       - name: E2E smoke test
         run: |

--- a/Makefile
+++ b/Makefile
@@ -99,10 +99,16 @@ $(KEEL_LIB): $(MBEDTLS_OBJS)
 		$(if $(COSMO),BACKEND=poll COSMO=1)
 ifdef COSMO
 	@# Ensure .aarch64/ counterpart archive exists for cosmocc fat linking
+	@echo "=== Checking for $(KEEL_DIR)/.aarch64/libkeel.a ==="
 	@if [ ! -f $(KEEL_DIR)/.aarch64/libkeel.a ]; then \
+		echo "=== Creating .aarch64/libkeel.a ===" && \
 		mkdir -p $(KEEL_DIR)/.aarch64 && \
-		$(AR) rcs $(KEEL_DIR)/.aarch64/libkeel.a \
-			$$(find $(KEEL_DIR)/src/.aarch64 $(KEEL_DIR)/parsers/.aarch64 $(KEEL_DIR)/vendor/llhttp/.aarch64 -name '*.o' 2>/dev/null); \
+		OBJS=$$(find $(KEEL_DIR)/src/.aarch64 $(KEEL_DIR)/parsers/.aarch64 $(KEEL_DIR)/vendor/llhttp/.aarch64 -name '*.o' 2>/dev/null) && \
+		echo "=== Found objects: $$OBJS ===" && \
+		$(AR) rcs $(KEEL_DIR)/.aarch64/libkeel.a $$OBJS && \
+		echo "=== Created $(KEEL_DIR)/.aarch64/libkeel.a ==="; \
+	else \
+		echo "=== $(KEEL_DIR)/.aarch64/libkeel.a already exists ==="; \
 	fi
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,6 @@ RUNTIME ?= all
 ifneq ($(findstring cosmo,$(CC)),)
   COSMO := 1
 endif
-ifneq ($(findstring cosmocc,$(CC)),)
-  AR    := cosmoar
-endif
-
 # Platform detection
 UNAME_S := $(shell uname -s)
 

--- a/Makefile
+++ b/Makefile
@@ -437,6 +437,7 @@ platform-cosmo:
 	cp $(BUILDDIR)/libhull_platform.a $(COSMO_STAGE)/libhull_platform.aarch64-cosmo.a
 	cp $(BUILDDIR)/platform_canary_hash $(COSMO_STAGE)/platform_canary_hash.aarch64-cosmo
 	$(MAKE) clean
+	$(MAKE) -C $(KEEL_DIR) clean
 	mkdir -p $(BUILDDIR)
 	cp $(COSMO_STAGE)/* $(BUILDDIR)/
 	echo "cosmocc" > $(BUILDDIR)/platform_cc

--- a/Makefile
+++ b/Makefile
@@ -91,26 +91,11 @@ KEEL_INC   := $(KEEL_DIR)/include
 KEEL_LIB   := $(KEEL_DIR)/libkeel.a
 
 # Build Keel with mbedTLS backend
-# Pass BACKEND=poll and COSMO=1 when cosmo is detected (arch-specific
-# compilers like x86_64-unknown-cosmo-cc don't trigger Keel's own detection)
+# Keel now detects the cosmo toolchain natively from CC and handles
+# poll backend, .aarch64/ archive creation, etc.
 $(KEEL_LIB): $(MBEDTLS_OBJS)
 	$(MAKE) -C $(KEEL_DIR) CC=$(CC) AR=$(AR) \
-		KEEL_TLS=mbedtls MBEDTLS_CONFIG_FILE=hull_config.h \
-		$(if $(COSMO),BACKEND=poll COSMO=1)
-ifdef COSMO
-	@# Ensure .aarch64/ counterpart archive exists for cosmocc fat linking
-	@echo "=== Checking for $(KEEL_DIR)/.aarch64/libkeel.a ==="
-	@if [ ! -f $(KEEL_DIR)/.aarch64/libkeel.a ]; then \
-		echo "=== Creating .aarch64/libkeel.a ===" && \
-		mkdir -p $(KEEL_DIR)/.aarch64 && \
-		OBJS=$$(find $(KEEL_DIR)/src/.aarch64 $(KEEL_DIR)/parsers/.aarch64 $(KEEL_DIR)/vendor/llhttp/.aarch64 -name '*.o' 2>/dev/null) && \
-		echo "=== Found objects: $$OBJS ===" && \
-		$(AR) rcs $(KEEL_DIR)/.aarch64/libkeel.a $$OBJS && \
-		echo "=== Created $(KEEL_DIR)/.aarch64/libkeel.a ==="; \
-	else \
-		echo "=== $(KEEL_DIR)/.aarch64/libkeel.a already exists ==="; \
-	fi
-endif
+		KEEL_TLS=mbedtls MBEDTLS_CONFIG_FILE=hull_config.h
 
 # ── mbedTLS (vendored) ─────────────────────────────────────────────
 

--- a/Makefile
+++ b/Makefile
@@ -432,6 +432,7 @@ platform-cosmo:
 	$(MAKE) platform CC=aarch64-unknown-cosmo-cc AR=aarch64-unknown-cosmo-ar
 	cp $(BUILDDIR)/libhull_platform.a $(COSMO_STAGE)/libhull_platform.aarch64-cosmo.a
 	cp $(BUILDDIR)/platform_canary_hash $(COSMO_STAGE)/platform_canary_hash.aarch64-cosmo
+	$(MAKE) clean
 	mkdir -p $(BUILDDIR)
 	cp $(COSMO_STAGE)/* $(BUILDDIR)/
 	echo "cosmocc" > $(BUILDDIR)/platform_cc

--- a/Makefile
+++ b/Makefile
@@ -95,12 +95,20 @@ KEEL_INC   := $(KEEL_DIR)/include
 KEEL_LIB   := $(KEEL_DIR)/libkeel.a
 
 # Build Keel with mbedTLS backend
-# Pass BACKEND=poll when cosmo is detected (arch-specific compilers
-# like x86_64-unknown-cosmo-cc don't trigger Keel's own cosmo detection)
+# Pass BACKEND=poll and COSMO=1 when cosmo is detected (arch-specific
+# compilers like x86_64-unknown-cosmo-cc don't trigger Keel's own detection)
 $(KEEL_LIB): $(MBEDTLS_OBJS)
 	$(MAKE) -C $(KEEL_DIR) CC=$(CC) AR=$(AR) \
 		KEEL_TLS=mbedtls MBEDTLS_CONFIG_FILE=hull_config.h \
-		$(if $(COSMO),BACKEND=poll)
+		$(if $(COSMO),BACKEND=poll COSMO=1)
+ifdef COSMO
+	@# Ensure .aarch64/ counterpart archive exists for cosmocc fat linking
+	@if [ ! -f $(KEEL_DIR)/.aarch64/libkeel.a ]; then \
+		mkdir -p $(KEEL_DIR)/.aarch64 && \
+		$(AR) rcs $(KEEL_DIR)/.aarch64/libkeel.a \
+			$$(find $(KEEL_DIR)/src/.aarch64 $(KEEL_DIR)/parsers/.aarch64 $(KEEL_DIR)/vendor/llhttp/.aarch64 -name '*.o' 2>/dev/null); \
+	fi
+endif
 
 # ── mbedTLS (vendored) ─────────────────────────────────────────────
 

--- a/Makefile
+++ b/Makefile
@@ -95,9 +95,12 @@ KEEL_INC   := $(KEEL_DIR)/include
 KEEL_LIB   := $(KEEL_DIR)/libkeel.a
 
 # Build Keel with mbedTLS backend
+# Pass BACKEND=poll when cosmo is detected (arch-specific compilers
+# like x86_64-unknown-cosmo-cc don't trigger Keel's own cosmo detection)
 $(KEEL_LIB): $(MBEDTLS_OBJS)
 	$(MAKE) -C $(KEEL_DIR) CC=$(CC) AR=$(AR) \
-		KEEL_TLS=mbedtls MBEDTLS_CONFIG_FILE=hull_config.h
+		KEEL_TLS=mbedtls MBEDTLS_CONFIG_FILE=hull_config.h \
+		$(if $(COSMO),BACKEND=poll)
 
 # ── mbedTLS (vendored) ─────────────────────────────────────────────
 
@@ -616,10 +619,10 @@ $(BUILDDIR)/test_js: $(TESTDIR)/hull/runtime/js/test_js.c $(TEST_COMMON_DEPS) $(
 		$(TEST_CAP_OBJS) $(JS_RT_OBJS) $(MANIFEST_JS_OBJ) $(ALLOC_OBJ) $(QJS_OBJS) \
 		$(KEEL_LIB) $(SQLITE_OBJ) $(LOG_OBJ) $(SH_ARENA_OBJ) $(TWEETNACL_OBJ) -lm -lpthread
 
-# Lua runtime test — needs Lua + Lua runtime objects + stdlib headers + manifest (Lua-only) + cap_tool
-$(BUILDDIR)/test_lua: $(TESTDIR)/hull/runtime/lua/test_lua.c $(TEST_COMMON_DEPS) $(CAP_TOOL_OBJ) $(MANIFEST_LUA_OBJ) $(APP_ENTRIES_DEFAULT_OBJ) $(LUA_RT_OBJS) $(LUA_OBJS) $(STDLIB_LUA_HDRS) | $(BUILDDIR)
+# Lua runtime test — needs Lua + Lua runtime objects + stdlib headers + manifest (Lua-only) + cap_tool + build_assets
+$(BUILDDIR)/test_lua: $(TESTDIR)/hull/runtime/lua/test_lua.c $(TEST_COMMON_DEPS) $(CAP_TOOL_OBJ) $(BUILD_ASSET_OBJ) $(MANIFEST_LUA_OBJ) $(APP_ENTRIES_DEFAULT_OBJ) $(LUA_RT_OBJS) $(LUA_OBJS) $(STDLIB_LUA_HDRS) | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< \
-		$(TEST_CAP_OBJS) $(CAP_TOOL_OBJ) $(LUA_RT_OBJS) $(MANIFEST_LUA_OBJ) $(APP_ENTRIES_DEFAULT_OBJ) $(ALLOC_OBJ) $(LUA_OBJS) \
+		$(TEST_CAP_OBJS) $(CAP_TOOL_OBJ) $(BUILD_ASSET_OBJ) $(LUA_RT_OBJS) $(MANIFEST_LUA_OBJ) $(APP_ENTRIES_DEFAULT_OBJ) $(ALLOC_OBJ) $(LUA_OBJS) \
 		$(KEEL_LIB) $(SQLITE_OBJ) $(LOG_OBJ) $(SH_ARENA_OBJ) $(TWEETNACL_OBJ) -lm -lpthread
 
 # Tool hardening test — cap/tool.c compiled without runtime flags (self-contained C functions)

--- a/include/hull/build_assets.h
+++ b/include/hull/build_assets.h
@@ -14,10 +14,34 @@
 #include <stddef.h>
 
 /*
+ * Describes one arch-specific embedded platform archive.
+ * Used by multi-arch cosmo builds (HL_BUILD_EMBEDDED_MULTIARCH).
+ */
+typedef struct {
+    const char *arch;            /* e.g. "x86_64-cosmo", "aarch64-cosmo" */
+    const unsigned char *data;
+    unsigned int len;
+} HlEmbeddedPlatform;
+
+/*
  * Extract the embedded platform library to `dir/libhull_platform.a`.
+ * For multi-arch builds, extracts the first entry.
  * Returns 0 on success, -1 on error.
  */
 int hl_build_extract_platform(const char *dir);
+
+/*
+ * Get the list of embedded platform archives (multi-arch builds).
+ * Sets *out to the sentinel-terminated array.
+ * Returns the count (excluding sentinel), or 0 if not multi-arch.
+ */
+int hl_build_get_platforms(const HlEmbeddedPlatform **out);
+
+/*
+ * Extract a specific architecture's archive as `dir/libhull_platform.<arch>.a`.
+ * Returns 0 on success, -1 if arch not found or write error.
+ */
+int hl_build_extract_platform_arch(const char *dir, const char *arch);
 
 /*
  * Get the embedded app_main.c template (thin main() → hull_main() trampoline).

--- a/include/hull/cap/tool.h
+++ b/include/hull/cap/tool.h
@@ -135,6 +135,9 @@ int hl_tool_rmdir(const char *path, const HlToolUnveilCtx *ctx);
  *   tool.file_exists(path)        — check existence, return bool
  *   tool.stderr(msg)              — write to stderr
  *   tool.loadfile(path)           — load Lua chunk, return function or nil+err
+ *   tool.extract_platform(dir)    — extract embedded platform .a, return bool
+ *   tool.extract_platform_cosmo(dir) — extract multi-arch + .aarch64/ layout
+ *   tool.platform_archs()         — return table of embedded arch names or nil
  *   tool.cc                       — configured compiler (string field)
  *
  * The unveil context pointer is stored in the Lua registry for

--- a/tests/e2e_build.sh
+++ b/tests/e2e_build.sh
@@ -218,7 +218,7 @@ fi
 # Check binary size is reasonable (should be 1-10MB)
 if [ -f "$WORKDIR/myapp/myapp" ]; then
     SIZE=$(wc -c < "$WORKDIR/myapp/myapp" | tr -d ' ')
-    if [ "$SIZE" -gt 500000 ] && [ "$SIZE" -lt 10000000 ]; then
+    if [ "$SIZE" -gt 500000 ] && [ "$SIZE" -lt 20000000 ]; then
         pass "binary size reasonable (${SIZE} bytes)"
     else
         fail "binary size unexpected: $SIZE bytes"


### PR DESCRIPTION
## Summary
- Build both x86_64 and aarch64 platform archives via `make platform-cosmo` for cosmo fat APE binaries
- Embed both archives with `EMBED_PLATFORM=cosmo` and extract at `hull build` time using cosmocc's `.aarch64/` directory convention
- Fixes broken app binaries when a cosmo hull runs on aarch64 macOS with an x86_64-only embedded archive

## Test plan
- [ ] `make platform-cosmo` produces both arch-specific archives in `build/`
- [ ] `make CC=cosmocc` builds hull with dev-mode multi-arch support
- [ ] `make self-build CC=cosmocc` self-build chain works with multi-arch archives
- [ ] `make EMBED_PLATFORM=cosmo` embeds both archives in the hull binary
- [ ] Single-arch builds (`make platform && make EMBED_PLATFORM=1`) still work unchanged
- [ ] `hull eject` exports `.aarch64/` layout when multi-arch archives exist
- [ ] CI cosmo job passes with platform-cosmo + self-build