### PR TITLE
build(release): publish + sign the DuckDB feature archives (phase 5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -698,10 +698,58 @@ jobs:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
 
+  build-feature-native:
+    # Composable DuckDB feature archive (libhull_feature-duckdb-<arch>.a),
+    # shipped as a release asset and pulled by `hull feature install duckdb`
+    # -> `hull build --with=duckdb`. See docs/features_and_flavors.md.
+    #
+    # Built bare (not in the reproducible container): `make fetch-duckdb` needs
+    # network, and the archive is covered by the release signature only -- it is
+    # NOT part of the platform-sig cross-check -- so it need not be byte-
+    # reproducible across rebuilds. Its SHA-256 lands in the signed hull.sha256
+    # and `hull feature install` re-verifies the download against that.
+    #
+    # No cosmo feature: DuckDB is native-only (docs/features_and_flavors.md).
+    name: Build feature duckdb (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            os: ubuntu-24.04
+          - name: linux-aarch64
+            os: ubuntu-24.04-arm
+          - name: darwin-arm64
+            os: macos-15
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+
+      - name: Write VERSION file
+        run: echo "${GITHUB_REF_NAME#v}" > VERSION
+
+      - name: Fetch DuckDB static libs (with mbedTLS symbol isolation)
+        run: make fetch-duckdb
+
+      - name: Build DuckDB feature archive
+        run: make feature-duckdb
+
+      - name: Rename artifact (arch-qualified)
+        run: mv build/libhull_feature-duckdb.a libhull_feature-duckdb-${{ matrix.name }}.a
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: feature-duckdb-${{ matrix.name }}
+          path: libhull_feature-duckdb-${{ matrix.name }}.a
+
   release:
     name: Create Release
     runs-on: ubuntu-24.04
-    needs: [build-cosmo, build-native, build-wamrc, build-platform-cosmo-flavors]
+    needs: [build-cosmo, build-native, build-wamrc, build-platform-cosmo-flavors, build-feature-native]
     permissions:
       contents: write       # publish GitHub release + assets
       id-token: write       # SLSA: OIDC for Sigstore signing
@@ -742,6 +790,12 @@ jobs:
           mv artifacts/libhull-linux-aarch64/libhull-linux-aarch64.a  dist/
           mv artifacts/libhull-darwin-arm64/libhull-darwin-arm64.a    dist/
           mv artifacts/libhull-cosmo/*.a                              dist/
+          # Composable DuckDB feature archives (libhull_feature-duckdb-<arch>.a),
+          # native-only. Pulled by `hull feature install duckdb`. Added to the
+          # SHA-256 + publish steps below so they inherit the release signature.
+          mv artifacts/feature-duckdb-linux-x86_64/*.a   dist/
+          mv artifacts/feature-duckdb-linux-aarch64/*.a  dist/
+          mv artifacts/feature-duckdb-darwin-arm64/*.a   dist/
 
       - name: Make binaries executable
         run: chmod +x dist/*
@@ -826,6 +880,7 @@ jobs:
                     libhull_platform-*.a \
                     libhull-linux-x86_64.a libhull-linux-aarch64.a libhull-darwin-arm64.a \
                     libhull.x86_64-cosmo.a libhull.aarch64-cosmo.a \
+                    libhull_feature-duckdb-*.a \
                     > hull.sha256
           cat hull.sha256
 
@@ -925,6 +980,10 @@ jobs:
           # `hull platform install <flavor>` can fetch them. Covered by
           # hull.sha256 above, so they inherit the release signature.
           assets+=(dist/libhull_platform-*.a)
+          # Composable feature archives (libhull_feature-<name>-<arch>.a), so
+          # `hull feature install <name>` can fetch them. Also covered by
+          # hull.sha256, so they inherit the release signature.
+          assets+=(dist/libhull_feature-*.a)
           # libhull no-runtime embedding archives (native per-arch + dual-arch
           # cosmo) and the libhull-scoped SBOMs. Also covered by hull.sha256.
           assets+=(

--- a/tests/release_smoke.sh
+++ b/tests/release_smoke.sh
@@ -80,6 +80,25 @@ smoke_platform_install() {
     rm -rf "$PLAT_HOME"
 }
 
+# hull feature install <name> — LIVE fetch + verify of the published composable
+# feature archive (libhull_feature-<name>-<arch>.a). Native-only (DuckDB is not
+# built for cosmo). Uses an isolated HOME so a real ~/.hull/feature is untouched.
+smoke_feature_install() {
+    echo ""
+    echo "── hull feature install duckdb (LIVE GitHub HTTPS download) ──"
+    FEAT_HOME=$(mktemp -d)
+    OUT=$(HOME="$FEAT_HOME" "$HULL" feature install duckdb 2>&1)
+    RC=$?
+    echo "$OUT" | sed 's/^/    /'
+    assert "exits 0"                         [ "$RC" -eq 0 ]
+    assert_contains "SHA-256 verified"       "$OUT" "SHA-256 verified"
+    N=$(ls "$FEAT_HOME"/.hull/feature/libhull_feature-duckdb-*.a 2>/dev/null | wc -l | tr -d ' ')
+    assert "feature lib landed in ~/.hull/feature (got $N)"  [ "$N" -ge 1 ]
+    OUT=$(HOME="$FEAT_HOME" "$HULL" feature list 2>&1)
+    assert_contains "list shows duckdb installed"  "$OUT" "duckdb"
+    rm -rf "$FEAT_HOME"
+}
+
 if ! command -v "$HULL" >/dev/null 2>&1; then
     echo "release_smoke: '$HULL' not found on PATH — install hull first"
     exit 1
@@ -168,6 +187,9 @@ assert "file removed"                  [ ! -e "$WAMRC_PATH" ]
 
 # Per-flavor platform lib install (native single-arch lib).
 smoke_platform_install
+
+# Composable feature lib install (native-only; DuckDB is not built for cosmo).
+smoke_feature_install
 
 # ── Platform-sig E2E (post-§3.2: works on installed binaries) ──
 #


### PR DESCRIPTION
Make `hull feature install duckdb` live. A new build-feature-native job builds
libhull_feature-duckdb-<arch>.a on each native runner (linux-x86_64,
linux-aarch64, darwin-arm64) via `make fetch-duckdb && make feature-duckdb`, and
the release job folds the three archives into the Ed25519-signed hull.sha256 and
publishes them. `hull feature install duckdb` then downloads the arch-matched
asset, re-verifies its SHA-256 against the signed manifest, and caches it in
~/.hull/feature for `hull build --with=duckdb` (docs/features_and_flavors.md).

Details:
  - Built bare (not the reproducible container): fetch-duckdb needs network, and
    a feature archive is covered by the release signature only -- it is not in
    the platform-sig cross-check -- so byte-reproducibility across rebuilds is
    not required. Its SHA-256 in the signed hull.sha256 is the trust anchor.
  - All three release arches have DuckDB static libs (fetch-duckdb maps uname to
    osx-arm64 / linux-amd64 / linux-arm64). No cosmo: DuckDB is native-only.
  - Asset name libhull_feature-duckdb-<arch>.a matches feature_asset() in
    commands/feature.c, and both the SHA-256 manifest and the publish asset list
    pick it up via the libhull_feature-*.a glob, inheriting the release sig.
  - release_smoke.sh gains smoke_feature_install(): the post-release go/no-go now
    LIVE-installs duckdb into an isolated HOME, asserts SHA-256 verification, the
    lib landing in ~/.hull/feature, and `hull feature list` (native path only).

Signed-off-by: Mark Farkas <mark@artalis.io>
