### PR TITLE
feat(build): hull build --flavor=auto (infer minimal flavor from manifest)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ release-artifact layout).
   with the mbedtls-free hashing path, the contributor invariant (core code
   must hash via the cap layer, never mbedTLS directly), and refreshed the
   flavor binary-size table to measured values.
+- **`hull build --flavor=full|server-only|client-only|pure-compute`** builds
+  a flavored app binary from a full hull, linking a locally-built
+  `libhull_platform-<flavor>.a` (`make platform-<flavor>`) and validating the
+  app's manifest against the TARGET flavor's caps (a module needing a dropped
+  subsystem is rejected at build time). **`--flavor=auto`** infers the
+  minimal flavor from the declared modules. Design: `docs/build_flavors.md`.
+  Along the way: fixed the no-keel platform archive (missing `sh_seal_arena`),
+  a `tool.modules_resolve` parser that ignored the canonical array module
+  form, and `serve_cli.c` not detecting a built binary's embedded app.
 
 ## [0.4.0] — 2026-06-17
 

--- a/include/hull/module_resolver.h
+++ b/include/hull/module_resolver.h
@@ -143,6 +143,15 @@ int hl_build_flavor_all(const HlBuildFlavor **out);
  * `base` is normally hl_module_build_caps() (the running hull's caps). */
 uint32_t hl_build_flavor_caps(const HlBuildFlavor *f, uint32_t base);
 
+/* Aggregate required-caps (HL_MOD_CAP_* OR) of every module in a resolved
+ * set. The HTTP_SERVER / HTTP_CLIENT bits are what distinguish the flavors. */
+uint32_t hl_module_set_required_caps(const HlResolvedModuleSet *set);
+
+/* Pick the minimal flavor that still provides every cap in `needed_caps`:
+ * the flavor clearing the most caps without clearing a needed one. Always
+ * returns at least "full". Drives `hull build --flavor=auto`. */
+const HlBuildFlavor *hl_build_flavor_auto(uint32_t needed_caps);
+
 /* ── Pre-manifest import tracker ───────────────────────────────────── */
 
 /*

--- a/src/hull/module_resolver.c
+++ b/src/hull/module_resolver.c
@@ -180,6 +180,45 @@ uint32_t hl_build_flavor_caps(const HlBuildFlavor *f, uint32_t base)
     return f ? (base & ~f->clear_caps) : base;
 }
 
+uint32_t hl_module_set_required_caps(const HlResolvedModuleSet *set)
+{
+    if (!set) return 0;
+    uint32_t caps = 0;
+    size_t total = 0;
+    const HlModuleSpec *all = hl_module_registry_all(&total);
+    for (size_t i = 0; i < total; i++) {
+        if (hl_module_set_contains_index(set, (int)i))
+            caps |= all[i].required_caps;
+    }
+    return caps;
+}
+
+/* Popcount without relying on a builtin (cosmo/older toolchains). */
+static int popcount32(uint32_t v)
+{
+    int n = 0;
+    while (v) { v &= v - 1; n++; }
+    return n;
+}
+
+const HlBuildFlavor *hl_build_flavor_auto(uint32_t needed_caps)
+{
+    /* Pick the flavor clearing the most caps without clearing one the app
+     * needs. Flavors only differ in the HTTP_SERVER / HTTP_CLIENT bits, so
+     * only those of `needed_caps` matter here; "full" (clears nothing) is
+     * always a valid fallback. */
+    const HlBuildFlavor *best = NULL;
+    int best_bits = -1;
+    size_t n = sizeof(BUILD_FLAVORS) / sizeof(BUILD_FLAVORS[0]);
+    for (size_t i = 0; i < n; i++) {
+        const HlBuildFlavor *f = &BUILD_FLAVORS[i];
+        if (f->clear_caps & needed_caps) continue;   /* would drop a needed cap */
+        int bits = popcount32(f->clear_caps);
+        if (bits > best_bits) { best_bits = bits; best = f; }
+    }
+    return best;
+}
+
 /* ── The resolver ──────────────────────────────────────────────────── */
 
 int hl_module_resolver_resolve(const HlManifest *manifest,

--- a/src/hull/tool_orchestration.c
+++ b/src/hull/tool_orchestration.c
@@ -185,6 +185,20 @@ static int l_tool_modules_resolve(lua_State *L)
     }
     lua_setfield(L, -2, "modules");
 
+    /* auto = the minimal build flavor that still satisfies this app's
+     * declared modules (drives `hull build --flavor=auto`). Computed from
+     * the resolved set's aggregate required-caps. */
+    const HlBuildFlavor *autf =
+        hl_build_flavor_auto(hl_module_set_required_caps(&set));
+    if (autf) {
+        lua_newtable(L);
+        lua_pushstring(L, autf->name);
+        lua_setfield(L, -2, "name");
+        lua_pushstring(L, autf->asset);
+        lua_setfield(L, -2, "asset");
+        lua_setfield(L, -2, "auto");
+    }
+
     return 1;
 }
 

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -697,6 +697,23 @@ typedef struct {
         is_cosmo = cc:find("cosmocc") ~= nil
     end
 
+    -- --flavor=auto: infer the minimal flavor from the app's declared modules
+    -- (resolve with full caps, then pick the smallest flavor that still
+    -- satisfies them). Resolves to a concrete flavor name the block below
+    -- handles. Falls back to "full" if the manifest can't be read.
+    if opts.flavor == "auto" then
+        local picked = "full"
+        local manifest = extract_app_manifest(opts.app_dir)
+        if manifest then
+            local r = tool.modules_resolve(manifest)
+            if r.ok and r.auto and r.auto.name then
+                picked = r.auto.name
+            end
+        end
+        print("hull build: --flavor=auto selected '" .. picked .. "'")
+        opts.flavor = picked
+    end
+
     -- ── Build flavor (--flavor) ──
     -- Validate the requested flavor and (for non-default flavors) check the
     -- app's manifest against the TARGET flavor's caps, aborting if a declared

--- a/tests/e2e_build_flavor.sh
+++ b/tests/e2e_build_flavor.sh
@@ -69,4 +69,16 @@ if command -v nm >/dev/null 2>&1; then
     pass "zero mbedTLS hashing symbols"
 fi
 
+# ── 5. --flavor=auto infers the minimal flavor from the manifest ───────
+out=$("$HULL" build --flavor=auto "$WORK/pc" -o "$WORK/pc/auto" 2>&1) \
+    || fail "auto build failed: $out"
+echo "$out" | grep -q "auto selected 'pure-compute'" \
+    || fail "auto should select pure-compute for an app.main app: $out"
+set +e
+"$WORK/pc/auto" >/dev/null 2>&1
+rc=$?
+set -e
+[ "$rc" -eq 7 ] || fail "auto pure-compute binary should exit 7, got $rc"
+pass "--flavor=auto -> pure-compute for an app.main app"
+
 echo "PASS: e2e_build_flavor"

--- a/tests/hull/test_module_resolver.c
+++ b/tests/hull/test_module_resolver.c
@@ -587,4 +587,31 @@ UTEST(build_flavor, server_only_rejects_http_client)
     ASSERT_TRUE(strstr(err, "HTTP_CLIENT") != NULL);
 }
 
+UTEST(build_flavor, auto_picks_minimal)
+{
+    /* No caps needed -> pure-compute (clears the most). */
+    ASSERT_STREQ(hl_build_flavor_auto(0)->name, "pure-compute");
+    /* A non-HTTP cap (DB) doesn't constrain the flavor (all keep DB). */
+    ASSERT_STREQ(hl_build_flavor_auto(HL_MOD_CAP_DB)->name, "pure-compute");
+    ASSERT_STREQ(hl_build_flavor_auto(HL_MOD_CAP_HTTP_SERVER)->name, "server-only");
+    ASSERT_STREQ(hl_build_flavor_auto(HL_MOD_CAP_HTTP_CLIENT)->name, "client-only");
+    ASSERT_STREQ(hl_build_flavor_auto(HL_MOD_CAP_HTTP)->name, "full");
+}
+
+UTEST(build_flavor, auto_from_resolved_manifest)
+{
+    HlManifest m;
+    clear_manifest(&m);
+    add_module(&m, "hull/http-server", 1);
+
+    HlResolvedModuleSet s = {0};
+    char err[256] = {0};
+    ASSERT_EQ(0, hl_module_resolver_resolve_caps(&m, &s, hl_module_build_caps(),
+                                                 err, sizeof(err)));
+    uint32_t req = hl_module_set_required_caps(&s);
+    ASSERT_TRUE((req & HL_MOD_CAP_HTTP_SERVER) != 0);
+    /* An app needing the HTTP server but not the client -> server-only. */
+    ASSERT_STREQ(hl_build_flavor_auto(req)->name, "server-only");
+}
+
 UTEST_MAIN();


### PR DESCRIPTION
Adds `--flavor=auto`, which picks the smallest build flavor that still satisfies an app's declared modules, so the flavor becomes a derived property of the app rather than a flag the author reasons about.

- `app.main` app, no HTTP modules → **pure-compute**
- declares `hull/http-server` → **server-only**
- declares `hull/http-client` → **client-only**
- needs both halves → **full**

## How
- `module_resolver`: `hl_module_set_required_caps()` aggregates a resolved set's required caps; `hl_build_flavor_auto()` picks the flavor clearing the most caps without clearing a needed one (always at least `full`).
- `tool.modules_resolve` returns an `auto = {name, asset}` field (the inferred flavor).
- `build.lua`: `--flavor=auto` resolves the manifest, prints the selection, and hands the concrete flavor to the existing path (validate + target-cap check + platform-lib redirect). Falls back to `full` if the manifest can't be read.

## Tests
- 2 unit cases (auto over explicit cap masks + over a resolved manifest).
- e2e case (`--flavor=auto` → pure-compute for an app.main app, builds + runs + exit 7).

Validated: `make test` 50/50 (test_module_resolver 33/33); `make e2e-build-flavor` passes all 5 cases.

Second of three follow-ons from `docs/build_flavors.md` (MVP merged in #35). Next: cosmo per-flavor coverage, then signed published per-flavor platform libs + auto-fetch.