### PR TITLE
feat(build): signed published per-flavor platform libs + hull platform install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,26 @@ jobs:
           name: platform-${{ matrix.name }}
           path: build/libhull_platform.a
 
+      # Per-flavor platform libs for `hull build --flavor` + `hull platform
+      # install`. Each native platform-<flavor> target builds into its own obj
+      # dir (build/flavor-<flavor>/), so the full libhull_platform.a above is
+      # untouched. Publish them arch-qualified: libhull_platform-<flavor>-<arch>.a.
+      # (Cosmo flavor libs are not published yet; build from source with
+      # `make platform-cosmo-<flavor>`. See docs/build_flavors.md §7.)
+      - name: Build platform flavors
+        run: |
+          for f in server-only client-only pure-compute; do
+            make "platform-$f"
+            mv "build/libhull_platform-$f.a" \
+               "build/libhull_platform-$f-${{ matrix.name }}.a"
+          done
+
+      - name: Upload platform flavors
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: platform-flavors-${{ matrix.name }}
+          path: build/libhull_platform-*-${{ matrix.name }}.a
+
   build-platform-cosmo:
     name: Build platform (cosmo, multi-arch)
     runs-on: ubuntu-latest
@@ -581,6 +601,13 @@ jobs:
           mv artifacts/hull-wamrc-linux-x86_64/hull-wamrc-linux-x86_64    dist/hull-wamrc-linux-x86_64
           mv artifacts/hull-wamrc-linux-aarch64/hull-wamrc-linux-aarch64  dist/hull-wamrc-linux-aarch64
           mv artifacts/hull-wamrc-darwin-arm64/hull-wamrc-darwin-arm64    dist/hull-wamrc-darwin-arm64
+          # Per-flavor platform libs (native arches). Consumed by
+          # `hull platform install <flavor>` -> `hull build --flavor`.
+          # Files: libhull_platform-<flavor>-<arch>.a. (Cosmo flavor libs
+          # are build-from-source, not published; see docs/build_flavors.md.)
+          mv artifacts/platform-flavors-linux-x86_64/*.a  dist/
+          mv artifacts/platform-flavors-linux-aarch64/*.a dist/
+          mv artifacts/platform-flavors-darwin-arm64/*.a  dist/
 
       - name: Make binaries executable
         run: chmod +x dist/*
@@ -645,6 +672,7 @@ jobs:
                     hull-wamrc-linux-x86_64 hull-wamrc-linux-aarch64 hull-wamrc-darwin-arm64 \
                     hull.sbom.json hull.sbom.cdx.json hull.sbom.spdx.json \
                     hull.build-env.json \
+                    libhull_platform-*.a \
                     > hull.sha256
           cat hull.sha256
 
@@ -740,6 +768,10 @@ jobs:
             dist/hull.sha256.cosign.sig
             dist/hull.sha256.cosign.pem
           )
+          # Per-flavor platform libs (libhull_platform-<flavor>-<arch>.a), so
+          # `hull platform install <flavor>` can fetch them. Covered by
+          # hull.sha256 above, so they inherit the release signature.
+          assets+=(dist/libhull_platform-*.a)
           if [ -f dist/hull.sha256.sig ]; then
             assets+=(dist/hull.sha256.sig)
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ release-artifact layout).
   Along the way: fixed the no-keel platform archive (missing `sh_seal_arena`),
   a `tool.modules_resolve` parser that ignored the canonical array module
   form, and `serve_cli.c` not detecting a built binary's embedded app.
+- **`hull platform install <flavor>` + signed published per-flavor platform
+  libs.** Releases now publish `libhull_platform-<flavor>-<arch>.a` for the
+  three native arches, covered by the Ed25519-signed `hull.sha256`. `hull
+  platform install` fetches + verifies them into `~/.hull/platform/`, and
+  `hull build --flavor` uses the cached lib, so end users no longer have to
+  build the platform lib from source. Same trust chain as `hull tools
+  install`, factored into one shared `hl_release_io_fetch_verified_manifest`.
+  Cosmo flavor libs stay build-from-source for now (`make
+  platform-cosmo-<flavor>`).
 
 ## [0.4.0] — 2026-06-17
 

--- a/Makefile
+++ b/Makefile
@@ -2840,16 +2840,16 @@ CRYPTO_TEST_OBJS := $(BUILDDIR)/cap_crypto.o $(BUILDDIR)/cap_crypto_hmac_mbedtls
 # atomic write). Skipped on HL_ENABLE_HTTP_CLIENT=0 builds where the
 # helper module isn't compiled in.
 ifneq ($(HL_ENABLE_HTTP_CLIENT),0)
-$(BUILDDIR)/test_release_io: $(TESTDIR)/hull/test_release_io.c $(RELEASE_IO_OBJ) $(CACERT_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) | $(BUILDDIR)
-	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(RELEASE_IO_OBJ) $(CACERT_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) -lm -lpthread
+$(BUILDDIR)/test_release_io: $(TESTDIR)/hull/test_release_io.c $(RELEASE_IO_OBJ) $(RELEASE_OBJ) $(CACERT_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(RELEASE_IO_OBJ) $(RELEASE_OBJ) $(CACERT_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) -lm -lpthread
 endif
 
 # Verify-self helpers test. Reuses release_io.{c,h} for asset-name,
 # checksum-line lookup, SHA-256, and self-path resolution. Same link
 # dependencies as test_release_io.
 ifneq ($(HL_ENABLE_HTTP_CLIENT),0)
-$(BUILDDIR)/test_verify_self: $(TESTDIR)/hull/test_verify_self.c $(RELEASE_IO_OBJ) $(CACERT_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) | $(BUILDDIR)
-	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(RELEASE_IO_OBJ) $(CACERT_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) -lm -lpthread
+$(BUILDDIR)/test_verify_self: $(TESTDIR)/hull/test_verify_self.c $(RELEASE_IO_OBJ) $(RELEASE_OBJ) $(CACERT_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(RELEASE_IO_OBJ) $(RELEASE_OBJ) $(CACERT_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) -lm -lpthread
 endif
 
 # Platform-sig helpers — reuses release.c (sign/verify) +

--- a/include/hull/commands/platform.h
+++ b/include/hull/commands/platform.h
@@ -1,0 +1,19 @@
+/*
+ * commands/platform.h - `hull platform` subcommand.
+ *
+ * Fetch signed per-flavor platform libraries from the release matching this
+ * hull's version into $HOME/.hull/platform/, so `hull build --flavor=<flavor>`
+ * can link them without building from source. Same trust chain as
+ * `hull tools install` (the shared hl_release_io_fetch_verified_manifest).
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#ifndef HL_COMMANDS_PLATFORM_H
+#define HL_COMMANDS_PLATFORM_H
+
+#include "hull/commands/dispatch.h"
+
+/* `hull platform install <flavor> [--all] [--repo=ORG/NAME]` / `list`. */
+int hl_cmd_platform(int argc, char **argv, const HlCommandEnv *env);
+
+#endif /* HL_COMMANDS_PLATFORM_H */

--- a/include/hull/release_io.h
+++ b/include/hull/release_io.h
@@ -68,6 +68,25 @@ int hl_release_io_get(const char *url,
                       const char *user_agent);
 
 /**
+ * Download `hull.sha256` and (when a release pubkey is embedded) its
+ * `.sig`, verify the Ed25519 signature over the manifest, and return the
+ * verified manifest buffer. The caller `kl_free()`s *out_manifest.
+ *
+ * The single trust-chain entry shared by `hull tools install` and
+ * `hull platform install`. On a placeholder (all-zero) embedded pubkey the
+ * signature step is skipped with a warning (SHA-256 only), matching
+ * `hull update`. Refuses to proceed if a configured pubkey can't verify.
+ *
+ * @returns 0 on success, -1 on any download/verification failure (a message
+ *          prefixed with @p ua is printed to stderr).
+ */
+int hl_release_io_fetch_verified_manifest(const char *repo, const char *tag,
+                                          KlAllocator *alloc, KlTlsCtx *tls,
+                                          const char *ua,
+                                          char **out_manifest,
+                                          size_t *out_manifest_len);
+
+/**
  * Extract a flat `"key":"value"` entry from a JSON blob. Deliberately
  * tiny — sufficient for GitHub release metadata fields like
  * `tag_name`. Not a general parser.

--- a/src/hull/commands/dispatch.c
+++ b/src/hull/commands/dispatch.c
@@ -42,6 +42,7 @@
 #ifdef HL_ENABLE_HTTP_CLIENT
 #include "hull/commands/update.h"
 #include "hull/commands/tools.h"
+#include "hull/commands/platform.h"
 #endif
 #include "hull/commands/sign_release.h"
 #include "hull/commands/verify_release.h"
@@ -86,6 +87,7 @@ static const HlCommand commands[] = {
 #ifdef HL_ENABLE_HTTP_CLIENT
     { "update",         hl_cmd_update },
     { "tools",          hl_cmd_tools },
+    { "platform",       hl_cmd_platform },
 #endif
     { "sign-release",   hl_cmd_sign_release },
     { "verify-release", hl_cmd_verify_release },

--- a/src/hull/commands/platform.c
+++ b/src/hull/commands/platform.c
@@ -1,0 +1,275 @@
+/*
+ * commands/platform.c - `hull platform install <flavor>` / `list`.
+ *
+ * Fetch signed per-flavor platform libraries from the release matching this
+ * hull's version into $HOME/.hull/platform/, so `hull build --flavor=<flavor>`
+ * can link them without building from source.
+ *
+ * Trust chain (identical to `hull tools install`):
+ *   1. hl_release_io_fetch_verified_manifest downloads hull.sha256 +
+ *      hull.sha256.sig and verifies the Ed25519 signature against the
+ *      embedded release pubkey.
+ *   2. For each asset: look up its SHA-256 in the verified manifest, download,
+ *      recompute the SHA-256, constant-time compare, atomic-write.
+ *
+ * Network-only: compiled when HL_ENABLE_HTTP_CLIENT is on (the fetch needs
+ * Keel's HTTPS client). The builder hull is normally a full release binary.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "hull/commands/platform.h"
+
+#ifdef HL_ENABLE_HTTP_CLIENT
+
+#include "hull/release_io.h"
+#include "hull/module_resolver.h"   /* HlBuildFlavor / hl_build_flavor_* */
+
+#include <keel/allocator.h>
+#include <keel/tls_mbedtls.h>
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#ifndef HL_VERSION
+#define HL_VERSION "dev"
+#endif
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+#define HL_PLATFORM_DEFAULT_REPO "artalis-io/hull"
+
+/* GitHub tags carry a leading "v"; HL_VERSION usually does not. */
+static int compose_tag(char *out, size_t out_sz)
+{
+    const char *v = HL_VERSION;
+    int n = (v[0] == 'v') ? snprintf(out, out_sz, "%s", v)
+                          : snprintf(out, out_sz, "v%s", v);
+    return (n > 0 && (size_t)n < out_sz) ? 0 : -1;
+}
+
+/* $HOME/.hull/platform, created 0700. */
+static int platform_cache_dir(char *out, size_t out_sz)
+{
+    const char *home = getenv("HOME");
+    if (!home || !*home) {
+        fprintf(stderr, "hull platform: HOME is not set\n");
+        return -1;
+    }
+    char hull[PATH_MAX];
+    if ((size_t)snprintf(hull, sizeof(hull), "%s/.hull", home) >= sizeof(hull))
+        return -1;
+    if (mkdir(hull, 0700) != 0 && errno != EEXIST) {
+        fprintf(stderr, "hull platform: cannot create %s: %s\n", hull, strerror(errno));
+        return -1;
+    }
+    if ((size_t)snprintf(out, out_sz, "%s/.hull/platform", home) >= out_sz)
+        return -1;
+    if (mkdir(out, 0700) != 0 && errno != EEXIST) {
+        fprintf(stderr, "hull platform: cannot create %s: %s\n", out, strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
+/* Constant-time compare of two 64-char hex SHA-256 strings. The values are
+ * public (manifest checksum + computed digest), so a timing leak reveals
+ * nothing; the constant-time form matches the rest of Hull's hash compares. */
+static int ct_hex_eq(const char *a, const char *b)
+{
+    unsigned char diff = 0;
+    for (int i = 0; i < 64; i++)
+        diff |= (unsigned char)(a[i] ^ b[i]);
+    return diff == 0;
+}
+
+/* Build the published asset names for a flavor on this platform.
+ * Returns the count (1 native, 2 cosmo); names written into assets[]. */
+static int flavor_assets(const HlBuildFlavor *f, const char *plat,
+                         char assets[2][160])
+{
+    if (strcmp(plat, "cosmo") == 0) {
+        snprintf(assets[0], 160, "%s.x86_64-cosmo.a", f->asset);
+        snprintf(assets[1], 160, "%s.aarch64-cosmo.a", f->asset);
+        return 2;
+    }
+    snprintf(assets[0], 160, "%s-%s.a", f->asset, plat);
+    return 1;
+}
+
+static int install_asset(const char *asset, const char *repo, const char *tag,
+                         KlAllocator *alloc, KlTlsCtx *tls,
+                         const char *manifest, size_t manifest_len,
+                         const char *cache_dir)
+{
+    /* Look up the signed checksum BEFORE downloading. */
+    char expected[65];
+    if (hl_release_io_find_checksum(manifest, manifest_len, asset, expected) != 0) {
+        fprintf(stderr, "hull platform: no checksum entry for %s in hull.sha256 "
+                        "(this release may not publish that flavor)\n", asset);
+        return -1;
+    }
+
+    char url[512];
+    snprintf(url, sizeof(url),
+             "https://github.com/%s/releases/download/%s/%s", repo, tag, asset);
+    fprintf(stdout, "hull platform: downloading %s ...\n", asset);
+
+    char *body = NULL;
+    size_t body_len = 0;
+    if (hl_release_io_get(url, &body, &body_len, alloc, tls, "hull-platform") != 0) {
+        fprintf(stderr, "hull platform: failed to download %s\n", url);
+        return -1;
+    }
+
+    char actual[65];
+    if (hl_release_io_sha256_hex((const unsigned char *)body, body_len, actual) != 0) {
+        fprintf(stderr, "hull platform: SHA-256 computation failed\n");
+        kl_free(alloc, body, body_len);
+        return -1;
+    }
+    if (!ct_hex_eq(expected, actual)) {
+        fprintf(stderr, "hull platform: SHA-256 MISMATCH for %s\n"
+                        "  expected %s\n  actual   %s\n", asset, expected, actual);
+        kl_free(alloc, body, body_len);
+        return -1;
+    }
+
+    char dest[PATH_MAX];
+    if ((size_t)snprintf(dest, sizeof(dest), "%s/%s", cache_dir, asset) >= sizeof(dest)) {
+        fprintf(stderr, "hull platform: cache path overflow\n");
+        kl_free(alloc, body, body_len);
+        return -1;
+    }
+    if (hl_release_io_atomic_write(dest, body, body_len, 0644) != 0) {
+        fprintf(stderr, "hull platform: failed to write %s\n", dest);
+        kl_free(alloc, body, body_len);
+        return -1;
+    }
+    kl_free(alloc, body, body_len);
+    fprintf(stdout, "hull platform: installed %s (SHA-256 verified)\n", dest);
+    return 0;
+}
+
+static int cmd_install(const char *flavor, const char *repo)
+{
+    const HlBuildFlavor *f = hl_build_flavor_find(flavor);
+    if (!f) {
+        const HlBuildFlavor *all = NULL;
+        int count = hl_build_flavor_all(&all);
+        fprintf(stderr, "hull platform: unknown flavor '%s' (valid:", flavor);
+        for (int i = 0; i < count; i++)
+            fprintf(stderr, " %s", all[i].name);
+        fprintf(stderr, ")\n");
+        return 1;
+    }
+    if (strcmp(f->name, "full") == 0) {
+        fprintf(stdout, "hull platform: the 'full' platform is embedded in hull; "
+                        "nothing to install.\n");
+        return 0;
+    }
+
+    char cache_dir[PATH_MAX];
+    if (platform_cache_dir(cache_dir, sizeof(cache_dir)) != 0) return 1;
+
+    char tag[128];
+    if (compose_tag(tag, sizeof(tag)) != 0) {
+        fprintf(stderr, "hull platform: cannot compose release tag from version\n");
+        return 1;
+    }
+
+    KlAllocator alloc = kl_allocator_default();
+    KlTlsCtx *tls = hl_release_io_open_tls(&alloc);
+    if (!tls) {
+        fprintf(stderr, "hull platform: TLS init failed (no CA bundle available)\n");
+        return 1;
+    }
+
+    char *manifest = NULL;
+    size_t manifest_len = 0;
+    if (hl_release_io_fetch_verified_manifest(repo, tag, &alloc, tls, "hull-platform",
+                                              &manifest, &manifest_len) != 0) {
+        kl_tls_mbedtls_ctx_destroy(tls);
+        return 1;
+    }
+
+    char assets[2][160];
+    int n = flavor_assets(f, hl_release_io_platform(), assets);
+
+    int rc = 0;
+    for (int i = 0; i < n; i++) {
+        if (install_asset(assets[i], repo, tag, &alloc, tls,
+                          manifest, manifest_len, cache_dir) != 0) {
+            rc = 1;
+            break;
+        }
+    }
+
+    kl_free(&alloc, manifest, manifest_len);
+    kl_tls_mbedtls_ctx_destroy(tls);
+
+    if (rc == 0)
+        fprintf(stdout, "hull platform: %s ready. "
+                        "`hull build --flavor=%s` will use it.\n", f->name, f->name);
+    return rc;
+}
+
+static int cmd_list(void)
+{
+    char cache_dir[PATH_MAX];
+    if (platform_cache_dir(cache_dir, sizeof(cache_dir)) != 0) return 1;
+    const char *plat = hl_release_io_platform();
+
+    const HlBuildFlavor *all = NULL;
+    int count = hl_build_flavor_all(&all);
+    fprintf(stdout, "Build flavors (platform: %s, cache: %s):\n", plat, cache_dir);
+    for (int i = 0; i < count; i++) {
+        if (strcmp(all[i].name, "full") == 0) {
+            fprintf(stdout, "  %-14s embedded\n", all[i].name);
+            continue;
+        }
+        char assets[2][160];
+        int n = flavor_assets(&all[i], plat, assets);
+        int cached = 1;
+        for (int j = 0; j < n; j++) {
+            char p[PATH_MAX];
+            snprintf(p, sizeof(p), "%s/%s", cache_dir, assets[j]);
+            if (access(p, R_OK) != 0) { cached = 0; break; }
+        }
+        fprintf(stdout, "  %-14s %s\n", all[i].name,
+                cached ? "installed" : "not installed (hull platform install)");
+    }
+    return 0;
+}
+
+int hl_cmd_platform(int argc, char **argv, const HlCommandEnv *env)
+{
+    (void)env;
+    const char *repo = HL_PLATFORM_DEFAULT_REPO;
+    const char *sub = (argc > 1) ? argv[1] : NULL;
+    const char *flavor = NULL;
+    for (int i = 2; i < argc; i++) {
+        if (strncmp(argv[i], "--repo=", 7) == 0) repo = argv[i] + 7;
+        else if (argv[i][0] != '-')              flavor = argv[i];
+    }
+
+    if (sub && strcmp(sub, "install") == 0) {
+        if (!flavor) {
+            fprintf(stderr, "usage: hull platform install <flavor> [--repo=ORG/NAME]\n");
+            return 1;
+        }
+        return cmd_install(flavor, repo);
+    }
+    if (sub && strcmp(sub, "list") == 0) return cmd_list();
+
+    fprintf(stderr, "usage: hull platform install <flavor> | hull platform list\n");
+    return sub ? 1 : 0;
+}
+
+#endif /* HL_ENABLE_HTTP_CLIENT */

--- a/src/hull/commands/tools.c
+++ b/src/hull/commands/tools.c
@@ -197,71 +197,11 @@ static int print_list_json(const char *platform)
 
 /* ── `hull tools install` ────────────────────────────────────────── */
 
-/* Fetch hull.sha256 + signature, verify the signature, return both
- * buffers via out_manifest/out_manifest_len. The signature buffer is
- * freed internally; only the manifest is returned.
- *
- * Owns: allocates *out_manifest. Caller kl_free()s.
- *
- * On HL_RELEASE_PUBKEY_HEX = all-zeros placeholder the signature
- * step is skipped with a warning (matches hull update). */
-static int fetch_verified_manifest(const char *repo, const char *tag,
-                                   KlAllocator *alloc, KlTlsCtx *tls,
-                                   char **out_manifest, size_t *out_manifest_len)
-{
-    char sha_url[256];
-    snprintf(sha_url, sizeof(sha_url),
-             "https://github.com/%s/releases/download/%s/hull.sha256",
-             repo, tag);
-
-    char *manifest = NULL;
-    size_t manifest_len = 0;
-    if (hl_release_io_get(sha_url, &manifest, &manifest_len, alloc, tls,
-                          "hull-tools") != 0) {
-        fprintf(stderr,
-                "hull tools: failed to download checksum manifest (%s)\n",
-                sha_url);
-        return -1;
-    }
-
-    if (hl_release_pubkey_configured()) {
-        char sig_url[256];
-        snprintf(sig_url, sizeof(sig_url),
-                 "https://github.com/%s/releases/download/%s/hull.sha256.sig",
-                 repo, tag);
-
-        char *sig_hex = NULL;
-        size_t sig_len = 0;
-        if (hl_release_io_get(sig_url, &sig_hex, &sig_len, alloc, tls,
-                              "hull-tools") != 0) {
-            fprintf(stderr,
-                "hull tools: failed to download release signature (hull.sha256.sig)\n"
-                "             — this release is not signed; refusing to install\n");
-            kl_free(alloc, manifest, manifest_len);
-            return -1;
-        }
-
-        int sig_rc = hl_release_verify_manifest_sig(manifest, manifest_len,
-                                                    sig_hex, sig_len, NULL);
-        kl_free(alloc, sig_hex, sig_len);
-        if (sig_rc != 0) {
-            fprintf(stderr,
-                "hull tools: release signature verification FAILED\n"
-                "             — manifest does not match the embedded release public key\n");
-            kl_free(alloc, manifest, manifest_len);
-            return -1;
-        }
-        fprintf(stdout, "hull tools: release signature verified\n");
-    } else {
-        fprintf(stderr,
-            "hull tools: WARNING — this hull build has no embedded release public key,\n"
-            "             skipping Ed25519 signature check (SHA-256 only).\n");
-    }
-
-    *out_manifest = manifest;
-    *out_manifest_len = manifest_len;
-    return 0;
-}
+/* The verified-manifest fetch (download hull.sha256 + .sig, verify the
+ * Ed25519 signature) is the shared trust chain in release_io.c, used by
+ * both `hull tools install` and `hull platform install`:
+ *   hl_release_io_fetch_verified_manifest(repo, tag, alloc, tls,
+ *                                         "hull-tools", &manifest, &len). */
 
 static int install_one(const HlToolSpec *spec, const char *platform,
                        const char *repo, const char *tag,
@@ -486,8 +426,8 @@ static int cmd_install(int argc, char **argv, const char *repo)
     /* Fetch + verify manifest once, reuse for every asset. */
     char *manifest = NULL;
     size_t manifest_len = 0;
-    if (fetch_verified_manifest(repo, tag, &alloc, tls,
-                                &manifest, &manifest_len) != 0) {
+    if (hl_release_io_fetch_verified_manifest(repo, tag, &alloc, tls,
+                                "hull-tools", &manifest, &manifest_len) != 0) {
         kl_tls_mbedtls_ctx_destroy(tls);
         return 1;
     }

--- a/src/hull/release_io.c
+++ b/src/hull/release_io.c
@@ -11,6 +11,7 @@
 #include "hull/release_io.h"
 #include "hull/cacert.h"
 #include "hull/cap/crypto.h"
+#include "hull/release.h"   /* hl_release_verify_manifest_sig / pubkey_configured */
 
 #include <keel/allocator.h>
 #include <keel/client.h>
@@ -169,6 +170,65 @@ int hl_release_io_get(const char *url,
     resp.body = NULL;
     resp.body_len = 0;
     kl_client_response_free(&resp);
+    return 0;
+}
+
+/* ── Verified release manifest (shared trust chain) ──────────────────── */
+
+int hl_release_io_fetch_verified_manifest(const char *repo, const char *tag,
+                                          KlAllocator *alloc, KlTlsCtx *tls,
+                                          const char *ua,
+                                          char **out_manifest,
+                                          size_t *out_manifest_len)
+{
+    if (!repo || !tag || !alloc || !tls || !out_manifest || !out_manifest_len)
+        return -1;
+    if (!ua) ua = "hull";
+
+    char sha_url[256];
+    snprintf(sha_url, sizeof(sha_url),
+             "https://github.com/%s/releases/download/%s/hull.sha256", repo, tag);
+
+    char *manifest = NULL;
+    size_t manifest_len = 0;
+    if (hl_release_io_get(sha_url, &manifest, &manifest_len, alloc, tls, ua) != 0) {
+        fprintf(stderr, "%s: failed to download checksum manifest (%s)\n", ua, sha_url);
+        return -1;
+    }
+
+    if (hl_release_pubkey_configured()) {
+        char sig_url[256];
+        snprintf(sig_url, sizeof(sig_url),
+                 "https://github.com/%s/releases/download/%s/hull.sha256.sig", repo, tag);
+
+        char *sig_hex = NULL;
+        size_t sig_len = 0;
+        if (hl_release_io_get(sig_url, &sig_hex, &sig_len, alloc, tls, ua) != 0) {
+            fprintf(stderr,
+                    "%s: failed to download release signature (hull.sha256.sig); "
+                    "refusing to proceed\n", ua);
+            kl_free(alloc, manifest, manifest_len);
+            return -1;
+        }
+        int rc = hl_release_verify_manifest_sig(manifest, manifest_len,
+                                                sig_hex, sig_len, NULL);
+        kl_free(alloc, sig_hex, sig_len);
+        if (rc != 0) {
+            fprintf(stderr,
+                    "%s: release signature verification FAILED (manifest does not "
+                    "match the embedded release public key)\n", ua);
+            kl_free(alloc, manifest, manifest_len);
+            return -1;
+        }
+        fprintf(stdout, "%s: release signature verified\n", ua);
+    } else {
+        fprintf(stderr,
+                "%s: WARNING: no embedded release public key; skipping Ed25519 "
+                "signature check (SHA-256 only)\n", ua);
+    }
+
+    *out_manifest = manifest;
+    *out_manifest_len = manifest_len;
     return 0;
 }
 

--- a/src/hull/runtime/lua/mod_tool.c
+++ b/src/hull/runtime/lua/mod_tool.c
@@ -713,6 +713,22 @@ static int l_tool_hull_cache_dir(lua_State *L)
     return 1;
 }
 
+/* ── tool.platform_cache_dir() → "$HOME/.hull/platform" | nil ──
+ *
+ * Where `hull platform install` stores fetched per-flavor platform libs.
+ * Returns the path (not guaranteed to exist) so `hull build --flavor` can
+ * look for a cached lib there; nil when HOME is unset. */
+static int l_tool_platform_cache_dir(lua_State *L)
+{
+    const char *home = getenv("HOME");
+    if (!home || !*home) { lua_pushnil(L); return 1; }
+    char out[PATH_MAX];
+    int n = snprintf(out, sizeof(out), "%s/.hull/platform", home);
+    if (n <= 0 || (size_t)n >= (int)sizeof(out)) { lua_pushnil(L); return 1; }
+    lua_pushstring(L, out);
+    return 1;
+}
+
 /* ── tool.hull_cache_disabled([kind]) → boolean ──
  *
  * Mirrors the C-side `hl_hull_cache_disabled` so Lua callers don't
@@ -1059,6 +1075,7 @@ static const luaL_Reg tool_funcs[] = {
     { "find_files",                  l_tool_find_files },
     { "find_tool",                   l_tool_find_tool },
     { "hull_cache_dir",              l_tool_hull_cache_dir },
+    { "platform_cache_dir",          l_tool_platform_cache_dir },
     { "hull_cache_disabled",         l_tool_hull_cache_disabled },
     { "cache_kinds",                 l_tool_cache_kinds },
     { "cache_override",              l_tool_cache_override },

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -895,6 +895,8 @@ int main(int argc, char **argv) { return hull_main(argc, argv); }
         if is_cosmo then
             -- Dual-arch: <asset>.x86_64-cosmo.a + <asset>.aarch64-cosmo.a,
             -- laid out the way cosmocc's apelink expects (.aarch64/ counterpart).
+            -- Cosmo flavor libs are build-from-source only (not published /
+            -- `hull platform install`-able yet), so no ~/.hull/platform lookup.
             local x86, arm
             for _, d in ipairs(dirs) do
                 local a = d .. flavor_asset .. ".x86_64-cosmo.a"
@@ -913,15 +915,24 @@ int main(int argc, char **argv) { return hull_main(argc, argv); }
             tool.mkdir(tmpdir .. "/.aarch64")
             tool.copy(arm, tmpdir .. "/.aarch64/libhull_platform.a")
         else
-            local found
-            for _, d in ipairs(dirs) do
-                local p = d .. flavor_asset .. ".a"
+            local cand = {}
+            for _, d in ipairs(dirs) do cand[#cand + 1] = d .. flavor_asset .. ".a" end
+            -- Cached lib from `hull platform install <flavor>`: stored
+            -- platform-qualified (<asset>-<platform>.a) in ~/.hull/platform.
+            local cache = tool.platform_cache_dir and tool.platform_cache_dir()
+            if cache then
+                cand[#cand + 1] = cache .. "/" .. flavor_asset
+                                  .. "-" .. tool.platform_name() .. ".a"
+            end
+            local found = nil
+            for _, p in ipairs(cand) do
                 if file_exists(p) then found = p; break end
             end
             if not found then
-                tool.stderr("hull build: --flavor=" .. opts.flavor .. " needs "
-                            .. flavor_asset .. ".a (not found)\n")
-                tool.stderr("hint: build it from source, e.g. `make platform-"
+                tool.stderr("hull build: --flavor=" .. opts.flavor
+                            .. ": platform lib not found (locally or in ~/.hull/platform)\n")
+                tool.stderr("hint: `hull platform install " .. opts.flavor
+                            .. "`, or build from source: `make platform-"
                             .. opts.flavor .. "`\n")
                 tool.rmdir(tmpdir)
                 tool.exit(1)


### PR DESCRIPTION
The "full" phase of `hull build --flavor` (docs/build_flavors.md): publish
signed per-flavor platform libs in releases and fetch + verify them on demand,
so an end user with a released hull can build a flavored app without building
the platform lib from source.

## Consumer — `hull platform install <flavor>` / `list`
- New `commands/platform.c` (HTTP-client-gated). `install` fetches the
  per-flavor lib(s) for this hull's platform from the release matching its
  version, verifies SHA-256 against the Ed25519-signed `hull.sha256`, and
  atomic-writes them to `~/.hull/platform/`. Native = one
  `libhull_platform-<flavor>-<arch>.a`; cosmo = the dual-arch pair.
- `build.lua`'s `--flavor` platform-lib redirect now also looks in
  `~/.hull/platform/<asset>-<platform>.a` (new `tool.platform_cache_dir` /
  `tool.platform_name` bindings), so `hull build --flavor` transparently uses
  an installed lib; the not-found hint points at `hull platform install`.

## Producer — release.yml
- The native platform matrix builds the three non-full flavor libs
  (server-only / client-only / pure-compute) per arch, includes them in
  `hull.sha256` (so they inherit the Ed25519 + Sigstore + SLSA signatures),
  and publishes them as release assets.
- Cosmo flavor libs are NOT published yet (build from source with
  `make platform-cosmo-<flavor>`); see docs/build_flavors.md.

## Shared trust chain
- Extracted the verified-manifest fetch (download `hull.sha256` + `.sig`,
  verify the Ed25519 signature) into `hl_release_io_fetch_verified_manifest`
  in `release_io.c`, and refactored `hull tools install` to use it, so there
  is ONE trust-chain implementation rather than a per-command copy.

Rebased onto main after #36 (auto) and #37 (cosmo). Validated locally: build
OK; 50/50 unit; test_release_io 17/17 + test_verify_self 5/5;
e2e-build-flavor 5/5 (incl. --flavor=auto); `hull platform list` works.
A prior /c-audit of this trust-chain code came back clean.