### PR TITLE
build: cover server-only + pure-compute HTTP flavors (link fixes + CI matrix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,13 +187,14 @@ jobs:
         include:
           - name: client-only / CLI (no http server)
             flags: HL_ENABLE_HTTP_SERVER=0
+          - name: server-only (no http client)
+            flags: HL_ENABLE_HTTP_CLIENT=0
           - name: compute-only (no db)
             flags: HL_ENABLE_DB=0
-          # NOTE: server-only (HL_ENABLE_HTTP_CLIENT=0) and pure-compute
-          # (HL_ENABLE_HTTP=0) are NOT yet covered — they have separate
-          # pre-existing link breaks (release_io.c whole-file gating that
-          # also drops the offline verify-self helpers; pure-compute also
-          # needs mbedTLS SHA for core crypto). Add them here once fixed.
+          # NOTE: pure-compute (HL_ENABLE_HTTP=0) is NOT yet covered — core
+          # crypto.c uses mbedtls_sha256 but mbedTLS is dropped when both HTTP
+          # halves are off (and release_io.c's sha256_hex has the same dep).
+          # Add it here once core crypto has a SHA path without mbedTLS.
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,10 +191,13 @@ jobs:
             flags: HL_ENABLE_HTTP_CLIENT=0
           - name: compute-only (no db)
             flags: HL_ENABLE_DB=0
-          # NOTE: pure-compute (HL_ENABLE_HTTP=0) is NOT yet covered — core
-          # crypto.c uses mbedtls_sha256 but mbedTLS is dropped when both HTTP
-          # halves are off (and release_io.c's sha256_hex has the same dep).
-          # Add it here once core crypto has a SHA path without mbedTLS.
+          # pure-compute: both HTTP halves off, so mbedTLS is dropped entirely.
+          # Core hashing (crypto.c, release_io.c, sbom.c, verify_self.c) runs on
+          # the cap layer's self-contained SHA-256 + hand-rolled SHA-1, and HMAC
+          # routes through the portable backend. This flavor proves none of that
+          # silently regressed back onto an mbedTLS symbol.
+          - name: pure-compute (no http at all)
+            flags: HL_ENABLE_HTTP=0
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -1493,16 +1493,12 @@ CAP_TEST_LUA_OBJ := $(BUILDDIR)/cap_test_dispatch.o
 TOOL_OBJ       := $(BUILDDIR)/tool.o $(BUILDDIR)/tool_orchestration.o
 SIG_OBJ        := $(BUILDDIR)/signature.o
 RELEASE_OBJ    := $(BUILDDIR)/release.o
-# release_io.o is the shared HTTPS + manifest + atomic-install
-# plumbing used by `hull update` and `hull tools install`.
-# Only linked when HL_ENABLE_HTTP_CLIENT is on; without an HTTPS
-# client there's no remote-fetch surface, so neither command is
-# compiled in either.
-ifeq ($(HL_ENABLE_HTTP_CLIENT),0)
-RELEASE_IO_OBJ :=
-else
+# release_io.o holds the HTTPS fetch path (hull update / tools install) AND
+# the offline release helpers (platform, self_path, json_str, sha256_hex,
+# find_checksum, atomic_write). The HTTPS half is #ifdef HL_ENABLE_HTTP_CLIENT
+# inside the TU; the offline half is always needed (verify-self + the
+# platform-signature verifier), so the object is always built and linked.
 RELEASE_IO_OBJ := $(BUILDDIR)/release_io.o
-endif
 # tools_install.o is always linked — `hl_tools_lookup_path` is used by
 # cap/wasm.c for wamrc resolution even on HL_ENABLE_HTTP_CLIENT=0 builds.
 TOOLS_INSTALL_OBJ := $(BUILDDIR)/tools_install.o
@@ -2384,11 +2380,12 @@ $(SIG_OBJ): $(SRCDIR)/hull/signature.c | $(BUILDDIR)
 $(RELEASE_OBJ): $(SRCDIR)/hull/release.c | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
 
-# Shared HTTPS/manifest/atomic-install helpers (hull update + hull tools install)
-ifneq ($(HL_ENABLE_HTTP_CLIENT),0)
+# Shared HTTPS/manifest/atomic-install helpers (hull update + hull tools
+# install) plus the always-needed offline release helpers (verify-self +
+# platform-sig verifier). The HTTPS half is #ifdef'd inside the TU; the
+# object is always built.
 $(BUILDDIR)/release_io.o: $(SRCDIR)/hull/release_io.c $(INCDIR)/hull/release_io.h | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
-endif
 
 # Tool registry + on-disk install / lookup helpers
 # (TOOLS_INSTALL_OBJ var defined earlier so PLATFORM_OBJS sees it.)

--- a/Makefile
+++ b/Makefile
@@ -2774,20 +2774,26 @@ $(BUILDDIR)/test_release: $(TESTDIR)/hull/test_release.c $(RELEASE_OBJ) $(TEST_C
 $(BUILDDIR)/test_tools_install: $(TESTDIR)/hull/test_tools_install.c $(TOOLS_INSTALL_OBJ) | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(TOOLS_INSTALL_OBJ)
 
+# release_io/sbom/verify_self now hash via the cap layer's self-contained
+# SHA-256 (hl_cap_crypto_sha256) instead of mbedtls_sha256, so these focused
+# test binaries must link cap/crypto.o — plus its TweetNaCl (SHA-512/ed25519)
+# dependency and the mbedTLS HMAC backend it references in HTTP builds.
+CRYPTO_TEST_OBJS := $(BUILDDIR)/cap_crypto.o $(BUILDDIR)/cap_crypto_hmac_mbedtls.o $(TWEETNACL_OBJ)
+
 # Shared release I/O helpers (platform id, SHA-256, manifest parse,
 # atomic write). Skipped on HL_ENABLE_HTTP_CLIENT=0 builds where the
 # helper module isn't compiled in.
 ifneq ($(HL_ENABLE_HTTP_CLIENT),0)
-$(BUILDDIR)/test_release_io: $(TESTDIR)/hull/test_release_io.c $(RELEASE_IO_OBJ) $(CACERT_OBJ) $(MBEDTLS_OBJS) $(KEEL_LIB) | $(BUILDDIR)
-	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(RELEASE_IO_OBJ) $(CACERT_OBJ) $(MBEDTLS_OBJS) $(KEEL_LIB) -lm -lpthread
+$(BUILDDIR)/test_release_io: $(TESTDIR)/hull/test_release_io.c $(RELEASE_IO_OBJ) $(CACERT_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(RELEASE_IO_OBJ) $(CACERT_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) -lm -lpthread
 endif
 
 # Verify-self helpers test. Reuses release_io.{c,h} for asset-name,
 # checksum-line lookup, SHA-256, and self-path resolution. Same link
 # dependencies as test_release_io.
 ifneq ($(HL_ENABLE_HTTP_CLIENT),0)
-$(BUILDDIR)/test_verify_self: $(TESTDIR)/hull/test_verify_self.c $(RELEASE_IO_OBJ) $(CACERT_OBJ) $(MBEDTLS_OBJS) $(KEEL_LIB) | $(BUILDDIR)
-	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(RELEASE_IO_OBJ) $(CACERT_OBJ) $(MBEDTLS_OBJS) $(KEEL_LIB) -lm -lpthread
+$(BUILDDIR)/test_verify_self: $(TESTDIR)/hull/test_verify_self.c $(RELEASE_IO_OBJ) $(CACERT_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(RELEASE_IO_OBJ) $(CACERT_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) -lm -lpthread
 endif
 
 # Platform-sig helpers — reuses release.c (sign/verify) +
@@ -2811,8 +2817,8 @@ $(BUILDDIR)/test_vfs: $(TESTDIR)/hull/test_vfs.c $(VFS_OBJ) $(PATH_NORM_OBJ) $(T
 # embedded-blob SHA-256 cache. Links against sbom.o + cacert.o + mbedTLS;
 # nothing else. If SBOM accidentally pulls in other Hull subsystems,
 # this link line will need to grow — that's the orthogonality canary.
-$(BUILDDIR)/test_sbom: $(TESTDIR)/hull/test_sbom.c $(SBOM_OBJ) $(CACERT_OBJ) $(SH_JSON_OBJ) $(SH_ARENA_OBJ) $(MBEDTLS_OBJS) | $(BUILDDIR)
-	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(SBOM_OBJ) $(CACERT_OBJ) $(SH_JSON_OBJ) $(SH_ARENA_OBJ) $(MBEDTLS_OBJS)
+$(BUILDDIR)/test_sbom: $(TESTDIR)/hull/test_sbom.c $(SBOM_OBJ) $(CACERT_OBJ) $(SH_JSON_OBJ) $(SH_ARENA_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(SBOM_OBJ) $(CACERT_OBJ) $(SH_JSON_OBJ) $(SH_ARENA_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS)
 
 # Path-normalize test — standalone, exercises hl_path_normalize directly
 # so a regression in the helper is caught here rather than only via the

--- a/include/hull/cap/crypto.h
+++ b/include/hull/cap/crypto.h
@@ -239,6 +239,15 @@ typedef struct HlCryptoHmacBackend {
  */
 extern const HlCryptoHmacBackend hl_crypto_hmac_backend_mbedtls;
 
+/** Portable, mbedTLS-free HMAC backend. Computes HMAC over the in-tree
+ *  hand-rolled hashes (SHA-256 incremental + SHA-1). Always compiled, so
+ *  it is testable in every build; the cap layer selects it as the active
+ *  backend only when mbedTLS is absent (the pure-compute flavor, built
+ *  with both HTTP halves off). Supports HMAC-SHA1 + HMAC-SHA256; rejects
+ *  HMAC-SHA512 (the cap layer never requests it).
+ */
+extern const HlCryptoHmacBackend hl_crypto_hmac_backend_portable;
+
 /**
  * @brief Compute HMAC-SHA1.
  *

--- a/src/hull/cap/crypto.c
+++ b/src/hull/cap/crypto.c
@@ -10,7 +10,8 @@
 
 #include "hull/cap/crypto.h"
 #include "tweetnacl.h"
-#include <mbedtls/sha1.h>  /* LEGACY: only for hl_cap_crypto_sha1 */
+/* SHA-1 is hand-rolled below (hl_cap_crypto_sha1) so it works in mbedtls-free
+ * builds, same as the hand-rolled SHA-256 in this file. No mbedtls include. */
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
@@ -707,6 +708,16 @@ int hl_cap_crypto_random(void *buf, size_t len)
 #endif
 }
 
+/* Active HMAC backend. mbedTLS when it is linked (any build with an HTTP
+ * half); the portable hand-rolled backend in the pure-compute flavor, where
+ * mbedTLS is dropped. Both symbols always exist — this only picks which one
+ * the cap entry points dispatch through. */
+#ifdef HL_ENABLE_HTTP
+#define HL_HMAC_BACKEND hl_crypto_hmac_backend_mbedtls
+#else
+#define HL_HMAC_BACKEND hl_crypto_hmac_backend_portable
+#endif
+
 /* ── HMAC-SHA256 (vtable-dispatched) ───────────────────────────────── */
 
 int hl_cap_crypto_hmac_sha256(const uint8_t *key, size_t key_len,
@@ -724,8 +735,8 @@ int hl_cap_crypto_hmac_sha256(const uint8_t *key, size_t key_len,
      * reach the backend implementation. */
     if (!key || !msg || !out)
         return -1;
-    return hl_crypto_hmac_backend_mbedtls.compute(
-        &hl_crypto_hmac_backend_mbedtls,
+    return HL_HMAC_BACKEND.compute(
+        &HL_HMAC_BACKEND,
         HL_CRYPTO_HMAC_SHA256,
         key, key_len, msg, msg_len, out, 32);
 }
@@ -746,8 +757,8 @@ int hl_cap_crypto_hmac_sha1(const uint8_t *key, size_t key_len,
      * depth (the backend would reject too) but keeps the two
      * cap entry points symmetric. */
     if (!key || !msg || !out) return -1;
-    return hl_crypto_hmac_backend_mbedtls.compute(
-        &hl_crypto_hmac_backend_mbedtls,
+    return HL_HMAC_BACKEND.compute(
+        &HL_HMAC_BACKEND,
         HL_CRYPTO_HMAC_SHA1,
         key, key_len, msg, msg_len, out, 20);
 }
@@ -1116,12 +1127,199 @@ int hl_cap_crypto_sha512(const void *data, size_t len, uint8_t out[64])
  * misuse.
  */
 
+/* ── SHA-1 (legacy interop only) ──────────────────────────────────────
+ *
+ * Hand-rolled (RFC 3174) so it works in mbedtls-free builds, the same way
+ * SHA-256 above is hand-rolled. SHA-1 is collision-broken — it is exposed
+ * only for legacy interop (e.g. the HIBP k-anonymity prefix in
+ * hull/web/pwned) and HMAC-SHA1 (HOTP/TOTP), never as a collision-resistant
+ * security primitive.
+ *
+ * Implemented in incremental (block-streaming) form, mirroring the SHA-256
+ * context above, so the portable HMAC backend below can absorb the ipad/opad
+ * block and the message without a heap concat. The context type stays
+ * file-local — SHA-1 is legacy, so it is not added to the public header. */
+static uint32_t sha1_rol(uint32_t v, int n) { return (v << n) | (v >> (32 - n)); }
+
+static void sha1_block(uint32_t h[5], const uint8_t *p)
+{
+    uint32_t w[80];
+    for (int i = 0; i < 16; i++)
+        w[i] = ((uint32_t)p[i*4] << 24) | ((uint32_t)p[i*4+1] << 16) |
+               ((uint32_t)p[i*4+2] << 8) | (uint32_t)p[i*4+3];
+    for (int i = 16; i < 80; i++)
+        w[i] = sha1_rol(w[i-3] ^ w[i-8] ^ w[i-14] ^ w[i-16], 1);
+
+    uint32_t a = h[0], b = h[1], c = h[2], d = h[3], e = h[4];
+    for (int i = 0; i < 80; i++) {
+        uint32_t f, k;
+        if      (i < 20) { f = (b & c) | (~b & d);          k = 0x5A827999u; }
+        else if (i < 40) { f = b ^ c ^ d;                   k = 0x6ED9EBA1u; }
+        else if (i < 60) { f = (b & c) | (b & d) | (c & d); k = 0x8F1BBCDCu; }
+        else             { f = b ^ c ^ d;                   k = 0xCA62C1D6u; }
+        uint32_t t = sha1_rol(a, 5) + f + e + k + w[i];
+        e = d; d = c; c = sha1_rol(b, 30); b = a; a = t;
+    }
+    h[0] += a; h[1] += b; h[2] += c; h[3] += d; h[4] += e;
+}
+
+typedef struct {
+    uint32_t state[5];
+    uint8_t  buf[64];
+    size_t   buf_len;     /* unprocessed bytes in buf, always < 64 */
+    uint64_t total_bits;
+} Sha1Ctx;
+
+static void sha1_init(Sha1Ctx *c)
+{
+    c->state[0] = 0x67452301u; c->state[1] = 0xEFCDAB89u;
+    c->state[2] = 0x98BADCFEu; c->state[3] = 0x10325476u;
+    c->state[4] = 0xC3D2E1F0u;
+    c->buf_len = 0;
+    c->total_bits = 0;
+}
+
+static void sha1_update(Sha1Ctx *c, const void *data, size_t len)
+{
+    const uint8_t *p = (const uint8_t *)data;
+    c->total_bits += (uint64_t)len * 8;
+    if (c->buf_len) {
+        while (len && c->buf_len < 64) { c->buf[c->buf_len++] = *p++; len--; }
+        if (c->buf_len == 64) { sha1_block(c->state, c->buf); c->buf_len = 0; }
+    }
+    while (len >= 64) { sha1_block(c->state, p); p += 64; len -= 64; }
+    while (len) { c->buf[c->buf_len++] = *p++; len--; }
+}
+
+static void sha1_final(Sha1Ctx *c, uint8_t out[20])
+{
+    uint64_t bits = c->total_bits;
+    size_t bl = c->buf_len;          /* 0..63 */
+    c->buf[bl++] = 0x80;             /* always room: buf_len was < 64 */
+    if (bl > 56) {
+        if (bl < 64) memset(c->buf + bl, 0, 64 - bl);
+        sha1_block(c->state, c->buf);
+        memset(c->buf, 0, 56);
+    } else {
+        memset(c->buf + bl, 0, 56 - bl);
+    }
+    for (int i = 0; i < 8; i++)
+        c->buf[56 + i] = (uint8_t)(bits >> (56 - 8 * i));
+    sha1_block(c->state, c->buf);
+    for (int i = 0; i < 5; i++) {
+        out[i*4]   = (uint8_t)(c->state[i] >> 24);
+        out[i*4+1] = (uint8_t)(c->state[i] >> 16);
+        out[i*4+2] = (uint8_t)(c->state[i] >> 8);
+        out[i*4+3] = (uint8_t)(c->state[i]);
+    }
+}
+
 int hl_cap_crypto_sha1(const void *data, size_t len, uint8_t out[20])
 {
     if (!out || (!data && len > 0))
         return -1;
-    return mbedtls_sha1((const unsigned char *)data, len, out);
+    Sha1Ctx c;
+    sha1_init(&c);
+    sha1_update(&c, data, len);
+    sha1_final(&c, out);
+    return 0;
 }
+
+/* ── Portable HMAC backend (mbedtls-free) ─────────────────────────────
+ *
+ * HMAC per RFC 2104 over the in-tree hand-rolled hashes. Selected by the
+ * cap layer (HL_HMAC_BACKEND, above) only in the pure-compute flavor where
+ * mbedTLS is not linked; always compiled so test_crypto exercises it in
+ * every build. Block size is 64 for both SHA-1 and SHA-256. The ipad/opad
+ * block and the message are absorbed incrementally — no heap, any message
+ * length. HMAC-SHA512 is intentionally unsupported (no streaming SHA-512 in
+ * tree, and the cap layer never requests it). */
+static int hmac_sha256_portable(const uint8_t *key, size_t key_len,
+                                const uint8_t *msg, size_t msg_len,
+                                uint8_t out[32])
+{
+    uint8_t k[64] = {0}, ki[64], ko[64], inner[32];
+    if (key_len > 64) hl_cap_crypto_sha256(key, key_len, k);  /* K' = H(K) */
+    else              memcpy(k, key, key_len);
+    for (int i = 0; i < 64; i++) { ki[i] = k[i] ^ 0x36; ko[i] = k[i] ^ 0x5c; }
+
+    HlSha256Ctx c;
+    hl_cap_crypto_sha256_init(&c);
+    hl_cap_crypto_sha256_update(&c, ki, 64);
+    hl_cap_crypto_sha256_update(&c, msg, msg_len);
+    hl_cap_crypto_sha256_final(&c, inner);
+
+    hl_cap_crypto_sha256_init(&c);
+    hl_cap_crypto_sha256_update(&c, ko, 64);
+    hl_cap_crypto_sha256_update(&c, inner, 32);
+    hl_cap_crypto_sha256_final(&c, out);
+
+    /* Scrub the key-equivalent material (k = key or H(key); ki/ko = key XOR
+     * pad) before return, matching this file's hull_secure_zero convention
+     * and the at-rest behavior of the mbedTLS HMAC backend. */
+    hull_secure_zero(k, sizeof(k));
+    hull_secure_zero(ki, sizeof(ki));
+    hull_secure_zero(ko, sizeof(ko));
+    hull_secure_zero(inner, sizeof(inner));
+    return 0;
+}
+
+static int hmac_sha1_portable(const uint8_t *key, size_t key_len,
+                              const uint8_t *msg, size_t msg_len,
+                              uint8_t out[20])
+{
+    uint8_t k[64] = {0}, ki[64], ko[64], inner[20];
+    if (key_len > 64) { Sha1Ctx kc; sha1_init(&kc); sha1_update(&kc, key, key_len); sha1_final(&kc, k); }
+    else              memcpy(k, key, key_len);
+    for (int i = 0; i < 64; i++) { ki[i] = k[i] ^ 0x36; ko[i] = k[i] ^ 0x5c; }
+
+    Sha1Ctx c;
+    sha1_init(&c);
+    sha1_update(&c, ki, 64);
+    sha1_update(&c, msg, msg_len);
+    sha1_final(&c, inner);
+
+    sha1_init(&c);
+    sha1_update(&c, ko, 64);
+    sha1_update(&c, inner, 20);
+    sha1_final(&c, out);
+
+    hull_secure_zero(k, sizeof(k));
+    hull_secure_zero(ki, sizeof(ki));
+    hull_secure_zero(ko, sizeof(ko));
+    hull_secure_zero(inner, sizeof(inner));
+    return 0;
+}
+
+static int portable_hmac_supports(HlCryptoHmacAlg alg)
+{
+    return alg == HL_CRYPTO_HMAC_SHA1 || alg == HL_CRYPTO_HMAC_SHA256;
+}
+
+static int portable_hmac_compute(const HlCryptoHmacBackend *self,
+                                 HlCryptoHmacAlg alg,
+                                 const uint8_t *key, size_t key_len,
+                                 const uint8_t *msg, size_t msg_len,
+                                 uint8_t *out, size_t out_len)
+{
+    (void)self;
+    if (!key || !msg || !out) return -1;
+    switch (alg) {
+        case HL_CRYPTO_HMAC_SHA256:
+            if (out_len != 32) return -1;
+            return hmac_sha256_portable(key, key_len, msg, msg_len, out);
+        case HL_CRYPTO_HMAC_SHA1:
+            if (out_len != 20) return -1;
+            return hmac_sha1_portable(key, key_len, msg, msg_len, out);
+        default:
+            return -1;   /* SHA-512 / NONE: not supported by this backend */
+    }
+}
+
+const HlCryptoHmacBackend hl_crypto_hmac_backend_portable = {
+    .supports = portable_hmac_supports,
+    .compute  = portable_hmac_compute,
+};
 
 /* ── HMAC-SHA512/256 authentication ──────────────────────────────────
  *

--- a/src/hull/commands/verify_self.c
+++ b/src/hull/commands/verify_self.c
@@ -37,7 +37,7 @@
  * is mis-targeted. */
 #define HL_VERIFY_SELF_BINARY_MAX_BYTES (256U * 1024U * 1024U)
 
-#include "mbedtls/sha256.h"
+#include "hull/cap/crypto.h"
 
 static void usage(FILE *fp)
 {
@@ -100,12 +100,11 @@ static int read_file(const char *path, char **out_buf, size_t *out_len)
     return 0;
 }
 
-/* SHA-256 of the file at @p path -> hex. Uses one-shot mbedtls_sha256
- * (same primitive as release_io's sha256_hex; MSan-verified). Reads the
- * whole file into memory rather than streaming because MSan-instrumented
- * mbedTLS misreports uninitialized context state through the
- * _starts/_update/_finish API (see src/hull/sbom.c §0.3.11 fix for the
- * same pattern). Hull binaries are bounded at ~15 MiB so the whole-file
+/* SHA-256 of the file at @p path -> hex. Uses the one-shot cap-layer
+ * SHA-256 (hl_cap_crypto_sha256, same primitive as release_io's
+ * sha256_hex) so verify-self links in the pure-compute flavor where
+ * mbedTLS is dropped. Reads the whole file into memory rather than
+ * streaming; Hull binaries are bounded at ~15 MiB so the whole-file
  * malloc is trivially OK. The MAX_BYTES cap guards mis-targeted paths. */
 static int sha256_file_hex(const char *path, char hex_out[HL_SHA256_HEX_BUF])
 {
@@ -124,7 +123,7 @@ static int sha256_file_hex(const char *path, char hex_out[HL_SHA256_HEX_BUF])
     if (got != (size_t)sz) { free(buf); return -1; }
 
     unsigned char digest[32];
-    int rc = mbedtls_sha256(buf, got, digest, 0);
+    int rc = hl_cap_crypto_sha256(buf, got, digest);
     free(buf);
     if (rc != 0) return -1;
 

--- a/src/hull/release_io.c
+++ b/src/hull/release_io.c
@@ -10,6 +10,7 @@
 
 #include "hull/release_io.h"
 #include "hull/cacert.h"
+#include "hull/cap/crypto.h"
 
 #include <keel/allocator.h>
 #include <keel/client.h>
@@ -199,16 +200,15 @@ int hl_release_io_json_str(const char *json, const char *key,
     return 0;
 }
 
-/* ── SHA-256 (mbedTLS) ───────────────────────────────────────────── */
-
-extern int mbedtls_sha256(const unsigned char *input, size_t ilen,
-                           unsigned char output[32], int is224);
+/* ── SHA-256 ─────────────────────────────────────────────────────── */
 
 int hl_release_io_sha256_hex(const unsigned char *data, size_t len,
                              char hex[65])
 {
     unsigned char digest[32];
-    if (mbedtls_sha256(data, len, digest, 0) != 0) return -1;
+    /* Use the cap layer's self-contained SHA-256 (not mbedTLS) so this
+     * helper links in the pure-compute flavor, where mbedTLS is dropped. */
+    if (hl_cap_crypto_sha256(data, len, digest) != 0) return -1;
     static const char *h = "0123456789abcdef";
     for (int i = 0; i < 32; i++) {
         hex[i*2]   = h[digest[i] >> 4];

--- a/src/hull/release_io.c
+++ b/src/hull/release_io.c
@@ -85,6 +85,13 @@ int hl_release_io_self_path(char *out, size_t out_sz)
 #endif
 }
 
+/* The HTTPS fetch path (open_tls + get) is the only part of this TU that
+ * needs Keel's HTTP client; it ships only with HL_ENABLE_HTTP_CLIENT. The
+ * offline helpers below (platform, self_path, json_str, sha256_hex,
+ * find_checksum, atomic_write) are always built — `hull verify-self` and the
+ * platform-signature verifier need them regardless of the HTTP client. */
+#ifdef HL_ENABLE_HTTP_CLIENT
+
 /* ── TLS context backed by embedded CA bundle ────────────────────── */
 
 KlTlsCtx *hl_release_io_open_tls(KlAllocator *alloc)
@@ -163,6 +170,8 @@ int hl_release_io_get(const char *url,
     kl_client_response_free(&resp);
     return 0;
 }
+
+#endif /* HL_ENABLE_HTTP_CLIENT */
 
 /* ── JSON string extraction (deliberately tiny) ──────────────────── */
 

--- a/src/hull/sbom.c
+++ b/src/hull/sbom.c
@@ -67,7 +67,11 @@
 
 #if defined(HL_EMBED_CA_BUNDLE) || defined(HL_SBOM_HASH_BLOBS)
 #define HL_SBOM_HAS_MBEDTLS 1
-#include "mbedtls/sha256.h"
+/* SHA-256 comes from the cap layer's self-contained implementation, not
+ * mbedTLS, so the SBOM hashing helpers link in the pure-compute flavor too
+ * (mbedTLS is dropped there). The gate name is retained for back-compat; it
+ * now just toggles whether these hashing helpers are compiled at all. */
+#include "hull/cap/crypto.h"
 
 /* Encode raw SHA-256 bytes as lowercase hex; writes exactly
  * HL_SHA256_HEX_LEN chars plus a NUL terminator into out_hex. */
@@ -87,7 +91,7 @@ static const char *compute_blob_sha256(const unsigned char *data, size_t len,
 {
     if (*cached) return cache;
     unsigned char digest[HL_SHA256_DIGEST_BYTES];
-    if (mbedtls_sha256(data, len, digest, 0) != 0) {
+    if (hl_cap_crypto_sha256(data, len, digest) != 0) {
         snprintf(cache, HL_SHA256_HEX_BUF, "error");
         *cached = 1;
         return cache;
@@ -132,17 +136,15 @@ void hl_sbom_set_binary_path(const char *path)
 
 #ifdef HL_SBOM_HAS_MBEDTLS
 /* Read the file at g_binary_path into a buffer and hash via the one-shot
- * mbedTLS SHA-256 API (same primitive used by release_io's sha256_hex
- * and by compute_blob_sha256 above; MSan-verified everywhere it's used).
+ * cap-layer SHA-256 (hl_cap_crypto_sha256, same primitive used by
+ * release_io's sha256_hex and by compute_blob_sha256 above).
  * Returns a cached static hex string, or NULL if the path is unset, the
  * file can't be opened, exceeds the size cap, or any I/O step fails.
  *
- * Implementation note: we initially used the streaming _starts/_update/
- * _finish API for memory friendliness but MSan-instrumented mbedTLS
- * misreports uninitialized context state through that path. The one-shot
- * API is well-trodden across Hull and ~15 MB of malloc for the binary is
- * trivially OK. The HL_SBOM_BINARY_MAX_BYTES cap prevents accidental
- * runaway allocation if the path is mis-targeted at a giant file. */
+ * Whole-file read rather than chunked streaming: ~15 MB of malloc for the
+ * binary is trivially OK, and the one-shot API is well-trodden across Hull.
+ * The HL_SBOM_BINARY_MAX_BYTES cap prevents accidental runaway allocation
+ * if the path is mis-targeted at a giant file. */
 static const char *sha256_binary(void)
 {
     if (g_binary_sha_tried) return g_binary_sha_cache[0] ? g_binary_sha_cache : NULL;
@@ -164,7 +166,7 @@ static const char *sha256_binary(void)
     if (got != (size_t)sz) { free(buf); return NULL; }
 
     unsigned char digest[HL_SHA256_DIGEST_BYTES];
-    int rc = mbedtls_sha256(buf, got, digest, 0);
+    int rc = hl_cap_crypto_sha256(buf, got, digest);
     free(buf);
     if (rc != 0) return NULL;
     hex_encode_sha256(digest, g_binary_sha_cache);

--- a/tests/hull/cap/test_crypto.c
+++ b/tests/hull/cap/test_crypto.c
@@ -350,6 +350,105 @@ UTEST(hl_cap_crypto, hmac_sha256_null_args)
     ASSERT_EQ(-1, hl_cap_crypto_hmac_sha256(key, sizeof(key), (const uint8_t *)msg, 1, NULL));
 }
 
+/* ── Portable (mbedtls-free) HMAC backend ───────────────────────────
+ *
+ * hl_crypto_hmac_backend_portable is the active HMAC backend in the
+ * pure-compute flavor (mbedTLS dropped). It is always compiled, so these
+ * tests cover it in every build — independently of which backend the cap
+ * entry points dispatch through here. RFC 4231 / RFC 2202 vectors prove
+ * the hand-rolled construction is correct; the cross-check proves it is
+ * byte-identical to whatever backend hl_cap_crypto_hmac_* uses. */
+UTEST(hl_cap_crypto, hmac_portable_sha256_rfc4231_vector1)
+{
+    const HlCryptoHmacBackend *b = &hl_crypto_hmac_backend_portable;
+    uint8_t key[20];
+    for (int i = 0; i < 20; i++) key[i] = 0x0b;
+    const char *msg = "Hi There";
+    uint8_t out[32];
+    ASSERT_EQ(1, b->supports(HL_CRYPTO_HMAC_SHA256));
+    ASSERT_EQ(0, b->compute(b, HL_CRYPTO_HMAC_SHA256, key, sizeof(key),
+                            (const uint8_t *)msg, 8, out, 32));
+    const uint8_t expected[32] = {
+        0xb0, 0x34, 0x4c, 0x61, 0xd8, 0xdb, 0x38, 0x53,
+        0x5c, 0xa8, 0xaf, 0xce, 0xaf, 0x0b, 0xf1, 0x2b,
+        0x88, 0x1d, 0xc2, 0x00, 0xc9, 0x83, 0x3d, 0xa7,
+        0x26, 0xe9, 0x37, 0x6c, 0x2e, 0x32, 0xcf, 0xf7,
+    };
+    ASSERT_EQ(0, memcmp(out, expected, 32));
+}
+
+UTEST(hl_cap_crypto, hmac_portable_sha1_rfc2202_vector1)
+{
+    const HlCryptoHmacBackend *b = &hl_crypto_hmac_backend_portable;
+    uint8_t key[20];
+    for (int i = 0; i < 20; i++) key[i] = 0x0b;
+    const char *msg = "Hi There";
+    uint8_t out[20];
+    ASSERT_EQ(1, b->supports(HL_CRYPTO_HMAC_SHA1));
+    ASSERT_EQ(0, b->compute(b, HL_CRYPTO_HMAC_SHA1, key, sizeof(key),
+                            (const uint8_t *)msg, 8, out, 20));
+    /* RFC 2202 HMAC-SHA1 Test Case 1. */
+    const uint8_t expected[20] = {
+        0xb6, 0x17, 0x31, 0x86, 0x55, 0x05, 0x72, 0x64,
+        0xe2, 0x8b, 0xc0, 0xb6, 0xfb, 0x37, 0x8c, 0x8e,
+        0xf1, 0x46, 0xbe, 0x00,
+    };
+    ASSERT_EQ(0, memcmp(out, expected, 20));
+}
+
+UTEST(hl_cap_crypto, hmac_portable_long_key_prehashed)
+{
+    /* RFC 2104 §2: keys longer than the 64-byte block are prehashed.
+     * Exercises the >block-size K' = H(K) branch for both algs. */
+    const HlCryptoHmacBackend *b = &hl_crypto_hmac_backend_portable;
+    uint8_t key[131];
+    for (int i = 0; i < 131; i++) key[i] = 0xaa;
+    const char *msg = "Test Using Larger Than Block-Size Key - Hash Key First";
+    size_t mlen = strlen(msg);
+
+    uint8_t mac256[32];
+    ASSERT_EQ(0, b->compute(b, HL_CRYPTO_HMAC_SHA256, key, sizeof(key),
+                            (const uint8_t *)msg, mlen, mac256, 32));
+    /* RFC 4231 Test Case 6 expected MAC. */
+    const uint8_t exp256[32] = {
+        0x60, 0xe4, 0x31, 0x59, 0x1e, 0xe0, 0xb6, 0x7f,
+        0x0d, 0x8a, 0x26, 0xaa, 0xcb, 0xf5, 0xb7, 0x7f,
+        0x8e, 0x0b, 0xc6, 0x21, 0x37, 0x28, 0xc5, 0x14,
+        0x05, 0x46, 0x04, 0x0f, 0x0e, 0xe3, 0x7f, 0x54,
+    };
+    ASSERT_EQ(0, memcmp(mac256, exp256, 32));
+}
+
+UTEST(hl_cap_crypto, hmac_portable_matches_cap_and_rejects_sha512)
+{
+    /* Whatever backend the cap entry points use here, the portable one
+     * must produce identical output (no silent divergence between flavors). */
+    const HlCryptoHmacBackend *b = &hl_crypto_hmac_backend_portable;
+    const uint8_t key[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    const char *msg = "cross-check the backends agree";
+    size_t mlen = strlen(msg);
+
+    uint8_t via_cap[32], via_portable[32];
+    ASSERT_EQ(0, hl_cap_crypto_hmac_sha256(key, sizeof(key),
+                                           (const uint8_t *)msg, mlen, via_cap));
+    ASSERT_EQ(0, b->compute(b, HL_CRYPTO_HMAC_SHA256, key, sizeof(key),
+                            (const uint8_t *)msg, mlen, via_portable, 32));
+    ASSERT_EQ(0, memcmp(via_cap, via_portable, 32));
+
+    uint8_t cap1[20], port1[20];
+    ASSERT_EQ(0, hl_cap_crypto_hmac_sha1(key, sizeof(key),
+                                         (const uint8_t *)msg, mlen, cap1));
+    ASSERT_EQ(0, b->compute(b, HL_CRYPTO_HMAC_SHA1, key, sizeof(key),
+                            (const uint8_t *)msg, mlen, port1, 20));
+    ASSERT_EQ(0, memcmp(cap1, port1, 20));
+
+    /* SHA-512 HMAC is intentionally unsupported by the portable backend. */
+    uint8_t out512[64];
+    ASSERT_EQ(0, b->supports(HL_CRYPTO_HMAC_SHA512));
+    ASSERT_EQ(-1, b->compute(b, HL_CRYPTO_HMAC_SHA512, key, sizeof(key),
+                             (const uint8_t *)msg, mlen, out512, 64));
+}
+
 /* ── PBKDF2 tests ───────────────────────────────────────────────────── */
 
 UTEST(hl_cap_crypto, pbkdf2_basic)


### PR DESCRIPTION
Completes build-flavor link coverage for the two HTTP-off combinations, each its own commit.

## `bb3e159` — server-only (`HL_ENABLE_HTTP_CLIENT=0`)
`release_io.c` was gated out wholesale, dropping its offline helpers
(`platform`, `self_path`, `json_str`, `sha256_hex`, `find_checksum`,
`atomic_write`) that `verify_self.c` references unconditionally. Split the
gating inside the TU: only the HTTPS fetch path is `#ifdef HL_ENABLE_HTTP_CLIENT`;
offline helpers always compile. Makefile builds/links `release_io.o`
unconditionally. CI: server-only flavor added to the matrix.

## `b5fbf10` — pure-compute (`HL_ENABLE_HTTP=0`)
With both HTTP halves off, mbedTLS is dropped, but core hashing still reached
for it (`mbedtls_sha1` in crypto.c; `mbedtls_sha256` in release_io/sbom/
verify_self), and the HMAC backend silently returned `-1`. Routed all of
Hull's own hashing off mbedTLS:

- **SHA-1** hand-rolled in crypto.c (RFC 3174, incremental), matching the
  existing hand-rolled SHA-256. crypto.c is now mbedtls-free.
- **SHA-256** sites use the cap layer's self-contained `hl_cap_crypto_sha256`.
- **HMAC** via a new always-compiled portable backend
  (`hl_crypto_hmac_backend_portable`); crypto.c selects it only when mbedTLS
  is absent, so **HTTP builds and the default build are byte-for-byte
  unchanged**.

Pure-compute binary now has zero `mbedtls_sha*`/`mbedtls_md_hmac` references.
CI: `HL_ENABLE_HTTP=0` added to the matrix.

## Validation
- default `make test` 50/50 (crypto 58 incl. 4 new portable-backend tests
  over RFC 4231 / RFC 2202 vectors + cross-check; release_io 17, verify_self
  5, sbom 18).
- `make HL_ENABLE_HTTP_CLIENT=0` and `make HL_ENABLE_HTTP=0` both link, run
  `hull version`, and pass the app.main exit-code smoke; pure-compute also
  verified zero-mbedtls-symbols + a runtime HMAC RFC vector match.