### PR TITLE
build: purge tool_orchestration.o on config-flag change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2035,7 +2035,7 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
           $(BUILDDIR)/sandbox.o $(BUILDDIR)/sandbox_tool.o $(BUILDDIR)/signature.o $(BUILDDIR)/release.o $(BUILDDIR)/release_io.o $(BUILDDIR)/tools_install.o $(BUILDDIR)/platform_sig.o \
           $(BUILDDIR)/test_runner.o $(BUILDDIR)/runtime_factory.o $(BUILDDIR)/hull_static.o \
           $(BUILDDIR)/migrate.o $(BUILDDIR)/vfs.o $(BUILDDIR)/cacert.o \
-          $(BUILDDIR)/app_context.o $(BUILDDIR)/tool.o $(BUILDDIR)/build_assets.o \
+          $(BUILDDIR)/app_context.o $(BUILDDIR)/tool.o $(BUILDDIR)/tool_orchestration.o $(BUILDDIR)/build_assets.o \
           $(BUILDDIR)/compiler.o $(BUILDDIR)/compiler_tcc.o \
           $(BUILDDIR)/hull_alloc.o $(BUILDDIR)/hull_async.o $(BUILDDIR)/hull_compress.o \
           $(BUILDDIR)/worker_db.o $(BUILDDIR)/worker_wasm.o $(BUILDDIR)/worker_gpu.o \


### PR DESCRIPTION
Surfaced while investigating the per-flavor SBOM follow-up (#50).

## Problem
The config-fingerprint purge block (Makefile) force-recompiles flag-dependent objects when a `HL_ENABLE_*` flag flips **in place**. It listed `tool.o` but not `tool_orchestration.o`, and no glob catches the latter. `tool_orchestration.c` gates its `hull dev` / `hull agent errors` tool-VM bindings on `HL_ENABLE_HTTP_SERVER`, so an in-place `make HL_ENABLE_HTTP=0` left a **stale** `tool_orchestration.o` still referencing `hl_dev_state*` / `hl_agent_errors` — whose definitions the same flip drops — and the hull link failed with undefined symbols.

A clean build was always fine; only the in-place flip broke. This is purge-list hygiene, not a code bug (the `#ifdef HL_ENABLE_HTTP_SERVER` gating was already correct).

## Fix
Add `tool_orchestration.o` to the purge list.

## Verified
`make && make HL_ENABLE_HTTP=0` (the exact failing scenario) now purges + recompiles it and links the pure-compute hull cleanly (runs `version` + `sbom`). Default build restored, unaffected.

Refs #50.