### PR TITLE
feat(site): sign install.sh with minisign + serve the verify path (roadmap 0.3.2)

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -10,6 +10,12 @@ on:
       # Changing it should redeploy so `curl gethull.dev/install.sh`
       # picks up new platform support, knobs, etc.
       - 'install.sh'
+      # The minisign signature + public key served next to install.sh for
+      # the offline "verify the installer" path. Re-sign install.sh whenever
+      # it changes; the verify-guard step below fails the deploy on a stale
+      # or missing signature.
+      - 'install.sh.minisig'
+      - 'minisign.pub'
       - '.github/workflows/deploy-site.yml'
 
 jobs:
@@ -32,6 +38,21 @@ jobs:
           cd site && make build
           echo "Build contents:"
           find build -type f
+
+      - name: Verify installer signature (fail deploy on stale/missing sig)
+        # The offline "verify the installer" path on gethull.dev tells users
+        # to check install.sh against minisign.pub. Enforce that the published
+        # signature actually matches the published install.sh, so a forgotten
+        # re-sign after editing install.sh blocks the deploy instead of
+        # shipping a broken verify path. The pubkey is the repo's committed
+        # minisign.pub (also cross-checkable on GitHub, a different origin
+        # than the S3 site).
+        run: |
+          set -eu
+          sudo apt-get update
+          sudo apt-get install -y minisign
+          cd site/build
+          minisign -Vm install.sh -p minisign.pub
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4

--- a/docs/roadmap_next.md
+++ b/docs/roadmap_next.md
@@ -224,19 +224,22 @@ not implementation cost.
   **Effort:** ~~low for runner-pin~~ (done); medium for Docker base; high
   for Nix flake.
 
-- [ ] **0.3.2. Bootstrap trust path.** The `curl ... | sh` install
-  is TOFU on top of TLS to `raw.githubusercontent.com` + GitHub
-  account integrity + `install.sh` content trust. A new user has
-  no out-of-band way to verify they got the real installer before
-  running it. Once installed, the chain is tight; getting there is
-  not. **Fix:** publish a detached PGP signature on `install.sh`
-  itself, or a Sigstore signature, with verification instructions
-  on gethull.dev. Chicken-and-egg: the verification path can't
-  require an existing hull. PGP via a well-known maintainer key
-  (or a Sigstore identity tied to gethull's GitHub) is the realistic
-  option. Document the "I don't trust GitHub: how do I verify
-  install.sh" path. **Effort:** medium. Mostly social-engineering
-  (key publication, KEYS file maintenance, docs) rather than code.
+- [x] **0.3.2. Bootstrap trust path. ✅ Done (minisign).** The
+  `curl ... | sh` install was TOFU on top of TLS + GitHub account
+  integrity + `install.sh` content trust, with no out-of-band way to
+  verify the installer before running it. Now `install.sh` is
+  minisign-signed and the signature + public key ship on gethull.dev
+  next to the installer (`install.sh.minisig`, `minisign.pub`; key ID
+  `595ED89D8DCEBD6A`, committed at the repo root and cross-checkable on
+  GitHub, a different origin than the S3 site). The landing page shows
+  both paths: the `curl | sh` trust path and an offline "verify the
+  installer first" path (`minisign -Vm install.sh -P <pubkey>`) that needs
+  no pre-installed hull. `deploy-site.yml` verify-guards the published
+  signature against the published installer, so a forgotten re-sign fails
+  the deploy. minisign was chosen over Sigstore for the bootstrap
+  (offline-verifiable, no extra online infra required). **Remaining:** the
+  installer signing key is currently a maintainer software key; moving it
+  to a YubiKey follows the same custody-hardening path as 0.3.3(b).
 
 - [ ] **0.3.3. Move release signing off GitHub Actions secrets.**
   The release private key currently lives encrypted in GitHub's

--- a/install.sh.minisig
+++ b/install.sh.minisig
@@ -1,0 +1,4 @@
+untrusted comment: signature from minisign secret key
+RURqvc6NndheWUjrTSSh16UeYBrYNcJmNBNL/edvVddzpnhOJq6s3z0ZhuH/lLBlElg2xPUiQazE3dQNZCZZz4yPaq9rzW5Ssgs=
+trusted comment: timestamp:1783873082	file:install.sh	hashed
+dS66PKMU0LiVgO/qn5X5x8Gh0ujjXqTsI9Qt1FkAas4Pp6yS1iW/VW1dI0JvAh1O72Fx5hmlplb1I9O7F1s5BA==

--- a/minisign.pub
+++ b/minisign.pub
@@ -1,0 +1,2 @@
+untrusted comment: minisign public key 595ED89D8DCEBD6A
+RWRqvc6NndheWcLIi3vsL+xoZfZw2j7fybSZ3rHJIOTHA2O3rrr6hD8h

--- a/site/Makefile
+++ b/site/Makefile
@@ -15,7 +15,10 @@ BUILD_DIR := build
 # Files that ship in the deployed site. install.sh is the symlink that
 # must be dereferenced; everything else is a regular file.
 STATIC_FILES := index.html verify.html mark.svg og-card.svg og-card.png
-SYMLINKED    := install.sh
+# Dereferenced symlinks to canonical repo-root files: install.sh plus its
+# minisign signature + public key, so `curl gethull.dev/install.sh{,.minisig}`
+# and the offline "verify the installer" path both work.
+SYMLINKED    := install.sh install.sh.minisig minisign.pub
 # Subdirs: vendored third-party assets (Tailwind, Lucide) and fonts.
 # Self-hosted so the "no third-party CDN" claim holds for the site too.
 SUBDIRS      := vendor fonts

--- a/site/index.html
+++ b/site/index.html
@@ -452,6 +452,16 @@
             distribution needed.
           </p>
           <p class="mt-3 text-[11px] text-mute-500 leading-relaxed">
+            Don't want to pipe a script from a host you haven't verified?
+            The installer is minisign-signed. Check
+            <code class="text-paper-100 text-[0.72rem]">install.sh</code>
+            against
+            <code class="text-paper-100 text-[0.72rem]">install.sh.minisig</code>
+            offline before running it (no Hull needed); the key is
+            cross-checkable on
+            <a href="https://github.com/artalis-io/hull/blob/main/minisign.pub" class="link">GitHub</a>.
+          </p>
+          <p class="mt-3 text-[11px] text-mute-500 leading-relaxed">
             Linux x86_64 &middot; Linux aarch64 (Graviton, DGX, Ampere, Pi&nbsp;4+) &middot; macOS arm64 &middot; Cosmopolitan APE fallback.
           </p>
         </div>
@@ -463,19 +473,28 @@
               <span>shell</span>
               <span class="ml-auto text-[10px] text-mute-500">copy &amp; paste</span>
             </header>
-<pre><span class="tk-com"># 1. Install. install.sh verifies the SHA-256 manifest as it downloads.</span>
+<pre><span class="tk-com"># Install (trusts TLS + our GitHub). install.sh verifies each</span>
+<span class="tk-com"># binary's SHA-256 against the manifest as it downloads.</span>
 $ curl -fsSL <span class="tk-str">https://gethull.dev/install.sh</span> | sh
-hull installed to ~/.local/bin/hull  (v0.4.0)
+hull installed to ~/.local/bin/hull  (v0.6.0)
 
-<span class="tk-com"># 2. Verify the release signature (Ed25519, embedded pubkey).</span>
+<span class="tk-com"># Don't trust gethull.dev? Verify the installer offline first</span>
+<span class="tk-com"># (minisign, no Hull needed). Cross-check the key below against</span>
+<span class="tk-com"># github.com/artalis-io/hull/blob/main/minisign.pub.</span>
+$ <span class="tk-kw">URL</span>=https://gethull.dev
+$ curl -fsSLO $URL/install.sh $URL/install.sh.minisig
+$ minisign -Vm install.sh -P <span class="tk-str">RWRqvc6NndheWcLIi3vsL+xoZfZw2j7fybSZ3rHJIOTHA2O3rrr6hD8h</span>
+<span class="tk-acc">Signature and comment signature verified</span>
+$ sh install.sh
+
+<span class="tk-com"># Then verify the release signature (Ed25519, embedded pubkey).</span>
 $ <span class="tk-kw">REL</span>=https://github.com/artalis-io/hull/releases/latest/download
 $ curl -fsSLO $REL/hull.sha256 $REL/hull.sha256.sig
 $ hull verify-release hull.sha256 hull.sha256.sig
 <span class="tk-acc">ok</span>. Signature valid
 
-<span class="tk-com"># 3. Inspect the toolchain.</span>
 $ hull doctor
-hull v0.4.0  &middot;  ca-bundle: embedded  &middot;  platform: embedded  &middot;  cc: ok
+hull v0.6.0  &middot;  ca-bundle: embedded  &middot;  platform: embedded  &middot;  cc: ok
 </pre>
           </div>
           <p class="mt-3 text-[11px] text-mute-400 leading-relaxed">

--- a/site/install.sh.minisig
+++ b/site/install.sh.minisig
@@ -1,0 +1,1 @@
+../install.sh.minisig

--- a/site/minisign.pub
+++ b/site/minisign.pub
@@ -1,0 +1,1 @@
+../minisign.pub


### PR DESCRIPTION
Roadmap **§0.3.2** (bootstrap trust path). Gives the `curl | sh` install an out-of-band verification path so a new user can verify the installer *before* running it, with no pre-installed Hull.

## What's here

- **`install.sh` is minisign-signed.** `install.sh.minisig` + `minisign.pub` committed at the repo root (key ID `595ED89D8DCEBD6A`).
- **Served on gethull.dev next to the installer.** `site/{install.sh.minisig,minisign.pub}` symlink the repo-root files; `site/Makefile` dereferences them into the deployed build (same `cp -L` path as `install.sh`).
- **Deploy verify-guard.** `deploy-site.yml` installs minisign and runs `minisign -Vm install.sh -p minisign.pub` against the built site before the S3 sync, so a forgotten re-sign after editing `install.sh` **fails the deploy** instead of shipping a broken verify path. Path triggers extended to the two new files.
- **Landing page shows both paths:** (1) trust TLS + our GitHub and pipe `install.sh`; (2) don't trust gethull.dev — download `install.sh` + `.minisig` and `minisign -Vm ... -P <inline pubkey>` offline, cross-checking the key against `minisign.pub` on GitHub (a different origin than the S3 site).
- Roadmap §0.3.2 marked done; the YubiKey key-custody follow-up noted under §0.3.3(b).

## Why minisign (not Sigstore)
The verify path can't require an already-installed Hull (chicken-and-egg). minisign is ubiquitous, offline-verifiable, and needs no extra online infra — the right fit for a bootstrap check.

## Validation
Site build includes both files as real (dereferenced) files, and `minisign -Vm install.sh -p minisign.pub` verifies the built installer locally. `deploy-site.yml` valid YAML. Key generation + signing were done out-of-band by the maintainer.

## Note for maintainers
**Re-sign `install.sh` whenever you edit it** (`minisign -Sm install.sh`, commit the new `.minisig`) — the deploy guard enforces this.