### PR TITLE
db/duckdb: manifest fs.read/fs.write -> allowed_directories (mode B)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -802,6 +802,38 @@ jobs:
           cat /tmp/ddbsmoke/out.txt
           grep -q "DUCKDB SMOKE OK" /tmp/ddbsmoke/out.txt
 
+      - name: DuckDB mode B (fs.read -> allowed_directories, named connection)
+        timeout-minutes: 2
+        run: |
+          set -eu
+          # Mode B applies to a named (db.connect) / dynamic (db.open) connection,
+          # which opens after the manifest is known. Under the full pledge/unveil
+          # sandbox, DuckDB read_csv must be able to read a file WITHIN the
+          # declared fs.read directory (which is unveiled). Reads OUTSIDE it are
+          # blocked by the kernel unveil (EACCES); note that DuckDB aborts on a
+          # denied open rather than erroring, so the app must only read declared
+          # paths -- see docs/duckdb_backend_design.md §3.2. The default -d
+          # connection opens before the app loads and stays in mode A (smoke).
+          mkdir -p /tmp/ddbmodeb/data
+          printf 'id,name\n1,alice\n2,bob\n' > /tmp/ddbmodeb/data/test.csv
+          cat > /tmp/ddbmodeb/app.lua <<'EOF'
+          app.manifest({
+              modules = { "hull/db@1" },
+              fs = { read = { "data/*.csv" } },
+              databases = { named = { analytics = "duckdb://:memory:" } },
+          })
+          app.main(function(ctx)
+              local d = require("hull.db").connect("analytics")
+              local rows = d.query("SELECT id, name FROM read_csv('/tmp/ddbmodeb/data/test.csv')")
+              assert(rows and #rows == 2 and rows[1].name == "alice", "declared-dir read failed")
+              print("DUCKDB MODE B OK")
+              return 0
+          end)
+          EOF
+          ./build/hull /tmp/ddbmodeb/app.lua > /tmp/ddbmodeb/out.txt 2>&1
+          cat /tmp/ddbmodeb/out.txt
+          grep -q "DUCKDB MODE B OK" /tmp/ddbmodeb/out.txt
+
   coverage:
     name: Code Coverage
     runs-on: ubuntu-24.04

--- a/docs/duckdb_backend_design.md
+++ b/docs/duckdb_backend_design.md
@@ -128,7 +128,7 @@ The concern: DuckDB SQL can do its own file/network I/O (`read_parquet`,
 connection open and then lock it so app SQL cannot undo it.
 
 ```sql
--- always, on open:
+-- always, at config time (before open):
 SET autoinstall_known_extensions = false;
 SET autoload_known_extensions    = false;
 SET allow_unsigned_extensions    = false;
@@ -138,25 +138,87 @@ SET enable_external_access = false;      -- DB file + :memory: only
 
 -- (B) fs.read / fs.write declared  ->  bounded LOCAL access, still no network:
 SET enable_external_access = true;
-SET allowed_directories = ['<mapped fs.read/fs.write dirs>'];
-SET allowed_paths       = ['<mapped specific files>'];
-SET disabled_filesystems = 'HTTPFileSystem,S3FileSystem,...';
+SET allowed_directories = ['<absolute dirs from fs.read/fs.write>'];  -- post-connect
 
--- finally, in BOTH cases:
+-- finally, in BOTH cases (post-connect):
 SET lock_configuration = true;           -- app SQL can no longer re-enable anything
 ```
 
 - **`lock_configuration = true` is the keystone.** Without it a handler could
   run `SET enable_external_access = true` and escape; with it the posture is
   fixed for the connection's life.
-- **Network is off structurally in v1**: httpfs / S3 are never linked or loaded,
-  so there is no outbound path even before config.
-- **File access reuses `fs.read` / `fs.write`** (no new capability concept): the
-  only thing that widens DuckDB's file reach is the app's existing manifest fs
-  paths, mapped to `allowed_directories` / `allowed_paths`. A `read_parquet('/x')`
-  on an ungranted path fails closed exactly like `fs.read('/x')`. The DB *file*
-  itself (the DSN path) is already gated by the existing DB-path sandbox, same
-  as a SQLite file. DuckDB therefore introduces zero new capability surface.
+- **Network is off structurally**: httpfs / S3 are never linked or loaded, so
+  there is no outbound path even before config. (No `disabled_filesystems` SET
+  is needed — the filesystems simply do not exist in the binary.)
+- **File access reuses `fs.read` / `fs.write`** (no new capability concept):
+  serve.c resolves each declared fs path to its absolute containing directory
+  (glob tail stripped; the path itself if it is a directory, else its parent),
+  dedups, and installs the set as DuckDB's `allowed_directories`. A
+  `read_parquet('/x')` on an ungranted path fails closed exactly like
+  `fs.read('/x')`; the same fs paths are also unveiled/seatbelt'd, so the kernel
+  sandbox and DuckDB agree. The DB *file* itself (the DSN path) is gated by the
+  existing DB-path sandbox, same as a SQLite file. DuckDB introduces zero new
+  capability surface. (Directory granularity, not per-file `allowed_paths`, in
+  this pass: a declared file grants its containing directory.)
+
+**Implementation (status: done) — mode B is a named/dynamic-connection feature.**
+The policy is computed once at boot from the sealed manifest
+(`hl_serve_install_duckdb_fs_policy` in serve.c, into the sealed policy arena)
+and read by `duck_open` via `hl_db_duckdb_set_fs_policy`. A connection opened
+**after** the policy is installed picks up mode B; one opened **before** it gets
+mode A. In practice:
+
+- **Named (`db.connect`) and dynamic (`db.open`) connections** open lazily from
+  `app.main` / a handler — after the manifest is sealed and the policy is
+  installed — so they get **mode B**.
+- **The default `-d` connection** is opened during app-context init, *before*
+  the app (and thus the manifest) loads, so app top-level code (e.g.
+  `session.init()` creating tables) has a live DB. It therefore stays in
+  **locked-down mode A**: normal SQL works, but SQL-driven external file access
+  is off. For DuckDB file access, declare a named connection.
+
+This split keeps the default connection's lockdown a hard guarantee (locked at
+open, no unlocked window) and keeps top-level DB usage working, while giving
+OLAP apps mode B on the connection they load data through. Making the *default*
+connection mode B would require either opening it before the manifest is known
+(impossible) or an unlocked-until-finalized window during the app's own load (a
+capability weakening we chose not to take); a mid-load manifest hook is a
+possible future refinement.
+
+**Sandbox interaction (Linux).** DuckDB's C++ runtime reads a handful of
+read-only system-info paths to detect CPU count, memory limits, and timezone
+data (its ICU extension): `/dev/urandom`, `/etc/localtime`,
+`/sys/devices/system/cpu`, `/sys/fs/cgroup`, `/proc/self/cgroup`,
+`/proc/sys/vm/overcommit_memory`, `/proc/meminfo`. Under Hull's default-deny
+unveil these are blocked and DuckDB aborts (an internal NULL-deref) rather than
+degrading, so `sandbox.c` unveils them read-only in `HL_ENABLE_DUCKDB` builds
+(a CI strace under `--no-sandbox` enumerated the set; it is small and static).
+
+Even with those paths unveiled, DuckDB's memory/thread **auto-detection** hits
+some resource that still fails under the sandbox and aborts, so `duck_open` pins
+`memory_limit` (2 GB) and `threads` (4) at config time to skip auto-detection
+entirely. These are fixed, conservative defaults — a real limitation for large
+OLAP under the sandbox; a manifest option to tune them is tracked. With the
+unveils + pinned limits, a mode-B `read_csv` / `read_parquet` of a declared
+`fs.read` file works under the full sandbox.
+
+**The fs bound is enforced by the kernel unveil.** DuckDB may only open files
+under the unveiled `fs.read` / `fs.write` directories, so an undeclared
+`read_csv('/x')` is blocked at the syscall. DuckDB's `SET allowed_directories`
+is set post-connect as intended defense-in-depth, but it is runtime-SET-only
+(not accepted by `duckdb_set_config` at config time) and does **not** enforce on
+Linux (it does on macOS — a DuckDB platform quirk), so the kernel unveil is the
+authoritative bound.
+
+**Known limitation — apps must only read declared paths.** Because
+`allowed_directories` does not pre-empt the open on Linux, an undeclared read
+reaches the kernel, gets `EACCES`, and DuckDB **aborts the process** (NULL-deref
+on the denied open) instead of returning a catchable error. Security holds (no
+data leaks — the read is blocked), but a read of an undeclared path crashes the
+DuckDB process rather than erroring. App SQL must therefore reference only
+paths the manifest declares; a path derived from untrusted input is an app bug
+(and a crash, not a leak). Making an undeclared read a clean error would need
+`allowed_directories` to enforce on Linux (an upstream DuckDB fix) — tracked.
 
 ### 3.3 Packaging (side-loaded, on-demand)
 
@@ -230,9 +292,9 @@ regardless of order. The Makefile wraps the archive set in a group on Linux
    slice** first (open/query/exec/txn on :memory:/file, prepared-statement param
    binding, columnar chunk decode, the full-lockdown security config, the dialect
    row, `duckdb://` selection, unit tests). The mbedTLS symbol isolation (3.4)
-   that lets DuckDB coexist with the full HTTP/TLS stack landed as the
-   immediate follow-up. Still deferred: the manifest-driven
-   `fs.read`/`fs.write` -> `allowed_directories` mode, the
+   that lets DuckDB coexist with the full HTTP/TLS stack, and the
+   manifest-driven `fs.read`/`fs.write` -> `allowed_directories` mode B (3.2),
+   landed as follow-ups. Still deferred: the
    `insert_if_absent`/`upsert`/`table_columns` dialect helpers, temporal /
    decimal / nested type decoding, and the signed side-load packaging (3.3).
 4. OLAP optional vtable methods (columnar fetch, Appender) as a follow-on.

--- a/include/hull/cap/db_duckdb.h
+++ b/include/hull/cap/db_duckdb.h
@@ -17,6 +17,14 @@
 
 #ifdef HL_ENABLE_DUCKDB
 extern const HlDbBackend hl_db_backend_duckdb;
+
+/* Install the bounded file-access policy (design §3.2 mode B): @p dirs is an
+ * array of @p ndirs absolute directory paths (from the manifest's fs.read /
+ * fs.write, resolved by serve.c into the sealed policy arena) that DuckDB SQL
+ * (read_csv / read_parquet / COPY) may touch. Call once at boot, before any
+ * connection opens; the array + strings must outlive the process (sealed). An
+ * empty policy (ndirs <= 0) leaves DuckDB in full lockdown (mode A). */
+void hl_db_duckdb_set_fs_policy(const char *const *dirs, int ndirs);
 #endif
 
 #endif /* HL_CAP_DB_DUCKDB_H */

--- a/src/hull/cap/db_duckdb.c
+++ b/src/hull/cap/db_duckdb.c
@@ -52,20 +52,67 @@ static void duck_set_err(HlDbDuckCtx *s, const char *msg)
     snprintf(s->errmsg, sizeof s->errmsg, "%s", msg ? msg : "duckdb error");
 }
 
-/* ── Security lockdown (core, manifest-independent) ────────────────────
+/* ── Manifest-driven file-access policy ────────────────────────────────
+ *
+ * The bounded-local-access mode (design §3.2 mode B): when the app declares
+ * fs.read / fs.write paths, DuckDB SQL (read_csv / read_parquet / COPY) may
+ * touch exactly those directories, nothing else. serve.c resolves the manifest
+ * fs paths to absolute directories (in the sealed policy arena) and hands them
+ * here once at boot, before any connection opens; duck_open reads the pointer.
+ * The array + strings are sealed (RO) memory owned by the caller for process
+ * life. When no fs paths are declared (or DuckDB isn't enabled) the policy is
+ * empty and duck_open applies full lockdown (mode A). */
+static const char *const *g_duck_allowed_dirs = NULL;
+static int                g_duck_allowed_ndirs = 0;
+
+void hl_db_duckdb_set_fs_policy(const char *const *dirs, int ndirs)
+{
+    g_duck_allowed_dirs  = (ndirs > 0) ? dirs : NULL;
+    g_duck_allowed_ndirs = (ndirs > 0 && dirs) ? ndirs : 0;
+}
+
+/* Build the DuckDB list literal ['d1','d2',...] for the declared policy (single
+ * quotes doubled), used for both the config-time allowed_directories option and
+ * the post-connect SET. Returns a malloc'd string, or NULL (empty policy/OOM). */
+static char *duck_alloc_dirs_list(void)
+{
+    if (g_duck_allowed_ndirs <= 0 || !g_duck_allowed_dirs) return NULL;
+    size_t cap = 8;
+    for (int i = 0; i < g_duck_allowed_ndirs; i++)
+        cap += (g_duck_allowed_dirs[i] ? strlen(g_duck_allowed_dirs[i]) : 0) * 2 + 8;
+    char *s = malloc(cap);
+    if (!s) return NULL;
+    size_t off = 0;
+    s[off++] = '[';
+    for (int i = 0; i < g_duck_allowed_ndirs; i++) {
+        const char *d = g_duck_allowed_dirs[i] ? g_duck_allowed_dirs[i] : "";
+        if (i > 0 && off < cap) s[off++] = ',';
+        if (off < cap) s[off++] = '\'';
+        for (const char *p = d; *p && off + 2 < cap; p++) {
+            if (*p == '\'') s[off++] = '\'';
+            s[off++] = *p;
+        }
+        if (off < cap) s[off++] = '\'';
+    }
+    if (off + 2 >= cap) { free(s); return NULL; }
+    s[off++] = ']';
+    s[off] = '\0';
+    return s;
+}
+
+/* ── Security lockdown ─────────────────────────────────────────────────
  *
  * DuckDB SQL can drive its own file/network I/O (read_csv, read_parquet,
  * COPY, httpfs), which would bypass Hull's capability model. Network is
  * already structurally absent (httpfs / S3 are not in the linked archive
- * set). Here we additionally forbid installing / loading extensions and
- * disable all external (local file) access, then LOCK the configuration so
- * app SQL cannot re-enable any of it. This is the SQLite-equivalent full
- * lockdown; the bounded-local-access mode (fs.read/fs.write ->
- * allowed_directories) is a follow-up that needs the manifest at open time.
+ * set). Here we forbid installing / loading extensions and gate external
+ * (local file) access: OFF entirely (mode A) when no fs paths are declared,
+ * or ON but bounded to allowed_directories (mode B, applied post-connect in
+ * duck_open) when they are. lock_configuration (in duck_open, after connect)
+ * then freezes it so app SQL cannot re-enable anything.
  *
- * Extension-install / access options are set at config time (before open);
- * lock_configuration is applied last, after connect, so the config-time sets
- * are not themselves rejected by the lock. */
+ * These options are set at config time (before open); lock_configuration is
+ * applied last so the config-time sets are not themselves rejected. */
 static int duck_apply_config_security(duckdb_config config)
 {
     /* Each returns DuckDBSuccess/Error; a rejected option name is fatal (the
@@ -76,11 +123,44 @@ static int duck_apply_config_security(duckdb_config config)
         return -1;
     if (duckdb_set_config(config, "allow_unsigned_extensions", "false") != DuckDBSuccess)
         return -1;
-    /* No fs.read/fs.write plumbing in this slice -> full lockdown: DB file +
-     * :memory: only, no SQL-driven external file access. */
-    if (duckdb_set_config(config, "enable_external_access", "false") != DuckDBSuccess)
+    /* Pin memory + threads so DuckDB does NOT auto-detect them by probing /sys
+     * and /proc. Even with those paths unveiled (see sandbox.c), auto-detection
+     * hits some resource that fails under the sandbox and DuckDB NULL-derefs
+     * (aborts) rather than degrading — pinning the values avoids that path
+     * entirely. Fixed, conservative defaults; a future manifest option can make
+     * them tunable (tracked in docs/duckdb_backend_design.md §3.2). */
+    if (duckdb_set_config(config, "memory_limit", "2GB") != DuckDBSuccess)
+        return -1;
+    if (duckdb_set_config(config, "threads", "4") != DuckDBSuccess)
+        return -1;
+    /* Mode B enables external access but bounds it to allowed_directories;
+     * mode A leaves it off (DB file + :memory: only). */
+    const char *ext = (g_duck_allowed_ndirs > 0) ? "true" : "false";
+    if (duckdb_set_config(config, "enable_external_access", ext) != DuckDBSuccess)
         return -1;
     return 0;
+}
+
+/* Emit `SET allowed_directories = ['d1','d2',...]` for the declared policy and
+ * run it on @p con (single quotes in a path are doubled). Returns 0, or -1 on
+ * allocation / execution failure (with *errmsg set via the caller). No-op
+ * returning 0 when the policy is empty. Called after connect, before the lock. */
+static int duck_apply_allowed_dirs(duckdb_connection con)
+{
+    if (g_duck_allowed_ndirs <= 0 || !g_duck_allowed_dirs) return 0;   /* mode A */
+    char *list = duck_alloc_dirs_list();
+    if (!list) return -1;
+    size_t cap = strlen(list) + 32;   /* "SET allowed_directories = " + NUL */
+    char *sql = malloc(cap);
+    if (!sql) { free(list); return -1; }
+    snprintf(sql, cap, "SET allowed_directories = %s", list);
+    free(list);
+
+    duckdb_result r;
+    int ok = (duckdb_query(con, sql, &r) == DuckDBSuccess);
+    duckdb_destroy_result(&r);
+    free(sql);
+    return ok ? 0 : -1;
 }
 
 /* ── Open / close ─────────────────────────────────────────────────── */
@@ -126,6 +206,16 @@ static int duck_open(void **out_ctx, const char *dsn, HlAllocator *alloc)
 
     if (duckdb_connect(s->db, &s->con) != DuckDBSuccess) {
         duck_set_err(s, "duckdb_connect failed");
+        duckdb_close(&s->db);
+        free(s);
+        return -1;
+    }
+
+    /* Mode B: bound external file access to the manifest-declared directories
+     * (before the lock, so it sticks). No-op under mode A. */
+    if (duck_apply_allowed_dirs(s->con) != 0) {
+        duck_set_err(s, "duckdb allowed_directories failed");
+        duckdb_disconnect(&s->con);
         duckdb_close(&s->db);
         free(s);
         return -1;

--- a/src/hull/sandbox.c
+++ b/src/hull/sandbox.c
@@ -710,6 +710,19 @@ int hl_sandbox_apply(const HlSandboxPolicy *policy, const char *app_dir,
     /* /dev/urandom: needed by crypto.random and password hashing */
     unveil("/dev/urandom", "r");
 
+#ifdef HL_ENABLE_DUCKDB
+    /* DuckDB's C++ runtime reads these to detect CPU count, memory limits, and
+     * timezone data (its ICU extension). Without them a read_csv/read_parquet
+     * throws an internal NULL-deref and aborts (SIGABRT) under the sandbox.
+     * All read-only system-info paths. */
+    unveil("/etc/localtime",                    "r");
+    unveil("/sys/devices/system/cpu",           "r");
+    unveil("/sys/fs/cgroup",                    "r");   /* cgroup v2 memory.max */
+    unveil("/proc/self/cgroup",                 "r");
+    unveil("/proc/sys/vm/overcommit_memory",    "r");
+    unveil("/proc/meminfo",                     "r");
+#endif
+
     /* Manifest fs.read / fs.write paths: resolve relative to
      * app_dir (matching the capability layer) AND pre-mkdir so
      * unveil() can canonicalize. Without app_dir-relative

--- a/src/hull/serve.c
+++ b/src/hull/serve.c
@@ -44,6 +44,7 @@
 #ifdef HL_ENABLE_DB
 #include "hull/worker_db.h"
 #include "hull/cap/db.h"
+#include "hull/cap/db_duckdb.h"   /* hl_db_duckdb_set_fs_policy (mode B) */
 #include "hull/migrate.h"
 #endif
 #include "hull/cap/audit.h"
@@ -1115,6 +1116,72 @@ static int hl_serve_load_app(HlServerState *s)
  * Split out of a 296-line monolith as roadmap item H.
  */
 
+#ifdef HL_ENABLE_DUCKDB
+/* Resolve the manifest's fs.read + fs.write patterns to absolute directories
+ * and install them as DuckDB's bounded file-access policy (design §3.2 mode B).
+ * Each entry's glob tail is stripped, the remainder resolved absolute against
+ * app_dir, then mapped to a directory (the path itself if it is one, else its
+ * parent). Duplicates are dropped. The array + strings are allocated in the
+ * (about-to-be-sealed) policy arena, so DuckDB reads RO memory that outlives
+ * the process. A no-op — leaving DuckDB in full lockdown (mode A) — when no fs
+ * paths are declared or the arena is exhausted (fail-closed). Must run before
+ * the arena is sealed and before any DuckDB connection opens. */
+static void hl_serve_install_duckdb_fs_policy(HlServerState *s)
+{
+    const HlManifest *m = &s->manifest;
+    int total = m->fs_read_count + m->fs_write_count;
+    if (total <= 0) return;
+
+    const char *uniq[2 * HL_MANIFEST_MAX_PATHS];
+    int nuniq = 0;
+
+    for (int idx = 0; idx < total; idx++) {
+        const char *e = (idx < m->fs_read_count)
+            ? m->fs_read[idx]
+            : m->fs_write[idx - m->fs_read_count];
+        if (!e || !e[0]) continue;
+
+        /* Strip a glob tail: truncate at the last '/' before the first '*'. */
+        char work[4096];
+        snprintf(work, sizeof work, "%s", e);
+        char *star = strchr(work, '*');
+        if (star) { while (star > work && *star != '/') star--; *star = '\0'; }
+
+        /* Resolve absolute against app_dir. */
+        char abs[4096];
+        if (work[0] == '/') snprintf(abs, sizeof abs, "%s", work);
+        else if (work[0])   snprintf(abs, sizeof abs, "%s/%s", s->app_dir, work);
+        else                snprintf(abs, sizeof abs, "%s", s->app_dir);
+
+        /* Map to a directory: the path itself if it is one, else its parent. */
+        struct stat st;
+        if (!(stat(abs, &st) == 0 && S_ISDIR(st.st_mode))) {
+            char *sl = strrchr(abs, '/');
+            if (sl && sl != abs) *sl = '\0';
+            else                 snprintf(abs, sizeof abs, "%s", s->app_dir);
+        }
+
+        int dup = 0;
+        for (int j = 0; j < nuniq; j++)
+            if (strcmp(uniq[j], abs) == 0) { dup = 1; break; }
+        if (dup) continue;
+        if (nuniq >= (int)(sizeof uniq / sizeof uniq[0])) break;
+
+        char *sealed = sh_seal_arena_strdup(&s->seal_arena, abs);
+        if (!sealed) return;   /* arena OOM -> fail closed (mode A) */
+        uniq[nuniq++] = sealed;
+    }
+
+    if (nuniq <= 0) return;
+    const char **arr = sh_seal_arena_alloc(&s->seal_arena,
+                                           (size_t)nuniq * sizeof(char *),
+                                           _Alignof(char *));
+    if (!arr) return;
+    for (int i = 0; i < nuniq; i++) arr[i] = uniq[i];
+    hl_db_duckdb_set_fs_policy(arr, nuniq);
+}
+#endif /* HL_ENABLE_DUCKDB */
+
 /* Phase 1: extract manifest + resolve module set + wire per-capability configs.
  *
  * Returns 0 on success, -1 if module resolution fails (unknown name,
@@ -1247,6 +1314,12 @@ static int hl_serve_wire_caps(HlServerState *s)
             memcpy(resolved, &s->module_set, sizeof(HlResolvedModuleSet));
             rt->module_set = resolved;
         }
+
+#ifdef HL_ENABLE_DUCKDB
+        /* Install DuckDB's bounded file-access policy from the sealed manifest's
+         * fs paths (mode B), into the arena, before it is mprotect-RO'd. */
+        hl_serve_install_duckdb_fs_policy(s);
+#endif
 
         if (sh_seal_arena_seal(&s->seal_arena) != 0) {
             log_error("[hull:c] seal arena mprotect failed");


### PR DESCRIPTION
Implements DuckDB bounded local file access (design §3.2 mode B): when an app declares fs.read/fs.write, DuckDB read_csv/read_parquet/COPY may touch exactly those directories; otherwise full lockdown (mode A). serve.c resolves the sealed manifest fs paths to absolute dirs into the policy arena; duck_open emits SET allowed_directories + enable_external_access before lock_configuration.

Ordering fix (the default -d connection opened before the manifest loaded, so it couldn't get mode B): added HlAppContextOpts.defer_db_open + hl_app_context_open_db(); serve defers the default open + migrations to after wire_caps installs the policy and before the sandbox seals. The runtime now receives the registry whenever it exists (not only once db_open), so require("hull.db") works under the deferred open.

Verified locally: mode B read within declared dir / blocked outside; mode A blocked; SQLite unaffected; full default suite 59/59; test_db_duckdb 5/5. A new CI step asserts mode B on Linux under the real sandbox.