### PR TITLE
fix(fuzz): correct the macOS libFuzzer note + complete fuzz/.gitignore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3476,10 +3476,12 @@ tsan:
 	done
 
 # ── Fuzzing (libFuzzer + ASan/UBSan) ────────────────────────────────
-# Mirrors vendor/keel/fuzz. Requires clang with libFuzzer support.
+# Mirrors vendor/keel/fuzz. Requires clang with the libFuzzer runtime.
 #   Linux: make fuzz CC=clang
-#   macOS: make fuzz                 (Apple clang ships libFuzzer)
-#      or: make fuzz CC=/opt/homebrew/opt/llvm@18/bin/clang
+#   macOS: make fuzz CC=/opt/homebrew/opt/llvm/bin/clang   (brew install llvm)
+# NOTE: Apple's clang does NOT ship the libFuzzer runtime
+# (libclang_rt.fuzzer_osx.a), so `make fuzz` with the default cc fails on macOS
+# with "library '...fuzzer_osx.a' not found". Use a Homebrew LLVM clang there.
 # Each harness compiles its parser sources fresh under the fuzzer
 # instrumentation — these parsers are small and self-contained, so no
 # libhull_platform.a link is needed. Keel already fuzzes the HTTP /

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,8 +1,13 @@
-# Built fuzz harnesses
+# Built fuzz harnesses (one per fuzz/fuzz_*.c; keep in sync with the Makefile)
 fuzz_sh_json
 fuzz_path_normalize
 fuzz_mime_sniff
+fuzz_host_match
 fuzz_pgwire
+fuzz_pg_dsn
+fuzz_pg_rewrite
+fuzz_mysqlwire
+fuzz_mysql_dsn
 # Debug symbol bundles (macOS)
 *.dSYM/
 # libFuzzer artifacts
@@ -11,5 +16,3 @@ leak-*
 timeout-*
 oom-*
 *.profraw
-fuzz_pg_dsn
-fuzz_pg_rewrite


### PR DESCRIPTION
Two hygiene fixes found while verifying the fuzzers run:

- Makefile: the fuzzing block claimed "macOS: make fuzz (Apple clang ships
  libFuzzer)". It does not -- Apple clang has no libFuzzer runtime
  (libclang_rt.fuzzer_osx.a), so `make fuzz` with the default cc fails on macOS
  with "library '...fuzzer_osx.a' not found". Point macOS users at a Homebrew
  LLVM clang (brew install llvm) instead. Linux/CI (CC=clang) is unaffected.
- fuzz/.gitignore listed only 6 of the 9 harnesses; building fuzz_host_match,
  fuzz_mysqlwire, or fuzz_mysql_dsn left an untracked binary in the tree. List
  all nine (kept in sync with the Makefile rules).

The fuzzers themselves are healthy: CI "Fuzz Testing" is green, and locally
(brew clang) fuzz_host_match / fuzz_sh_json / fuzz_mysqlwire all build, run, and
find coverage with no crashes. This commit only fixes the docs/hygiene that made
them look broken on macOS with the default compiler.

Signed-off-by: Mark Farkas <mark@artalis.io>
