### PR TITLE
fix(cli): make log thread-safe + mark event-loop thread in CLI flavor

### DIFF
--- a/src/hull/serve_cli.c
+++ b/src/hull/serve_cli.c
@@ -29,6 +29,8 @@
 
 #include "hull/app_context.h"
 #include "hull/shared/async_backend.h"
+#include "hull/shared/log_lock.h"
+#include "hull/shared/thread_affinity.h"
 #include "hull/manifest.h"
 #include "hull/module_resolver.h"
 #include "hull/runtime.h"
@@ -270,6 +272,16 @@ int hull_serve(int argc, char **argv)
         return 1;
     }
     rt->async_ctx = async_ctx;
+
+    /* Before the worker pool exists: make log.c thread-safe (workers run
+     * db.async / compute.async / gpu.async and log concurrently with this
+     * thread) and mark this as the event-loop thread so the loop-only
+     * thread-affinity assertions are live (not silently inert) in the CLI
+     * flavor. Mirrors serve.c's hl_serve_init_logging + the pre-infra mark.
+     * Both are required even though this flavor has no HTTP server, because
+     * it still spawns the same async worker pool below. */
+    hl_log_make_threadsafe();
+    hl_event_loop_mark_current();
 
     /* Worker pool for async ops that delegate to threads (db.async,
      * compute.async, gpu.async). Non-fatal if it fails — the runtime


### PR DESCRIPTION
Audit findings **F4/F5**. `serve_cli.c` (the `HL_ENABLE_HTTP_SERVER=0` / `app.main` entry) spins up the same db.async/compute.async/gpu.async worker pool as `serve.c` but never called `hl_log_make_threadsafe()` or `hl_event_loop_mark_current()`:

- **F4 (data race):** `log.c`'s callback list + stream write was unsynchronized while worker `work_fn`s log concurrently with the main thread.
- **F5 (inert asserts):** the event-loop thread was never captured, so `hl_assert_on_event_loop()` short-circuits to a no-op — the loop-only affinity assertions were silently inert and TSan-blind for this flavor.

Adds both calls before `pool_create`, mirroring `serve.c`. `serve_cli.o` is compiled in the default build, so this is covered by the standard build + tests + CI; no-op for the HTTP-server build.

Validated locally: default build clean under `-Werror`, 50/50 unit suites pass.

Note: a full `HL_ENABLE_HTTP_SERVER=0` link is blocked by a separate pre-existing gap (`tool_orchestration.c` references HTTP-gated `hl_agent_*` symbols unconditionally; CI does not build that flavor). Tracked separately.