### PR TITLE
build: make feature-duckdb -> libhull_feature-duckdb.a (DuckDB-as-feature, phase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,6 +773,26 @@ jobs:
           ./build/test_db_select
           ./build/test_crypto   # Hull's own mbedTLS must stay unaffected by the isolation
 
+      - name: DuckDB feature archive (link-smoke, no --start-group)
+        timeout-minutes: 5
+        run: |
+          set -e
+          # Phase 2 of DuckDB-as-a-feature: `make feature-duckdb` bundles the
+          # backend + isolated DuckDB static libs into ONE archive. This proves,
+          # on Linux/ELF, that the combined archive is self-contained -- linking a
+          # harness against ONLY it, with NO -Wl,--start-group, must resolve every
+          # DuckDB symbol and run. (The base build still needs --start-group for
+          # the separate archives; combining removes that at the composing link.)
+          make feature-duckdb
+          test -f build/libhull_feature-duckdb.a
+          nm build/libhull_feature-duckdb.a | grep -qw hl_db_backend_duckdb
+          cc -std=c11 -DHL_ENABLE_DUCKDB -Ivendor/duckdb -Iinclude \
+             tests/feature_duckdb_link.c build/libhull_feature-duckdb.a \
+             -lstdc++ -ldl -lm -lpthread -o /tmp/feature_duckdb_link
+          OUT=$(/tmp/feature_duckdb_link)
+          echo "$OUT"
+          echo "$OUT" | grep -q "FEATURE DUCKDB LINK OK"
+
       - name: DuckDB app smoke (duckdb://:memory:)
         timeout-minutes: 2
         run: |

--- a/Makefile
+++ b/Makefile
@@ -2411,6 +2411,34 @@ platform-server-only platform-client-only platform-pure-compute: platform-%:
 	cp $(BUILDDIR)/flavor-$*/libhull_platform.a $(BUILDDIR)/libhull_platform-$*.a
 	@echo "built $(BUILDDIR)/libhull_platform-$*.a"
 
+# ── DuckDB feature archive (composable feature: hull build --with=duckdb) ──
+# libhull_feature-duckdb.a bundles the DuckDB backend object (cap_db_duckdb.o,
+# which defines hl_db_backend_duckdb) + the isolated DuckDB static libs into ONE
+# self-contained archive. A build composes it in rather than compiling DuckDB
+# into the base platform lib -- the feature model, see docs/features_and_flavors.md.
+#
+# Combining the archives is deliberate: it makes the DuckDB engine's circular
+# refs (loader <-> extensions <-> core) INTRA-archive, so the composing link
+# needs no --start-group (ld iterates a single archive's members to a fixed
+# point). Each source archive is extracted into its own subdir first, because
+# distinct archives can share a member name (e.g. two `utils.o`); collecting
+# them by subdir keeps both -- ar tolerates duplicate member names in the output
+# and ld pulls whichever resolves a needed symbol via the archive index.
+# Native only (DuckDB is not cosmo-compatible). `feature-duckdb` re-invokes make
+# with HL_ENABLE_DUCKDB=1 so DUCKDB_ARCHIVES + cap_db_duckdb.o are in scope.
+feature-duckdb:
+	$(MAKE) $(BUILDDIR)/libhull_feature-duckdb.a HL_ENABLE_DUCKDB=1
+.PHONY: feature-duckdb
+
+$(BUILDDIR)/libhull_feature-duckdb.a: $(BUILDDIR)/cap_db_duckdb.o $(DUCKDB_ARCHIVES) | $(BUILDDIR)
+	@rm -f $@
+	$(AR) rcs $@ $(BUILDDIR)/cap_db_duckdb.o
+	@tmproot=$$(mktemp -d); n=0; for a in $(DUCKDB_ARCHIVES); do \
+		mkdir -p $$tmproot/$$n && ( cd $$tmproot/$$n && $(AR) x $(CURDIR)/$$a ) && \
+		$(AR) rcs $(CURDIR)/$@ $$tmproot/$$n/*.o && n=$$((n+1)); \
+	done; rm -rf $$tmproot
+	@echo "built $@ ($$(du -h $@ | cut -f1))"
+
 # Multi-arch cosmo platform: build x86_64 and aarch64 archives
 COSMO_STAGE := .cosmo_staging
 

--- a/tests/feature_duckdb_link.c
+++ b/tests/feature_duckdb_link.c
@@ -1,0 +1,47 @@
+/*
+ * feature_duckdb_link.c - link-smoke for the DuckDB feature archive.
+ *
+ * Compiled + linked against ONLY libhull_feature-duckdb.a (plus the C++ runtime
+ * and libc), with NO linker --start-group. It proves the combined feature
+ * archive is self-contained: bundling the DuckDB static libs into one archive
+ * turns their circular refs intra-archive, so ld resolves them by iterating a
+ * single archive to a fixed point -- no group needed at the composing link.
+ *
+ * Exercises the real backend vtable (hl_db_backend_duckdb), not just symbol
+ * presence: open :memory:, create a table, bind + insert a row, close.
+ *
+ * Not a utest (it links a special archive, not the default test objects); the
+ * CI DuckDB job builds + runs it. Compile with -DHL_ENABLE_DUCKDB.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "hull/cap/db_backend.h"
+#include "hull/cap/db_duckdb.h"
+#include <stdio.h>
+
+int main(void)
+{
+    void *ctx = NULL;
+    if (hl_db_backend_duckdb.open(&ctx, "duckdb://:memory:", NULL) != 0) {
+        fprintf(stderr, "feature link-smoke: open failed\n");
+        return 1;
+    }
+    HlDbHandle h;
+    h.backend = &hl_db_backend_duckdb;
+    h.ctx = ctx;
+
+    if (hl_db_exec(&h, "CREATE TABLE t (x INTEGER)", NULL, 0) != 0) {
+        fprintf(stderr, "feature link-smoke: create failed\n");
+        return 1;
+    }
+    HlValue v = { .type = HL_TYPE_INT, .i = 42 };
+    if (hl_db_exec(&h, "INSERT INTO t VALUES (?)", &v, 1) != 0) {
+        fprintf(stderr, "feature link-smoke: insert failed\n");
+        return 1;
+    }
+    hl_db_backend_duckdb.close(&h);
+
+    printf("FEATURE DUCKDB LINK OK\n");
+    return 0;
+}


### PR DESCRIPTION
Phase 2 of #4. `make feature-duckdb` bundles the DuckDB backend + isolated static libs into one self-contained archive (circular refs become intra-archive, so no --start-group at the composing link). New Linux CI link-smoke proves the combined ELF archive resolves with no group. Verified locally on arm64 (89MB, harness runs). Native only, no cosmo; per-arch archives are Phase 5.