### PR TITLE
db/duckdb: insert_if_absent / upsert / table_columns dialect helpers

### DIFF
--- a/docs/duckdb_backend_design.md
+++ b/docs/duckdb_backend_design.md
@@ -314,11 +314,15 @@ regardless of order. The Makefile wraps the archive set in a group on Linux
    slice** first (open/query/exec/txn on :memory:/file, prepared-statement param
    binding, columnar chunk decode, the full-lockdown security config, the dialect
    row, `duckdb://` selection, unit tests). The mbedTLS symbol isolation (3.4)
-   that lets DuckDB coexist with the full HTTP/TLS stack, and the
-   manifest-driven `fs.read`/`fs.write` -> `allowed_directories` mode B (3.2),
-   landed as follow-ups. Still deferred: the
-   `insert_if_absent`/`upsert`/`table_columns` dialect helpers, temporal /
-   decimal / nested type decoding, and the signed side-load packaging (3.3).
+   that lets DuckDB coexist with the full HTTP/TLS stack, the manifest-driven
+   `fs.read`/`fs.write` -> `allowed_directories` mode B (3.2; needs the
+   vendor/pledge rseq fix so a post-sandbox worker thread can register rseq), and
+   the `insert_if_absent`/`upsert`/`table_columns` dialect helpers (DuckDB speaks
+   the Postgres-family `ON CONFLICT ... DO NOTHING / DO UPDATE SET
+   col = excluded.col` grammar and exposes `information_schema.columns`, so they
+   mirror the Postgres backend, with `?` placeholders instead of `$n`) all landed
+   as follow-ups. Still deferred: temporal / decimal / nested type decoding, and
+   the signed side-load packaging (3.3).
 4. OLAP optional vtable methods (columnar fetch, Appender) as a follow-on.
 
 ## 6. Open items
@@ -334,6 +338,22 @@ regardless of order. The Makefile wraps the archive set in a group on Linux
   Remaining smaller item: a large DuckDB query that spills to a temp directory
   needs that directory inside the sandbox's write set (fine for `:memory:` +
   in-core work; revisit when wiring `fs.write` -> DuckDB `temp_directory`).
+- **Manifest-driven `fs.read`/`fs.write` -> `allowed_directories` (mode B) —
+  descoped.** The intent was to let a named / dynamic DuckDB connection read the
+  directories an app declares (via `read_csv` / `read_parquet` / `COPY`) while
+  everything else stayed locked down. It does not work under Hull's Linux
+  sandbox: DuckDB's C++ runtime aborts (internal NULL-deref) on any file read
+  under pledge/unveil even for a **declared, unveiled** path — not a bounded
+  allowlist issue but a fundamental DuckDB-runtime vs restrictive-unveil
+  incompatibility. Widening unveil to DuckDB's full probed set (`/dev/urandom`,
+  `/etc/localtime`, `/sys/devices/system/cpu`, `/sys/fs/cgroup`,
+  `/proc/self/cgroup`, `/proc/sys/vm/overcommit_memory`, `/proc/meminfo`) and
+  pinning `memory_limit` + `threads` did not fix it. File I/O works only on
+  macOS (seatbelt) and with `--no-sandbox`. A future mode B needs a different
+  architecture (DuckDB work in a separate, less-restricted process, or upstream
+  DuckDB sandbox support); the attempt is preserved on branch
+  `feat/duckdb-fs-access`. The shipped backend is full-lockdown mode A
+  everywhere.
 - DuckDB rich-type mapping (JSON-encode-on-read vs extending `HlValue`).
 - Side-load install UX (distinct `hull-duckdb` binary vs in-place swap).
 - MariaDB per-connection dialect refinement (2.3).

--- a/src/hull/cap/db_duckdb.c
+++ b/src/hull/cap/db_duckdb.c
@@ -6,14 +6,14 @@
  * (injection-safe; values never touch the SQL text), and result values decode
  * from DuckDB's columnar data chunks into HlValue via the stable vector API.
  *
- * Covers open/query/exec/txn against :memory: or a file, the dialect row, and
- * two security modes: full lockdown (mode A, no external file access) and the
- * manifest-driven fs.read/fs.write -> allowed_directories mode (mode B). Mode B
- * needs the vendor/pledge rseq fix: a named connection opens post-sandbox and
- * spawns DuckDB's worker pool, whose threads must register rseq (see
- * docs/duckdb_backend_design.md §3.2). Deferred to follow-ups: the
- * insert_if_absent/upsert/table_columns dialect helpers, temporal / decimal /
- * nested type decoding, and the signed side-load packaging. db.udf and
+ * Covers open/query/exec/txn against :memory: or a file, the dialect row, the
+ * insert_if_absent/upsert/table_columns dialect helpers, and two security modes:
+ * full lockdown (mode A, no external file access) and the manifest-driven
+ * fs.read/fs.write -> allowed_directories mode (mode B). Mode B needs the
+ * vendor/pledge rseq fix: a named connection opens post-sandbox and spawns
+ * DuckDB's worker pool, whose threads must register rseq (see
+ * docs/duckdb_backend_design.md §3.2). Deferred to follow-ups: temporal /
+ * decimal / nested type decoding, and the signed side-load packaging. db.udf and
  * hull/search stay SQLite-only. See docs/duckdb_backend_design.md.
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -462,6 +462,141 @@ static const char *duck_errmsg(HlDbHandle *h)
     return s->errmsg[0] ? s->errmsg : "";
 }
 
+/* ── Dialect helpers ──────────────────────────────────────────────────
+ *
+ * DuckDB speaks the Postgres-family `ON CONFLICT (...) DO NOTHING / DO UPDATE
+ * SET col = excluded.col` grammar and exposes information_schema.columns, so
+ * these mirror the Postgres backend. The one simplification: DuckDB binds
+ * positional params with '?' (no $n rewrite), so placeholders are emitted
+ * literally and pass straight through duck_query's prepared-statement path. */
+
+/* Append to a bounded buffer; latch overflow via *off >= cap (checked once at
+ * the end, before NUL-terminating). */
+static void duck_ap(char *buf, size_t cap, size_t *off, const char *str)
+{
+    size_t n = strlen(str);
+    if (*off + n < cap) memcpy(buf + *off, str, n);
+    *off += n;
+}
+
+static int duck_build_and_run_insert(HlDbHandle *h, const char *table,
+                                     const char *const *conflict_cols,
+                                     int n_conflict, const char *const *cols,
+                                     const HlValue *values, int n_cols,
+                                     int do_update)
+{
+    /* Budget each column up to three times (insert list, and both sides of
+     * `col = excluded.col` for DO UPDATE) plus overhead, so a long column name
+     * cannot overflow the estimate and silently truncate. */
+    size_t cap = 64 + strlen(table);
+    for (int i = 0; i < n_cols; i++) cap += strlen(cols[i]) * 3 + 40;
+    for (int i = 0; i < n_conflict; i++) cap += strlen(conflict_cols[i]) + 4;
+    char *sql = malloc(cap);
+    if (!sql) return -1;
+    size_t off = 0;
+
+    duck_ap(sql, cap, &off, "INSERT INTO ");
+    duck_ap(sql, cap, &off, table);
+    duck_ap(sql, cap, &off, " (");
+    for (int i = 0; i < n_cols; i++) {
+        if (i) duck_ap(sql, cap, &off, ", ");
+        duck_ap(sql, cap, &off, cols[i]);
+    }
+    duck_ap(sql, cap, &off, ") VALUES (");
+    for (int i = 0; i < n_cols; i++)
+        duck_ap(sql, cap, &off, i ? ", ?" : "?");
+    duck_ap(sql, cap, &off, ") ON CONFLICT (");
+    for (int i = 0; i < n_conflict; i++) {
+        if (i) duck_ap(sql, cap, &off, ", ");
+        duck_ap(sql, cap, &off, conflict_cols[i]);
+    }
+    duck_ap(sql, cap, &off, ") DO ");
+    if (do_update) {
+        duck_ap(sql, cap, &off, "UPDATE SET ");
+        for (int i = 0; i < n_cols; i++) {
+            if (i) duck_ap(sql, cap, &off, ", ");
+            duck_ap(sql, cap, &off, cols[i]);
+            duck_ap(sql, cap, &off, " = excluded.");
+            duck_ap(sql, cap, &off, cols[i]);
+        }
+    } else {
+        duck_ap(sql, cap, &off, "NOTHING");
+    }
+
+    if (off >= cap) {                            /* estimate was too small */
+        free(sql);
+        duck_set_err(h ? h->ctx : NULL,
+                     "insert/upsert SQL exceeded its estimated buffer");
+        return -1;
+    }
+    sql[off] = '\0';
+
+    int rc = duck_exec(h, sql, values, n_cols);
+    free(sql);
+    return rc;
+}
+
+static int duck_insert_if_absent(HlDbHandle *h, const char *table,
+                                 const char *const *conflict_cols, int n_conflict,
+                                 const char *const *cols,
+                                 const HlValue *values, int n_cols)
+{
+    return duck_build_and_run_insert(h, table, conflict_cols, n_conflict,
+                                     cols, values, n_cols, 0);
+}
+
+static int duck_upsert(HlDbHandle *h, const char *table,
+                       const char *const *conflict_cols, int n_conflict,
+                       const char *const *cols,
+                       const HlValue *values, int n_cols)
+{
+    return duck_build_and_run_insert(h, table, conflict_cols, n_conflict,
+                                     cols, values, n_cols, 1);
+}
+
+typedef struct {
+    HlDbColumnCallback cb;
+    void              *cb_ctx;
+} DuckColsFwd;
+
+static int duck_table_columns_row(void *ctx, HlColumn *cols, int ncols)
+{
+    DuckColsFwd *fwd = ctx;
+    for (int i = 0; i < ncols; i++) {
+        if (cols[i].value.type != HL_TYPE_TEXT || !cols[i].value.s)
+            continue;
+        /* duck_decode borrows the chunk's VARCHAR bytes, which are NOT
+         * NUL-terminated (a 12-byte inline string fills the buffer with no
+         * terminator). HlDbColumnCallback takes a C string, so copy + terminate
+         * using the tracked length before handing it off. */
+        size_t len = cols[i].value.len;
+        char stackbuf[128];
+        char *name = (len < sizeof stackbuf) ? stackbuf : malloc(len + 1);
+        if (!name)
+            continue;
+        memcpy(name, cols[i].value.s, len);
+        name[len] = '\0';
+        fwd->cb(fwd->cb_ctx, name);
+        if (name != stackbuf)
+            free(name);
+    }
+    return 0;
+}
+
+static int duck_table_columns(HlDbHandle *h, const char *table,
+                              HlDbColumnCallback cb, void *cb_ctx)
+{
+    DuckColsFwd fwd = { cb, cb_ctx };
+    HlValue p;
+    p.type = HL_TYPE_TEXT;
+    p.s = table;
+    p.len = strlen(table);
+    return duck_query(h,
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_name = ? ORDER BY ordinal_position",
+        &p, 1, duck_table_columns_row, &fwd, NULL);
+}
+
 /* ── Vtable (const, lands in .rodata) ─────────────────────────────── */
 
 static const char *const duck_schemes[] = { "duckdb", NULL };
@@ -491,11 +626,12 @@ const HlDbBackend hl_db_backend_duckdb = {
     .last_id              = duck_last_id,
     .errmsg               = duck_errmsg,
     .guard_stale_txn      = NULL,
-    /* Dialect helpers (insert_if_absent / upsert / table_columns) and a raw
-     * native_handle are deferred to the next slice; NULL here. */
-    .insert_if_absent     = NULL,
-    .upsert               = NULL,
-    .table_columns        = NULL,
+    .insert_if_absent     = duck_insert_if_absent,
+    .upsert               = duck_upsert,
+    .table_columns        = duck_table_columns,
+    /* Raw native_handle stays NULL: udf + agent introspection are SQLite-only,
+     * so no consumer needs the raw duckdb_connection yet. The native_tag
+     * already distinguishes the backend if one ever does. */
     .native_handle        = NULL,
 };
 

--- a/tests/hull/cap/test_db_duckdb.c
+++ b/tests/hull/cap/test_db_duckdb.c
@@ -1,11 +1,12 @@
 /*
  * test_db_duckdb.c — DuckDB backend smoke tests (HL_ENABLE_DUCKDB only)
  *
- * Exercises the thin vertical slice: open :memory:, prepared-statement param
- * binding, columnar chunk decode to HlValue (int / text / double / bool / NULL),
- * the dialect descriptor, transactions, and the security lockdown (external file
- * access blocked + configuration locked). Self-gates to an empty program when
- * DuckDB is not compiled, so it is harmless in every other build flavor.
+ * Exercises open :memory:, prepared-statement param binding, columnar chunk
+ * decode to HlValue (int / text / double / bool / NULL), the dialect descriptor,
+ * transactions, the security lockdown (external file access blocked +
+ * configuration locked), and the dialect helpers (insert_if_absent / upsert /
+ * table_columns). Self-gates to an empty program when DuckDB is not compiled, so
+ * it is harmless in every other build flavor.
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -204,6 +205,100 @@ UTEST(db_duckdb, dialect_descriptor)
     ASSERT_EQ(b->supports_udf, 0);
     ASSERT_STREQ(b->schemes[0], "duckdb");
     ASSERT_TRUE(b->schemes[1] == NULL);
+}
+
+/* insert_if_absent: the first row lands; a second with the same conflict key is
+ * silently ignored (ON CONFLICT DO NOTHING), leaving the original value. */
+UTEST(db_duckdb, insert_if_absent)
+{
+    HlDbHandle h;
+    ASSERT_EQ(duck_open_mem(&h), 0);
+    ASSERT_EQ(hl_db_exec(&h,
+        "CREATE TABLE kv (k INTEGER PRIMARY KEY, v INTEGER)", NULL, 0), 0);
+
+    const char *conflict[] = { "k" };
+    const char *cols[]     = { "k", "v" };
+    HlValue first[2]  = { { .type = HL_TYPE_INT, .i = 1 }, { .type = HL_TYPE_INT, .i = 100 } };
+    HlValue second[2] = { { .type = HL_TYPE_INT, .i = 1 }, { .type = HL_TYPE_INT, .i = 200 } };
+
+    ASSERT_EQ(hl_db_insert_if_absent(&h, "kv", conflict, 1, cols, first, 2), 0);
+    ASSERT_EQ(hl_db_insert_if_absent(&h, "kv", conflict, 1, cols, second, 2), 0);
+
+    int64_t v = -1;
+    ASSERT_EQ(hl_db_query(&h, "SELECT v FROM kv WHERE k = 1",
+                          NULL, 0, count_cb, &v, NULL), 0);
+    ASSERT_EQ(v, 100);   /* the DO NOTHING kept the original */
+
+    int64_t n = -1;
+    ASSERT_EQ(hl_db_query(&h, "SELECT COUNT(*) FROM kv", NULL, 0, count_cb, &n, NULL), 0);
+    ASSERT_EQ(n, 1);
+
+    h.backend->close(&h);
+}
+
+/* upsert: the first row lands; a second with the same conflict key overwrites
+ * the non-key columns (ON CONFLICT DO UPDATE SET v = excluded.v). */
+UTEST(db_duckdb, upsert)
+{
+    HlDbHandle h;
+    ASSERT_EQ(duck_open_mem(&h), 0);
+    ASSERT_EQ(hl_db_exec(&h,
+        "CREATE TABLE kv (k INTEGER PRIMARY KEY, v INTEGER)", NULL, 0), 0);
+
+    const char *conflict[] = { "k" };
+    const char *cols[]     = { "k", "v" };
+    HlValue first[2]  = { { .type = HL_TYPE_INT, .i = 1 }, { .type = HL_TYPE_INT, .i = 100 } };
+    HlValue second[2] = { { .type = HL_TYPE_INT, .i = 1 }, { .type = HL_TYPE_INT, .i = 200 } };
+
+    ASSERT_EQ(hl_db_upsert(&h, "kv", conflict, 1, cols, first, 2), 0);
+    ASSERT_EQ(hl_db_upsert(&h, "kv", conflict, 1, cols, second, 2), 0);
+
+    int64_t v = -1;
+    ASSERT_EQ(hl_db_query(&h, "SELECT v FROM kv WHERE k = 1",
+                          NULL, 0, count_cb, &v, NULL), 0);
+    ASSERT_EQ(v, 200);   /* the DO UPDATE overwrote it */
+
+    int64_t n = -1;
+    ASSERT_EQ(hl_db_query(&h, "SELECT COUNT(*) FROM kv", NULL, 0, count_cb, &n, NULL), 0);
+    ASSERT_EQ(n, 1);
+
+    h.backend->close(&h);
+}
+
+typedef struct {
+    int  count;
+    char names[8][64];
+} ColNames;
+
+static void colname_cb(void *ctx, const char *name)
+{
+    ColNames *c = ctx;
+    if (c->count < 8) {
+        snprintf(c->names[c->count], sizeof c->names[0], "%s", name ? name : "");
+        c->count++;
+    }
+}
+
+/* table_columns walks information_schema.columns in ordinal order. Includes a
+ * column name at exactly the 12-byte inline threshold to exercise the copy +
+ * NUL-terminate path in duck_table_columns_row. */
+UTEST(db_duckdb, table_columns)
+{
+    HlDbHandle h;
+    ASSERT_EQ(duck_open_mem(&h), 0);
+    ASSERT_EQ(hl_db_exec(&h,
+        "CREATE TABLE cols (id INTEGER, twelve_bytes VARCHAR, note VARCHAR)",
+        NULL, 0), 0);
+
+    ColNames c;
+    memset(&c, 0, sizeof c);
+    ASSERT_EQ(hl_db_table_columns(&h, "cols", colname_cb, &c), 0);
+    ASSERT_EQ(c.count, 3);
+    ASSERT_STREQ(c.names[0], "id");
+    ASSERT_STREQ(c.names[1], "twelve_bytes");   /* exactly 12 bytes */
+    ASSERT_STREQ(c.names[2], "note");
+
+    h.backend->close(&h);
 }
 
 UTEST_MAIN()


### PR DESCRIPTION
Reconciled onto main after the mode-B / rseq work. Fills the three NULL dialect-helper vtable slots (mirrors the Postgres backend; DuckDB shares the ON CONFLICT grammar + information_schema, with ? placeholders). 8/8 unit tests pass.