### PR TITLE
ci: registry-less snapshot-pinned reproducible build container (§0.3.1)

### DIFF
--- a/.github/actions/hull-build-container/action.yml
+++ b/.github/actions/hull-build-container/action.yml
@@ -1,0 +1,45 @@
+name: Hull reproducible build container
+description: >
+  Build the registry-less, snapshot-pinned reproducible build image
+  (.github/docker/Dockerfile.build) and run a command inside it with the repo
+  bind-mounted at /src. Immutability across time comes from the base-image
+  digest pin plus the apt snapshot pin, not from a published image, so nothing
+  is pushed or pulled from a Hull-controlled registry. Roadmap 0.3.1;
+  see docs/security.md "Build-environment immutability".
+
+inputs:
+  run:
+    description: Command(s) to execute inside the container (multi-line ok).
+    required: true
+  source-date-epoch:
+    description: >
+      Optional SOURCE_DATE_EPOCH apt-snapshot pin. Empty derives it from the
+      digest-pinned base image, which is already deterministic.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Build reproducible container
+      shell: bash
+      run: |
+        docker build \
+          --build-arg SOURCE_DATE_EPOCH="${{ inputs.source-date-epoch }}" \
+          -t hull-build:pinned \
+          -f .github/docker/Dockerfile.build \
+          .github/docker
+    - name: Run in reproducible container
+      shell: bash
+      # The payload is passed as an environment variable and eval'd INSIDE the
+      # container. It must not be embedded in a double-quoted host string, or
+      # host bash would expand any $(...) / $VAR before docker runs. The host
+      # only ever sees the single-quoted 'eval "$HULL_RUN"'.
+      env:
+        HULL_RUN: ${{ inputs.run }}
+      run: |
+        docker run --rm \
+          -e HULL_RUN \
+          -v "$PWD":/src -w /src \
+          hull-build:pinned \
+          bash -euo pipefail -c 'eval "$HULL_RUN"'

--- a/.github/docker/Dockerfile.build
+++ b/.github/docker/Dockerfile.build
@@ -1,0 +1,69 @@
+# Hull reproducible build container (roadmap 0.3.1).
+#
+# Registry-less: this image is rebuilt in CI from source on every run and is
+# never pushed. Immutability across time comes from two pins, not from a
+# published digest:
+#
+#   1. the base image is pinned by manifest-list digest (below), and
+#   2. the apt archive is pinned to a snapshot.ubuntu.com point-in-time via
+#      the vendored repro-sources-list.sh (SOURCE_DATE_EPOCH).
+#
+# Given both, apt-get resolves byte-identical gcc / glibc / binutils on every
+# rebuild, so a `hull` built inside this container is byte-reproducible across
+# time, not just same-machine. macOS is out of scope: no container touches the
+# macos-15 Xcode runner. See docs/security.md "Build-environment immutability"
+# and .github/docker/README.md.
+#
+# No `# syntax=` directive on purpose: it would pull a frontend image at build
+# time, a network dependency and a drift source. Plain COPY/RUN builds with any
+# builder and stays hermetic.
+
+# ubuntu:24.04 multi-arch manifest-list digest. Resolves the arch-correct
+# sub-image on both ubuntu-24.04 (amd64) and ubuntu-24.04-arm (arm64) runners.
+# Bumping this is an explicit, reviewed change (it re-pins the whole toolchain).
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
+
+# Snapshot timestamp for the apt archive. Empty => repro-sources-list.sh
+# derives it from the mtime of the base image's ubuntu.sources, which is
+# constant because the base is digest-pinned, so the derived snapshot is
+# already deterministic. Pass a value to record the pin explicitly in logs.
+ARG SOURCE_DATE_EPOCH=""
+ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
+
+# Pin apt to a point-in-time snapshot, then install the toolchain that
+# determines the Linux hull binary's bytes. The vendored helper covers the
+# main / restricted / universe / multiverse / -updates / -security / -backports
+# pockets, so security-patched package versions are frozen too.
+COPY repro-sources-list.sh /usr/local/bin/repro-sources-list.sh
+RUN chmod 0755 /usr/local/bin/repro-sources-list.sh \
+ && /usr/local/bin/repro-sources-list.sh \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+      build-essential clang xxd curl ca-certificates git unzip \
+ && rm -rf /var/lib/apt/lists/*
+
+# LC_ALL is load-bearing: the Makefile sorts VFS entries with `LC_ALL=C sort`,
+# so a differing collation order would reorder embedded assets.
+ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
+
+# Trust any bind-mounted repo (the build runs via `docker run -v <repo>:/src`
+# as root over host-owned files; without this git aborts with "dubious
+# ownership" and the Makefile's submodule-SHA stamping fails).
+RUN git config --system --add safe.directory '*'
+
+# Bake the SHA-pinned cosmocc so the cosmo jobs are hermetic and the APE
+# toolchain freezes with the image. These MUST stay in sync with the Makefile
+# (COSMOCC_VERSION / COSMOCC_SHA256); .github/docker/README.md documents the
+# bump procedure.
+ARG COSMOCC_VERSION=4.0.2
+ARG COSMOCC_SHA256=85b8c37a406d862e656ad4ec14be9f6ce474c1b436b9615e91a55208aced3f44
+RUN curl -fsSL -o /tmp/cosmocc.zip "https://cosmo.zip/pub/cosmocc/cosmocc-${COSMOCC_VERSION}.zip" \
+ && echo "${COSMOCC_SHA256}  /tmp/cosmocc.zip" | sha256sum -c - \
+ && mkdir -p /opt/cosmo \
+ && unzip -q -o /tmp/cosmocc.zip -d /opt/cosmo \
+ && rm -f /tmp/cosmocc.zip
+ENV PATH="/opt/cosmo/bin:${PATH}"
+
+# The build itself runs with the repo bind-mounted at /src; nothing is COPYed
+# into the image. See .github/actions/hull-build-container.
+WORKDIR /src

--- a/.github/docker/README.md
+++ b/.github/docker/README.md
@@ -1,0 +1,70 @@
+# Reproducible build container (roadmap 0.3.1)
+
+This directory holds a **registry-less, snapshot-pinned** build environment used
+by the reproducibility-critical Linux and cosmo CI/release jobs. It closes the
+"versioned runner images still get monthly patch updates" gap so that
+"reproducible across time" holds indefinitely for the Linux and cosmo artifacts,
+not just within a major-version window.
+
+Design rationale (and why this over a published GHCR image or a Nix flake) lives
+in [`docs/security.md` → "Build-environment immutability"](../../docs/security.md).
+
+## How it works
+
+- **`Dockerfile.build`** pins two things:
+  1. the base image by manifest-list digest (`FROM ubuntu:24.04@sha256:...`), and
+  2. the apt archive to a `snapshot.ubuntu.com` point-in-time via
+     `repro-sources-list.sh`.
+
+  With both pinned, `apt-get install` resolves byte-identical
+  `gcc` / `glibc` / `binutils` on every rebuild, so a `hull` built inside is
+  byte-reproducible across time. The SHA-pinned cosmocc is baked in the same way.
+
+- **`repro-sources-list.sh`** is vendored verbatim from upstream (see provenance
+  below). It rewrites the apt sources to the snapshot, covering the
+  `main` / `restricted` / `universe` / `multiverse` / `-updates` / `-security` /
+  `-backports` pockets, and derives `SOURCE_DATE_EPOCH` from the (digest-pinned,
+  hence constant) base-image mtime unless one is passed explicitly.
+
+- **`.github/actions/hull-build-container`** is the composite action jobs use:
+  it `docker build`s the image, then `docker run`s a command with the repo
+  bind-mounted at `/src`. The `container:` job key is deliberately not used
+  because it requires a pre-existing image; a registry-less image built in-job
+  must be run via `docker run`.
+
+macOS is out of scope: `hull-darwin-arm64` builds on a real `macos-15` runner
+with Xcode, which no container touches. Its reproducibility stays bounded by the
+`macos-15` image patch window.
+
+## Vendored dependency provenance
+
+| File | Upstream | Version | SHA-256 |
+|------|----------|---------|---------|
+| `repro-sources-list.sh` | [reproducible-containers/repro-sources-list.sh](https://github.com/reproducible-containers/repro-sources-list.sh) | `v0.1.4` (commit `39fbf150e3a5062d4c6b9a241f25af133e7cb6f0`) | `c125df9762b0c7233459087bb840c0e5dbfc4d9690ee227f1ed8994f4d51d2e0` |
+
+The script is Apache-2.0 licensed; its header is retained verbatim.
+
+## Bump procedures
+
+**Base image digest.** Re-pin `FROM ubuntu:24.04@sha256:...` deliberately (it
+re-pins the entire toolchain). Get the current multi-arch manifest-list digest:
+
+```sh
+docker buildx imagetools inspect ubuntu:24.04 | grep -i '^Digest:'
+```
+
+Bumping the digest changes the derived apt-snapshot timestamp and therefore the
+frozen toolchain. That is expected: it is the reviewed act of moving the pin.
+
+**cosmocc.** Keep the `COSMOCC_VERSION` / `COSMOCC_SHA256` build args in
+`Dockerfile.build` in sync with the Makefile's `COSMOCC_VERSION` /
+`COSMOCC_SHA256`.
+
+**`repro-sources-list.sh`.** Re-vendor at a pinned tag and update the table
+above:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/reproducible-containers/repro-sources-list.sh/<TAG>/repro-sources-list.sh \
+  -o .github/docker/repro-sources-list.sh
+shasum -a 256 .github/docker/repro-sources-list.sh
+```

--- a/.github/docker/repro-sources-list.sh
+++ b/.github/docker/repro-sources-list.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+#
+#   Copyright The repro-sources-list.sh Authors.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# -----------------------------------------------------------------------------
+# repro-sources-list.sh:
+# configures /etc/apt/sources.list and similar files for installing packages from a snapshot.
+#
+# This script is expected to be executed inside Dockerfile.
+#
+# The following distributions are supported:
+# - debian:11    (/etc/apt/sources.list)
+# - debian:12    (/etc/apt/sources.list.d/debian.sources)
+# - ubuntu:22.04 (/etc/apt/sources.list)
+# - ubuntu:24.04 (/etc/apt/sources.listd/ubuntu.sources)
+# - archlinux    (/etc/pacman.d/mirrorlist)
+#
+# For the further information, see https://github.com/reproducible-containers/repro-sources-list.sh
+# -----------------------------------------------------------------------------
+
+set -eux -o pipefail
+
+. /etc/os-release
+
+: "${KEEP_CACHE:=1}"
+
+keep_apt_cache() {
+	rm -f /etc/apt/apt.conf.d/docker-clean
+	echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache
+}
+
+case "${ID}" in
+"debian")
+	: "${SNAPSHOT_ARCHIVE_BASE:=http://snapshot.debian.org/archive/}"
+	: "${BACKPORTS:=}"
+	if [ -e /etc/apt/sources.list.d/debian.sources ]; then
+		: "${SOURCE_DATE_EPOCH:=$(stat --format=%Y /etc/apt/sources.list.d/debian.sources)}"
+		rm -f /etc/apt/sources.list.d/debian.sources
+	else
+		: "${SOURCE_DATE_EPOCH:=$(stat --format=%Y /etc/apt/sources.list)}"
+	fi
+	snapshot="$(printf "%(%Y%m%dT%H%M%SZ)T\n" "${SOURCE_DATE_EPOCH}")"
+	# TODO: use the new format for Debian >= 12
+	echo "deb [check-valid-until=no] ${SNAPSHOT_ARCHIVE_BASE}debian/${snapshot} ${VERSION_CODENAME} main" >/etc/apt/sources.list
+	echo "deb [check-valid-until=no] ${SNAPSHOT_ARCHIVE_BASE}debian-security/${snapshot} ${VERSION_CODENAME}-security main" >>/etc/apt/sources.list
+	echo "deb [check-valid-until=no] ${SNAPSHOT_ARCHIVE_BASE}debian/${snapshot} ${VERSION_CODENAME}-updates main" >>/etc/apt/sources.list
+	if [ "${BACKPORTS}" = 1 ]; then echo "deb [check-valid-until=no] ${SNAPSHOT_ARCHIVE_BASE}debian/${snapshot} ${VERSION_CODENAME}-backports main" >>/etc/apt/sources.list; fi
+	if [ "${KEEP_CACHE}" = 1 ]; then keep_apt_cache; fi
+	;;
+"ubuntu")
+	: "${SNAPSHOT_ARCHIVE_BASE:=http://snapshot.ubuntu.com/}"
+	if [ -e /etc/apt/sources.list.d/ubuntu.sources ]; then
+		: "${SOURCE_DATE_EPOCH:=$(stat --format=%Y /etc/apt/sources.list.d/ubuntu.sources)}"
+		rm -f /etc/apt/sources.list.d/ubuntu.sources
+	else
+		: "${SOURCE_DATE_EPOCH:=$(stat --format=%Y /etc/apt/sources.list)}"
+	fi
+	snapshot="$(printf "%(%Y%m%dT%H%M%SZ)T\n" "${SOURCE_DATE_EPOCH}")"
+	# TODO: use the new format for Ubuntu >= 24.04
+	echo "deb [check-valid-until=no] ${SNAPSHOT_ARCHIVE_BASE}ubuntu/${snapshot} ${VERSION_CODENAME} main restricted" >/etc/apt/sources.list
+	echo "deb [check-valid-until=no] ${SNAPSHOT_ARCHIVE_BASE}ubuntu/${snapshot} ${VERSION_CODENAME}-updates main restricted" >>/etc/apt/sources.list
+	echo "deb [check-valid-until=no] ${SNAPSHOT_ARCHIVE_BASE}ubuntu/${snapshot} ${VERSION_CODENAME} universe" >>/etc/apt/sources.list
+	echo "deb [check-valid-until=no] ${SNAPSHOT_ARCHIVE_BASE}ubuntu/${snapshot} ${VERSION_CODENAME}-updates universe" >>/etc/apt/sources.list
+	echo "deb [check-valid-until=no] ${SNAPSHOT_ARCHIVE_BASE}ubuntu/${snapshot} ${VERSION_CODENAME} multiverse" >>/etc/apt/sources.list
+	echo "deb [check-valid-until=no] ${SNAPSHOT_ARCHIVE_BASE}ubuntu/${snapshot} ${VERSION_CODENAME}-updates multiverse" >>/etc/apt/sources.list
+	echo "deb [check-valid-until=no] ${SNAPSHOT_ARCHIVE_BASE}ubuntu/${snapshot} ${VERSION_CODENAME}-backports main restricted universe multiverse" >>/etc/apt/sources.list
+	echo "deb [check-valid-until=no] ${SNAPSHOT_ARCHIVE_BASE}ubuntu/${snapshot} ${VERSION_CODENAME}-security main restricted" >>/etc/apt/sources.list
+	echo "deb [check-valid-until=no] ${SNAPSHOT_ARCHIVE_BASE}ubuntu/${snapshot} ${VERSION_CODENAME}-security universe" >>/etc/apt/sources.list
+	echo "deb [check-valid-until=no] ${SNAPSHOT_ARCHIVE_BASE}ubuntu/${snapshot} ${VERSION_CODENAME}-security multiverse" >>/etc/apt/sources.list
+	if [ "${KEEP_CACHE}" = 1 ]; then keep_apt_cache; fi
+	# http://snapshot.ubuntu.com is redirected to https, so we have to install ca-certificates
+	export DEBIAN_FRONTEND=noninteractive
+	apt-get -o Acquire::https::Verify-Peer=false update >&2
+	apt-get -o Acquire::https::Verify-Peer=false install -y ca-certificates >&2
+	;;
+"arch")
+	: "${SNAPSHOT_ARCHIVE_BASE:=http://archive.archlinux.org/}"
+	: "${SOURCE_DATE_EPOCH:=$(stat --format=%Y /var/log/pacman.log)}"
+	export SOURCE_DATE_EPOCH
+	# shellcheck disable=SC2016
+	date -d "@${SOURCE_DATE_EPOCH}" "+Server = ${SNAPSHOT_ARCHIVE_BASE}repos/%Y/%m/%d/\$repo/os/\$arch" >/etc/pacman.d/mirrorlist
+	;;
+*)
+	echo >&2 "Unsupported distribution: ${ID}"
+	exit 1
+	;;
+esac
+
+: "${WRITE_SOURCE_DATE_EPOCH:=/dev/null}"
+echo "${SOURCE_DATE_EPOCH}" >"${WRITE_SOURCE_DATE_EPOCH}"
+echo "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,38 @@ jobs:
         timeout-minutes: 5
         run: make reproducible-check
 
+  # Reproducible build inside the registry-less, snapshot-pinned container
+  # (roadmap 0.3.1). Proves the containerized toolchain yields a byte-identical
+  # hull across a clean rebuild, and exercises the whole mechanism (base-image
+  # digest pin + apt snapshot pin + baked SHA-pinned cosmocc) that the Linux and
+  # cosmo release jobs will adopt. This is what makes "reproducible across time"
+  # hold indefinitely for the Linux artifacts, not just within the runner's
+  # major-version window. macOS is intentionally excluded: no container touches
+  # the macos-15 Xcode runner. See docs/security.md "Build-environment
+  # immutability" and .github/docker/README.md.
+  reproducibility-container:
+    name: Reproducible build (Linux container)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+      - name: Build twice in the reproducible container and cmp
+        uses: ./.github/actions/hull-build-container
+        with:
+          run: |
+            make
+            cp build/hull /tmp/hull-c1
+            make clean
+            make
+            if cmp -s /tmp/hull-c1 build/hull; then
+              echo "PASS: containerized build byte-identical across rebuilds ($(wc -c < build/hull) bytes)"
+            else
+              echo "FAIL: containerized build differs between rebuilds"
+              sha256sum /tmp/hull-c1 build/hull
+              exit 1
+            fi
+
   # Cosmo APE byte-reproducibility (roadmap 0.3.7). The reproducibility job
   # above builds twice in ONE job and cmps; that pattern can't be used for
   # cosmo because a second `make platform-cosmo` in one job corrupts the
@@ -296,14 +328,16 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           submodules: true
-      - name: Install cosmocc
-        run: |
-          COSMOCC_DIR=/opt/cosmo make fetch-cosmocc
-          echo "/opt/cosmo/bin" >> $GITHUB_PATH
-      - name: Build platform (multi-arch)
-        run: make platform-cosmo
-      - name: Build hull (cosmocc APE)
-        run: make CC=cosmocc
+      # Build inside the snapshot-pinned reproducible container (roadmap 0.3.1).
+      # cosmocc is baked into the image, so there is no fetch step. One
+      # `make platform-cosmo` per job: the a/b split exists because a second
+      # cosmo platform build in one job corrupts the loader.
+      - name: Build hull-cosmo in the reproducible container
+        uses: ./.github/actions/hull-build-container
+        with:
+          run: |
+            make platform-cosmo
+            make CC=cosmocc
       - name: Upload hull-cosmo
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:

--- a/docs/security.md
+++ b/docs/security.md
@@ -1471,6 +1471,58 @@ Reproducing Hull under a different compiler version is out of scope: that
 is a property of each upstream project, and pinning the runner is
 precisely how Hull sidesteps needing it.
 
+#### Build-environment immutability (why a snapshot-pinned Dockerfile, not Nix)
+
+The gate above proves the build is deterministic *given a fixed
+toolchain*. What fixes the toolchain across time is the CI runner.
+Pinning `runs-on:` to versioned labels (`ubuntu-24.04`, `macos-15`, see
+roadmap §0.3.1) removed the largest source of drift, a `latest` label
+silently jumping a major OS between a release and a rebuild, but
+versioned images still receive GitHub's monthly patch updates. So the
+toolchain is fixed only within a major-version window, not indefinitely.
+
+The chosen mechanism to close that gap for the Linux and cosmo
+build/release jobs is a **reproducible, snapshot-pinned Dockerfile built
+in CI, with no image registry**. The Dockerfile pins its base by digest
+(`FROM ubuntu:24.04@sha256:...`) and pins the apt archive to a fixed
+point in time via the Ubuntu snapshot service (`snapshot.ubuntu.com`,
+driven by a recorded `SOURCE_DATE_EPOCH` using the upstream
+`repro-sources-list.sh` helper), so `apt-get install` resolves to
+byte-identical package versions (gcc, glibc, binutils) on every rebuild,
+anywhere, indefinitely. The SHA-pinned cosmocc is baked in the same way.
+A verifier reproduces the toolchain by rebuilding the Dockerfile from
+this repo at the recorded timestamp; nothing is pulled from a registry
+Hull controls, so there is no hosted image to trust or to rot.
+
+This was chosen over both a published+digest-pinned image and a Nix flake:
+
+- **vs. a published image (GHCR + `container: @sha256`).** A pushed image
+  pinned by digest is also immutable, but it moves the trust anchor to a
+  registry artifact and adds hosting plus a publish workflow. The
+  snapshot-pinned Dockerfile achieves the same fixed toolchain *from
+  source in the repo*, which fits a project whose whole verification
+  story is "rebuild from source and compare."
+- **vs. Nix.** (1) The claim needs the environment *fixed*, not itself
+  rebuildable-from-a-compiler-source: pinning the base digest plus the
+  apt snapshot fixes the toolchain bytes, and nobody re-derives clang to
+  verify Hull. (2) Hull's dependencies are already fetch-and-pin (cosmocc
+  SHA-pinned, wgpu-native, the LLVM for `wamrc`, every vendored archive),
+  which a Dockerfile matches and a Nix derivation would fight (cosmocc in
+  particular is awkward to package). (3) macOS cannot be containerized
+  regardless: `hull-darwin-arm64` builds on a real `macos-15` runner with
+  Xcode, so the immutable base only ever covers `linux-x86_64`,
+  `linux-aarch64`, and the cosmo APE. That caps the payoff and argues for
+  the option that fits the existing grain.
+
+The honest resulting claim: with the snapshot-pinned Dockerfile,
+"reproducible across time" holds indefinitely for the Linux and cosmo
+artifacts and within a major-version window for macOS (a real `macos-15`
+runner with Xcode, which no container touches). BuildKit's
+`rewrite-timestamp` can additionally make the produced image itself
+byte-reproducible, but Hull does not depend on that: it rebuilds the
+image and runs the build inside it rather than shipping the image.
+Rollout status is tracked in roadmap §0.3.1.
+
 #### Self-hosted alternative
 
 Run your own build host. Pin your own platform key. Your customers


### PR DESCRIPTION
Closes the **build-environment immutability** gap in roadmap §0.3.1. Versioned runner labels (`ubuntu-24.04`) still receive GitHub's monthly patch updates, so the toolchain was fixed only within a major-version window. This freezes it **indefinitely** for the Linux and cosmo artifacts via a reproducible, **registry-less** Dockerfile.

Design decision (Docker over Nix, registry-less over GHCR) was landed separately in `docs/security.md → "Build-environment immutability"` (commit in this branch).

## How it works

Two pins make the toolchain byte-identical on every rebuild, with **nothing published or hosted**:
1. `FROM ubuntu:24.04@sha256:...` pinned by multi-arch manifest-list digest (resolves per-arch on `ubuntu-24.04` and `ubuntu-24.04-arm`).
2. apt pinned to a `snapshot.ubuntu.com` point-in-time via the vendored `repro-sources-list.sh` (`SOURCE_DATE_EPOCH` derived from the digest-pinned base image mtime, so deterministic).

SHA-pinned cosmocc is baked in the same way. A verifier reproduces the toolchain by rebuilding the Dockerfile from this repo; there is no image to trust or to rot.

## Changes

- **`.github/docker/Dockerfile.build`** — the pinned environment. No `# syntax=` directive (avoids a frontend-image network dep at build time). `LC_ALL=C.UTF-8` for the Makefile's `LC_ALL=C sort`; `git safe.directory '*'` for the bind-mounted root-owned repo.
- **`.github/docker/repro-sources-list.sh`** — vendored verbatim from [`reproducible-containers/repro-sources-list.sh` v0.1.4](https://github.com/reproducible-containers/repro-sources-list.sh) (Apache-2.0). Covers main/restricted/universe/multiverse/-updates/-security/-backports.
- **`.github/docker/README.md`** — provenance table + base-digest / cosmocc / script bump procedures.
- **`.github/actions/hull-build-container`** — composite action: `docker build`s the image, then runs a payload inside it with the repo at `/src`. The payload is passed as an env var and `eval`'d **in the container**, so host bash never expands its `$(...)` / `$VAR`.
- **`ci.yml`** — new `reproducibility-container` job (build twice in-container, `cmp`); `reproducibility-cosmo` now builds inside the container (cosmocc baked, fetch step dropped). **Every macOS job untouched** (no container touches the `macos-15` Xcode runner).

## Validated locally (arm64)

- Image builds: base digest resolves, snapshot apt installs **version-pinned** `gcc-13` / `clang-18` / `binutils` / `xxd` (e.g. `5.38.2-3.2ubuntu0.2`), cosmocc 14.1.0 baked, `LC_ALL=C.UTF-8` set.
- Composite run path: `$(...)` expands **in-container** (`pwd=/src`), `git safe.directory` works over the root-owned mount, zero working-tree pollution.

The CI jobs here are the real test of the in-container `make` and the **amd64** side of the base digest (my local build could only exercise arm64).

## Scope / deferred (follow-up PR)

Per the agreed landing order, wiring `release.yml`'s Linux + cosmo build jobs and flipping roadmap §0.3.1 to done both follow **once these CI gates prove green**.

## Honest resulting claim

"Reproducible across time" holds indefinitely for `linux-x86_64` / `linux-aarch64` / cosmo, and within a major-version window for macOS (a real Xcode runner, which no container touches).