### PR TITLE
ci: wire release platform builds into the reproducible container (§0.3.1)

### DIFF
--- a/.github/actions/hull-build-container/action.yml
+++ b/.github/actions/hull-build-container/action.yml
@@ -17,6 +17,14 @@ inputs:
       digest-pinned base image, which is already deterministic.
     required: false
     default: ""
+  user:
+    description: >
+      Container user. Default (empty) runs as root, fine when the job only
+      builds + uploads. Set to "host" to run as the runner's uid:gid so build
+      outputs are host-owned; required when later HOST steps write into build/
+      (e.g. the release Platform-sig E2E does keygen/sign into build/).
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -37,8 +45,17 @@ runs:
       # only ever sees the single-quoted 'eval "$HULL_RUN"'.
       env:
         HULL_RUN: ${{ inputs.run }}
+        HULL_USER: ${{ inputs.user }}
       run: |
+        user_args=()
+        if [ "$HULL_USER" = host ]; then
+          # Run as the runner user so build/ outputs are host-owned and later
+          # host steps can read/execute/write them. HOME is set because the
+          # uid has no /etc/passwd entry in the image.
+          user_args=(--user "$(id -u):$(id -g)" -e HOME=/tmp)
+        fi
         docker run --rm \
+          "${user_args[@]}" \
           -e HULL_RUN \
           -v "$PWD":/src -w /src \
           hull-build:pinned \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,34 @@ jobs:
               exit 1
             fi
 
+  # Proves the release build-native interleaving: build hull inside the
+  # container as the runner user (user: host), then on the HOST run the produced
+  # binary and write alongside it in build/. release.yml's Platform-sig E2E does
+  # exactly this (host-side keygen/sign into build/ + running the freshly built
+  # hull), and release.yml is tag-only so it cannot be exercised on a PR. This
+  # job is the PR-validatable proxy for that ownership + run path. Roadmap 0.3.1.
+  reproducibility-container-interleave:
+    name: Reproducible build (Linux container, host interleave)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+      - name: Build hull in-container as the runner user
+        uses: ./.github/actions/hull-build-container
+        with:
+          user: host
+          run: make
+      - name: Host runs the container-built binary and writes into build/
+        run: |
+          set -eu
+          ./build/hull version
+          # build/ must be host-writable (user: host), exactly as the release
+          # Platform-sig E2E requires when it does keygen/sign into build/.
+          touch build/interleave-probe
+          test -f build/interleave-probe
+          echo "PASS: host ran the container-built hull and wrote into build/"
+
   # Cosmo APE byte-reproducibility (roadmap 0.3.7). The reproducibility job
   # above builds twice in ONE job and cmps; that pattern can't be used for
   # cosmo because a second `make platform-cosmo` in one job corrupts the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,16 @@ jobs:
       - name: Write VERSION file
         run: echo "${GITHUB_REF_NAME#v}" > VERSION
 
-      - name: Build platform library
+      # Linux builds in the snapshot-pinned reproducible container (roadmap
+      # 0.3.1) so the shipped platform .a is byte-reproducible across time.
+      # macOS builds bare: no container touches the macos-15 Xcode runner.
+      - name: Build platform library (Linux, reproducible container)
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/hull-build-container
+        with:
+          run: make platform
+      - name: Build platform library (macOS)
+        if: runner.os == 'macOS'
         run: make platform
 
       - name: Upload libhull_platform.a
@@ -56,7 +65,18 @@ jobs:
       # untouched. Publish them arch-qualified: libhull_platform-<flavor>-<arch>.a.
       # (Cosmo flavor libs are not published yet; build from source with
       # `make platform-cosmo-<flavor>`. See docs/build_flavors.md §7.)
-      - name: Build platform flavors
+      - name: Build platform flavors (Linux, reproducible container)
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/hull-build-container
+        with:
+          run: |
+            for f in server-only client-only pure-compute; do
+              make "platform-$f"
+              mv "build/libhull_platform-$f.a" \
+                 "build/libhull_platform-$f-${{ matrix.name }}.a"
+            done
+      - name: Build platform flavors (macOS)
+        if: runner.os == 'macOS'
         run: |
           for f in server-only client-only pure-compute; do
             make "platform-$f"
@@ -82,13 +102,12 @@ jobs:
       - name: Write VERSION file
         run: echo "${GITHUB_REF_NAME#v}" > VERSION
 
-      - name: Install cosmocc
-        run: |
-          COSMOCC_DIR=/opt/cosmo make fetch-cosmocc
-          echo "/opt/cosmo/bin" >> "$GITHUB_PATH"
-
-      - name: Build platform (multi-arch)
-        run: make platform-cosmo
+      # cosmocc is baked into the reproducible container (roadmap 0.3.1), so
+      # there is no fetch step; the dual-arch platform .a's are frozen with it.
+      - name: Build platform (multi-arch, reproducible container)
+        uses: ./.github/actions/hull-build-container
+        with:
+          run: make platform-cosmo
 
       - name: Upload cosmo platform archives
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
@@ -124,13 +143,12 @@ jobs:
       - name: Write VERSION file
         run: echo "${GITHUB_REF_NAME#v}" > VERSION
 
-      - name: Install cosmocc
-        run: |
-          COSMOCC_DIR=/opt/cosmo make fetch-cosmocc
-          echo "/opt/cosmo/bin" >> "$GITHUB_PATH"
-
-      - name: Build cosmo flavor platform lib (dual-arch)
-        run: make platform-cosmo-${{ matrix.flavor }}
+      # cosmocc is baked into the reproducible container (roadmap 0.3.1), so
+      # there is no fetch step.
+      - name: Build cosmo flavor platform lib (dual-arch, reproducible container)
+        uses: ./.github/actions/hull-build-container
+        with:
+          run: make platform-cosmo-${{ matrix.flavor }}
 
       - name: Upload cosmo flavor archives
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4


### PR DESCRIPTION
Extends the registry-less snapshot-pinned container (#60) to the **release** path, so shipped artifacts, not just the CI repro gates, are byte-reproducible across time. **Staged**: this lands the foundation + the low-risk platform jobs; the intricate final-binary jobs (`build-native`, `build-cosmo`) follow once the new interleave-proof job is green on main.

## Why staged

`release.yml` is **tag-only** (`on: push: tags: v*`), so it can't run on a PR — the first true test of any release-job change is an actual release. To de-risk, this PR:
1. wires only **build + upload** jobs (no host-runs-binary, no rebuild hazard), which are structurally identical to the already-green `reproducibility-cosmo` job; and
2. adds a **PR-validatable** CI job that proves the ownership/run mechanism the deferred jobs need.

## Changes

- **`hull-build-container`** — new optional `user` input. `user: host` runs the container as the runner `uid:gid` (`HOME=/tmp`) so `build/` outputs are host-owned; required when later **host** steps write into `build/` (the release Platform-sig E2E does keygen/sign there). Default stays root.
- **`ci.yml`** — new `reproducibility-container-interleave` job: builds hull in-container as `user: host`, then on the **host** runs the produced binary and writes into `build/`. This is the PR-validatable proxy for the `build-native` ownership + run path.
- **`release.yml`** — `build-platform-native` (Linux rows), `build-platform-cosmo`, `build-platform-cosmo-flavors` now build in-container. **Every macOS row stays bare** (no container touches the `macos-15` Xcode runner); baked cosmocc drops the per-job fetch step. `build-cosmo` keeps its own cosmocc install (deferred with `build-native`).

## Validation

- `reproducibility-container-interleave` (this PR) proves `user: host` end-to-end.
- The composite `--user` model was checked locally: container outputs are host-owned and the host can write into the container-created `build/`.
- The wired platform jobs run only on tag push; they mirror the green `reproducibility-cosmo` pattern. First live exercise is the next release (recommend a throwaway pre-release tag before the next real one).

## Deferred to follow-up PR

`build-native` (Linux) + `build-cosmo` — the final-binary jobs whose host-side E2E runs the built binary and writes into `build/`. They land on the `user: host` primitive proven by the interleave job here, plus the roadmap §0.3.1 flip.