### PR TITLE
fix(ws): defer async on_close conn teardown until the handler completes (F3)

### DIFF
--- a/include/hull/runtime/js.h
+++ b/include/hull/runtime/js.h
@@ -132,6 +132,13 @@ typedef struct HlJS {
      * will wire timer_ctx on the new continuation. */
     void           *active_timer;    /* HlJSTimer* during timer callback */
 
+    /* Deferred-teardown hook: if set while a handler runs,
+     * hl_js_async_cont_create captures it so the action (e.g. ws on_close
+     * conn teardown in ws.c) runs only once the async handler completes,
+     * not while it is still suspended. Subsystem-agnostic. */
+    void          (*active_on_complete)(struct HlJS *js, void *ctx);
+    void           *active_on_complete_ctx;
+
     /* UDF lifecycle: 1 while JS runtime is valid, 0 before JS_FreeRuntime.
      * UDF destroy callbacks check this before calling JS_FreeValue. */
     int             udf_runtime_alive;

--- a/include/hull/runtime/lua.h
+++ b/include/hull/runtime/lua.h
@@ -122,6 +122,13 @@ typedef struct HlLua {
      * will wire timer_ctx on the new continuation. */
     void       *active_timer;       /* HlLuaTimer* during timer callback */
 
+    /* Deferred-teardown hook: if set while a handler runs,
+     * hl_lua_async_cont_create captures it so the action (e.g. ws on_close
+     * conn teardown in ws.c) runs only once the async handler completes,
+     * not while it is still suspended. Subsystem-agnostic. */
+    void      (*active_on_complete)(struct HlLua *lua, void *ctx);
+    void       *active_on_complete_ctx;
+
     /* UDF lifecycle: 1 while Lua state is valid, 0 before lua_close.
      * UDF destroy callbacks check this before calling luaL_unref. */
     int         udf_runtime_alive;

--- a/src/hull/runtime/js/async.c
+++ b/src/hull/runtime/js/async.c
@@ -34,6 +34,12 @@ typedef struct HlJsAsyncCont {
     KlConn           *conn;         /* connection to resume (NULL = detached) */
     JSValue           handler_promise; /* outer handler promise */
     void             *timer_ctx;    /* HlJSTimer* if running in a timer callback */
+    /* Generic "handler finally completed" hook (subsystem-agnostic). Lets a
+     * dispatch site defer teardown that must not run while the handler is
+     * still suspended (e.g. the ws on_close conn teardown in ws.c). Called
+     * once on fulfilled / rejected completion. */
+    void            (*on_complete)(HlJS *js, void *ctx);
+    void             *on_complete_ctx;
 } HlJsAsyncCont;
 
 /*
@@ -93,8 +99,16 @@ static void hl_js_async_resume(HlAsyncCont *self, void *driver)
     jc->resolve = JS_UNDEFINED;
     jc->reject = JS_UNDEFINED;
 
+    /* Re-arm the deferred-teardown hook so a re-await inside the handler
+     * carries it onto the next continuation. */
+    js->active_on_complete     = jc->on_complete;
+    js->active_on_complete_ctx = jc->on_complete_ctx;
+
     /* Drain microtasks — this continues the handler past the await */
     hl_js_run_jobs(js);
+
+    js->active_on_complete     = NULL;
+    js->active_on_complete_ctx = NULL;
 
     /* Check outer handler promise state (per-continuation ref) */
     JSPromiseStateEnum state = JS_PromiseState(ctx, jc->handler_promise);
@@ -116,6 +130,13 @@ static void hl_js_async_resume(HlAsyncCont *self, void *driver)
         js->async_pending = 0;
         js->active_conn = NULL;
         js->dispatch_depth--;
+
+        /* Handler that awaited has now completed — run any deferred-teardown
+         * hook (e.g. ws on_close conn teardown). */
+        if (jc->on_complete) {
+            jc->on_complete(js, jc->on_complete_ctx);
+            jc->on_complete = NULL;
+        }
 
 #ifdef HL_ENABLE_HTTP_SERVER
         if (conn) {
@@ -159,6 +180,12 @@ static void hl_js_async_resume(HlAsyncCont *self, void *driver)
         js->async_pending = 0;
         js->active_conn = NULL;
         js->dispatch_depth--;
+
+        /* Run any deferred-teardown hook (handler rejected after awaiting). */
+        if (jc->on_complete) {
+            jc->on_complete(js, jc->on_complete_ctx);
+            jc->on_complete = NULL;
+        }
 
 #ifdef HL_ENABLE_HTTP_SERVER
         if (conn) {
@@ -284,6 +311,8 @@ HlAsyncCont *hl_js_async_cont_create(HlJS *js,
     jc->conn            = js->active_conn;
     jc->handler_promise = JS_UNDEFINED;
     jc->timer_ctx       = js->active_timer;  /* inherit timer ctx if in timer callback */
+    jc->on_complete     = js->active_on_complete;     /* deferred-teardown hook */
+    jc->on_complete_ctx = js->active_on_complete_ctx;
 
     /* Store pointer so dispatch/resume can wire handler_promise */
     js->last_async_cont = jc;

--- a/src/hull/runtime/js/ws.c
+++ b/src/hull/runtime/js/ws.c
@@ -165,6 +165,16 @@ void hl_js_ws_on_message(KlWsServerConn *ws_conn, const char *data,
     js->dispatch_depth--;
 }
 
+/* Deferred-teardown hook (HlJS::active_on_complete): invalidate the conn
+ * object and remove it from the registry once an async on_close handler has
+ * finally completed. Runs from hl_js_async_resume's completion path. */
+static void hl_js_ws_close_teardown(HlJS *js, void *ctx)
+{
+    HlWsConn *conn = (HlWsConn *)ctx;
+    hl_js_ws_invalidate_conn(js->ctx, conn);
+    hl_ws_registry_remove(js->base.ws_registry, conn);
+}
+
 void hl_js_ws_on_close(KlWsServerConn *ws_conn, uint16_t code,
                                 const char *reason, size_t reason_len,
                                 void *user_data)
@@ -189,6 +199,12 @@ void hl_js_ws_on_close(KlWsServerConn *ws_conn, uint16_t code,
         js->last_async_cont = NULL;
         js->async_pending = 0;
         js->instruction_count = 0;
+
+        /* Arm the deferred-teardown hook: if the handler awaits, the
+         * continuation captures it so the conn teardown runs at completion,
+         * not while the handler is still suspended and holding the conn. */
+        js->active_on_complete     = hl_js_ws_close_teardown;
+        js->active_on_complete_ctx = conn;
 
         /* Look up handler */
         JSValue global = JS_GetGlobalObject(ctx);
@@ -223,10 +239,21 @@ void hl_js_ws_on_close(KlWsServerConn *ws_conn, uint16_t code,
         }
 
         JS_FreeValue(ctx, handler);
+        js->active_on_complete     = NULL;
+        js->active_on_complete_ctx = NULL;
         js->dispatch_depth--;
+
+        if (js->async_pending) {
+            /* Handler is suspended on an async op — the continuation captured
+             * the teardown hook; it runs once the handler completes. Do NOT
+             * tear the conn down now while the handler still references it. */
+            return;
+        }
     }
 
-    /* Invalidate conn object and remove from registry */
+    /* Invalidate conn object and remove from registry (sync completion, error,
+     * or no on_close handler). The async path defers this to handler
+     * completion via active_on_complete. */
     hl_js_ws_invalidate_conn(ctx, conn);
     hl_ws_registry_remove(js->base.ws_registry, conn);
 }

--- a/src/hull/runtime/lua/async.c
+++ b/src/hull/runtime/lua/async.c
@@ -33,6 +33,12 @@ typedef struct HlLuaAsyncCont {
     int                thread_ref;    /* registry ref for coroutine */
     KlConn            *conn;          /* connection to resume (NULL = detached) */
     void              *timer_ctx;     /* HlLuaTimer* if running in a timer callback */
+    /* Generic "handler finally completed" hook. Lets a dispatch site defer
+     * teardown that must not run while the handler is still suspended (e.g.
+     * the ws on_close conn teardown in ws.c) without coupling this async
+     * core to any subsystem. Called once on LUA_OK / error completion. */
+    void             (*on_complete)(HlLua *lua, void *ctx);
+    void              *on_complete_ctx;
 } HlLuaAsyncCont;
 
 /*
@@ -70,6 +76,10 @@ static void hl_lua_async_resume(HlAsyncCont *self, void *driver)
     lua->active_co = co;
     lua->active_conn = conn;
     lua->active_thread_ref = lc->thread_ref;
+    /* Re-arm the deferred-teardown hook so a further yield inside the handler
+     * carries it onto the next continuation. */
+    lua->active_on_complete     = lc->on_complete;
+    lua->active_on_complete_ctx = lc->on_complete_ctx;
 
     /* Push driver result onto the coroutine stack so lua_resume
      * delivers it as the return value of the yield point */
@@ -81,6 +91,9 @@ static void hl_lua_async_resume(HlAsyncCont *self, void *driver)
 
     int nres = 0;
     int status = lua_resume(co, lua->L, nargs, &nres);
+
+    lua->active_on_complete     = NULL;
+    lua->active_on_complete_ctx = NULL;
 
     if (status == LUA_OK) {
         /* Handler completed */
@@ -103,6 +116,13 @@ static void hl_lua_async_resume(HlAsyncCont *self, void *driver)
         lua->active_co = NULL;
         lua->active_conn = NULL;
         lua->dispatch_depth--;
+
+        /* Handler that yielded has now completed — run any deferred-teardown
+         * hook (e.g. ws on_close conn teardown). */
+        if (lc->on_complete) {
+            lc->on_complete(lua, lc->on_complete_ctx);
+            lc->on_complete = NULL;
+        }
 
         if (conn) {
             /* Attached mode — response is ready */
@@ -162,6 +182,12 @@ static void hl_lua_async_resume(HlAsyncCont *self, void *driver)
         lua->active_co = NULL;
         lua->active_conn = NULL;
         lua->dispatch_depth--;
+
+        /* Run any deferred-teardown hook (handler errored after yielding). */
+        if (lc->on_complete) {
+            lc->on_complete(lua, lc->on_complete_ctx);
+            lc->on_complete = NULL;
+        }
 
 #ifdef HL_ENABLE_HTTP_SERVER
         if (conn) {
@@ -240,6 +266,8 @@ HlAsyncCont *hl_lua_async_cont_create(HlLua *lua, HlAllocator *alloc,
     lc->thread_ref = lua->active_thread_ref;
     lc->conn       = lua->active_conn;
     lc->timer_ctx  = lua->active_timer;  /* inherit timer ctx if in timer callback */
+    lc->on_complete     = lua->active_on_complete;     /* deferred-teardown hook */
+    lc->on_complete_ctx = lua->active_on_complete_ctx;
 
     return &lc->base;
 }

--- a/src/hull/runtime/lua/ws.c
+++ b/src/hull/runtime/lua/ws.c
@@ -152,6 +152,16 @@ void hl_lua_ws_on_message(KlWsServerConn *ws_conn, const char *data,
     }
 }
 
+/* Deferred-teardown hook (HlLua::active_on_complete): invalidate the conn
+ * userdata and remove it from the registry once an async on_close handler
+ * has finally completed. Runs from hl_lua_async_resume's completion path. */
+static void hl_lua_ws_close_teardown(HlLua *lua, void *ctx)
+{
+    HlWsConn *conn = (HlWsConn *)ctx;
+    hl_lua_ws_invalidate_conn(lua->L, conn);
+    hl_ws_registry_remove(lua->base.ws_registry, conn);
+}
+
 void hl_lua_ws_on_close(KlWsServerConn *ws_conn, uint16_t code,
                                  const char *reason, size_t reason_len,
                                  void *user_data)
@@ -198,8 +208,18 @@ void hl_lua_ws_on_close(KlWsServerConn *ws_conn, uint16_t code,
                         INSTR_COUNT(lua->max_instructions));
         }
 
+        /* Arm the deferred-teardown hook: if the handler yields (async op),
+         * hl_lua_async_cont_create captures it so the teardown below runs
+         * only once the async handler completes, not while it is still
+         * suspended and holding the conn. */
+        lua->active_on_complete     = hl_lua_ws_close_teardown;
+        lua->active_on_complete_ctx = conn;
+
         int nres = 0;
         int status = lua_resume(co, lua->L, 3, &nres);
+
+        lua->active_on_complete     = NULL;
+        lua->active_on_complete_ctx = NULL;
 
         if (status == LUA_OK) {
             luaL_unref(lua->L, LUA_REGISTRYINDEX, thread_ref);
@@ -207,7 +227,11 @@ void hl_lua_ws_on_close(KlWsServerConn *ws_conn, uint16_t code,
             lua->active_co = NULL;
             lua->dispatch_depth--;
         } else if (status == LUA_YIELD) {
-            /* Async op in flight */
+            /* Async op in flight — the continuation captured `conn`; the
+             * teardown is deferred to hl_lua_async_resume's completion. Do
+             * NOT invalidate/remove the conn here while the handler still
+             * references it. */
+            return;
         } else {
             const char *err = lua_tostring(co, -1);
             log_error("[hull:ws] on_close error: %s", err ? err : "unknown");
@@ -218,7 +242,9 @@ void hl_lua_ws_on_close(KlWsServerConn *ws_conn, uint16_t code,
         }
     }
 
-    /* Invalidate conn userdata and remove from registry */
+    /* Invalidate conn userdata and remove from registry (sync completion,
+     * handler error, or no on_close handler). The async-yield path defers
+     * this to async-handler completion via active_ws_close_conn. */
     hl_lua_ws_invalidate_conn(lua->L, conn);
     hl_ws_registry_remove(lua->base.ws_registry, conn);
 }


### PR DESCRIPTION
Audit finding **F3**. The WS server `on_close` handler tore the conn down (invalidate + registry remove + free) unconditionally after dispatching the handler, even when the handler awaited an async op and was still suspended holding the conn — the continuation then ran against an already-torn-down conn (latent UAF, masked today by the userdata nulling). Inconsistent with `on_open`/`on_message`, which leave the conn alive across a yield.

**Fix — a generic, subsystem-agnostic completion hook** on the async continuation (no WS code in the async core):
- `HlLuaAsyncCont` / `HlJsAsyncCont` gain `on_complete(ctx)`, captured from `HlLua`/`HlJS` `active_on_complete` at cont-create, re-armed before each resume, invoked once on final completion (LUA_OK / promise fulfilled or rejected). The async cores have **zero WS knowledge** (no `ws.h`, no `#ifdef HL_ENABLE_HTTP_SERVER`, no `hl_*_ws_*`).
- `ws.c` (both runtimes) arms the hook with a static `ws_close_teardown` callback + the conn before dispatching `on_close`, and on the async-yield path returns early instead of tearing down. Sync/error/no-handler tear down inline as before.

(Generic hook in the async core rather than a separate `async_ws` TU: the async core gains a reusable deferral primitive and WS teardown stays in `ws.c` with the other WS handlers.)

Cancellation unaffected (conn freed at registry teardown; cancel never derefs the hook ctx).

**Validated:** both runtimes build clean; 50/50 unit suites (every async continuation now exercises the `on_complete` capture/restore plumbing with a NULL hook); green under ASan. A live async-on_close e2e needs a WS-server fixture (none exists), so the WS path is covered by inspection + the async-core plumbing tests.