### PR TITLE
feat(libhull): seal per-call base_dir + fail-closed lifecycle (L-3)

### DIFF
--- a/docs/build_flavors.md
+++ b/docs/build_flavors.md
@@ -274,6 +274,12 @@ smaller, produced by an unchanged full `hull`.
 
 ## 8. Related direction: a no-runtime embedding flavor (`libhull`)
 
+> **Now partly shipped.** The `hl_embed_*` ABI, the `libhull.a` archive,
+> and the sealed fail-closed lifecycle described below have landed (phases
+> L-1..L-3). See **[libhull_flavor.md](libhull_flavor.md)** for the trust
+> boundary and seal lifecycle. The rest of this section is the original
+> design rationale.
+
 A separate idea surfaced alongside this: a flavor with **`HL_ENABLE_LUA=0`
 AND `HL_ENABLE_JS=0`** (no scripting runtime at all), exposing just the
 kernel sandbox (pledge/unveil/seatbelt) + the capability layer so an

--- a/docs/libhull_flavor.md
+++ b/docs/libhull_flavor.md
@@ -1,0 +1,143 @@
+# libhull: the no-runtime embedding flavor
+
+`libhull` packages Hull's hardened core as a static archive
+(`build/libhull.a`) that a native program (C / Rust / Zig) links directly.
+There is no Lua or QuickJS runtime and no `app.main` lifecycle: the host
+owns `main()` and drives the two-phase kernel sandbox and the capability
+layer itself, through the stable ABI in
+[`include/hull/embed.h`](../include/hull/embed.h).
+
+It generalizes Hull's hardening beyond the script-app model — Hull as an
+SDK, not only Hull as a runtime. This document covers the **trust
+boundary** and the **seal lifecycle**, which are the security-relevant
+parts an embedder must understand. For the build/flavor context see
+[build_flavors.md §8](build_flavors.md); for the sealed-memory mechanism
+see [security.md §4b](security.md).
+
+Status: L-1 (archive + sandbox split), L-2 (`hl_embed_*` ABI), and L-3
+(policy sealing + fail-closed ordering + death test) have landed. L-4
+(sign/SBOM for the archive) and L-5 (a non-C reference embedder) are
+pending.
+
+## Building
+
+```sh
+make libhull            # -> build/libhull.a  (runtime-free core)
+make embed-c-smoke      # links examples/embed_c against it and runs it
+```
+
+A host links only the archive, Keel, and libm/pthread; the sole Hull
+include is the ABI header. `build/libhull.a` is listed twice because it and
+Keel are mutually dependent (libhull's cap layer calls Keel's TLS, which
+calls libhull's mbedTLS), and GNU ld resolves static archives strictly
+left-to-right; macOS's linker resolves the cycle on its own:
+
+```sh
+cc -std=c11 -Iinclude \
+   -o my_host my_host.c build/libhull.a vendor/keel/libkeel.a build/libhull.a -lm -lpthread
+```
+
+## The trust boundary
+
+The embedding contract is deliberately **weaker** than "Hull owns
+`main`". Be explicit about which side of the line each responsibility
+sits on.
+
+### The host is trusted to
+
+- **Sequence the lifecycle correctly.** Call `hl_embed_sandbox_phase1()`
+  early (before touching untrusted input), build the policy with the
+  `hl_embed_allow_*` calls, then `hl_embed_seal()` before any capability
+  use. Hull provides the primitives; the host orders them.
+- **Declare an honest policy.** There is no `app.manifest()` to parse — a
+  native host is trusted and states its filesystem / network / GPU / TUI
+  policy directly in C. A policy that grants more than the app needs
+  widens the sandbox; that is the host's call, exactly as a manifest would
+  be.
+- **Treat a failed seal as fatal.** `hl_embed_seal()` returns non-zero if
+  either the RO policy seal or the kernel sandbox could not be applied.
+  The host **must** abort rather than proceed — running capabilities
+  without the kernel boundary is the one outcome the design forbids.
+
+### libhull enforces (regardless of host bugs)
+
+- **The capability boundary.** `hl_embed_fs_*` validates every path
+  (traversal / symlink-escape rejection) against the sealed base
+  directory, and `hl_embed_fs_*` refuses to run at all until the handle is
+  sealed. Crypto goes through the same cap layer.
+- **The kernel sandbox.** After `hl_embed_seal()`, pledge/unveil (Linux /
+  Cosmo) or Seatbelt (macOS) is in force: default-deny filesystem, network
+  only if declared, `exec`/`fork` blocked.
+- **W^X.** The seal sets `wx_enforced` and declares no dynamic code — no
+  guest-controlled memory is ever executable.
+- **Read-only security policy.** The one datum the capability layer reads
+  on every call — the filesystem base directory — is sealed into a
+  page-backed read-only mapping (see below), so an arbitrary-write
+  primitive cannot repoint the app's filesystem root after seal.
+
+Everything the host can reach through the ABI is mediated. What the host
+does with its *own* code (before seal, or outside the cap layer) is
+outside Hull's enforcement — the same as any library.
+
+## The seal lifecycle (fail-closed)
+
+```
+hl_embed_new(app_dir)         state = NEW    caps refuse (return -1)
+  hl_embed_sandbox_phase1()   pledge; exec/fork blocked during setup
+  hl_embed_allow_read/write() accumulate policy (rejected once sealed)
+  hl_embed_allow_network/gpu/tui()
+hl_embed_seal(db_path):
+  1. seal base_dir into a read-only sh_seal_arena   ── fail -> return -1
+  2. build the resolved HlSandboxPolicy
+  3. hl_sandbox_apply(...) (default-deny kernel)    ── fail -> return -1
+  4. free every writable alias of the policy
+  state = SEALED                                     caps live
+hl_embed_free(e)              heap freed first, RO arena destroyed LAST
+```
+
+Two properties make this fail-closed:
+
+1. **Capabilities gate on `SEALED`.** Every `hl_embed_fs_*` call checks the
+   state first and returns `-1` with a message before seal. A host that
+   forgets to seal gets no filesystem access, not unmediated access.
+2. **`SEALED` is set only after both seals succeed.** The base_dir RO seal
+   runs *before* the (on macOS irreversible) kernel sandbox, so a seal
+   failure aborts before anything irreversible; and if the kernel sandbox
+   fails, the state stays `NEW` and capabilities remain closed. There is
+   no window where the handle reports sealed while enforcement is missing.
+
+### Why base_dir specifically is sealed
+
+The resolved policy's path allowlists are read exactly once — by
+`hl_sandbox_apply` at seal time — and never again, so their post-seal
+mutability does not affect enforcement (and libhull frees those heap
+copies right after applying the sandbox). The **base directory** is
+different: `hl_cap_fs_*` reads `HlFsConfig.base_dir` on *every* call to
+resolve and bounds-check paths. Per the c-audit §5b rule for boot-built,
+per-call-read, security-influencing state, it is copied into an
+`sh_seal_arena` (RW mmap → `mprotect` RO) during seal, and the writable
+heap copy is freed. After seal there is no writable alias of the app's
+filesystem root anywhere in the process.
+
+This is verified by a fork+SIGSEGV death test
+(`tests/hull/test_embed.c::embed.sealed_base_dir_is_readonly`): a child
+seals, then writes to the base_dir mapping and must die with SIGSEGV /
+SIGBUS. Without a real RO mapping the write would silently succeed and the
+test would fail.
+
+## Testing
+
+| Surface | Where |
+|---|---|
+| ABI guards, policy limits, fail-closed-before-seal, crypto, identity, NULL-safety | `tests/hull/test_embed.c` (`make test`) |
+| Sealed base_dir is read-only (fork+SIGSEGV) | `tests/hull/test_embed.c` (`make test`) |
+| Full sealed integration (sandbox + cap fs I/O + traversal) | `examples/embed_c` (`make embed-c-smoke`) |
+| The underlying RO-arena mechanism | `tests/hull/test_seal_arena.c` |
+
+## Reference host
+
+[`examples/embed_c`](../examples/embed_c/) is the canonical consumer. It
+includes only `<hull/embed.h>`, builds a policy in C, seals, and drives
+capability-mediated filesystem I/O, crypto, and identity — exiting
+non-zero on any failure. It is the L-2/L-3 link witness: a runtime
+dependency leaking into the core would fail its link.

--- a/examples/embed_c/README.md
+++ b/examples/embed_c/README.md
@@ -81,6 +81,10 @@ Unit tests for the guard / limit / identity surface live in
 `tests/hull/test_embed.c` (run by `make test`); the sealed integration
 path is this example, run by `make embed-c-smoke`.
 
+For the trust boundary between the host and libhull, and how the seal
+lifecycle stays fail-closed, see
+[docs/libhull_flavor.md](../../docs/libhull_flavor.md).
+
 ## What is NOT in libhull
 
 The archive deliberately excludes `main`/`serve`/`entry`, the CLI command

--- a/include/hull/embed_internal.h
+++ b/include/hull/embed_internal.h
@@ -1,0 +1,35 @@
+/*
+ * embed_internal.h — internal accessors for the embedding ABI.
+ *
+ * NOT part of the stable ABI (hull/embed.h). These exist only so Hull's
+ * own tests can inspect an HlEmbed handle — in particular so the
+ * fork+SIGSEGV death test can reach the sealed base_dir mapping and prove
+ * it is read-only. External embedders must not rely on these symbols.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef HL_EMBED_INTERNAL_H
+#define HL_EMBED_INTERNAL_H
+
+#include "hull/embed.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Effective filesystem base directory the handle resolves against. After
+ * a successful hl_embed_seal() this points into the read-only sealed
+ * arena; before seal it is the heap copy. NULL if @p e is NULL.
+ */
+const char *hl_embed_base_dir(const HlEmbed *e);
+
+/* 1 if the handle has been successfully sealed, else 0. */
+int hl_embed_is_sealed(const HlEmbed *e);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HL_EMBED_INTERNAL_H */

--- a/src/hull/embed.c
+++ b/src/hull/embed.c
@@ -1,16 +1,25 @@
 /*
  * embed.c — implementation of the libhull embedding ABI (embed.h).
  *
- * Thin, allocation-light wrapper over the internal sandbox + capability
- * layer. The opaque HlEmbed handle accumulates a C-built policy, then
- * hl_embed_seal() resolves it into an HlSandboxPolicy and applies the
- * kernel sandbox. The filesystem capability calls fail closed until that
- * seal has succeeded.
+ * Thin wrapper over the internal sandbox + capability layer. The opaque
+ * HlEmbed handle accumulates a C-built policy; hl_embed_seal() resolves
+ * it into an HlSandboxPolicy, applies the kernel sandbox, and seals the
+ * one datum the capability layer reads on every call — the filesystem
+ * base directory (HlFsConfig.base_dir) — into a page-backed read-only
+ * arena (sh_seal_arena). After a successful seal there is no writable
+ * alias of that path left in the process, so an arbitrary-write primitive
+ * cannot repoint the app's filesystem root. See docs/security.md §4b and
+ * the c-audit §5b sealed-runtime-table rules.
+ *
+ * Fail-closed: the fs capability calls refuse to run until the handle is
+ * SEALED, and hl_embed_seal marks SEALED only after BOTH the arena seal
+ * and the kernel sandbox have succeeded.
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 #include "hull/embed.h"
+#include "hull/embed_internal.h"
 
 #include "hull/sandbox.h"
 #include "hull/manifest.h"
@@ -19,16 +28,21 @@
 #include "hull/module_registry.h"
 #include "hull/release_io.h"
 
+#include <sh_seal_arena.h>
+
 #include <stdlib.h>
 #include <string.h>
 
 enum { HL_EMBED_NEW = 0, HL_EMBED_SEALED = 1 };
 
-struct HlEmbed {
-    char       *app_dir;                          /* absolute, owned */
-    HlFsConfig  fs;                               /* base_dir aliases app_dir */
+/* One page is ample for a single base_dir path plus alignment slack. */
+#define HL_EMBED_ARENA_SIZE 8192
 
-    char       *reads[HL_MANIFEST_MAX_PATHS];     /* owned dups */
+struct HlEmbed {
+    char       *app_dir;                          /* owned pre-seal; NULLed after seal */
+    HlFsConfig  fs;                               /* base_dir: app_dir pre-seal, sealed copy post-seal */
+
+    char       *reads[HL_MANIFEST_MAX_PATHS];     /* owned dups; freed at seal or free */
     int         nreads;
     char       *writes[HL_MANIFEST_MAX_PATHS];    /* owned dups */
     int         nwrites;
@@ -38,6 +52,8 @@ struct HlEmbed {
     int         gpu;
     int         tui;
 
+    ShSealArena arena;                            /* holds the sealed base_dir */
+    int         arena_ready;                      /* 1 once arena is initialised */
     int         state;                            /* HL_EMBED_NEW / _SEALED */
 };
 
@@ -66,12 +82,24 @@ HlEmbed *hl_embed_new(const char *app_dir)
     return e;
 }
 
+static void embed_free_heap_policy(HlEmbed *e)
+{
+    for (int i = 0; i < e->nreads; i++)  { free(e->reads[i]);  e->reads[i]  = NULL; }
+    for (int i = 0; i < e->nwrites; i++) { free(e->writes[i]); e->writes[i] = NULL; }
+    e->nreads = 0;
+    e->nwrites = 0;
+    free(e->app_dir);
+    e->app_dir = NULL;
+}
+
 void hl_embed_free(HlEmbed *e)
 {
     if (!e) return;
-    for (int i = 0; i < e->nreads; i++) free(e->reads[i]);
-    for (int i = 0; i < e->nwrites; i++) free(e->writes[i]);
-    free(e->app_dir);
+    /* Free heap-owned policy strings first, then destroy the sealed arena
+     * LAST — fs.base_dir may alias into it (c-audit §5b: arena destroyed
+     * after every consumer). No capability call can run during teardown. */
+    embed_free_heap_policy(e);
+    if (e->arena_ready) sh_seal_arena_destroy(&e->arena);
     free(e);
 }
 
@@ -126,16 +154,49 @@ int hl_embed_sandbox_phase1(HlEmbed *e)
     return hl_sandbox_apply_pledge();
 }
 
+/*
+ * Seal the per-call base_dir into the read-only arena. On success sets
+ * e->fs.base_dir to the in-arena (RO) copy and returns 0. On any failure
+ * the arena is torn down and e->fs.base_dir is left pointing at the
+ * original heap copy (harmless — the caller aborts the seal). Must run
+ * BEFORE hl_sandbox_apply so a seal failure aborts before the (on macOS
+ * irreversible) kernel sandbox is applied.
+ */
+static int embed_seal_base_dir(HlEmbed *e)
+{
+    if (sh_seal_arena_init(&e->arena, HL_EMBED_ARENA_SIZE, "hl_embed") != 0)
+        return -1;
+    char *sealed = sh_seal_arena_strdup(&e->arena, e->app_dir);
+    if (!sealed) {
+        sh_seal_arena_destroy(&e->arena);
+        return -1;
+    }
+    if (sh_seal_arena_seal(&e->arena) != 0) {  /* fail closed on seal error */
+        sh_seal_arena_destroy(&e->arena);
+        return -1;
+    }
+    e->arena_ready = 1;
+    e->fs.base_dir = sealed;         /* now points into the RO mapping */
+    e->fs.base_len = strlen(sealed);
+    return 0;
+}
+
 int hl_embed_seal(HlEmbed *e, const char *db_path)
 {
     if (!e || e->state == HL_EMBED_SEALED) return -1;
 
+    /* 1. Seal the per-call base_dir first (nothing irreversible yet). */
+    if (embed_seal_base_dir(e) != 0) return -1;
+
+    /* 2. Build the resolved policy. Path arrays are read once by
+     *    hl_sandbox_apply and never again, so they may stay on the heap;
+     *    base_dir (read every cap call) is already the sealed copy. */
     HlSandboxPolicy policy;
     memset(&policy, 0, sizeof(policy));
-    policy.fs_read         = (const char *const *)e->reads;
-    policy.fs_read_count   = e->nreads;
-    policy.fs_write        = (const char *const *)e->writes;
-    policy.fs_write_count  = e->nwrites;
+    policy.fs_read          = (const char *const *)e->reads;
+    policy.fs_read_count    = e->nreads;
+    policy.fs_write         = (const char *const *)e->writes;
+    policy.fs_write_count   = e->nwrites;
     policy.network_inbound  = e->net_inbound;
     policy.network_outbound = e->net_outbound;
     policy.gpu              = e->gpu;
@@ -143,8 +204,14 @@ int hl_embed_seal(HlEmbed *e, const char *db_path)
     policy.wx_enforced      = 1;   /* no runtime dynamic code */
     /* allow_dynamic_code / allow_dynamic_libraries stay 0 (zeroed above). */
 
-    int rc = hl_sandbox_apply(&policy, e->app_dir, db_path, NULL, NULL, NULL);
+    /* 3. Apply the kernel sandbox against the sealed base_dir. */
+    int rc = hl_sandbox_apply(&policy, e->fs.base_dir, db_path,
+                              NULL, NULL, NULL);
     if (rc != 0) return -1;        /* fail closed: leave state NEW */
+
+    /* 4. Success. Drop every writable alias of the policy — the sealed
+     *    base_dir is the only path the cap layer will read from here on. */
+    embed_free_heap_policy(e);
 
     e->state = HL_EMBED_SEALED;
     return 0;
@@ -200,4 +267,16 @@ const char *hl_embed_platform(void)
 size_t hl_embed_module_count(void)
 {
     return hl_module_registry_count();
+}
+
+/* ── Internal test accessors (embed_internal.h — NOT the stable ABI) ── */
+
+const char *hl_embed_base_dir(const HlEmbed *e)
+{
+    return e ? e->fs.base_dir : NULL;
+}
+
+int hl_embed_is_sealed(const HlEmbed *e)
+{
+    return (e && e->state == HL_EMBED_SEALED) ? 1 : 0;
 }

--- a/tests/hull/test_embed.c
+++ b/tests/hull/test_embed.c
@@ -17,9 +17,13 @@
 
 #include "utest.h"
 #include "hull/embed.h"
+#include "hull/embed_internal.h"
 
 #include <string.h>
 #include <stdint.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/wait.h>
 
 UTEST(embed, abi_version)
 {
@@ -126,6 +130,59 @@ UTEST(embed, identity)
     ASSERT_TRUE(plat != NULL);
     ASSERT_TRUE(plat[0] != '\0');
     ASSERT_TRUE(hl_embed_module_count() > 0);
+}
+
+/*
+ * Death test: after hl_embed_seal(), the base_dir the capability layer
+ * reads on every call must live in a read-only mapping. Fork a child,
+ * seal, then write to that mapping — the child MUST die with SIGSEGV /
+ * SIGBUS. Runs in a child because hl_embed_seal also applies the (on
+ * macOS irreversible) kernel sandbox to the calling process.
+ *
+ * Child exit codes: 42 = sandbox unavailable in this environment (soft
+ * skip), 43 = sealed-flag wrong, 44 = base_dir NULL, 0 = write did NOT
+ * fault (which is a failure — the page was writable).
+ */
+UTEST(embed, sealed_base_dir_is_readonly)
+{
+    pid_t pid = fork();
+    ASSERT_TRUE(pid >= 0);
+
+    if (pid == 0) {
+        HlEmbed *e = hl_embed_new("/tmp");
+        if (!e) _exit(44);
+        if (hl_embed_is_sealed(e) != 0) _exit(43);
+        hl_embed_allow_read(e, ".");
+        if (hl_embed_seal(e, NULL) != 0) _exit(42);   /* no kernel sandbox here */
+        if (hl_embed_is_sealed(e) != 1) _exit(43);
+
+        const char *bd = hl_embed_base_dir(e);
+        if (!bd) _exit(44);
+
+        /* Restore default fault handlers so the fault terminates the child
+         * (WIFSIGNALED) instead of being caught by a sanitizer handler that
+         * prints and _exit(1)s — same rationale as test_seal_arena. */
+        signal(SIGSEGV, SIG_DFL);
+        signal(SIGBUS,  SIG_DFL);
+
+        /* Deliberately cast away const to prove the mapping is RO. */
+        char *w = (char *)(uintptr_t)bd;
+        w[0] = 'Z';           /* expected: SIGSEGV / SIGBUS */
+        _exit(0);             /* reached only if the page was writable */
+    }
+
+    int status = 0;
+    ASSERT_EQ(waitpid(pid, &status, 0), pid);
+
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 42) {
+        /* Kernel sandbox couldn't be applied (restricted CI sandbox);
+         * the RO-arena guarantee is still covered by test_seal_arena. */
+        UTEST_SKIP("kernel sandbox unavailable in this environment");
+    }
+
+    ASSERT_TRUE(WIFSIGNALED(status));
+    int sig = WTERMSIG(status);
+    ASSERT_TRUE(sig == SIGSEGV || sig == SIGBUS);
 }
 
 UTEST_MAIN();


### PR DESCRIPTION
**Stacked on #44 (L-2)** — base is `feat/libhull-l2`; GitHub retargets down the stack as the earlier PRs merge.

Third phase of the **libhull** flavor. L-2 gave embedders a versioned ABI; L-3 hardens its trust boundary so a bug or an arbitrary-write primitive in the host can't defeat the capability layer after seal.

## The hardening

`hl_cap_fs_*` reads `HlFsConfig.base_dir` — the app's filesystem root — on **every** call to resolve and bounds-check paths. Per the c-audit §5b rule for boot-built, per-call-read, security-influencing state (the same pattern `HlManifest` already uses), `hl_embed_seal()` now:

1. Seals `base_dir` into a page-backed **read-only** `sh_seal_arena` (RW mmap → `mprotect` RO) — **before** the on-macOS-irreversible kernel sandbox, so a seal failure aborts before anything irreversible.
2. Applies the kernel sandbox against the sealed path.
3. Frees **every writable heap alias** of the policy (the base_dir copy and the path arrays, which the sandbox has already consumed).
4. Marks the handle `SEALED` **only after both seals succeed** — any failure returns `-1` with state left `NEW`, so `hl_embed_fs_*` stays fail-closed.

`hl_embed_free` destroys the arena **last** (after the heap policy), since `base_dir` aliases into it. After a successful seal there is no writable copy of the filesystem root anywhere in the process.

## What's here

- **`src/hull/embed.c`** — the sealed-arena lifecycle above.
- **`include/hull/embed_internal.h`** — non-ABI accessors (`hl_embed_base_dir` / `hl_embed_is_sealed`) so tests can inspect a handle. Not part of the stable ABI.
- **`tests/hull/test_embed.c`** — a fork+SIGSEGV **death test**: a child seals, then writes to the `base_dir` mapping and must die with SIGSEGV/SIGBUS (resets `SIGSEGV`/`SIGBUS` to `SIG_DFL` so sanitizer handlers don't mask the fault, mirroring `test_seal_arena`). Soft-skips if the kernel sandbox is unavailable in the environment.
- **`docs/libhull_flavor.md`** — new trust-boundary + seal-lifecycle doc: *host is trusted to* vs *libhull enforces*, the fail-closed ordering, and why `base_dir` specifically is sealed. Cross-linked from `build_flavors.md §8`.

## Validation (macOS arm64)

- `make test` — 51 binaries green, `test_embed` **8/8** including `sealed_base_dir_is_readonly` (the death test).
- `make embed-c-smoke` — 12/12 (sealing is transparent to the host).
- `make` — hull builds clean.

## Next

L-4: sign + SBOM the `libhull.a` artifact. L-5: a non-C reference embedder (Rust/Zig) + finalize `docs/libhull_flavor.md`.