### PR TITLE
Actualize docs: README, CLAUDE.md, roadmap, audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,210 @@
 # Hull
 
-True digital freedom has arrived.
+Local-first application platform. Single binary, zero dependencies, runs anywhere.
+
+Write backend logic in Lua or JavaScript, frontend in HTML5, data in SQLite. `hull build` produces a single portable executable — under 2 MB — that runs on Linux, macOS, Windows, FreeBSD, OpenBSD, and NetBSD.
 
 ## Why
 
-AI coding assistants solved code generation. Millions of people can now describe software and have it built. But the output is always the same: a React frontend, a Node.js backend, a Postgres database, and a cloud deployment problem. The vibecoder swapped one dependency — coding skill — for another: the cloud. They don't own anything more than before. They just rent different things.
+AI coding assistants solved code generation. But the output is always the same: a React frontend, a Node.js backend, a Postgres database, and a cloud deployment problem. Hull is the missing piece. The AI writes Lua, `hull build` produces a single file. That file is the product. No cloud. No hosting. No dependencies.
 
-Hull is the missing piece. The AI writes Lua, `hull build` produces a single file. That file is the product. No cloud. No hosting. No dependencies. The developer owns it.
+Six vendored C libraries. One build command. One file. That's the entire stack.
 
-Never depend on hyperscalers. Never depend on cloud vendors, database vendors, deployment pipelines, the software supply chain, or even a specific LLM provider — bring your own model, local or cloud, any that writes Lua. Six vendored C libraries. One build command. One file. That's the entire stack.
+## Quick Start
 
-Your data lives in an encrypted-at-rest SQLite file. Copy it, back it up, move it — it's yours. And Hull itself is built with Hull. `hull eject` copies the build tool into your project. No vendor lock-in. Walk away anytime and maintain your own copy.
+```bash
+# Build hull
+make
+make test
 
-The person who receives that file can trust it. Every Hull app declares exactly what it can access — files, hosts, resources. The kernel enforces it. Ed25519 signatures prove integrity. `hull inspect` and [verify.gethull.dev](https://verify.gethull.dev) let anyone verify that what the app claims is what the app does. Verifiable by guarantees, auditable by design.
+# Create a new project
+./build/hull new myapp
+cd myapp
 
-## What
+# Run in development mode (hot reload)
+../build/hull dev app.lua
 
-Local-first application platform. Single binary, zero dependencies, runs anywhere.
+# Build a standalone binary
+../build/hull build -o myapp .
 
-Write backend logic in Lua, frontend in HTML5/JS, data in SQLite. `hull build` produces a single portable executable — under 2 MB — that runs on Linux, macOS, Windows, FreeBSD, OpenBSD, and NetBSD.
+# Run it
+./myapp -p 8080 -d app.db
+```
 
-## Start here
+## Hull Tools
 
-| You are | Read this |
-|---------|-----------|
-| A developer who wants to build with Hull | [MANIFESTO.md](MANIFESTO.md) — design, architecture, security model, standard library |
-| A developer who wants implementation details | [docs/MANIFESTO_FULL.md](docs/MANIFESTO_FULL.md) — full feature docs with C/Lua code examples |
-| Exploring whether Hull fits your use case | [PERSONAS.md](PERSONAS.md) — eight real-world personas and how Hull solves their problems |
-| An investor evaluating the opportunity | [INVESTORS.md](INVESTORS.md) — the problem, the product, economics, moat, risks |
+Hull ships 10 subcommands for the full development lifecycle:
 
-## What it does
+| Command | Purpose |
+|---------|---------|
+| `hull new <name>` | Scaffold a new project with example routes and tests |
+| `hull dev <app>` | Development server with hot reload |
+| `hull build -o <out> <dir>` | Compile app into a standalone binary |
+| `hull test <dir>` | In-process test runner (no TCP, memory SQLite) |
+| `hull inspect <dir>` | Display declared capabilities and signature status |
+| `hull verify [--developer-key <key>]` | Verify Ed25519 signatures and file integrity |
+| `hull eject <dir>` | Export to a standalone Makefile project |
+| `hull keygen <name>` | Generate Ed25519 signing keypair |
+| `hull sign-platform <key>` | Sign platform library with per-arch hashes |
+| `hull manifest <app>` | Extract and print manifest as JSON |
 
-- **Ship as a file.** One binary = the entire application. No installer, no runtime, no Docker, no cloud.
-- **Own your data.** SQLite file on the user's machine. Backup = copy a file.
-- **Built-in everything.** Routing, auth, RBAC, email, CSV, i18n, FTS, PDF, templates, validation, rate limiting, WebSockets, sessions, CSRF.
-- **Sandboxed.** Kernel sandbox (pledge/unveil) on Linux/OpenBSD. Windows App Container and macOS App Sandbox are on the roadmap. Lua sandbox is always in effect on all platforms.
-- **Own the business outcome.** Deploy it on your terms. License it on your terms. Built-in Ed25519 license key system for commercial distribution. Offline verification, no activation server. No platform takes a cut.
-- **Native speed when you need it.** Lua is faster than Python and Ruby for application logic — fast enough for HTTP handlers, business logic, and database queries. When you need more, optional WASM compute plugins let you write performance-critical code in C, Rust, or Zig. Sandboxed, gas-metered, no I/O — pure computation at near-native speed. Lua stays in control.
-- **AI-friendly.** Zero compilation — instant iteration speed. Lua is small, consistent, and LLMs generate it reliably. Errors include file, line, stack trace, and request context — piped straight to the LLM. The entire frontend and backend conversation is auditable, so you can steer the LLM to adhere to your specs. Ralph loop it, Gastown it, or just let your agentic tool harness do its job — Hull's zero-compilation feedback loop is built for autonomous iteration.
+### Build Pipeline
+
+```
+Source files (Lua/JS/HTML/CSS)
+        ↓
+hull build: collect → generate app_registry.c → compile → link → sign
+        ↓
+Single binary + package.sig (Ed25519 signed)
+```
+
+The build links against `libhull_platform.a` — a static archive containing Keel HTTP server, Lua 5.4, QuickJS, SQLite, mbedTLS, TweetNaCl, and the kernel sandbox. The platform library is signed separately with the gethull.dev key.
+
+### Cross-Platform Builds
+
+Hull supports three compiler targets:
+
+| Compiler | Target | Binary Type |
+|----------|--------|-------------|
+| `gcc` / `clang` | Linux | ELF |
+| `gcc` / `clang` | macOS | Mach-O |
+| `cosmocc` | Any x86_64/aarch64 | APE (Actually Portable Executable) |
+
+Cosmopolitan APE binaries run on Linux, macOS, Windows, FreeBSD, OpenBSD, and NetBSD from a single file. Hull builds multi-architecture platform archives (`make platform-cosmo`) so the resulting APE binary is a true fat binary for both x86_64 and aarch64.
 
 ## Architecture
 
-Six vendored C libraries, zero external dependencies. Built on [Cosmopolitan libc](https://github.com/jart/cosmopolitan) for cross-platform APE binaries.
+```
+┌─────────────────────────────────────────────┐
+│  Application Code (Lua / JS)                │  ← Developer writes this
+├─────────────────────────────────────────────┤
+│  Standard Library (stdlib/)                 │  ← json, session, jwt, csrf, auth
+├─────────────────────────────────────────────┤
+│  Runtimes (Lua 5.4 + QuickJS)              │  ← Sandboxed interpreters
+├─────────────────────────────────────────────┤
+│  Capability Layer (src/hull/cap/)           │  ← C enforcement boundary
+│  fs, db, crypto, time, env, http, tool      │
+├─────────────────────────────────────────────┤
+│  Hull Core                                  │  ← Manifest, sandbox, signatures
+├─────────────────────────────────────────────┤
+│  Keel HTTP Server (vendor/keel/)            │  ← Event loop + routing
+├─────────────────────────────────────────────┤
+│  Kernel Sandbox (pledge + unveil)           │  ← OS enforcement
+└─────────────────────────────────────────────┘
+```
+
+Each layer only talks to the one directly below it. Application code cannot bypass the capability layer.
+
+### Vendored Libraries
 
 | Component | Purpose |
 |-----------|---------|
-| [Keel](https://github.com/artalis-io/keel) | HTTP server (epoll/kqueue/io_uring/poll) |
-| [Lua 5.4](https://www.lua.org/) | Application scripting |
-| [SQLite](https://sqlite.org/) | Database |
-| [mbedTLS](https://github.com/Mbed-TLS/mbedtls) | TLS client |
-| [TweetNaCl](https://tweetnacl.cr.yp.to/) | Ed25519 signatures |
-| [pledge/unveil](https://github.com/jart/pledge) | Kernel sandbox |
-| [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime) | WebAssembly compute plugins *(optional)* |
+| [Keel](https://github.com/artalis-io/keel) | HTTP server (epoll/kqueue/io_uring/poll), routing, middleware, TLS vtable |
+| [Lua 5.4](https://www.lua.org/) | Application scripting (1.9x faster than QuickJS) |
+| [QuickJS](https://bellard.org/quickjs/) | ES2023 JavaScript runtime with instruction-count gas metering |
+| [SQLite](https://sqlite.org/) | Embedded database (WAL mode, parameterized queries) |
+| [mbedTLS](https://github.com/Mbed-TLS/mbedtls) | TLS client for outbound HTTPS |
+| [TweetNaCl](https://tweetnacl.cr.yp.to/) | Ed25519 signatures, XSalsa20+Poly1305, Curve25519 |
+| [pledge/unveil](https://github.com/jart/pledge) | Kernel sandbox (Linux seccomp/landlock) |
+
+## Security Model
+
+Hull apps declare a manifest of exactly what they can access — files, hosts, environment variables. The kernel enforces it.
+
+```lua
+app.manifest({
+    fs = { read = {"data/"}, write = {"data/uploads/"} },
+    env = {"PORT", "DATABASE_URL"},
+    hosts = {"api.stripe.com"}
+})
+```
+
+**Three verification points:**
+
+| When | Tool | Checks |
+|------|------|--------|
+| Before download | [verify.gethull.dev](https://verify.gethull.dev) (offline browser tool) | Platform sig, app sig, canary, manifest |
+| Before install | `hull verify --developer-key dev.pub` | Both signatures + file hashes |
+| At startup | `./myapp --verify-sig dev.pub` | Signatures verified before accepting connections |
+
+**Defense depth by platform:**
+
+| Platform | Kernel Sandbox | Violation | Static Binary |
+|----------|---------------|-----------|---------------|
+| Linux (gcc/clang) | seccomp-bpf + Landlock | SIGKILL | No |
+| Cosmopolitan APE | Native pledge/unveil | SIGKILL | Yes (no LD_PRELOAD) |
+| macOS | C-level validation only | Error return | No |
+
+See [docs/security.md](docs/security.md) for the full attack model and [docs/architecture.md](docs/architecture.md) for implementation details.
 
 ## Performance
 
-77,000–86,000 requests/sec on a single core with Lua or QuickJS scripting. ~15% overhead vs raw C (Keel baseline: 101,000 req/s). SQLite write-heavy routes sustain 19,000 req/s.
+77,000–86,000 requests/sec on a single core. ~15% overhead vs raw C (Keel baseline: 101,000 req/s). SQLite write-heavy routes sustain 19,000 req/s.
 
-See [docs/benchmark.md](docs/benchmark.md) for full results and methodology.
+| Route | Lua 5.4 | QuickJS |
+|-------|--------:|--------:|
+| GET /health (no DB) | 98,531 req/s | 52,263 req/s |
+| GET / (DB write + JSON) | 6,866 req/s | 4,588 req/s |
+| GET /greet/:name (params) | 102,204 req/s | 57,405 req/s |
+
+See [docs/benchmark.md](docs/benchmark.md) for methodology.
+
+## Examples
+
+Eight example apps in both Lua and JavaScript:
+
+| Example | What it demonstrates |
+|---------|---------------------|
+| [hello](examples/hello/) | Routing, query strings, route params, body echo |
+| [rest_api](examples/rest_api/) | CRUD API with JSON bodies |
+| [auth](examples/auth/) | Session-based authentication (register, login, logout) |
+| [jwt_api](examples/jwt_api/) | JWT Bearer authentication with refresh tokens |
+| [crud_with_auth](examples/crud_with_auth/) | Task CRUD with per-user isolation |
+| [middleware](examples/middleware/) | Request ID, logging, rate limiting, CORS |
+| [webhooks](examples/webhooks/) | Webhook delivery with HMAC-SHA256 signatures |
+| [bench_db](examples/bench_db/) | SQLite performance benchmarks |
+
+```bash
+# Run an example
+./build/hull -p 8080 -d /tmp/test.db examples/hello/app.lua
+
+# Run its tests
+./build/hull test examples/hello
+```
+
+## Documentation
+
+| Document | Content |
+|----------|---------|
+| [MANIFESTO.md](MANIFESTO.md) | Design philosophy, architecture, security model |
+| [docs/architecture.md](docs/architecture.md) | System layers, capability API, build pipeline |
+| [docs/security.md](docs/security.md) | Trust model, attack model, sandbox enforcement |
+| [docs/roadmap.md](docs/roadmap.md) | What's built, what's next |
+| [docs/benchmark.md](docs/benchmark.md) | Performance methodology and results |
+| [docs/keel_audit.md](docs/keel_audit.md) | Keel HTTP server C code audit report |
+| [CLAUDE.md](CLAUDE.md) | Development guide for contributors |
+
+## Building Hull
+
+```bash
+make                    # build hull binary
+make test               # run 79 unit tests
+make e2e                # end-to-end tests (all examples, both runtimes)
+make debug              # ASan + UBSan build
+make msan               # MSan + UBSan (Linux clang only)
+make check              # full validation (clean + ASan + test + e2e)
+make analyze            # Clang static analyzer
+make cppcheck           # cppcheck static analysis
+make platform           # build libhull_platform.a
+make platform-cosmo     # build multi-arch cosmo platform archives
+make self-build         # reproducible build verification (hull→hull2→hull3)
+make CC=cosmocc         # build with Cosmopolitan (APE binary)
+make clean              # remove all build artifacts
+```
 
 ## Status
 
-Hull is in active development.
+Hull is in active development. All core features are implemented and tested across Linux, macOS, and Cosmopolitan APE. See [docs/roadmap.md](docs/roadmap.md) for what's next.
 
 ## License
 

--- a/docs/keel_audit.md
+++ b/docs/keel_audit.md
@@ -1,0 +1,135 @@
+# Keel HTTP Server — C Code Audit Report
+
+**Date:** 2026-03-01
+**Auditor:** Claude Code (`/c-audit`)
+**Keel version:** `464fab8` (vendor/keel submodule)
+**Files scanned:** 47 (16 src, 17 headers, 1 parser, 13 test suites)
+**Total lines of code:** ~13,550
+**Test count:** 229 unit tests across 13 suites
+
+## Summary
+
+| Severity | Count |
+|----------|------:|
+| Critical | 2 |
+| High | 5 |
+| Medium | 8 |
+| Low | 7 |
+| Informational | 4 |
+
+---
+
+## Critical Issues
+
+| # | File:Line | Issue | Suggested Fix |
+|---|-----------|-------|---------------|
+| C-1 | `src/event_kqueue.c:28-49` | **kqueue `kl_event_mod` does not support READ\|WRITE bitmask.** The if/else treats the mask as either READ or WRITE, never both. When `server.c:395` passes `KL_EVENT_READ | KL_EVENT_WRITE` for HTTP/2 connections, the WRITE filter is incorrectly disabled. Stalls HTTP/2 write flushing on macOS. | Add a branch for `(mask & KL_EVENT_READ) && (mask & KL_EVENT_WRITE)` that enables both kevent filters. |
+| C-2 | `src/websocket.c:220-226` | **WebSocket `ws_send_frame` does not handle partial writes.** `conn_write()` may return fewer bytes on non-blocking sockets (especially TLS WANT_WRITE). Header short-write causes payload to proceed at wrong offset, corrupting the frame. | Use `writev_all()` from response.c, or implement a write-retry loop for header+payload. |
+
+## High Issues
+
+| # | File:Line | Issue | Suggested Fix |
+|---|-----------|-------|---------------|
+| H-1 | `src/event_poll.c:49-71` | **`grow_arrays()` inconsistent state on partial failure.** If `kl_realloc` for `udata` fails after `fds` succeeded, `st->fds` points to new allocation but `st->capacity` is stale. Next `kl_free` gets wrong size. | Save old fds pointer; on udata failure, revert fds or update capacity. |
+| H-2 | `src/tls_mbedtls.c:281` | **`read_file()` uses raw `malloc`/`free`.** Key material in `key_buf` is freed without zeroing. Private key residue remains in heap. | Add `explicit_bzero(key_buf, key_len)` before `free(key_buf)`. |
+| H-3 | `src/h2.c:509-511` | **HTTP/2 101 upgrade `conn_write` does not handle partial writes.** Short write on non-blocking socket corrupts protocol stream. | Use write-all loop or buffer for event loop completion. |
+| H-4 | `src/websocket.c:376-377` | **WebSocket 101 handshake same partial-write issue.** | Same fix as H-3. |
+| H-5 | `src/response.c:246-273` | **`writev_all` plaintext spin loop on EAGAIN.** `KL_WRITE_SPIN_MAX = 65536` busy-spins when kernel buffer is full, blocking all connections on this event loop tick. | Return partial-write indication and let event loop re-arm for `KL_EVENT_WRITE`, or reduce spin limit significantly. |
+
+## Medium Issues
+
+| # | File:Line | Issue | Suggested Fix |
+|---|-----------|-------|---------------|
+| M-1 | `src/server.c:180` | **`signal(SIGPIPE, SIG_IGN)` is process-global.** Affects all threads/libraries. | Use `MSG_NOSIGNAL`/`SO_NOSIGPIPE` per-socket, or document requirement. |
+| M-2 | `src/response.c:60-73` | **`format_uint` buffer `tmp[20]` has zero margin for 64-bit max (20 digits).** | Use `tmp[21]` or add `_Static_assert(sizeof(size_t) <= 8)`. |
+| M-3 | `src/connection.c:339-340` | **`memcpy` of params does not locally validate `num_params` against `KL_MAX_PARAMS`.** Relies on router invariant. | Add `if (c->num_params > KL_MAX_PARAMS) c->num_params = KL_MAX_PARAMS;` before memcpy. |
+| M-4 | `src/tls_mbedtls.c:336-338` | **Static RNG personalization `"keel-tls"`.** Identical for all instances, reduces entropy diversity. | Append PID or timestamp to personalization string. |
+| M-5 | `src/connection.c:34-39` | **`kl_monotonic_ms()` returns 0 on failure.** Causes immediate timeout for all connections. | Return previous known-good value, or treat 0 as sentinel. |
+| M-6 | `src/body_reader_buffer.c:58` | **`(size_t)user_data` pointer-to-integer round-trip.** Implementation-defined on `sizeof(void*) < sizeof(size_t)` platforms. | Use `(uintptr_t)` cast or config struct pointer. |
+| M-7 | `src/cors.c:129` | **`snprintf` in hot request path** for CORS `max_age_seconds`. | Use `format_uint` helper or static lookup table. |
+| M-8 | `src/response.c:224-242` | **`kl_sendfile_impl` fallback does not handle partial `write()`.** | Wrap in retry loop for short writes / EAGAIN. |
+
+## Low Issues
+
+| # | File:Line | Issue | Suggested Fix |
+|---|-----------|-------|---------------|
+| L-1 | `src/event_kqueue.c:47` | **`kevent` return value unchecked in `kl_event_mod`.** | Check return value, return -1 on failure. |
+| L-2 | `src/event_kqueue.c:55` | **`kevent` return value unchecked in `kl_event_del`.** | Same as L-1. |
+| L-3 | `src/router.c:186-195` | **`strlen()` on route method/pattern on every match** (constant strings). | Cache `method_len`/`pattern_len` in `KlRoute` at registration. |
+| L-4 | `src/router.c:166-167` | **`strlen()` on middleware pattern on every request.** | Cache `pattern_len` in `KlMiddlewareEntry`. |
+| L-5 | `src/server.c:24` | **`kl_signal_server` global atomic supports only one server instance.** | Document limitation or maintain server list. |
+| L-6 | `src/response.c:189-192` | **`kl_response_header` silently drops headers on alloc failure.** Partial writes not rolled back. | Check each `hdr_append` return and roll back or set error flag. |
+| L-7 | `include/keel/request.h:51-61` | **`kl_request_header` returns non-null-terminated pointer.** Users may pass to `strcmp` causing OOB read. | Rename to `_raw` or deprecate in favor of `kl_request_header_len`. |
+
+## Informational Notes
+
+| # | File | Note |
+|---|------|------|
+| I-1 | `src/tls_mbedtls.c` | Raw `malloc`/`free` usage is intentional (documented lines 303-308). Startup-only, outside KlAllocator lifecycle. Key scrubbing (H-2) should still be added. |
+| I-2 | `Makefile` | Build hardening is solid: `-Wall -Wextra -Wpedantic -Wshadow -Wformat=2 -Werror -fstack-protector-strong`. Debug with ASan+UBSan. Fuzz with both sanitizers. Cosmo correctly omits `-fstack-protector-strong`. |
+| I-3 | `parsers/parser_llhttp.c:121-127` | Request smuggling mitigation present: `Transfer-Encoding: chunked` zeroes `Content-Length` (RFC 7230 §3.3.3). |
+| I-4 | `src/response.c:177-180` | Header injection guard present: `contains_crlf()` rejects names/values with `\r`/`\n`. |
+
+## Build Hardening
+
+| Feature | Status |
+|---------|--------|
+| `-Wall -Wextra -Wpedantic -Werror` | Present |
+| `-Wshadow -Wformat=2` | Present |
+| `-fstack-protector-strong` | Present (non-Cosmo) |
+| ASan + UBSan debug build | `make debug` |
+| Fuzz testing (libFuzzer) | 2 targets (parser + multipart) |
+| Static analysis | `scan-build` + `cppcheck` |
+| Vendor code isolation | Separate `VENDOR_CFLAGS` with `-w` |
+
+## Test Coverage
+
+| Module | Tests | Notes |
+|--------|------:|-------|
+| allocator | 4 | Basic alloc/free/realloc, custom allocator |
+| router | 21 | Params, matching, HEAD fallback, middleware, prefixes |
+| parser (llhttp) | 9 | Parsing, headers, body, keep-alive |
+| response | 14 | Status lines, headers, body modes, streaming, injection guard |
+| body_reader | 30 | Growth, limits, multipart state machine, boundary spanning |
+| chunked | 17 | Basic, extensions, trailers, overflow, boundary split |
+| cors | 17 | All middleware paths, preflight, credentials |
+| connection | 4 | Pool init/acquire/release, pool full |
+| timeout | 4 | Timeout sweep, body timeout |
+| tls | 20 | Vtable validation, mbedTLS lifecycle, handshake states |
+| websocket | 38 | Frame parser, SHA-1, base64, UTF-8, fragmentation, close |
+| h2 | 29 | Streams, callbacks, request lifecycle, header extraction |
+| integration | 22 | End-to-end with real server |
+| **Total** | **229** | |
+
+### Coverage Gaps
+
+1. No unit tests for event loop backends (`event_epoll.c`, `event_kqueue.c`, `event_poll.c`, `event_iouring.c`) — only indirect via integration tests
+2. No test for `kl_event_mod` with `READ|WRITE` bitmask (the C-1 kqueue bug)
+3. No test for `writev_all` partial write / EAGAIN handling (H-5)
+4. No test for `kl_sendfile_impl` fallback partial write (M-8)
+5. No test for WebSocket partial write scenarios (C-2)
+6. No fuzz target for WebSocket frame parser
+7. No test for `kl_monotonic_ms` failure path (M-5)
+
+## Recommendations
+
+### Immediate (Critical/High)
+
+1. Fix kqueue `kl_event_mod` READ|WRITE bitmask (C-1) — actively breaks HTTP/2 on macOS
+2. Fix WebSocket `ws_send_frame` partial writes (C-2) — corrupts frames on non-blocking sockets
+3. Fix all `conn_write` call sites expecting complete writes (H-3, H-4)
+4. Scrub private key material before free (H-2) — `explicit_bzero` in tls_mbedtls.c
+5. Fix `grow_arrays` partial failure in event_poll.c (H-1)
+
+### Short-term (Medium)
+
+6. Add WebSocket fuzz target
+7. Add event loop unit tests for combined READ|WRITE mask
+8. Replace process-global `signal(SIGPIPE, SIG_IGN)` with per-socket suppression (M-1)
+9. Add defensive `num_params` bounds check before memcpy (M-3)
+
+### Long-term (Low/Performance)
+
+10. Cache `strlen` results for route patterns at registration time (L-3, L-4)
+11. Refactor `writev_all` to return partial progress instead of busy-spinning (H-5)
+12. Deprecate `kl_request_header` in favor of `kl_request_header_len` (L-7)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,203 +1,126 @@
-# Hull — Roadmap & Benchmarks
+# Hull — Roadmap
 
 ## What's Built
 
-- Lua 5.4 + QuickJS runtimes with HTTP route dispatch
-- SQLite with parameterized queries (injection-proof)
-- Request body reading + route parameter extraction
-- Crypto: SHA-256, SHA-512, PBKDF2, HMAC-SHA256, base64url, random bytes, password hash/verify, Ed25519 (sign/verify/keypair), secretbox, box
-- Filesystem: sandboxed read/write/exists/delete
-- Time, env, logging modules
-- Keel HTTP server (epoll/kqueue/poll)
-- Cosmopolitan APE cross-platform builds
-- CI pipeline (Linux, macOS, ASan, MSan, static analysis, Cosmo) + benchmarks
-- Tool hardening: shell-free `tool.spawn` with compiler allowlist, `tool.find_files`, `tool.copy`, `tool.rmdir` with unveil path validation
-- Command module architecture: table-driven dispatcher (`src/hull/commands/`)
-- `hull test` subcommand: in-process test runner for Lua and JS apps (no TCP, direct router dispatch)
-- JS manifest parity: `app.manifest()` + sandbox enforcement for QuickJS apps
-- Middleware `req.ctx` persistence: JSON-serialized context passing between middleware and handlers
-- Auth stdlib: `hull.cookie`, `hull.session`, `hull.jwt`, `hull.csrf`, `hull.auth` (Lua + JS)
-- Cosmo sandbox test coverage: `sandbox_violation.c` compiles/runs under cosmocc
-- Self-build chain: `make self-build` proves hull→hull2→hull3 reproducibility
+### Core Platform
+- Dual-runtime support: Lua 5.4 + QuickJS (ES2023), one active per app
+- Keel HTTP server (epoll/kqueue/io_uring/poll) with route params and middleware
+- SQLite with WAL mode, parameterized queries, prepared statement cache, performance PRAGMAs
+- Request body reading, multipart/form-data, chunked transfer-encoding
+- WebSocket support (text, binary, ping/pong, close)
+- HTTP/2 support (h2c upgrade)
+
+### Capabilities (C enforcement layer)
+- **Crypto:** SHA-256, SHA-512, HMAC-SHA256, HMAC-SHA512/256, PBKDF2, base64url, random bytes, password hash/verify, Ed25519 (sign/verify/keypair), XSalsa20+Poly1305 secretbox, Curve25519 box
+- **Filesystem:** Sandboxed read/write/exists/delete with path traversal rejection, symlink escape prevention
+- **Database:** Query/exec with parameterized binding, batch transactions, statement cache
+- **HTTP client:** Outbound HTTP/HTTPS with host allowlist enforcement (mbedTLS)
+- **Environment:** Allowlist-enforced env var access
+- **Time:** now, now_ms, clock, date, datetime
+
+### Standard Library (Lua + JS)
+- `hull.json` — canonical JSON encode/decode (sorted keys for deterministic signatures)
+- `hull.cookie` — cookie parsing and serialization with secure defaults
+- `hull.session` — server-side SQLite-backed sessions with sliding expiry
+- `hull.jwt` — JWT HS256 sign/verify/decode (no "none" algorithm, constant-time comparison)
+- `hull.csrf` — stateless CSRF tokens via HMAC-SHA256
+- `hull.auth` — authentication middleware factories (session auth, JWT Bearer auth)
+
+### Build & Deployment
+- `hull build` — compile Lua/JS apps into standalone binaries
+- `hull new` — project scaffolding with example routes and tests
+- `hull dev` — development server with hot reload
+- `hull test` — in-process test runner (no TCP, memory SQLite, both runtimes)
+- `hull eject` — export to standalone Makefile project
+- `hull inspect` — display capabilities and signature status
+- `hull verify` — dual-layer Ed25519 signature verification
+- `hull keygen` — Ed25519 keypair generation
+- `hull sign-platform` — sign platform libraries with per-arch hashes
+- `hull manifest` — extract and print manifest as JSON
+- Multi-arch Cosmopolitan APE builds (`make platform-cosmo`)
+- Self-build reproducibility chain (hull → hull2 → hull3)
+
+### Security
+- Kernel sandbox: pledge/unveil on Linux (seccomp-bpf + landlock) and Cosmopolitan
+- Manifest-driven capability declaration and enforcement
+- Dual-layer Ed25519 signatures (platform + app)
+- Platform canary with integrity hash
+- Browser verifier (offline, zero-dependency HTML tool)
+- Runtime startup verification (`--verify-sig`)
+- Shell-free tool mode with compiler allowlist
+- Lua sandbox (removed io/os/load, memory limit, custom allocator)
+- QuickJS sandbox (removed eval/std/os, memory limit, instruction-count gas metering)
+
+### CI/CD
+- Linux, macOS, Cosmopolitan APE builds
+- ASan + UBSan, MSan + UBSan sanitizer runs
+- Static analysis (scan-build + cppcheck)
+- Code coverage
+- E2E tests for all 8 examples in both runtimes
+- Sandbox violation tests (Linux + Cosmo)
+- Benchmarks (Lua vs QuickJS, DB vs non-DB routes)
 
 ## Roadmap
 
-### High Impact — Unlocks Real Apps
+### Next — Standard Library Expansion
 
-1. ~~**JSON module** — `json.encode()` / `json.decode()`~~ ✓
-2. **HTTP client** — `http.get()` / `http.post()` (cap declared, not wired)
-3. ~~**Session + CSRF** — cookie sessions, CSRF tokens~~ ✓ (hull.cookie, hull.session, hull.jwt, hull.csrf, hull.auth)
-4. **Template engine** — `{{ }}` HTML templates
-5. **Validation** — input schema validation
-6. **Rate limiting** — middleware
-7. **Static file serving** — `app.static("/public")`
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Template engine (`{{ }}` HTML templates) | Planned | Server-side rendering |
+| Input validation (schema-based) | Planned | Declarative field validation |
+| Rate limiting middleware | Planned | Token bucket or sliding window |
+| Static file serving (`app.static("/public")`) | Planned | With caching headers |
+| CSV encode/decode (RFC 4180) | Planned | Import/export |
+| FTS5 search wrapper | Planned | Full-text search stdlib |
+| i18n (locale detection + translations) | Planned | Message bundles |
+| RBAC (role-based access control) | Planned | Permission middleware |
+| Email (SMTP / API) | Planned | Outbound notifications |
+| License key system | Planned | Ed25519 offline verification for commercial distribution |
 
-### Medium Impact — Production Features
+### Future — Advanced Features
 
-8. **Email** — SMTP / API providers (cap declared, not wired)
-9. **Search** — FTS5 wrapper
-10. **CSV** — RFC 4180 encode/decode
-11. **RBAC** — role-based access control
-12. **i18n** — locale detection + translations
-13. **PDF** — document builder
-14. **Multipart / file uploads**
-15. **WebSockets**
-16. **Scheduled tasks** — `app.every()`, `app.daily()`
+| Feature | Status | Notes |
+|---------|--------|-------|
+| WASM compute plugins (WAMR) | Architecture designed | Sandboxed, gas-metered, no I/O — pure computation |
+| Database encryption at rest | Planned | SQLite SEE or custom VFS |
+| Background work / coroutines | Planned | `app.every()`, `app.daily()` |
+| Compression (gzip/zstd) | [Plan](compression_plan.md) | Response compression middleware |
+| ETag support | [Plan](etag_plan.md) | Conditional request handling |
+| HTTP/2 full support | [Plan](http2_plan.md) | Currently h2c upgrade only |
+| PDF document builder | Planned | Report generation |
 
-### Build Pipeline & Security — MVP Roadmap
+### Phase 9 — Trusted Rebuild Infrastructure
 
-**Phase 1: TweetNaCl + Ed25519** ✓
-- [x] Vendor `tweetnacl.c` + `tweetnacl.h` (770 lines, public domain) to `vendor/tweetnacl/`
-- [x] Implement `hl_cap_crypto_ed25519_verify()` in `crypto.c` (replace stub)
-- [x] Add `hl_cap_crypto_ed25519_sign()` in `crypto.c`
-- [x] Add `hl_cap_crypto_ed25519_keypair()` in `crypto.c`
-- [x] All TweetNaCl calls wrapped behind `hl_cap_crypto_*` — only `crypto.c` includes `tweetnacl.h`
-- [x] Expose to Lua: `crypto.ed25519_sign()`, `crypto.ed25519_verify()`, `crypto.ed25519_keypair()`
-- [x] Add tweetnacl.o to Makefile VENDOR_OBJS
-
-**Phase 2: Manifest System** ✓
-- [x] Add `app.manifest(table)` in `modules.c` — stores in `__hull_manifest` registry key
-- [x] Add `app.get_manifest()` — retrieves stored manifest table
-- [x] Create `include/hull/manifest.h` — HlManifest struct
-- [x] Create `src/hull/manifest.c` — `hl_manifest_extract()` reads Lua registry → C struct
-- [x] Wire manifest extraction into `main.c` (logging manifest contents after app load)
-
-**Phase 3: Subcommand Routing + Tool Mode** ✓
-- [x] Extract existing server logic into `hull_serve()`
-- [x] Add subcommand dispatch: `build`, `verify`, `inspect`, `manifest`, `keygen`
-- [x] Create `include/hull/tool.h` + `src/hull/tool.c` — tool mode Lua VM (unsandboxed)
-- [x] Add `int sandbox` flag to `HlLuaConfig` (default: 1)
-- [x] Implement `hull_keygen()` — pure C Ed25519 keypair generation
-- [x] Pass CLI args as Lua `arg` global table
-
-**Phase 4: Platform Library Embedding** ✓
-- [x] New Makefile target: `libhull_platform.a` (3.2MB, all .o except main/tool/build_assets)
-- [x] `make EMBED_PLATFORM=1` — xxd .a + templates into build_assets.c
-- [x] Create `src/hull/build_assets.c` + `include/hull/build_assets.h` — extraction API
-- [x] Create `templates/app_main.c` — main() → hull_main() trampoline
-- [x] Create `templates/entry.h` — HlStdlibEntry type definition
-- [x] Replace `#ifdef HL_APP_EMBEDDED` with default/override pattern for `hl_app_lua_entries`
-- [x] Create `src/hull/app_entries_default.c` — empty sentinel array
-
-**Phase 5: Lua Build/Verify/Inspect/Manifest Scripts** ✓
-- [x] Create `stdlib/lua/hull/manifest.lua` — extract + print manifest as JSON
-- [x] Create `stdlib/lua/hull/build.lua` — full build + sign:
-  - Extract platform .a, collect app files, generate app_registry.c (xxd in Lua)
-  - Generate app_main.c from template, invoke CC, link, sign
-- [x] Create `stdlib/lua/hull/verify.lua` — app + platform signature verification
-- [x] Create `stdlib/lua/hull/inspect.lua` — display capabilities + signature status
-- [x] Define `hull.sig` JSON format (version, files, manifest, signature, public_key)
-- [x] Rename `main()` → `hull_main()` (exported from platform .a); thin entry.c for hull binary
-- [x] Canonical JSON encoding (sorted keys) for deterministic signatures
-
-**Phase 6: pledge/unveil Sandbox** ✓
-- [x] Vendor jart/pledge polyfill for Linux (seccomp-bpf + landlock)
-- [x] Create `include/hull/sandbox.h` + `src/hull/sandbox.c` — platform-dispatching sandbox
-- [x] Derive pledge promises from manifest (fs → rpath/wpath, hosts → inet/dns)
-- [x] Call unveil/pledge in `main.c` after manifest extraction, before event loop
-- [x] No-op on macOS (C-level validation handles it); native on Cosmopolitan builds
-- [x] E2E sandbox tests + standalone violation test for CI
-
-**Phase 7: Post-MVP Hardening** ✓
-
-Phase 7a: Cosmo sandbox test coverage ✓
-- [x] Add `__COSMOPOLITAN__` code path to `tests/sandbox_violation.c` (extern decls for pledge/unveil)
-- [x] Refactor platform detection: `SANDBOX_SUPPORTED` + `HAS_PLEDGE_MODE` macros
-- [x] Update `tests/e2e_sandbox.sh` to compile violation test with cosmocc (no polyfill objects needed)
-
-Phase 7b: QuickJS manifest parity ✓
-- [x] Add `app.manifest(obj)` + `app.getManifest()` to JS `hull:app` module (`src/hull/runtime/js/modules.c`)
-- [x] Add `hl_manifest_extract_js()` to `src/hull/manifest.c` — read `globalThis.__hull_manifest` into HlManifest
-- [x] Wire manifest extraction + sandbox into `main.c` QuickJS path (after `wire_js_routes`, before event loop)
-- [x] Unit tests in `tests/hull/runtime/js/test_js.c`, extend `e2e_sandbox.sh` for JS manifest app
-
-Phase 7c: Tool mode hardening ✓
-- [x] Shell-free `tool.spawn(argv)` with compiler allowlist (cc, gcc, clang, cosmocc, cosmoar, ar) — no `system()`/`popen()`
-- [x] `tool.find_files(dir, pattern)` — pure C recursive `opendir`/`fnmatch`, skips dotdirs/vendor/node_modules
-- [x] `tool.copy(src, dst)`, `tool.rmdir(path)` — pure C, no shell
-- [x] Unveil path validation on all filesystem tool functions (mandatory, not optional)
-- [x] Configurable compiler via `tool.cc` (default: `cosmocc`, overridable with `--cc`)
-- [x] Removed `tool.exec()` and `tool.read()` entirely
-- [x] Migrated `build.lua` to shell-free tool API
-- [x] Unit tests: `tests/hull/cap/test_tool.c` (allowlist, find_files, copy, rmdir, unveil enforcement)
-
-Phase 7d: Self-build test ✓
-- [x] Create `tests/fixtures/null_app/app.lua` (minimal fixture)
-- [x] Add `make self-build` target: hull→hull2→hull3, verify keygen at each step
-- [x] Add Step 13 to `tests/e2e_build.sh`: self-build chain test
-
-Phase 7e: Command module architecture ✓
-- [x] Table-driven dispatcher in `src/hull/commands/dispatch.c` — one line per command
-- [x] Each command in its own `.c`/`.h` under `src/hull/commands/` (keygen, build, verify, inspect, manifest, test)
-- [x] `hull_main()` reduced to `hl_command_dispatch()` + fallback to `hull_serve()`
-- [x] Unit tests: `tests/hull/commands/test_dispatch.c`
-
-Phase 7f: `hull test` subcommand ✓
-- [x] In-process test runner — no TCP, no pipes, direct `kl_router_match` + handler dispatch
-- [x] Supports both Lua (`test_*.lua`) and JS (`test_*.js`) test files
-- [x] Recursive test discovery via `hl_tool_find_files()`
-- [x] `test("desc", fn)` registration + `test.get/post/put/delete/patch` HTTP dispatch
-- [x] `test.eq(a, b)`, `test.ok(val)`, `test.err(fn, pattern)` assertions
-- [x] `:memory:` SQLite for test isolation
-- [x] Refactored route wiring out of `main.c` into `runtime/lua.h` and `runtime/js.h`
-- [x] Unit tests: `tests/hull/cap/test_test.c` (planned)
-
-**Phase 8: Dual-Layer Signature Verification** ✓
-- [x] Dual-layer `package.sig` format: platform signature (inner) + app signature (outer)
-- [x] `--verify-sig pubkey.pub` CLI flag: verify both layers on startup, refuse to start if invalid
-- [x] Platform canary: `HULL_PLATFORM_CANARY` magic + integrity hash in binary
-- [x] Browser verifier (`verify/index.html`): offline Ed25519 + SHA-256, canary scanner
-- [x] `hull sign-platform` subcommand: sign platform libraries with per-arch hashes
-- [x] Platform public key pinning: hardcoded in CLI + browser tool
-
-**Phase 9: Trusted Rebuild Infrastructure**
 - [ ] Reproducible build verification service at `api.gethull.dev/ci/v1`
-- [ ] Build metadata attestation: `cc_version` + `flags` recorded in `package.sig`
-- [ ] Binary hash comparison: rebuild from source, compare against signed `binary_hash`
-- [ ] "Reproducible Build Verified" badge for passing apps
+- [ ] Build metadata attestation: `cc_version` + `flags` in `package.sig`
+- [ ] Binary hash comparison: rebuild from source, compare against signed hash
+- [ ] "Reproducible Build Verified" badge
 - [ ] Self-hosted rebuild: run your own service, pin your own platform key
 
-Hull's architecture makes reproducible builds achievable now:
+Hull's architecture makes reproducible builds achievable:
 
-1. **App developers cannot write C** — only Lua/JS source, HTML/CSS/JS static assets, WASM plugins
-2. **Platform binary is hash-pinned** — `platform.sig` locks the exact `libhull_platform.a` bytes
-3. **Trampoline is deterministic** — generated from template + app registry, hash in `package.sig`
-4. **Cosmopolitan produces deterministic output** — static linking, no ASLR, no timestamps
-5. **Build metadata is signed** — `cc_version` + `flags` in `package.sig`, attested by developer
+1. App developers cannot write C — only Lua/JS source
+2. Platform binary is hash-pinned — `platform.sig` locks exact bytes
+3. Trampoline is deterministic — generated from template + app registry
+4. Cosmopolitan produces deterministic output — static linking, no timestamps
+5. Build metadata is signed — `cc_version` + `flags` attested by developer
 
-Trusted rebuild flow:
-```
-Developer submits: source files + manifest + signing key
-                            ↓
-api.gethull.dev/ci/v1:
-  1. Verify source hashes match package.sig
-  2. Rebuild with recorded cc_version + flags
-  3. Compare binary_hash
-  4. If match → "Reproducible Build Verified" badge
-  5. If mismatch → flag for investigation
-```
+### Keel HTTP Server — Audit Backlog
 
-A passing reproducible build check proves the developer **could not have** injected custom native code. The binary is provably just "Hull platform + declared source files."
+The [Keel C audit](keel_audit.md) identified issues to address upstream:
 
-### Build Tool — Future Enhancements
-
-- [ ] `hull new` — project scaffolding
-- [ ] `hull dev` — hot-reload development server
-- [x] `hull test` — in-process test runner (Lua + JS)
-- [ ] License key system (Ed25519 offline verification)
-- [ ] Database backup/restore
-- [ ] `hull eject` — export to standalone Makefile project
-
-### Advanced
-
-- [ ] WASM compute plugins (WAMR)
-- [ ] Database encryption at rest
-- [ ] Background work / coroutines
+| Priority | Issue | Impact |
+|----------|-------|--------|
+| Critical | kqueue READ\|WRITE bitmask (C-1) | HTTP/2 broken on macOS |
+| Critical | WebSocket partial writes (C-2) | Frame corruption on non-blocking sockets |
+| High | Protocol upgrade partial writes (H-3, H-4) | 101 response corruption |
+| High | Private key material not zeroed (H-2) | Key residue in heap |
+| High | writev_all busy-spin on EAGAIN (H-5) | Event loop starvation |
+| Medium | Add WebSocket fuzz target | Attack surface coverage gap |
 
 ## Benchmark Baseline
 
 Measured on GitHub Actions Ubuntu runner (2 threads, 50 connections, 5s duration via `wrk`).
-Commit: `f1e3996` (2026-02-26).
 
 ### GET /health (no DB — pure runtime overhead)
 
@@ -220,8 +143,4 @@ Commit: `f1e3996` (2026-02-26).
 | Lua 5.4 | 102,204 | 485 us | 6.98 ms |
 | QuickJS | 57,405 | 870 us | 7.71 ms |
 
-### Summary
-
-- Lua is ~1.9x faster than QuickJS across all benchmarks.
-- Non-DB routes sustain 50k-100k req/s on a single CI VM core with sub-millisecond average latency.
-- DB-bound routes (SQLite write per request) sustain 5k-7k req/s.
+Lua is ~1.9x faster than QuickJS. Non-DB routes sustain 50k–100k req/s on a single CI VM core.

--- a/docs/security.md
+++ b/docs/security.md
@@ -331,7 +331,31 @@ Run your own rebuild service. Pin your own platform key. Your customers trust yo
 
 ---
 
-## 8. Known Limitations
+## 8. Keel HTTP Server Audit
+
+The Keel HTTP server library (vendored at `vendor/keel/`) has been audited for memory safety, input validation, resource management, and network security. Full report: [keel_audit.md](keel_audit.md).
+
+**Key findings relevant to security:**
+
+| Severity | Issue | Impact |
+|----------|-------|--------|
+| Critical | kqueue `kl_event_mod` doesn't handle READ\|WRITE bitmask | HTTP/2 write starvation on macOS |
+| Critical | WebSocket `ws_send_frame` partial writes | Frame corruption on non-blocking sockets |
+| High | HTTP/2 and WebSocket 101 upgrade partial writes | Protocol stream corruption |
+| High | TLS private key material not zeroed before free | Key residue in heap memory |
+| Informational | Request smuggling mitigation present | `Transfer-Encoding: chunked` zeroes `Content-Length` (RFC 7230 §3.3.3) |
+| Informational | Header injection guard present | `contains_crlf()` rejects `\r`/`\n` in header names/values |
+
+**Build hardening verified:**
+- `-Wall -Wextra -Wpedantic -Wshadow -Wformat=2 -Werror` in production
+- `-fstack-protector-strong` (non-Cosmopolitan builds)
+- ASan + UBSan debug build (`make debug`)
+- Two libFuzzer targets (HTTP parser + multipart parser)
+- 229 unit tests across 13 suites
+
+---
+
+## 9. Known Limitations
 
 These are real, not theoretical:
 


### PR DESCRIPTION
## Summary

- Rewrite README with detailed Hull tools guide, build pipeline diagram, cross-platform builds, security model, and examples index
- Rewrite CLAUDE.md with comprehensive cosmo build guide (`.aarch64/` convention, `COSMO_FAT`, embedding), capability invariants, `/c-audit` reference
- Actualize roadmap: expand "What's Built" section, remove completed phase checklists, add Keel audit backlog
- Add multi-arch Cosmopolitan build section to architecture docs
- Add Keel HTTP server audit reference to security docs
- Add full Keel C code audit report (`docs/keel_audit.md`) — 47 files scanned, 2 Critical, 5 High, 8 Medium findings

## Test plan

- [ ] Verify all doc links resolve correctly
- [ ] Verify build commands in README work