### PR TITLE
Add CSP headers, default-deny sandbox, one-shot manifest

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,7 +72,7 @@ The server startup sequence:
 8. Verify app signature if `--verify-sig` provided
 9. Wire routes from runtime into Keel router (`rt->vt->wire_routes_server`)
 10. Extract manifest from runtime (`rt->vt->extract_manifest`)
-11. Apply kernel sandbox based on manifest (`hl_sandbox_apply`)
+11. Apply kernel sandbox — always active, scoped by manifest (`hl_sandbox_apply`)
 12. Run Keel event loop
 
 ### Manifest Extraction (`manifest.c`)
@@ -91,11 +91,30 @@ Extraction reads the stored manifest table from the runtime:
 - **Lua:** `__hull_manifest` in Lua registry → `hl_manifest_extract()`
 - **QuickJS:** `globalThis.__hull_manifest` → `hl_manifest_extract_js()`
 
-Result: `HlManifest` struct with up to 32 entries per category (`fs_read`, `fs_write`, `env`, `hosts`).
+Result: `HlManifest` struct with up to 32 entries per category (`fs_read`, `fs_write`, `env`, `hosts`), plus optional `csp` policy string.
+
+`app.manifest()` is **one-shot** — calling it a second time raises a runtime error. The manifest is extracted into a C struct during startup, capabilities are wired from that struct, and the kernel sandbox is sealed. After sealing, the runtime-side registry key is irrelevant — C-level configs and kernel restrictions are immutable.
+
+### Content-Security-Policy (CSP)
+
+Hull injects a `Content-Security-Policy` header on every `res:html()` / `res.html()` response at the C level. This is wired from `HlRuntime.csp_policy` into the Lua and JS response bindings.
+
+**Default policy** (always active unless explicitly disabled):
+```
+default-src 'none'; style-src 'unsafe-inline'; img-src 'self'; form-action 'self'; frame-ancestors 'none'
+```
+
+**Configuration via manifest:**
+- No `app.manifest()` → default CSP (secure by default)
+- `app.manifest({})` → default CSP
+- `app.manifest({ csp = "custom-policy" })` → custom policy
+- `app.manifest({ csp = false })` → CSP disabled (opt-out)
+
+CSP is injected in `lua_res_html()` (`runtime/lua/bindings.c`) and `js_res_html()` (`runtime/js/bindings.c`). Non-HTML responses (`res:json()`, `res:text()`) do not receive CSP headers.
 
 ### Sandbox Application (`sandbox.c`)
 
-After manifest extraction, `hl_sandbox_apply()` locks down the process:
+After manifest extraction, `hl_sandbox_apply()` always locks down the process (even without `app.manifest()`):
 
 | Step | Action | Effect |
 |------|--------|--------|
@@ -106,6 +125,8 @@ After manifest extraction, `hl_sandbox_apply()` locks down the process:
 | 5 | `pledge("stdio inet rpath wpath cpath flock [dns]")` | Syscall filter |
 
 After sealing, any attempt to access undeclared paths triggers SIGKILL (Linux/Cosmo) or returns ENOENT.
+
+The sandbox is **always applied**, even if `app.manifest()` is not called. An app without a manifest is sandboxed identically to `app.manifest({})` — only the database file and TLS certificate paths are accessible.
 
 ### Signature Verification (`signature.c`)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -65,6 +65,14 @@ This is the primary threat model. Hull exists to make it possible to trust apps 
 - **Prevention:** Manifest is signed in `package.sig`. At runtime, pledge/unveil enforce the declared capabilities at the kernel level. Accessing undeclared paths triggers SIGKILL (Linux/Cosmo).
 - **Remaining risk:** macOS has no kernel sandbox — pledge/unveil are no-ops. C-level validation in capability functions is the only defense. A bug in `hl_cap_fs_validate()` on macOS would allow bypass. Linux and Cosmopolitan are kernel-enforced.
 
+**Attack: Call `app.manifest()` again at runtime to escalate capabilities**
+
+- **Prevention:** Three independent barriers make this a non-issue:
+  1. **One-shot enforcement:** `app.manifest()` errors on second call in both Lua and JS runtimes. The first call writes to a registry key; any subsequent call raises a runtime error (`"app.manifest() can only be called once"`).
+  2. **Startup-only extraction:** The manifest is read from the runtime into a C struct (`HlManifest`) once during startup (step 10 of the boot sequence). C-level capabilities (`rt->env_cfg`, `rt->http_cfg`, `rt->csp_policy`) are wired from this struct and never re-read from the runtime state.
+  3. **Kernel seal:** `unveil(NULL, NULL)` seals filesystem visibility and `pledge()` restricts syscall families. Both are one-way operations — the kernel refuses to add permissions after sealing, regardless of what the runtime state says.
+- Even without the one-shot guard, a second `app.manifest()` call would only overwrite the Lua/JS registry key with no effect on the already-wired C capabilities or the sealed kernel sandbox. The guard exists to make the immutability explicit and prevent developer confusion.
+
 **Attack: SQL injection through user input**
 
 - **Prevention:** All database access goes through `hl_cap_db_query()` / `hl_cap_db_exec()` which use SQLite parameterized binding (`sqlite3_bind_*`). SQL is always a literal string from app code. No string concatenation, ever. SQL injection is structurally impossible.
@@ -100,8 +108,20 @@ This is the primary threat model. Hull exists to make it possible to trust apps 
 
 **Attack: Cross-site scripting (XSS) via template output**
 
-- **Prevention:** Hull's template engine (`hull.template`) HTML-escapes all `{{ }}` output by default. The five dangerous characters (`& < > " '`) are replaced with HTML entities. This prevents reflected and stored XSS from user-controlled data rendered into HTML templates.
-- **Remaining risk:** Raw output (`{{{ }}}`) and the `| raw` filter bypass escaping. Developers must only use raw output with trusted content. Templates don't escape for JavaScript string contexts (e.g. inline `<script>` blocks) — use `{{ var | json }}` to safely embed data in JS contexts.
+- **Prevention:** Two layers of defense:
+  1. **Template auto-escaping:** Hull's template engine (`hull.template`) HTML-escapes all `{{ }}` output by default. The five dangerous characters (`& < > " '`) are replaced with HTML entities. This prevents reflected and stored XSS from user-controlled data rendered into HTML templates.
+  2. **Content-Security-Policy (CSP):** Hull injects a strict CSP header on every `res:html()` / `res.html()` response by default: `default-src 'none'; style-src 'unsafe-inline'; img-src 'self'; form-action 'self'; frame-ancestors 'none'`. This blocks inline scripts, external script loads, `eval()`, object embeds, and iframe embedding — even if an attacker bypasses template escaping, the browser refuses to execute injected scripts.
+- **Remaining risk:** Raw output (`{{{ }}}`) and the `| raw` filter bypass escaping. Developers must only use raw output with trusted content. Templates don't escape for JavaScript string contexts (e.g. inline `<script>` blocks) — use `{{ var | json }}` to safely embed data in JS contexts. Apps that require client-side JavaScript must customize the CSP (e.g. `app.manifest({ csp = "default-src 'self'; script-src 'self'" })`).
+
+**Attack: Clickjacking — embedding the app in a malicious iframe**
+
+- **Prevention:** The default CSP includes `frame-ancestors 'none'`, which instructs the browser to refuse rendering the page inside any `<iframe>`, `<frame>`, or `<object>` tag. This prevents UI redress attacks where a malicious site overlays invisible frames over the app to trick users into clicking hidden elements.
+- **Actor:** Any third-party website operator. Does not require compromising the app — just embedding it.
+
+**Attack: MIME type confusion / content sniffing**
+
+- **Prevention:** The default CSP's `default-src 'none'` prevents the browser from loading any sub-resources (scripts, stylesheets, fonts, media) that an attacker might inject via reflected content. Combined with `Content-Type: text/html; charset=utf-8` set by `res:html()`, the browser cannot misinterpret response content.
+- **Actor:** Network MITM or injection via stored user content.
 
 **Attack: Template injection (server-side template injection / SSTI)**
 
@@ -125,6 +145,49 @@ This is the primary threat model. Hull exists to make it possible to trust apps 
 **Attack: Session fixation / brute-force session IDs**
 
 - **Prevention:** `hull.middleware.session` generates 32 random bytes (256-bit entropy) via `crypto.random()` for session IDs. IDs are hex-encoded (64 chars). Sessions are server-side (SQLite) with sliding expiry. Expired sessions are automatically pruned.
+
+### Browser-Level Security Headers
+
+Hull injects security headers automatically at the C level to provide defense in depth:
+
+**Content-Security-Policy (CSP):**
+
+Default policy (applied to all `res:html()` / `res.html()` responses):
+```
+default-src 'none'; style-src 'unsafe-inline'; img-src 'self'; form-action 'self'; frame-ancestors 'none'
+```
+
+| Directive | Value | Blocks |
+|-----------|-------|--------|
+| `default-src` | `'none'` | All resource types not explicitly allowed (scripts, fonts, media, objects, workers, WebSockets) |
+| `style-src` | `'unsafe-inline'` | External stylesheets (inline styles allowed for SSR convenience) |
+| `img-src` | `'self'` | Images from external origins |
+| `form-action` | `'self'` | Form submissions to external origins (data exfiltration via `<form action="evil.com">`) |
+| `frame-ancestors` | `'none'` | Embedding in iframes on any origin (clickjacking) |
+
+**What the default CSP mitigates:**
+
+| Attack | Actor | How CSP Blocks It |
+|--------|-------|-------------------|
+| Reflected XSS (injected `<script>`) | Any user who can craft a malicious URL | `default-src 'none'` blocks inline script execution |
+| Stored XSS (persisted `<script>`) | Authenticated user who stores malicious content | `default-src 'none'` blocks inline script execution |
+| External script injection (`<script src="evil.js">`) | Attacker who bypasses template escaping | `default-src 'none'` blocks all external script loads |
+| `eval()`-based XSS | Attacker who injects data into JS eval context | `default-src 'none'` implicitly disables `eval()` and `Function()` |
+| Clickjacking (iframe embedding) | Any third-party site operator | `frame-ancestors 'none'` refuses rendering in iframes |
+| Form action hijacking | Attacker who injects `<form action="evil.com">` | `form-action 'self'` restricts form targets to same origin |
+| Data exfiltration via `<img src="evil.com/steal?data=...">` | Attacker with XSS who tries to leak data via image tags | `img-src 'self'` blocks images from external origins |
+| Keylogging via injected external JS | Attacker who loads a remote keylogger script | `default-src 'none'` blocks all external resource loads |
+
+**CSP configuration:**
+
+| Manifest | Behavior |
+|----------|----------|
+| No `app.manifest()` | Default strict CSP (defense in depth) |
+| `app.manifest({})` | Default strict CSP |
+| `app.manifest({ csp = "custom..." })` | Custom CSP string |
+| `app.manifest({ csp = false })` | CSP disabled (opt-out) |
+
+**Where CSP is injected:** At the C level in `lua_res_html()` and `js_res_html()`, not in application code. This means the CSP cannot be forgotten, bypassed, or misconfigured by app developers — it's structural, like parameterized SQL. Only `res:json()` and `res:text()` skip CSP (non-HTML content types are not vulnerable to script injection).
 
 ### B. Malicious Third Party (MITM / CDN Compromise)
 
@@ -253,10 +316,13 @@ app.manifest({
 | C | Every capability function validates against manifest | Returns error on violation |
 | Signature | Manifest is signed — tampering invalidates signature | Ed25519 forgery required |
 
-**No manifest declared?** If the app doesn't call `app.manifest()`:
-- No kernel sandbox is applied
-- C-level capabilities still function (with defaults)
+**No manifest declared?** Even if the app doesn't call `app.manifest()`, the default-deny posture is identical to `app.manifest({})`:
+- **Kernel sandbox is applied** — pledge/unveil restrict to only the database file and TLS paths
+- **CSP is active** — the default strict policy is injected on all HTML responses
+- **C-level capabilities deny all** — env returns NULL, HTTP requests fail, filesystem operations fail
 - Signature still covers the absence of manifest (`"manifest": null`)
+
+All example apps declare `app.manifest()` explicitly, even when the empty `{}` is sufficient, as a best practice.
 
 ---
 
@@ -374,7 +440,7 @@ These are real, not theoretical:
 | Lua lacks instruction-count metering | Infinite loops are only caught by memory limit | QuickJS has precise gas metering |
 | Canary is not foolproof | Attacker could embed magic bytes in custom binary | Reproducible builds (Phase 9) eliminate this |
 | `realpath()` is TOCTOU | Race between check and use | Kernel unveil prevents actual access |
-| No manifest = no kernel sandbox | Unsigned apps have reduced protection | Signature verification catches missing manifest |
+| Default CSP blocks client-side JS | Apps needing fetch/AJAX must customize CSP | `app.manifest({ csp = "default-src 'self'; connect-src 'self'" })` |
 | 32-entry limit per manifest category | Large apps may hit ceiling | Sufficient for most production apps |
 | `req.ctx` uses raw malloc (not tracked) | ctx JSON bypasses runtime memory limits | Capped at 64KB; bounded by runtime heap indirectly |
 | HMAC-SHA256 binding returns hex string | Callers must use constant-time comparison | `hull.jwt` and `hull.middleware.csrf` stdlib use constant-time internally |

--- a/examples/auth/app.js
+++ b/examples/auth/app.js
@@ -12,6 +12,8 @@ import { auth } from "hull:middleware:auth";
 import { session } from "hull:middleware:session";
 import { time } from "hull:time";
 
+app.manifest({});
+
 // Initialize database
 session.init({ ttl: 3600 });
 

--- a/examples/auth/app.lua
+++ b/examples/auth/app.lua
@@ -6,6 +6,8 @@
 local session = require("hull.middleware.session")
 local auth = require("hull.middleware.auth")
 
+app.manifest({})
+
 -- Initialize database
 session.init({ ttl = 3600 })
 

--- a/examples/bench_db/app.js
+++ b/examples/bench_db/app.js
@@ -14,6 +14,8 @@ import { db } from "hull:db";
 import { log } from "hull:log";
 import { time } from "hull:time";
 
+app.manifest({});
+
 // Schema
 db.exec("CREATE TABLE IF NOT EXISTS events (id INTEGER PRIMARY KEY AUTOINCREMENT, kind TEXT NOT NULL, payload TEXT, ts INTEGER NOT NULL)");
 db.exec("CREATE INDEX IF NOT EXISTS idx_events_ts ON events (ts DESC)");

--- a/examples/bench_db/app.lua
+++ b/examples/bench_db/app.lua
@@ -7,6 +7,8 @@
 --   GET  /mixed       — mixed: 1 INSERT + 1 SELECT (20 rows)
 --   GET  /health      — baseline (no DB)
 
+app.manifest({})
+
 -- Schema
 db.exec("CREATE TABLE IF NOT EXISTS events (id INTEGER PRIMARY KEY AUTOINCREMENT, kind TEXT NOT NULL, payload TEXT, ts INTEGER NOT NULL)")
 db.exec("CREATE INDEX IF NOT EXISTS idx_events_ts ON events (ts DESC)")

--- a/examples/crud_with_auth/app.js
+++ b/examples/crud_with_auth/app.js
@@ -12,6 +12,8 @@ import { auth } from "hull:middleware:auth";
 import { session } from "hull:middleware:session";
 import { time } from "hull:time";
 
+app.manifest({});
+
 // Initialize database
 session.init({ ttl: 3600 });
 

--- a/examples/crud_with_auth/app.lua
+++ b/examples/crud_with_auth/app.lua
@@ -6,6 +6,8 @@
 local session = require("hull.middleware.session")
 local auth = require("hull.middleware.auth")
 
+app.manifest({})
+
 -- Initialize database
 session.init({ ttl = 3600 })
 

--- a/examples/hello/app.js
+++ b/examples/hello/app.js
@@ -8,6 +8,8 @@ import { db } from "hull:db";
 import { log } from "hull:log";
 import { time } from "hull:time";
 
+app.manifest({});
+
 // Initialize database
 db.exec("CREATE TABLE IF NOT EXISTS visits (id INTEGER PRIMARY KEY AUTOINCREMENT, path TEXT, ts INTEGER)");
 

--- a/examples/hello/app.lua
+++ b/examples/hello/app.lua
@@ -3,6 +3,8 @@
 -- Run: hull app.lua -p 3000
 -- Visit: http://localhost:3000/
 
+app.manifest({})
+
 -- Initialize database
 db.exec("CREATE TABLE IF NOT EXISTS visits (id INTEGER PRIMARY KEY AUTOINCREMENT, path TEXT, ts INTEGER)")
 

--- a/examples/jwt_api/app.js
+++ b/examples/jwt_api/app.js
@@ -11,6 +11,10 @@ import { jwt } from "hull:jwt";
 import { log } from "hull:log";
 import { time } from "hull:time";
 
+app.manifest({
+    env: ["JWT_SECRET"],
+});
+
 let JWT_SECRET = "change-me-in-production";
 try { const v = env.get("JWT_SECRET"); if (v) JWT_SECRET = v; } catch (e) {}
 

--- a/examples/jwt_api/app.lua
+++ b/examples/jwt_api/app.lua
@@ -5,6 +5,10 @@
 
 local jwt = require("hull.jwt")
 
+app.manifest({
+    env = {"JWT_SECRET"},
+})
+
 local ok, val = pcall(env.get, "JWT_SECRET")
 local JWT_SECRET = (ok and val) or "change-me-in-production"
 

--- a/examples/middleware/app.js
+++ b/examples/middleware/app.js
@@ -9,6 +9,8 @@ import { cors } from "hull:middleware:cors";
 import { ratelimit } from "hull:middleware:ratelimit";
 import { time } from "hull:time";
 
+app.manifest({});
+
 // ── Request ID middleware ────────────────────────────────────────────
 // Assigns a unique ID to every request, available via req.ctx.request_id
 // and returned in the X-Request-ID response header.

--- a/examples/middleware/app.lua
+++ b/examples/middleware/app.lua
@@ -6,6 +6,8 @@
 local cors = require("hull.middleware.cors")
 local ratelimit = require("hull.middleware.ratelimit")
 
+app.manifest({})
+
 -- ── Request ID middleware ────────────────────────────────────────────
 -- Assigns a unique ID to every request, available via req.ctx.request_id
 -- and returned in the X-Request-ID response header.

--- a/examples/rest_api/app.js
+++ b/examples/rest_api/app.js
@@ -7,6 +7,8 @@ import { app } from "hull:app";
 import { db } from "hull:db";
 import { time } from "hull:time";
 
+app.manifest({});
+
 // Initialize database
 db.exec(`CREATE TABLE IF NOT EXISTS tasks (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/examples/rest_api/app.lua
+++ b/examples/rest_api/app.lua
@@ -3,6 +3,8 @@
 -- Run: hull app.lua -p 3000
 -- CRUD API for managing tasks
 
+app.manifest({})
+
 -- Initialize database
 db.exec([[CREATE TABLE IF NOT EXISTS tasks (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/examples/todo/.gitignore
+++ b/examples/todo/.gitignore
@@ -1,0 +1,3 @@
+certs/
+todo
+todo.com

--- a/examples/todo/app.js
+++ b/examples/todo/app.js
@@ -18,6 +18,8 @@ import { session } from "hull:middleware:session";
 import { template } from "hull:template";
 import { time } from "hull:time";
 
+app.manifest({});  // sandbox: no fs, no env, no outbound HTTP; default CSP
+
 // ── Database setup ──────────────────────────────────────────────────
 
 session.init({ ttl: 3600 });

--- a/examples/todo/app.lua
+++ b/examples/todo/app.lua
@@ -14,6 +14,8 @@ local csrf     = require("hull.middleware.csrf")
 local ratelimit = require("hull.middleware.ratelimit")
 local logger   = require("hull.middleware.logger")
 
+app.manifest({})  -- sandbox: no fs, no env, no outbound HTTP; default CSP
+
 -- ── Database setup ──────────────────────────────────────────────────
 
 session.init({ ttl = 3600 })

--- a/examples/todo/build.sh
+++ b/examples/todo/build.sh
@@ -21,20 +21,27 @@ if [ ! -x "$HULL" ]; then
     exit 1
 fi
 
-echo "Building todo app..."
-"$HULL" build -o "$OUTPUT" "$SCRIPT_DIR"
+echo "Building todo app (cosmocc)..."
+"$HULL" build --cc cosmocc -o "$OUTPUT" "$SCRIPT_DIR"
 
 echo ""
 echo "Built: $OUTPUT"
 ls -lh "$OUTPUT"
 
 if [ "${1:-}" = "--run" ]; then
-    PORT="${PORT:-8080}"
+    # Generate self-signed certs if needed
+    "$SCRIPT_DIR/gen-certs.sh"
+
+    PORT="${PORT:-8443}"
     DB="${DB:-/tmp/todo.db}"
+    CERT="$SCRIPT_DIR/certs/cert.pem"
+    KEY="$SCRIPT_DIR/certs/key.pem"
+
     echo ""
-    echo "Running todo app..."
-    echo "  http://localhost:$PORT"
+    echo "Running todo app (HTTPS)..."
+    echo "  https://localhost:$PORT"
     echo "  Database: $DB"
     echo ""
-    exec "$OUTPUT" -p "$PORT" -d "$DB"
+    exec "$OUTPUT" -p "$PORT" -d "$DB" \
+        --tls-cert "$CERT" --tls-key "$KEY"
 fi

--- a/examples/todo/dev.sh
+++ b/examples/todo/dev.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Start the todo app in development mode (hot reload).
+# Start the todo app in development mode (hot reload + HTTPS).
 #
 # Usage: ./examples/todo/dev.sh
 #
@@ -18,12 +18,18 @@ if [ ! -x "$HULL" ]; then
     exit 1
 fi
 
-PORT="${PORT:-8080}"
-DB="${DB:-/tmp/todo.db}"
+# Generate self-signed certs if needed
+"$SCRIPT_DIR/gen-certs.sh"
 
-echo "Starting todo app in dev mode..."
-echo "  http://localhost:$PORT"
+PORT="${PORT:-8443}"
+DB="${DB:-/tmp/todo.db}"
+CERT="$SCRIPT_DIR/certs/cert.pem"
+KEY="$SCRIPT_DIR/certs/key.pem"
+
+echo "Starting todo app in dev mode (HTTPS)..."
+echo "  https://localhost:$PORT"
 echo "  Database: $DB"
 echo ""
 
-exec "$HULL" dev "$SCRIPT_DIR/app.lua" -p "$PORT" -d "$DB"
+exec "$HULL" dev "$SCRIPT_DIR/app.lua" -p "$PORT" -d "$DB" \
+    --tls-cert "$CERT" --tls-key "$KEY"

--- a/examples/todo/gen-certs.sh
+++ b/examples/todo/gen-certs.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CERT_DIR="$SCRIPT_DIR/certs"
+CERT="$CERT_DIR/cert.pem"
+KEY="$CERT_DIR/key.pem"
+
+if [ -f "$CERT" ] && [ -f "$KEY" ]; then
+    echo "Certs already exist at $CERT_DIR — skipping."
+    exit 0
+fi
+
+mkdir -p "$CERT_DIR"
+
+openssl ecparam -genkey -name prime256v1 -noout -out "$KEY"
+openssl req -new -x509 -key "$KEY" -out "$CERT" -days 365 \
+    -subj "/CN=localhost" \
+    -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+
+echo "Generated self-signed TLS cert:"
+echo "  cert: $CERT"
+echo "  key:  $KEY"

--- a/examples/webhooks/app.js
+++ b/examples/webhooks/app.js
@@ -16,6 +16,7 @@ import { time } from "hull:time";
 
 // Manifest: allow outbound HTTP to localhost for webhook delivery
 app.manifest({
+    env: ["WEBHOOK_SECRET"],
     hosts: ["127.0.0.1"],
 });
 

--- a/examples/webhooks/app.lua
+++ b/examples/webhooks/app.lua
@@ -8,6 +8,7 @@
 
 -- Manifest: allow outbound HTTP to localhost for webhook delivery
 app.manifest({
+    env = {"WEBHOOK_SECRET"},
     hosts = {"127.0.0.1"},
 })
 

--- a/examples/webhooks/app.lua
+++ b/examples/webhooks/app.lua
@@ -63,7 +63,7 @@ end
 local function deliver_webhook(webhook, event_type, payload_str, event_id)
     local sig = sign_payload(payload_str)
 
-    local ok, result = pcall(function()
+    local send_ok, result = pcall(function()
         return http.post(webhook.url, payload_str, {
             headers = {
                 ["Content-Type"] = "application/json",
@@ -74,7 +74,7 @@ local function deliver_webhook(webhook, event_type, payload_str, event_id)
     end)
 
     local status, resp_body
-    if ok and result then
+    if send_ok and result then
         status = result.status
         resp_body = result.body or ""
     else

--- a/include/hull/manifest.h
+++ b/include/hull/manifest.h
@@ -39,6 +39,10 @@ typedef struct HlManifest {
     const char *hosts[HL_MANIFEST_MAX_HOSTS];
     int         hosts_count;
 
+    /* Content-Security-Policy for HTML responses */
+    const char *csp;        /* Custom CSP string (NULL if not set or disabled) */
+    int         csp_set;    /* 1 if app explicitly set csp key in manifest */
+
     /* Whether app.manifest() was called */
     int         present;
 } HlManifest;

--- a/include/hull/runtime.h
+++ b/include/hull/runtime.h
@@ -43,6 +43,7 @@ struct HlRuntime {
     HlFsConfig   *fs_cfg;
     HlEnvConfig  *env_cfg;
     HlHttpConfig *http_cfg;
+    const char   *csp_policy;  /* CSP header value for HTML responses (NULL = none) */
 };
 
 #endif /* HL_RUNTIME_H */

--- a/include/hull/sandbox.h
+++ b/include/hull/sandbox.h
@@ -24,15 +24,18 @@
  * Apply kernel sandbox based on manifest capabilities.
  *
  *   manifest       — declared capabilities (may have present==0)
+ *   app_dir        — application directory (always unveiled read-only)
  *   db_path        — SQLite database path (always allowed rw)
  *   ca_bundle_path — CA certificate bundle (unveiled read-only, may be NULL)
  *   tls_cert_path  — TLS certificate file (unveiled read-only, may be NULL)
  *   tls_key_path   — TLS private key file (unveiled read-only, may be NULL)
  *
- * When manifest.present is false, no sandbox is applied (permissive).
+ * The sandbox always applies (default-deny).  The app directory is
+ * always unveiled for reading (templates, static assets, source files).
  * Returns 0 on success, -1 on error (logged).
  */
-int hl_sandbox_apply(const HlManifest *manifest, const char *db_path,
+int hl_sandbox_apply(const HlManifest *manifest, const char *app_dir,
+                      const char *db_path,
                       const char *ca_bundle_path,
                       const char *tls_cert_path,
                       const char *tls_key_path);

--- a/src/hull/main.c
+++ b/src/hull/main.c
@@ -507,8 +507,23 @@ static int hull_serve(int argc, char **argv)
         rt->http_cfg = &http_cfg_storage;
     }
 
+    /* Derive app directory from entry point for sandbox unveil */
+    char app_dir[4096];
+    {
+        const char *slash = strrchr(entry_point, '/');
+        if (slash) {
+            size_t len = (size_t)(slash - entry_point);
+            if (len >= sizeof(app_dir)) len = sizeof(app_dir) - 1;
+            memcpy(app_dir, entry_point, len);
+            app_dir[len] = '\0';
+        } else {
+            app_dir[0] = '.';
+            app_dir[1] = '\0';
+        }
+    }
+
     /* Apply kernel sandbox (pledge/unveil) from manifest */
-    if (hl_sandbox_apply(&manifest, db_path, ca_bundle_path,
+    if (hl_sandbox_apply(&manifest, app_dir, db_path, ca_bundle_path,
                           tls_cert_path, tls_key_path) != 0) {
         log_error("[hull:c] sandbox enforcement failed");
         rt->vt->free_manifest_strings(rt, &manifest);

--- a/src/hull/main.c
+++ b/src/hull/main.c
@@ -48,6 +48,12 @@
 #include <string.h>
 #include <stdarg.h>
 
+/* ── Default Content-Security-Policy ───────────────────────────────── */
+
+#define HL_DEFAULT_CSP \
+    "default-src 'none'; style-src 'unsafe-inline'; " \
+    "img-src 'self'; form-action 'self'; frame-ancestors 'none'"
+
 /* ── Logging ───────────────────────────────────────────────────────── */
 
 /* Custom log callback: suppresses file:line in release builds */
@@ -447,6 +453,14 @@ static int hull_serve(int argc, char **argv)
                  manifest.fs_read_count, manifest.fs_write_count,
                  manifest.env_count, manifest.hosts_count);
     }
+
+    /* Wire CSP policy to runtime.
+     * Default CSP is always active — even without app.manifest().
+     * Explicit csp="custom" overrides; csp=false disables. */
+    if (manifest.csp_set)
+        rt->csp_policy = manifest.csp;    /* custom or NULL (disabled) */
+    else
+        rt->csp_policy = HL_DEFAULT_CSP;  /* default */
 
     /* Wire env_cfg from manifest (if app declares env vars) */
     HlEnvConfig env_cfg_storage = {0};

--- a/src/hull/manifest.c
+++ b/src/hull/manifest.c
@@ -89,6 +89,17 @@ int hl_manifest_extract(lua_State *L, HlManifest *out)
                                            out->hosts,
                                            HL_MANIFEST_MAX_HOSTS);
 
+    /* csp = "policy-string" or false */
+    lua_getfield(L, manifest_idx, "csp");
+    if (lua_isstring(L, -1)) {
+        out->csp = lua_tostring(L, -1);
+        out->csp_set = 1;
+    } else if (lua_isboolean(L, -1) && !lua_toboolean(L, -1)) {
+        out->csp = NULL;
+        out->csp_set = 1;  /* explicitly disabled */
+    }
+    lua_pop(L, 1);
+
     lua_pop(L, 1); /* pop manifest table */
     return 0;
 }
@@ -174,6 +185,17 @@ int hl_manifest_extract_js(JSContext *ctx, HlManifest *out)
                                               out->hosts,
                                               HL_MANIFEST_MAX_HOSTS);
 
+    /* csp = "policy-string" or false */
+    JSValue csp_val = JS_GetPropertyStr(ctx, manifest, "csp");
+    if (JS_IsString(csp_val)) {
+        out->csp = JS_ToCString(ctx, csp_val);
+        out->csp_set = 1;
+    } else if (JS_IsBool(csp_val) && !JS_ToBool(ctx, csp_val)) {
+        out->csp = NULL;
+        out->csp_set = 1;  /* explicitly disabled */
+    }
+    JS_FreeValue(ctx, csp_val);
+
     JS_FreeValue(ctx, manifest);
     return 0;
 }
@@ -191,6 +213,7 @@ void hl_manifest_free_js_strings(JSContext *ctx, HlManifest *m)
         if (m->env[i]) JS_FreeCString(ctx, m->env[i]);
     for (int i = 0; i < m->hosts_count; i++)
         if (m->hosts[i]) JS_FreeCString(ctx, m->hosts[i]);
+    if (m->csp) JS_FreeCString(ctx, m->csp);
 }
 
 #endif /* HL_ENABLE_JS */

--- a/src/hull/runtime/js/bindings.c
+++ b/src/hull/runtime/js/bindings.c
@@ -211,6 +211,8 @@ static const char *hl_js_stash_body(JSContext *ctx, const char *data,
         js->response_body = NULL;
         js->response_body_size = 0;
     }
+    if (len >= SIZE_MAX)
+        return NULL;
     js->response_body = hl_alloc_malloc(js->base.alloc, len + 1);
     if (!js->response_body)
         return NULL;
@@ -331,7 +333,11 @@ static JSValue js_res_html(JSContext *ctx, JSValueConst this_val,
         const char *copy = hl_js_stash_body(ctx, html, html_len);
         JS_FreeCString(ctx, html);
         if (copy) {
+            HlJS *js_rt = (HlJS *)JS_GetContextOpaque(ctx);
             kl_response_header(res, "Content-Type", "text/html; charset=utf-8");
+            if (js_rt && js_rt->base.csp_policy)
+                kl_response_header(res, "Content-Security-Policy",
+                                   js_rt->base.csp_policy);
             kl_response_body(res, copy, html_len);
         }
     }

--- a/src/hull/runtime/js/modules.c
+++ b/src/hull/runtime/js/modules.c
@@ -238,7 +238,7 @@ static JSValue js_app_config(JSContext *ctx, JSValueConst this_val,
     return JS_UNDEFINED;
 }
 
-/* app.manifest(obj) — declare application capabilities */
+/* app.manifest(obj) — declare application capabilities (one-shot) */
 static JSValue js_app_manifest(JSContext *ctx, JSValueConst this_val,
                                 int argc, JSValueConst *argv)
 {
@@ -246,7 +246,16 @@ static JSValue js_app_manifest(JSContext *ctx, JSValueConst this_val,
     if (argc < 1)
         return JS_ThrowTypeError(ctx, "app.manifest requires an object");
 
+    /* Reject second call — manifest is immutable once declared */
     JSValue global = JS_GetGlobalObject(ctx);
+    JSValue existing = JS_GetPropertyStr(ctx, global, "__hull_manifest");
+    int already_set = !JS_IsUndefined(existing) && !JS_IsNull(existing);
+    JS_FreeValue(ctx, existing);
+    if (already_set) {
+        JS_FreeValue(ctx, global);
+        return JS_ThrowTypeError(ctx, "app.manifest() can only be called once");
+    }
+
     JS_SetPropertyStr(ctx, global, "__hull_manifest", JS_DupValue(ctx, argv[0]));
     JS_FreeValue(ctx, global);
 

--- a/src/hull/runtime/lua/bindings.c
+++ b/src/hull/runtime/lua/bindings.c
@@ -55,6 +55,8 @@ static const char *hl_lua_stash_body(lua_State *L, const char *data,
         hlua->response_body = NULL;
         hlua->response_body_size = 0;
     }
+    if (len >= SIZE_MAX)
+        return NULL;
     hlua->response_body = hl_alloc_malloc(hlua->base.alloc, len + 1);
     if (!hlua->response_body)
         return NULL;
@@ -268,11 +270,15 @@ static int lua_res_json(lua_State *L)
 static int lua_res_html(lua_State *L)
 {
     KlResponse *res = check_response(L, 1);
+    HlLua *hlua = get_hl_lua_from_L(L);
     size_t len;
     const char *html = luaL_checklstring(L, 2, &len);
     const char *copy = hl_lua_stash_body(L, html, len);
     if (copy) {
         kl_response_header(res, "Content-Type", "text/html; charset=utf-8");
+        if (hlua && hlua->base.csp_policy)
+            kl_response_header(res, "Content-Security-Policy",
+                               hlua->base.csp_policy);
         kl_response_body(res, copy, len);
     }
     return 0;

--- a/src/hull/runtime/lua/modules.c
+++ b/src/hull/runtime/lua/modules.c
@@ -223,10 +223,17 @@ static int lua_app_config(lua_State *L)
     return 0;
 }
 
-/* app.manifest(tbl) — declare application capabilities */
+/* app.manifest(tbl) — declare application capabilities (one-shot) */
 static int lua_app_manifest(lua_State *L)
 {
     luaL_checktype(L, 1, LUA_TTABLE);
+
+    /* Reject second call — manifest is immutable once declared */
+    lua_getfield(L, LUA_REGISTRYINDEX, "__hull_manifest");
+    if (!lua_isnil(L, -1))
+        return luaL_error(L, "app.manifest() can only be called once");
+    lua_pop(L, 1);
+
     lua_pushvalue(L, 1);
     lua_setfield(L, LUA_REGISTRYINDEX, "__hull_manifest");
     return 0;

--- a/src/hull/sandbox.c
+++ b/src/hull/sandbox.c
@@ -132,7 +132,8 @@ int hl_tool_sandbox_init(HlToolUnveilCtx *ctx,
 
 /* ── Public API ────────────────────────────────────────────────────── */
 
-int hl_sandbox_apply(const HlManifest *manifest, const char *db_path,
+int hl_sandbox_apply(const HlManifest *manifest, const char *app_dir,
+                      const char *db_path,
                       const char *ca_bundle_path,
                       const char *tls_cert_path,
                       const char *tls_key_path)
@@ -151,6 +152,15 @@ int hl_sandbox_apply(const HlManifest *manifest, const char *db_path,
 #endif
 
     /* ── Unveil: restrict filesystem visibility ─────────────── */
+
+    /* App directory: always readable (templates, static assets, source) */
+    if (app_dir) {
+        if (unveil(app_dir, "r") != 0)
+            log_warn("[sandbox] unveil failed for app dir: %s", app_dir);
+    }
+
+    /* /dev/urandom: needed by crypto.random and password hashing */
+    unveil("/dev/urandom", "r");
 
     for (int i = 0; i < manifest->fs_read_count; i++) {
         if (unveil(manifest->fs_read[i], "r") != 0)

--- a/src/hull/sandbox.c
+++ b/src/hull/sandbox.c
@@ -137,10 +137,8 @@ int hl_sandbox_apply(const HlManifest *manifest, const char *db_path,
                       const char *tls_cert_path,
                       const char *tls_key_path)
 {
-    if (!manifest || !manifest->present) {
-        log_info("[sandbox] no manifest — sandbox not applied");
+    if (!manifest)
         return 0;
-    }
 
     if (!sb_supported()) {
         log_info("[sandbox] kernel sandbox not available on this platform");

--- a/tests/e2e_sandbox.sh
+++ b/tests/e2e_sandbox.sh
@@ -3,7 +3,7 @@
 #
 # Tests:
 #   1. Hull with manifest logs "[sandbox] applied" (Linux/cosmo only)
-#   2. Hull without manifest logs "no manifest" (permissive)
+#   2. Hull without manifest — default-deny sandbox still applied
 #   3. Manifest without hosts — no dns promise
 #   4. JS manifest app — sandbox applied (feature parity)
 #   5. Kernel enforcement: pledge/unveil violations blocked (Linux only)
@@ -160,10 +160,10 @@ else
     fail "hull did not start with manifest app"
 fi
 
-# ── Test 2: Hull without manifest — permissive ──────────────────────
+# ── Test 2: Hull without manifest — default-deny sandbox ────────────
 
 echo ""
-echo "=== Test 2: Hull without manifest — permissive ==="
+echo "=== Test 2: Hull without manifest — default-deny sandbox ==="
 
 cat > "$WORKDIR/nomanifest.lua" << 'EOF'
 app.get("/", function(req, res)
@@ -186,8 +186,12 @@ if wait_for_server 19881; then
     stop_server
 
     LOG2=$(cat "$LOGFILE2")
-    check_contains "no manifest log" "$LOG2" "no manifest"
-    check_not_contains "sandbox should NOT be applied" "$LOG2" "[sandbox] applied"
+    if [ "$SANDBOX_EXPECTED" = "1" ]; then
+        check_contains "sandbox applied (no manifest)" "$LOG2" "[sandbox] applied"
+        check_not_contains "no dns without manifest" "$LOG2" " dns"
+    else
+        check_contains "sandbox not available log" "$LOG2" "kernel sandbox not available"
+    fi
 else
     stop_server
     fail "hull did not start without manifest"


### PR DESCRIPTION
## Summary

- Inject `Content-Security-Policy` header on all `res:html()` responses at the C level — default strict policy blocks inline scripts, external resources, iframes, and form exfiltration
- Sandbox (pledge/unveil) always applied even without `app.manifest()` — default deny for filesystem, env vars, and outbound HTTP
- `app.manifest()` is one-shot — second call raises a runtime error to prevent capability escalation attempts
- All 9 example apps declare `app.manifest()` with required capabilities
- Todo example upgraded with HTTPS, cosmocc build, self-signed cert generation
- Overflow guards in `hl_lua_stash_body` / `hl_js_stash_body` for `SIZE_MAX` wrap
- Security docs: CSP attack/mitigation matrix, one-shot manifest rationale, updated sandbox sections

## Test plan

- [x] `make clean && make` — compiles with no warnings
- [x] `make test` — 13/13 unit test suites pass
- [x] `make hull-test-examples` — all 9 examples load successfully
- [x] `make e2e-examples` — 158/158 e2e tests pass