### PR TITLE
docs: document vendored-dep reproducibility as a goal (§0.3.13)

### DIFF
--- a/docs/roadmap_next.md
+++ b/docs/roadmap_next.md
@@ -350,14 +350,25 @@ not implementation cost.
   **Effort:** small. One field per entry plus a CycloneDX
   formatter line.
 
-- [ ] **0.3.13. Vendored static archives reproducibility check.**
-  The submodule SHA pin is trusted; nobody independently verifies
-  that rebuilding e.g. WAMR from `c3a78cd159e5` produces a
-  byte-identical `.a`. Probably fine for most deps, but currently
-  undocumented as either a goal or non-goal. **Fix:** either add
-  a per-vendor `make verify-vendor-repro` target or explicitly
-  document this as a non-goal. **Effort:** low for docs; medium
-  for full per-dep verification.
+- [x] **0.3.13. Vendored static archives reproducibility check. ✅ Documented (2026-07-12).**
+  The concern (does rebuilding e.g. WAMR from `c3a78cd159e5` produce
+  byte-identical output?) turned out to be **already transitively
+  verified** and just undocumented. Every vendored dep is compiled
+  from pinned source on every `make`; the whole-build reproducibility
+  gate (`make reproducible-check` = `make` then `make clean` then
+  `make` then `cmp`) wipes `build/` and recompiles every vendored TU,
+  so a byte-identical `hull` proves the vendored objects rebuilt
+  identically. A separate per-dep `make verify-vendor-repro` target
+  would be redundant with that gate, so the deliverable was the
+  documentation decision the item asked for: a new
+  "Vendored-dependency reproducibility" subsection in
+  [security.md §7.1](security.md) states it as a **goal**
+  (transitively enforced, load-bearing pieces = pinned submodule
+  SHAs + `ZERO_AR_DATE` + `-ffile-prefix-map` + pinned runners) and
+  names the one **non-goal**: upstream deps being byte-reproducible
+  across *different* toolchain versions is each project's own
+  concern; Hull pins both source SHA and toolchain, which is what
+  its claim rests on.
 
 - [x] **0.3.14. Published build-environment manifest. ✅ Partial.** Specify
   what ubuntu image, what Xcode version, what cosmocc commit, what

--- a/docs/security.md
+++ b/docs/security.md
@@ -1433,6 +1433,44 @@ Tier 4 makes that detectable as soon as anyone re-derives.
    runners and byte-compares them (identical across runners, not just
    same-machine).
 
+#### Vendored-dependency reproducibility
+
+Every dependency is vendored (submodules: keel, wamr, tcc; source
+snapshots: lua, quickjs, sqlite, mbedtls, tweetnacl, miniz, stb,
+sh_arena, sh_json, log.c, pledge). None ship as a prebuilt binary;
+every vendored translation unit is compiled from the pinned source on
+every `make`. That makes vendored-dependency reproducibility a **goal**,
+and it is transitively enforced by the whole-build reproducibility gate
+above: `make reproducible-check` runs `make` then `make clean` then
+`make` then `cmp`, and `make clean` wipes `build/`, so the second `make`
+recompiles every vendored TU from the pinned source. A byte-identical
+`hull` therefore proves the vendored objects rebuilt byte-for-byte too.
+There is no separate "did WAMR rebuild identically" question to answer:
+if it hadn't, `hull` would not match. This holds for all three artifact
+types (native Linux, native macOS, and the cosmo APE, the last
+byte-compared across two independent runners by `reproducibility-cosmo`).
+
+Load-bearing pieces:
+
+- **Pinned source.** Submodules are locked to exact SHAs; snapshots are
+  committed verbatim. The rebuild always starts from identical bytes.
+- **`ZERO_AR_DATE=1`** makes the vendored archives (`libkeel.a`, the
+  platform library) mtime-free.
+- **`-ffile-prefix-map`** strips per-build tempdir paths out of vendored
+  `.o` content.
+- **Pinned CI runners** (`ubuntu-24.04` / `macos-15`, see roadmap
+  §0.3.1) fix the toolchain version so the two rebuild passes share one
+  compiler.
+
+**Non-goal:** whether an upstream dependency (WAMR, Keel, mbedTLS, ...)
+is itself byte-reproducible across *different* toolchain versions is the
+dependency's own concern, not Hull's. Hull's reproducibility claim rests
+on pinning both the dependency *source* (the SHA) and the *toolchain*
+(the runner); with those two fixed, the rebuild is deterministic.
+Reproducing Hull under a different compiler version is out of scope: that
+is a property of each upstream project, and pinning the runner is
+precisely how Hull sidesteps needing it.
+
 #### Self-hosted alternative
 
 Run your own build host. Pin your own platform key. Your customers


### PR DESCRIPTION
Closes roadmap **§0.3.13** (vendored static archives reproducibility check).

## The realization

The item asked to *either* add a per-vendor `make verify-vendor-repro` target *or* explicitly document vendored-dep reproducibility as a goal/non-goal. It turned out the property is **already transitively verified** and just undocumented:

Every vendored dependency (keel/wamr/tcc submodules; lua/quickjs/sqlite/mbedtls/tweetnacl/miniz/stb/sh_*/log.c/pledge snapshots) is compiled from pinned source on every `make` — none ship prebuilt. The whole-build reproducibility gate (`make reproducible-check` = `make` → `make clean` → `make` → `cmp`) wipes `build/`, so the second `make` recompiles **every vendored TU** from the pinned source. A byte-identical `hull` therefore proves the vendored objects rebuilt byte-for-byte. A separate `make verify-vendor-repro` target would be redundant with that gate.

So the deliverable is the documentation decision the item called for.

## Changes (docs only)

- **`security.md §7.1`** gains a **"Vendored-dependency reproducibility"** subsection:
  - States it as a **goal**, transitively enforced by the whole-build reproducibility gate (recompile-from-pinned-source → byte-identical hull, across native Linux, native macOS, and the cosmo APE — the last byte-compared across two independent runners by `reproducibility-cosmo`).
  - Load-bearing pieces: pinned submodule SHAs + `ZERO_AR_DATE` + `-ffile-prefix-map` + pinned CI runners (§0.3.1).
  - Names the one **non-goal**: whether an *upstream* dep is byte-reproducible across *different* toolchain versions is that project's own concern. Hull pins both source SHA and toolchain, which is what its claim rests on.
- **`roadmap_next.md §0.3.13`** marked done with the rationale for docs-over-redundant-target.

No code changes.