### PR TITLE
feat(csv): opt-in formula-injection sanitizer on csv.encode

### DIFF
--- a/stdlib/js/hull/csv.js
+++ b/stdlib/js/hull/csv.js
@@ -128,6 +128,11 @@ function parse(text, opts) {
  * @param {boolean} [opts.headers=false]
  * @param {string}  [opts.separator=","]
  * @param {string}  [opts.quote='"']
+ * @param {boolean} [opts.sanitizeFormulas=false]  Prefix a "'" to any cell
+ *   beginning with = + - @ (or a leading tab/CR) to neutralize spreadsheet
+ *   formula/DDE injection when the export is opened in Excel/Sheets. Off by
+ *   default (it prepends a character to affected cells). Lua-parity alias:
+ *   `sanitize_formulas`.
  * @returns {string}  CSV text (LF line endings).
  */
 function encode(rows, opts) {
@@ -136,6 +141,10 @@ function encode(rows, opts) {
     const sep = (opts && opts.separator) || ",";
     const quo = (opts && opts.quote) || '"';
     const useHeaders = !!(opts && opts.headers);
+    // Opt-in CSV formula-injection defense (Lua-parity alias: sanitize_formulas):
+    // prefix a "'" to any cell beginning with = + - @ (or a leading tab/CR) so a
+    // spreadsheet app treats it as text, not a formula/DDE. Off by default.
+    const sanitize = !!(opts && (opts.sanitizeFormulas ?? opts.sanitize_formulas));
     const doubledQuote = quo + quo;
 
     function needsQuoting(value) {
@@ -148,7 +157,13 @@ function encode(rows, opts) {
     }
 
     function quoteField(value) {
-        const s = String(value);
+        let s = String(value);
+        if (sanitize && s.length > 0) {
+            const c = s[0];
+            if (c === "=" || c === "+" || c === "-" || c === "@" ||
+                c === "\t" || c === "\r")
+                s = "'" + s;
+        }
         if (needsQuoting(s)) {
             const parts = [];
             for (let i = 0; i < s.length; i++) {

--- a/stdlib/lua/hull/csv.lua
+++ b/stdlib/lua/hull/csv.lua
@@ -225,6 +225,10 @@ end
 --   - `headers`   (boolean, default `false`)
 --   - `separator` (string, default `","`)
 --   - `quote`     (string, default `'"'`)
+--   - `sanitize_formulas` (boolean, default `false`) Prefix a `'` to any cell
+--     beginning with `= + - @` (or a leading tab/CR) to neutralize spreadsheet
+--     formula/DDE injection when the export is opened in Excel/Sheets. Off by
+--     default (it prepends a character to affected cells).
 --
 -- @treturn string  CSV text with LF line endings. Values containing the
 --   separator, quote, CR, or LF are auto-quoted; embedded quotes are
@@ -238,6 +242,11 @@ function csv.encode(rows, opts)
     local sep   = opts.separator or ","
     local quote = opts.quote or '"'
     local use_headers = opts.headers or false
+    -- Opt-in CSV formula-injection defense: prefix a "'" to any cell that
+    -- begins with = + - @ (or a leading tab/CR), so a spreadsheet app opening
+    -- the export treats it as text, not a formula/DDE. Off by default (changes
+    -- cell content). See the doc comment above csv.encode.
+    local sanitize = opts.sanitize_formulas or false
     local escaped_quote = quote .. quote
 
     -- Determine if a field value needs quoting
@@ -255,6 +264,13 @@ function csv.encode(rows, opts)
             return ""
         end
         val = tostring(val)
+        if sanitize and #val > 0 then
+            local c = val:sub(1, 1)
+            if c == "=" or c == "+" or c == "-" or c == "@"
+               or c == "\t" or c == "\r" then
+                val = "'" .. val
+            end
+        end
         if needs_quoting(val) then
             return quote .. val:gsub(quote, escaped_quote) .. quote
         end

--- a/tests/hull/runtime/js/test_js.c
+++ b/tests/hull/runtime/js/test_js.c
@@ -376,6 +376,36 @@ UTEST(js_runtime, hull_time_module)
     cleanup_js();
 }
 
+UTEST(js_runtime, csv_encode_sanitize_formulas)
+{
+    init_js();
+
+    /* Import hull:csv and encode with/without the opt-in formula sanitizer. */
+    const char *code =
+        "import { csv } from 'hull:csv';\n"
+        "globalThis.__csv_plain = csv.encode([['=cmd|calc']]);\n"
+        "globalThis.__csv_safe = csv.encode("
+        "  [['=cmd|calc'],['@x'],['ok']], { sanitizeFormulas: true });\n"
+        "globalThis.__csv_alias = csv.encode([['=x']], { sanitize_formulas: true });\n";
+
+    JSValue val = JS_Eval(js.ctx, code, strlen(code), "<test>",
+                          JS_EVAL_TYPE_MODULE);
+    if (JS_IsException(val))
+        hl_js_dump_error(&js);
+    JS_FreeValue(js.ctx, val);
+    hl_js_run_jobs(&js);
+
+    /* Off by default: the formula cell is emitted verbatim. */
+    ASSERT_EQ(eval_int("globalThis.__csv_plain === '=cmd|calc\\n' ? 1 : 0"), 1);
+    /* Opt-in: leading = / @ prefixed with '; a non-formula cell untouched. */
+    ASSERT_EQ(eval_int(
+        "globalThis.__csv_safe === \"'=cmd|calc\\n'@x\\nok\\n\" ? 1 : 0"), 1);
+    /* snake_case alias (Lua parity) also enables it. */
+    ASSERT_EQ(eval_int("globalThis.__csv_alias === \"'=x\\n\" ? 1 : 0"), 1);
+
+    cleanup_js();
+}
+
 UTEST(js_runtime, hull_app_module)
 {
     init_js();

--- a/tests/hull/runtime/lua/test_lua.c
+++ b/tests/hull/runtime/lua/test_lua.c
@@ -3739,6 +3739,29 @@ UTEST(lua_stdlib, csv_encode_headers)
     cleanup_lua();
 }
 
+UTEST(lua_stdlib, csv_encode_sanitize_formulas)
+{
+    init_lua();
+    ASSERT_TRUE(lua_initialized);
+
+    /* Off by default: a formula cell is emitted verbatim. */
+    char *plain = eval_str("require('hull.csv').encode({{'=cmd|calc'}})");
+    ASSERT_NE(plain, NULL);
+    ASSERT_STREQ(plain, "=cmd|calc\n");
+    free(plain);
+
+    /* Opt-in: a leading = / @ (etc.) is prefixed with a ' so a spreadsheet
+     * treats it as text; a non-formula cell is untouched. */
+    char *safe = eval_str(
+        "require('hull.csv').encode({{'=cmd|calc'},{'@x'},{'ok'}}, "
+        "{ sanitize_formulas = true })");
+    ASSERT_NE(safe, NULL);
+    ASSERT_STREQ(safe, "'=cmd|calc\n'@x\nok\n");
+    free(safe);
+
+    cleanup_lua();
+}
+
 /* ── hull.search tests ───────────────────────────────────────────────── */
 
 UTEST(lua_stdlib, search_create_and_query)


### PR DESCRIPTION
The audit's note-only CSV finding: csv.encode emitted cells verbatim, so a value
beginning with = + - @ (or a leading tab/CR) is interpreted as a formula/DDE when
the export is opened in Excel/LibreOffice/Sheets. Add an opt-in defense: with
`sanitize_formulas = true` (Lua) / `sanitizeFormulas: true` (JS, snake_case alias
accepted for parity), such a cell is prefixed with a single quote so the
spreadsheet treats it as text. Sanitization runs BEFORE RFC 4180 quoting, so it
composes with the separator/quote/newline escaping.

Off by default -- it prepends a character to affected cells, which would change
existing exports. Documented in both module doc blocks. Both siblings fixed
together (the gap was shared, not a divergence).

Tests: test_lua.c + test_js.c each gain csv_encode_sanitize_formulas (default-off
verbatim, opt-in prefixes =/@, non-formula cell untouched, JS alias). Full unit
suite 60/60; verified in both runtimes via app.main.

Signed-off-by: Mark Farkas <mark@artalis.io>
