### PR TITLE
feat(libhull): versioned hl_embed_* C ABI for native hosts (L-2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1456,6 +1456,7 @@ MODULE_RESOLVER_OBJ := $(BUILDDIR)/module_resolver.o
 MODULE_OBJ       := $(MODULE_REGISTRY_OBJ) $(MODULE_RESOLVER_OBJ)
 SANDBOX_OBJ      := $(BUILDDIR)/sandbox.o
 SANDBOX_TOOL_OBJ := $(BUILDDIR)/sandbox_tool.o
+EMBED_OBJ        := $(BUILDDIR)/embed.o
 
 # Async backend implementations
 #   async/keel.c — wraps Keel's KlEventCtx + KlThreadPool. Compiled
@@ -2322,11 +2323,14 @@ $(BUILDDIR)/hull: $(CAP_OBJS) $(CAP_TOOL_OBJ) $(CAP_TEST_OBJ) $(CMD_OBJS) $(RT_O
 	$(CC) $(LDFLAGS) -o $@ $(CAP_OBJS) $(CAP_TOOL_OBJ) $(CAP_TEST_OBJ) $(CMD_OBJS) $(RT_OBJS) $(ALLOC_OBJ) $(ASYNC_OBJ) $(COMPRESS_OBJ) $(MINIZ_OBJ) $(WORKER_DB_OBJ) $(WORKER_WASM_OBJ) $(WORKER_GPU_OBJ) $(MANIFEST_OBJ) $(MODULE_OBJ) $(ASYNC_BACKEND_OBJS) $(NET_BACKEND_OBJS) $(SANDBOX_OBJ) $(SANDBOX_TOOL_OBJ) $(SIG_OBJ) $(RELEASE_OBJ) $(RELEASE_IO_OBJ) $(TOOLS_INSTALL_OBJ) $(PLATFORM_SIG_OBJ) $(EMBEDDED_PLATFORM_SIG_OBJ) $(TEST_RUNNER_OBJ) $(RUNTIME_FACTORY_OBJ) $(STATIC_OBJ) $(MIGRATE_OBJ) $(VFS_OBJ) $(PATH_NORM_OBJ) $(THREAD_AFFINITY_OBJ) $(CACHE_DIR_OBJ) $(BLOB_STORE_OBJ) $(CACHE_REGISTRY_OBJ) $(CACERT_OBJ) $(CSP_OBJ) $(SH_SEAL_ARENA_OBJ) $(SBOM_OBJ) $(APP_CONTEXT_OBJ) $(AGENT_LIB_OBJ) $(AGENT_API_OBJ) $(TOOL_OBJ) $(BUILD_ASSET_OBJ) $(COMPILER_OBJ) $(COMPILER_TCC_OBJ) $(MAIN_OBJ) $(SERVE_OBJ) $(ENTRY_OBJ) $(APP_EXTRA_OBJS) $(STDLIB_REGISTRY_O) $(WAMR_OBJS) $(VEND_OBJS) $(MBEDTLS_OBJS) \
 		$(SQLITE_OBJ) $(LOG_OBJ) $(LOG_LOCK_OBJ) $(SH_ARENA_OBJ) $(SH_JSON_OBJ) $(TWEETNACL_OBJ) $(STB_OBJ) $(PLEDGE_OBJS) $(KEEL_LIB) $(WGPU_LIB) $(WGPU_FRAMEWORKS) -lm -lpthread
 
-# ── libhull: no-runtime embedding library (Phase L-1) ────────────────
+# ── libhull: no-runtime embedding library (Phase L-1/L-2) ────────────
 # The runtime-agnostic hardened core as a static archive, for a native
 # host (C/Rust/Zig) that owns main() and drives the two-phase sandbox +
-# the capability layer directly (no Lua/JS runtime, no app.main lifecycle).
-# Includes ONLY runtime-free objects: cap/* (fs/db/crypto/env/time/image/
+# the capability layer (no Lua/JS runtime, no app.main lifecycle). The
+# host targets the stable ABI in <hull/embed.h> (embed.o, first object
+# below) and never includes an internal Hull header.
+# Includes ONLY runtime-free objects: embed.o (the hl_embed_* ABI),
+# cap/* (fs/db/crypto/env/time/image/
 # mime/wasm/gpu/blob/http/ws/smtp/body/audit), the async workers + async/
 # net backend vtables, manifest.o (runtime-free struct + seal helpers, NOT
 # the manifest_lua/js VM extractors), module registry/resolver, sandbox,
@@ -2338,7 +2342,7 @@ $(BUILDDIR)/hull: $(CAP_OBJS) $(CAP_TOOL_OBJ) $(CAP_TEST_OBJ) $(CMD_OBJS) $(RT_O
 # runtime_factory, static.c (HTTP-serving middleware), embedded stdlib.
 # Link a host with: build/libhull.a $(KEEL_LIB) -lm -lpthread.
 MANIFEST_CORE_OBJ := $(BUILDDIR)/manifest.o
-LIBHULL_OBJS := $(CAP_OBJS) $(ALLOC_OBJ) $(ASYNC_OBJ) $(COMPRESS_OBJ) $(MINIZ_OBJ) \
+LIBHULL_OBJS := $(EMBED_OBJ) $(CAP_OBJS) $(ALLOC_OBJ) $(ASYNC_OBJ) $(COMPRESS_OBJ) $(MINIZ_OBJ) \
 	$(WORKER_DB_OBJ) $(WORKER_WASM_OBJ) $(WORKER_GPU_OBJ) $(MANIFEST_CORE_OBJ) \
 	$(MODULE_OBJ) $(ASYNC_BACKEND_OBJS) $(NET_BACKEND_OBJS) $(SANDBOX_OBJ) \
 	$(SIG_OBJ) $(RELEASE_OBJ) $(RELEASE_IO_OBJ) $(TOOLS_INSTALL_OBJ) \
@@ -2479,6 +2483,9 @@ $(SANDBOX_OBJ): $(SRCDIR)/hull/sandbox.c | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
 
 $(SANDBOX_TOOL_OBJ): $(SRCDIR)/hull/sandbox_tool.c | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
+
+$(EMBED_OBJ): $(SRCDIR)/hull/embed.c | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
 
 # Signature verification
@@ -2787,6 +2794,13 @@ $(BUILDDIR)/test_cfi: $(TESTDIR)/hull/test_cfi.c | $(BUILDDIR)
 # CSP preset registry — tiny, no deps beyond <string.h>.
 $(BUILDDIR)/test_csp: $(TESTDIR)/hull/test_csp.c $(CSP_OBJ) | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(CSP_OBJ)
+
+# Embedding ABI — links the whole libhull.a the way a native host does,
+# so this also link-tests the archive on every `make test`. Only the
+# non-sealing surface runs in-process; the sealed path is embed-c-smoke.
+$(BUILDDIR)/test_embed: $(TESTDIR)/hull/test_embed.c $(BUILDDIR)/libhull.a $(KEEL_LIB) | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< \
+		$(BUILDDIR)/libhull.a $(KEEL_LIB) $(WGPU_LIB) $(WGPU_FRAMEWORKS) -lm -lpthread
 
 # Arena lifetime helpers — mark/rewind/strdup/memdup over sh_arena.
 # Needs only the alloc wrapper + the sh_arena bump allocator.

--- a/examples/embed_c/README.md
+++ b/examples/embed_c/README.md
@@ -26,34 +26,53 @@ linked, an accidental dependency on Lua/QuickJS from the core would fail
 the link here — the smoke test is a standing witness that the archive is
 genuinely runtime-free.
 
-To link a host by hand:
+The host includes exactly **one** Hull header, `<hull/embed.h>` — the
+stable, versioned embedding ABI. It never reaches into an internal Hull
+header, so it is insulated from the internal sandbox / capability struct
+layout. To link a host by hand you only need the include root:
 
 ```sh
 make libhull
-cc -std=c11 -Iinclude -Ivendor/keel/include -Ivendor/mbedtls/include \
-   -Ivendor/wamr/core/iwasm/include \
+cc -std=c11 -Iinclude \
    -o my_host my_host.c build/libhull.a vendor/keel/libkeel.a -lm -lpthread
 ```
 
 ## What the host demonstrates
 
-`main.c` runs the embedding sequence a real native consumer would:
+`main.c` runs the embedding sequence a real native consumer would, all
+through the `hl_embed_*` ABI:
 
-1. `hl_sandbox_apply_pledge()` — phase-1 syscall reduction.
-2. Build an `HlSandboxPolicy` **in C** (a native host is trusted; it does
-   not parse an `app.manifest` — it declares policy directly). Filesystem
-   paths in the policy are **app_dir-relative**, the same contract as a
-   manifest's `fs.read` / `fs.write`; absolute paths are rejected by the
-   sandbox path resolver.
-3. `hl_sandbox_apply()` — phase-2 default-deny sandbox.
-4. `hl_cap_fs_write` / `_read` — capability-mediated I/O, plus a
+1. `hl_embed_new(app_dir)` — create the handle (app_dir is absolute; all
+   capability fs access resolves under it).
+2. `hl_embed_sandbox_phase1()` — phase-1 syscall reduction.
+3. `hl_embed_allow_read` / `hl_embed_allow_write` — build the policy **in
+   C** (a native host is trusted; it does not parse an `app.manifest`).
+   Paths are **app_dir-relative**, the same contract as a manifest's
+   `fs.read` / `fs.write`; absolute paths are rejected.
+4. Fail-closed check: capability calls return `-1` **before** the sandbox
+   is sealed.
+5. `hl_embed_seal()` — phase-2 default-deny sandbox; the host treats a
+   non-zero return as fatal.
+6. `hl_embed_fs_write` / `_read` — capability-mediated I/O, plus a
    path-traversal rejection check.
-5. `hl_cap_crypto_sha256` — capability-mediated crypto (verified against a
-   known vector).
-6. `hl_release_io_platform` / `hl_module_registry_count` — signed-artifact
-   / SBOM identity.
+7. `hl_embed_sha256` — capability-mediated crypto (known-vector check).
+8. `hl_embed_platform` / `hl_embed_module_count` — signed-artifact / SBOM
+   identity.
 
-The host exits non-zero if any capability check fails.
+The host exits non-zero if any check fails.
+
+## The ABI
+
+`include/hull/embed.h` is the whole surface: an opaque `HlEmbed` handle,
+`hl_embed_abi_version()` for version negotiation, the `hl_embed_allow_*`
+policy builders, the `hl_embed_sandbox_phase1` / `hl_embed_seal`
+lifecycle, and the `hl_embed_fs_*` / `hl_embed_sha256` /
+`hl_embed_platform` / `hl_embed_module_count` capability calls. It depends
+only on `<stddef.h>` / `<stdint.h>`.
+
+Unit tests for the guard / limit / identity surface live in
+`tests/hull/test_embed.c` (run by `make test`); the sealed integration
+path is this example, run by `make embed-c-smoke`.
 
 ## What is NOT in libhull
 

--- a/examples/embed_c/main.c
+++ b/examples/embed_c/main.c
@@ -1,23 +1,17 @@
 /*
  * embed_c — reference native host for the libhull no-runtime flavor.
  *
- * This program links ONLY build/libhull.a (the runtime-free Hull core:
- * kernel sandbox, capability layer, WASM/GPU compute, signed-artifact
- * plumbing) plus vendor/keel/libkeel.a. Neither Lua nor QuickJS is
- * linked. The host owns main() and drives the Hull core directly:
+ * Links ONLY build/libhull.a (the runtime-free Hull core) plus
+ * vendor/keel/libkeel.a. Neither Lua nor QuickJS is linked. The host
+ * owns main() and drives the core exclusively through the stable
+ * embedding ABI in <hull/embed.h> — it never includes an internal Hull
+ * header. That is the whole point of the ABI: an embedder targets
+ * hl_embed_* and is insulated from the internal sandbox / capability
+ * struct layout.
  *
- *   1. hl_sandbox_apply_pledge()  — phase-1 syscall reduction
- *   2. build an HlSandboxPolicy by hand (a native host is trusted; it
- *      does not parse an app.manifest — it declares policy in C)
- *   3. hl_sandbox_apply()          — phase-2 default-deny sandbox
- *   4. hl_cap_fs_write / _read     — capability-mediated I/O
- *   5. hl_cap_crypto_sha256        — capability-mediated crypto
- *   6. hl_release_io_platform /    — signed-artifact / SBOM identity
- *      hl_module_registry_count
- *
- * Its real job is to be a LINK witness: if this binary links with no
- * undefined symbols, the core object subset in build/libhull.a is
- * genuinely runtime-free. `make embed-c-smoke` builds and runs it.
+ * It doubles as a link witness: if this binary links with no undefined
+ * symbols, the core object subset in build/libhull.a (including embed.o)
+ * is genuinely runtime-free. `make embed-c-smoke` builds and runs it.
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -28,11 +22,7 @@
 #include <stdint.h>
 #include <unistd.h>
 
-#include "hull/sandbox.h"
-#include "hull/cap/fs.h"
-#include "hull/cap/crypto.h"
-#include "hull/module_registry.h"
-#include "hull/release_io.h"
+#include "hull/embed.h"   /* the ONLY Hull header a native host needs */
 
 static int failures = 0;
 
@@ -44,7 +34,8 @@ static void check(int ok, const char *what)
 
 int main(void)
 {
-    printf("embed_c: libhull no-runtime host\n");
+    printf("embed_c: libhull no-runtime host (ABI v%d)\n",
+           hl_embed_abi_version());
 
     /* A native host owns its working directory. Use a fresh temp dir so
      * the sandbox's read/write allowlist is a single known path. */
@@ -54,68 +45,63 @@ int main(void)
         perror("mkdtemp");
         return 1;
     }
-    if (chdir(dir) != 0) {
-        perror("chdir");
-        return 1;
-    }
+
+    HlEmbed *e = hl_embed_new(dir);
+    check(e != NULL, "hl_embed_new(app_dir)");
+    if (!e) return 1;
 
     /* ── 1. phase-1 sandbox (pledge) ──────────────────────────────── */
-    check(hl_sandbox_apply_pledge() == 0, "phase-1 pledge applied");
+    check(hl_embed_sandbox_phase1(e) == 0, "phase-1 sandbox applied");
 
-    /* ── 2. build a policy in C (no app.manifest) ─────────────────── */
-    /* Policy fs paths are app_dir-relative — the same contract as a
-     * manifest's fs.read/fs.write ("data/", "uploads/"). "." grants the
-     * app_dir (our temp cwd) itself. Absolute paths are rejected by the
-     * sandbox path resolver, exactly as for a real manifest. */
-    const char *rw[] = { "." };
-    HlSandboxPolicy policy;
-    memset(&policy, 0, sizeof(policy));
-    policy.fs_read        = rw;
-    policy.fs_read_count  = 1;
-    policy.fs_write       = rw;
-    policy.fs_write_count = 1;
-    policy.network_inbound  = 0;
-    policy.network_outbound = 0;
-    policy.wx_enforced      = 1;
+    /* ── 2. build policy in C (app_dir-relative, like a manifest) ──── */
+    check(hl_embed_allow_read(e, ".") == 0,  "allow_read(\".\")");
+    check(hl_embed_allow_write(e, ".") == 0, "allow_write(\".\")");
+    hl_embed_allow_network(e, 0, 0);
 
-    /* ── 3. phase-2 sandbox (default-deny) ────────────────────────── */
-    int sb = hl_sandbox_apply(&policy, dir, NULL, NULL, NULL, NULL);
-    check(sb == 0, "phase-2 sandbox applied");
+    /* fail-closed: capabilities must refuse before seal */
+    const char *pre_err = NULL;
+    int pre = hl_embed_fs_exists(e, "note.txt", &pre_err);
+    check(pre == -1 && pre_err != NULL, "capabilities fail closed before seal");
+
+    /* ── 3. phase-2 sandbox (default-deny) — MUST check ───────────── */
+    int sealed = hl_embed_seal(e, NULL);
+    check(sealed == 0, "hl_embed_seal applied sandbox");
+    if (sealed != 0) { hl_embed_free(e); return 1; }
 
     /* ── 4. capability-mediated filesystem I/O ────────────────────── */
-    HlFsConfig fs = { .base_dir = dir, .base_len = strlen(dir) };
     const char *err = NULL;
     const char *payload = "hull embed_c capability write\n";
 
-    int w = hl_cap_fs_write(&fs, "note.txt", payload, strlen(payload), &err);
-    check(w == 0, "hl_cap_fs_write under sandbox");
+    int w = hl_embed_fs_write(e, "note.txt", payload, strlen(payload), &err);
+    check(w == 0, "hl_embed_fs_write under sandbox");
 
     char buf[128];
-    int64_t n = hl_cap_fs_read(&fs, "note.txt", buf, sizeof(buf), &err);
+    int64_t n = hl_embed_fs_read(e, "note.txt", buf, sizeof(buf), &err);
     check(n == (int64_t)strlen(payload) &&
           memcmp(buf, payload, (size_t)n) == 0,
-          "hl_cap_fs_read round-trips");
+          "hl_embed_fs_read round-trips");
 
     /* traversal must still be rejected by the cap layer */
-    int bad = hl_cap_fs_exists(&fs, "../escape", &err);
-    check(bad == -1, "hl_cap_fs rejects path traversal");
+    int bad = hl_embed_fs_exists(e, "../escape", &err);
+    check(bad == -1, "hl_embed_fs rejects path traversal");
 
-    /* ── 5. capability-mediated crypto ────────────────────────────── */
+    /* ── 5. capability-mediated crypto (stateless) ────────────────── */
     uint8_t digest[32];
-    int c = hl_cap_crypto_sha256("abc", 3, digest);
+    int c = hl_embed_sha256("abc", 3, digest);
     /* SHA-256("abc") = ba7816bf 8f01cfea ... */
     check(c == 0 && digest[0] == 0xba && digest[1] == 0x78 &&
           digest[2] == 0x16 && digest[3] == 0xbf,
-          "hl_cap_crypto_sha256(\"abc\") matches known vector");
+          "hl_embed_sha256(\"abc\") matches known vector");
 
     /* ── 6. signed-artifact / SBOM identity ───────────────────────── */
-    const char *plat = hl_release_io_platform();
-    check(plat != NULL && plat[0] != '\0', "hl_release_io_platform reports arch");
-    size_t mods = hl_module_registry_count();
-    check(mods > 0, "hl_module_registry_count populated");
+    const char *plat = hl_embed_platform();
+    check(plat != NULL && plat[0] != '\0', "hl_embed_platform reports arch");
+    size_t mods = hl_embed_module_count();
+    check(mods > 0, "hl_embed_module_count populated");
     printf("  platform=%s modules=%zu\n", plat ? plat : "(null)", mods);
 
-    hl_cap_fs_delete(&fs, "note.txt", &err);
+    hl_embed_fs_delete(e, "note.txt", &err);
+    hl_embed_free(e);
     rmdir(dir);
 
     printf("embed_c: %s (%d failure%s)\n",

--- a/include/hull/embed.h
+++ b/include/hull/embed.h
@@ -1,0 +1,160 @@
+/*
+ * embed.h — stable C ABI for the libhull no-runtime flavor.
+ *
+ * This is the ONLY header a native host (C/Rust/Zig) needs to embed the
+ * runtime-free Hull core (build/libhull.a). It exposes an opaque handle
+ * and a small, versioned function surface over the internal
+ * hl_sandbox_* / hl_cap_* layer, so an embedder never reaches into
+ * Hull's internal headers (whose layout is not stable across releases).
+ *
+ * Deliberately depends only on <stddef.h> / <stdint.h> — no HlManifest,
+ * HlSandboxPolicy, or HlFsConfig leak across this boundary.
+ *
+ * Lifecycle (fail-closed): the capability calls refuse to run until the
+ * kernel sandbox has been applied via hl_embed_seal(). The intended order
+ * is:
+ *
+ *     HlEmbed *e = hl_embed_new(app_dir);
+ *     hl_embed_sandbox_phase1(e);          // optional, recommended
+ *     hl_embed_allow_read(e, "data");      // build policy in C
+ *     hl_embed_allow_write(e, "out");
+ *     if (hl_embed_seal(e, db_path) != 0)  // apply sandbox — MUST check
+ *         abort();                         // fail closed on seal failure
+ *     hl_embed_fs_write(e, "out/x", ...);  // capabilities now live
+ *     hl_embed_free(e);
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef HL_EMBED_H
+#define HL_EMBED_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * ABI version. Bumped on any breaking change to the signatures or
+ * semantics below. A host can compile-time check HL_EMBED_ABI_VERSION
+ * and runtime-check hl_embed_abi_version() to detect a mismatch against
+ * the libhull.a it linked.
+ */
+#define HL_EMBED_ABI_VERSION 1
+
+/* Returns the ABI version compiled into libhull.a. */
+int hl_embed_abi_version(void);
+
+/* Opaque embedding handle. Never inspect its fields. */
+typedef struct HlEmbed HlEmbed;
+
+/* ── Construction ──────────────────────────────────────────────────── */
+
+/*
+ * Create an embedding handle rooted at @p app_dir (an ABSOLUTE path).
+ * All capability filesystem access resolves relative to this directory,
+ * and the kernel sandbox unveils it. Returns NULL on allocation failure
+ * or if @p app_dir is NULL / not absolute.
+ */
+HlEmbed *hl_embed_new(const char *app_dir);
+
+/* Destroy a handle and free its policy storage. NULL-safe. */
+void hl_embed_free(HlEmbed *e);
+
+/* ── Policy (call before hl_embed_seal) ────────────────────────────── */
+
+/*
+ * Add an app_dir-relative path to the filesystem read / write allowlist.
+ * Same contract as a manifest's fs.read / fs.write: relative paths only
+ * (absolute paths and ".." are rejected). Up to 32 entries each.
+ *
+ * Returns 0 on success, -1 if the list is full, the handle is already
+ * sealed, or @p rel_path is NULL.
+ */
+int hl_embed_allow_read(HlEmbed *e, const char *rel_path);
+int hl_embed_allow_write(HlEmbed *e, const char *rel_path);
+
+/*
+ * Declare network intent. @p inbound = the process may accept
+ * connections; @p outbound = it may open sockets. The host allowlist
+ * itself is still enforced per-call in the capability layer; this only
+ * decides whether the sandbox unveils network syscalls at all.
+ * No-op after seal.
+ */
+void hl_embed_allow_network(HlEmbed *e, int inbound, int outbound);
+
+/* Enable GPU device access (all devices). No-op after seal. */
+void hl_embed_allow_gpu(HlEmbed *e, int enabled);
+
+/* Enable controlling-tty access for terminal UI. No-op after seal. */
+void hl_embed_allow_tui(HlEmbed *e, int enabled);
+
+/* ── Lifecycle ─────────────────────────────────────────────────────── */
+
+/*
+ * Phase-1 sandbox: pledge-only, blocks exec/proc/fork. Optional but
+ * recommended — call early, before building policy, to reduce the
+ * syscall surface during host setup. Returns 0 on success, -1 on error.
+ */
+int hl_embed_sandbox_phase1(HlEmbed *e);
+
+/*
+ * Phase-2 sandbox: apply the default-deny kernel sandbox from the policy
+ * accumulated above and mark the handle sealed. @p db_path may be NULL
+ * (no database); when set, it is granted read/write.
+ *
+ * W^X is enforced (no runtime dynamic code). Returns 0 on success. A
+ * non-zero return means the sandbox could not be applied — the host MUST
+ * treat this as fatal and NOT proceed, because the capability layer is
+ * then running without kernel enforcement. Idempotent-safe: a second
+ * call after a successful seal returns -1.
+ */
+int hl_embed_seal(HlEmbed *e, const char *db_path);
+
+/* ── Capabilities (require a successful hl_embed_seal) ──────────────── */
+
+/*
+ * Read a whole file into @p buf. Returns bytes read (>= 0), or -1 on
+ * failure (unsealed handle, path rejected, too large, I/O error). The
+ * optional @p err receives a static description.
+ */
+int64_t hl_embed_fs_read(HlEmbed *e, const char *path,
+                         char *buf, size_t buf_size, const char **err);
+
+/*
+ * Write @p len bytes to @p path (parent dirs created, atomic replace).
+ * Returns 0 on success, -1 on failure. @p err optional.
+ */
+int hl_embed_fs_write(HlEmbed *e, const char *path,
+                      const void *data, size_t len, const char **err);
+
+/*
+ * Test existence. Returns 1 if present, 0 if absent, -1 on rejection /
+ * unsealed handle. @p err optional.
+ */
+int hl_embed_fs_exists(HlEmbed *e, const char *path, const char **err);
+
+/* Delete a file. Returns 0 on success or already-absent, -1 otherwise. */
+int hl_embed_fs_delete(HlEmbed *e, const char *path, const char **err);
+
+/*
+ * SHA-256 of @p data into @p out (32 bytes). Stateless — needs no handle
+ * and works before seal. Returns 0 on success, -1 on internal failure.
+ */
+int hl_embed_sha256(const void *data, size_t len, uint8_t out[32]);
+
+/* ── Identity ──────────────────────────────────────────────────────── */
+
+/* Platform arch string, e.g. "darwin-arm64" / "linux-x86_64". */
+const char *hl_embed_platform(void);
+
+/* Number of first-party modules in the embedded registry. */
+size_t hl_embed_module_count(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HL_EMBED_H */

--- a/src/hull/embed.c
+++ b/src/hull/embed.c
@@ -1,0 +1,203 @@
+/*
+ * embed.c — implementation of the libhull embedding ABI (embed.h).
+ *
+ * Thin, allocation-light wrapper over the internal sandbox + capability
+ * layer. The opaque HlEmbed handle accumulates a C-built policy, then
+ * hl_embed_seal() resolves it into an HlSandboxPolicy and applies the
+ * kernel sandbox. The filesystem capability calls fail closed until that
+ * seal has succeeded.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "hull/embed.h"
+
+#include "hull/sandbox.h"
+#include "hull/manifest.h"
+#include "hull/cap/fs.h"
+#include "hull/cap/crypto.h"
+#include "hull/module_registry.h"
+#include "hull/release_io.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+enum { HL_EMBED_NEW = 0, HL_EMBED_SEALED = 1 };
+
+struct HlEmbed {
+    char       *app_dir;                          /* absolute, owned */
+    HlFsConfig  fs;                               /* base_dir aliases app_dir */
+
+    char       *reads[HL_MANIFEST_MAX_PATHS];     /* owned dups */
+    int         nreads;
+    char       *writes[HL_MANIFEST_MAX_PATHS];    /* owned dups */
+    int         nwrites;
+
+    int         net_inbound;
+    int         net_outbound;
+    int         gpu;
+    int         tui;
+
+    int         state;                            /* HL_EMBED_NEW / _SEALED */
+};
+
+int hl_embed_abi_version(void)
+{
+    return HL_EMBED_ABI_VERSION;
+}
+
+/* ── Construction ──────────────────────────────────────────────────── */
+
+HlEmbed *hl_embed_new(const char *app_dir)
+{
+    if (!app_dir || app_dir[0] != '/') return NULL;
+
+    HlEmbed *e = calloc(1, sizeof(*e));
+    if (!e) return NULL;
+
+    e->app_dir = strdup(app_dir);
+    if (!e->app_dir) {
+        free(e);
+        return NULL;
+    }
+    e->fs.base_dir = e->app_dir;
+    e->fs.base_len = strlen(e->app_dir);
+    e->state = HL_EMBED_NEW;
+    return e;
+}
+
+void hl_embed_free(HlEmbed *e)
+{
+    if (!e) return;
+    for (int i = 0; i < e->nreads; i++) free(e->reads[i]);
+    for (int i = 0; i < e->nwrites; i++) free(e->writes[i]);
+    free(e->app_dir);
+    free(e);
+}
+
+/* ── Policy ────────────────────────────────────────────────────────── */
+
+static int embed_add_path(char **list, int *count, const char *rel_path)
+{
+    if (*count >= HL_MANIFEST_MAX_PATHS) return -1;
+    char *dup = strdup(rel_path);
+    if (!dup) return -1;
+    list[*count] = dup;
+    (*count)++;
+    return 0;
+}
+
+int hl_embed_allow_read(HlEmbed *e, const char *rel_path)
+{
+    if (!e || !rel_path || e->state != HL_EMBED_NEW) return -1;
+    return embed_add_path(e->reads, &e->nreads, rel_path);
+}
+
+int hl_embed_allow_write(HlEmbed *e, const char *rel_path)
+{
+    if (!e || !rel_path || e->state != HL_EMBED_NEW) return -1;
+    return embed_add_path(e->writes, &e->nwrites, rel_path);
+}
+
+void hl_embed_allow_network(HlEmbed *e, int inbound, int outbound)
+{
+    if (!e || e->state != HL_EMBED_NEW) return;
+    e->net_inbound  = inbound ? 1 : 0;
+    e->net_outbound = outbound ? 1 : 0;
+}
+
+void hl_embed_allow_gpu(HlEmbed *e, int enabled)
+{
+    if (!e || e->state != HL_EMBED_NEW) return;
+    e->gpu = enabled ? 1 : 0;
+}
+
+void hl_embed_allow_tui(HlEmbed *e, int enabled)
+{
+    if (!e || e->state != HL_EMBED_NEW) return;
+    e->tui = enabled ? 1 : 0;
+}
+
+/* ── Lifecycle ─────────────────────────────────────────────────────── */
+
+int hl_embed_sandbox_phase1(HlEmbed *e)
+{
+    if (!e) return -1;
+    return hl_sandbox_apply_pledge();
+}
+
+int hl_embed_seal(HlEmbed *e, const char *db_path)
+{
+    if (!e || e->state == HL_EMBED_SEALED) return -1;
+
+    HlSandboxPolicy policy;
+    memset(&policy, 0, sizeof(policy));
+    policy.fs_read         = (const char *const *)e->reads;
+    policy.fs_read_count   = e->nreads;
+    policy.fs_write        = (const char *const *)e->writes;
+    policy.fs_write_count  = e->nwrites;
+    policy.network_inbound  = e->net_inbound;
+    policy.network_outbound = e->net_outbound;
+    policy.gpu              = e->gpu;
+    policy.tui              = e->tui;
+    policy.wx_enforced      = 1;   /* no runtime dynamic code */
+    /* allow_dynamic_code / allow_dynamic_libraries stay 0 (zeroed above). */
+
+    int rc = hl_sandbox_apply(&policy, e->app_dir, db_path, NULL, NULL, NULL);
+    if (rc != 0) return -1;        /* fail closed: leave state NEW */
+
+    e->state = HL_EMBED_SEALED;
+    return 0;
+}
+
+/* ── Capabilities ──────────────────────────────────────────────────── */
+
+static int embed_sealed(const HlEmbed *e, const char **err)
+{
+    if (e && e->state == HL_EMBED_SEALED) return 1;
+    if (err) *err = "hl_embed: capabilities unavailable before hl_embed_seal()";
+    return 0;
+}
+
+int64_t hl_embed_fs_read(HlEmbed *e, const char *path,
+                         char *buf, size_t buf_size, const char **err)
+{
+    if (!embed_sealed(e, err)) return -1;
+    return hl_cap_fs_read(&e->fs, path, buf, buf_size, err);
+}
+
+int hl_embed_fs_write(HlEmbed *e, const char *path,
+                      const void *data, size_t len, const char **err)
+{
+    if (!embed_sealed(e, err)) return -1;
+    return hl_cap_fs_write(&e->fs, path, (const char *)data, len, err);
+}
+
+int hl_embed_fs_exists(HlEmbed *e, const char *path, const char **err)
+{
+    if (!embed_sealed(e, err)) return -1;
+    return hl_cap_fs_exists(&e->fs, path, err);
+}
+
+int hl_embed_fs_delete(HlEmbed *e, const char *path, const char **err)
+{
+    if (!embed_sealed(e, err)) return -1;
+    return hl_cap_fs_delete(&e->fs, path, err);
+}
+
+int hl_embed_sha256(const void *data, size_t len, uint8_t out[32])
+{
+    return hl_cap_crypto_sha256(data, len, out);
+}
+
+/* ── Identity ──────────────────────────────────────────────────────── */
+
+const char *hl_embed_platform(void)
+{
+    return hl_release_io_platform();
+}
+
+size_t hl_embed_module_count(void)
+{
+    return hl_module_registry_count();
+}

--- a/tests/hull/test_embed.c
+++ b/tests/hull/test_embed.c
@@ -1,0 +1,131 @@
+/*
+ * test_embed.c — unit tests for the libhull embedding ABI (hull/embed.h).
+ *
+ * Covers the surface that is safe to exercise inside the shared test
+ * runner: version, handle construction, policy limits, the fail-closed
+ * guard, stateless crypto, identity, and NULL-safety.
+ *
+ * The SEALED path (hl_embed_sandbox_phase1 / hl_embed_seal) is
+ * deliberately NOT tested here — hl_embed_seal applies a real, on macOS
+ * irreversible, kernel sandbox to the calling process, which would
+ * restrict the rest of the runner. That path is covered end-to-end by
+ * the standalone `make embed-c-smoke` host (examples/embed_c), which runs
+ * as its own process.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "utest.h"
+#include "hull/embed.h"
+
+#include <string.h>
+#include <stdint.h>
+
+UTEST(embed, abi_version)
+{
+    ASSERT_EQ(hl_embed_abi_version(), HL_EMBED_ABI_VERSION);
+    ASSERT_EQ(HL_EMBED_ABI_VERSION, 1);
+}
+
+UTEST(embed, new_rejects_bad_args)
+{
+    ASSERT_TRUE(hl_embed_new(NULL) == NULL);
+    ASSERT_TRUE(hl_embed_new("relative/path") == NULL);  /* not absolute */
+    ASSERT_TRUE(hl_embed_new("") == NULL);
+
+    HlEmbed *e = hl_embed_new("/tmp");
+    ASSERT_TRUE(e != NULL);
+    hl_embed_free(e);
+    hl_embed_free(NULL);  /* NULL-safe */
+}
+
+UTEST(embed, allow_path_limits)
+{
+    HlEmbed *e = hl_embed_new("/tmp");
+    ASSERT_TRUE(e != NULL);
+
+    /* 32 entries accepted, 33rd rejected (HL_MANIFEST_MAX_PATHS). */
+    for (int i = 0; i < 32; i++)
+        ASSERT_EQ(hl_embed_allow_read(e, "data"), 0);
+    ASSERT_EQ(hl_embed_allow_read(e, "data"), -1);
+
+    for (int i = 0; i < 32; i++)
+        ASSERT_EQ(hl_embed_allow_write(e, "out"), 0);
+    ASSERT_EQ(hl_embed_allow_write(e, "out"), -1);
+
+    /* NULL args rejected without crashing. */
+    ASSERT_EQ(hl_embed_allow_read(e, NULL), -1);
+    ASSERT_EQ(hl_embed_allow_write(e, NULL), -1);
+    ASSERT_EQ(hl_embed_allow_read(NULL, "x"), -1);
+
+    hl_embed_free(e);
+}
+
+UTEST(embed, fail_closed_before_seal)
+{
+    HlEmbed *e = hl_embed_new("/tmp");
+    ASSERT_TRUE(e != NULL);
+
+    char buf[16];
+    const char *err;
+
+    err = NULL;
+    ASSERT_EQ(hl_embed_fs_exists(e, "x", &err), -1);
+    ASSERT_TRUE(err != NULL);
+
+    err = NULL;
+    ASSERT_EQ(hl_embed_fs_write(e, "x", "y", 1, &err), -1);
+    ASSERT_TRUE(err != NULL);
+
+    err = NULL;
+    ASSERT_EQ(hl_embed_fs_read(e, "x", buf, sizeof(buf), &err), -1);
+    ASSERT_TRUE(err != NULL);
+
+    err = NULL;
+    ASSERT_EQ(hl_embed_fs_delete(e, "x", &err), -1);
+    ASSERT_TRUE(err != NULL);
+
+    hl_embed_free(e);
+}
+
+UTEST(embed, null_safety)
+{
+    char buf[16];
+    const char *err = NULL;
+
+    ASSERT_EQ(hl_embed_seal(NULL, NULL), -1);
+    ASSERT_EQ(hl_embed_sandbox_phase1(NULL), -1);
+    ASSERT_EQ(hl_embed_fs_read(NULL, "x", buf, sizeof(buf), &err), -1);
+    ASSERT_EQ(hl_embed_fs_write(NULL, "x", "y", 1, &err), -1);
+    ASSERT_EQ(hl_embed_fs_exists(NULL, "x", &err), -1);
+    ASSERT_EQ(hl_embed_fs_delete(NULL, "x", &err), -1);
+
+    /* void setters must be NULL-safe (no crash, no effect). */
+    hl_embed_allow_network(NULL, 1, 1);
+    hl_embed_allow_gpu(NULL, 1);
+    hl_embed_allow_tui(NULL, 1);
+}
+
+UTEST(embed, sha256_known_vector)
+{
+    /* SHA-256("abc") per FIPS 180-4. */
+    static const uint8_t expect[32] = {
+        0xba,0x78,0x16,0xbf,0x8f,0x01,0xcf,0xea,
+        0x41,0x41,0x40,0xde,0x5d,0xae,0x22,0x23,
+        0xb0,0x03,0x61,0xa3,0x96,0x17,0x7a,0x9c,
+        0xb4,0x10,0xff,0x61,0xf2,0x00,0x15,0xad,
+    };
+    uint8_t out[32];
+    ASSERT_EQ(hl_embed_sha256("abc", 3, out), 0);
+    ASSERT_EQ(memcmp(out, expect, 32), 0);
+}
+
+UTEST(embed, identity)
+{
+    const char *plat = hl_embed_platform();
+    ASSERT_TRUE(plat != NULL);
+    ASSERT_TRUE(plat[0] != '\0');
+    ASSERT_TRUE(hl_embed_module_count() > 0);
+}
+
+UTEST_MAIN();


### PR DESCRIPTION
**Stacked on #43 (L-1)** — base is `feat/libhull-l1`; GitHub retargets to `main` once L-1 merges.

Second phase of the **libhull** flavor. L-1 shipped the runtime-free archive (`libhull.a`) but the reference host called internal functions (`hl_sandbox_*`, `hl_cap_*`) directly. Those headers are not stable across releases. L-2 adds a versioned ABI so embedders target a small, stable surface instead.

## What's here

- **`include/hull/embed.h`** — the only header a native host needs. Opaque `HlEmbed` handle, `hl_embed_abi_version()` for version negotiation, `hl_embed_allow_*` policy builders, the `hl_embed_sandbox_phase1` / `hl_embed_seal` lifecycle, and `hl_embed_fs_*` / `hl_embed_sha256` / `hl_embed_platform` / `hl_embed_module_count` capabilities. Depends only on `<stddef.h>` / `<stdint.h>` — no `HlManifest`, `HlSandboxPolicy`, or `HlFsConfig` crosses the boundary.
- **`src/hull/embed.c`** — thin wrapper over `hl_sandbox_*` / `hl_cap_*`, added to `LIBHULL_OBJS`. **Fail-closed by construction:** the fs capability calls return `-1` until `hl_embed_seal()` has successfully applied the kernel sandbox, and a non-zero seal is documented as fatal for the host.
- **`examples/embed_c`** converted to consume the ABI as the reference host (drops all direct internal calls); README rewritten. Host include line is now just `-Iinclude`.
- **`tests/hull/test_embed.c`** — unit coverage for version, handle construction, the 32-path policy limit, the fail-closed guard, known-vector crypto, identity, and NULL-safety. It links `libhull.a` directly, so `make test` now link-tests the archive on every run. The **sealed** path stays with `embed-c-smoke` — `hl_embed_seal` applies a real (on macOS irreversible) sandbox that must not run inside the shared test runner.

## Validation (macOS arm64)

- `make embed-c-smoke` — 12/12 via the ABI (incl. the fail-closed-before-seal assertion).
- `make test` — 51 binaries green (`test_embed` 7/7), 0 failures.
- `make` — hull builds clean.
- `embed.h` includes only `<stddef.h>` / `<stdint.h>` (verified).

## Next

L-3: seal the C-built policy through `hl_seal_arena` + strict fail-closed state assertions + a fork/SIGSEGV death test for the sealed transition + trust-boundary docs. L-4: sign/SBOM. L-5: `docs/libhull_flavor.md` + a non-C reference embedder.