### PR TITLE
Block user code from accessing _hull_* internal tables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Application Code (Lua or JS)
         ↓
 Capability Layer (C)          # enforces security boundaries
         ↓
-    db.query() / db.exec()    # SQLite (WAL mode, parameterized)
+    db.query() / db.exec()    # SQLite (WAL mode, parameterized, _hull_* tables blocked)
     fs.read() / fs.write()    # sandboxed filesystem
     crypto.sha256() / etc.    # cryptographic primitives
     http.get() / http.post()  # outbound HTTP (host allowlist)
@@ -438,7 +438,7 @@ end)
 -- Both inserts succeed or both roll back
 ```
 
-All queries are parameterized (no SQL injection possible). SQLite is in WAL mode with prepared statement caching.
+All queries are parameterized (no SQL injection possible). SQLite is in WAL mode with prepared statement caching. Tables prefixed with `_hull_` are reserved for internal middleware and cannot be accessed via `db.exec()`/`db.query()` — attempts will raise an error.
 
 ## Response API
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,7 @@ Violation = SIGKILL on Linux/Cosmo. No-op on macOS (C-level validation only).
 ### Capability Enforcement Invariants
 
 - **SQL injection impossible:** All DB access uses `sqlite3_bind_*` parameterized binding. SQL is always a literal string.
+- **Internal tables protected:** `hl_cap_db_check_namespace()` blocks user code from accessing `_hull_*` tables. Enforcement uses call-stack inspection — Lua checks `ar.source` for `hull.` prefix, JS checks module name for `hull:` prefix — so stdlib modules transparently bypass the check via normal `db.exec`/`db.query`. No internal API is exposed. Tables: `_hull_outbox`, `_hull_inbox_processed`, `_hull_idempotency_keys`, `_hull_sessions`.
 - **Path traversal blocked:** `hl_cap_fs_validate()` rejects absolute paths, `..` components, symlink escapes via `realpath()` ancestor check. Plus kernel unveil.
 - **Host allowlist enforced:** `hl_cap_http_request()` validates target host against manifest's `hosts` array.
 - **Env allowlist enforced:** `hl_cap_env_get()` checks against manifest's `env` array (max 32 entries).

--- a/include/hull/cap/db.h
+++ b/include/hull/cap/db.h
@@ -56,4 +56,7 @@ int hl_cap_db_rollback(sqlite3 *db);
  * Safe to call unconditionally before each request dispatch. */
 void hl_cap_db_guard_stale_txn(sqlite3 *db);
 
+/* Namespace protection: reject SQL referencing _hull_* tables */
+int hl_cap_db_check_namespace(const char *sql);
+
 #endif /* HL_CAP_DB_H */

--- a/src/hull/cap/db.c
+++ b/src/hull/cap/db.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 
 /* ── Prepared statement cache ──────────────────────────────────────── */
 
@@ -388,4 +389,18 @@ void hl_cap_db_guard_stale_txn(sqlite3 *db)
         fprintf(stderr, "[hull:c] rolling back stale transaction from previous request\n");
         sqlite3_exec(db, "ROLLBACK", NULL, NULL, NULL);
     }
+}
+
+/* ── Namespace protection ──────────────────────────────────────────── */
+
+int hl_cap_db_check_namespace(const char *sql)
+{
+    if (!sql)
+        return -1;
+    for (const char *p = sql; *p; p++) {
+        if ((*p == '_' || *p == 'H' || *p == 'h') &&
+            strncasecmp(p, "_hull_", 6) == 0)
+            return -1;
+    }
+    return 0;
 }

--- a/src/hull/runtime/js/modules.c
+++ b/src/hull/runtime/js/modules.c
@@ -502,9 +502,29 @@ static void js_free_hl_values(JSContext *ctx, HlValue *params, int count)
     js_free(ctx, params);
 }
 
-/* db.query(sql, params?) */
-static JSValue js_db_query(JSContext *ctx, JSValueConst this_val,
-                            int argc, JSValueConst *argv)
+/* Check if the immediate JS caller is a stdlib module (module name starts
+ * with "hull:").  User modules start with "./" — so a simple prefix check
+ * is sufficient.  Returns 1 for stdlib, 0 for user code.
+ *
+ * n_stack_levels=1 skips the C function stack frame (level 0) to reach
+ * the JS caller's frame. */
+static int js_is_stdlib_caller(JSContext *ctx)
+{
+    JSAtom name = JS_GetScriptOrModuleName(ctx, 1);
+    if (name == JS_ATOM_NULL)
+        return 0;
+    const char *str = JS_AtomToCString(ctx, name);
+    JS_FreeAtom(ctx, name);
+    if (!str)
+        return 0;
+    int is_stdlib = (strncmp(str, "hull:", 5) == 0);
+    JS_FreeCString(ctx, str);
+    return is_stdlib;
+}
+
+/* db.query implementation */
+static JSValue js_db_query_impl(JSContext *ctx, JSValueConst this_val,
+                                int argc, JSValueConst *argv)
 {
     (void)this_val;
     HlJS *js = (HlJS *)JS_GetContextOpaque(ctx);
@@ -517,6 +537,12 @@ static JSValue js_db_query(JSContext *ctx, JSValueConst this_val,
     const char *sql = JS_ToCString(ctx, argv[0]);
     if (!sql)
         return JS_EXCEPTION;
+
+    if (!js_is_stdlib_caller(ctx) && hl_cap_db_check_namespace(sql) != 0) {
+        JS_FreeCString(ctx, sql);
+        return JS_ThrowInternalError(ctx,
+            "access denied: _hull_* tables are reserved");
+    }
 
     HlValue *params = NULL;
     int nparams = 0;
@@ -548,9 +574,9 @@ static JSValue js_db_query(JSContext *ctx, JSValueConst this_val,
     return qc.array;
 }
 
-/* db.exec(sql, params?) */
-static JSValue js_db_exec(JSContext *ctx, JSValueConst this_val,
-                           int argc, JSValueConst *argv)
+/* db.exec implementation */
+static JSValue js_db_exec_impl(JSContext *ctx, JSValueConst this_val,
+                                int argc, JSValueConst *argv)
 {
     (void)this_val;
     HlJS *js = (HlJS *)JS_GetContextOpaque(ctx);
@@ -563,6 +589,12 @@ static JSValue js_db_exec(JSContext *ctx, JSValueConst this_val,
     const char *sql = JS_ToCString(ctx, argv[0]);
     if (!sql)
         return JS_EXCEPTION;
+
+    if (!js_is_stdlib_caller(ctx) && hl_cap_db_check_namespace(sql) != 0) {
+        JS_FreeCString(ctx, sql);
+        return JS_ThrowInternalError(ctx,
+            "access denied: _hull_* tables are reserved");
+    }
 
     HlValue *params = NULL;
     int nparams = 0;
@@ -584,6 +616,14 @@ static JSValue js_db_exec(JSContext *ctx, JSValueConst this_val,
 
     return JS_NewInt32(ctx, rc);
 }
+
+static JSValue js_db_query(JSContext *ctx, JSValueConst this_val,
+                            int argc, JSValueConst *argv)
+{ return js_db_query_impl(ctx, this_val, argc, argv); }
+
+static JSValue js_db_exec(JSContext *ctx, JSValueConst this_val,
+                           int argc, JSValueConst *argv)
+{ return js_db_exec_impl(ctx, this_val, argc, argv); }
 
 /* db.lastId() */
 static JSValue js_db_last_id(JSContext *ctx, JSValueConst this_val,

--- a/src/hull/runtime/lua/modules.c
+++ b/src/hull/runtime/lua/modules.c
@@ -389,14 +389,31 @@ static void lua_free_hl_values(lua_State *L, HlValue *params, int count)
         lua_pop(L, count);
 }
 
-/* db.query(sql, params?) */
-static int lua_db_query(lua_State *L)
+/* Check if the immediate Lua caller is a stdlib module (chunk name starts
+ * with "hull.").  User modules start with "./" — so a simple prefix check
+ * is sufficient.  Returns 1 for stdlib, 0 for user code. */
+static int lua_is_stdlib_caller(lua_State *L)
+{
+    lua_Debug ar;
+    /* level 0 = this C function, level 1 = Lua caller */
+    if (lua_getstack(L, 1, &ar) == 0)
+        return 0;
+    if (lua_getinfo(L, "S", &ar) == 0)
+        return 0;
+    return ar.source && strncmp(ar.source, "hull.", 5) == 0;
+}
+
+/* db.query implementation */
+static int lua_db_query_impl(lua_State *L)
 {
     HlLua *lua = get_hl_lua(L);
     if (!lua || !lua->base.stmt_cache)
         return luaL_error(L, "database not available");
 
     const char *sql = luaL_checkstring(L, 1);
+
+    if (!lua_is_stdlib_caller(L) && hl_cap_db_check_namespace(sql) != 0)
+        return luaL_error(L, "access denied: _hull_* tables are reserved");
 
     HlValue *params = NULL;
     int nparams = 0;
@@ -440,14 +457,17 @@ static int lua_db_query(lua_State *L)
     return 1; /* result table already on stack */
 }
 
-/* db.exec(sql, params?) */
-static int lua_db_exec(lua_State *L)
+/* db.exec implementation */
+static int lua_db_exec_impl(lua_State *L)
 {
     HlLua *lua = get_hl_lua(L);
     if (!lua || !lua->base.stmt_cache)
         return luaL_error(L, "database not available");
 
     const char *sql = luaL_checkstring(L, 1);
+
+    if (!lua_is_stdlib_caller(L) && hl_cap_db_check_namespace(sql) != 0)
+        return luaL_error(L, "access denied: _hull_* tables are reserved");
 
     HlValue *params = NULL;
     int nparams = 0;
@@ -466,6 +486,9 @@ static int lua_db_exec(lua_State *L)
     lua_pushinteger(L, rc);
     return 1;
 }
+
+static int lua_db_query(lua_State *L) { return lua_db_query_impl(L); }
+static int lua_db_exec(lua_State *L) { return lua_db_exec_impl(L); }
 
 /* db.last_id() */
 static int lua_db_last_id(lua_State *L)

--- a/stdlib/js/hull/middleware/session.js
+++ b/stdlib/js/hull/middleware/session.js
@@ -1,7 +1,7 @@
 /*
  * hull:session -- Server-side sessions backed by SQLite
  *
- * session.init(opts)          - creates hull_sessions table, opts.ttl default 86400
+ * session.init(opts)          - creates _hull_sessions table, opts.ttl default 86400
  * session.create(data)        - returns session_id (64-char hex)
  * session.load(sessionId)     - returns data object or null
  * session.update(sessionId, data) - boolean
@@ -23,7 +23,7 @@ function init(opts) {
     sessionTtl = o.ttl !== undefined ? o.ttl : 86400;
 
     db.exec(
-        "CREATE TABLE IF NOT EXISTS hull_sessions (" +
+        "CREATE TABLE IF NOT EXISTS _hull_sessions (" +
         "  id TEXT PRIMARY KEY," +
         "  data TEXT NOT NULL," +
         "  created_at INTEGER NOT NULL," +
@@ -32,8 +32,8 @@ function init(opts) {
         ")"
     );
     db.exec(
-        "CREATE INDEX IF NOT EXISTS idx_hull_sessions_expires " +
-        "ON hull_sessions(expires_at)"
+        "CREATE INDEX IF NOT EXISTS idx__hull_sessions_expires " +
+        "ON _hull_sessions(expires_at)"
     );
 }
 
@@ -52,7 +52,7 @@ function create(data) {
     const encoded = json.encode(data || {});
 
     db.exec(
-        "INSERT INTO hull_sessions (id, data, created_at, last_accessed, expires_at) VALUES (?, ?, ?, ?, ?)",
+        "INSERT INTO _hull_sessions (id, data, created_at, last_accessed, expires_at) VALUES (?, ?, ?, ?, ?)",
         [id, encoded, now, now, expiresAt]
     );
 
@@ -65,7 +65,7 @@ function load(sessionId) {
 
     const now = time.now();
     const rows = db.query(
-        "SELECT data, expires_at FROM hull_sessions WHERE id = ?",
+        "SELECT data, expires_at FROM _hull_sessions WHERE id = ?",
         [sessionId]
     );
 
@@ -74,20 +74,20 @@ function load(sessionId) {
 
     // Check expiry
     if (rows[0].expires_at <= now) {
-        db.exec("DELETE FROM hull_sessions WHERE id = ?", [sessionId]);
+        db.exec("DELETE FROM _hull_sessions WHERE id = ?", [sessionId]);
         return null;
     }
 
     // Touch: update last_accessed and extend expiration
     db.exec(
-        "UPDATE hull_sessions SET last_accessed = ?, expires_at = ? WHERE id = ?",
+        "UPDATE _hull_sessions SET last_accessed = ?, expires_at = ? WHERE id = ?",
         [now, now + sessionTtl, sessionId]
     );
 
     const decoded = json.decode(rows[0].data);
     if (decoded == null) {
         // Corrupted session data — destroy and return null
-        db.exec("DELETE FROM hull_sessions WHERE id = ?", [sessionId]);
+        db.exec("DELETE FROM _hull_sessions WHERE id = ?", [sessionId]);
         return null;
     }
     return decoded;
@@ -101,7 +101,7 @@ function update(sessionId, data) {
     const encoded = json.encode(data || {});
 
     const affected = db.exec(
-        "UPDATE hull_sessions SET data = ?, last_accessed = ?, expires_at = ? WHERE id = ? AND expires_at > ?",
+        "UPDATE _hull_sessions SET data = ?, last_accessed = ?, expires_at = ? WHERE id = ? AND expires_at > ?",
         [encoded, now, now + sessionTtl, sessionId, now]
     );
 
@@ -113,7 +113,7 @@ function destroy(sessionId) {
         return false;
 
     const affected = db.exec(
-        "DELETE FROM hull_sessions WHERE id = ?",
+        "DELETE FROM _hull_sessions WHERE id = ?",
         [sessionId]
     );
 
@@ -123,7 +123,7 @@ function destroy(sessionId) {
 function cleanup() {
     const now = time.now();
     return db.exec(
-        "DELETE FROM hull_sessions WHERE expires_at <= ?",
+        "DELETE FROM _hull_sessions WHERE expires_at <= ?",
         [now]
     );
 }

--- a/stdlib/lua/hull/middleware/session.lua
+++ b/stdlib/lua/hull/middleware/session.lua
@@ -21,7 +21,7 @@ function session.init(opts)
     end
 
     db.exec([[
-        CREATE TABLE IF NOT EXISTS hull_sessions (
+        CREATE TABLE IF NOT EXISTS _hull_sessions (
             id TEXT PRIMARY KEY,
             data TEXT NOT NULL,
             created_at INTEGER NOT NULL,
@@ -30,8 +30,8 @@ function session.init(opts)
         )
     ]])
     db.exec([[
-        CREATE INDEX IF NOT EXISTS idx_hull_sessions_expires
-        ON hull_sessions(expires_at)
+        CREATE INDEX IF NOT EXISTS idx__hull_sessions_expires
+        ON _hull_sessions(expires_at)
     ]])
 end
 
@@ -53,7 +53,7 @@ function session.create(data)
     local encoded = json.encode(data or {})
 
     db.exec(
-        "INSERT INTO hull_sessions (id, data, created_at, last_accessed, expires_at) VALUES (?, ?, ?, ?, ?)",
+        "INSERT INTO _hull_sessions (id, data, created_at, last_accessed, expires_at) VALUES (?, ?, ?, ?, ?)",
         { id, encoded, now, now, now + _ttl }
     )
 
@@ -70,7 +70,7 @@ function session.load(session_id)
 
     local now = time.now()
     local rows = db.query(
-        "SELECT data, expires_at FROM hull_sessions WHERE id = ?",
+        "SELECT data, expires_at FROM _hull_sessions WHERE id = ?",
         { session_id }
     )
 
@@ -83,20 +83,20 @@ function session.load(session_id)
     -- Check expiry
     if row.expires_at <= now then
         -- Expired -- clean it up
-        db.exec("DELETE FROM hull_sessions WHERE id = ?", { session_id })
+        db.exec("DELETE FROM _hull_sessions WHERE id = ?", { session_id })
         return nil
     end
 
     -- Update last_accessed and extend expiry
     db.exec(
-        "UPDATE hull_sessions SET last_accessed = ?, expires_at = ? WHERE id = ?",
+        "UPDATE _hull_sessions SET last_accessed = ?, expires_at = ? WHERE id = ?",
         { now, now + _ttl, session_id }
     )
 
     local decoded = json.decode(row.data)
     if not decoded then
         -- Corrupted session data — destroy and return nil
-        db.exec("DELETE FROM hull_sessions WHERE id = ?", { session_id })
+        db.exec("DELETE FROM _hull_sessions WHERE id = ?", { session_id })
         return nil
     end
     return decoded
@@ -112,7 +112,7 @@ function session.update(session_id, data)
     local encoded = json.encode(data or {})
 
     db.exec(
-        "UPDATE hull_sessions SET data = ?, last_accessed = ?, expires_at = ? WHERE id = ?",
+        "UPDATE _hull_sessions SET data = ?, last_accessed = ?, expires_at = ? WHERE id = ?",
         { encoded, now, now + _ttl, session_id }
     )
 end
@@ -123,7 +123,7 @@ function session.destroy(session_id)
         return
     end
 
-    db.exec("DELETE FROM hull_sessions WHERE id = ?", { session_id })
+    db.exec("DELETE FROM _hull_sessions WHERE id = ?", { session_id })
 end
 
 --- Delete all expired sessions.
@@ -131,7 +131,7 @@ end
 function session.cleanup()
     local now = time.now()
     local count = db.exec(
-        "DELETE FROM hull_sessions WHERE expires_at <= ?",
+        "DELETE FROM _hull_sessions WHERE expires_at <= ?",
         { now }
     )
     return count

--- a/tests/hull/cap/test_db.c
+++ b/tests/hull/cap/test_db.c
@@ -390,4 +390,31 @@ UTEST(hl_cap_db, stmt_cache_reuse)
     teardown_db();
 }
 
+/* ── Namespace check tests ──────────────────────────────────────────── */
+
+UTEST(hl_cap_db, namespace_check_blocks_hull_tables)
+{
+    ASSERT_EQ(hl_cap_db_check_namespace("SELECT * FROM _hull_outbox"), -1);
+    ASSERT_EQ(hl_cap_db_check_namespace("DROP TABLE _hull_migrations"), -1);
+    ASSERT_EQ(hl_cap_db_check_namespace("INSERT INTO _HULL_OUTBOX VALUES(1)"), -1);
+    ASSERT_EQ(hl_cap_db_check_namespace("SELECT * FROM users"), 0);
+    ASSERT_EQ(hl_cap_db_check_namespace("SELECT * FROM hull_data"), 0);
+    ASSERT_EQ(hl_cap_db_check_namespace(NULL), -1);
+}
+
+UTEST(hl_cap_db, namespace_check_case_insensitive)
+{
+    ASSERT_EQ(hl_cap_db_check_namespace("SELECT * FROM _Hull_Outbox"), -1);
+    ASSERT_EQ(hl_cap_db_check_namespace("SELECT * FROM _HULL_sessions"), -1);
+    ASSERT_EQ(hl_cap_db_check_namespace("CREATE TABLE _hull_test (id INT)"), -1);
+}
+
+UTEST(hl_cap_db, namespace_check_allows_normal_tables)
+{
+    ASSERT_EQ(hl_cap_db_check_namespace("CREATE TABLE users (id INT)"), 0);
+    ASSERT_EQ(hl_cap_db_check_namespace("SELECT * FROM orders"), 0);
+    ASSERT_EQ(hl_cap_db_check_namespace("INSERT INTO items VALUES (1)"), 0);
+    ASSERT_EQ(hl_cap_db_check_namespace(""), 0);
+}
+
 UTEST_MAIN();

--- a/tests/hull/runtime/js/test_js.c
+++ b/tests/hull/runtime/js/test_js.c
@@ -831,6 +831,113 @@ UTEST(js_cap, db_not_available_without_config)
     cleanup_js();
 }
 
+/* ── DB namespace protection tests ──────────────────────────────────── */
+
+UTEST(js_cap, db_namespace_blocks_hull_tables)
+{
+    init_js_with_caps();
+    ASSERT_TRUE(js_initialized);
+
+    const char *code =
+        "import { db } from 'hull:db';\n"
+        "try {\n"
+        "  db.exec('CREATE TABLE _hull_test (id INT)');\n"
+        "  globalThis.__test_ns_block = 0;\n"
+        "} catch (e) {\n"
+        "  globalThis.__test_ns_block = String(e).includes('reserved') ? 1 : 0;\n"
+        "}\n";
+
+    JSValue val = JS_Eval(js.ctx, code, strlen(code), "<test>",
+                          JS_EVAL_TYPE_MODULE);
+    if (JS_IsException(val))
+        hl_js_dump_error(&js);
+    JS_FreeValue(js.ctx, val);
+    hl_js_run_jobs(&js);
+
+    int result = eval_int("globalThis.__test_ns_block");
+    ASSERT_EQ(result, 1);
+
+    cleanup_js_caps();
+}
+
+UTEST(js_cap, db_namespace_blocks_hull_query)
+{
+    init_js_with_caps();
+    ASSERT_TRUE(js_initialized);
+
+    const char *code =
+        "import { db } from 'hull:db';\n"
+        "try {\n"
+        "  db.query('SELECT * FROM _hull_outbox');\n"
+        "  globalThis.__test_ns_qblock = 0;\n"
+        "} catch (e) {\n"
+        "  globalThis.__test_ns_qblock = String(e).includes('reserved') ? 1 : 0;\n"
+        "}\n";
+
+    JSValue val = JS_Eval(js.ctx, code, strlen(code), "<test>",
+                          JS_EVAL_TYPE_MODULE);
+    if (JS_IsException(val))
+        hl_js_dump_error(&js);
+    JS_FreeValue(js.ctx, val);
+    hl_js_run_jobs(&js);
+
+    int result = eval_int("globalThis.__test_ns_qblock");
+    ASSERT_EQ(result, 1);
+
+    cleanup_js_caps();
+}
+
+UTEST(js_cap, db_namespace_no_internal_bypass)
+{
+    init_js_with_caps();
+    ASSERT_TRUE(js_initialized);
+
+    /* db._exec and db._query must not exist — no bypass possible */
+    const char *code =
+        "import { db } from 'hull:db';\n"
+        "globalThis.__test_ns_nobypass = "
+        "  (db._exec === undefined && db._query === undefined) ? 1 : 0;\n";
+
+    JSValue val = JS_Eval(js.ctx, code, strlen(code), "<test>",
+                          JS_EVAL_TYPE_MODULE);
+    if (JS_IsException(val))
+        hl_js_dump_error(&js);
+    JS_FreeValue(js.ctx, val);
+    hl_js_run_jobs(&js);
+
+    int result = eval_int("globalThis.__test_ns_nobypass");
+    ASSERT_EQ(result, 1);
+
+    cleanup_js_caps();
+}
+
+UTEST(js_cap, db_namespace_allows_normal_tables)
+{
+    init_js_with_caps();
+    ASSERT_TRUE(js_initialized);
+
+    const char *code =
+        "import { db } from 'hull:db';\n"
+        "db.exec('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)');\n"
+        "db.exec('INSERT INTO users (name) VALUES (?)', ['alice']);\n"
+        "const rows = db.query('SELECT name FROM users');\n"
+        "globalThis.__test_ns_normal = rows[0].name;\n";
+
+    JSValue val = JS_Eval(js.ctx, code, strlen(code), "<test>",
+                          JS_EVAL_TYPE_MODULE);
+    if (JS_IsException(val))
+        hl_js_dump_error(&js);
+    JS_FreeValue(js.ctx, val);
+    hl_js_run_jobs(&js);
+
+    char *name = eval_str("globalThis.__test_ns_normal");
+    ASSERT_NE(name, NULL);
+    ASSERT_STREQ(name, "alice");
+    free(name);
+
+    cleanup_js_caps();
+}
+
 /* ── Manifest tests ────────────────────────────────────────────────── */
 
 UTEST(js_cap, app_manifest_store_and_get)

--- a/tests/hull/runtime/lua/test_lua.c
+++ b/tests/hull/runtime/lua/test_lua.c
@@ -1127,6 +1127,72 @@ UTEST(lua_cap, db_not_available_without_config)
     cleanup_lua();
 }
 
+/* ── DB namespace protection tests ──────────────────────────────────── */
+
+UTEST(lua_cap, db_namespace_blocks_hull_tables)
+{
+    init_lua_with_caps();
+    ASSERT_TRUE(lua_initialized);
+
+    int result = eval_int(
+        "(function() "
+        "  local ok, err = pcall(db.exec, 'CREATE TABLE _hull_test (id INT)') "
+        "  if not ok and string.find(tostring(err), 'reserved') then return 1 end "
+        "  return 0 "
+        "end)()");
+    ASSERT_EQ(result, 1);
+
+    cleanup_lua_caps();
+}
+
+UTEST(lua_cap, db_namespace_blocks_hull_query)
+{
+    init_lua_with_caps();
+    ASSERT_TRUE(lua_initialized);
+
+    int result = eval_int(
+        "(function() "
+        "  local ok, err = pcall(db.query, 'SELECT * FROM _hull_outbox') "
+        "  if not ok and string.find(tostring(err), 'reserved') then return 1 end "
+        "  return 0 "
+        "end)()");
+    ASSERT_EQ(result, 1);
+
+    cleanup_lua_caps();
+}
+
+UTEST(lua_cap, db_namespace_no_internal_bypass)
+{
+    init_lua_with_caps();
+    ASSERT_TRUE(lua_initialized);
+
+    /* db._exec and db._query must not exist — no bypass possible */
+    int result = eval_int(
+        "(function() "
+        "  return (db._exec == nil and db._query == nil) and 1 or 0 "
+        "end)()");
+    ASSERT_EQ(result, 1);
+
+    cleanup_lua_caps();
+}
+
+UTEST(lua_cap, db_namespace_allows_normal_tables)
+{
+    init_lua_with_caps();
+    ASSERT_TRUE(lua_initialized);
+
+    int result = eval_int(
+        "(function() "
+        "  db.exec('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)') "
+        "  db.exec('INSERT INTO users (name) VALUES (?)', {'alice'}) "
+        "  local rows = db.query('SELECT name FROM users') "
+        "  return rows[1].name == 'alice' and 1 or 0 "
+        "end)()");
+    ASSERT_EQ(result, 1);
+
+    cleanup_lua_caps();
+}
+
 /* ── Manifest tests ────────────────────────────────────────────────── */
 
 #include "hull/manifest.h"


### PR DESCRIPTION
## Summary
- Add `hl_cap_db_check_namespace()` to block user SQL from referencing `_hull_*` internal tables
- Use call-stack inspection (Lua `lua_getinfo` / JS `JS_GetScriptOrModuleName`) so stdlib modules transparently bypass the check — no internal API exposed
- Rename `hull_sessions` → `_hull_sessions` for naming consistency

## Test plan
- [x] C unit tests for `hl_cap_db_check_namespace()` (3 tests: blocks, case-insensitive, allows normal)
- [x] Lua integration tests: user code blocked, no `db._exec`/`db._query` bypass, normal tables work
- [x] JS integration tests: same 4 tests
- [x] All 18 unit test suites pass (362 tests)
- [x] All e2e suites pass (433 tests): basic, http, build, templates, migrate, agent, examples
- [x] Session middleware works correctly through namespace protection (both runtimes)