### PR TITLE
feat(db): point the duckdb:// reserved-scheme hint at the composable feature (phase 6)

### DIFF
--- a/src/hull/cap/db_select.c
+++ b/src/hull/cap/db_select.c
@@ -62,13 +62,17 @@ static const HlDbBackend *const BACKENDS[] = {
 /* Schemes Hull recognizes but may not have compiled: a helpful, specific error
  * instead of a bare "unknown scheme". Reserving duckdb/mysql/mariadb keeps the
  * routing forward-compatible; each resolves to a real backend the moment one is
- * compiled in (it would then match a BACKENDS[] entry before reaching here). */
+ * compiled in (it would then match a BACKENDS[] entry before reaching here).
+ * DuckDB additionally resolves when composed as a build feature: the feature
+ * loop above (hl_db_feature_backends) matches duckdb:// before this table, so
+ * this hint fires only for a base app with neither the compile flag nor the
+ * feature, and points at the feature path. See docs/features_and_flavors.md. */
 static const struct { const char *scheme; const char *msg; } RESERVED[] = {
     { "postgres",   "postgres:// requires a build with HL_ENABLE_POSTGRES" },
     { "postgresql", "postgresql:// requires a build with HL_ENABLE_POSTGRES" },
     { "sqlite",     "sqlite:// requires a build with HL_ENABLE_SQLITE" },
     { "file",       "file: URIs require a build with HL_ENABLE_SQLITE" },
-    { "duckdb",     "the DuckDB backend (duckdb://) is not available in this build" },
+    { "duckdb",     "duckdb:// needs the DuckDB feature: run 'hull feature install duckdb', then build the app with 'hull build --with=duckdb'" },
     { "mysql",      "the MySQL/MariaDB backend (mysql://) is not available in this build" },
     { "mariadb",    "the MySQL/MariaDB backend (mariadb://) is not available in this build" },
 };

--- a/tests/hull/cap/test_db_select.c
+++ b/tests/hull/cap/test_db_select.c
@@ -96,6 +96,9 @@ UTEST(db_select, reserved_schemes)
 #ifndef HL_ENABLE_DUCKDB
     ASSERT_FALSE(hl_db_backend_select("duckdb://x.duckdb", &err));
     ASSERT_TRUE(err); ASSERT_TRUE(strstr(err, "DuckDB") != NULL);
+    /* The hint points at the composable-feature path, not just a build flag. */
+    ASSERT_TRUE(strstr(err, "feature install") != NULL);
+    ASSERT_TRUE(strstr(err, "--with=duckdb") != NULL);
     err = NULL;
 #endif
 #ifndef HL_ENABLE_MYSQL


### PR DESCRIPTION
When a duckdb:// DSN is used on a build with neither HL_ENABLE_DUCKDB nor the
composed feature, db_select's reserved-scheme error now guides the user down the
supported path: "run 'hull feature install duckdb', then build the app with
'hull build --with=duckdb'", instead of the dead-end "not available in this
build". The feature-backend loop (hl_db_feature_backends) already matches
duckdb:// before this table, so the hint fires only for a base app that has
neither route -- exactly the case where the feature-install guidance is the fix.

Strengthen test_db_select's reserved_schemes case to assert the hint names both
'hull feature install' and '--with=duckdb', locking the guidance in.

Completes the DuckDB-as-a-composable-feature epic (phases 1-6). See
docs/features_and_flavors.md.

Signed-off-by: Mark Farkas <mark@artalis.io>
