### PR TITLE
feat(build): publish signed cosmo per-flavor platform libs + cosmo hull platform install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,49 @@ jobs:
             build/libhull_platform.x86_64-cosmo.a
             build/libhull_platform.aarch64-cosmo.a
 
+  # Per-flavor cosmo platform libs (dual-arch), for `hull platform install
+  # <flavor>` -> `hull build --flavor` on a cosmo hull. One flavor per fresh
+  # runner (matrix): each does exactly ONE `make platform-cosmo-<flavor>` and
+  # uploads its dual-arch pair. This isolation is REQUIRED -- a second cosmo
+  # platform build in the same job corrupts the dynamic loader (system
+  # cc/sh/gcc/clang can no longer mmap libc.so.6, while static cosmo APEs are
+  # fine; disk + RAM are abundant, so it is not a resource limit). The lib
+  # build itself always succeeds; we just never shell out to a compiler after
+  # it (SHA-256 + sign + publish happen later on clean runners). Mirrors the
+  # build-platform-cosmo job above, which proves one cosmo build + upload works.
+  build-platform-cosmo-flavors:
+    name: Build platform (cosmo, ${{ matrix.flavor }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [server-only, client-only, pure-compute]
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+
+      - name: Write VERSION file
+        run: echo "${GITHUB_REF_NAME#v}" > VERSION
+
+      - name: Install cosmocc
+        run: |
+          COSMOCC_DIR=/opt/cosmo make fetch-cosmocc
+          echo "/opt/cosmo/bin" >> "$GITHUB_PATH"
+
+      - name: Build cosmo flavor platform lib (dual-arch)
+        run: make platform-cosmo-${{ matrix.flavor }}
+
+      - name: Upload cosmo flavor archives
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: platform-cosmo-flavor-${{ matrix.flavor }}
+          path: |
+            build/libhull_platform-${{ matrix.flavor }}.x86_64-cosmo.a
+            build/libhull_platform-${{ matrix.flavor }}.aarch64-cosmo.a
+          if-no-files-found: error
+
   # ────────────────────────────────────────────────────────────────────
   # Stage 2: build + sign the platform manifest. Generates the
   # `embedded_platform_sig.h` header that gets baked into every hull
@@ -580,7 +623,7 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [build-cosmo, build-native, build-wamrc]
+    needs: [build-cosmo, build-native, build-wamrc, build-platform-cosmo-flavors]
     permissions:
       contents: write       # publish GitHub release + assets
       id-token: write       # SLSA: OIDC for Sigstore signing
@@ -601,13 +644,18 @@ jobs:
           mv artifacts/hull-wamrc-linux-x86_64/hull-wamrc-linux-x86_64    dist/hull-wamrc-linux-x86_64
           mv artifacts/hull-wamrc-linux-aarch64/hull-wamrc-linux-aarch64  dist/hull-wamrc-linux-aarch64
           mv artifacts/hull-wamrc-darwin-arm64/hull-wamrc-darwin-arm64    dist/hull-wamrc-darwin-arm64
-          # Per-flavor platform libs (native arches). Consumed by
-          # `hull platform install <flavor>` -> `hull build --flavor`.
-          # Files: libhull_platform-<flavor>-<arch>.a. (Cosmo flavor libs
-          # are build-from-source, not published; see docs/build_flavors.md.)
+          # Per-flavor platform libs. Consumed by `hull platform install
+          # <flavor>` -> `hull build --flavor`. Native files:
+          # libhull_platform-<flavor>-<arch>.a; cosmo files (dual-arch):
+          # libhull_platform-<flavor>.{x86_64,aarch64}-cosmo.a. All match the
+          # `libhull_platform-*.a` glob in the SHA-256 + publish steps below,
+          # so they inherit the release signature automatically.
           mv artifacts/platform-flavors-linux-x86_64/*.a  dist/
           mv artifacts/platform-flavors-linux-aarch64/*.a dist/
           mv artifacts/platform-flavors-darwin-arm64/*.a  dist/
+          mv artifacts/platform-cosmo-flavor-server-only/*.a   dist/
+          mv artifacts/platform-cosmo-flavor-client-only/*.a   dist/
+          mv artifacts/platform-cosmo-flavor-pure-compute/*.a  dist/
 
       - name: Make binaries executable
         run: chmod +x dist/*

--- a/docs/build_flavors.md
+++ b/docs/build_flavors.md
@@ -259,12 +259,15 @@ smaller, produced by an unchanged full `hull`.
 1. ~~Named flavors only, or free-form flag composition?~~ **Resolved (§4.4):
    named flavors for published libs; free-form only via build-from-source.**
 2. Does `--flavor=auto` become the default, and when? (Behavior change.)
-3. ~~Cosmo: per-flavor × per-arch, worth it?~~ **Building cosmo flavor libs
-   from source is supported** (`make platform-cosmo-<flavor>` -> dual-arch
-   `libhull_platform-<flavor>.{x86_64,aarch64}-cosmo.a`; `hull build --flavor`
-   lays them out in the `.aarch64/` apelink layout). Whether to *publish*
-   signed cosmo flavor libs in releases is still open (it does double the
-   per-flavor artifact count).
+3. ~~Cosmo: per-flavor × per-arch, worth it?~~ **Resolved: cosmo flavor libs
+   are now published** (dual-arch `libhull_platform-<flavor>.{x86_64,aarch64}-cosmo.a`,
+   covered by the signed `hull.sha256`). `hull platform install <flavor>` on a
+   cosmo hull fetches + verifies the pair into `~/.hull/platform/`, and
+   `hull build --flavor` lays them out in the `.aarch64/` apelink layout.
+   `make platform-cosmo-<flavor>` still works for build-from-source. The
+   release producer builds each cosmo flavor on its **own fresh runner** (a
+   second cosmo platform build in one job corrupts the dynamic loader), so no
+   double-up in a single job.
 4. Cache location: `~/.hull/platform/` as a sibling of `~/.hull/tools/`
    (signed durable store, not a prunable cache), consistent with
    [blob.md](blob.md)'s store split.

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -895,18 +895,24 @@ int main(int argc, char **argv) { return hull_main(argc, argv); }
         if is_cosmo then
             -- Dual-arch: <asset>.x86_64-cosmo.a + <asset>.aarch64-cosmo.a,
             -- laid out the way cosmocc's apelink expects (.aarch64/ counterpart).
-            -- Cosmo flavor libs are build-from-source only (not published /
-            -- `hull platform install`-able yet), so no ~/.hull/platform lookup.
+            -- Search local build dirs, then the ~/.hull/platform cache where
+            -- `hull platform install <flavor>` stores the fetched+verified pair
+            -- (as <asset>.x86_64-cosmo.a / <asset>.aarch64-cosmo.a).
+            local search = { hull_dir, "build/", "../build/", "" }
+            local cache = tool.platform_cache_dir and tool.platform_cache_dir()
+            if cache then search[#search + 1] = cache .. "/" end
             local x86, arm
-            for _, d in ipairs(dirs) do
+            for _, d in ipairs(search) do
                 local a = d .. flavor_asset .. ".x86_64-cosmo.a"
                 local b = d .. flavor_asset .. ".aarch64-cosmo.a"
                 if file_exists(a) and file_exists(b) then x86, arm = a, b; break end
             end
             if not (x86 and arm) then
-                tool.stderr("hull build: --flavor=" .. opts.flavor .. " needs "
-                            .. flavor_asset .. ".{x86_64,aarch64}-cosmo.a (not found)\n")
-                tool.stderr("hint: build it from source, e.g. `make platform-cosmo-"
+                tool.stderr("hull build: --flavor=" .. opts.flavor .. ": "
+                            .. flavor_asset .. ".{x86_64,aarch64}-cosmo.a not found"
+                            .. " (locally or in ~/.hull/platform)\n")
+                tool.stderr("hint: `hull platform install " .. opts.flavor
+                            .. "`, or build from source: `make platform-cosmo-"
                             .. opts.flavor .. "`\n")
                 tool.rmdir(tmpdir)
                 tool.exit(1)

--- a/tests/release_smoke.sh
+++ b/tests/release_smoke.sh
@@ -55,6 +55,31 @@ assert_contains() {
     fi
 }
 
+# hull platform install <flavor> — LIVE fetch + verify of the published
+# per-flavor platform lib(s). Native binaries pull one
+# libhull_platform-<flavor>-<arch>.a; cosmo binaries pull the dual-arch pair
+# libhull_platform-<flavor>.{x86_64,aarch64}-cosmo.a. Uses an isolated HOME so
+# a real ~/.hull/platform is never touched. Works for both flavors of binary.
+smoke_platform_install() {
+    echo ""
+    echo "── hull platform install pure-compute (LIVE GitHub HTTPS download) ──"
+    PLAT_HOME=$(mktemp -d)
+    OUT=$(HOME="$PLAT_HOME" "$HULL" platform install pure-compute 2>&1)
+    RC=$?
+    echo "$OUT" | sed 's/^/    /'
+    assert "exits 0"                         [ "$RC" -eq 0 ]
+    assert_contains "SHA-256 verified"       "$OUT" "SHA-256 verified"
+    if echo "$OUT" | grep -q "release signature verified"; then
+        echo "  ok  release signature verified (Ed25519)"
+        PASS=$((PASS + 1))
+    fi
+    N=$(ls "$PLAT_HOME"/.hull/platform/libhull_platform-pure-compute*.a 2>/dev/null | wc -l | tr -d ' ')
+    assert "flavor lib(s) landed in ~/.hull/platform (got $N)"  [ "$N" -ge 1 ]
+    OUT=$(HOME="$PLAT_HOME" "$HULL" platform list 2>&1)
+    assert_contains "list shows pure-compute installed"  "$OUT" "pure-compute"
+    rm -rf "$PLAT_HOME"
+}
+
 if ! command -v "$HULL" >/dev/null 2>&1; then
     echo "release_smoke: '$HULL' not found on PATH — install hull first"
     exit 1
@@ -75,6 +100,9 @@ case "$VERSION" in
         OUT=$("$HULL" agent tools 2>&1)
         assert_contains "registry lists wamrc"             "$OUT" "\"name\":\"wamrc\""
         assert_contains "wamrc not available on cosmo"     "$OUT" "\"available_for_platform\":false"
+        # Cosmo DOES publish per-flavor platform libs (dual-arch), so the
+        # `hull platform install` path is exercised on cosmo binaries.
+        smoke_platform_install
         echo ""
         echo "── Summary ──"
         echo "  Passed: $PASS"
@@ -137,6 +165,9 @@ echo "── hull tools uninstall wamrc ──"
 OUT=$("$HULL" tools uninstall wamrc 2>&1)
 assert_contains "uninstalled"          "$OUT" "uninstalled wamrc"
 assert "file removed"                  [ ! -e "$WAMRC_PATH" ]
+
+# Per-flavor platform lib install (native single-arch lib).
+smoke_platform_install
 
 # ── Platform-sig E2E (post-§3.2: works on installed binaries) ──
 #


### PR DESCRIPTION
Completes the `hull platform install` story for **cosmo** (v0.5.0 shipped it
for native only).

## Producer — `release.yml`
New `build-platform-cosmo-flavors` matrix job (server-only / client-only /
pure-compute), **one flavor per fresh runner**. This isolation is required: a
second cosmo platform build in the same job corrupts the dynamic loader
(system `cc`/`sh`/`gcc`/`clang` can no longer `mmap` libc.so.6; static cosmo
APEs are fine; disk + RAM are abundant, so it is not a resource limit). Each
job does exactly one `make platform-cosmo-<flavor>` and uploads its dual-arch
pair. The `release` job `needs` it and `mv`s the pairs into `dist/`, where the
existing `libhull_platform-*.a` globs fold them into the Ed25519 / Sigstore /
SLSA-signed `hull.sha256` and publish them — **no manifest / sign-platform
changes**.

## Consumer
- `platform.c` was already cosmo-ready (`flavor_assets()` emits + installs the
  dual-arch pair into `~/.hull/platform/`). No change.
- `build.lua`'s `--flavor` cosmo branch now also searches `~/.hull/platform/`
  for an installed pair (was local build dirs only), symmetric with native.

## Docs + tests
- `docs/build_flavors.md §7`: cosmo flavor libs are now published (dropped the
  "build-from-source only" caveat).
- `tests/release_smoke.sh`: live `hull platform install pure-compute` check on
  both native and cosmo binaries (dual-arch pair verified into the cache).

## Testing notes
Validated locally: build OK, `e2e-build-flavor` 5/5 (native path + `--flavor=auto`
unregressed). The cosmo producer + install path can't be tested in normal CI
(the release job only runs on tag push, and the install path needs the assets
to already exist) — it gets its real end-to-end test on the next release tag,
where `release_smoke.sh` validates the cosmo install. Same can't-test-pre-release
limitation as `hull tools install`.