### PR TITLE
ci: retry network fetches to survive transient download flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1059,7 +1059,10 @@ jobs:
       - name: Install Zig 0.13.0
         run: |
           set -eu
-          curl -fsSL https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz \
+          # --retry-all-errors also retries a partial transfer (curl exit 18),
+          # the observed ziglang.org download flake.
+          curl -fsSL --retry 3 --retry-all-errors --retry-delay 2 \
+            https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz \
             -o /tmp/zig.tar.xz
           sudo mkdir -p /opt/zig
           sudo tar -xJf /tmp/zig.tar.xz -C /opt/zig --strip-components=1

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ endif
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
 
+# Retry knob for network fetches (toolchains + vendored assets). --retry-all-errors
+# also retries partial transfers (curl exit 18), the observed CI download flake.
+CURL_RETRY := --retry 3 --retry-all-errors --retry-delay 2
+
 # ── Version string ────────────────────────────────────────────────────
 #
 # Precedence (highest to lowest):
@@ -1147,8 +1151,8 @@ endif
 fetch-ca-bundle:
 	@mkdir -p $(CACERT_DIR)
 	@echo "Fetching Mozilla CA bundle from curl.se …"
-	curl -fsSL https://curl.se/ca/cacert.pem -o $(CACERT_PEM)
-	curl -fsSL https://curl.se/ca/cacert.pem.sha256 -o $(CACERT_SHA256)
+	curl $(CURL_RETRY) -fsSL https://curl.se/ca/cacert.pem -o $(CACERT_PEM)
+	curl $(CURL_RETRY) -fsSL https://curl.se/ca/cacert.pem.sha256 -o $(CACERT_SHA256)
 	@echo "Verifying SHA-256 …"
 	@cd $(CACERT_DIR) && (sha256sum -c cacert.pem.sha256 2>/dev/null \
 	    || shasum -a 256 -c cacert.pem.sha256)
@@ -1169,7 +1173,7 @@ PWNED_SRC_TMP := /tmp/seclists_top10k.txt
 .PHONY: fetch-pwned-blocklist
 fetch-pwned-blocklist:
 	@echo "Fetching SecLists top 10K from danielmiessler/SecLists …"
-	curl -fsSL $(PWNED_SRC_URL) -o $(PWNED_SRC_TMP)
+	curl $(CURL_RETRY) -fsSL $(PWNED_SRC_URL) -o $(PWNED_SRC_TMP)
 	@bash scripts/build_pwned_blocklist.sh $(PWNED_SRC_TMP)
 
 # ── HTMX + Pico (vendored assets for `hull init --profile htmx`) ───
@@ -1200,7 +1204,7 @@ PICO_CLASSLESS_CSS   := $(PICO_DIR)/pico.classless.min.css
 fetch-htmx:
 	@mkdir -p $(HTMX_DIR)
 	@echo "Fetching HTMX $(HTMX_VERSION) from github.com/bigskysoftware/htmx …"
-	curl -fsSL $(HTMX_URL) -o $(HTMX_MIN_JS)
+	curl $(CURL_RETRY) -fsSL $(HTMX_URL) -o $(HTMX_MIN_JS)
 	@echo "Verifying SHA-256 (pinned: $(HTMX_MIN_SHA256)) …"
 	@actual=$$(shasum -a 256 $(HTMX_MIN_JS) | awk '{print $$1}'); \
 	if [ "$$actual" != "$(HTMX_MIN_SHA256)" ]; then \
@@ -1217,7 +1221,7 @@ fetch-htmx:
 fetch-pico:
 	@mkdir -p $(PICO_DIR)
 	@echo "Fetching Pico classless $(PICO_VERSION) from github.com/picocss/pico …"
-	curl -fsSL $(PICO_URL) -o $(PICO_CLASSLESS_CSS)
+	curl $(CURL_RETRY) -fsSL $(PICO_URL) -o $(PICO_CLASSLESS_CSS)
 	@echo "Verifying SHA-256 (pinned: $(PICO_CLASSLESS_SHA256)) …"
 	@actual=$$(shasum -a 256 $(PICO_CLASSLESS_CSS) | awk '{print $$1}'); \
 	if [ "$$actual" != "$(PICO_CLASSLESS_SHA256)" ]; then \
@@ -1253,8 +1257,8 @@ UNICODE_EAW_H      := $(UNICODE_DIR)/eaw.h
 fetch-unicode:
 	@mkdir -p $(UNICODE_DIR)
 	@echo "Fetching Unicode $(HL_UNICODE_VERSION) data from unicode.org …"
-	curl -fsSL $(UNICODE_BASE_URL)/EastAsianWidth.txt -o $(UNICODE_EAW_TXT)
-	curl -fsSL $(UNICODE_BASE_URL)/UnicodeData.txt   -o $(UNICODE_UCD_TXT)
+	curl $(CURL_RETRY) -fsSL $(UNICODE_BASE_URL)/EastAsianWidth.txt -o $(UNICODE_EAW_TXT)
+	curl $(CURL_RETRY) -fsSL $(UNICODE_BASE_URL)/UnicodeData.txt   -o $(UNICODE_UCD_TXT)
 	@echo "Recording SHA-256 …"
 	@cd $(UNICODE_DIR) && (shasum -a 256 EastAsianWidth.txt > EastAsianWidth.txt.sha256 \
 	    || sha256sum    EastAsianWidth.txt > EastAsianWidth.txt.sha256)
@@ -3991,7 +3995,7 @@ fetch-wgpu:
 			echo "Supported: macos-aarch64, macos-x86_64, linux-x86_64, linux-aarch64"; \
 			exit 1; \
 		fi; \
-		curl -sL -o /tmp/$(WGPU_ZIP) "$(WGPU_URL)"; \
+		curl $(CURL_RETRY) -sL -o /tmp/$(WGPU_ZIP) "$(WGPU_URL)"; \
 		echo "Verifying SHA-256..."; \
 		ACTUAL=$$($(SHA256CMD) /tmp/$(WGPU_ZIP) | cut -d' ' -f1); \
 		if [ "$$ACTUAL" != "$(WGPU_EXPECTED_SHA)" ]; then \
@@ -4021,7 +4025,7 @@ fetch-duckdb:
 			echo "Supported: osx-arm64, osx-amd64, linux-amd64, linux-arm64 (glibc)"; \
 			exit 1; \
 		fi; \
-		curl -sL -o /tmp/$(DUCKDB_ZIP) "$(DUCKDB_URL)"; \
+		curl $(CURL_RETRY) -sL -o /tmp/$(DUCKDB_ZIP) "$(DUCKDB_URL)"; \
 		echo "Verifying SHA-256..."; \
 		ACTUAL=$$($(SHA256CMD) /tmp/$(DUCKDB_ZIP) | cut -d' ' -f1); \
 		if [ "$$ACTUAL" != "$(DUCKDB_EXPECTED_SHA)" ]; then \
@@ -4068,7 +4072,7 @@ fetch-cosmocc:
 		echo "cosmocc already installed: $$(which cosmocc)"; \
 	else \
 		echo "=== Fetching cosmocc $(COSMOCC_VERSION) to $(COSMOCC_DIR) ==="; \
-		curl -sL -o /tmp/cosmocc.zip "$(COSMOCC_URL)"; \
+		curl $(CURL_RETRY) -sL -o /tmp/cosmocc.zip "$(COSMOCC_URL)"; \
 		echo "Verifying SHA-256..."; \
 		ACTUAL=$$($(SHA256CMD) /tmp/cosmocc.zip | cut -d' ' -f1); \
 		if [ "$$ACTUAL" != "$(COSMOCC_SHA256)" ]; then \


### PR DESCRIPTION
Bare `curl` on the toolchain/asset fetches has no retry, so a transient CDN
hiccup fails the whole job. The Zig toolchain download (ziglang.org) flaked with
curl exit 18 (partial transfer) on an unrelated PR this week; the same shape can
hit the wgpu / duckdb / cosmocc / CA-bundle / vendored-asset fetches.

Add `--retry 3 --retry-all-errors --retry-delay 2`:
- Makefile: one CURL_RETRY variable applied to all 10 download curls
  (fetch-ca-bundle, fetch-pwned, fetch-htmx, fetch-pico, fetch-unicode,
  fetch-wgpu, fetch-duckdb, cosmocc). Downloads still SHA-256-verify after, so a
  corrupt fetch is still caught; retry only covers the transient case.
- ci.yml: the Zig 0.13.0 install curl (the one actually observed flaking).

--retry-all-errors (curl 7.71+, present on all CI runners) is what makes plain
partial-transfer failures (exit 18) retryable -- plain --retry does not cover
them. install.sh is intentionally left as-is (broad end-user curl-version range;
not a CI toolchain fetch).

Verified: `make -n` expands CURL_RETRY into every fetch curl; Makefile parses;
ci.yml is valid YAML.

Signed-off-by: Mark Farkas <mark@artalis.io>
