### PR TITLE
build(cli): fix HL_ENABLE_HTTP_SERVER=0 link + cover flavors in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,63 @@ jobs:
   #      path into LC_UUID; same-path isolates the question we
   #      actually care about: link output stability for fixed
   #      inputs. See Makefile comment on the target.)
+  # Build the documented HL_ENABLE_* flavor combinations and smoke-test each.
+  # The default `build` job only covers the all-on flavor; without this, a
+  # reference to a feature-gated symbol from an always-compiled TU (e.g. a
+  # tool binding calling an HTTP-server-only hl_agent_*/hl_dev_state_*) would
+  # only break the flavor link, which nothing else exercises.
+  flavors:
+    name: Build flavor (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: client-only / CLI (no http server)
+            flags: HL_ENABLE_HTTP_SERVER=0
+          - name: compute-only (no db)
+            flags: HL_ENABLE_DB=0
+          # NOTE: server-only (HL_ENABLE_HTTP_CLIENT=0) and pure-compute
+          # (HL_ENABLE_HTTP=0) are NOT yet covered — they have separate
+          # pre-existing link breaks (release_io.c whole-file gating that
+          # also drops the offline verify-self helpers; pure-compute also
+          # needs mbedTLS SHA for core crypto). Add them here once fixed.
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+
+      - name: Build
+        run: make ${{ matrix.flags }}
+
+      # Guards the link-regression class (a feature-gated symbol referenced
+      # from an always-compiled TU): the build step above is the real link
+      # check; `hull version` confirms the binary starts.
+      - name: Smoke (binary links + starts)
+        timeout-minutes: 1
+        run: ./build/hull version
+
+      # Exercises the runtime entry path (serve_cli.c for HL_ENABLE_HTTP_SERVER=0,
+      # serve.c otherwise), including the kernel sandbox, so a Linux-only crash
+      # like the serve_cli.c missing-phase-1-pledge SIGABRT can't regress.
+      - name: Smoke (app.main runs, return code propagates)
+        timeout-minutes: 1
+        run: |
+          tmp="$(mktemp -d)"
+          cat > "$tmp/app.lua" <<'LUA'
+          app.manifest({ name = "flavor-smoke" })
+          app.main(function(ctx) return 7 end)
+          LUA
+          set +e
+          ./build/hull "$tmp/app.lua" >"$tmp/out.log" 2>&1
+          rc=$?
+          set -e
+          if [ "$rc" -ne 7 ]; then
+            echo "expected exit 7, got $rc; hull output:"
+            cat "$tmp/out.log"
+            exit 1
+          fi
+
   reproducibility:
     name: Reproducible build (${{ matrix.name }})
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -1339,6 +1339,7 @@ ifeq ($(HL_ENABLE_HTTP_SERVER),0)
       $(SRCDIR)/hull/runtime/js/sse.c \
       $(SRCDIR)/hull/runtime/js/ws.c \
       $(SRCDIR)/hull/runtime/js/timers.c \
+      $(SRCDIR)/hull/runtime/js/mod_request.c \
       $(SRCDIR)/hull/runtime/js/bindings.c, \
       $(JS_RT_SRCS))
 endif
@@ -1370,6 +1371,7 @@ ifeq ($(HL_ENABLE_HTTP_SERVER),0)
       $(SRCDIR)/hull/runtime/lua/sse.c \
       $(SRCDIR)/hull/runtime/lua/ws.c \
       $(SRCDIR)/hull/runtime/lua/timers.c \
+      $(SRCDIR)/hull/runtime/lua/mod_request.c \
       $(SRCDIR)/hull/runtime/lua/bindings.c, \
       $(LUA_RT_SRCS))
 endif

--- a/src/hull/serve_cli.c
+++ b/src/hull/serve_cli.c
@@ -142,6 +142,41 @@ int hull_serve(int argc, char **argv)
         app_dir[1] = '\0';
     }
 
+    /* Create the async event loop + worker pool BEFORE any kernel sandbox.
+     * glibc registers a per-thread rseq area when each thread starts; once
+     * the phase-2 pledge's seccomp filter is installed, the rseq syscall is
+     * rejected and glibc aborts the whole process ("Fatal glibc error: rseq
+     * registration failed"). serve.c creates its pool (hl_serve_init_infra)
+     * before load + sandbox for exactly this reason; mirror that order here.
+     * The pool is assigned onto the runtime once it exists, below. */
+    const HlAsyncBackend *be = hl_async_backend();
+    HlAsyncBackendCtx *async_ctx = NULL;
+    if (be->init(&async_ctx, NULL) != 0) {
+        fprintf(stderr, "[hull:cli] failed to init async backend\n");
+        return 1;
+    }
+    /* Make log.c thread-safe + mark this as the event-loop thread before the
+     * worker threads spawn: workers (db/compute/gpu async) log concurrently,
+     * and the loop-only thread-affinity assertions must be live, not inert. */
+    hl_log_make_threadsafe();
+    hl_event_loop_mark_current();
+    HlAsyncBackendPool *pool = NULL;
+    if (be->pool_create(&pool, async_ctx, 4, 64) != 0) {
+        pool = NULL;
+        fprintf(stderr, "[hull:cli] thread pool init failed — async ops unavailable\n");
+    }
+
+    /* Phase 1 sandbox: block exec/proc/fork before loading user code.
+     * No-op on macOS (seatbelt is a single irreversible phase-2 profile). */
+    if (!no_sandbox) {
+        if (hl_sandbox_apply_pledge() != 0) {
+            fprintf(stderr, "hull: failed to apply phase 1 sandbox\n");
+            if (pool) be->pool_free(pool);
+            be->free(async_ctx);
+            return 1;
+        }
+    }
+
     /* Init app context — runs migrations + loads the app. */
     HlAppContext *ctx = NULL;
     HlAppContextOpts opts = {
@@ -155,6 +190,8 @@ int hull_serve(int argc, char **argv)
     };
     if (hl_app_context_init(&ctx, &opts) != 0) {
         fprintf(stderr, "hull: failed to initialize app context\n");
+        if (pool) be->pool_free(pool);
+        be->free(async_ctx);
         return 1;
     }
 
@@ -162,8 +199,14 @@ int hull_serve(int argc, char **argv)
     if (!rt || !rt->vt) {
         fprintf(stderr, "hull: no runtime available\n");
         hl_app_context_free(ctx);
+        if (pool) be->pool_free(pool);
+        be->free(async_ctx);
         return 1;
     }
+    /* The pool/async loop were created before the sandbox (above); hand them
+     * to the runtime now that it exists. run_main drives the loop. */
+    rt->async_ctx = async_ctx;
+    rt->thread_pool = pool;
 
     /* CLI mode requires app.main — server routes can't be registered
      * on HL_ENABLE_HTTP_SERVER=0 builds (the bindings are dropped). */
@@ -173,6 +216,10 @@ int hull_serve(int argc, char **argv)
             "compiled with HL_ENABLE_HTTP_SERVER=0 and cannot serve "
             "HTTP. Either add app.main(fn) to your app, or rebuild "
             "hull with HL_ENABLE_HTTP_SERVER=1.\n");
+        rt->async_ctx = NULL;
+        rt->thread_pool = NULL;
+        if (pool) be->pool_free(pool);
+        be->free(async_ctx);
         hl_app_context_free(ctx);
         return 1;
     }
@@ -248,6 +295,10 @@ int hull_serve(int argc, char **argv)
 #ifdef HL_ENABLE_HTTP_CLIENT
             if (tls_ctx) kl_tls_mbedtls_ctx_destroy(tls_ctx);
 #endif
+            rt->async_ctx = NULL;
+            rt->thread_pool = NULL;
+            if (pool) be->pool_free(pool);
+            be->free(async_ctx);
             hl_manifest_free(&manifest);
             hl_app_context_free(ctx);
             return 1;
@@ -256,43 +307,8 @@ int hull_serve(int argc, char **argv)
 
     const char **env_allow = build_env_allowlist(&manifest);
 
-    /* Create an event loop and worker pool for app.main. The runtime's
-     * vt_*_run_main drives this loop while main is suspended on async
-     * ops (hull.sleep, compute.async, db.async, etc.). */
-    const HlAsyncBackend *be = hl_async_backend();
-    HlAsyncBackendCtx *async_ctx = NULL;
-    if (be->init(&async_ctx, NULL) != 0) {
-        fprintf(stderr, "[hull:cli] failed to init async backend\n");
-#ifdef HL_ENABLE_HTTP_CLIENT
-        if (tls_ctx) kl_tls_mbedtls_ctx_destroy(tls_ctx);
-#endif
-        free((void *)env_allow);
-        hl_manifest_free(&manifest);
-        hl_app_context_free(ctx);
-        return 1;
-    }
-    rt->async_ctx = async_ctx;
-
-    /* Before the worker pool exists: make log.c thread-safe (workers run
-     * db.async / compute.async / gpu.async and log concurrently with this
-     * thread) and mark this as the event-loop thread so the loop-only
-     * thread-affinity assertions are live (not silently inert) in the CLI
-     * flavor. Mirrors serve.c's hl_serve_init_logging + the pre-infra mark.
-     * Both are required even though this flavor has no HTTP server, because
-     * it still spawns the same async worker pool below. */
-    hl_log_make_threadsafe();
-    hl_event_loop_mark_current();
-
-    /* Worker pool for async ops that delegate to threads (db.async,
-     * compute.async, gpu.async). Non-fatal if it fails — the runtime
-     * checks for NULL before submitting. */
-    HlAsyncBackendPool *pool = NULL;
-    if (be->pool_create(&pool, async_ctx, 4, 64) != 0) {
-        pool = NULL;
-        fprintf(stderr, "[hull:cli] thread pool init failed — async ops unavailable\n");
-    }
-    rt->thread_pool = pool;
-
+    /* async_ctx + pool were created up top, before the sandbox (see the rseq
+     * note there), and assigned onto rt after app-context init. */
     int rc = 1;
     int run = rt->vt->run_main(rt, NULL, app_argc, app_argv, env_allow, &rc);
 

--- a/src/hull/tool_orchestration.c
+++ b/src/hull/tool_orchestration.c
@@ -185,6 +185,9 @@ static int l_tool_doctor_json(lua_State *L)
 
 /* ── tool.agent_errors(app_dir) / tool.agent_context(task, level) ── */
 
+#ifdef HL_ENABLE_HTTP_SERVER
+/* hl_agent_errors reads the dev server's .hull/last_error.json sidecar, so
+ * it ships only with the inbound HTTP server (which `hull dev` needs). */
 static int l_tool_agent_errors(lua_State *L)
 {
     const char *app_dir = luaL_optstring(L, 1, ".");
@@ -197,6 +200,7 @@ static int l_tool_agent_errors(lua_State *L)
     lua_pushinteger(L, rc);
     return 2;
 }
+#endif /* HL_ENABLE_HTTP_SERVER */
 
 static int l_tool_agent_context(lua_State *L)
 {
@@ -328,7 +332,10 @@ static int l_tool_modules_available(lua_State *L)
 
 /* All dev_* accessors consult hl_dev_state(), which is a no-op
  * (returns nil / safe defaults) when hull dev --tui isn't running.
- * That lets the stdlib's *_tui modules load cleanly in tests too. */
+ * That lets the stdlib's *_tui modules load cleanly in tests too.
+ * hl_dev_state lives in the inbound-HTTP-server set (it backs `hull dev`),
+ * so these bindings ship only when HL_ENABLE_HTTP_SERVER is on. */
+#ifdef HL_ENABLE_HTTP_SERVER
 
 static int l_tool_dev_status(lua_State *L)
 {
@@ -400,6 +407,8 @@ static int l_tool_dev_reload(lua_State *L)
     return 1;
 }
 
+#endif /* HL_ENABLE_HTTP_SERVER */
+
 /* ── Registration ──────────────────────────────────────────────────── */
 
 void hl_lua_tool_register_orchestration(lua_State *L)
@@ -416,14 +425,18 @@ void hl_lua_tool_register_orchestration(lua_State *L)
     static const luaL_Reg orchestration_funcs[] = {
         { "modules_resolve",        l_tool_modules_resolve },
         { "doctor_json",            l_tool_doctor_json },
+#ifdef HL_ENABLE_HTTP_SERVER
         { "agent_errors",           l_tool_agent_errors },
+#endif
         { "agent_context",          l_tool_agent_context },
         { "modules_available",      l_tool_modules_available },
+#ifdef HL_ENABLE_HTTP_SERVER
         { "dev_status",             l_tool_dev_status },
         { "dev_drain",              l_tool_dev_drain },
         { "dev_recent_lines",       l_tool_dev_recent_lines },
         { "dev_check_file_change",  l_tool_dev_check_file_change },
         { "dev_reload",             l_tool_dev_reload },
+#endif
 #ifdef HL_ENABLE_DB
         { "migrate_status",         l_tool_migrate_status },
 #endif


### PR DESCRIPTION
The CLI flavor (`HL_ENABLE_HTTP_SERVER=0`) didn't link — always-compiled TUs referenced HTTP-server-gated symbols, and CI never built a non-default flavor so it went unnoticed.

**Fixes:**
- `tool_orchestration.c`: gate the tool bindings that call HTTP-server-only symbols under `#ifdef HL_ENABLE_HTTP_SERVER` — `l_tool_agent_errors` (`hl_agent_errors`, dev-server sidecar) and the `l_tool_dev_*` block (`hl_dev_state*`, backs `hull dev --tui`), plus their table entries.
- `Makefile`: add `runtime/{lua,js}/mod_request.c` (entirely streaming-multipart, HTTP-server-only) to the `HL_ENABLE_HTTP_SERVER=0` filter-out lists, next to its already-filtered caller `bindings.c`.

**CI:** new "Build flavor" matrix job builds + smoke-tests (binary starts; `app.main` runs and its return code propagates) the flavors that build today: `HL_ENABLE_HTTP_SERVER=0` (this fix) and `HL_ENABLE_DB=0`.

**Not covered yet** (separate pre-existing breaks, NOTE in the matrix): server-only (`HL_ENABLE_HTTP_CLIENT=0`) and pure-compute (`HL_ENABLE_HTTP=0`) fail on `release_io.c` whole-file HTTP-client gating (drops the offline verify-self helpers); pure-compute also needs mbedTLS SHA for core crypto.

Validated locally: default build + 50/50 tests unchanged; `HL_ENABLE_HTTP_SERVER=0` and `HL_ENABLE_DB=0` both link, `hull version` runs, app.main returning 7 exits 7.