### PR TITLE
feat(libhull): sign + SBOM the archive, dual-arch cosmo (L-4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,6 +401,23 @@ jobs:
           name: hull-cosmo
           path: hull-cosmo
 
+      # ── libhull: dual-arch cosmo embedding archive ──
+      # Under the fat cosmocc driver, `make libhull` emits build/libhull.a
+      # (x86_64) plus its build/.aarch64/libhull.a sibling. Publish them
+      # arch-qualified, mirroring libhull_platform.{x86_64,aarch64}-cosmo.a.
+      - name: Build + rename cosmo libhull.a (dual-arch)
+        run: |
+          make libhull CC=cosmocc
+          cp build/libhull.a          libhull.x86_64-cosmo.a
+          cp build/.aarch64/libhull.a libhull.aarch64-cosmo.a
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: libhull-cosmo
+          path: |
+            libhull.x86_64-cosmo.a
+            libhull.aarch64-cosmo.a
+
   build-native:
     name: Build (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
@@ -553,6 +570,20 @@ jobs:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
 
+      # ── libhull: the no-runtime embedding archive for this arch ──
+      # Built from the same objects as the hull binary above; published so
+      # hl_embed_* native hosts can fetch + verify a known-good archive.
+      # Its SHA-256 goes into the release-signed hull.sha256 manifest.
+      - name: Build + rename libhull.a
+        run: |
+          make libhull
+          cp build/libhull.a libhull-${{ matrix.name }}.a
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: libhull-${{ matrix.name }}
+          path: libhull-${{ matrix.name }}.a
+
   build-wamrc:
     # Side-loaded `wamrc` (WAMR AOT compiler) shipped as a separate
     # release asset and pulled by `hull tools install wamrc`. See
@@ -656,6 +687,14 @@ jobs:
           mv artifacts/platform-cosmo-flavor-server-only/*.a   dist/
           mv artifacts/platform-cosmo-flavor-client-only/*.a   dist/
           mv artifacts/platform-cosmo-flavor-pure-compute/*.a  dist/
+          # libhull: the no-runtime embedding archive (libhull L-4). Native
+          # per-arch (libhull-<arch>.a) + dual-arch cosmo
+          # (libhull.{x86_64,aarch64}-cosmo.a). Added explicitly to the
+          # SHA-256 + publish steps below so they inherit the release signature.
+          mv artifacts/libhull-linux-x86_64/libhull-linux-x86_64.a    dist/
+          mv artifacts/libhull-linux-aarch64/libhull-linux-aarch64.a  dist/
+          mv artifacts/libhull-darwin-arm64/libhull-darwin-arm64.a    dist/
+          mv artifacts/libhull-cosmo/*.a                              dist/
 
       - name: Make binaries executable
         run: chmod +x dist/*
@@ -673,7 +712,12 @@ jobs:
           ./hull-linux-x86_64 sbom --format=json      > hull.sbom.json
           ./hull-linux-x86_64 sbom --format=cyclonedx > hull.sbom.cdx.json
           ./hull-linux-x86_64 sbom --format=spdx      > hull.sbom.spdx.json
-          ls -la hull.sbom.*
+          # libhull-scoped SBOM: describes the no-runtime embedding archive
+          # (drops the Lua/QuickJS runtimes). Same signature inheritance.
+          ./hull-linux-x86_64 sbom --subject=libhull --format=json      > libhull.sbom.json
+          ./hull-linux-x86_64 sbom --subject=libhull --format=cyclonedx > libhull.sbom.cdx.json
+          ./hull-linux-x86_64 sbom --subject=libhull --format=spdx      > libhull.sbom.spdx.json
+          ls -la hull.sbom.* libhull.sbom.*
 
       - name: Generate build-environment manifest
         # §0.3.14. Capture the release-workflow runner identity, commit,
@@ -719,8 +763,11 @@ jobs:
           sha256sum hull-cosmo hull-linux-x86_64 hull-linux-aarch64 hull-darwin-arm64 \
                     hull-wamrc-linux-x86_64 hull-wamrc-linux-aarch64 hull-wamrc-darwin-arm64 \
                     hull.sbom.json hull.sbom.cdx.json hull.sbom.spdx.json \
+                    libhull.sbom.json libhull.sbom.cdx.json libhull.sbom.spdx.json \
                     hull.build-env.json \
                     libhull_platform-*.a \
+                    libhull-linux-x86_64.a libhull-linux-aarch64.a libhull-darwin-arm64.a \
+                    libhull.x86_64-cosmo.a libhull.aarch64-cosmo.a \
                     > hull.sha256
           cat hull.sha256
 
@@ -820,6 +867,18 @@ jobs:
           # `hull platform install <flavor>` can fetch them. Covered by
           # hull.sha256 above, so they inherit the release signature.
           assets+=(dist/libhull_platform-*.a)
+          # libhull no-runtime embedding archives (native per-arch + dual-arch
+          # cosmo) and the libhull-scoped SBOMs. Also covered by hull.sha256.
+          assets+=(
+            dist/libhull-linux-x86_64.a
+            dist/libhull-linux-aarch64.a
+            dist/libhull-darwin-arm64.a
+            dist/libhull.x86_64-cosmo.a
+            dist/libhull.aarch64-cosmo.a
+            dist/libhull.sbom.json
+            dist/libhull.sbom.cdx.json
+            dist/libhull.sbom.spdx.json
+          )
           if [ -f dist/hull.sha256.sig ]; then
             assets+=(dist/hull.sha256.sig)
           fi

--- a/Makefile
+++ b/Makefile
@@ -2354,12 +2354,38 @@ LIBHULL_OBJS := $(EMBED_OBJ) $(CAP_OBJS) $(ALLOC_OBJ) $(ASYNC_OBJ) $(COMPRESS_OB
 	$(SQLITE_OBJ) $(LOG_OBJ) $(LOG_LOCK_OBJ) $(SH_ARENA_OBJ) $(SH_JSON_OBJ) \
 	$(TWEETNACL_OBJ) $(STB_OBJ) $(PLEDGE_OBJS)
 
+# Under the fat cosmocc driver, every object has a build/<dir>/.aarch64/<name>.o
+# sibling, and a linked archive must ship a concomitant build/.aarch64/libhull.a.
+# Mirror exactly how Keel builds .aarch64/libkeel.a: the per-object aarch64
+# siblings, archived with the single-arch cosmo ar for each arch (plain cosmoar
+# recurses into .aarch64/ and fails). `make CC=cosmocc` sets $(notdir CC)=cosmocc.
+ifeq ($(notdir $(CC)),cosmocc)
+  LIBHULL_COSMO_FAT  := 1
+  LIBHULL_OBJS_ARM64 := $(foreach o,$(LIBHULL_OBJS),$(dir $(o)).aarch64/$(notdir $(o)))
+endif
+
 .PHONY: libhull
-libhull: $(BUILDDIR)/libhull.a
+libhull: $(BUILDDIR)/libhull.a $(BUILDDIR)/libhull.a.sha256
 $(BUILDDIR)/libhull.a: $(LIBHULL_OBJS) | $(BUILDDIR)
 	@rm -f $@
+ifeq ($(LIBHULL_COSMO_FAT),1)
+	x86_64-unknown-cosmo-ar rcs $@ $(LIBHULL_OBJS)
+	@mkdir -p $(BUILDDIR)/.aarch64
+	@rm -f $(BUILDDIR)/.aarch64/libhull.a
+	aarch64-unknown-cosmo-ar rcs $(BUILDDIR)/.aarch64/libhull.a $(LIBHULL_OBJS_ARM64)
+	@echo "built $@ + .aarch64/libhull.a ($(words $(LIBHULL_OBJS)) objects, dual-arch)"
+else
 	$(AR) rcs $@ $(LIBHULL_OBJS)
 	@echo "built $@ ($(words $(LIBHULL_OBJS)) objects)"
+endif
+
+# Checksum sidecar: the raw SHA-256 of the archive, one hex line. This is the
+# value the signed release manifest (hull.sha256) carries for libhull.a, so a
+# consumer can verify a downloaded archive offline against the Ed25519-signed
+# manifest via hl_release_io_verify_local_asset.
+$(BUILDDIR)/libhull.a.sha256: $(BUILDDIR)/libhull.a
+	@$(SHA256CMD) $< | awk '{print $$1}' > $@
+	@echo "libhull.a sha256: $$(cat $@)"
 
 # embed-c-smoke: link the reference native host (examples/embed_c) against
 # libhull.a alone — no Lua/JS runtime linked — and run it. Proves the core
@@ -2757,16 +2783,6 @@ ifeq ($(HL_ENABLE_DB),0)
       %/test_db.c %/test_db_backend.c \
       %/test_js.c %/test_lua.c, \
       $(TEST_SRCS))
-endif
-
-# test_embed links the whole libhull.a archive the way a native host does.
-# Under cosmocc (fat APE) every archive needs a concomitant .aarch64/ sibling,
-# which the single-arch `make libhull` rule does not emit — a dual-arch cosmo
-# libhull.a is a later packaging concern (libhull L-4/L-5). Skip it under the
-# cosmo toolchain; the ABI stays covered by the Linux/macOS test_embed and the
-# standalone `make embed-c-smoke` host.
-ifneq ($(findstring cosmo,$(CC)),)
-  TEST_SRCS := $(filter-out %/test_embed.c,$(TEST_SRCS))
 endif
 
 # Flatten test paths to build/ binaries: tests/hull/cap/test_body.c → build/test_body

--- a/docs/libhull_flavor.md
+++ b/docs/libhull_flavor.md
@@ -15,16 +15,21 @@ parts an embedder must understand. For the build/flavor context see
 see [security.md §4b](security.md).
 
 Status: L-1 (archive + sandbox split), L-2 (`hl_embed_*` ABI), and L-3
-(policy sealing + fail-closed ordering + death test) have landed. L-4
-(sign/SBOM for the archive) and L-5 (a non-C reference embedder) are
-pending.
+(policy sealing + fail-closed ordering + death test) and L-4 (release
+signing + SBOM for the archive, incl. the dual-arch cosmo build) have
+landed. L-5 (a non-C reference embedder) is pending.
 
 ## Building
 
 ```sh
-make libhull            # -> build/libhull.a  (runtime-free core)
+make libhull            # -> build/libhull.a (+ .sha256 sidecar)
 make embed-c-smoke      # links examples/embed_c against it and runs it
 ```
+
+`make libhull` also writes `build/libhull.a.sha256` (the raw archive hash,
+one hex line). Under the fat cosmocc driver (`make libhull CC=cosmocc`) it
+additionally emits `build/.aarch64/libhull.a`, the concomitant sibling
+cosmocc requires to link a dual-arch APE.
 
 A host links only the archive, Keel, and libm/pthread; the sole Hull
 include is the ABI header. `build/libhull.a` is listed twice because it and
@@ -125,12 +130,49 @@ seals, then writes to the base_dir mapping and must die with SIGSEGV /
 SIGBUS. Without a real RO mapping the write would silently succeed and the
 test would fail.
 
+## Signing and verification
+
+Each release publishes `libhull.a` as signed artifacts, so an embedder can
+verify the exact archive it links:
+
+- **Native, per-arch:** `libhull-linux-x86_64.a`, `libhull-linux-aarch64.a`,
+  `libhull-darwin-arm64.a`.
+- **Cosmo, dual-arch:** `libhull.x86_64-cosmo.a`, `libhull.aarch64-cosmo.a`.
+
+Their SHA-256s are lines in the release `hull.sha256` manifest, which is
+signed with the Ed25519 **release** key (and Sigstore + SLSA), exactly like
+the `hull` binaries and the per-flavor platform libs. This is the same
+trust chain [`hull platform install`](build_flavors.md) uses. To verify a
+downloaded archive offline, cross-check its SHA-256 against the
+signature-verified manifest via `hl_release_io_verify_local_asset(dir,
+asset)` — it re-checks the manifest signature against the **embedded**
+release pubkey (the trust anchor baked into the binary), then matches the
+asset's hash to the signed manifest line. `make libhull` also drops a
+`build/libhull.a.sha256` sidecar for local checks.
+
+Note the asymmetry (same as `hull build --flavor`): `libhull.a` is covered
+by the **release** signature, not the inner **platform** signature — it is
+a standalone archive a foreign host links, not an embedded platform lib
+cross-checked at app-build time.
+
+## SBOM
+
+`hull sbom --subject=libhull [--format=human|json|cyclonedx|spdx]` emits an
+SBOM scoped to the embedding surface: the subject component is named
+`libhull`, the script runtimes (Lua, QuickJS) and the `hull build` compiler
+backend (TinyCC) are dropped, and the linked core (Keel, mbedTLS, WAMR,
+SQLite, tweetnacl, the CA bundle, …) is kept. Each release also publishes
+`libhull.sbom.{json,cdx.json,spdx.json}`, covered by `hull.sha256` so they
+inherit the release signature. The per-component membership is the
+`in_libhull` flag on `HlSbomEntry` (`src/hull/sbom.c`).
+
 ## Testing
 
 | Surface | Where |
 |---|---|
 | ABI guards, policy limits, fail-closed-before-seal, crypto, identity, NULL-safety | `tests/hull/test_embed.c` (`make test`) |
 | Sealed base_dir is read-only (fork+SIGSEGV) | `tests/hull/test_embed.c` (`make test`) |
+| libhull SBOM scope (flags + filter + subject rename) | `tests/hull/test_sbom.c` (`make test`) |
 | Full sealed integration (sandbox + cap fs I/O + traversal) | `examples/embed_c` (`make embed-c-smoke`) |
 | The underlying RO-arena mechanism | `tests/hull/test_seal_arena.c` |
 

--- a/include/hull/sbom.h
+++ b/include/hull/sbom.h
@@ -50,12 +50,23 @@ typedef struct {
      * at runtime from the actual bytes. Returns a static hex string
      * (cached on first call) or NULL if no embedded blob. */
     const char *(*embedded_blob_sha256)(void);
+    /* 1 if this component is part of the libhull embedding surface (linked
+     * by a libhull.a + libkeel.a native host); 0 for runtime-only
+     * components (the Lua / QuickJS script engines) that libhull excludes.
+     * Consumed by the `hull sbom --subject=libhull` scope. */
+    int in_libhull;
 } HlSbomEntry;
 
 /* Returns a pointer to the static entry table. Sets *count to its length.
  * Build-flag gating (HL_ENABLE_*) is applied at compile time.
  * The returned pointer is valid for the lifetime of the process. */
 const HlSbomEntry *hl_sbom_entries(size_t *count);
+
+/* Scope the next hl_sbom_format() to the libhull embedding surface: the
+ * subject component is named "libhull" and components with in_libhull == 0
+ * (the script runtimes) are omitted. Pass 0 to restore the default
+ * whole-hull scope. Process-global, like hl_sbom_set_binary_path. */
+void hl_sbom_set_scope_libhull(int on);
 
 /* Format the SBOM and write to `fp`. Returns 0 on success, -1 on error.
  * Errors are printed to stderr. */

--- a/src/hull/commands/sbom.c
+++ b/src/hull/commands/sbom.c
@@ -60,14 +60,23 @@ int hl_cmd_sbom(int argc, char **argv, const HlCommandEnv *env)
             return 0;
         }
         /* --subject=<hull|libhull>: scope the SBOM. "libhull" describes the
-         * no-runtime embedding archive (drops the Lua/QuickJS runtimes). */
-        const char *sub = NULL;
-        if (strncmp(argv[i], "--subject=", 10) == 0) {
-            sub = argv[i] + 10;
-        } else if (strcmp(argv[i], "--subject") == 0 && i + 1 < argc) {
-            sub = argv[++i];
-        }
-        if (sub) {
+         * no-runtime embedding archive (drops the Lua/QuickJS runtimes).
+         * Self-contained: a --subject arg always continues or returns, so no
+         * value-consuming (i-advancing) path falls through to --format below. */
+        if (strcmp(argv[i], "--subject") == 0 ||
+            strncmp(argv[i], "--subject=", 10) == 0) {
+            const char *sub = NULL;
+            if (argv[i][9] == '=') {
+                sub = argv[i] + 10;          /* --subject=VALUE */
+            } else if (i + 1 < argc) {
+                sub = argv[++i];             /* --subject VALUE */
+            }
+            if (!sub) {
+                fprintf(stderr,
+                        "hull sbom: --subject requires a value (hull|libhull)\n");
+                usage(stderr);
+                return 1;
+            }
             if (strcmp(sub, "libhull") == 0)   hl_sbom_set_scope_libhull(1);
             else if (strcmp(sub, "hull") == 0) hl_sbom_set_scope_libhull(0);
             else {

--- a/src/hull/commands/sbom.c
+++ b/src/hull/commands/sbom.c
@@ -22,9 +22,14 @@
 static void usage(FILE *fp)
 {
     fprintf(fp,
-        "Usage: hull sbom [--format=<format>]\n"
+        "Usage: hull sbom [--format=<format>] [--subject=<hull|libhull>]\n"
         "\n"
         "Print the Software Bill of Materials for this hull binary.\n"
+        "\n"
+        "Subject (default hull):\n"
+        "  hull        The whole hull binary.\n"
+        "  libhull     The no-runtime embedding archive (libhull.a): drops the\n"
+        "              Lua/QuickJS runtimes; keeps the linked core + Keel.\n"
         "\n"
         "Formats:\n"
         "  human       Default. Pretty table mirroring LICENSING.md style.\n"
@@ -53,6 +58,26 @@ int hl_cmd_sbom(int argc, char **argv, const HlCommandEnv *env)
         if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
             usage(stdout);
             return 0;
+        }
+        /* --subject=<hull|libhull>: scope the SBOM. "libhull" describes the
+         * no-runtime embedding archive (drops the Lua/QuickJS runtimes). */
+        const char *sub = NULL;
+        if (strncmp(argv[i], "--subject=", 10) == 0) {
+            sub = argv[i] + 10;
+        } else if (strcmp(argv[i], "--subject") == 0 && i + 1 < argc) {
+            sub = argv[++i];
+        }
+        if (sub) {
+            if (strcmp(sub, "libhull") == 0)   hl_sbom_set_scope_libhull(1);
+            else if (strcmp(sub, "hull") == 0) hl_sbom_set_scope_libhull(0);
+            else {
+                fprintf(stderr,
+                        "hull sbom: unknown subject '%s' (expected hull|libhull)\n",
+                        sub);
+                usage(stderr);
+                return 1;
+            }
+            continue;
         }
         const char *val = NULL;
         if (strncmp(argv[i], "--format=", 9) == 0) {

--- a/src/hull/sbom.c
+++ b/src/hull/sbom.c
@@ -134,6 +134,25 @@ void hl_sbom_set_binary_path(const char *path)
     g_binary_sha_tried = 0;
 }
 
+/* When set, formatters scope output to the libhull embedding surface:
+ * subject named "libhull", components filtered to entries with in_libhull. */
+static int g_sbom_libhull = 0;
+
+void hl_sbom_set_scope_libhull(int on) { g_sbom_libhull = on ? 1 : 0; }
+
+/* Subject component name for the current scope. */
+static const char *sbom_subject_name(void)
+{
+    return g_sbom_libhull ? "libhull" : "hull";
+}
+
+/* True if entry @e should be emitted under the current scope. In libhull
+ * scope, runtime-only components (in_libhull == 0) are omitted. */
+static int sbom_entry_visible(const HlSbomEntry *e)
+{
+    return !g_sbom_libhull || e->in_libhull;
+}
+
 #ifdef HL_SBOM_HAS_MBEDTLS
 /* Read the file at g_binary_path into a buffer and hash via the one-shot
  * cap-layer SHA-256 (hl_cap_crypto_sha256, same primitive used by
@@ -195,6 +214,7 @@ static const HlSbomEntry sbom_entries[] = {
     /* ── Submodule: HTTP server library (own project) ── */
     {
         .name = "keel",
+        .in_libhull = 1,
         .version = HULL_VENDOR_KEEL_VERSION,
         .commit = HULL_VENDOR_KEEL_COMMIT,
         .license_spdx = "MIT",
@@ -235,6 +255,7 @@ static const HlSbomEntry sbom_entries[] = {
     /* ── Snapshot: SQLite ── */
     {
         .name = "sqlite",
+        .in_libhull = 1,
         .version = "3.x",
         .commit = "",
         .license_spdx = "blessing",   /* SQLite uses "Public Domain" / blessing */
@@ -248,6 +269,7 @@ static const HlSbomEntry sbom_entries[] = {
     /* ── Snapshot: mbedTLS ── */
     {
         .name = "mbedtls",
+        .in_libhull = 1,
         .version = "3.x",
         .commit = "",
         .license_spdx = "Apache-2.0",
@@ -260,6 +282,7 @@ static const HlSbomEntry sbom_entries[] = {
     /* ── Snapshot: TweetNaCl ── */
     {
         .name = "tweetnacl",
+        .in_libhull = 1,
         .version = "20140427",
         .commit = "",
         .license_spdx = "blessing",   /* public domain */
@@ -271,6 +294,7 @@ static const HlSbomEntry sbom_entries[] = {
     /* ── Snapshot: jart/pledge polyfill ── */
     {
         .name = "pledge",
+        .in_libhull = 1,
         .version = "",
         .commit = "",
         .license_spdx = "ISC",
@@ -282,6 +306,7 @@ static const HlSbomEntry sbom_entries[] = {
     /* ── Snapshot: log.c ── */
     {
         .name = "log.c",
+        .in_libhull = 1,
         .version = "",
         .commit = "",
         .license_spdx = "MIT",
@@ -293,6 +318,7 @@ static const HlSbomEntry sbom_entries[] = {
     /* ── Snapshot: sh_arena ── */
     {
         .name = "sh_arena",
+        .in_libhull = 1,
         .version = "",
         .commit = "",
         .license_spdx = "MIT",
@@ -304,6 +330,7 @@ static const HlSbomEntry sbom_entries[] = {
     /* ── Snapshot: sh_json ── */
     {
         .name = "sh_json",
+        .in_libhull = 1,
         .version = "",
         .commit = "",
         .license_spdx = "MIT",
@@ -315,6 +342,7 @@ static const HlSbomEntry sbom_entries[] = {
     /* ── Snapshot: miniz ── */
     {
         .name = "miniz",
+        .in_libhull = 1,
         .version = "",
         .commit = "",
         .license_spdx = "MIT",
@@ -327,6 +355,7 @@ static const HlSbomEntry sbom_entries[] = {
     /* ── Submodule: WAMR ── */
     {
         .name = "wamr",
+        .in_libhull = 1,
         .version = HULL_VENDOR_WAMR_VERSION,
         .commit = HULL_VENDOR_WAMR_COMMIT,
         .license_spdx = "Apache-2.0",
@@ -340,6 +369,7 @@ static const HlSbomEntry sbom_entries[] = {
     /* ── Snapshot: wgpu-native ── */
     {
         .name = "wgpu-native",
+        .in_libhull = 1,
         .version = "",
         .commit = "",
         .license_spdx = "MPL-2.0 OR Apache-2.0",
@@ -366,6 +396,7 @@ static const HlSbomEntry sbom_entries[] = {
     /* ── Snapshot: stb (image codecs) ── */
     {
         .name = "stb",
+        .in_libhull = 1,
         .version = "",
         .commit = "",
         .license_spdx = "MIT OR blessing",  /* dual-licensed */
@@ -378,6 +409,7 @@ static const HlSbomEntry sbom_entries[] = {
     /* ── Embedded blob: Mozilla CA bundle ── */
     {
         .name = "mozilla-ca-bundle",
+        .in_libhull = 1,
         .version = "",   /* upstream is dated; date lives in the PEM */
         .commit = "",
         .license_spdx = "MPL-2.0",
@@ -390,6 +422,15 @@ static const HlSbomEntry sbom_entries[] = {
 
 static const size_t sbom_entries_count =
     sizeof(sbom_entries) / sizeof(sbom_entries[0]);
+
+/* Count of entries visible under the current scope (see sbom_entry_visible). */
+static size_t sbom_visible_count(void)
+{
+    size_t n = 0;
+    for (size_t i = 0; i < sbom_entries_count; i++)
+        if (sbom_entry_visible(&sbom_entries[i])) n++;
+    return n;
+}
 
 const HlSbomEntry *hl_sbom_entries(size_t *count)
 {
@@ -411,9 +452,15 @@ int hl_sbom_parse_format(const char *str)
 
 static void format_human(FILE *fp)
 {
-    fprintf(fp, "Hull SBOM\n");
-    fprintf(fp, "Hull %s, plus %zu component(s):\n",
-            HL_VERSION, sbom_entries_count - 1);
+    if (g_sbom_libhull) {
+        fprintf(fp, "libhull SBOM\n");
+        fprintf(fp, "libhull (Hull %s), plus %zu component(s):\n",
+                HL_VERSION, sbom_visible_count());
+    } else {
+        fprintf(fp, "Hull SBOM\n");
+        fprintf(fp, "Hull %s, plus %zu component(s):\n",
+                HL_VERSION, sbom_entries_count - 1);
+    }
     const char *bin_sha = sha256_binary();
     if (bin_sha) fprintf(fp, "Binary sha256: %s\n", bin_sha);
     fputc('\n', fp);
@@ -429,6 +476,7 @@ static void format_human(FILE *fp)
 
     for (size_t i = 0; i < sbom_entries_count; i++) {
         const HlSbomEntry *e = &sbom_entries[i];
+        if (!sbom_entry_visible(e)) continue;
         char vc[40];
         /* Prefer a tagged version string over the raw commit SHA — it
          * reads better in human output. Falls back to commit if no
@@ -450,6 +498,7 @@ static void format_human(FILE *fp)
     }
     fprintf(fp, "\nUrls (full):\n");
     for (size_t i = 0; i < sbom_entries_count; i++) {
+        if (!sbom_entry_visible(&sbom_entries[i])) continue;
         fprintf(fp, "  %-20s %s\n", sbom_entries[i].name, sbom_entries[i].url);
     }
 }
@@ -490,13 +539,17 @@ static void format_json(FILE *fp)
     sh_json_writer_init(&w, stdio_write_fn, fp);
     sh_json_write_object_start(&w);
     sh_json_write_kv_string(&w, "hull_version", HL_VERSION);
-    const char *bin_sha = sha256_binary();
+    sh_json_write_kv_string(&w, "subject", sbom_subject_name());
+    /* The runtime binary hash describes the hull binary, not libhull.a — omit
+     * it in libhull scope (the archive's own hash lives in libhull.a.sha256). */
+    const char *bin_sha = g_sbom_libhull ? NULL : sha256_binary();
     if (bin_sha)
         sh_json_write_kv_string(&w, "binary_sha256", bin_sha);
     sh_json_write_key(&w, "components");
     sh_json_write_array_start(&w);
     for (size_t i = 0; i < sbom_entries_count; i++) {
         const HlSbomEntry *e = &sbom_entries[i];
+        if (!sbom_entry_visible(e)) continue;
         sh_json_write_object_start(&w);
         sh_json_write_kv_string(&w, "name",         e->name);
         sh_json_write_kv_string(&w, "version",      e->version);
@@ -534,13 +587,13 @@ static void format_cyclonedx(FILE *fp)
     /* metadata.component describes the subject of the BOM (this binary).
      * Includes the SHA-256 of the running binary when known, so a consumer
      * can cross-check against the signed hull.sha256 release manifest. */
-    const char *bin_sha = sha256_binary();
+    const char *bin_sha = g_sbom_libhull ? NULL : sha256_binary();
     sh_json_write_key(&w, "metadata");
     sh_json_write_object_start(&w);
     sh_json_write_key(&w, "component");
     sh_json_write_object_start(&w);
-    sh_json_write_kv_string(&w, "type",    "application");
-    sh_json_write_kv_string(&w, "name",    "hull");
+    sh_json_write_kv_string(&w, "type",    g_sbom_libhull ? "library" : "application");
+    sh_json_write_kv_string(&w, "name",    sbom_subject_name());
     sh_json_write_kv_string(&w, "version", HL_VERSION);
     if (bin_sha) {
         sh_json_write_key(&w, "hashes");
@@ -558,6 +611,7 @@ static void format_cyclonedx(FILE *fp)
     sh_json_write_array_start(&w);
     for (size_t i = 0; i < sbom_entries_count; i++) {
         const HlSbomEntry *e = &sbom_entries[i];
+        if (!sbom_entry_visible(e)) continue;
         sh_json_write_object_start(&w);
         sh_json_write_kv_string(&w, "type", "library");
         sh_json_write_kv_string(&w, "name", e->name);
@@ -643,7 +697,7 @@ static void format_spdx(FILE *fp)
      * SPDX document is the running hull binary; binary_sha256 is emitted
      * as a checksum on that package so consumers can cross-reference the
      * signed release manifest. */
-    const char *bin_sha = sha256_binary();
+    const char *bin_sha = g_sbom_libhull ? NULL : sha256_binary();
     sh_json_write_key(&w, "documentDescribes");
     sh_json_write_array_start(&w);
     sh_json_write_string(&w, "SPDXRef-Package-hull-binary");
@@ -654,12 +708,14 @@ static void format_spdx(FILE *fp)
     /* The hull-binary package itself. */
     sh_json_write_object_start(&w);
     sh_json_write_kv_string(&w, "SPDXID",           "SPDXRef-Package-hull-binary");
-    sh_json_write_kv_string(&w, "name",             "hull");
+    sh_json_write_kv_string(&w, "name",             sbom_subject_name());
     sh_json_write_kv_string(&w, "versionInfo",      HL_VERSION);
     sh_json_write_kv_string(&w, "downloadLocation", "https://github.com/artalis-io/hull");
     sh_json_write_kv_string(&w, "licenseConcluded", "AGPL-3.0-or-later");
     sh_json_write_kv_string(&w, "licenseDeclared",  "AGPL-3.0-or-later");
-    sh_json_write_kv_string(&w, "comment",          "the running hull binary");
+    sh_json_write_kv_string(&w, "comment",
+                            g_sbom_libhull ? "the libhull embedding archive"
+                                           : "the running hull binary");
     if (bin_sha) {
         sh_json_write_key(&w, "checksums");
         sh_json_write_array_start(&w);
@@ -674,6 +730,7 @@ static void format_spdx(FILE *fp)
     /* Vendored components. */
     for (size_t i = 0; i < sbom_entries_count; i++) {
         const HlSbomEntry *e = &sbom_entries[i];
+        if (!sbom_entry_visible(e)) continue;
         sh_json_write_object_start(&w);
         {
             /* SPDX IDs must match [A-Za-z0-9.-]+; sanitize the name. */

--- a/tests/hull/test_sbom.c
+++ b/tests/hull/test_sbom.c
@@ -322,4 +322,74 @@ UTEST(sbom, binary_sha256_present_when_path_set)
     hl_sbom_set_binary_path(NULL);
 }
 
+/* ── libhull scope (hull sbom --subject=libhull) ───────────────────── */
+
+static int sbom_count(const char *hay, const char *needle)
+{
+    int c = 0;
+    for (const char *p = hay; (p = strstr(p, needle)); p += strlen(needle)) c++;
+    return c;
+}
+
+/* The excluded set: script runtimes + compiler backend + the hull
+ * self-entry. Everything else is part of the libhull embedding surface. */
+static int sbom_is_excluded(const char *name)
+{
+    return strcmp(name, "lua") == 0 || strcmp(name, "quickjs") == 0 ||
+           strcmp(name, "tinycc") == 0 || strcmp(name, "hull") == 0;
+}
+
+UTEST(sbom, in_libhull_flags_match_policy)
+{
+    size_t n = 0;
+    const HlSbomEntry *e = hl_sbom_entries(&n);
+    ASSERT_GT(n, 0u);
+    for (size_t i = 0; i < n; i++) {
+        if (sbom_is_excluded(e[i].name))
+            ASSERT_EQ_MSG(e[i].in_libhull, 0, e[i].name);
+        else
+            ASSERT_EQ_MSG(e[i].in_libhull, 1, e[i].name);
+    }
+}
+
+UTEST(sbom, libhull_scope_filters_and_renames)
+{
+    hl_sbom_set_scope_libhull(0);
+    char *def = format_to_string(HL_SBOM_JSON);
+    ASSERT_NE(def, NULL);
+    int def_components = sbom_count(def, "\"name\"");
+
+    hl_sbom_set_scope_libhull(1);
+    char *lh = format_to_string(HL_SBOM_JSON);
+    ASSERT_NE(lh, NULL);
+    int lh_components = sbom_count(lh, "\"name\"");
+
+    /* Subject renamed, core kept, JS runtime dropped, strictly fewer
+     * components than the whole-hull SBOM. */
+    ASSERT_NE_MSG(strstr(lh, "libhull"), NULL, "libhull scope names the subject");
+    ASSERT_NE_MSG(strstr(lh, "mbedtls"), NULL, "libhull keeps the linked core");
+    ASSERT_EQ_MSG(strstr(lh, "quickjs"), NULL, "libhull drops the JS runtime");
+    ASSERT_LT(lh_components, def_components);
+
+    free(def);
+    free(lh);
+    hl_sbom_set_scope_libhull(0);  /* restore global for later tests */
+}
+
+UTEST(sbom, all_formats_render_under_libhull_scope)
+{
+    hl_sbom_set_scope_libhull(1);
+    const HlSbomFormat fmts[] = {
+        HL_SBOM_HUMAN, HL_SBOM_JSON, HL_SBOM_CYCLONEDX, HL_SBOM_SPDX,
+    };
+    for (size_t i = 0; i < sizeof(fmts) / sizeof(fmts[0]); i++) {
+        char *out = format_to_string(fmts[i]);
+        ASSERT_NE(out, NULL);
+        ASSERT_GT(strlen(out), 0u);
+        ASSERT_NE_MSG(strstr(out, "libhull"), NULL, "libhull subject present");
+        free(out);
+    }
+    hl_sbom_set_scope_libhull(0);
+}
+
 UTEST_MAIN()


### PR DESCRIPTION
Fourth phase of the **libhull** flavor. Makes `libhull.a` a first-class, verifiable release artifact with its own SBOM, and finishes the cosmo packaging story.

## What's here

- **Dual-arch cosmo `libhull.a`.** `make libhull` now writes a `build/libhull.a.sha256` sidecar, and under the fat cosmocc driver also builds `build/.aarch64/libhull.a` — the concomitant sibling cosmocc needs to link a dual-arch APE. Mirrors exactly how Keel builds `.aarch64/libkeel.a` (per-object aarch64 siblings, single-arch cosmo `ar` per arch). This makes `test_embed` linkable under cosmocc, so the **L-3 cosmo `test_embed` skip is removed** — the Cosmo CI job now exercises it.
- **Scoped SBOM.** `hull sbom --subject=libhull [--format=human|json|cyclonedx|spdx]` scopes to the embedding surface: subject named `libhull`, the script runtimes (Lua/QuickJS) + the `hull build` compiler (TinyCC) dropped, the linked core (Keel, mbedTLS, WAMR, SQLite, tweetnacl, CA bundle, …) kept. Membership is a new `in_libhull` flag on `HlSbomEntry`; every format honors it and omits the hull-binary hash (which doesn't describe the archive). **Default whole-hull output is byte-unchanged.**
- **Release publishing.** `release.yml` builds `libhull.a` per native arch (`libhull-<arch>.a`) + the dual-arch cosmo pair (`libhull.{x86_64,aarch64}-cosmo.a`), hashes them and the libhull-scoped SBOMs into the Ed25519-signed `hull.sha256`, and publishes them. A consumer verifies a downloaded archive offline via `hl_release_io_verify_local_asset` — same trust chain as `hull platform install`. `libhull.a` is covered by the **release** signature, not the inner platform signature (documented asymmetry).
- **Tests + docs.** `test_sbom.c` gains 3 scope tests (flags match policy; scope filters runtimes + renames subject + shrinks the set; all formats render under scope). `docs/libhull_flavor.md` gets signing/verify + SBOM sections.

## Validation (macOS arm64)

- `make test` — 51 binaries green (`test_sbom` **21/21** incl. the 3 new, `test_embed` 8/8).
- `make embed-c-smoke` — OK; `build/libhull.a.sha256` matches the archive.
- All four SBOM formats scope correctly; default output unchanged.
- `release.yml` is valid YAML.

## Can't be tested locally (Cosmo CI is the gate)

The fat cosmo archive rule and the release YAML aren't buildable here (no cosmocc; release runs only on a tag). **The Cosmo (APE) CI job is the real validator** — it builds the fat `libhull.a` and runs the now-un-skipped `test_embed` under cosmocc. If the `.aarch64` sibling path is wrong, that job fails and I'll iterate.

## Next

L-5: a non-C reference embedder (Rust/Zig) + finalize `docs/libhull_flavor.md`. This is the last phase of the epic.