### PR TITLE
fix(release): install llvm-objcopy for the macOS DuckDB feature build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -732,6 +732,15 @@ jobs:
       - name: Write VERSION file
         run: echo "${GITHUB_REF_NAME#v}" > VERSION
 
+      # fetch-duckdb isolates DuckDB's bundled mbedTLS/psa symbols via
+      # objcopy --redefine-syms. macOS runners ship no objcopy, and GNU gobjcopy
+      # handles Mach-O poorly, so install Homebrew LLVM: fetch-duckdb's Makefile
+      # rule finds /opt/homebrew/opt/llvm/bin/llvm-objcopy automatically. Linux
+      # runners already have objcopy. (Caught by the release dry-run.)
+      - name: Install llvm-objcopy (macOS)
+        if: runner.os == 'macOS'
+        run: brew install llvm
+
       - name: Fetch DuckDB static libs (with mbedTLS symbol isolation)
         run: make fetch-duckdb
 


### PR DESCRIPTION
The release dry-run (pre-release tag) caught it: Build feature duckdb
(darwin-arm64) failed while both Linux arches passed. make fetch-duckdb isolates
DuckDB's bundled mbedTLS/psa symbols with objcopy --redefine-syms, but the
macos-15 runner ships no objcopy, and GNU gobjcopy handles Mach-O poorly, so the
step errored with "needs objcopy or llvm-objcopy". (A local macOS build works
only because Homebrew LLVM is already present.)

Install Homebrew LLVM on the macOS feature job before fetch-duckdb: it lands
llvm-objcopy at /opt/homebrew/opt/llvm/bin/llvm-objcopy, exactly the fallback the
fetch-duckdb Makefile rule probes, so no PATH change is needed. Linux runners
already have objcopy. Feature builds are release-only (tag-triggered), so this is
validated by re-running the dry-run.

Signed-off-by: Mark Farkas <mark@artalis.io>
