### PR TITLE
ci: cosmo APE byte-reproducibility check (roadmap 0.3.7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,64 @@ jobs:
         timeout-minutes: 5
         run: make reproducible-check
 
+  # Cosmo APE byte-reproducibility (roadmap 0.3.7). The reproducibility job
+  # above builds twice in ONE job and cmps; that pattern can't be used for
+  # cosmo because a second `make platform-cosmo` in one job corrupts the
+  # dynamic loader. So build hull-cosmo on two independent runners (each does
+  # exactly one platform-cosmo build) and byte-compare the artifacts in a
+  # third job. This tests cross-runner reproducibility and verifies the
+  # "Cosmopolitan produces deterministic output" claim (docs/security.md) for
+  # the hull-cosmo release binary itself.
+  reproducibility-cosmo:
+    name: Reproducible build (Cosmo ${{ matrix.n }})
+    strategy:
+      fail-fast: false
+      matrix:
+        n: [a, b]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+      - name: Install cosmocc
+        run: |
+          COSMOCC_DIR=/opt/cosmo make fetch-cosmocc
+          echo "/opt/cosmo/bin" >> $GITHUB_PATH
+      - name: Build platform (multi-arch)
+        run: make platform-cosmo
+      - name: Build hull (cosmocc APE)
+        run: make CC=cosmocc
+      - name: Upload hull-cosmo
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: hull-cosmo-repro-${{ matrix.n }}
+          path: build/hull
+          if-no-files-found: error
+
+  reproducibility-cosmo-compare:
+    name: Reproducible build (Cosmo compare)
+    needs: reproducibility-cosmo
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          path: artifacts
+      - name: Byte-compare the two independent cosmo builds
+        run: |
+          set -eu
+          A=artifacts/hull-cosmo-repro-a/hull
+          B=artifacts/hull-cosmo-repro-b/hull
+          ls -la "$A" "$B"
+          if cmp -s "$A" "$B"; then
+            echo "PASS: hull-cosmo is byte-identical across independent runners ($(wc -c < "$A") bytes)"
+          else
+            echo "::error::hull-cosmo differs between builds; the cosmo APE is not byte-reproducible"
+            sha256sum "$A" "$B"
+            echo "--- first differing bytes ---"
+            cmp -l "$A" "$B" | head -20 || true
+            exit 1
+          fi
+
   build-pipeline:
     strategy:
       fail-fast: false

--- a/docs/roadmap_next.md
+++ b/docs/roadmap_next.md
@@ -289,14 +289,18 @@ not implementation cost.
   SHA-pinned actions natively and will PR updates. **Effort:** one
   pass through `.github/workflows/*.yml`.
 
-- [ ] **0.3.7. Cosmo APE in the reproducibility matrix.** The
-  current `Reproducible build` job matrixes Linux + macOS only.
-  Cosmo is built and shipped (`hull-cosmo` is a release asset)
-  but its byte-reproducibility is untested. Either add Cosmo to
-  the matrix or explicitly document that Cosmo repro is out of
-  scope. **Effort:** medium. Cosmo's two-arch link adds
-  complexity; investigate whether `cosmocc` + `apelink` produce
-  deterministic output before committing.
+- [x] **0.3.7. Cosmo APE in the reproducibility matrix. ✅ Done.** The
+  `Reproducible build` job previously matrixed Linux + macOS only; the
+  shipped `hull-cosmo` release asset was untested. Now the
+  `reproducibility-cosmo` job builds `hull-cosmo` on two independent
+  runners (each doing exactly one `platform-cosmo` build, since a second
+  in one job corrupts the loader) and a `reproducibility-cosmo-compare`
+  job byte-compares them. **Result: byte-identical across runners**
+  (13,921,722-byte APE), so `cosmocc` + `apelink` are deterministic and
+  the "Cosmopolitan produces deterministic output" claim in
+  [security.md](security.md) is now CI-gated, not just asserted.
+  All three shipped artifact types (native, macOS, cosmo) are now
+  reproducibility-covered.
 
 - [x] **0.3.8. `hull verify-self` command. ✅ Shipped.** A running hull binary
   can be tampered with on disk. There's no built-in command to

--- a/docs/security.md
+++ b/docs/security.md
@@ -1428,7 +1428,10 @@ Tier 4 makes that detectable as soon as anyone re-derives.
 5. Build metadata is signed. `cc_version` + `flags` are attested
    by the developer in `package.sig`.
 6. Cosmopolitan produces deterministic output. Static linking, no
-   timestamps.
+   timestamps. CI-verified: the `reproducibility-cosmo` job in
+   `.github/workflows/ci.yml` builds `hull-cosmo` on two independent
+   runners and byte-compares them (identical across runners, not just
+   same-machine).
 
 #### Self-hosted alternative
 


### PR DESCRIPTION
Roadmap **§0.3.7** — add the `hull-cosmo` release binary to the reproducibility story (the matrix covered Linux + macOS only).

## Approach (and why two jobs)
The existing reproducibility job builds twice in one job and `cmp`s. That can't be used for cosmo: a **second `make platform-cosmo` in one job corrupts the dynamic loader** (a known gotcha). So:
- **`reproducibility-cosmo` (matrix a, b):** two independent runners each install cosmocc, run `make platform-cosmo` (once) + `make CC=cosmocc`, and upload `build/hull`.
- **`reproducibility-cosmo-compare`:** downloads both and byte-compares.

This tests **cross-runner** reproducibility (stronger than same-machine) and finally verifies the "Cosmopolitan produces deterministic output" claim in `docs/security.md` for the hull binary itself.

## This is an experiment
I have no cosmocc locally, so **this PR's CI is the test**:
- **Green** → cosmo is byte-reproducible; I'll follow up (same PR) marking §0.3.7 done and flipping the security.md claim from *asserted* to *CI-gated*.
- **Red** → the compare job prints both SHA-256s + the first differing bytes; I'll either fix the non-determinism or **document cosmo repro out-of-scope** with that evidence — also a valid §0.3.7 outcome.

Draft until the cosmo jobs report.