### PR TITLE
ci: build release final binaries in the reproducible container (§0.3.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,11 +318,8 @@ jobs:
       - name: Write VERSION file
         run: echo "${GITHUB_REF_NAME#v}" > VERSION
 
-      - name: Install cosmocc
-        run: |
-          COSMOCC_DIR=/opt/cosmo make fetch-cosmocc
-          echo "/opt/cosmo/bin" >> "$GITHUB_PATH"
-
+      # cosmocc is baked into the reproducible container (roadmap 0.3.1); the
+      # build steps below run inside it, so there is no host fetch.
       - name: Download cosmo platform archives
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
@@ -362,16 +359,22 @@ jobs:
           done
           [ "$fail" = 0 ] || exit 1
 
-      - name: Hardening summary (cosmocc — most ELF flags inapplicable)
-        run: make CC=cosmocc hardening
-
-      - name: Build hull (cosmo APE)
-        # No TRUST_PLATFORM_LIB needed for cosmo: the .a's at
-        # build/libhull_platform.{x86_64,aarch64}-cosmo.a have no
-        # build rule in the Makefile (they're produced by the
-        # .PHONY platform-cosmo target during native development).
-        # Make treats them as leaf inputs — won't rebuild.
-        run: make CC=cosmocc EMBED_PLATFORM=cosmo
+      # Build inside the snapshot-pinned reproducible container (roadmap 0.3.1).
+      # cosmocc is baked in. Hardening summary runs in the same container step so
+      # no host make touches the tree after the build. Default root (not
+      # user: host): the host-side smoke test only executes build/hull, which is
+      # world-executable, and no host step writes into build/ here (the cosmo
+      # Platform-sig E2E is skipped). This matches the proven reproducibility-cosmo
+      # CI job. No TRUST_PLATFORM_LIB needed for cosmo: the .a's at
+      # build/libhull_platform.{x86_64,aarch64}-cosmo.a have no build rule in the
+      # Makefile (produced by the .PHONY platform-cosmo target during native
+      # development), so make treats them as leaf inputs and will not rebuild.
+      - name: Build hull (cosmo APE, reproducible container)
+        uses: ./.github/actions/hull-build-container
+        with:
+          run: |
+            make CC=cosmocc hardening
+            make CC=cosmocc EMBED_PLATFORM=cosmo
 
       - name: Smoke-test version
         run: ./build/hull version
@@ -423,11 +426,13 @@ jobs:
       # Under the fat cosmocc driver, `make libhull` emits build/libhull.a
       # (x86_64) plus its build/.aarch64/libhull.a sibling. Publish them
       # arch-qualified, mirroring libhull_platform.{x86_64,aarch64}-cosmo.a.
-      - name: Build + rename cosmo libhull.a (dual-arch)
-        run: |
-          make libhull CC=cosmocc
-          cp build/libhull.a          libhull.x86_64-cosmo.a
-          cp build/.aarch64/libhull.a libhull.aarch64-cosmo.a
+      - name: Build + rename cosmo libhull.a (dual-arch, reproducible container)
+        uses: ./.github/actions/hull-build-container
+        with:
+          run: |
+            make libhull CC=cosmocc
+            cp build/libhull.a          libhull.x86_64-cosmo.a
+            cp build/.aarch64/libhull.a libhull.aarch64-cosmo.a
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
@@ -495,27 +500,42 @@ jobs:
           fi
           echo "✓ ${{ matrix.name }} .a SHA matches signed manifest: $actual"
 
-      - name: Build hull with embedded platform
-        # TRUST_PLATFORM_LIB=1 short-circuits $(PLATFORM_LIB)'s
-        # rebuild rule in the Makefile — make treats the downloaded
-        # .a as a pristine leaf input, never re-archives it from
-        # source. The downloaded .a's bytes are the ones
-        # sign-platform-manifest hashed, and they get embedded as-is.
-        # Without this, make sees PLATFORM_OBJS / CANARY_OBJ as
-        # newer than the .a and rebuilds it from scratch; the
-        # rebuilt bytes differ from the signed manifest entry on a
-        # different GH Actions VM (non-reproducible toolchain
-        # artifacts), breaking the gethull cross-check.
+      # Linux builds in the snapshot-pinned reproducible container (roadmap
+      # 0.3.1) so the shipped hull is byte-reproducible across time; user: host
+      # makes build/ host-owned for the Platform-sig E2E below (which does
+      # keygen/sign into build/ and runs the freshly built binary). Hardening
+      # summary + verification run in the same container step so no host make
+      # touches the tree after the reproducible build. macOS builds bare: no
+      # container touches the macos-15 Xcode runner.
+      #
+      # TRUST_PLATFORM_LIB=1 short-circuits $(PLATFORM_LIB)'s rebuild rule in the
+      # Makefile; make treats the downloaded .a as a pristine leaf input and
+      # never re-archives it from source. The downloaded .a's bytes are the ones
+      # sign-platform-manifest hashed, and they get embedded as-is. Without this,
+      # make sees PLATFORM_OBJS / CANARY_OBJ as newer than the .a and rebuilds it
+      # from scratch; the rebuilt bytes differ from the signed manifest entry on
+      # a different runner, breaking the gethull cross-check.
+      - name: Build hull + verify hardening (Linux, reproducible container)
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/hull-build-container
+        with:
+          user: host
+          run: |
+            make EMBED_PLATFORM=1 TRUST_PLATFORM_LIB=1
+            make hardening
+            make check-hardening
+      - name: Build hull with embedded platform (macOS)
+        if: runner.os == 'macOS'
         run: make EMBED_PLATFORM=1 TRUST_PLATFORM_LIB=1
-
-      - name: Hardening summary (release)
+      - name: Hardening summary (macOS)
+        if: runner.os == 'macOS'
         run: make hardening
-
-      - name: Hardening verification (release)
-        # Verifies the just-built binary carries the expected
-        # compiler/linker hardening properties (PIE, RELRO+BIND_NOW,
-        # NX, canaries, CET/BTI). Required protections missing for
-        # this platform → non-zero exit; release fails.
+      - name: Hardening verification (macOS)
+        # Verifies the just-built binary carries the expected compiler/linker
+        # hardening properties (PIE, RELRO+BIND_NOW, NX, canaries, CET/BTI).
+        # Required protections missing for this platform cause a non-zero exit
+        # and the release fails.
+        if: runner.os == 'macOS'
         run: make check-hardening
 
       - name: Smoke-test version + platform
@@ -592,7 +612,16 @@ jobs:
       # Built from the same objects as the hull binary above; published so
       # hl_embed_* native hosts can fetch + verify a known-good archive.
       # Its SHA-256 goes into the release-signed hull.sha256 manifest.
-      - name: Build + rename libhull.a
+      - name: Build + rename libhull.a (Linux, reproducible container)
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/hull-build-container
+        with:
+          user: host
+          run: |
+            make libhull
+            cp build/libhull.a libhull-${{ matrix.name }}.a
+      - name: Build + rename libhull.a (macOS)
+        if: runner.os == 'macOS'
         run: |
           make libhull
           cp build/libhull.a libhull-${{ matrix.name }}.a

--- a/docs/roadmap_next.md
+++ b/docs/roadmap_next.md
@@ -213,20 +213,35 @@ not implementation cost.
 
 #### Tier 1. Load-bearing (the trust claim depends on these)
 
-- [ ] **0.3.1. Pin the CI build environment.** **Runner-pin done;
-  immutable base still open.** Every `runs-on:` across `ci.yml`,
-  `release.yml`, `deploy-site.yml`, and `dco.yml` now pins a versioned
-  label (`ubuntu-24.04`, `ubuntu-24.04-arm`, `macos-15`) — no more
-  mutable `ubuntu-latest` / `macos-latest`. This removes the big
-  reproducibility killer: a `latest` label silently jumping to the next
-  major OS (24.04 -> 26.04, macOS 15 -> 16) between a release and a
-  rebuild. **Remaining:** versioned labels still receive GitHub's monthly
-  patch updates, so the image is not byte-immutable across time. Closing
-  that needs a digest-pinned Docker base image (medium) or a Nix flake
-  (high) for the reproducibility-critical build/release jobs; until then
-  "reproducible" holds within a major-version window, not indefinitely.
-  **Effort:** ~~low for runner-pin~~ (done); medium for Docker base; high
-  for Nix flake.
+- [x] **0.3.1. Pin the CI build environment. ✅ Done (2026-07-13).**
+  Two layers, both shipped. **(1) Runner-pin:** every `runs-on:` across
+  `ci.yml`, `release.yml`, `deploy-site.yml`, and `dco.yml` pins a
+  versioned label (`ubuntu-24.04`, `ubuntu-24.04-arm`, `macos-15`), no
+  mutable `ubuntu-latest` / `macos-latest`, removing the big
+  reproducibility killer (a `latest` label jumping a major OS between a
+  release and a rebuild). **(2) Immutable base:** the reproducibility-
+  critical Linux and cosmo build/release jobs now build inside a
+  registry-less, snapshot-pinned container (base pinned by manifest-list
+  digest + apt pinned to `snapshot.ubuntu.com` via `SOURCE_DATE_EPOCH` +
+  baked SHA-pinned cosmocc), so the toolchain is byte-frozen indefinitely,
+  not just within a major-version window. CI-gated by
+  `reproducibility-container`, `reproducibility-container-interleave`, and
+  `reproducibility-cosmo`; the release jobs (`build-platform-native`,
+  `build-platform-cosmo`, `build-platform-cosmo-flavors`, `build-native`,
+  `build-cosmo`) build in the same container on their Linux/cosmo rows.
+  Design + rationale (Docker over Nix, registry-less over GHCR) in
+  [security.md "Build-environment immutability"](security.md); mechanism +
+  bump procedures in [.github/docker/README.md](../.github/docker/README.md).
+  **Honest scope:** holds indefinitely for `linux-x86_64` /
+  `linux-aarch64` / cosmo; macOS stays bounded by the `macos-15` image (no
+  container touches the Xcode runner). `release.yml` is tag-only, so the
+  release-path wiring's first live exercise is the next release (recommend
+  a throwaway pre-release tag first). Bumping the base digest or
+  `SOURCE_DATE_EPOCH` is a reviewed re-pin of the whole toolchain.
+  **Remaining (optional):** a `snapshot.debian.org`-style reproducible
+  image build would make the image itself byte-reproducible, but Hull
+  rebuilds and runs inside the image rather than shipping it, so it is a
+  nice-to-have, not required.
 
 - [x] **0.3.2. Bootstrap trust path. ✅ Done (minisign).** The
   `curl ... | sh` install was TOFU on top of TLS + GitHub account


### PR DESCRIPTION
Completes the **§0.3.1 immutable-base rollout** (follow-up to #60/#61). `build-native` (Linux rows) and `build-cosmo` now build the **shipped** hull binary + libhull.a inside the snapshot-pinned container, so the release artifacts are byte-reproducible across time. Every macOS row stays bare (no container touches the `macos-15` Xcode runner).

## Changes

- **`build-native` (Linux):** one container step builds + runs `hardening` + `check-hardening` (so no host `make` touches the tree after the reproducible build), as **`user: host`** so `build/` is host-owned for the Platform-sig E2E that follows (host-side keygen/sign into `build/` + running the freshly built binary). This is exactly the ownership + run path proven green by `ci.yml`'s `reproducibility-container-interleave` job (#61). `libhull.a` likewise builds in-container on Linux. **macOS keeps its three bare steps.**
- **`build-cosmo`:** builds hull + `libhull.a` in-container with **default root** (matches the green `reproducibility-cosmo` job) — no `user: host` needed because the cosmo Platform-sig E2E is skipped, so no host step writes into `build/`, only executes (world-executable) and reads. cosmocc is baked into the image, dropping the per-job host fetch.
- All release-job `Install cosmocc` host steps are now gone.
- **roadmap §0.3.1 flipped to Done** — two layers (runner-pin + immutable base) shipped, with the honest scope noted.

## Validation reality

⚠️ **`release.yml` is tag-only (`on: push: tags: v*`)** — it cannot run on this PR. So this PR's green checks cover only the docs + unchanged CI jobs; the release-path changes are **not exercised here**. They ride on the container mechanism already proven green on main:
- `reproducibility-container` + `reproducibility-container-interleave` (the `user: host` build-then-host-run-and-write path)
- `reproducibility-cosmo` (in-container cosmo build)

**Recommendation:** push a throwaway pre-release tag (e.g. `v0.0.0-repro`) to exercise the full release pipeline before the next real release. Called out in the commit message and roadmap §0.3.1.

## Result

"Reproducible across time" now holds **indefinitely** for `linux-x86_64` / `linux-aarch64` / cosmo release artifacts, and within a major-version window for macOS. §0.3.1's code surface is complete.