### PR TITLE
vendor/sh_arena: overflow guard + ASan poisoning (debug instrumentation)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -521,6 +521,13 @@ LOG_CFLAGS := -std=c11 -O2 -w -DLOG_USE_COLOR
 SH_ARENA_DIR    := $(VENDDIR)/sh_arena
 SH_ARENA_OBJ    := $(BUILDDIR)/sh_arena.o
 SH_ARENA_CFLAGS := -std=c11 -O2 -w
+# Under ASan (`make debug`) instrument the arena TU so its manual ASan
+# poison/unpoison calls activate (dangling-into-arena reads in Hull code
+# become hard ASan errors). Other vendored TUs intentionally stay
+# uninstrumented; this one is tiny and the integration needs it ASan-aware.
+ifdef DEBUG
+SH_ARENA_CFLAGS += -fsanitize=address,undefined -fno-omit-frame-pointer
+endif
 
 # ── sh_json (vendored from otto) ──────────────────────────────────────
 

--- a/tests/hull/test_arena.c
+++ b/tests/hull/test_arena.c
@@ -14,11 +14,25 @@
 #include "utest.h"
 #include "hull/alloc.h"
 #include <sh_arena.h>
+#include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 /* Create via the Hull wrapper with a NULL allocator (== sh_arena_create),
  * so the test covers the same construction path callers use. */
 static SHArena *make(void) { return hl_arena_create(NULL, 4096); }
+
+/* __has_feature is clang-only; 0 fallback so the #if parses on GCC. */
+#ifndef __has_feature
+#  define __has_feature(x) 0
+#endif
+#if defined(__SANITIZE_ADDRESS__) || __has_feature(address_sanitizer)
+#  define SH_ARENA_TEST_ASAN 1
+#else
+#  define SH_ARENA_TEST_ASAN 0
+#endif
 
 UTEST(hl_arena, mark_is_used_offset)
 {
@@ -117,5 +131,65 @@ UTEST(hl_arena, null_safety)
     ASSERT_EQ(hl_arena_memdup(a, NULL, 4), (void *)NULL);
     hl_arena_free(NULL, a);
 }
+
+/* ── Overflow guard (unconditional) ─────────────────────────────────── */
+
+UTEST(hl_arena, alloc_rejects_overflow)
+{
+    SHArena *a = make();  /* 4096-byte capacity */
+
+    /* Near-SIZE_MAX sizes must fail closed, not wrap through the
+     * alignment round-up / bounds check into an undersized region. */
+    ASSERT_EQ(sh_arena_alloc(a, SIZE_MAX), (void *)NULL);
+    ASSERT_EQ(sh_arena_alloc(a, SIZE_MAX - 3), (void *)NULL);
+    ASSERT_EQ(sh_arena_alloc(a, SIZE_MAX - (SH_ARENA_ALIGN - 1)), (void *)NULL);
+
+    /* A plain over-capacity request is also NULL (normal OOM). */
+    ASSERT_EQ(sh_arena_alloc(a, 1u << 20), (void *)NULL);
+
+    /* The arena is still usable after rejected requests. */
+    void *p = sh_arena_alloc(a, 64);
+    ASSERT_TRUE(p != NULL);
+    ASSERT_EQ(sh_arena_used(a), (size_t)64);
+
+    hl_arena_free(NULL, a);
+}
+
+/* ── ASan poisoning: reading a reset region traps ───────────────────── */
+
+#if SH_ARENA_TEST_ASAN
+UTEST(hl_arena, reset_poisons_arena_under_asan)
+{
+    pid_t pid = fork();
+    ASSERT_TRUE(pid >= 0);
+
+    if (pid == 0) {
+        /* Child: allocate, use, reset (re-poisons), then read the now-
+         * dangling region. ASan must trap the instrumented read. */
+        SHArena *a = hl_arena_create(NULL, 4096);
+        volatile unsigned char *p = sh_arena_alloc(a, 64);
+        if (!p) _exit(0);          /* unexpected — fail the test */
+        p[0] = 0x7;                /* live: fine */
+        sh_arena_reset(a);         /* re-poisons the whole buffer */
+        unsigned char sink = p[0]; /* dangling read → ASan error */
+        (void)sink;
+        _exit(0);                  /* reached only if poisoning is inactive */
+    }
+
+    int status = 0;
+    ASSERT_EQ(waitpid(pid, &status, 0), pid);
+    /* ASan aborts the child on the poisoned read: either a signal or a
+     * non-zero exit (depending on abort_on_error). Exit 0 means the read
+     * was NOT trapped — poisoning regressed. */
+    int trapped = WIFSIGNALED(status) ||
+                  (WIFEXITED(status) && WEXITSTATUS(status) != 0);
+    ASSERT_TRUE(trapped);
+}
+#else
+UTEST(hl_arena, reset_poisons_arena_under_asan)
+{
+    UTEST_SKIP("address sanitizer not enabled in this build");
+}
+#endif
 
 UTEST_MAIN();

--- a/vendor/sh_arena/sh_arena.c
+++ b/vendor/sh_arena/sh_arena.c
@@ -1,11 +1,47 @@
 /*
  * sh_arena.c - Arena allocator implementation
+ *
+ * ── Hull local modification ─────────────────────────────────────────
+ * This vendored file carries two deliberate, documented Hull changes
+ * (kept minimal so it stays easy to diff against upstream):
+ *
+ *   1. Unconditional integer-overflow guard in sh_arena_alloc(), for
+ *      parity with sh_seal_arena_alloc() which already guards it. The
+ *      original `(size + ALIGN-1)` round-up and `used + size` bounds
+ *      check could both wrap for a near-SIZE_MAX size and hand back a
+ *      pointer to an undersized region. Now they fail closed (NULL).
+ *
+ *   2. AddressSanitizer-integrated poisoning (active only when this TU
+ *      is built with -fsanitize=address — Hull's `make debug`). The
+ *      arena is one malloc, so ASan can't see sub-allocation lifetimes
+ *      on its own. We poison the whole buffer on create/reset, unpoison
+ *      each sub-allocation, and unpoison before free — turning a
+ *      dangling read into a reset/freed arena region (from instrumented
+ *      Hull code) into a hard ASan error. Compiled to nothing without
+ *      ASan, so release is unaffected.
+ * ────────────────────────────────────────────────────────────────────
  */
 
 #include "sh_arena.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>  /* For SIZE_MAX */
+
+/* ASan manual poisoning — no-ops unless this TU is ASan-instrumented.
+ * __has_feature is clang-only; define a 0 fallback so the #if parses on
+ * GCC (where an undefined __has_feature(x) would otherwise be a syntax
+ * error, not just false). GCC reports ASan via __SANITIZE_ADDRESS__. */
+#ifndef __has_feature
+#  define __has_feature(x) 0
+#endif
+#if defined(__SANITIZE_ADDRESS__) || __has_feature(address_sanitizer)
+#  include <sanitizer/asan_interface.h>
+#  define SH_ARENA_POISON(p, n)   __asan_poison_memory_region((p), (n))
+#  define SH_ARENA_UNPOISON(p, n) __asan_unpoison_memory_region((p), (n))
+#else
+#  define SH_ARENA_POISON(p, n)   ((void)(p), (void)(n))
+#  define SH_ARENA_UNPOISON(p, n) ((void)(p), (void)(n))
+#endif
 
 SHArena *sh_arena_create(size_t capacity)
 {
@@ -20,6 +56,9 @@ SHArena *sh_arena_create(size_t capacity)
 
     arena->capacity = capacity;
     arena->used = 0;
+    /* Nothing handed out yet: the whole buffer is off-limits until a
+     * sub-allocation unpoisons its region. */
+    SH_ARENA_POISON(arena->buffer, capacity);
     return arena;
 }
 
@@ -27,15 +66,22 @@ void *sh_arena_alloc(SHArena *arena, size_t size)
 {
     if (!arena || !arena->buffer) return NULL;
 
+    /* Guard the alignment round-up against wrap (a near-SIZE_MAX size
+     * would otherwise round to a tiny value and pass the bounds check). */
+    if (size > SIZE_MAX - (SH_ARENA_ALIGN - 1)) return NULL;
+
     /* Align to SH_ARENA_ALIGN bytes for double/pointer alignment */
     size = (size + SH_ARENA_ALIGN - 1) & ~(size_t)(SH_ARENA_ALIGN - 1);
 
-    if (arena->used + size > arena->capacity) {
+    /* Non-wrapping bounds check: capacity - used cannot underflow because
+     * used <= capacity is an invariant. */
+    if (size > arena->capacity - arena->used) {
         return NULL;  /* Out of space */
     }
 
     void *ptr = arena->buffer + arena->used;
     arena->used += size;
+    SH_ARENA_UNPOISON(ptr, size);  /* this region is now live */
     return ptr;
 }
 
@@ -56,6 +102,10 @@ void *sh_arena_calloc(SHArena *arena, size_t count, size_t size)
 void sh_arena_reset(SHArena *arena)
 {
     if (arena) {
+        /* Re-poison everything: every prior sub-allocation is now invalid,
+         * so a retained pointer read traps under ASan instead of silently
+         * reading reusable bytes. */
+        SH_ARENA_POISON(arena->buffer, arena->capacity);
         arena->used = 0;
     }
 }
@@ -63,6 +113,9 @@ void sh_arena_reset(SHArena *arena)
 void sh_arena_free(SHArena *arena)
 {
     if (arena) {
+        /* Unpoison before free so the allocator's own bookkeeping (and
+         * ASan's free interceptor) see a clean region. */
+        SH_ARENA_UNPOISON(arena->buffer, arena->capacity);
         free(arena->buffer);
         free(arena);
     }


### PR DESCRIPTION
Recommendation #3 from the C-core hardening audit. Two deliberate, documented edits to the Hull-vendored `sh_arena.c` (rationale in a header comment; contained to one file).

## Changes
1. **Overflow guard** (unconditional) — `sh_arena_alloc` could wrap in *both* the alignment round-up and the `used + size > capacity` bounds check for a near-`SIZE_MAX` size, handing back an undersized region. Now fails closed, matching `sh_seal_arena_alloc`'s non-wrapping form.
2. **ASan-integrated poisoning** (active only under `make debug`, where the Makefile now ASan-instruments `sh_arena.c`) — the arena is one malloc, so ASan can't track sub-allocation lifetimes. Poison the buffer on create/reset, unpoison each sub-alloc, unpoison before free → a dangling read into a reset/freed arena region from instrumented Hull code becomes a hard ASan error. Compiles to nothing without ASan (release unaffected).

**Skipped** the audit's magic-canary + owner-tid: ASan already traps the `SHArena` struct's own use-after-free, and struct fields risk cross-TU ABI drift (`alloc.c` does `sizeof(SHArena)`).

## Tests
`alloc_rejects_overflow` (unconditional); `reset_poisons_arena_under_asan` (fork death test asserting ASan traps a dangling read; self-skips when ASan off).

## Verified
- `make test` 50/50 (release).
- `make debug` full suite **50/50 with poisoning active** — no false positives, no latent dangling-read surfaced; death test traps.
- `sh_arena.c` compiles clean under cosmocc (poison no-op without ASan).