### PR TITLE
fix(image): refcount image.from_buffer borrows so the source can't dangle (F1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1421,7 +1421,7 @@ also useful for WiFi codes, contact cards, payment links, etc.
 
 **image**. Image creation, encoding, and decoding via pluggable codec vtable (stb_image default).
 - `image.new(w, h, format, pixels)` → HlImage. Formats: `"rgba8"`, `"r8"`, `"rgba16float"`, `"r32float"`.
-- `image.from_buffer(buf, w, h, format)` → HlImage (zero-copy borrow from WasmBuffer/MappedBuffer).
+- `image.from_buffer(buf, w, h, format)` → HlImage. Zero-copy borrow from a `MappedBuffer`/`WasmBuffer` (the source's bytes back the image directly). The borrow is refcounted: closing the source (`buf:close()`) while the image is alive is safe and defers the source's actual munmap/free until the last borrowing image is freed (no dangling pixels). Other sources (string, `ArrayBuffer`/typed array, another image) have no refcountable object to pin and are copied.
 - `image.decode(data, format?)` → HlImage. Auto-detects PNG/JPEG/BMP from magic bytes.
 - `image.encode(img, format, opts?)` → bytes. `opts.quality` for JPEG (default 90).
 - `img:width()`, `img:height()`, `img:format()`, `img:size()`. Properties.

--- a/include/hull/cap/fs.h
+++ b/include/hull/cap/fs.h
@@ -137,6 +137,8 @@ typedef struct HlMappedBuffer {
     size_t        len;    /**< Mapping length in bytes. */
     int           closed; /**< `1` iff already munmap'd; further `_munmap` is a no-op. */
     HlAllocator  *alloc;  /**< Tracked allocator (NULL = raw malloc). */
+    int           borrow_count;  /**< Live zero-copy borrowers (e.g. images). */
+    int           pending_free;  /**< close()/gc was deferred while borrowed. */
 } HlMappedBuffer;
 
 /**
@@ -168,7 +170,30 @@ HlMappedBuffer *hl_cap_fs_mmap(const HlFsConfig *cfg, const char *path,
  * no-op.
  *
  * @param buf  Buffer to unmap. May be NULL (no-op).
+ *
+ * If the buffer still has live borrowers (`borrow_count > 0`), the actual
+ * `munmap` + struct free is deferred: the call records `pending_free` and
+ * returns, keeping the mapping valid for the borrowers. The last
+ * @ref hl_cap_fs_mmap_release then completes the teardown.
  */
 void hl_cap_fs_munmap(HlMappedBuffer *buf);
+
+/**
+ * @brief Register a zero-copy borrower of a mapped buffer.
+ *
+ * Increments `borrow_count` so a subsequent @ref hl_cap_fs_munmap (explicit
+ * close or GC) defers the real unmap until the borrower releases. Event-loop
+ * thread only; not atomic. @param buf May be NULL (no-op).
+ */
+void hl_cap_fs_mmap_borrow(HlMappedBuffer *buf);
+
+/**
+ * @brief Release a borrow taken with @ref hl_cap_fs_mmap_borrow.
+ *
+ * Decrements `borrow_count`; if it reaches 0 and a close was deferred
+ * (`pending_free`), completes the `munmap` + struct free now. `void *` typed
+ * so it can be used directly as an `HlImage::on_free` hook. NULL-safe.
+ */
+void hl_cap_fs_mmap_release(void *buf);
 
 #endif /* HL_CAP_FS_H */

--- a/include/hull/cap/image.h
+++ b/include/hull/cap/image.h
@@ -44,6 +44,13 @@ typedef struct HlImage {
      * the codec's allocator (stb uses its own); NULL means the pixels
      * came from plain malloc (image.new) and hl_image_free uses free(). */
     void        (*free_pixels)(void *pixels);
+    /* Optional borrow-release hook. Called by hl_image_free regardless of
+     * `owned`, BEFORE the pixels/struct are freed. image.from_buffer uses it
+     * to release a refcounted zero-copy source (HlMappedBuffer / HlWasmBuffer)
+     * whose teardown was deferred while this image borrowed its pixels. NULL
+     * for owned (copied) images. */
+    void        (*on_free)(void *ctx);
+    void         *on_free_ctx;
 } HlImage;
 
 /* ── Codec vtable ──────────────────────────────────────────────────── */

--- a/include/hull/cap/wasm_buffer.h
+++ b/include/hull/cap/wasm_buffer.h
@@ -40,6 +40,8 @@ typedef struct HlWasmBuffer {
     const void    *data;      /* native host pointer, always valid while !closed */
     size_t         len;
     int            closed;
+    int            borrow_count; /* live zero-copy borrowers (e.g. images) */
+    int            pending_free; /* close()/gc deferred while borrowed */
     HlAllocator   *alloc;     /* tracked allocator (NULL = raw malloc) */
 
     union {
@@ -115,8 +117,33 @@ void *hl_wasm_buffer_materialize(const HlWasmBuffer *buf, size_t *out_len,
  * Destroy buffer and release all backing resources.
  * For WASM kind: frees WASM allocation and returns instance to pool.
  * Safe to call multiple times (idempotent). Safe on NULL.
+ *
+ * NOTE: this releases the BACKING resources but does NOT free the
+ * HlWasmBuffer struct itself. Bindings should call hl_wasm_buffer_close()
+ * (below) for full teardown so borrow-deferral is honored.
  */
 void hl_wasm_buffer_destroy(HlWasmBuffer *buf);
+
+/**
+ * Full teardown for a binding close()/finalizer: destroys the backing AND
+ * frees the struct. If the buffer still has live zero-copy borrowers
+ * (borrow_count > 0), the teardown is deferred (records pending_free and
+ * returns); the last hl_wasm_buffer_release() completes it. Safe on NULL.
+ */
+void hl_wasm_buffer_close(HlWasmBuffer *buf);
+
+/**
+ * Register a zero-copy borrower so a subsequent close()/gc defers teardown.
+ * Event-loop thread only; not atomic. NULL-safe.
+ */
+void hl_wasm_buffer_borrow(HlWasmBuffer *buf);
+
+/**
+ * Release a borrow; if it was the last and a close was deferred, completes
+ * the teardown now. `void *` typed for use as an HlImage::on_free hook.
+ * NULL-safe.
+ */
+void hl_wasm_buffer_release(void *buf);
 
 #endif /* HL_ENABLE_WASM */
 #endif /* HL_CAP_WASM_BUFFER_H */

--- a/src/hull/cap/fs.c
+++ b/src/hull/cap/fs.c
@@ -337,6 +337,8 @@ HlMappedBuffer *hl_cap_fs_mmap(const HlFsConfig *cfg, const char *path,
     buf->len = (size_t)st.st_size;
     buf->closed = 0;
     buf->alloc = alloc;
+    buf->borrow_count = 0;
+    buf->pending_free = 0;
 
 audit:
     {
@@ -351,9 +353,36 @@ audit:
 void hl_cap_fs_munmap(HlMappedBuffer *buf)
 {
     if (!buf) return;
+    /* Defer the real teardown while a zero-copy borrower (e.g. an image
+     * created via image.from_buffer) still points into the mapping. The
+     * last hl_cap_fs_mmap_release completes it. The owning userdata detaches
+     * (sets its pointer to NULL) regardless, so no new borrows can start. */
+    if (buf->borrow_count > 0) {
+        buf->pending_free = 1;
+        return;
+    }
     if (!buf->closed && buf->addr) {
         munmap(buf->addr, buf->len);
         buf->closed = 1;
     }
     hl_alloc_free(buf->alloc, buf, sizeof(HlMappedBuffer));
+}
+
+void hl_cap_fs_mmap_borrow(HlMappedBuffer *buf)
+{
+    if (buf) buf->borrow_count++;
+}
+
+void hl_cap_fs_mmap_release(void *p)
+{
+    HlMappedBuffer *buf = (HlMappedBuffer *)p;
+    if (!buf) return;
+    if (buf->borrow_count > 0) buf->borrow_count--;
+    if (buf->borrow_count == 0 && buf->pending_free) {
+        if (!buf->closed && buf->addr) {
+            munmap(buf->addr, buf->len);
+            buf->closed = 1;
+        }
+        hl_alloc_free(buf->alloc, buf, sizeof(HlMappedBuffer));
+    }
 }

--- a/src/hull/cap/image.c
+++ b/src/hull/cap/image.c
@@ -267,6 +267,11 @@ int hl_image_encode(const HlImage *img, const char *fmt_name,
 void hl_image_free(HlImage *img)
 {
     if (!img) return;
+    /* Release a borrowed zero-copy source first (may complete the source's
+     * deferred munmap/free). Must run before we drop our borrowed `pixels`
+     * pointer; for owned images this is NULL. */
+    if (img->on_free)
+        img->on_free(img->on_free_ctx);
     if (img->owned && img->pixels) {
         /* Decoded pixels are freed through the codec's allocator;
          * image.new() pixels (free_pixels == NULL) use plain free(). */

--- a/src/hull/cap/wasm_buffer.c
+++ b/src/hull/cap/wasm_buffer.c
@@ -184,4 +184,35 @@ void hl_wasm_buffer_destroy(HlWasmBuffer *buf)
     buf->len = 0;
 }
 
+void hl_wasm_buffer_close(HlWasmBuffer *buf)
+{
+    if (!buf) return;
+    /* Keep the buffer (and its native `data`) alive while an image borrows
+     * it; the last hl_wasm_buffer_release completes teardown. */
+    if (buf->borrow_count > 0) {
+        buf->pending_free = 1;
+        return;
+    }
+    HlAllocator *a = buf->alloc;
+    hl_wasm_buffer_destroy(buf);
+    hl_alloc_free(a, buf, sizeof(*buf));
+}
+
+void hl_wasm_buffer_borrow(HlWasmBuffer *buf)
+{
+    if (buf) buf->borrow_count++;
+}
+
+void hl_wasm_buffer_release(void *p)
+{
+    HlWasmBuffer *buf = (HlWasmBuffer *)p;
+    if (!buf) return;
+    if (buf->borrow_count > 0) buf->borrow_count--;
+    if (buf->borrow_count == 0 && buf->pending_free) {
+        HlAllocator *a = buf->alloc;
+        hl_wasm_buffer_destroy(buf);
+        hl_alloc_free(a, buf, sizeof(*buf));
+    }
+}
+
 #endif /* HL_ENABLE_WASM */

--- a/src/hull/runtime/js/mod_compute.c
+++ b/src/hull/runtime/js/mod_compute.c
@@ -26,11 +26,8 @@ static void js_wasm_buf_finalizer(JSRuntime *rt, JSValue val)
 {
     (void)rt;
     HlWasmBuffer *buf = JS_GetOpaque(val, js_wasm_buf_class_id);
-    if (buf) {
-        HlAllocator *a = buf->alloc;
-        hl_wasm_buffer_destroy(buf);
-        hl_alloc_free(a, buf, sizeof(HlWasmBuffer));
-    }
+    if (buf)
+        hl_wasm_buffer_close(buf); /* defers if still borrowed by an image */
 }
 
 static JSClassDef js_wasm_buf_class = {
@@ -44,9 +41,7 @@ static JSValue js_wasm_buf_close(JSContext *ctx, JSValueConst this_val,
     (void)argc; (void)argv;
     HlWasmBuffer *buf = JS_GetOpaque2(ctx, this_val, js_wasm_buf_class_id);
     if (buf) {
-        HlAllocator *a = buf->alloc;
-        hl_wasm_buffer_destroy(buf);
-        hl_alloc_free(a, buf, sizeof(HlWasmBuffer));
+        hl_wasm_buffer_close(buf); /* defers if still borrowed by an image */
         JS_SetOpaque(this_val, NULL);
     }
     return JS_UNDEFINED;

--- a/src/hull/runtime/js/mod_image.c
+++ b/src/hull/runtime/js/mod_image.c
@@ -6,6 +6,10 @@
 
 #include "mod_buffer.h"
 #include "hull/cap/image.h"
+#include "hull/cap/fs.h"
+#ifdef HL_ENABLE_WASM
+#include "hull/cap/wasm_buffer.h"
+#endif
 
 #include <stdlib.h>
 #include <string.h>
@@ -176,8 +180,40 @@ static JSValue js_image_from_buffer(JSContext *ctx, JSValueConst this_val,
         return JS_ThrowTypeError(ctx, "unknown image format");
     }
 
-    HlImage *img = hl_image_from_view(w, h, (HlImageFormat)fmt,
-                                       view.data, view.len, NULL);
+    /* Borrow refcountable zero-copy sources (mmap / WASM buffer) with deferred
+     * source teardown; copy everything else (string, ArrayBuffer, TypedArray,
+     * image) since there is no stable refcountable object to pin. */
+    HlMappedBuffer *mmap_src = JS_GetOpaque(argv[0], js_mmap_class_id);
+    if (mmap_src && mmap_src->closed) mmap_src = NULL;
+#ifdef HL_ENABLE_WASM
+    HlWasmBuffer *wasm_src = JS_GetOpaque(argv[0], js_wasm_buf_class_id);
+    if (wasm_src && wasm_src->closed) wasm_src = NULL;
+#endif
+
+    HlImage *img;
+    if (mmap_src) {
+        img = hl_image_from_view(w, h, (HlImageFormat)fmt,
+                                 view.data, view.len, NULL);
+        if (img) {
+            hl_cap_fs_mmap_borrow(mmap_src);
+            img->on_free = hl_cap_fs_mmap_release;
+            img->on_free_ctx = mmap_src;
+        }
+    }
+#ifdef HL_ENABLE_WASM
+    else if (wasm_src) {
+        img = hl_image_from_view(w, h, (HlImageFormat)fmt,
+                                 view.data, view.len, NULL);
+        if (img) {
+            hl_wasm_buffer_borrow(wasm_src);
+            img->on_free = hl_wasm_buffer_release;
+            img->on_free_ctx = wasm_src;
+        }
+    }
+#endif
+    else {
+        img = hl_image_new(w, h, (HlImageFormat)fmt, view.data, view.len, NULL);
+    }
     if (needs_free) JS_FreeCString(ctx, str_out);
 
     if (!img)

--- a/src/hull/runtime/lua/mod_compute.c
+++ b/src/hull/runtime/lua/mod_compute.c
@@ -65,9 +65,8 @@ static int lua_wasm_buf_close(lua_State *L)
 {
     HlWasmBuffer **pp = luaL_testudata(L, 1, HL_WASM_BUF_MT);
     if (pp && *pp) {
-        HlAllocator *a = (*pp)->alloc;
-        hl_wasm_buffer_destroy(*pp);
-        hl_alloc_free(a, *pp, sizeof(HlWasmBuffer));
+        /* Defers backing+struct teardown if an image still borrows it. */
+        hl_wasm_buffer_close(*pp);
         *pp = NULL;
     }
     return 0;

--- a/src/hull/runtime/lua/mod_image.c
+++ b/src/hull/runtime/lua/mod_image.c
@@ -6,6 +6,10 @@
 
 #include "mod_buffer.h"
 #include "hull/cap/image.h"
+#include "hull/cap/fs.h"
+#ifdef HL_ENABLE_WASM
+#include "hull/cap/wasm_buffer.h"
+#endif
 
 #include <stdlib.h>
 #include <string.h>
@@ -139,9 +143,42 @@ static int l_image_from_buffer(lua_State *L)
     if (fmt < 0)
         return luaL_error(L, "unknown image format: %s", fmt_name);
 
-    HlImage *img = hl_image_from_view((uint32_t)w, (uint32_t)h,
-                                       (HlImageFormat)fmt,
-                                       view.data, view.len, NULL);
+    /* Refcountable zero-copy sources (mmap / WASM buffer) are borrowed and
+     * their teardown is deferred until this image is freed (so buf:close()
+     * while an image borrows it can't dangle the pixels). Other sources
+     * (Lua string, image) have no stable object to pin, so they are copied. */
+    HlMappedBuffer **mp = (HlMappedBuffer **)luaL_testudata(L, 1, HL_MMAP_MT);
+    HlMappedBuffer *mmap_src = (mp && *mp && !(*mp)->closed) ? *mp : NULL;
+#ifdef HL_ENABLE_WASM
+    HlWasmBuffer **wp = (HlWasmBuffer **)luaL_testudata(L, 1, HL_WASM_BUF_MT);
+    HlWasmBuffer *wasm_src = (wp && *wp && !(*wp)->closed) ? *wp : NULL;
+#endif
+
+    HlImage *img;
+    if (mmap_src) {
+        img = hl_image_from_view((uint32_t)w, (uint32_t)h, (HlImageFormat)fmt,
+                                 view.data, view.len, NULL);
+        if (img) {
+            hl_cap_fs_mmap_borrow(mmap_src);
+            img->on_free = hl_cap_fs_mmap_release;
+            img->on_free_ctx = mmap_src;
+        }
+    }
+#ifdef HL_ENABLE_WASM
+    else if (wasm_src) {
+        img = hl_image_from_view((uint32_t)w, (uint32_t)h, (HlImageFormat)fmt,
+                                 view.data, view.len, NULL);
+        if (img) {
+            hl_wasm_buffer_borrow(wasm_src);
+            img->on_free = hl_wasm_buffer_release;
+            img->on_free_ctx = wasm_src;
+        }
+    }
+#endif
+    else {
+        img = hl_image_new((uint32_t)w, (uint32_t)h, (HlImageFormat)fmt,
+                           view.data, view.len, NULL);
+    }
     if (!img)
         return luaL_error(L, "image.from_buffer: invalid dimensions or data size");
 

--- a/tests/hull/cap/test_fs.c
+++ b/tests/hull/cap/test_fs.c
@@ -252,6 +252,53 @@ UTEST(hl_cap_fs, mmap_basic)
     teardown_fs();
 }
 
+/* Regression (audit F1): a zero-copy borrower (e.g. image.from_buffer)
+ * must keep the mapping alive even if the source is closed first. */
+UTEST(hl_cap_fs, mmap_borrow_defers_close)
+{
+    setup_fs();
+    const char *data = "borrowed mmap bytes";
+    ASSERT_EQ(hl_cap_fs_write(&test_cfg, "mmap_borrow.txt", data, strlen(data), NULL), 0);
+
+    HlMappedBuffer *buf = hl_cap_fs_mmap(&test_cfg, "mmap_borrow.txt", NULL, NULL);
+    ASSERT_NE(buf, NULL);
+
+    hl_cap_fs_mmap_borrow(buf);
+    ASSERT_EQ(buf->borrow_count, 1);
+
+    /* Close while borrowed: teardown is deferred, mapping stays valid. */
+    hl_cap_fs_munmap(buf);
+    ASSERT_EQ(buf->pending_free, 1);
+    ASSERT_EQ(buf->closed, 0);
+    ASSERT_EQ(memcmp(buf->addr, data, strlen(data)), 0);
+
+    /* Last release completes the deferred munmap + free (ASan/leak-san
+     * confirms it runs exactly once and nothing dangles). */
+    hl_cap_fs_mmap_release(buf);
+    teardown_fs();
+}
+
+/* A borrow that is released BEFORE any close must not tear the buffer down;
+ * the normal munmap still owns teardown. */
+UTEST(hl_cap_fs, mmap_release_without_close_keeps_buffer)
+{
+    setup_fs();
+    const char *data = "still open";
+    ASSERT_EQ(hl_cap_fs_write(&test_cfg, "mmap_rel.txt", data, strlen(data), NULL), 0);
+    HlMappedBuffer *buf = hl_cap_fs_mmap(&test_cfg, "mmap_rel.txt", NULL, NULL);
+    ASSERT_NE(buf, NULL);
+
+    hl_cap_fs_mmap_borrow(buf);
+    hl_cap_fs_mmap_release(buf);
+    ASSERT_EQ(buf->borrow_count, 0);
+    ASSERT_EQ(buf->pending_free, 0);
+    ASSERT_EQ(buf->closed, 0);
+    ASSERT_EQ(memcmp(buf->addr, data, strlen(data)), 0);
+
+    hl_cap_fs_munmap(buf); /* normal teardown, no borrowers */
+    teardown_fs();
+}
+
 UTEST(hl_cap_fs, mmap_path_traversal)
 {
     setup_fs();

--- a/tests/hull/cap/test_image.c
+++ b/tests/hull/cap/test_image.c
@@ -122,6 +122,29 @@ UTEST(hull_cap_image, from_view)
     hl_image_free(img);  /* should NOT free pixels */
 }
 
+/* Regression (audit F1): hl_image_free must invoke the on_free borrow-release
+ * hook exactly once, before dropping the (borrowed) pixels. This is the seam
+ * image.from_buffer uses to release a refcounted mmap/WASM source. */
+static void test_image_on_free(void *ctx) { (*(int *)ctx)++; }
+
+UTEST(hull_cap_image, on_free_hook_runs_once)
+{
+    uint8_t pixels[8];
+    memset(pixels, 0xAB, sizeof(pixels));
+
+    HlImage *img = hl_image_from_view(2, 1, HL_IMAGE_RGBA8,
+                                       pixels, sizeof(pixels), NULL);
+    ASSERT_TRUE(img != NULL);
+    ASSERT_EQ(0, img->owned);
+
+    int released = 0;
+    img->on_free = test_image_on_free;
+    img->on_free_ctx = &released;
+
+    hl_image_free(img);
+    ASSERT_EQ(1, released);  /* hook ran exactly once */
+}
+
 UTEST(hull_cap_image, free_null)
 {
     /* Should not crash */


### PR DESCRIPTION
Audit finding **F1** (HIGH), fixed with the refcount design.

`image.from_buffer` / `fromBuffer` returned a long-lived `HlImage` that **borrowed** its pixels (`hl_image_from_view`, `owned=0`) with nothing keeping the source alive: the JS string path was a **guaranteed UAF** (cstring freed before return); ArrayBuffer dangled on GC/detach; MappedBuffer/WasmBuffer dangled on an explicit `buf:close()` while the image was alive.

**Fix — refcount the borrow (preserves zero-copy):**
- `HlMappedBuffer` / `HlWasmBuffer` gain `borrow_count` + `pending_free`. Closing/GC-ing a source while `borrow_count > 0` **defers** the real munmap/destroy + struct free; the last release completes it. New: `hl_cap_fs_mmap_borrow/_release`, `hl_wasm_buffer_borrow/_release/_close` (bindings route through `_close`).
- `HlImage` gains a generic `on_free(ctx)` hook (called by `hl_image_free`); `from_buffer` borrows the source + points `on_free` at the matching release fn.
- `from_buffer` **copies** (`hl_image_new`) for non-refcountable sources (string, ArrayBuffer, typed array, image) — also removes the JS-string UAF.

Refcounts are event-loop-only (plain int, no atomics — workers only touch deep-copied inputs).

**Tests:** `mmap_borrow_defers_close`, `mmap_release_without_close_keeps_buffer` (test_fs.c) prove the deferral/teardown; `on_free_hook_runs_once` (test_image.c) proves the image seam. **Validated under ASan** (`make DEBUG=1 test`): 50/50 suites, new tests green, no leak/UAF. CLAUDE.md updated.