### PR TITLE
feat(sbom): hull sbom --flavor + per-flavor release SBOMs (closes #50)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -717,7 +717,17 @@ jobs:
           ./hull-linux-x86_64 sbom --subject=libhull --format=json      > libhull.sbom.json
           ./hull-linux-x86_64 sbom --subject=libhull --format=cyclonedx > libhull.sbom.cdx.json
           ./hull-linux-x86_64 sbom --subject=libhull --format=spdx      > libhull.sbom.spdx.json
-          ls -la hull.sbom.* libhull.sbom.*
+          # Per-flavor SBOMs for the published `hull build --flavor` platform
+          # libs. Named to match libhull_platform-<flavor>.a. Today only
+          # pure-compute differs (drops Keel + mbedTLS); the others equal the
+          # full hull SBOM minus the binary hash, published for symmetry so a
+          # `hull platform install <flavor>` consumer has its own bill.
+          for f in server-only client-only pure-compute; do
+            ./hull-linux-x86_64 sbom --flavor="$f" --format=json      > "libhull_platform-$f.sbom.json"
+            ./hull-linux-x86_64 sbom --flavor="$f" --format=cyclonedx > "libhull_platform-$f.sbom.cdx.json"
+            ./hull-linux-x86_64 sbom --flavor="$f" --format=spdx      > "libhull_platform-$f.sbom.spdx.json"
+          done
+          ls -la hull.sbom.* libhull.sbom.* libhull_platform-*.sbom.*
 
       - name: Generate build-environment manifest
         # §0.3.14. Capture the release-workflow runner identity, commit,
@@ -764,6 +774,7 @@ jobs:
                     hull-wamrc-linux-x86_64 hull-wamrc-linux-aarch64 hull-wamrc-darwin-arm64 \
                     hull.sbom.json hull.sbom.cdx.json hull.sbom.spdx.json \
                     libhull.sbom.json libhull.sbom.cdx.json libhull.sbom.spdx.json \
+                    libhull_platform-*.sbom.* \
                     hull.build-env.json \
                     libhull_platform-*.a \
                     libhull-linux-x86_64.a libhull-linux-aarch64.a libhull-darwin-arm64.a \
@@ -879,6 +890,8 @@ jobs:
             dist/libhull.sbom.cdx.json
             dist/libhull.sbom.spdx.json
           )
+          # Per-flavor platform-lib SBOMs (hull sbom --flavor).
+          assets+=(dist/libhull_platform-*.sbom.*)
           if [ -f dist/hull.sha256.sig ]; then
             assets+=(dist/hull.sha256.sig)
           fi

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ hull build --flavor=auto -o myapp .        # infer the minimal flavor
 
 Releases publish signed per-flavor platform libs for every target: native `libhull_platform-<flavor>-<arch>.a` (linux-x86_64, linux-aarch64, darwin-arm64) and cosmo dual-arch `libhull_platform-<flavor>.{x86_64,aarch64}-cosmo.a`, all covered by the Ed25519-signed `hull.sha256` (plus Sigstore/cosign signatures and SLSA provenance). See [docs/build_flavors.md](docs/build_flavors.md) for the full design.
 
+Each flavor also gets a signed SBOM (`libhull_platform-<flavor>.sbom.{json,cdx.json,spdx.json}`), generated with `hull sbom --flavor=<flavor>` — it reports the exact dependency set that flavor links (e.g. `pure-compute` omits Keel + mbedTLS). Run it locally against any hull binary to inspect a flavor's bill of materials without building it.
+
 ### libhull: embed the hardened core (no runtime)
 
 `make libhull` produces `libhull.a`, Hull's runtime-free core as a static archive a native program (C / Rust / Zig) links directly. There is no Lua/QuickJS runtime and no `app.main` lifecycle: the host owns `main()` and drives the two-phase kernel sandbox, the capability-mediated I/O layer, the WASM/GPU compute isolation, and the signed-artifact/SBOM machinery itself, through one stable header, [`<hull/embed.h>`](include/hull/embed.h).

--- a/include/hull/sbom.h
+++ b/include/hull/sbom.h
@@ -55,6 +55,10 @@ typedef struct {
      * components (the Lua / QuickJS script engines) that libhull excludes.
      * Consumed by the `hull sbom --subject=libhull` scope. */
     int in_libhull;
+    /* 1 if this component is only present when HTTP is compiled in (Keel +
+     * mbedTLS). The `pure-compute` build flavor (HL_ENABLE_HTTP=0) drops
+     * these; consumed by the `hull sbom --flavor=<flavor>` scope. */
+    int needs_http;
 } HlSbomEntry;
 
 /* Returns a pointer to the static entry table. Sets *count to its length.
@@ -67,6 +71,14 @@ const HlSbomEntry *hl_sbom_entries(size_t *count);
  * (the script runtimes) are omitted. Pass 0 to restore the default
  * whole-hull scope. Process-global, like hl_sbom_set_binary_path. */
 void hl_sbom_set_scope_libhull(int on);
+
+/* Scope the next hl_sbom_format() to a `hull build --flavor` target: report
+ * the dependency set that flavor's platform lib links. Today only
+ * "pure-compute" changes the set (drops the needs_http components — Keel +
+ * mbedTLS); "full" / "server-only" / "client-only" link the same vendored
+ * set. @p flavor is one of those four names, or NULL/"" to clear the scope.
+ * Returns 0 on success, -1 on an unknown flavor. Process-global. */
+int hl_sbom_set_scope_flavor(const char *flavor);
 
 /* Format the SBOM and write to `fp`. Returns 0 on success, -1 on error.
  * Errors are printed to stderr. */

--- a/src/hull/commands/sbom.c
+++ b/src/hull/commands/sbom.c
@@ -23,6 +23,7 @@ static void usage(FILE *fp)
 {
     fprintf(fp,
         "Usage: hull sbom [--format=<format>] [--subject=<hull|libhull>]\n"
+        "                 [--flavor=<full|server-only|client-only|pure-compute>]\n"
         "\n"
         "Print the Software Bill of Materials for this hull binary.\n"
         "\n"
@@ -30,6 +31,10 @@ static void usage(FILE *fp)
         "  hull        The whole hull binary.\n"
         "  libhull     The no-runtime embedding archive (libhull.a): drops the\n"
         "              Lua/QuickJS runtimes; keeps the linked core + Keel.\n"
+        "\n"
+        "Flavor (report a `hull build --flavor` platform lib's deps):\n"
+        "  full / server-only / client-only   Same vendored set as the binary.\n"
+        "  pure-compute                       Drops Keel + mbedTLS (no HTTP).\n"
         "\n"
         "Formats:\n"
         "  human       Default. Pretty table mirroring LICENSING.md style.\n"
@@ -83,6 +88,32 @@ int hl_cmd_sbom(int argc, char **argv, const HlCommandEnv *env)
                 fprintf(stderr,
                         "hull sbom: unknown subject '%s' (expected hull|libhull)\n",
                         sub);
+                usage(stderr);
+                return 1;
+            }
+            continue;
+        }
+        /* --flavor=<full|server-only|client-only|pure-compute>: report the
+         * dependency set that flavor's platform lib links (the SBOM analogue
+         * of `hull build --flavor`). Self-contained like --subject above. */
+        if (strcmp(argv[i], "--flavor") == 0 ||
+            strncmp(argv[i], "--flavor=", 9) == 0) {
+            const char *fl = NULL;
+            if (argv[i][8] == '=') {
+                fl = argv[i] + 9;            /* --flavor=VALUE */
+            } else if (i + 1 < argc) {
+                fl = argv[++i];              /* --flavor VALUE */
+            }
+            if (!fl) {
+                fprintf(stderr, "hull sbom: --flavor requires a value "
+                        "(full|server-only|client-only|pure-compute)\n");
+                usage(stderr);
+                return 1;
+            }
+            if (hl_sbom_set_scope_flavor(fl) != 0) {
+                fprintf(stderr, "hull sbom: unknown flavor '%s' "
+                        "(expected full|server-only|client-only|pure-compute)\n",
+                        fl);
                 usage(stderr);
                 return 1;
             }

--- a/src/hull/sbom.c
+++ b/src/hull/sbom.c
@@ -140,17 +140,70 @@ static int g_sbom_libhull = 0;
 
 void hl_sbom_set_scope_libhull(int on) { g_sbom_libhull = on ? 1 : 0; }
 
-/* Subject component name for the current scope. */
-static const char *sbom_subject_name(void)
+/* Build-flavor scope (hull build --flavor). NONE = the binary's actual set. */
+typedef enum {
+    SBOM_FLAVOR_NONE = 0,
+    SBOM_FLAVOR_FULL,
+    SBOM_FLAVOR_SERVER_ONLY,
+    SBOM_FLAVOR_CLIENT_ONLY,
+    SBOM_FLAVOR_PURE_COMPUTE,
+} SbomFlavor;
+
+static SbomFlavor  g_sbom_flavor      = SBOM_FLAVOR_NONE;
+static const char *g_sbom_flavor_name = NULL;   /* static string; for the subject */
+
+int hl_sbom_set_scope_flavor(const char *flavor)
 {
-    return g_sbom_libhull ? "libhull" : "hull";
+    if (!flavor || !flavor[0]) {
+        g_sbom_flavor = SBOM_FLAVOR_NONE;
+        g_sbom_flavor_name = NULL;
+        return 0;
+    }
+    static const struct { const char *name; SbomFlavor f; } tbl[] = {
+        { "full",         SBOM_FLAVOR_FULL },
+        { "server-only",  SBOM_FLAVOR_SERVER_ONLY },
+        { "client-only",  SBOM_FLAVOR_CLIENT_ONLY },
+        { "pure-compute", SBOM_FLAVOR_PURE_COMPUTE },
+    };
+    for (size_t i = 0; i < sizeof(tbl) / sizeof(tbl[0]); i++) {
+        if (strcmp(flavor, tbl[i].name) == 0) {
+            g_sbom_flavor = tbl[i].f;
+            g_sbom_flavor_name = tbl[i].name;
+            return 0;
+        }
+    }
+    return -1;
 }
 
-/* True if entry @e should be emitted under the current scope. In libhull
- * scope, runtime-only components (in_libhull == 0) are omitted. */
+/* Subject component name for the current scope. Static-buffer for the flavor
+ * form; single-threaded CLI use, like the rest of the sbom module. */
+static const char *sbom_subject_name(void)
+{
+    if (g_sbom_libhull) return "libhull";
+    if (g_sbom_flavor != SBOM_FLAVOR_NONE && g_sbom_flavor_name) {
+        static char buf[48];
+        snprintf(buf, sizeof(buf), "hull (%s)", g_sbom_flavor_name);
+        return buf;
+    }
+    return "hull";
+}
+
+/* True if entry @e should be emitted under the current scope. libhull scope
+ * drops runtime-only components; the pure-compute flavor drops needs_http
+ * ones (Keel + mbedTLS). */
 static int sbom_entry_visible(const HlSbomEntry *e)
 {
-    return !g_sbom_libhull || e->in_libhull;
+    if (g_sbom_libhull && !e->in_libhull) return 0;
+    if (g_sbom_flavor == SBOM_FLAVOR_PURE_COMPUTE && e->needs_http) return 0;
+    return 1;
+}
+
+/* True when any non-default scope (libhull or a flavor) is active. Such an
+ * SBOM describes an archive/flavor, not the running binary, so the binary
+ * hash is omitted. */
+static int sbom_scoped(void)
+{
+    return g_sbom_libhull || g_sbom_flavor != SBOM_FLAVOR_NONE;
 }
 
 #ifdef HL_SBOM_HAS_MBEDTLS
@@ -219,6 +272,7 @@ static const HlSbomEntry sbom_entries[] = {
     {
         .name = "keel",
         .in_libhull = 1,
+        .needs_http = 1,
         .version = HULL_VENDOR_KEEL_VERSION,
         .commit = HULL_VENDOR_KEEL_COMMIT,
         .license_spdx = "MIT",
@@ -279,6 +333,7 @@ static const HlSbomEntry sbom_entries[] = {
     {
         .name = "mbedtls",
         .in_libhull = 1,
+        .needs_http = 1,
         .version = "3.x",
         .commit = "",
         .license_spdx = "Apache-2.0",
@@ -466,12 +521,16 @@ static void format_human(FILE *fp)
         fprintf(fp, "libhull SBOM\n");
         fprintf(fp, "libhull (Hull %s), plus %zu component(s):\n",
                 HL_VERSION, sbom_visible_count());
+    } else if (g_sbom_flavor != SBOM_FLAVOR_NONE) {
+        fprintf(fp, "%s SBOM\n", sbom_subject_name());
+        fprintf(fp, "Hull %s (%s flavor), plus %zu component(s):\n",
+                HL_VERSION, g_sbom_flavor_name, sbom_visible_count());
     } else {
         fprintf(fp, "Hull SBOM\n");
         fprintf(fp, "Hull %s, plus %zu component(s):\n",
                 HL_VERSION, sbom_entries_count - 1);
     }
-    const char *bin_sha = sha256_binary();
+    const char *bin_sha = sbom_scoped() ? NULL : sha256_binary();
     if (bin_sha) fprintf(fp, "Binary sha256: %s\n", bin_sha);
     fputc('\n', fp);
 
@@ -552,7 +611,7 @@ static void format_json(FILE *fp)
     sh_json_write_kv_string(&w, "subject", sbom_subject_name());
     /* The runtime binary hash describes the hull binary, not libhull.a — omit
      * it in libhull scope (the archive's own hash lives in libhull.a.sha256). */
-    const char *bin_sha = g_sbom_libhull ? NULL : sha256_binary();
+    const char *bin_sha = sbom_scoped() ? NULL : sha256_binary();
     if (bin_sha)
         sh_json_write_kv_string(&w, "binary_sha256", bin_sha);
     sh_json_write_key(&w, "components");
@@ -597,7 +656,7 @@ static void format_cyclonedx(FILE *fp)
     /* metadata.component describes the subject of the BOM (this binary).
      * Includes the SHA-256 of the running binary when known, so a consumer
      * can cross-check against the signed hull.sha256 release manifest. */
-    const char *bin_sha = g_sbom_libhull ? NULL : sha256_binary();
+    const char *bin_sha = sbom_scoped() ? NULL : sha256_binary();
     sh_json_write_key(&w, "metadata");
     sh_json_write_object_start(&w);
     sh_json_write_key(&w, "component");
@@ -707,7 +766,7 @@ static void format_spdx(FILE *fp)
      * SPDX document is the running hull binary; binary_sha256 is emitted
      * as a checksum on that package so consumers can cross-reference the
      * signed release manifest. */
-    const char *bin_sha = g_sbom_libhull ? NULL : sha256_binary();
+    const char *bin_sha = sbom_scoped() ? NULL : sha256_binary();
     sh_json_write_key(&w, "documentDescribes");
     sh_json_write_array_start(&w);
     sh_json_write_string(&w, "SPDXRef-Package-hull-binary");
@@ -724,8 +783,10 @@ static void format_spdx(FILE *fp)
     sh_json_write_kv_string(&w, "licenseConcluded", "AGPL-3.0-or-later");
     sh_json_write_kv_string(&w, "licenseDeclared",  "AGPL-3.0-or-later");
     sh_json_write_kv_string(&w, "comment",
-                            g_sbom_libhull ? "the libhull embedding archive"
-                                           : "the running hull binary");
+                            g_sbom_libhull ? "the libhull embedding archive" :
+                            g_sbom_flavor != SBOM_FLAVOR_NONE
+                                ? "a hull build --flavor platform library"
+                                : "the running hull binary");
     if (bin_sha) {
         sh_json_write_key(&w, "checksums");
         sh_json_write_array_start(&w);

--- a/tests/hull/test_sbom.c
+++ b/tests/hull/test_sbom.c
@@ -392,4 +392,45 @@ UTEST(sbom, all_formats_render_under_libhull_scope)
     hl_sbom_set_scope_libhull(0);
 }
 
+/* ── flavor scope (hull sbom --flavor=X) ───────────────────────────── */
+
+UTEST(sbom, needs_http_flags_match_policy)
+{
+    size_t n = 0;
+    const HlSbomEntry *e = hl_sbom_entries(&n);
+    for (size_t i = 0; i < n; i++) {
+        int http = strcmp(e[i].name, "keel") == 0 || strcmp(e[i].name, "mbedtls") == 0;
+        ASSERT_EQ_MSG(e[i].needs_http, http, e[i].name);
+    }
+}
+
+UTEST(sbom, flavor_scope_unknown_rejected)
+{
+    ASSERT_EQ(hl_sbom_set_scope_flavor("bogus"), -1);
+    ASSERT_EQ(hl_sbom_set_scope_flavor("full"), 0);
+    ASSERT_EQ(hl_sbom_set_scope_flavor("pure-compute"), 0);
+    ASSERT_EQ(hl_sbom_set_scope_flavor(NULL), 0);   /* clears */
+}
+
+UTEST(sbom, pure_compute_flavor_drops_http_deps)
+{
+    hl_sbom_set_scope_flavor("pure-compute");
+    char *pc = format_to_string(HL_SBOM_JSON);
+    ASSERT_NE(pc, NULL);
+    ASSERT_NE_MSG(strstr(pc, "pure-compute"), NULL, "subject names the flavor");
+    ASSERT_EQ_MSG(strstr(pc, "\"mbedtls\""), NULL, "pure-compute drops mbedTLS");
+    ASSERT_EQ_MSG(strstr(pc, "\"keel\""), NULL, "pure-compute drops Keel");
+
+    /* full / server-only keep the HTTP deps (same vendored set as the binary). */
+    hl_sbom_set_scope_flavor("server-only");
+    char *so = format_to_string(HL_SBOM_JSON);
+    ASSERT_NE(so, NULL);
+    ASSERT_NE_MSG(strstr(so, "mbedtls"), NULL, "server-only keeps mbedTLS");
+    ASSERT_LT(sbom_count(pc, "\"name\""), sbom_count(so, "\"name\""));
+
+    free(pc);
+    free(so);
+    hl_sbom_set_scope_flavor(NULL);
+}
+
 UTEST_MAIN()


### PR DESCRIPTION
Closes #50. The per-flavor platform libs (`hull build --flavor`) had no SBOM of their own — only `hull.sbom` (full) and `libhull.sbom` (no-runtime) shipped. This adds the SBOM analogue of `hull build --flavor`.

## What's here

- **`hull sbom --flavor=<full|server-only|client-only|pure-compute>`** — reports the dependency set that flavor's platform lib links, generated from any (full) hull binary (no per-flavor hull build needed — same mechanism as `--subject=libhull`). A new `needs_http` flag on `HlSbomEntry` marks Keel + mbedTLS; `pure-compute` drops them (`HL_ENABLE_HTTP=0` unlinks both). Subject renamed `hull (<flavor>)`, binary hash omitted (the SBOM describes a flavor lib, not the running binary). `full` / `server-only` / `client-only` link the same vendored set as the binary.
- **`release.yml`** generates `libhull_platform-<flavor>.sbom.{json,cdx,spdx}` for the three published flavors and folds them into the Ed25519-signed `hull.sha256`, so a `hull platform install <flavor>` consumer gets a signed bill of materials for the lib they linked.
- **`test_sbom`** — `needs_http` flags match policy; unknown flavor rejected; pure-compute drops the HTTP deps + renames subject + shrinks the set.
- README note under Build Flavors.

## Validation

- `make test` 51/0 (`test_sbom` 24/24, incl. 3 new).
- scan-build clean on the `--flavor` parsing.
- All formats scope correctly; **default output unchanged**; `release.yml` valid YAML.

## Notes

- The **release.yml half is untestable locally** (tag-only); the `--flavor` filter itself is fully validated + unit-tested.
- **Narrowness (documented):** only `pure-compute` actually differs at the vendored-dependency level; `server-only`/`client-only` equal the full set (they differ in which cap *code* compiles, not which vendored lib). The three per-flavor SBOMs are published for symmetry so every `hull platform install <flavor>` has a named, signed SBOM.