### PR TITLE
ci: pin all runners to versioned labels (roadmap 0.3.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,14 @@ jobs:
       matrix:
         include:
           - name: Linux
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - name: Linux (clang)
-            os: ubuntu-latest
+            os: ubuntu-24.04
             cc: clang
           - name: Linux (aarch64)
             os: ubuntu-24.04-arm
           - name: macOS
-            os: macos-latest
+            os: macos-15
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -184,7 +184,7 @@ jobs:
   # only break the flavor link, which nothing else exercises.
   flavors:
     name: Build flavor (${{ matrix.name }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -245,9 +245,9 @@ jobs:
       matrix:
         include:
           - name: Linux
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - name: macOS
-            os: macos-latest
+            os: macos-15
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -283,9 +283,9 @@ jobs:
       matrix:
         include:
           - name: Linux
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - name: macOS
-            os: macos-latest
+            os: macos-15
 
     name: Build Pipeline (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
@@ -301,7 +301,7 @@ jobs:
 
   sanitizers:
     name: ASan + UBSan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -316,7 +316,7 @@ jobs:
 
   msan:
     name: MSan + UBSan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -339,7 +339,7 @@ jobs:
 
   tsan:
     name: TSan (worker pool)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -363,7 +363,7 @@ jobs:
 
   fuzz:
     name: Fuzz Testing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -398,7 +398,7 @@ jobs:
 
   analyze:
     name: Static Analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -418,7 +418,7 @@ jobs:
 
   cosmo:
     name: Cosmopolitan (APE)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -495,7 +495,7 @@ jobs:
 
   gpu:
     name: GPU Compute (macOS Metal)
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -522,7 +522,7 @@ jobs:
 
   coverage:
     name: Code Coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -544,7 +544,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -570,9 +570,9 @@ jobs:
       matrix:
         include:
           - name: Linux
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - name: macOS
-            os: macos-latest
+            os: macos-15
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -624,7 +624,7 @@ jobs:
 
   benchmark:
     name: Benchmark (${{ matrix.runtime }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'push'
 
     strategy:
@@ -657,7 +657,7 @@ jobs:
   # ran (grep for the OK line) rather than silently pass.
   embed-rust:
     name: libhull embedder (Rust)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -675,7 +675,7 @@ jobs:
 
   embed-zig:
     name: libhull embedder (Zig)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check:
     name: Sign-off check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     # Promote the CF distribution ID to job-level env so step-level `if:`
     # conditions can read it. (`secrets` context is not allowed in `if:`;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,11 @@ jobs:
       matrix:
         include:
           - name: linux-x86_64
-            os: ubuntu-latest
+            os: ubuntu-24.04
           - name: linux-aarch64
             os: ubuntu-24.04-arm
           - name: darwin-arm64
-            os: macos-latest
+            os: macos-15
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -72,7 +72,7 @@ jobs:
 
   build-platform-cosmo:
     name: Build platform (cosmo, multi-arch)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -110,7 +110,7 @@ jobs:
   # build-platform-cosmo job above, which proves one cosmo build + upload works.
   build-platform-cosmo-flavors:
     name: Build platform (cosmo, ${{ matrix.flavor }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -158,7 +158,7 @@ jobs:
 
   sign-platform-manifest:
     name: Sign platform manifest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [build-platform-native, build-platform-cosmo]
     env:
       HULL_PLATFORM_KEY: ${{ secrets.HULL_PLATFORM_KEY }}
@@ -289,7 +289,7 @@ jobs:
 
   build-cosmo:
     name: Build (Cosmopolitan APE)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [build-platform-cosmo, sign-platform-manifest]
 
     steps:
@@ -428,13 +428,13 @@ jobs:
       matrix:
         include:
           - name: linux-x86_64
-            os: ubuntu-latest
+            os: ubuntu-24.04
             artifact: hull-linux-x86_64
           - name: linux-aarch64
             os: ubuntu-24.04-arm
             artifact: hull-linux-aarch64
           - name: darwin-arm64
-            os: macos-latest
+            os: macos-15
             artifact: hull-darwin-arm64
 
     steps:
@@ -601,13 +601,13 @@ jobs:
       matrix:
         include:
           - name: linux-x86_64
-            os: ubuntu-latest
+            os: ubuntu-24.04
             artifact: hull-wamrc-linux-x86_64
           - name: linux-aarch64
             os: ubuntu-24.04-arm
             artifact: hull-wamrc-linux-aarch64
           - name: darwin-arm64
-            os: macos-latest
+            os: macos-15
             artifact: hull-wamrc-darwin-arm64
 
     steps:
@@ -653,7 +653,7 @@ jobs:
 
   release:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [build-cosmo, build-native, build-wamrc, build-platform-cosmo-flavors]
     permissions:
       contents: write       # publish GitHub release + assets

--- a/docs/roadmap_next.md
+++ b/docs/roadmap_next.md
@@ -209,19 +209,20 @@ not implementation cost.
 
 #### Tier 1. Load-bearing (the trust claim depends on these)
 
-- [ ] **0.3.1. Pin the CI build environment.** **Partial.** ARM
-  runners now pin `ubuntu-24.04-arm`; the rest of `ci.yml` and
-  `release.yml` still uses mutable `ubuntu-latest` / `macos-latest`
-  labels at ~10 sites. No Docker base or Nix flake yet. `ubuntu-latest`
-  and `macos-latest` are mutable labels. GitHub rotates the runner
-  image without notice. Reproducibility passes today against
-  today's image. Six months from now, a rebuild of v0.1.5 source
-  against the new image may not reproduce. **Fix (remainder):** complete
-  the pin across all `runs-on:` entries (digest-pinned Docker base or
-  a Nix flake). Without this, "reproducible" has a sliding expiry date
-  and the reproducibility-from-clean-room claim is only true in a
-  narrow time window. **Effort:** low for runner-pin; medium for Docker
-  base; high for Nix flake. Start with runner-pin.
+- [ ] **0.3.1. Pin the CI build environment.** **Runner-pin done;
+  immutable base still open.** Every `runs-on:` across `ci.yml`,
+  `release.yml`, `deploy-site.yml`, and `dco.yml` now pins a versioned
+  label (`ubuntu-24.04`, `ubuntu-24.04-arm`, `macos-15`) — no more
+  mutable `ubuntu-latest` / `macos-latest`. This removes the big
+  reproducibility killer: a `latest` label silently jumping to the next
+  major OS (24.04 -> 26.04, macOS 15 -> 16) between a release and a
+  rebuild. **Remaining:** versioned labels still receive GitHub's monthly
+  patch updates, so the image is not byte-immutable across time. Closing
+  that needs a digest-pinned Docker base image (medium) or a Nix flake
+  (high) for the reproducibility-critical build/release jobs; until then
+  "reproducible" holds within a major-version window, not indefinitely.
+  **Effort:** ~~low for runner-pin~~ (done); medium for Docker base; high
+  for Nix flake.
 
 - [ ] **0.3.2. Bootstrap trust path.** The `curl ... | sh` install
   is TOFU on top of TLS to `raw.githubusercontent.com` + GitHub


### PR DESCRIPTION
Roadmap **§0.3.1** (Trust-chain hardening, Tier 1) — the low-effort runner-pin step.

## Problem
`runs-on: ubuntu-latest` / `macos-latest` are mutable labels. GitHub rotates them to the next major OS (24.04 → 26.04, macOS 15 → 16) without notice, so a rebuild of a tagged release months later can land on a different toolchain and **fail to reproduce** — the reproducibility guarantee has a sliding expiry.

## Change
Pin every `runs-on:` across `ci.yml`, `release.yml`, `deploy-site.yml`, and `dco.yml` to a versioned label:
- `ubuntu-latest` → `ubuntu-24.04` (matches the already-pinned `ubuntu-24.04-arm`)
- `macos-latest` → `macos-15`

27 sites in total. Only runner labels changed (verified: no other workflow lines touched).

## Scope (honest)
This removes the **major-version jump**, the big reproducibility killer. Versioned labels still receive GitHub's **monthly patch updates**, so the image isn't byte-immutable across time — full immutability needs a digest-pinned Docker base (medium) or a Nix flake (high) for the build/release jobs. Those remain open under §0.3.1; the roadmap entry is updated to reflect runner-pin done / immutable-base still open.

## Verification
No behavior change intended (`-latest` already resolved to 24.04 / 15). All four workflow YAMLs validate. **This PR's own CI run on the pinned images is the real test** — if `macos-15` / `ubuntu-24.04` surface any image-specific difference, it shows here.