### PR TITLE
db/select: composable feature-backend hook (DuckDB-as-feature, phase 1)

### DIFF
--- a/include/hull/cap/db_backend.h
+++ b/include/hull/cap/db_backend.h
@@ -333,4 +333,18 @@ static inline int hl_db_quote_ident(HlDbHandle *h, const char *name,
  */
 const HlDbBackend *hl_db_backend_select(const char *dsn, const char **err);
 
+/*
+ * Feature backends: large, composable DB connectors (e.g. DuckDB) that are NOT
+ * compiled into the base but linked in at `hull build` time from a signed
+ * feature lib. Returns a table of `*count` backends the build composed in;
+ * hl_db_backend_select iterates it after the base BACKENDS[].
+ *
+ * The base ships a WEAK default returning an empty set (a base build has no
+ * feature backends). A feature build links a STRONG override — a generated
+ * const registry that references each composed feature's backend — which the
+ * linker prefers. The override MUST be a direct object (not an archive member)
+ * so it displaces the weak default. See docs/features_and_flavors.md §3.2.
+ */
+const HlDbBackend *const *hl_db_feature_backends(size_t *count);
+
 #endif /* HL_CAP_DB_BACKEND_H */

--- a/src/hull/cap/db_select.c
+++ b/src/hull/cap/db_select.c
@@ -81,6 +81,19 @@ static int scheme_in(const char *const *list, const char *scheme)
     return 0;
 }
 
+/* Weak default: a base build has no composed feature backends. A feature build
+ * (`hull build --with=<feature>`) links a generated STRONG override — a const
+ * table referencing each composed feature's backend — which the linker prefers
+ * over this. See db_backend.h + docs/features_and_flavors.md §3.2. Kept in this
+ * TU (which is always linked) so the symbol always resolves; the override, being
+ * a direct object rather than an archive member, displaces it. */
+__attribute__((weak))
+const HlDbBackend *const *hl_db_feature_backends(size_t *count)
+{
+    if (count) *count = 0;
+    return NULL;
+}
+
 const HlDbBackend *hl_db_backend_select(const char *dsn, const char **err)
 {
     if (err) *err = NULL;
@@ -89,10 +102,18 @@ const HlDbBackend *hl_db_backend_select(const char *dsn, const char **err)
     size_t slen = dsn_scheme(dsn, scheme, sizeof scheme);
 
     if (slen > 0) {
-        /* Explicit "<scheme>://": route to the backend that claims it. */
+        /* Explicit "<scheme>://": route to the backend that claims it. First the
+         * base backends compiled into this binary. */
         for (size_t i = 0; i < sizeof BACKENDS / sizeof BACKENDS[0]; i++)
             if (scheme_in(BACKENDS[i]->schemes, scheme))
                 return BACKENDS[i];
+        /* Then feature backends composed in at build time (empty in a base
+         * build; a generated registry fills this in a `--with=<feature>` build). */
+        size_t fcount = 0;
+        const HlDbBackend *const *feats = hl_db_feature_backends(&fcount);
+        for (size_t i = 0; i < fcount; i++)
+            if (feats && feats[i] && scheme_in(feats[i]->schemes, scheme))
+                return feats[i];
         /* A scheme Hull knows but this build lacks: specific hint. */
         for (size_t i = 0; i < sizeof RESERVED / sizeof RESERVED[0]; i++)
             if (strcmp(RESERVED[i].scheme, scheme) == 0) {

--- a/tests/hull/cap/test_db_select.c
+++ b/tests/hull/cap/test_db_select.c
@@ -116,4 +116,36 @@ UTEST(db_select, unknown_scheme)
     ASSERT_TRUE(err); ASSERT_TRUE(strstr(err, "unknown") != NULL);
 }
 
+/* Feature-composition hook: a STRONG override of the base's weak
+ * hl_db_feature_backends (this is exactly how a `hull build --with=<feature>`
+ * build injects a composed backend). The synthetic "featuretest" scheme is
+ * claimed by no base backend and is not reserved, so it exercises only the
+ * feature path. This strong definition displaces db_select.c's weak default for
+ * the whole test binary; it is inert for every other scheme, so the tests above
+ * are unaffected. */
+static const char *const feature_schemes[] = { "featuretest", NULL };
+static const HlDbBackend feature_backend = {
+    .name    = "featuretest",
+    .schemes = feature_schemes,
+};
+static const HlDbBackend *const FEATURE_TABLE[] = { &feature_backend };
+const HlDbBackend *const *hl_db_feature_backends(size_t *count)
+{
+    if (count) *count = 1;
+    return FEATURE_TABLE;
+}
+
+UTEST(db_select, feature_backend_composed)
+{
+    const char *err = NULL;
+    const HlDbBackend *b = hl_db_backend_select("featuretest://x", &err);
+    ASSERT_TRUE(b);
+    ASSERT_STREQ(b->name, "featuretest");
+    ASSERT_FALSE(err);
+    /* Base backends still win + a truly unknown scheme still errors. */
+    err = NULL;
+    ASSERT_FALSE(hl_db_backend_select("bogus://x", &err));
+    ASSERT_TRUE(err);
+}
+
 UTEST_MAIN()


### PR DESCRIPTION
Phase 1 of #4 (DuckDB as the first composable feature, see docs/features_and_flavors.md). Adds a weak-default feature-backend table to hl_db_backend_select; a later feature build links a generated strong override. Inert on its own (base builds route unchanged). New test exercises the weak->strong mechanism. Verified locally: default 7/7, HL_ENABLE_DUCKDB=1 7/7 + test_db_duckdb 8/8.