### PR TITLE
Fix tool sandbox unveil paths for Cosmopolitan builds

### DIFF
--- a/src/hull/sandbox.c
+++ b/src/hull/sandbox.c
@@ -82,7 +82,7 @@ int hl_tool_sandbox_init(HlToolUnveilCtx *ctx,
     /* System compilers and headers */
     hl_tool_unveil_add(ctx, "/usr", "rx");
 
-#ifdef __linux__
+#if defined(__COSMOPOLITAN__) || defined(__linux__)
     hl_tool_unveil_add(ctx, "/lib", "r");
     hl_tool_unveil_add(ctx, "/lib64", "r");
 #endif
@@ -108,7 +108,7 @@ int hl_tool_sandbox_init(HlToolUnveilCtx *ctx,
         if (app_dir)     unveil(app_dir, "r");
         unveil("/tmp", "rwc");
         unveil("/usr", "rx");
-#ifdef __linux__
+#if defined(__COSMOPOLITAN__) || defined(__linux__)
         unveil("/lib", "r");
         unveil("/lib64", "r");
 #endif


### PR DESCRIPTION
## Summary
- Add `__COSMOPOLITAN__` guard alongside `__linux__` for `/lib` and `/lib64` unveil paths in the tool sandbox
- Without this, cosmocc-built hull binaries miss these paths because cosmocc defines `__COSMOPOLITAN__` instead of `__linux__`
- Affects both the C-level `HlToolUnveilCtx` and kernel-level `unveil()` calls

## Test plan
- [x] `make && make test` passes (79 tests)
- [ ] CI passes on all platforms