### PR TITLE
feat(libhull): Rust + Zig reference embedders (L-5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,3 +649,53 @@ jobs:
 
       - name: Template Benchmark
         run: RUNTIME=${{ matrix.runtime }} DURATION=5s CONNECTIONS=50 THREADS=2 sh bench/bench_template.sh
+
+  # ── libhull reference embedders (L-5) ──
+  # Prove the hl_embed_* C ABI is consumable from a foreign language. Each job
+  # links libhull.a + Keel and runs examples/embed_{rust,zig} through the ABI.
+  # The make target skips when the toolchain is absent, so we assert it actually
+  # ran (grep for the OK line) rather than silently pass.
+  embed-rust:
+    name: libhull embedder (Rust)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+
+      - name: Rust toolchain
+        run: rustc --version && cargo --version   # preinstalled on GitHub runners
+
+      - name: Run Rust reference embedder
+        run: |
+          out=$(make embed-rust-smoke 2>&1); echo "$out"
+          echo "$out" | grep -q "embed-rust-smoke: OK" \
+            || { echo "::error::embed_rust did not run to completion"; exit 1; }
+
+  embed-zig:
+    name: libhull embedder (Zig)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+
+      - name: Install Zig 0.13.0
+        run: |
+          set -eu
+          curl -fsSL https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz \
+            -o /tmp/zig.tar.xz
+          sudo mkdir -p /opt/zig
+          sudo tar -xJf /tmp/zig.tar.xz -C /opt/zig --strip-components=1
+          echo "/opt/zig" >> "$GITHUB_PATH"
+
+      - name: Zig version
+        run: zig version
+
+      - name: Run Zig reference embedder
+        run: |
+          out=$(make embed-zig-smoke 2>&1); echo "$out"
+          echo "$out" | grep -q "embed-zig-smoke: OK" \
+            || { echo "::error::embed_zig did not run to completion"; exit 1; }

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ Thumbs.db
 # regenerable on demand. Scoped to this path so other npm work
 # in the tree isn't accidentally swallowed.
 tests/.playwright/
+
+# libhull Rust reference embedder (examples/embed_rust)
+examples/embed_rust/target/
+examples/embed_rust/Cargo.lock

--- a/Makefile
+++ b/Makefile
@@ -2408,6 +2408,41 @@ embed-c-smoke: $(BUILDDIR)/libhull.a $(KEEL_LIB)
 	@$(BUILDDIR)/embed_c
 	@echo "embed-c-smoke: OK"
 
+# embed-rust-smoke / embed-zig-smoke: the non-C reference hosts (L-5). Each
+# links libhull.a the same way embed_c does (archive repeated for the GNU-ld /
+# lld cycle) and drives the hl_embed_* ABI from a foreign language. Both SKIP
+# CLEANLY when the toolchain is absent (like the Playwright targets), so a
+# plain `make check` on a box without cargo/zig is unaffected; CI installs the
+# toolchains and runs them for real.
+.PHONY: embed-rust-smoke
+embed-rust-smoke: $(BUILDDIR)/libhull.a $(KEEL_LIB)
+	@if ! command -v cargo >/dev/null 2>&1; then \
+		echo "embed-rust-smoke: cargo not found, skipping"; \
+	else \
+		echo "── building + running embed_rust (no-runtime host) ──"; \
+		HULL_LIBHULL_A="$(abspath $(BUILDDIR)/libhull.a)" \
+		HULL_LIBKEEL_A="$(abspath $(KEEL_LIB))" \
+		cargo run --quiet --release --manifest-path examples/embed_rust/Cargo.toml && \
+		echo "embed-rust-smoke: OK"; \
+	fi
+
+.PHONY: embed-zig-smoke
+embed-zig-smoke: $(BUILDDIR)/libhull.a $(KEEL_LIB)
+	@if ! command -v zig >/dev/null 2>&1; then \
+		echo "embed-zig-smoke: zig not found, skipping"; \
+	else \
+		echo "── building + running embed_zig (no-runtime host) ──"; \
+		zig build-exe examples/embed_zig/main.zig -I$(INCDIR) -lc \
+			-femit-bin=$(BUILDDIR)/embed_zig \
+			$(BUILDDIR)/libhull.a $(KEEL_LIB) $(BUILDDIR)/libhull.a -lm -lpthread && \
+		$(BUILDDIR)/embed_zig && \
+		echo "embed-zig-smoke: OK"; \
+	fi
+
+# Run every reference embedder that has a toolchain available.
+.PHONY: embed-smoke
+embed-smoke: embed-c-smoke embed-rust-smoke embed-zig-smoke
+
 # Capability sources
 $(BUILDDIR)/cap_%.o: $(SRCDIR)/hull/cap/%.c | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<

--- a/docs/libhull_flavor.md
+++ b/docs/libhull_flavor.md
@@ -15,9 +15,9 @@ parts an embedder must understand. For the build/flavor context see
 see [security.md §4b](security.md).
 
 Status: L-1 (archive + sandbox split), L-2 (`hl_embed_*` ABI), and L-3
-(policy sealing + fail-closed ordering + death test) and L-4 (release
-signing + SBOM for the archive, incl. the dual-arch cosmo build) have
-landed. L-5 (a non-C reference embedder) is pending.
+(policy sealing + fail-closed ordering + death test), L-4 (release signing
++ SBOM for the archive, incl. the dual-arch cosmo build), and L-5 (Rust +
+Zig reference embedders) have landed. The epic is complete.
 
 ## Building
 
@@ -176,10 +176,27 @@ inherit the release signature. The per-component membership is the
 | Full sealed integration (sandbox + cap fs I/O + traversal) | `examples/embed_c` (`make embed-c-smoke`) |
 | The underlying RO-arena mechanism | `tests/hull/test_seal_arena.c` |
 
-## Reference host
+## Reference hosts
 
-[`examples/embed_c`](../examples/embed_c/) is the canonical consumer. It
-includes only `<hull/embed.h>`, builds a policy in C, seals, and drives
-capability-mediated filesystem I/O, crypto, and identity — exiting
-non-zero on any failure. It is the L-2/L-3 link witness: a runtime
-dependency leaking into the core would fail its link.
+Three reference hosts drive the identical embedding sequence (build a
+policy in C-declared terms, seal, then capability-mediated fs I/O + crypto
++ identity), each exiting non-zero on any failure. They are the link
+witnesses: a runtime dependency leaking into the core would fail their
+link.
+
+| Host | Language | How it binds the ABI | Runs via |
+|---|---|---|---|
+| [`examples/embed_c`](../examples/embed_c/) | C | `#include <hull/embed.h>` | `make embed-c-smoke` |
+| [`examples/embed_rust`](../examples/embed_rust/) | Rust | an `extern "C"` block + `build.rs` link | `make embed-rust-smoke` |
+| [`examples/embed_zig`](../examples/embed_zig/) | Zig | `@cImport("hull/embed.h")` — the header directly | `make embed-zig-smoke` |
+
+`make embed-smoke` runs all three. The Rust/Zig targets **skip cleanly**
+when `cargo`/`zig` is absent (so a plain checkout is unaffected); CI
+installs both toolchains and asserts each host runs to completion. The Zig
+host is the strongest ABI-cleanliness proof: `@cImport` consumes
+`embed.h` as-is, so a clean compile means the header is FFI-consumable with
+no massaging.
+
+All three link `libhull.a` twice around Keel (`libhull.a libkeel.a
+libhull.a`) to resolve the archive cycle under GNU ld / lld; macOS's linker
+handles it without the repeat.

--- a/examples/embed_rust/Cargo.toml
+++ b/examples/embed_rust/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "embed_rust"
+version = "0.0.0"
+edition = "2021"
+publish = false
+description = "Reference Rust host for the libhull no-runtime embedding flavor"
+
+[[bin]]
+name = "embed_rust"
+path = "src/main.rs"
+
+[profile.release]
+# Keep the link simple + deterministic for a reference example.
+lto = false

--- a/examples/embed_rust/README.md
+++ b/examples/embed_rust/README.md
@@ -1,0 +1,22 @@
+# embed_rust — Rust host for the libhull no-runtime flavor
+
+Reference Rust consumer of the [`hl_embed_*` ABI](../../include/hull/embed.h).
+Links only `libhull.a` + Keel (no Lua/QuickJS runtime) and drives the
+runtime-free Hull core — two-phase sandbox, capability-mediated filesystem
+I/O (incl. traversal rejection), crypto, and identity — via a small
+`extern "C"` block. The analogue of [`../embed_c`](../embed_c/), from Rust.
+
+## Run
+
+```sh
+make embed-rust-smoke      # from the repo root; builds libhull.a first
+```
+
+The target skips cleanly if `cargo` is absent. `build.rs` links the
+archives in the order `libhull.a libkeel.a libhull.a` (the archive cycle
+needs the repeat under GNU ld / lld); override the archive paths with the
+`HULL_LIBHULL_A` / `HULL_LIBKEEL_A` env vars (the make target sets them to
+absolute in-tree paths).
+
+See [docs/libhull_flavor.md](../../docs/libhull_flavor.md) for the trust
+boundary and the full embedding story.

--- a/examples/embed_rust/build.rs
+++ b/examples/embed_rust/build.rs
@@ -1,0 +1,44 @@
+//! Link the reference Rust host against the runtime-free Hull core.
+//!
+//! libhull.a and Keel are mutually dependent (libhull's capability layer
+//! calls Keel's TLS, which calls libhull's mbedTLS), and GNU ld / lld resolve
+//! static archives strictly left-to-right, so libhull.a is passed twice:
+//! `libhull.a libkeel.a libhull.a`. We pass the archives as positional link
+//! args (not `-l`, which cargo would dedup) to preserve that order.
+//!
+//! Paths default to the in-tree build (../../build/libhull.a,
+//! ../../vendor/keel/libkeel.a) and can be overridden with the env vars
+//! HULL_LIBHULL_A and HULL_LIBKEEL_A (the `make embed-rust-smoke` target sets
+//! them to absolute paths).
+
+use std::env;
+use std::path::PathBuf;
+
+fn resolve(var: &str, default_rel: &str) -> PathBuf {
+    if let Ok(p) = env::var(var) {
+        return PathBuf::from(p);
+    }
+    let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    manifest.join(default_rel)
+}
+
+fn main() {
+    let libhull = resolve("HULL_LIBHULL_A", "../../build/libhull.a");
+    let libkeel = resolve("HULL_LIBKEEL_A", "../../vendor/keel/libkeel.a");
+
+    // Absolute paths so the linker (run from the target dir) finds them.
+    let libhull = libhull.canonicalize().unwrap_or(libhull);
+    let libkeel = libkeel.canonicalize().unwrap_or(libkeel);
+
+    // Order matters: libhull -> keel -> libhull resolves the archive cycle.
+    println!("cargo:rustc-link-arg={}", libhull.display());
+    println!("cargo:rustc-link-arg={}", libkeel.display());
+    println!("cargo:rustc-link-arg={}", libhull.display());
+    // mbedTLS/WAMR need libm; pthread comes in via Rust's std on all targets.
+    println!("cargo:rustc-link-lib=m");
+
+    println!("cargo:rerun-if-changed={}", libhull.display());
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=HULL_LIBHULL_A");
+    println!("cargo:rerun-if-env-changed=HULL_LIBKEEL_A");
+}

--- a/examples/embed_rust/src/main.rs
+++ b/examples/embed_rust/src/main.rs
@@ -1,0 +1,168 @@
+//! embed_rust — reference Rust host for the libhull no-runtime flavor.
+//!
+//! Links only libhull.a + Keel (see build.rs); no Lua/QuickJS runtime. Drives
+//! the runtime-free Hull core through the stable C ABI in <hull/embed.h> via a
+//! small `extern "C"` block — the analogue of examples/embed_c, from Rust.
+//! Exits non-zero on any capability failure.
+//!
+//! SPDX-License-Identifier: AGPL-3.0-or-later
+
+use std::cell::Cell;
+use std::ffi::{c_char, c_int, c_void, CStr, CString};
+use std::process::exit;
+use std::ptr;
+
+#[repr(C)]
+struct HlEmbed {
+    _private: [u8; 0],
+}
+
+extern "C" {
+    fn hl_embed_abi_version() -> c_int;
+    fn hl_embed_new(app_dir: *const c_char) -> *mut HlEmbed;
+    fn hl_embed_free(e: *mut HlEmbed);
+    fn hl_embed_sandbox_phase1(e: *mut HlEmbed) -> c_int;
+    fn hl_embed_allow_read(e: *mut HlEmbed, rel_path: *const c_char) -> c_int;
+    fn hl_embed_allow_write(e: *mut HlEmbed, rel_path: *const c_char) -> c_int;
+    fn hl_embed_allow_network(e: *mut HlEmbed, inbound: c_int, outbound: c_int);
+    fn hl_embed_seal(e: *mut HlEmbed, db_path: *const c_char) -> c_int;
+    fn hl_embed_fs_write(
+        e: *mut HlEmbed,
+        path: *const c_char,
+        data: *const c_void,
+        len: usize,
+        err: *mut *const c_char,
+    ) -> c_int;
+    fn hl_embed_fs_read(
+        e: *mut HlEmbed,
+        path: *const c_char,
+        buf: *mut c_char,
+        buf_size: usize,
+        err: *mut *const c_char,
+    ) -> i64;
+    fn hl_embed_fs_exists(e: *mut HlEmbed, path: *const c_char, err: *mut *const c_char) -> c_int;
+    fn hl_embed_fs_delete(e: *mut HlEmbed, path: *const c_char, err: *mut *const c_char) -> c_int;
+    fn hl_embed_sha256(data: *const c_void, len: usize, out: *mut u8) -> c_int;
+    fn hl_embed_platform() -> *const c_char;
+    fn hl_embed_module_count() -> usize;
+
+    fn chdir(path: *const c_char) -> c_int;
+}
+
+fn cstr(s: &str) -> CString {
+    CString::new(s).unwrap()
+}
+
+fn main() {
+    let failures = Cell::new(0u32);
+    let check = |ok: bool, what: &str| {
+        println!("  [{}] {}", if ok { "PASS" } else { "FAIL" }, what);
+        if !ok {
+            failures.set(failures.get() + 1);
+        }
+    };
+
+    unsafe {
+        println!(
+            "embed_rust: libhull no-runtime host (ABI v{})",
+            hl_embed_abi_version()
+        );
+
+        // A native host owns its working directory. Absolute temp dir.
+        let dir = std::env::temp_dir().join(format!("hull-embed-rust-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let dir_c = cstr(dir.to_str().expect("utf-8 path"));
+        assert_eq!(chdir(dir_c.as_ptr()), 0, "chdir into temp dir");
+
+        // 1. handle
+        let e = hl_embed_new(dir_c.as_ptr());
+        check(!e.is_null(), "hl_embed_new(app_dir)");
+        if e.is_null() {
+            exit(1);
+        }
+
+        // 2. phase-1 sandbox
+        check(hl_embed_sandbox_phase1(e) == 0, "phase-1 sandbox applied");
+
+        // 3. policy (app_dir-relative, like a manifest)
+        let dot = cstr(".");
+        check(hl_embed_allow_read(e, dot.as_ptr()) == 0, "allow_read(\".\")");
+        check(hl_embed_allow_write(e, dot.as_ptr()) == 0, "allow_write(\".\")");
+        hl_embed_allow_network(e, 0, 0);
+
+        // fail-closed before seal
+        let note = cstr("note.txt");
+        let mut pre_err: *const c_char = ptr::null();
+        check(
+            hl_embed_fs_exists(e, note.as_ptr(), &mut pre_err) == -1 && !pre_err.is_null(),
+            "capabilities fail closed before seal",
+        );
+
+        // 4. seal (phase-2 sandbox) — must check
+        let sealed = hl_embed_seal(e, ptr::null());
+        check(sealed == 0, "hl_embed_seal applied sandbox");
+        if sealed != 0 {
+            hl_embed_free(e);
+            exit(1);
+        }
+
+        // 5. capability-mediated fs I/O
+        let mut err: *const c_char = ptr::null();
+        let payload = b"hull embed_rust capability write\n";
+        let w = hl_embed_fs_write(
+            e,
+            note.as_ptr(),
+            payload.as_ptr() as *const c_void,
+            payload.len(),
+            &mut err,
+        );
+        check(w == 0, "hl_embed_fs_write under sandbox");
+
+        let mut buf = [0 as c_char; 128];
+        let n = hl_embed_fs_read(e, note.as_ptr(), buf.as_mut_ptr(), buf.len(), &mut err);
+        let round_ok = n == payload.len() as i64 && {
+            let read = std::slice::from_raw_parts(buf.as_ptr() as *const u8, n as usize);
+            read == &payload[..]
+        };
+        check(round_ok, "hl_embed_fs_read round-trips");
+
+        let esc = cstr("../escape");
+        check(
+            hl_embed_fs_exists(e, esc.as_ptr(), &mut err) == -1,
+            "hl_embed_fs rejects path traversal",
+        );
+
+        // 6. crypto (stateless)
+        let mut digest = [0u8; 32];
+        let abc = b"abc";
+        let cc = hl_embed_sha256(abc.as_ptr() as *const c_void, 3, digest.as_mut_ptr());
+        check(
+            cc == 0 && digest[0] == 0xba && digest[1] == 0x78 && digest[2] == 0x16 && digest[3] == 0xbf,
+            "hl_embed_sha256(\"abc\") matches known vector",
+        );
+
+        // 7. identity
+        let plat = hl_embed_platform();
+        check(!plat.is_null() && *plat != 0, "hl_embed_platform reports arch");
+        check(hl_embed_module_count() > 0, "hl_embed_module_count populated");
+        let plat_str = if plat.is_null() {
+            "(null)".to_string()
+        } else {
+            CStr::from_ptr(plat).to_string_lossy().into_owned()
+        };
+        println!("  platform={} modules={}", plat_str, hl_embed_module_count());
+
+        hl_embed_fs_delete(e, note.as_ptr(), &mut err);
+        hl_embed_free(e);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    let f = failures.get();
+    println!(
+        "embed_rust: {} ({} failure{})",
+        if f == 0 { "OK" } else { "FAILED" },
+        f,
+        if f == 1 { "" } else { "s" }
+    );
+    exit(if f == 0 { 0 } else { 1 });
+}

--- a/examples/embed_zig/README.md
+++ b/examples/embed_zig/README.md
@@ -1,0 +1,24 @@
+# embed_zig — Zig host for the libhull no-runtime flavor
+
+Reference Zig consumer of the [`hl_embed_*` ABI](../../include/hull/embed.h).
+Zig `@cImport`s `hull/embed.h` **directly** — no hand-written bindings — and
+links only `libhull.a` + Keel (no Lua/QuickJS runtime), driving the same
+embedding sequence as [`../embed_c`](../embed_c/): two-phase sandbox,
+capability-mediated filesystem I/O (incl. traversal rejection), crypto, and
+identity.
+
+Because `@cImport` consumes the header as-is, a clean compile is itself
+evidence the ABI header is FFI-consumable with no massaging.
+
+## Run
+
+```sh
+make embed-zig-smoke       # from the repo root; builds libhull.a first
+```
+
+The target skips cleanly if `zig` is absent. Built and tested with **Zig
+0.13.0**; the archives are linked `libhull.a libkeel.a libhull.a` (the cycle
+needs the repeat under lld).
+
+See [docs/libhull_flavor.md](../../docs/libhull_flavor.md) for the trust
+boundary and the full embedding story.

--- a/examples/embed_zig/main.zig
+++ b/examples/embed_zig/main.zig
@@ -89,10 +89,14 @@ pub fn main() u8 {
     const plat = c.hl_embed_platform();
     check(plat != null and plat[0] != 0, "hl_embed_platform reports arch");
     check(c.hl_embed_module_count() > 0, "hl_embed_module_count populated");
-    std.debug.print(
-        "  platform={s} modules={d}\n",
-        .{ if (plat != null) plat else "(null)", c.hl_embed_module_count() },
-    );
+    if (plat != null) {
+        std.debug.print(
+            "  platform={s} modules={d}\n",
+            .{ std.mem.span(plat), c.hl_embed_module_count() },
+        );
+    } else {
+        std.debug.print("  platform=(null) modules={d}\n", .{c.hl_embed_module_count()});
+    }
 
     _ = c.hl_embed_fs_delete(e, "note.txt", &err);
     c.hl_embed_free(e);

--- a/examples/embed_zig/main.zig
+++ b/examples/embed_zig/main.zig
@@ -1,0 +1,106 @@
+//! embed_zig — reference Zig host for the libhull no-runtime flavor.
+//!
+//! Zig @cImports include/hull/embed.h DIRECTLY (no hand-written bindings) and
+//! links libhull.a + Keel; no Lua/QuickJS runtime. Drives the runtime-free
+//! Hull core through the stable C ABI — the analogue of examples/embed_c, from
+//! Zig. Because @cImport consumes the header as-is, a clean compile is itself
+//! evidence the ABI header is FFI-consumable. Exits non-zero on any failure.
+//!
+//! Built with Zig 0.13.0. SPDX-License-Identifier: AGPL-3.0-or-later
+
+const std = @import("std");
+const c = @cImport({
+    @cInclude("hull/embed.h");
+    @cInclude("stdlib.h"); // mkdtemp
+    @cInclude("unistd.h"); // chdir, rmdir
+});
+
+var failures: u32 = 0;
+
+fn check(ok: bool, what: []const u8) void {
+    std.debug.print("  [{s}] {s}\n", .{ if (ok) "PASS" else "FAIL", what });
+    if (!ok) failures += 1;
+}
+
+pub fn main() u8 {
+    std.debug.print(
+        "embed_zig: libhull no-runtime host (ABI v{d})\n",
+        .{c.hl_embed_abi_version()},
+    );
+
+    // A native host owns its working directory. Fresh absolute temp dir.
+    var tmpl: [64]u8 = undefined;
+    const path = std.fmt.bufPrintZ(&tmpl, "/tmp/hull-embed-zig.XXXXXX", .{}) catch return 1;
+    const dir = c.mkdtemp(path.ptr);
+    if (dir == null) return 1;
+    if (c.chdir(dir) != 0) return 1;
+
+    // 1. handle
+    const e = c.hl_embed_new(dir);
+    check(e != null, "hl_embed_new(app_dir)");
+    if (e == null) return 1;
+
+    // 2. phase-1 sandbox
+    check(c.hl_embed_sandbox_phase1(e) == 0, "phase-1 sandbox applied");
+
+    // 3. policy (app_dir-relative, like a manifest)
+    check(c.hl_embed_allow_read(e, ".") == 0, "allow_read(\".\")");
+    check(c.hl_embed_allow_write(e, ".") == 0, "allow_write(\".\")");
+    c.hl_embed_allow_network(e, 0, 0);
+
+    // fail-closed before seal
+    var pre_err: [*c]const u8 = null;
+    check(
+        c.hl_embed_fs_exists(e, "note.txt", &pre_err) == -1 and pre_err != null,
+        "capabilities fail closed before seal",
+    );
+
+    // 4. seal (phase-2 sandbox) — must check
+    const sealed = c.hl_embed_seal(e, null);
+    check(sealed == 0, "hl_embed_seal applied sandbox");
+    if (sealed != 0) {
+        c.hl_embed_free(e);
+        return 1;
+    }
+
+    // 5. capability-mediated fs I/O
+    var err: [*c]const u8 = null;
+    const payload = "hull embed_zig capability write\n";
+    const w = c.hl_embed_fs_write(e, "note.txt", payload, payload.len, &err);
+    check(w == 0, "hl_embed_fs_write under sandbox");
+
+    var buf: [128]u8 = undefined;
+    const n = c.hl_embed_fs_read(e, "note.txt", &buf, buf.len, &err);
+    const round_ok = n == @as(i64, @intCast(payload.len)) and
+        std.mem.eql(u8, buf[0..@intCast(n)], payload[0..payload.len]);
+    check(round_ok, "hl_embed_fs_read round-trips");
+
+    check(c.hl_embed_fs_exists(e, "../escape", &err) == -1, "hl_embed_fs rejects path traversal");
+
+    // 6. crypto (stateless)
+    var digest: [32]u8 = undefined;
+    const cc = c.hl_embed_sha256("abc", 3, &digest);
+    check(
+        cc == 0 and digest[0] == 0xba and digest[1] == 0x78 and digest[2] == 0x16 and digest[3] == 0xbf,
+        "hl_embed_sha256(\"abc\") matches known vector",
+    );
+
+    // 7. identity
+    const plat = c.hl_embed_platform();
+    check(plat != null and plat[0] != 0, "hl_embed_platform reports arch");
+    check(c.hl_embed_module_count() > 0, "hl_embed_module_count populated");
+    std.debug.print(
+        "  platform={s} modules={d}\n",
+        .{ if (plat != null) plat else "(null)", c.hl_embed_module_count() },
+    );
+
+    _ = c.hl_embed_fs_delete(e, "note.txt", &err);
+    c.hl_embed_free(e);
+    _ = c.rmdir(dir);
+
+    std.debug.print(
+        "embed_zig: {s} ({d} failure{s})\n",
+        .{ if (failures == 0) "OK" else "FAILED", failures, if (failures == 1) "" else "s" },
+    );
+    return if (failures == 0) 0 else 1;
+}


### PR DESCRIPTION
Final phase of the **libhull** flavor: prove the `hl_embed_*` C ABI is consumable from foreign languages.

## What's here

- **`examples/embed_rust`** — a Rust host binding the ABI via an `extern "C"` block + `build.rs` (links `libhull.a libkeel.a libhull.a` for the archive cycle; paths overridable via `HULL_LIBHULL_A` / `HULL_LIBKEEL_A`).
- **`examples/embed_zig`** — a Zig host that **`@cImport`s `include/hull/embed.h` directly** (no hand-written bindings). A clean compile is itself evidence the header is FFI-consumable with no massaging. Targets Zig 0.13.0.
- Both drive the identical embedding sequence as [`examples/embed_c`](../tree/main/examples/embed_c) (two-phase sandbox, capability fs I/O incl. traversal rejection, crypto, identity) and exit non-zero on any failure.
- **`make embed-rust-smoke` / `embed-zig-smoke`** build+run each when the toolchain is present and **skip cleanly** otherwise (single-shell `if/else`); `make embed-smoke` runs all three.
- **Two CI jobs** install cargo (preinstalled) / zig-0.13.0 and **assert each host runs to completion** (grep the OK line, so a silent skip fails the job).
- `docs/libhull_flavor.md` marks the epic complete and documents all three reference hosts; per-example READMEs added.

## Validation

- **Locally checkable (green):** Makefile parses, hull builds, both smoke targets skip cleanly (no cargo/zig on my box), both YAMLs valid.
- **CI-validated only:** the Rust/Zig hosts themselves — neither toolchain is installed locally, so the two new CI jobs are the real gate. The **Zig job is the higher iteration risk** (FFI coercions / std churn); I may need a round or two.

## The epic

L-1 (archive + sandbox split) → L-2 (`hl_embed_*` ABI) → L-3 (sealed base_dir + fail-closed) → L-4 (sign + SBOM + dual-arch cosmo) → **L-5 (Rust + Zig embedders)**. This is the last one.