### PR TITLE
cap/wasm: fix shared-segment use-after-free vs in-flight async calls (R1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,30 @@ jobs:
         timeout-minutes: 15
         run: make msan
 
+  tsan:
+    name: TSan (worker pool)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+
+      - name: Install clang
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang
+
+      - name: TSan test (worker-pool / shared-state paths)
+        # ThreadSanitizer over the suites that spin worker threads: the
+        # WASM compute worker (cap/wasm.c + worker_wasm.c, home of the
+        # shared-segment vs in-flight-async-call fix) and both thread-pool
+        # async backends (Keel-backed + poll). Guards against a regression
+        # of the inflight_async use-after-free fix and any future race in
+        # the worker handoff shared by db.async / compute.async / gpu.async.
+        timeout-minutes: 15
+        run: make CC=clang tsan
+
   analyze:
     name: Static Analysis
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -97,10 +97,11 @@ ifndef COSMO
       LDFLAGS += -pie
     endif
 
-    ifndef DEBUG
+    ifeq ($(DEBUG)$(TSAN),)
       # _FORTIFY_SOURCE=3 requires glibc 2.34+ / gcc 12+ / clang 9+; on
       # older toolchains it emits a noisy warning and behaves as =2.
       # We intentionally leave the warning loud so stale CI is visible.
+      # Skipped under sanitizer builds (DEBUG/TSAN) which use -O0/-O1.
       CFLAGS += -D_FORTIFY_SOURCE=3
     endif
 
@@ -208,6 +209,13 @@ export ZERO_AR_DATE := 1
 ifdef DEBUG
 CFLAGS += -g -O0 -fsanitize=address,undefined -fno-omit-frame-pointer
 LDFLAGS += -fsanitize=address,undefined
+else ifdef TSAN
+# ThreadSanitizer build. Appends to the normal CFLAGS (Hull's own TUs get
+# instrumented; vendor TUs stay uninstrumented, which TSan tolerates — it
+# just won't flag races inside vendored code). Used to validate the
+# worker-pool / shared-state paths (cap/wasm.c segments, worker_*.c).
+CFLAGS += -g -O1 -fsanitize=thread -fno-omit-frame-pointer
+LDFLAGS += -fsanitize=thread
 else
 CFLAGS += -O2
 endif
@@ -2018,7 +2026,7 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
 
 # ── Targets ─────────────────────────────────────────────────────────
 
-.PHONY: all clean test debug msan e2e e2e-build e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-tcc e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint platform platform-cosmo hardening check-hardening
+.PHONY: all clean test debug msan tsan e2e e2e-build e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-tcc e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint platform platform-cosmo hardening check-hardening
 
 all: $(BUILDDIR)/hull
 
@@ -2917,6 +2925,29 @@ msan:
 		KEEL_TLS=mbedtls MBEDTLS_CONFIG_FILE=hull_config.h \
 		KEEL_COMPRESS=miniz MINIZ_DIR=$(CURDIR)/$(MINIZ_DIR)
 	$(MAKE) CC=clang MSAN=1 test
+
+# ThreadSanitizer — validate the worker-pool / shared-state paths under a
+# real race detector. Targeted at the suites that actually spin worker
+# threads, rather than the whole test set, to keep the signal on the
+# threading code and avoid TSan's cost on single-threaded suites:
+#   - test_wasm           : WASM compute worker + the shared-segment vs
+#                           in-flight-async-call path (cap/wasm.c +
+#                           worker_wasm.c; home of the inflight_async fix)
+#   - test_async_backend  : the Keel-backed thread-pool async backend
+#   - test_async_backend_poll : the poll-based thread-pool async backend
+# The db.async (worker_db.c) and gpu.async (worker_gpu.c) workers ride the
+# same pool backends covered here; their cap-layer suites are
+# single-threaded so they add no race coverage. TSAN=1 appends
+# -fsanitize=thread to Hull's own TUs; vendor objects (WAMR, mbedTLS,
+# keel.a) stay uninstrumented, which TSan tolerates.
+TSAN_TESTS := test_wasm test_async_backend test_async_backend_poll
+tsan:
+	$(MAKE) clean
+	$(MAKE) TSAN=1 $(addprefix $(BUILDDIR)/,$(TSAN_TESTS))
+	@for t in $(TSAN_TESTS); do \
+		echo "── TSan: $$t ──"; \
+		TSAN_OPTIONS="halt_on_error=1" $(BUILDDIR)/$$t || exit 1; \
+	done
 
 # ── E2E tests ──────────────────────────────────────────────────────
 

--- a/include/hull/cap/wasm.h
+++ b/include/hull/cap/wasm.h
@@ -97,6 +97,15 @@ typedef struct {
     HlWasmPool pool;       /* per-module instance pool */
     HlWasmSharedData *shared_data;  /* NULL until compute.data() called */
     pthread_mutex_t mutex;  /* guards pool + shared_data for this module */
+    /* Count of async compute calls (pooled or persistent) currently in
+     * flight on this module. A worker thread may hold a snapshot of
+     * shared_data/chain_head taken under mutex in pool_acquire / the
+     * persistent path and use it unlocked during its gas-metered call;
+     * hl_cap_wasm_data_load refuses to free/rebuild segments while this
+     * is non-zero to avoid a use-after-free. Touched ONLY on the event-
+     * loop thread (async submit/completion + data_load all run there),
+     * so it is a plain int and needs no atomics/lock. */
+    int inflight_async;
 } HlWasmModule;
 
 /* Forward decl — the full ShSealArena type lives in sh_seal_arena.h.
@@ -217,6 +226,16 @@ void hl_cap_wasm_destroy(HlWasmCache *cache);
  */
 int hl_cap_wasm_load(HlWasmCache *cache, const char *name,
                      const struct HlVfs *app_vfs, const char *app_dir);
+
+/**
+ * Look up an already-loaded module by name. Returns NULL if not loaded.
+ *
+ * Thread-safe (takes the cache pool mutex around the lookup). The
+ * returned pointer is stable for the cache's lifetime (module slots are
+ * append-only and never move). Used by the async worker layer to take a
+ * stable module handle at submit time for the in-flight-call counter.
+ */
+HlWasmModule *hl_cap_wasm_module_lookup(HlWasmCache *cache, const char *name);
 
 /**
  * Call a WASM compute module.

--- a/include/hull/worker_wasm.h
+++ b/include/hull/worker_wasm.h
@@ -46,6 +46,13 @@ typedef struct HlWorkerWasmOp {
     /* Persistent instance mode (NULL = use pooled call) */
     HlWasmInstance *persistent_inst;
 
+    /* Module this op targets, resolved at submit time on the event loop
+     * (pooled: looked up by name; persistent: persistent_inst->module).
+     * Used to bump/clear mod->inflight_async so segment mutation can be
+     * refused while this call is outstanding. NULL if the module was not
+     * resolvable at submit (the worker then fails as before). */
+    HlWasmModule  *mod;
+
     /* Buffer mode */
     int            want_buffer;   /* 1 = return HlWasmBuffer instead of raw bytes */
 

--- a/src/hull/cap/wasm.c
+++ b/src/hull/cap/wasm.c
@@ -212,6 +212,18 @@ static HlWasmModule *cache_find(HlWasmCache *cache, const char *name)
     return NULL;
 }
 
+HlWasmModule *hl_cap_wasm_module_lookup(HlWasmCache *cache, const char *name)
+{
+    if (!cache || !cache->initialized || !name)
+        return NULL;
+    /* cache->count / modules[] reads race with concurrent inserts under
+     * C11; take the cache-level mutex (same as data_load's lookup). */
+    pthread_mutex_lock(&cache->pool_mutex);
+    HlWasmModule *mod = cache_find(cache, name);
+    pthread_mutex_unlock(&cache->pool_mutex);
+    return mod;
+}
+
 /* ── Instance pool ─────────────────────────────────────────────────── */
 
 /* Drain all pooled instances for a module. Caller must hold mod->mutex. */

--- a/src/hull/cap/wasm_data.c
+++ b/src/hull/cap/wasm_data.c
@@ -190,6 +190,7 @@ int hl_cap_wasm_data_load(HlWasmCache *cache, const char *module_name,
     static const char *err_too_many  = "too_many_segments";
     static const char *err_too_large = "data_too_large";
     static const char *err_bad_name  = "segment_name_too_long";
+    static const char *err_busy      = "async_calls_in_flight";
 
     if (!cache || !cache->initialized || !module_name) {
         if (err_msg) *err_msg = err_internal;
@@ -220,6 +221,21 @@ int hl_cap_wasm_data_load(HlWasmCache *cache, const char *module_name,
             if (err_msg) *err_msg = err_internal;
             return -1;
         }
+    }
+
+    /* Refuse to add/replace/remove segments while any async compute call
+     * on this module is in flight. A worker thread may hold a snapshot of
+     * shared_data / chain_head (taken under mod->mutex in pool_acquire or
+     * the persistent-instance path) and dereference it unlocked during its
+     * gas-metered call; freeing or rebuilding the chain here would be a
+     * use-after-free. inflight_async is event-loop-only (this function,
+     * the async submit, and the async completion all run on the event-loop
+     * thread), so the read needs no lock. The documented usage pattern
+     * loads all segments at startup before dispatching work, which never
+     * trips this; dynamic callers must drain in-flight calls first. */
+    if (mod->inflight_async > 0) {
+        if (err_msg) *err_msg = err_busy;
+        return -1;
     }
 
     pthread_mutex_lock(&mod->mutex);

--- a/src/hull/worker_wasm.c
+++ b/src/hull/worker_wasm.c
@@ -78,9 +78,21 @@ static void wasm_work_fn(void *ud)
 
 /* ── done_fn: runs on event loop after work completes ──────────────── */
 
+/* Drop this op's in-flight reservation on its module (event loop only).
+ * Pairs with the bump in hl_worker_wasm_submit. Once it reaches zero,
+ * hl_cap_wasm_data_load may mutate the module's shared segments again. */
+static void wasm_inflight_release(HlWorkerWasmOp *op)
+{
+    if (op->mod && op->mod->inflight_async > 0)
+        op->mod->inflight_async--;
+    op->mod = NULL;
+}
+
 static void wasm_done_fn(void *ud)
 {
     HlWorkerWasmOp *op = (HlWorkerWasmOp *)ud;
+
+    wasm_inflight_release(op);
 
     /* Clear busy flag for persistent instances (event loop thread) */
     if (op->persistent_inst)
@@ -107,6 +119,8 @@ static void wasm_cancel_fn(void *ud)
 {
     HlWorkerWasmOp *op = (HlWorkerWasmOp *)ud;
 
+    wasm_inflight_release(op);
+
     /* Clear busy flag for persistent instances */
     if (op->persistent_inst)
         atomic_store(&op->persistent_inst->busy, 0);
@@ -122,9 +136,26 @@ static void wasm_cancel_fn(void *ud)
 int hl_worker_wasm_submit(HlAsyncBackendPool *pool, HlWorkerWasmOp *op)
 {
     if (!pool || !op) return -1;
+
+    /* Reserve an in-flight slot on the target module BEFORE the worker can
+     * run, so a concurrent compute.segment() (hl_cap_wasm_data_load, event
+     * loop) cannot free/rebuild segments this call is about to snapshot.
+     * Runs on the event loop; the bindings already pre-load the module, so
+     * the pooled lookup is a cache hit. Released in done/cancel. */
+    if (op->persistent_inst)
+        op->mod = op->persistent_inst->module;
+    else if (op->wasm_cache)
+        op->mod = hl_cap_wasm_module_lookup((HlWasmCache *)op->wasm_cache,
+                                            op->name);
+    if (op->mod)
+        op->mod->inflight_async++;
+
     const HlAsyncBackend *be = hl_async_backend();
-    return be->pool_submit(pool, wasm_work_fn, wasm_done_fn,
-                           wasm_cancel_fn, op);
+    int rc = be->pool_submit(pool, wasm_work_fn, wasm_done_fn,
+                             wasm_cancel_fn, op);
+    if (rc != 0)
+        wasm_inflight_release(op);  /* op reaches neither done nor cancel */
+    return rc;
 }
 
 void hl_worker_wasm_op_free(HlWorkerWasmOp *op)

--- a/tests/hull/cap/test_wasm.c
+++ b/tests/hull/cap/test_wasm.c
@@ -1774,6 +1774,146 @@ UTEST(hl_cap_wasm, shared_data_load_unload)
     hl_cap_wasm_destroy(&cache);
 }
 
+/* ── R1: segment mutation refused while async compute calls in flight ──
+ *
+ * A worker thread holds a snapshot of mod->shared_data / chain_head taken
+ * under mod->mutex (pool_acquire / the persistent path) and dereferences
+ * it unlocked during its gas-metered call. The event-loop-side
+ * hl_cap_wasm_data_load must NOT free/rebuild those segments while a call
+ * is outstanding, or the worker reads freed memory. The guard is the
+ * per-module inflight_async counter, bumped at async submit and cleared
+ * at completion (both event-loop-thread). */
+
+UTEST(hl_cap_wasm, data_load_refused_while_async_in_flight)
+{
+    HlWasmCache cache;
+    ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    HlVfs vfs;
+    hl_vfs_init(&vfs, test_entries, NULL);
+
+    const char *err = NULL;
+    const char data[] = "segment-bytes";
+
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "shared_read", "seg0",
+                                    data, sizeof(data) - 1, NULL,
+                                    &vfs, NULL, &err), 0);
+
+    HlWasmModule *mod = hl_cap_wasm_module_lookup(&cache, "shared_read");
+    ASSERT_NE(mod, NULL);
+    ASSERT_EQ(mod->inflight_async, 0);       /* counter starts clear */
+    ASSERT_NE(mod->shared_data, NULL);
+    ASSERT_EQ(mod->shared_data->count, 1);
+
+    /* Reserve an in-flight slot, exactly as hl_worker_wasm_submit does. */
+    mod->inflight_async = 1;
+
+    /* All three mutation forms must refuse and leave the segment intact. */
+    err = NULL;                              /* add/replace */
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "shared_read", "seg1",
+                                    data, sizeof(data) - 1, NULL,
+                                    &vfs, NULL, &err), -1);
+    ASSERT_STREQ(err, "async_calls_in_flight");
+
+    err = NULL;                              /* remove one */
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "shared_read", "seg0",
+                                    NULL, 0, NULL, &vfs, NULL, &err), -1);
+    ASSERT_STREQ(err, "async_calls_in_flight");
+
+    err = NULL;                              /* remove all */
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "shared_read", NULL,
+                                    NULL, 0, NULL, &vfs, NULL, &err), -1);
+    ASSERT_STREQ(err, "async_calls_in_flight");
+
+    ASSERT_NE(mod->shared_data, NULL);       /* nothing was freed */
+    ASSERT_EQ(mod->shared_data->count, 1);
+
+    /* Once the call completes, mutation is allowed again. */
+    mod->inflight_async = 0;
+    err = NULL;
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "shared_read", NULL,
+                                    NULL, 0, NULL, &vfs, NULL, &err), 0);
+    ASSERT_EQ(mod->shared_data, NULL);
+
+    hl_cap_wasm_destroy(&cache);
+}
+
+/* Cross-thread regression test for R1: a worker thread holds a real
+ * shared_data snapshot (as pool_acquire hands to the gas-metered call)
+ * while the event loop attempts to free the segment. The guard must
+ * refuse the free, so the worker's snapshot stays valid. Run under TSan
+ * to prove no data race, and under ASan to prove no use-after-free; both
+ * would fire if the guard regressed and the free proceeded. */
+typedef struct {
+    HlWasmModule *mod;
+    atomic_int    snapshotted;
+    atomic_int    release;
+    int           observed_count;
+} SnapHoldCtx;
+
+static void *snapshot_holder(void *arg)
+{
+    SnapHoldCtx *c = (SnapHoldCtx *)arg;
+    /* Snapshot under the module mutex, exactly like pool_acquire. */
+    pthread_mutex_lock(&c->mod->mutex);
+    const HlWasmSharedData *sd = c->mod->shared_data;
+    pthread_mutex_unlock(&c->mod->mutex);
+
+    atomic_store(&c->snapshotted, 1);
+
+    /* Dereference the held snapshot until released. */
+    int last = -1;
+    while (!atomic_load(&c->release))
+        if (sd) last = sd->count;
+    if (sd) last = sd->count;
+    c->observed_count = last;
+    return NULL;
+}
+
+UTEST(hl_cap_wasm, data_load_free_blocked_while_worker_holds_snapshot)
+{
+    HlWasmCache cache;
+    ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    HlVfs vfs;
+    hl_vfs_init(&vfs, test_entries, NULL);
+
+    const char *err = NULL;
+    const char data[] = "ABCDEFGHIJ";
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "shared_read", "seg0",
+                                    data, sizeof(data) - 1, NULL,
+                                    &vfs, NULL, &err), 0);
+
+    HlWasmModule *mod = hl_cap_wasm_module_lookup(&cache, "shared_read");
+    ASSERT_NE(mod, NULL);
+
+    /* Reserve the in-flight slot as the event loop would at submit. */
+    mod->inflight_async = 1;
+
+    SnapHoldCtx ctx = { .mod = mod, .snapshotted = 0, .release = 0,
+                        .observed_count = -1 };
+    pthread_t th;
+    ASSERT_EQ(pthread_create(&th, NULL, snapshot_holder, &ctx), 0);
+
+    while (!atomic_load(&ctx.snapshotted)) { /* wait for the snapshot */ }
+
+    /* Event loop tries to free the held segment — must be refused. */
+    err = NULL;
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "shared_read", NULL,
+                                    NULL, 0, NULL, &vfs, NULL, &err), -1);
+    ASSERT_STREQ(err, "async_calls_in_flight");
+
+    atomic_store(&ctx.release, 1);
+    pthread_join(th, NULL);
+    ASSERT_EQ(ctx.observed_count, 1);        /* snapshot stayed valid */
+
+    /* Free now succeeds with no call in flight. */
+    mod->inflight_async = 0;
+    err = NULL;
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "shared_read", NULL,
+                                    NULL, 0, NULL, &vfs, NULL, &err), 0);
+
+    hl_cap_wasm_destroy(&cache);
+}
+
 /* Shared heap probe removed — the root cause was using invokeNative_general.c
  * (32-bit generic invoker) on 64-bit platforms, which mangled native function
  * arguments. Fixed by using platform-specific assembly invokers (em64_simd.s


### PR DESCRIPTION
Fixes the R1 use-after-free from the C-core hardening audit: a `compute.async` worker holds a snapshot of `mod->shared_data`/`chain_head` (taken under `mod->mutex` in `pool_acquire` / the persistent path) and dereferences it unlocked during its gas-metered call, while `compute.segment()` → `hl_cap_wasm_data_load` on the event-loop thread frees/rebuilds those segments. The mutex covers the snapshot read, not its lifetime during the call.

## Fix
A per-module `inflight_async` counter: bumped in `hl_worker_wasm_submit` (event loop, before the worker can run), cleared in `wasm_done_fn`/`wasm_cancel_fn`, checked in `hl_cap_wasm_data_load` (refuses segment mutation with `async_calls_in_flight` while non-zero). All touch points are event-loop-confined → plain `int`, no atomics. Zero behaviour change for the documented load-at-startup pattern.

The other two worker pools are race-free by construction: `db.async` uses per-thread TLS sqlite connections + deep-copied inputs; `gpu.async` holds the per-device mutex across the whole dispatch. WASM was the only pool that released its lock after snapshotting a structure the event loop can free.

## Tests + tooling
- 2 new tests in `test_wasm.c`: a deterministic guard test and a threaded reproducer (provokes the race under TSan with the guard removed, clean with it).
- New `TSAN=1` build mode + `make tsan` target running the worker-pool suites (`test_wasm` + both async-backend pool backends).
- New **TSan (worker pool)** CI job.

Verified: `make test` 49/49; `make tsan` green (58/8/10, no races); normal release build unchanged.