### PR TITLE
fix(ws-client): free conn on network close instead of leaking (F2)

### DIFF
--- a/src/hull/runtime/js/mod_ws_client.c
+++ b/src/hull/runtime/js/mod_ws_client.c
@@ -28,7 +28,11 @@
 static JSClassID js_ws_client_conn_class_id;
 
 typedef struct {
-    KlWsClientConn *client;      /* NULL after free */
+    KlWsClientConn *client;      /* NULL after free (finalizer only) */
+    int             closed;      /* 1 after on_close: fail methods closed,
+                                  * but keep `client` so the finalizer still
+                                  * frees it (Keel does not free the conn on
+                                  * close) */
     JSValue         on_open;     /* DupValue'd callbacks */
     JSValue         on_message;
     JSValue         on_close;
@@ -88,7 +92,7 @@ static JSValue js_ws_client_send(JSContext *ctx, JSValueConst this_val,
     (void)argc;
     HlJSWsClientUD *ud = (HlJSWsClientUD *)JS_GetOpaque2(ctx, this_val,
                                                              js_ws_client_conn_class_id);
-    if (!ud || !ud->client)
+    if (!ud || !ud->client || ud->closed)
         return JS_ThrowTypeError(ctx, "client connection closed");
 
     size_t len;
@@ -106,7 +110,7 @@ static JSValue js_ws_client_send_binary(JSContext *ctx, JSValueConst this_val,
     (void)argc;
     HlJSWsClientUD *ud = (HlJSWsClientUD *)JS_GetOpaque2(ctx, this_val,
                                                              js_ws_client_conn_class_id);
-    if (!ud || !ud->client)
+    if (!ud || !ud->client || ud->closed)
         return JS_ThrowTypeError(ctx, "client connection closed");
 
     size_t len;
@@ -127,7 +131,7 @@ static JSValue js_ws_client_close(JSContext *ctx, JSValueConst this_val,
 {
     HlJSWsClientUD *ud = (HlJSWsClientUD *)JS_GetOpaque2(ctx, this_val,
                                                              js_ws_client_conn_class_id);
-    if (!ud || !ud->client)
+    if (!ud || !ud->client || ud->closed)
         return JS_UNDEFINED;
 
     uint32_t code = 1000;
@@ -149,7 +153,7 @@ static JSValue js_ws_client_ping(JSContext *ctx, JSValueConst this_val,
 {
     HlJSWsClientUD *ud = (HlJSWsClientUD *)JS_GetOpaque2(ctx, this_val,
                                                              js_ws_client_conn_class_id);
-    if (!ud || !ud->client)
+    if (!ud || !ud->client || ud->closed)
         return JS_UNDEFINED;
 
     const char *data = NULL;
@@ -257,7 +261,11 @@ static void js_ws_client_on_close(KlWsClientConn *ws, uint16_t code,
         JS_FreeValue(ud->ctx, ud->self_ref);
         ud->self_ref = JS_UNDEFINED;
     }
-    ud->client = NULL;
+    /* Mark closed (methods fail closed) but keep `client` non-NULL so the
+     * finalizer frees the KlWsClientConn — Keel does NOT free it on close,
+     * and we must not free it here (Keel touches `ws` immediately after this
+     * callback returns: `ws->state = WSC_CLOSED; wsc_close_connection(ws)`). */
+    ud->closed = 1;
 }
 
 static void js_ws_client_on_error(KlWsClientConn *ws, const char *msg,
@@ -373,6 +381,7 @@ static JSValue js_ws_connect(JSContext *ctx, JSValueConst this_val,
     ud->ctx = ctx;
     ud->js = js;
     ud->client = NULL;
+    ud->closed = 0;
 
     JS_SetOpaque(obj, ud);
 

--- a/src/hull/runtime/lua/mod_ws_client.c
+++ b/src/hull/runtime/lua/mod_ws_client.c
@@ -31,7 +31,10 @@
 #define HL_WS_CLIENT_CONN_MT "HlWsClientConn"
 
 typedef struct HlLuaWsClientUD {
-    KlWsClientConn *client;      /* NULL after free */
+    KlWsClientConn *client;      /* NULL after free (GC only) */
+    int             closed;      /* 1 after on_close: fail methods closed,
+                                  * but keep `client` so __gc still frees it
+                                  * (Keel does not free the conn on close) */
     int             on_open_ref;
     int             on_message_ref;
     int             on_close_ref;
@@ -47,7 +50,7 @@ static int lua_ws_client_send(lua_State *L)
 {
     HlLuaWsClientUD *ud = (HlLuaWsClientUD *)luaL_checkudata(L, 1,
                                                                 HL_WS_CLIENT_CONN_MT);
-    if (!ud->client)
+    if (!ud->client || ud->closed)
         return luaL_error(L, "client connection closed");
 
     size_t len;
@@ -62,7 +65,7 @@ static int lua_ws_client_send_binary(lua_State *L)
 {
     HlLuaWsClientUD *ud = (HlLuaWsClientUD *)luaL_checkudata(L, 1,
                                                                 HL_WS_CLIENT_CONN_MT);
-    if (!ud->client)
+    if (!ud->client || ud->closed)
         return luaL_error(L, "client connection closed");
 
     size_t len;
@@ -77,7 +80,7 @@ static int lua_ws_client_close(lua_State *L)
 {
     HlLuaWsClientUD *ud = (HlLuaWsClientUD *)luaL_checkudata(L, 1,
                                                                 HL_WS_CLIENT_CONN_MT);
-    if (!ud->client)
+    if (!ud->client || ud->closed)
         return 0;
 
     uint16_t code = (uint16_t)luaL_optinteger(L, 2, 1000);
@@ -92,7 +95,7 @@ static int lua_ws_client_ping(lua_State *L)
 {
     HlLuaWsClientUD *ud = (HlLuaWsClientUD *)luaL_checkudata(L, 1,
                                                                 HL_WS_CLIENT_CONN_MT);
-    if (!ud->client)
+    if (!ud->client || ud->closed)
         return 0;
 
     size_t len = 0;
@@ -207,7 +210,11 @@ static void lua_ws_client_on_close(KlWsClientConn *ws, uint16_t code,
         luaL_unref(ud->L, LUA_REGISTRYINDEX, ud->self_ref);
         ud->self_ref = LUA_NOREF;
     }
-    ud->client = NULL;
+    /* Mark closed (methods fail closed) but keep `client` non-NULL so __gc
+     * frees the KlWsClientConn — Keel does NOT free it on close, and we must
+     * not free it here either (Keel touches `ws` immediately after this
+     * callback returns: `ws->state = WSC_CLOSED; wsc_close_connection(ws)`). */
+    ud->closed = 1;
 }
 
 static void lua_ws_client_on_error(KlWsClientConn *ws, const char *msg,
@@ -265,6 +272,7 @@ static int lua_ws_connect(lua_State *L)
     HlLuaWsClientUD *ud = (HlLuaWsClientUD *)lua_newuserdata(L,
                                                                 sizeof(HlLuaWsClientUD));
     ud->client = NULL;
+    ud->closed = 0;
     ud->on_open_ref = LUA_NOREF;
     ud->on_message_ref = LUA_NOREF;
     ud->on_close_ref = LUA_NOREF;


### PR DESCRIPTION
Audit finding **F2**. The WebSocket client `on_close` handler nulled `ud->client` without freeing the `KlWsClientConn`, so the GC finalizer's `if (ud->client)` guard skipped `kl_ws_client_free` — the conn struct + its upgrade/handshake/msg buffers leaked for the process lifetime on every peer/network-initiated close. Unbounded for long-running services that open client WebSockets.

**The conn cannot be freed inside `on_close`** (the audit's first-pass suggestion would be a UAF): Keel touches `ws` immediately after the callback returns (`ws->state = WSC_CLOSED; wsc_close_connection(ws)` at `vendor/keel/src/websocket_client.c:664-665`) and `kl_ws_client_free` frees the struct.

**Fix:** keep `ud->client` non-NULL after close + add a `closed` flag. `on_close` sets `closed=1` so methods fail closed with the identical "client connection closed" error / no-op as before; the finalizer's existing `kl_ws_client_free` now runs → conn freed exactly once at GC. No double-free (the runtime-destroy path only frees the tracking array, never the conns). Same fix in both Lua and JS runtimes. `on_error` already left `client` intact, so it never leaked and is unchanged.

Verified: default build clean, 50/50 unit suites pass. A full leak regression would need an ASan e2e with a live connect → peer-close → GC cycle; no live WS-client harness exists today, so this is covered by inspection against Keel's close sequence + the build/test matrix.