### PR TITLE
feat(build): hull build --flavor MVP (resolver target-caps + flavored app binaries)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2045,7 +2045,7 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
 
 # ── Targets ─────────────────────────────────────────────────────────
 
-.PHONY: all clean test debug msan tsan fuzz fuzz-run e2e e2e-build e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-tcc e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint platform platform-cosmo hardening check-hardening
+.PHONY: all clean test debug msan tsan fuzz fuzz-run e2e e2e-build e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-tcc e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint platform platform-cosmo platform-server-only platform-client-only platform-pure-compute hardening check-hardening
 
 all: $(BUILDDIR)/hull
 
@@ -2152,20 +2152,50 @@ $(PLATFORM_LIB): | $(BUILDDIR)
 	@test -f $@ || (echo "ERROR: TRUST_PLATFORM_LIB=1 but $@ is missing"; exit 1)
 	@echo "$@: trusting pre-built artifact (TRUST_PLATFORM_LIB=1)"
 else
-$(PLATFORM_LIB): $(PLATFORM_OBJS) $(CANARY_OBJ) $(KEEL_LIB) | $(BUILDDIR)
+# When both HTTP halves are off, KEEL_LIB is empty and the keel-merge below is
+# skipped. But the platform objects still reference sh_seal_arena (Hull's
+# manifest seal / sealed runtime tables), which normally arrives bundled inside
+# the merged keel archive. Add Hull's own instrumented sh_seal_arena.o directly
+# in that case so the no-keel (pure-compute) platform archive is self-contained.
+ifeq ($(KEEL_LIB),)
+PLATFORM_NOKEEL_OBJS := $(SH_SEAL_ARENA_OBJ)
+else
+PLATFORM_NOKEEL_OBJS :=
+endif
+$(PLATFORM_LIB): $(PLATFORM_OBJS) $(CANARY_OBJ) $(PLATFORM_NOKEEL_OBJS) $(KEEL_LIB) | $(BUILDDIR)
 	@rm -f $@
-	$(AR) rcs $@ $(PLATFORM_OBJS) $(CANARY_OBJ)
-	@# Merge keel objects into the platform archive
-	@tmpdir=$$(mktemp -d) && \
+	$(AR) rcs $@ $(PLATFORM_OBJS) $(CANARY_OBJ) $(PLATFORM_NOKEEL_OBJS)
+	@# Merge keel objects into the platform archive. KEEL_LIB is empty when
+	@# both HTTP halves are off (pure-compute flavor), in which case there is
+	@# nothing to merge -- skip rather than `ar x` the empty path (a dir).
+	@if [ -n "$(KEEL_LIB)" ]; then \
+		tmpdir=$$(mktemp -d) && \
 		cd $$tmpdir && \
 		$(AR) x $(CURDIR)/$(KEEL_LIB) && \
 		$(AR) rcs $(CURDIR)/$@ *.o && \
-		rm -rf $$tmpdir
+		rm -rf $$tmpdir ; \
+	fi
 	@# Record the CC used so hull build can auto-detect
 	@echo "$(CC)" > $(BUILDDIR)/platform_cc
 endif
 
 platform: $(PLATFORM_LIB)
+
+# ── Build-flavor platform libraries (hull build --flavor) ──────────────
+# Produce $(BUILDDIR)/libhull_platform-<flavor>.a, the platform archive a
+# non-default flavor links against. Each flavor compiles with a different
+# HL_ENABLE_* set, so it builds in a dedicated object dir (BUILDDIR override)
+# to avoid clobbering the default build or build/hull. `hull build
+# --flavor=<flavor>` discovers the result in $(BUILDDIR)/. See
+# docs/build_flavors.md.
+PLATFORM_FLAVOR_FLAGS_server-only  := HL_ENABLE_HTTP_CLIENT=0
+PLATFORM_FLAVOR_FLAGS_client-only  := HL_ENABLE_HTTP_SERVER=0
+PLATFORM_FLAVOR_FLAGS_pure-compute := HL_ENABLE_HTTP=0
+
+platform-server-only platform-client-only platform-pure-compute: platform-%:
+	$(MAKE) platform BUILDDIR=$(BUILDDIR)/flavor-$* $(PLATFORM_FLAVOR_FLAGS_$*)
+	cp $(BUILDDIR)/flavor-$*/libhull_platform.a $(BUILDDIR)/libhull_platform-$*.a
+	@echo "built $(BUILDDIR)/libhull_platform-$*.a"
 
 # Multi-arch cosmo platform: build x86_64 and aarch64 archives
 COSMO_STAGE := .cosmo_staging
@@ -3146,6 +3176,10 @@ e2e-cache-cosmo:
 
 e2e-tcc: $(BUILDDIR)/hull $(BUILDDIR)/libhull_platform.a
 	sh tests/e2e_tcc.sh
+
+# `hull build --flavor` MVP. Builds the pure-compute platform lib itself.
+e2e-build-flavor: $(BUILDDIR)/hull
+	sh tests/e2e_build_flavor.sh
 
 e2e-install:
 	sh tests/e2e_install.sh

--- a/include/hull/module_resolver.h
+++ b/include/hull/module_resolver.h
@@ -99,6 +99,50 @@ int hl_module_resolver_resolve(const HlManifest *manifest,
                                 HlResolvedModuleSet *out,
                                 char *errbuf, size_t errlen);
 
+/*
+ * Compile-time capabilities THIS hull build provides, as an HL_MOD_CAP_*
+ * bitset (DB / WASM / GPU / HTTP_SERVER / HTTP_CLIENT / TUI). This is what
+ * the plain resolver validates declared modules against.
+ */
+uint32_t hl_module_build_caps(void);
+
+/*
+ * Resolve against an EXPLICIT build-cap set instead of this binary's
+ * compiled-in flags. Used by `hull build --flavor`, which must validate an
+ * app's manifest against the TARGET flavor's caps (e.g. reject hull/web/
+ * ws-server when building --flavor=pure-compute) even though the running
+ * hull is full-HTTP. hl_module_resolver_resolve() == this with
+ * hl_module_build_caps().
+ */
+int hl_module_resolver_resolve_caps(const HlManifest *manifest,
+                                     HlResolvedModuleSet *out,
+                                     uint32_t build_caps,
+                                     char *errbuf, size_t errlen);
+
+/* ── Build flavors ─────────────────────────────────────────────────────
+ *
+ * A build flavor is a named, finite cut of the platform's capability set,
+ * carried by a correspondingly-compiled libhull_platform.a. `hull build
+ * --flavor=<name>` selects one. The registry is the single source of truth
+ * (resolver target-caps, platform-lib asset name, doctor/agent listing).
+ * See docs/build_flavors.md.
+ */
+typedef struct {
+    const char *name;        /* "pure-compute" */
+    uint32_t    clear_caps;  /* HL_MOD_CAP_* this flavor turns OFF vs full */
+    const char *asset;       /* platform-lib stem, "libhull_platform-<flavor>" */
+} HlBuildFlavor;
+
+/* Look up a flavor by name; NULL if unknown. "full" is a zero-clear entry. */
+const HlBuildFlavor *hl_build_flavor_find(const char *name);
+
+/* Enumerate the flavor table. Returns count; writes the table base to *out. */
+int hl_build_flavor_all(const HlBuildFlavor **out);
+
+/* Target build-caps for a flavor: base with the flavor's clear_caps removed.
+ * `base` is normally hl_module_build_caps() (the running hull's caps). */
+uint32_t hl_build_flavor_caps(const HlBuildFlavor *f, uint32_t base);
+
 /* ── Pre-manifest import tracker ───────────────────────────────────── */
 
 /*

--- a/src/hull/module_resolver.c
+++ b/src/hull/module_resolver.c
@@ -141,11 +141,60 @@ static const char *cap_label(uint32_t cap)
     }
 }
 
+uint32_t hl_module_build_caps(void)
+{
+    return build_provided_caps();
+}
+
+/* ── Build flavors ─────────────────────────────────────────────────────
+ *
+ * Each flavor clears a subset of the build caps vs `full`. The asset stem
+ * names the matching libhull_platform-<flavor>.a. Single source of truth
+ * for the resolver target-caps, the platform-lib lookup, and listing.
+ * Note: HL_MOD_CAP_HTTP == HTTP_CLIENT | HTTP_SERVER (the alias). */
+static const HlBuildFlavor BUILD_FLAVORS[] = {
+    { "full",         0,                      "libhull_platform" },
+    { "server-only",  HL_MOD_CAP_HTTP_CLIENT, "libhull_platform-server-only" },
+    { "client-only",  HL_MOD_CAP_HTTP_SERVER, "libhull_platform-client-only" },
+    { "pure-compute", HL_MOD_CAP_HTTP,        "libhull_platform-pure-compute" },
+};
+
+const HlBuildFlavor *hl_build_flavor_find(const char *name)
+{
+    if (!name) return NULL;
+    for (size_t i = 0; i < sizeof(BUILD_FLAVORS) / sizeof(BUILD_FLAVORS[0]); i++) {
+        if (strcmp(BUILD_FLAVORS[i].name, name) == 0)
+            return &BUILD_FLAVORS[i];
+    }
+    return NULL;
+}
+
+int hl_build_flavor_all(const HlBuildFlavor **out)
+{
+    if (out) *out = BUILD_FLAVORS;
+    return (int)(sizeof(BUILD_FLAVORS) / sizeof(BUILD_FLAVORS[0]));
+}
+
+uint32_t hl_build_flavor_caps(const HlBuildFlavor *f, uint32_t base)
+{
+    return f ? (base & ~f->clear_caps) : base;
+}
+
 /* ── The resolver ──────────────────────────────────────────────────── */
 
 int hl_module_resolver_resolve(const HlManifest *manifest,
                                 HlResolvedModuleSet *out,
                                 char *errbuf, size_t errlen)
+{
+    return hl_module_resolver_resolve_caps(manifest, out,
+                                           build_provided_caps(),
+                                           errbuf, errlen);
+}
+
+int hl_module_resolver_resolve_caps(const HlManifest *manifest,
+                                     HlResolvedModuleSet *out,
+                                     uint32_t build_caps,
+                                     char *errbuf, size_t errlen)
 {
     if (!out) {
         ERR0("module resolver: null output");
@@ -163,7 +212,7 @@ int hl_module_resolver_resolve(const HlManifest *manifest,
     /* No manifest, or manifest with no `modules` key: intrinsic only. */
     if (!manifest || !manifest->modules_declared) return 0;
 
-    const uint32_t prov_build    = build_provided_caps();
+    const uint32_t prov_build    = build_caps;
     const uint32_t build_cap_mask = HL_MOD_CAP_DB | HL_MOD_CAP_WASM
                                     | HL_MOD_CAP_GPU | HL_MOD_CAP_HTTP
                                     | HL_MOD_CAP_TUI;

--- a/src/hull/serve_cli.c
+++ b/src/hull/serve_cli.c
@@ -28,6 +28,7 @@
  */
 
 #include "hull/app_context.h"
+#include "hull/entry.h"        /* HlEntry / hl_app_entries[] (embedded apps) */
 #include "hull/shared/async_backend.h"
 #include "hull/shared/log_lock.h"
 #include "hull/shared/thread_affinity.h"
@@ -113,16 +114,35 @@ int hull_serve(int argc, char **argv)
     int entry_idx = cli_parse_args(argc, argv, &app_argc, &app_argv,
                                     &no_migrate, &no_sandbox, &db_path);
     if (!db_path) db_path = getenv("HULL_DB");
-    if (entry_idx < 0) {
-        fprintf(stderr,
-            "hull: no entry point given. Usage: hull run <app.lua|app.js> "
-            "[-- args...]\n");
-        return 1;
+
+    /* Resolve the entry point. A `hull build` binary embeds its app and is run
+     * with no argv entry, so when none is given fall back to the embedded
+     * entry the same way serve.c does (serve.c is not compiled in this
+     * HTTP-server-less flavor, so the scan is replicated here). The embedded
+     * Lua entry is registered as "./app", the JS entry as "./app.js"; the
+     * "app.lua"/"app.js" name then resolves from the app VFS, and realpath()
+     * below harmlessly fails for it (leaving app_dir = "."). */
+    const char *entry;
+    if (entry_idx >= 0) {
+        entry = argv[entry_idx];
+    } else {
+        extern const HlEntry hl_app_entries[];
+        const char *embedded = NULL;
+        for (int i = 0; hl_app_entries[i].name; i++) {
+            if (strcmp(hl_app_entries[i].name, "./app.js") == 0) { embedded = "app.js"; break; }
+            if (strcmp(hl_app_entries[i].name, "./app") == 0)    { embedded = "app.lua"; break; }
+        }
+        if (!embedded) {
+            fprintf(stderr,
+                "hull: no entry point given. Usage: hull run <app.lua|app.js> "
+                "[-- args...]\n");
+            return 1;
+        }
+        entry = embedded;
     }
 
     /* Derive app_dir from the entry point path (parent directory of
      * the .lua/.js file, or "." if no slash). app_context needs both. */
-    const char *entry = argv[entry_idx];
     char entry_abs[4096];
     if (realpath(entry, entry_abs) != NULL)
         entry = entry_abs;

--- a/src/hull/tool_orchestration.c
+++ b/src/hull/tool_orchestration.c
@@ -91,15 +91,33 @@ static int l_tool_modules_resolve(lua_State *L)
         m.modules_declared = 1;
         lua_pushnil(L);
         while (lua_next(L, -2) != 0 && m.modules_count < HL_MANIFEST_MAX_MODULES) {
-            if (lua_type(L, -2) == LUA_TSTRING &&
-                lua_type(L, -1) == LUA_TSTRING) {
-                const char *name = lua_tostring(L, -2);
-                const char *vstr = lua_tostring(L, -1);
-                char *end = NULL;
-                long v = strtol(vstr, &end, 10);
-                if (end != vstr && v >= 1 && v <= 255) {
-                    char *copy = strdup(name);
+            if (lua_isstring(L, -1)) {
+                /* Canonical form: each VALUE is a spec "vendor/name@major"
+                 * (array `{"hull/db@1"}` or keyed `{db="hull/db@1"}`; the
+                 * value carries the spec either way). Same parse as
+                 * manifest_declares_module() in mod_app.c: strip the "@N"
+                 * major for the registry lookup. Falls back to the legacy
+                 * key=name / value=version-number form for a bare number. */
+                const char *val = lua_tostring(L, -1);
+                int is_spec = strchr(val, '/') != NULL || strchr(val, '@') != NULL;
+                const char *spec = NULL;
+                size_t nlen = 0;
+                long v = 0;
+                if (is_spec) {
+                    spec = val;
+                    const char *at = strchr(spec, '@');
+                    nlen = at ? (size_t)(at - spec) : strlen(spec);
+                    v = at ? strtol(at + 1, NULL, 10) : 1;
+                } else if (lua_type(L, -2) == LUA_TSTRING) {
+                    spec = lua_tostring(L, -2);
+                    nlen = strlen(spec);
+                    v = strtol(val, NULL, 10);
+                }
+                if (spec && nlen > 0 && v >= 1 && v <= 255) {
+                    char *copy = malloc(nlen + 1);
                     if (copy) {
+                        memcpy(copy, spec, nlen);
+                        copy[nlen] = '\0';
                         owned_names[owned_count] = copy;
                         m.modules[m.modules_count].name = copy;
                         m.modules[m.modules_count].api_major = (uint8_t)v;

--- a/src/hull/tool_orchestration.c
+++ b/src/hull/tool_orchestration.c
@@ -113,9 +113,28 @@ static int l_tool_modules_resolve(lua_State *L)
     }
     lua_pop(L, 1);
 
+    /* Optional arg 2: a build flavor name. When set, validate against the
+     * TARGET flavor's caps (e.g. `hull build --flavor=pure-compute` rejects
+     * hull/web/ws-server) rather than this running hull's compiled-in caps. */
+    uint32_t caps = hl_module_build_caps();
+    if (lua_gettop(L) >= 2 && lua_isstring(L, 2)) {
+        const char *flavor = lua_tostring(L, 2);
+        const HlBuildFlavor *f = hl_build_flavor_find(flavor);
+        if (!f) {
+            for (int i = 0; i < owned_count; i++) free(owned_names[i]);
+            lua_newtable(L);
+            lua_pushboolean(L, 0);
+            lua_setfield(L, -2, "ok");
+            lua_pushfstring(L, "unknown build flavor '%s'", flavor);
+            lua_setfield(L, -2, "error");
+            return 1;
+        }
+        caps = hl_build_flavor_caps(f, caps);
+    }
+
     HlResolvedModuleSet set;
     char err[HL_MODULE_RESOLVER_ERR_MAX] = {0};
-    int rc = hl_module_resolver_resolve(&m, &set, err, sizeof(err));
+    int rc = hl_module_resolver_resolve_caps(&m, &set, caps, err, sizeof(err));
 
     for (int i = 0; i < owned_count; i++) free(owned_names[i]);
 
@@ -148,6 +167,41 @@ static int l_tool_modules_resolve(lua_State *L)
     }
     lua_setfield(L, -2, "modules");
 
+    return 1;
+}
+
+/* ── tool.build_flavor(name) → {ok, asset|error} ──────────────────── */
+
+/* Validate a `hull build --flavor=<name>` value against the flavor registry
+ * and return the platform-lib asset stem so build.lua can locate/link it.
+ * Unknown name → {ok=false, error=...} listing the valid flavors. */
+static int l_tool_build_flavor(lua_State *L)
+{
+    const char *name = luaL_checkstring(L, 1);
+    const HlBuildFlavor *f = hl_build_flavor_find(name);
+
+    lua_newtable(L);
+    if (!f) {
+        const HlBuildFlavor *all = NULL;
+        int n = hl_build_flavor_all(&all);
+        char valid[256];
+        size_t off = 0;
+        for (int i = 0; i < n && off + 1 < sizeof(valid); i++) {
+            int w = snprintf(valid + off, sizeof(valid) - off, "%s%s",
+                             i ? ", " : "", all[i].name);
+            if (w < 0) break;
+            off += (size_t)w;
+        }
+        lua_pushboolean(L, 0);
+        lua_setfield(L, -2, "ok");
+        lua_pushfstring(L, "unknown build flavor '%s' (valid: %s)", name, valid);
+        lua_setfield(L, -2, "error");
+        return 1;
+    }
+    lua_pushboolean(L, 1);
+    lua_setfield(L, -2, "ok");
+    lua_pushstring(L, f->asset);
+    lua_setfield(L, -2, "asset");
     return 1;
 }
 
@@ -424,6 +478,7 @@ void hl_lua_tool_register_orchestration(lua_State *L)
 
     static const luaL_Reg orchestration_funcs[] = {
         { "modules_resolve",        l_tool_modules_resolve },
+        { "build_flavor",           l_tool_build_flavor },
         { "doctor_json",            l_tool_doctor_json },
 #ifdef HL_ENABLE_HTTP_SERVER
         { "agent_errors",           l_tool_agent_errors },

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -69,6 +69,11 @@ local function parse_args()
             opts.target = arg[i]
         elseif a == "--no-verify-platform" then
             opts.verify_platform = false
+        elseif a == "--flavor" then
+            i = i + 1
+            opts.flavor = arg[i]
+        elseif a:sub(1, 9) == "--flavor=" then
+            opts.flavor = a:sub(10)
         elseif a:sub(1, 1) ~= "-" then
             opts.app_dir = a
         end
@@ -358,6 +363,41 @@ local function generate_app_registry(app_dir, files)
     return table.concat(parts, "\n")
 end
 
+-- Execute the app entry to capture its manifest table (or nil). Lua entry
+-- runs in this same VM; JS entry runs in a transient HlJS via
+-- tool.extract_manifest_js and the JSON result is decoded into the same
+-- shape app.get_manifest() returns. Used by sign_app (to persist the
+-- resolved module set) and by main (to validate --flavor before building).
+local function extract_app_manifest(app_dir)
+    local manifest = nil
+    local lua_entry = app_dir .. "/app.lua"
+    local js_entry  = app_dir .. "/app.js"
+    if file_exists(lua_entry) then
+        local chunk = tool.loadfile(lua_entry)
+        if chunk then
+            local ok, err = pcall(chunk)
+            if ok then
+                manifest = app.get_manifest()
+            else
+                tool.stderr("hull build: warning: Lua manifest extraction failed: " .. tostring(err) .. "\n")
+            end
+        end
+    elseif file_exists(js_entry) then
+        local ok, js_json_or_err = pcall(tool.extract_manifest_js, js_entry)
+        if not ok then
+            tool.stderr("hull build: warning: JS manifest extraction failed: " .. tostring(js_json_or_err) .. "\n")
+        elseif js_json_or_err then
+            local decoded, decode_err = json.decode(js_json_or_err)
+            if decoded then
+                manifest = decoded
+            else
+                tool.stderr("hull build: warning: JS manifest JSON decode failed: " .. tostring(decode_err) .. "\n")
+            end
+        end
+    end
+    return manifest
+end
+
 local function sign_app(app_dir, key_file, sign_ctx, files)
     local key_data = read_file(key_file)
     if not key_data then
@@ -393,38 +433,8 @@ local function sign_app(app_dir, key_file, sign_ctx, files)
         end
     end
 
-    -- Execute the app entry to capture its manifest. Lua entry runs
-    -- in this same VM; JS entry runs in a transient HlJS spun up by
-    -- tool.extract_manifest_js and the resulting JSON-stringified
-    -- manifest is decoded into the same shape app.get_manifest() would
-    -- return on the Lua side. Either path is fine — the rest of the
-    -- build pipeline only cares about the resulting table.
-    local manifest = nil
-    local lua_entry = app_dir .. "/app.lua"
-    local js_entry  = app_dir .. "/app.js"
-    if file_exists(lua_entry) then
-        local chunk = tool.loadfile(lua_entry)
-        if chunk then
-            local ok, err = pcall(chunk)
-            if ok then
-                manifest = app.get_manifest()
-            else
-                tool.stderr("hull build: warning: Lua manifest extraction failed: " .. tostring(err) .. "\n")
-            end
-        end
-    elseif file_exists(js_entry) then
-        local ok, js_json_or_err = pcall(tool.extract_manifest_js, js_entry)
-        if not ok then
-            tool.stderr("hull build: warning: JS manifest extraction failed: " .. tostring(js_json_or_err) .. "\n")
-        elseif js_json_or_err then
-            local decoded, decode_err = json.decode(js_json_or_err)
-            if decoded then
-                manifest = decoded
-            else
-                tool.stderr("hull build: warning: JS manifest JSON decode failed: " .. tostring(decode_err) .. "\n")
-            end
-        end
-    end
+    -- Capture the app's manifest (shared with main's --flavor validation).
+    local manifest = extract_app_manifest(app_dir)
 
     -- Resolve the manifest's modules block against the canonical registry.
     -- The result is the full set of admitted modules (declared + intrinsic
@@ -434,7 +444,7 @@ local function sign_app(app_dir, key_file, sign_ctx, files)
     -- this field, so tampering invalidates the package.
     local modules_resolved = nil
     if manifest then
-        local r = tool.modules_resolve(manifest)
+        local r = tool.modules_resolve(manifest, sign_ctx.flavor)
         if r.ok then
             modules_resolved = r.modules
         else
@@ -687,6 +697,38 @@ typedef struct {
         is_cosmo = cc:find("cosmocc") ~= nil
     end
 
+    -- ── Build flavor (--flavor) ──
+    -- Validate the requested flavor and (for non-default flavors) check the
+    -- app's manifest against the TARGET flavor's caps, aborting if a declared
+    -- module needs a subsystem the flavor drops. MVP: the flavor's
+    -- libhull_platform-<flavor>.a must be built locally; signed fetch is a
+    -- follow-on phase. See docs/build_flavors.md.
+    local flavor_asset = nil
+    if opts.flavor and opts.flavor ~= "full" then
+        if is_cosmo then
+            tool.stderr("hull build: --flavor is not supported with cosmo builds yet\n")
+            tool.rmdir(tmpdir)
+            tool.exit(1)
+        end
+        local fr = tool.build_flavor(opts.flavor)
+        if not fr.ok then
+            tool.stderr("hull build: " .. tostring(fr.error) .. "\n")
+            tool.rmdir(tmpdir)
+            tool.exit(1)
+        end
+        flavor_asset = fr.asset
+        local manifest = extract_app_manifest(opts.app_dir)
+        if manifest then
+            local r = tool.modules_resolve(manifest, opts.flavor)
+            if not r.ok then
+                tool.stderr("hull build: --flavor=" .. opts.flavor .. ": "
+                            .. tostring(r.error) .. "\n")
+                tool.rmdir(tmpdir)
+                tool.exit(1)
+            end
+        end
+    end
+
     -- Guard: ensure compiler vtable is available
     if not tool.compiler then
         tool.stderr("hull build: no C compiler available\n")
@@ -830,6 +872,35 @@ int main(int argc, char **argv) { return hull_main(argc, argv); }
     -- Extract platform library (if embedded)
     local platform_extracted = false
     local platform_lib = tmpdir .. "/libhull_platform.a"
+
+    -- --flavor: link a locally-built non-default platform lib instead of the
+    -- embedded (full) one. The flavor lib isn't covered by the signed
+    -- platform manifest yet, so the platform-sig cross-check is skipped (MVP;
+    -- signed fetch is a follow-on phase). Native only (guarded above).
+    if flavor_asset then
+        local hull_dir = __hull_exe and (__hull_exe:match("(.*/)") or "") or ""
+        local cand = {
+            hull_dir .. flavor_asset .. ".a",
+            "build/" .. flavor_asset .. ".a",
+            "../build/" .. flavor_asset .. ".a",
+            flavor_asset .. ".a",
+        }
+        local found = nil
+        for _, p in ipairs(cand) do
+            if file_exists(p) then found = p; break end
+        end
+        if not found then
+            tool.stderr("hull build: --flavor=" .. opts.flavor .. " needs "
+                        .. flavor_asset .. ".a (not found)\n")
+            tool.stderr("hint: build it from source, e.g. `make platform-"
+                        .. opts.flavor .. "`\n")
+            tool.rmdir(tmpdir)
+            tool.exit(1)
+        end
+        tool.copy(found, platform_lib)
+        platform_extracted = true
+        opts.verify_platform = false
+    end
 
     -- Try to find platform library in known locations
     -- 1. Check if build_assets has it embedded (multi-arch cosmo)
@@ -1095,6 +1166,7 @@ int main(int argc, char **argv) { return hull_main(argc, argv); }
 
         local sign_ctx = {
             cc = cc,
+            flavor = opts.flavor,
             binary_hash = nil,
             trampoline_hash = crypto.sha256(app_main),
             platform_sig_path = platform_sig_path,

--- a/tests/e2e_build_flavor.sh
+++ b/tests/e2e_build_flavor.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# e2e_build_flavor.sh - `hull build --flavor` MVP.
+#
+# Proves a full (default) hull can build a non-default-flavor app binary:
+#   1. unknown flavor is rejected with the valid list
+#   2. an app needing a dropped subsystem is rejected at BUILD time
+#      (resolver validates against the TARGET flavor's caps)
+#   3. a valid pure-compute app builds, runs, and returns app.main's exit code
+#   4. the resulting binary has zero mbedTLS hashing symbols
+#
+# Native only (cosmo flavor libs are out of MVP scope). See docs/build_flavors.md.
+set -eu
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+HULL="$ROOT/build/hull"
+LIB="$ROOT/build/libhull_platform-pure-compute.a"
+
+[ -x "$HULL" ] || { echo "SKIP: $HULL not built"; exit 0; }
+case "$(file "$HULL" 2>/dev/null || true)" in
+    *cosmo*|*"APE"*) echo "SKIP: --flavor not supported for cosmo builds yet"; exit 0;;
+esac
+
+# Build the pure-compute platform lib if absent (CI builds it fresh).
+if [ ! -f "$LIB" ]; then
+    echo "building pure-compute platform lib..."
+    make -C "$ROOT" platform-pure-compute >/dev/null 2>&1 || {
+        echo "SKIP: could not build pure-compute platform lib (no system cc?)"; exit 0; }
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+fail() { echo "FAIL: $1"; exit 1; }
+pass() { echo "  ok: $1"; }
+
+# ── 1. unknown flavor ──────────────────────────────────────────────────
+mkdir -p "$WORK/pc"
+printf 'app.manifest({ modules = {} })\napp.main(function() return 7 end)\n' > "$WORK/pc/app.lua"
+if out=$("$HULL" build --flavor=bogus "$WORK/pc" -o "$WORK/pc/x" 2>&1); then
+    fail "unknown flavor should error"
+fi
+echo "$out" | grep -q "unknown build flavor 'bogus'" || fail "unknown-flavor message missing: $out"
+echo "$out" | grep -q "pure-compute" || fail "unknown-flavor should list valid flavors"
+pass "unknown flavor rejected with valid list"
+
+# ── 2. forbidden module rejected at build time ─────────────────────────
+mkdir -p "$WORK/srv"
+printf 'app.manifest({ modules = { "hull/http-server@1" } })\napp.get("/", function(req, res) res:text("hi") end)\n' > "$WORK/srv/app.lua"
+if out=$("$HULL" build --flavor=pure-compute "$WORK/srv" -o "$WORK/srv/x" 2>&1); then
+    fail "pure-compute build of an http-server app should be rejected"
+fi
+echo "$out" | grep -q "HL_ENABLE_HTTP_SERVER" || fail "expected HTTP_SERVER rejection: $out"
+pass "forbidden module (hull/http-server) rejected at build time"
+
+# ── 3. valid pure-compute app builds, runs, returns app.main exit ──────
+"$HULL" build --flavor=pure-compute "$WORK/pc" -o "$WORK/pc/app" >/dev/null 2>&1 \
+    || fail "valid pure-compute build failed"
+[ -x "$WORK/pc/app" ] || fail "pure-compute binary not produced"
+set +e
+"$WORK/pc/app" >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -eq 7 ] || fail "expected app.main exit 7, got $rc"
+pass "pure-compute app builds, runs, returns exit 7"
+
+# ── 4. no mbedTLS hashing symbols in the pure-compute binary ───────────
+if command -v nm >/dev/null 2>&1; then
+    n=$(nm "$WORK/pc/app" 2>/dev/null | grep -cE 'mbedtls_sha|mbedtls_md_hmac' || true)
+    [ "$n" -eq 0 ] || fail "pure-compute binary has $n mbedTLS hashing symbols"
+    pass "zero mbedTLS hashing symbols"
+fi
+
+echo "PASS: e2e_build_flavor"

--- a/tests/hull/test_module_resolver.c
+++ b/tests/hull/test_module_resolver.c
@@ -513,4 +513,78 @@ UTEST(module_resolver, tiny_errbuf_truncates_safely)
     ASSERT_EQ((int)err[sizeof(err) - 1], 0);
 }
 
+/* ── Build flavors + resolve-against-target-caps (hull build --flavor) ── */
+
+UTEST(build_flavor, registry_lookup)
+{
+    ASSERT_TRUE(hl_build_flavor_find(NULL) == NULL);
+    ASSERT_TRUE(hl_build_flavor_find("bogus") == NULL);
+
+    const HlBuildFlavor *full = hl_build_flavor_find("full");
+    ASSERT_TRUE(full != NULL);
+    ASSERT_EQ((int)full->clear_caps, 0);
+
+    const HlBuildFlavor *po = hl_build_flavor_find("pure-compute");
+    ASSERT_TRUE(po != NULL);
+    /* HL_MOD_CAP_HTTP == HTTP_CLIENT | HTTP_SERVER. */
+    ASSERT_EQ((int)po->clear_caps, (int)HL_MOD_CAP_HTTP);
+
+    ASSERT_EQ((int)hl_build_flavor_find("server-only")->clear_caps,
+              (int)HL_MOD_CAP_HTTP_CLIENT);
+    ASSERT_EQ((int)hl_build_flavor_find("client-only")->clear_caps,
+              (int)HL_MOD_CAP_HTTP_SERVER);
+
+    const HlBuildFlavor *all = NULL;
+    ASSERT_GE(hl_build_flavor_all(&all), 4);
+    ASSERT_TRUE(all != NULL);
+}
+
+UTEST(build_flavor, caps_clear_http)
+{
+    uint32_t base = HL_MOD_CAP_DB | HL_MOD_CAP_HTTP_CLIENT | HL_MOD_CAP_HTTP_SERVER;
+    uint32_t pc = hl_build_flavor_caps(hl_build_flavor_find("pure-compute"), base);
+    ASSERT_TRUE((pc & HL_MOD_CAP_HTTP_CLIENT) == 0);
+    ASSERT_TRUE((pc & HL_MOD_CAP_HTTP_SERVER) == 0);
+    ASSERT_TRUE((pc & HL_MOD_CAP_DB) != 0);   /* unrelated caps preserved */
+    /* full and a NULL flavor pass the base through unchanged. */
+    ASSERT_EQ((int)hl_build_flavor_caps(hl_build_flavor_find("full"), base), (int)base);
+    ASSERT_EQ((int)hl_build_flavor_caps(NULL, base), (int)base);
+}
+
+UTEST(build_flavor, pure_compute_rejects_http_server)
+{
+    HlManifest m;
+    clear_manifest(&m);
+    add_module(&m, "hull/http-server", 1);
+
+    HlResolvedModuleSet s = {0};
+    char err[256] = {0};
+
+    /* This (default) test build is full, so full caps admit hull/http-server. */
+    uint32_t full = hl_module_build_caps();
+    ASSERT_EQ(hl_module_resolver_resolve_caps(&m, &s, full, err, sizeof(err)), 0);
+
+    /* Under pure-compute caps the HTTP_SERVER gate trips at build time. */
+    uint32_t pc = hl_build_flavor_caps(hl_build_flavor_find("pure-compute"), full);
+    ASSERT_EQ(hl_module_resolver_resolve_caps(&m, &s, pc, err, sizeof(err)), -1);
+    ASSERT_TRUE(strstr(err, "HTTP_SERVER") != NULL);
+}
+
+UTEST(build_flavor, server_only_rejects_http_client)
+{
+    HlManifest m;
+    clear_manifest(&m);
+    add_module(&m, "hull/http-client", 1);
+
+    HlResolvedModuleSet s = {0};
+    char err[256] = {0};
+
+    uint32_t full = hl_module_build_caps();
+    ASSERT_EQ(hl_module_resolver_resolve_caps(&m, &s, full, err, sizeof(err)), 0);
+
+    uint32_t so = hl_build_flavor_caps(hl_build_flavor_find("server-only"), full);
+    ASSERT_EQ(hl_module_resolver_resolve_caps(&m, &s, so, err, sizeof(err)), -1);
+    ASSERT_TRUE(strstr(err, "HTTP_CLIENT") != NULL);
+}
+
 UTEST_MAIN();


### PR DESCRIPTION
Implements the MVP from `docs/build_flavors.md`: a full (default) hull can now build a flavored app binary (`hull build --flavor=pure-compute|server-only|client-only`) against a locally-built per-flavor platform lib, validating the app's manifest against the **target** flavor's caps. Two commits.

## `06b021e` — C core
- `module_resolver`: `hl_module_resolver_resolve_caps(manifest, out, build_caps, ...)` + `hl_module_build_caps()`; the plain resolver delegates with the compiled-in caps (unchanged behavior).
- Flavor registry (`HlBuildFlavor` + `hl_build_flavor_find/all/caps`, co-located in module_resolver.c): name → cleared caps → platform-lib asset stem.
- tool bindings: `tool.modules_resolve(manifest, flavor?)` validates against the flavor's target caps; `tool.build_flavor(name)` validates + returns the asset stem.
- 4 unit tests in `test_module_resolver` (31/31).

## `073149e` — end-to-end wiring
- **build.lua**: `--flavor` parsing + validation; resolve-against-target-caps that **aborts** the build when a declared module needs a dropped subsystem; redirect the linked platform archive to a locally-built `libhull_platform-<flavor>.a`. Factored `extract_app_manifest` out of `sign_app` so both paths share it.
- **Makefile**: `platform-<flavor>` targets (dedicated obj dir, never clobbers `build/hull`) + `e2e-build-flavor` + `tests/e2e_build_flavor.sh`.

### Pre-existing bugs the MVP exposed and fixes
- **no-keel platform archive**: relied on the keel merge to supply `sh_seal_arena` (manifest seal); now bundles `SH_SEAL_ARENA_OBJ` directly. Also guarded a keel-merge step that ran `ar x` on an empty path when `KEEL_LIB` is empty (broke building *any* no-keel platform lib).
- **`tool.modules_resolve`** parsed only an old keyed form, so the build-time module gate was a **no-op** for the canonical array form every app uses; now parses `"vendor/name@major"` specs.
- **serve_cli.c** only resolved an entry from argv, so a built `HL_ENABLE_HTTP_SERVER=0` binary couldn't find its own embedded app; now detects it like serve.c (fixes built **client-only/CLI** binaries too, not just pure-compute).

## Scope / follow-ons (per the design doc)
- MVP is **native + locally-built** platform libs. Signed fetch of per-flavor libs (the "full" phase), `--flavor=auto` manifest inference, and cosmo per-flavor coverage are follow-ons.

## Validated
- `make test` **50/50**; `make e2e-build-flavor` passes (unknown-flavor rejected, forbidden-module rejected **at build time**, valid pure-compute app builds + runs + returns exit 7, **zero mbedTLS symbols**); full default build still works.