### PR TITLE
fix(test): gate e2e_postgres readiness on a real TCP+SCRAM connection

### DIFF
--- a/tests/e2e_postgres.sh
+++ b/tests/e2e_postgres.sh
@@ -45,11 +45,19 @@ docker run -d --name "$CONTAINER" \
     -e POSTGRES_PASSWORD=s3cretpw \
     -p "${PGPORT}:5432" postgres:16-alpine >/dev/null
 
-echo "=== waiting for postgres ==="
+echo "=== waiting for postgres (real TCP + SCRAM connection, as the app connects) ==="
+# postgres:16 runs initdb on first start, briefly bringing PG up on a local
+# unix socket before restarting the real networked instance. A default
+# (unix-socket) `pg_isready` can pass on that transient init instance, so the
+# hull app's later TCP connect races the restart and is refused ("failed to open
+# database connection"). Gate on a REAL connection instead: TCP (-h 127.0.0.1) +
+# SCRAM auth + a query against the target db -- exactly what the app does --
+# mirroring the proven e2e_mysql.sh readiness check.
 ready=0
 i=0
-while [ "$i" -lt 30 ]; do
-    if docker exec "$CONTAINER" pg_isready -U hull -d hulldb >/dev/null 2>&1; then
+while [ "$i" -lt 60 ]; do
+    if docker exec -e PGPASSWORD=s3cretpw "$CONTAINER" \
+           psql -h 127.0.0.1 -U hull -d hulldb -tAc 'SELECT 1' >/dev/null 2>&1; then
         ready=1
         break
     fi


### PR DESCRIPTION
e2e_postgres.sh waited with `docker exec ... pg_isready` (PG's INTERNAL unix
socket), but the hull app connects over the host-mapped TCP port. postgres:16
runs initdb on first start -- briefly bringing PG up on a local socket before
restarting the real networked instance -- so a unix-socket pg_isready can pass on
that transient init instance while the app's later TCP connect races the restart
and is refused ("failed to open database connection"). This flaked pg-e2e on
nearly every PR (green on re-run), and twice-consecutively on a docs-only change.

Gate on a REAL connection instead -- TCP (-h 127.0.0.1) + SCRAM auth + a query
against the target db, exactly what the app does -- mirroring the already-robust
e2e_mysql.sh check (which carries the same initdb-restart comment). Also bump the
wait ceiling 30s -> 60s for cold-runner headroom.

Verified: full e2e_postgres passes locally (backend + db.open dynamic + TLS
phases), using the new readiness gate.

Signed-off-by: Mark Farkas <mark@artalis.io>
