### PR TITLE
build: enable -Werror=cast-qual + clean the 46 existing const-drop sites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,14 @@ CFLAGS  := -std=c11 -Wall -Wextra -Wpedantic -Wshadow -Wformat=2
 # TU that includes them, and we can't edit the vendor source. Unused
 # parameters in Hull code itself should be silenced with `(void)x;`.
 CFLAGS  += -Werror=unused-function -Werror=unused-variable
+# Casts that drop `const` (or `volatile`) are a hard error in Hull code:
+# they're the primitive that would launder a sealed / .rodata table back
+# into something writable. Legitimate const-drops (freeing owned-but-
+# const-typed memory, POSIX execvp's argv, in-place scratch) go through
+# hl_free_const / hl_alloc_free_const or a documented `(T)(uintptr_t)x`.
+# Vendored TUs compile with their own relaxed *_CFLAGS, so this is
+# Hull-source-only.
+CFLAGS  += -Werror=cast-qual
 LDFLAGS :=
 
 # Header-dependency tracking. -MMD writes a sibling .d file listing every

--- a/include/hull/alloc.h
+++ b/include/hull/alloc.h
@@ -16,6 +16,8 @@
 #define HL_ALLOC_H
 
 #include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
 #include <keel/allocator.h>
 
 /* Forward declarations */
@@ -42,6 +44,23 @@ void *hl_alloc_calloc(HlAllocator *a, size_t count, size_t size);
 void *hl_alloc_realloc(HlAllocator *a, void *ptr,
                        size_t old_size, size_t new_size);
 void  hl_alloc_free(HlAllocator *a, void *ptr, size_t size);
+
+/* Free memory the caller OWNS but holds through a const-qualified pointer.
+ * Some structs type owned strings as `const char *` for a read-only API
+ * (e.g. HlValue.value.s, which is a borrowed query column in one context
+ * and a deep-copied owned string in another). When this code owns the
+ * bytes, freeing them is correct; the cast to mutable goes through
+ * uintptr_t so -Wcast-qual stays clean. The const here is a typing
+ * artifact, not an immutability guarantee — never use these on a pointer
+ * into sealed / .rodata memory. */
+static inline void hl_free_const(const void *p)
+{
+    free((void *)(uintptr_t)p);
+}
+static inline void hl_alloc_free_const(HlAllocator *a, const void *p, size_t size)
+{
+    hl_alloc_free(a, (void *)(uintptr_t)p, size);
+}
 
 /* Return a KlAllocator vtable routing through this tracker. */
 KlAllocator hl_alloc_kl(HlAllocator *a);

--- a/include/hull/cap/types.h
+++ b/include/hull/cap/types.h
@@ -58,7 +58,7 @@ static inline void hl_kv_free(HlKV *kvs, int count)
         free(kvs[i].key);
         if ((kvs[i].value.type == HL_TYPE_TEXT ||
              kvs[i].value.type == HL_TYPE_BLOB) && kvs[i].value.s)
-            free((void *)kvs[i].value.s);
+            free((void *)(uintptr_t)kvs[i].value.s);  /* value.s is const-typed for the read API but owned here */
     }
     free(kvs);
 }

--- a/src/hull/cap/db.c
+++ b/src/hull/cap/db.c
@@ -33,7 +33,7 @@ void hl_stmt_cache_destroy(HlStmtCache *cache)
 {
     for (int i = 0; i < cache->count; i++) {
         sqlite3_finalize(cache->entries[i].stmt);
-        hl_alloc_free(cache->alloc, (void *)cache->entries[i].sql,
+        hl_alloc_free_const(cache->alloc, cache->entries[i].sql,
                       cache->entries[i].sql_len + 1);
     }
     cache->count = 0;
@@ -68,7 +68,7 @@ static sqlite3_stmt *cache_get(HlStmtCache *cache, const char *sql)
     /* Evict oldest (LRU) if cache is full */
     if (cache->count >= HL_STMT_CACHE_SIZE) {
         sqlite3_finalize(cache->entries[0].stmt);
-        hl_alloc_free(cache->alloc, (void *)cache->entries[0].sql,
+        hl_alloc_free_const(cache->alloc, cache->entries[0].sql,
                       cache->entries[0].sql_len + 1);
         for (int j = 0; j < cache->count - 1; j++)
             cache->entries[j] = cache->entries[j + 1];

--- a/src/hull/cap/gpu_wgpu.c
+++ b/src/hull/cap/gpu_wgpu.c
@@ -842,7 +842,9 @@ static int wgpu_dispatch(HlGpuDevice *dev, HlGpuPipeline *pipeline,
             if (err_msg) *err_msg = "output_texture_not_found";
             goto cleanup;
         }
-        rc = wgpu_texture_read(dev, (HlGpuTexture *)tex,
+        /* readback reads the texture, never mutates it; the backend vtable
+         * slot is non-const so launder through uintptr_t to keep it. */
+        rc = wgpu_texture_read(dev, (HlGpuTexture *)(uintptr_t)tex,
                                 output, output_len);
         if (rc != HL_GPU_OK && err_msg)
             *err_msg = "texture_readback_failed";

--- a/src/hull/cap/image.c
+++ b/src/hull/cap/image.c
@@ -6,6 +6,7 @@
 
 #include "hull/cap/image.h"
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -126,7 +127,7 @@ HlImage *hl_image_from_view(uint32_t w, uint32_t h, HlImageFormat fmt,
     HlImage *img = calloc(1, sizeof(*img));
     if (!img) return NULL;
 
-    img->pixels    = (void *)data; /* borrowed — NOT owned */
+    img->pixels    = (void *)(uintptr_t)data; /* borrowed — NOT owned, never written when owned=0 */
     img->width     = w;
     img->height    = h;
     img->format    = fmt;

--- a/src/hull/cap/test.c
+++ b/src/hull/cap/test.c
@@ -28,6 +28,7 @@
 #include "hull/alloc.h"
 #include "hull/reqctx.h"
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -90,7 +91,7 @@ int hl_cap_test_dispatch(KlRouter *router, const char *method,
     KlBufReader fake_buf;
     memset(&fake_buf, 0, sizeof(fake_buf));
     if (body_data && body_len > 0) {
-        fake_buf.data = (char *)body_data;
+        fake_buf.data = (char *)(uintptr_t)body_data;  /* KlBody.data is char* but not modified here */
         fake_buf.len = body_len;
         fake_buf.cap = body_len;
         req.body_reader = &fake_buf.base;

--- a/src/hull/cap/tool.c
+++ b/src/hull/cap/tool.c
@@ -16,6 +16,7 @@
 #include "hull/cap/audit.h"
 #include "hull/build_assets.h"
 #include "hull/compiler.h"
+#include "hull/alloc.h"
 
 #include <dirent.h>
 #include <errno.h>
@@ -86,8 +87,8 @@ void hl_tool_unveil_free(HlToolUnveilCtx *ctx)
 {
     if (!ctx) return;
     for (int i = 0; i < ctx->count; i++) {
-        free((void *)ctx->entries[i].path);
-        free((void *)ctx->entries[i].perms);
+        hl_free_const(ctx->entries[i].path);
+        hl_free_const(ctx->entries[i].perms);
     }
     memset(ctx, 0, sizeof(*ctx));
 }
@@ -213,7 +214,7 @@ int hl_tool_spawn(const char *const argv[])
 
     if (pid == 0) {
         /* Child: exec */
-        execvp(argv[0], (char *const *)argv);
+        execvp(argv[0], (char *const *)(uintptr_t)argv);  /* POSIX execvp takes char*const[] but does not modify argv */
         _exit(127);
     }
 
@@ -267,7 +268,7 @@ char *hl_tool_spawn_read(const char *const argv[], size_t *out_len)
         close(pipefd[0]);
         dup2(pipefd[1], STDOUT_FILENO);
         close(pipefd[1]);
-        execvp(argv[0], (char *const *)argv);
+        execvp(argv[0], (char *const *)(uintptr_t)argv);  /* POSIX execvp takes char*const[] but does not modify argv */
         _exit(127);
     }
 
@@ -381,7 +382,7 @@ static int find_files_recurse(const char *dir, const char *pattern,
 /* String comparison for qsort */
 static int str_compare(const void *a, const void *b)
 {
-    return strcmp(*(const char **)a, *(const char **)b);
+    return strcmp(*(const char *const *)a, *(const char *const *)b);
 }
 
 char **hl_tool_find_files_ex(const char *dir, const char *pattern,

--- a/src/hull/commands/check.c
+++ b/src/hull/commands/check.c
@@ -14,6 +14,7 @@
 #include "hull/commands/verify.h"
 #include "hull/commands/modules.h"
 
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -25,7 +26,7 @@ int hl_cmd_check(int argc, char **argv, const HlCommandEnv *env)
     fprintf(stderr, "[hull:check] validating manifest...\n");
     {
         const char *list_argv[3] = { "check", "list", env->app_dir };
-        int rc = hl_cmd_modules(3, (char **)list_argv, env);
+        int rc = hl_cmd_modules(3, (char **)(uintptr_t)list_argv, env);  /* hl_cmd_modules does not modify argv */
         if (rc != 0) {
             fprintf(stderr, "[hull:check] manifest validation failed\n");
             return rc;
@@ -40,7 +41,7 @@ int hl_cmd_check(int argc, char **argv, const HlCommandEnv *env)
     fprintf(stderr, "[hull:check] analyzing imports...\n");
     {
         const char *analyze_argv[3] = { "check", "analyze", env->app_dir };
-        int rc = hl_cmd_modules(3, (char **)analyze_argv, env);
+        int rc = hl_cmd_modules(3, (char **)(uintptr_t)analyze_argv, env);  /* hl_cmd_modules does not modify argv */
         if (rc != 0) {
             fprintf(stderr, "[hull:check] import analysis failed\n");
             return rc;

--- a/src/hull/commands/dev.c
+++ b/src/hull/commands/dev.c
@@ -18,6 +18,7 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <signal.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -312,7 +313,7 @@ int hl_dev_state_reload(HlDevState *s)
         dup2(pfd_for_child, STDERR_FILENO);
         close(pfd_for_child);
         close(s->pipe_fd);
-        execvp(s->hull_exe, (char *const *)s->child_argv);
+        execvp(s->hull_exe, (char *const *)(uintptr_t)s->child_argv);  /* POSIX execvp does not modify argv */
         _exit(127);
     }
     close(pfd_for_child);
@@ -501,7 +502,7 @@ int hl_cmd_dev(int argc, char **argv, const HlCommandEnv *env)
             /* Child: restore default signal handlers and exec */
             signal(SIGINT, SIG_DFL);
             signal(SIGTERM, SIG_DFL);
-            execvp(hull_exe, (char *const *)child_argv);
+            execvp(hull_exe, (char *const *)(uintptr_t)child_argv);  /* POSIX execvp does not modify argv */
             _exit(127);
         }
 

--- a/src/hull/manifest.c
+++ b/src/hull/manifest.c
@@ -48,7 +48,7 @@ const char *hl_manifest_strdup(HlAllocator *alloc, const char *s)
 void hl_manifest_str_free(HlAllocator *alloc, const char **sp)
 {
     if (*sp) {
-        hl_alloc_free(alloc, (void *)*sp, strlen(*sp) + 1);
+        hl_alloc_free_const(alloc, *sp, strlen(*sp) + 1);
         *sp = NULL;
     }
 }

--- a/src/hull/migrate.c
+++ b/src/hull/migrate.c
@@ -11,6 +11,7 @@
 #ifdef HL_ENABLE_DB
 
 #include "hull/migrate.h"
+#include "hull/alloc.h"
 #include "hull/vfs.h"
 #include "hull/cap/db_backend.h"
 
@@ -151,7 +152,7 @@ static int execute_migration(sqlite3 *db, const char *name,
 
 static int cmp_strings(const void *a, const void *b)
 {
-    return strcmp(*(const char **)a, *(const char **)b);
+    return strcmp(*(const char *const *)a, *(const char *const *)b);
 }
 
 /* ── Discover filesystem migrations ───────────────────────────────── */
@@ -487,8 +488,8 @@ void hl_migrate_status_free(HlMigrationStatus *entries, int count)
     if (!entries)
         return;
     for (int i = 0; i < count; i++) {
-        free((void *)entries[i].name);
-        free((void *)entries[i].applied_at);
+        hl_free_const(entries[i].name);
+        hl_free_const(entries[i].applied_at);
     }
     free(entries);
 }

--- a/src/hull/runtime/js/mod_image.c
+++ b/src/hull/runtime/js/mod_image.c
@@ -317,13 +317,13 @@ static JSValue js_image_from_wasm(JSContext *ctx, JSValueConst this_val,
     if (argc < 1) return JS_ThrowTypeError(ctx, "image.fromWasm: data required");
 
     size_t len;
-    uint8_t *data = JS_GetArrayBuffer(ctx, &len, argv[0]);
+    const uint8_t *data = JS_GetArrayBuffer(ctx, &len, argv[0]);
     const char *str_data = NULL;
     if (!data) {
         /* Try string */
         str_data = JS_ToCStringLen(ctx, &len, argv[0]);
         if (!str_data) return JS_ThrowTypeError(ctx, "image.fromWasm: ArrayBuffer or string required");
-        data = (uint8_t *)str_data;
+        data = (const uint8_t *)str_data;
     }
 
     if (len < 9) {

--- a/src/hull/runtime/js/mod_test.c
+++ b/src/hull/runtime/js/mod_test.c
@@ -210,7 +210,7 @@ static JSValue js_test_http(JSContext *ctx, const char *method,
             JS_FreeValue(ctx, json_str);
         }
 
-        hl_alloc_free(state->js->base.alloc, (void *)result.body,
+        hl_alloc_free_const(state->js->base.alloc, result.body,
                       result.body_len + 1);
     }
 
@@ -241,7 +241,7 @@ static JSValue js_test_http(JSContext *ctx, const char *method,
             while (p < end && (*p == '\r' || *p == '\n')) p++;
         }
         JS_SetPropertyStr(ctx, obj, "headers", hdrs);
-        hl_alloc_free(state->js->base.alloc, (void *)result.hdr_buf,
+        hl_alloc_free_const(state->js->base.alloc, result.hdr_buf,
                       result.hdr_len + 1);
     }
 

--- a/src/hull/runtime/js/mod_worker.c
+++ b/src/hull/runtime/js/mod_worker.c
@@ -86,8 +86,8 @@ static int js_object_to_kv(JSContext *ctx, JSValueConst obj,
             const char *sv = JS_ToCStringLen(ctx, &slen, val);
             kvs[count].value.type = HL_TYPE_TEXT;
             if (sv) {
-                kvs[count].value.s = malloc(slen + 1);
-                if (!kvs[count].value.s) {
+                char *buf = malloc(slen + 1);
+                if (!buf) {
                     /* OOM on string dup: mark NIL, bump count so op_free
                      * releases the already-strdup'd key. */
                     kvs[count].value.type = HL_TYPE_NIL;
@@ -100,8 +100,9 @@ static int js_object_to_kv(JSContext *ctx, JSValueConst obj,
                     hl_kv_free(kvs, count);
                     return -1;
                 }
-                memcpy((void *)kvs[count].value.s, sv, slen);
-                ((char *)kvs[count].value.s)[slen] = '\0';
+                memcpy(buf, sv, slen);
+                buf[slen] = '\0';
+                kvs[count].value.s = buf;
                 kvs[count].value.len = slen;
                 JS_FreeCString(ctx, sv);
             }

--- a/src/hull/runtime/js/runtime.c
+++ b/src/hull/runtime/js/runtime.c
@@ -981,7 +981,7 @@ void hl_js_free(HlJS *js)
         js->rt = NULL;
     }
     if (js->app_dir) {
-        hl_alloc_free(js->base.alloc, (void *)js->app_dir, js->app_dir_size);
+        hl_alloc_free_const(js->base.alloc, js->app_dir, js->app_dir_size);
         js->app_dir = NULL;
         js->app_dir_size = 0;
     }

--- a/src/hull/runtime/js/worker.c
+++ b/src/hull/runtime/js/worker.c
@@ -259,8 +259,8 @@ static int capture_result(JSContext *ctx, JSValue val,
                 const char *sv = JS_ToCStringLen(ctx, &slen, pval);
                 op->result_kvs[idx].value.type = HL_TYPE_TEXT;
                 if (sv) {
-                    op->result_kvs[idx].value.s = malloc(slen + 1);
-                    if (!op->result_kvs[idx].value.s) {
+                    char *buf = malloc(slen + 1);
+                    if (!buf) {
                         /* OOM on string dup: mark NIL, bump count so
                          * op_free releases the strdup'd key. */
                         op->result_kvs[idx].value.type = HL_TYPE_NIL;
@@ -272,8 +272,9 @@ static int capture_result(JSContext *ctx, JSValue val,
                         js_free(ctx, tab);
                         return -1;
                     }
-                    memcpy((void *)op->result_kvs[idx].value.s, sv, slen);
-                    ((char *)op->result_kvs[idx].value.s)[slen] = '\0';
+                    memcpy(buf, sv, slen);
+                    buf[slen] = '\0';
+                    op->result_kvs[idx].value.s = buf;
                     op->result_kvs[idx].value.len = slen;
                     JS_FreeCString(ctx, sv);
                 }

--- a/src/hull/runtime/lua/bindings.c
+++ b/src/hull/runtime/lua/bindings.c
@@ -23,6 +23,7 @@
 #include <keel/response.h>
 #include <keel/router.h>
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -141,8 +142,8 @@ void hl_lua_make_request(lua_State *L, KlRequest *req)
             klen = hl_query_decode_inplace(pair, klen);
             pair[klen] = '\0';
             if (vlen > 0) {
-                vlen = hl_query_decode_inplace((char *)val, vlen);
-                ((char *)val)[vlen] = '\0';
+                vlen = hl_query_decode_inplace((char *)(uintptr_t)val, vlen);
+                ((char *)(uintptr_t)val)[vlen] = '\0';
             }
             lua_pushlstring(L, val, vlen);
             lua_setfield(L, -2, pair);

--- a/src/hull/runtime/lua/mod_test.c
+++ b/src/hull/runtime/lua/mod_test.c
@@ -181,7 +181,7 @@ static int l_test_http(lua_State *L, const char *method)
             }
         }
 
-        hl_alloc_free(lua->base.alloc, (void *)result.body,
+        hl_alloc_free_const(lua->base.alloc, result.body,
                       result.body_len + 1);
     }
 
@@ -216,7 +216,7 @@ static int l_test_http(lua_State *L, const char *method)
             while (p < end && (*p == '\r' || *p == '\n')) p++;
         }
         lua_setfield(L, -2, "headers");
-        hl_alloc_free(lua->base.alloc, (void *)result.hdr_buf,
+        hl_alloc_free_const(lua->base.alloc, result.hdr_buf,
                       result.hdr_len + 1);
     }
 

--- a/src/hull/runtime/lua/mod_worker.c
+++ b/src/hull/runtime/lua/mod_worker.c
@@ -78,17 +78,19 @@ static int lua_table_to_kv(lua_State *L, int idx, HlKV **out_kvs, int *out_count
             size_t slen;
             const char *sv = lua_tolstring(L, -1, &slen);
             kvs[i].value.type = HL_TYPE_TEXT;
-            kvs[i].value.s = malloc(slen + 1);
-            if (!kvs[i].value.s) {
+            char *buf = malloc(slen + 1);
+            if (!buf) {
                 /* OOM on string dup: include this kv (with key + nil value
                  * slot) in the free count so the key is also released. */
+                kvs[i].value.s = NULL;
                 kvs[i].value.type = HL_TYPE_NIL;
                 lua_pop(L, 2);
                 hl_kv_free(kvs, i + 1);
                 return -1;
             }
-            memcpy((void *)kvs[i].value.s, sv, slen);
-            ((char *)kvs[i].value.s)[slen] = '\0';
+            memcpy(buf, sv, slen);
+            buf[slen] = '\0';
+            kvs[i].value.s = buf;
             kvs[i].value.len = slen;
             break;
         }

--- a/src/hull/runtime/lua/runtime.c
+++ b/src/hull/runtime/lua/runtime.c
@@ -411,7 +411,7 @@ void hl_lua_free(HlLua *lua)
         lua->L = NULL;
     }
     if (lua->app_dir) {
-        hl_alloc_free(lua->base.alloc, (void *)lua->app_dir, lua->app_dir_size);
+        hl_alloc_free_const(lua->base.alloc, lua->app_dir, lua->app_dir_size);
         lua->app_dir = NULL;
         lua->app_dir_size = 0;
     }

--- a/src/hull/runtime/lua/worker.c
+++ b/src/hull/runtime/lua/worker.c
@@ -230,17 +230,19 @@ static int capture_result(lua_State *L, HlLuaWorkerDispatchOp *op)
                 size_t slen;
                 const char *sv = lua_tolstring(L, -1, &slen);
                 op->result_kvs[idx].value.type = HL_TYPE_TEXT;
-                op->result_kvs[idx].value.s = malloc(slen + 1);
-                if (!op->result_kvs[idx].value.s) {
+                char *buf = malloc(slen + 1);
+                if (!buf) {
                     /* OOM on string dup: mark slot NIL but bump count so
                      * the key allocation is released by op_free. */
+                    op->result_kvs[idx].value.s = NULL;
                     op->result_kvs[idx].value.type = HL_TYPE_NIL;
                     op->result_count++;
                     lua_pop(L, 2);
                     return -1;
                 }
-                memcpy((void *)op->result_kvs[idx].value.s, sv, slen);
-                ((char *)op->result_kvs[idx].value.s)[slen] = '\0';
+                memcpy(buf, sv, slen);
+                buf[slen] = '\0';
+                op->result_kvs[idx].value.s = buf;
                 op->result_kvs[idx].value.len = slen;
                 break;
             }

--- a/src/hull/worker_db.c
+++ b/src/hull/worker_db.c
@@ -409,18 +409,19 @@ HlValue *hl_deep_copy_params(const HlValue *src, int n)
         dst[i] = src[i];
         if ((src[i].type == HL_TYPE_TEXT || src[i].type == HL_TYPE_BLOB) &&
             src[i].s && src[i].len > 0) {
-            dst[i].s = malloc(src[i].len + 1);
-            if (!dst[i].s) {
+            char *buf = malloc(src[i].len + 1);
+            if (!buf) {
                 /* Clean up already-copied strings */
                 for (int j = 0; j < i; j++) {
                     if ((dst[j].type == HL_TYPE_TEXT || dst[j].type == HL_TYPE_BLOB) && dst[j].s)
-                        free((void *)dst[j].s);
+                        hl_free_const(dst[j].s);
                 }
                 free(dst);
                 return NULL;
             }
-            memcpy((void *)dst[i].s, src[i].s, src[i].len);
-            ((char *)dst[i].s)[src[i].len] = '\0';
+            memcpy(buf, src[i].s, src[i].len);
+            buf[src[i].len] = '\0';
+            dst[i].s = buf;
         }
     }
     return dst;
@@ -434,7 +435,7 @@ void hl_worker_db_op_free(HlWorkerDbOp *op)
         for (int i = 0; i < op->nparams; i++) {
             if ((op->params[i].type == HL_TYPE_TEXT ||
                  op->params[i].type == HL_TYPE_BLOB) && op->params[i].s)
-                free((void *)op->params[i].s);
+                hl_free_const(op->params[i].s);
         }
         free(op->params);
     }

--- a/src/hull/worker_gpu.c
+++ b/src/hull/worker_gpu.c
@@ -12,6 +12,7 @@
 #ifdef HL_ENABLE_GPU
 
 #include "hull/worker_gpu.h"
+#include "hull/alloc.h"
 #include "hull/async.h"
 #include "hull/async_backend.h"
 #include "hull/thread_affinity.h"
@@ -142,7 +143,7 @@ void hl_worker_gpu_op_free(HlWorkerGpuOp *op)
     }
     if (op->buffers) {
         for (int i = 0; i < op->buffer_count; i++)
-            free((void *)op->buffers[i].name);
+            hl_free_const(op->buffers[i].name);
     }
     free(op->buffers);
     op->buffers = NULL;
@@ -159,7 +160,7 @@ void hl_worker_gpu_op_free(HlWorkerGpuOp *op)
     }
     if (op->stages) {
         for (int s = 0; s < op->stage_count; s++)
-            free((void *)op->stages[s].shader);
+            hl_free_const(op->stages[s].shader);
         free(op->stages);
         op->stages = NULL;
     }

--- a/tests/hull/cap/test_wasm_buffer.c
+++ b/tests/hull/cap/test_wasm_buffer.c
@@ -85,7 +85,7 @@ UTEST(hl_wasm_buffer, materialize)
     ASSERT_EQ(memcmp(copy, data, len), 0);
 
     /* Copy should be independent of buffer */
-    ASSERT_NE(copy, (void *)hl_wasm_buffer_data(buf));
+    ASSERT_NE((const void *)copy, (const void *)hl_wasm_buffer_data(buf));
 
     free(copy);
     hl_wasm_buffer_destroy(buf);

--- a/tests/hull/test_arena.c
+++ b/tests/hull/test_arena.c
@@ -112,7 +112,7 @@ UTEST(hl_arena, memdup_copies_bytes)
     const unsigned char src[4] = { 0xDE, 0xAD, 0xBE, 0xEF };
     unsigned char *copy = hl_arena_memdup(a, src, sizeof(src));
     ASSERT_TRUE(copy != NULL);
-    ASSERT_TRUE((void *)copy != (void *)src);
+    ASSERT_TRUE((const void *)copy != (const void *)src);
     ASSERT_EQ(0, memcmp(copy, src, sizeof(src)));
     /* n == 0 returns a non-crashing result (NULL or empty alloc). */
     (void)hl_arena_memdup(a, src, 0);

--- a/tests/hull/test_manifest_seal.c
+++ b/tests/hull/test_manifest_seal.c
@@ -210,7 +210,8 @@ UTEST(manifest_seal, write_to_sealed_string_faults)
          * also run leak detection on the still-live src manifest). */
         signal(SIGSEGV, SIG_DFL);
         signal(SIGBUS,  SIG_DFL);
-        char *target = (char *)dst.fs_write[0];
+        /* Deliberate write to a sealed (RO) string to prove it faults. */
+        char *target = (char *)(uintptr_t)dst.fs_write[0];
         target[0] = '/';
         _exit(0);
     }

--- a/tests/hull/test_signature.c
+++ b/tests/hull/test_signature.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <dirent.h>
@@ -284,7 +285,7 @@ UTEST(hl_sig, verify_bad_sig)
     ASSERT_EQ(hl_sig_read(sig_path, &sig), 0);
 
     /* Tamper with the signature (cast away const for test only) */
-    ((char *)sig.signature_hex)[0] =
+    ((char *)(uintptr_t)sig.signature_hex)[0] =
         (sig.signature_hex[0] == 'a') ? 'b' : 'a';
 
     int rc = hl_sig_verify(&sig, test_pk);
@@ -335,7 +336,7 @@ UTEST(hl_sig, verify_platform_tampered_sig)
     ASSERT_EQ(hl_sig_read(sig_path, &sig), 0);
 
     /* Tamper with platform signature (cast away const for test only) */
-    ((char *)sig.platform.signature_hex)[0] =
+    ((char *)(uintptr_t)sig.platform.signature_hex)[0] =
         (sig.platform.signature_hex[0] == 'a') ? 'b' : 'a';
 
     int rc = hl_sig_verify_platform(&sig, plat_pk);


### PR DESCRIPTION
Makes casts that drop `const`/`volatile` a hard compile error in Hull's own source — the primitive that would launder a sealed/`.rodata` table back into something writable. Vendored TUs keep their relaxed `*_CFLAGS`, so this is Hull-source-only.

The sweep found 41 sites in `src/hull`/`include/hull` + 5 in tests. **None launder a sealed/rodata table** — all are benign const-drops, confirming the audit finding that dispatch tables are already const-correct. The flag is purely preventive.

Fixes by category (cleanest-first):
- **qsort comparators** → proper `(const char *const *)`.
- **in-place writes into a malloc'd buffer stored in a const field** (worker deep-copy, table→kv) → rewritten to write through a `char *buf` local then assign — no cast.
- **owned-but-const-typed frees** → two documented helpers `hl_free_const` / `hl_alloc_free_const` (one centralized uintptr launder).
- **POSIX execvp / hl_cmd_modules argv / borrowed data / tamper death-tests** → documented `(T)(uintptr_t)x` or const-correct retype.

Verified: clang `make` + `make test` **50/50** with `-Werror=cast-qual`; **gcc-14 `-Werror=cast-qual` clean** on the changed TUs (checked gcc this time after the sh_arena `__has_feature` break).