### PR TITLE
fix(audit): one-fwrite records + document db stmt-cache invariant (F6)

### DIFF
--- a/src/hull/cap/audit.c
+++ b/src/hull/cap/audit.c
@@ -10,15 +10,32 @@
 
 #include "hull/cap/audit.h"
 #include <stdio.h>
+#include <string.h>
 #include <time.h>
 
 int hl_audit_enabled = 0;
 
-static int audit_stderr_write(void *ctx, const char *data, size_t len)
+/* Per-record scratch buffer. Audit records are emitted from BOTH the event
+ * loop and worker threads (compute.async / gpu.async audit from their
+ * work_fn). The ShJsonWriter emits token-by-token, so writing straight to
+ * stderr lets two records interleave byte-wise and corrupt the JSONL.
+ * Instead each record accumulates into a thread-local buffer and is flushed
+ * with ONE fwrite, which the stdio stream lock makes atomic relative to
+ * other threads. A record is always built start-to-finish on one thread
+ * (tight begin/end pair, no nesting), so the buffer needs no further lock. */
+#define HL_AUDIT_BUF_MAX 4096
+typedef struct { char data[HL_AUDIT_BUF_MAX]; size_t len; } HlAuditBuf;
+static _Thread_local HlAuditBuf g_audit_buf;
+
+static int audit_buf_write(void *ctx, const char *data, size_t len)
 {
-    (void)ctx;
-    size_t w = fwrite(data, 1, len, stderr);
-    return w == len ? 0 : -1;
+    HlAuditBuf *b = (HlAuditBuf *)ctx;
+    if (!b) return -1;
+    size_t avail = sizeof(b->data) - b->len;
+    if (len > avail) len = avail; /* truncate oversized records (rare) */
+    memcpy(b->data + b->len, data, len);
+    b->len += len;
+    return 0;
 }
 
 ShJsonWriter hl_audit_begin(const char *cap)
@@ -27,12 +44,13 @@ ShJsonWriter hl_audit_begin(const char *cap)
 
     if (!hl_audit_enabled) {
         /* Return a writer with error=1 — all writes become no-ops */
-        sh_json_writer_init(&w, audit_stderr_write, NULL);
+        sh_json_writer_init(&w, audit_buf_write, NULL);
         w.error = 1;
         return w;
     }
 
-    sh_json_writer_init(&w, audit_stderr_write, NULL);
+    g_audit_buf.len = 0;
+    sh_json_writer_init(&w, audit_buf_write, &g_audit_buf);
     sh_json_write_object_start(&w);
 
     /* Timestamp: ISO 8601 UTC. L4: gmtime_r can fail (e.g. very large
@@ -61,6 +79,10 @@ void hl_audit_end(ShJsonWriter *w)
         return;
 
     sh_json_write_object_end(w);
-    /* Write newline directly to stderr (not through JSON writer) */
-    fputc('\n', stderr);
+    /* Append the newline into the buffer, then emit the whole record with a
+     * single fwrite so concurrent event-loop / worker audit lines cannot
+     * interleave byte-wise on the shared stderr. */
+    if (g_audit_buf.len < sizeof(g_audit_buf.data))
+        g_audit_buf.data[g_audit_buf.len++] = '\n';
+    fwrite(g_audit_buf.data, 1, g_audit_buf.len, stderr);
 }

--- a/src/hull/cap/db.c
+++ b/src/hull/cap/db.c
@@ -65,7 +65,9 @@ static sqlite3_stmt *cache_get(HlStmtCache *cache, const char *sql)
     if (rc != SQLITE_OK)
         return NULL;
 
-    /* Evict oldest (LRU) if cache is full */
+    /* Evict oldest (LRU) if cache is full. NOTE: this finalize is why row
+     * callbacks must not re-enter the cache mid-iteration — see the INVARIANT
+     * note at the cb() call site in the query loop below. */
     if (cache->count >= HL_STMT_CACHE_SIZE) {
         sqlite3_finalize(cache->entries[0].stmt);
         hl_alloc_free_const(cache->alloc, cache->entries[0].sql,
@@ -292,6 +294,14 @@ int hl_cap_db_query(HlStmtCache *cache, const char *sql,
             column_to_value(stmt, i, &vals[i]);
             cols[i].value = vals[i];
         }
+        /* INVARIANT: the row callback MUST NOT re-enter the statement cache
+         * (db.query / db.exec with a new SQL string). `stmt` is mid-iteration
+         * and is owned by the LRU cache; a re-entrant cache_get that evicts it
+         * (sqlite3_finalize) would dangle `stmt` for the next sqlite3_step ->
+         * use-after-free. All current callers are pure C result-marshallers
+         * that build the result set and only hand it to script AFTER this
+         * loop ends, so this holds. Preserve it if a streaming/per-row script
+         * callback API is ever added (pin the in-use stmt against eviction). */
         if (cb(ctx, cols, ncols) != 0)
             break; /* caller requested stop */
     }


### PR DESCRIPTION
Audit finding **F6** (last of the batch), two small parts:

1. **Audit JSONL interleave.** With `--audit`, records emitted from `compute.async` / `gpu.async` worker threads share stderr with the event loop, and `ShJsonWriter` wrote token-by-token (many `fwrite`s + a separate newline `fputc`), so two records could interleave byte-wise and corrupt the JSONL. Each record now accumulates into a **thread-local buffer** and flushes with a **single `fwrite`**, which the stdio stream lock makes atomic relative to other threads. Lock-free (records are built start-to-finish on one thread, no nesting), no log-lock coupling. Oversized records (>4 KiB, none in practice) truncate rather than interleave. Output format unchanged (`test_audit` green).
2. **db prepared-statement cache non-reentrancy** (iterator-invalidation note). Documents the invariant at the row-callback call site + the LRU-evict site in `cap/db.c`: a row callback must not re-enter the statement cache (evicting the in-flight `stmt` would dangle it for the next `sqlite3_step`). Holds today (pure C result-marshallers); comment-only, to preserve it if a streaming per-row script callback API is ever added.

Validated: build clean, 50/50 unit suites (incl. `test_audit`), green under ASan. The concurrent-interleave fix is exercised by the TSan CI job.