### PR TITLE
feat(gpu): base-resident GPU feature seam (Phase 0.1 of GPU-as-a-feature)

### DIFF
--- a/include/hull/cap/gpu.h
+++ b/include/hull/cap/gpu.h
@@ -32,7 +32,11 @@
 #ifndef HL_CAP_GPU_H
 #define HL_CAP_GPU_H
 
-#ifdef HL_ENABLE_GPU
+/* The GPU types + the generic cap API are ALWAYS declared: the generic dispatch
+ * layer (cap/gpu.c) and the composable-feature hook (cap/gpu_feature.c) are
+ * base-resident. Only the concrete wgpu backend symbol (at the bottom) is gated
+ * on a compiled-in HL_ENABLE_GPU build; a `hull build --with=gpu` feature
+ * supplies that backend instead. */
 
 #include "hull/limits/gpu.h"
 
@@ -354,8 +358,15 @@ int  hl_cap_gpu_texture_read(HlGpuCtx *ctx, int device, const char *name,
                               HlGpuTexFormat *out_format);
 void hl_cap_gpu_texture_destroy(HlGpuCtx *ctx, int device, const char *name);
 
-/* Backend selection (defined in gpu_wgpu.c) */
-extern const HlGpuBackend hl_gpu_backend_wgpu;
+/* Composable-feature hook: the base returns NO backend (weak default in
+ * cap/gpu_feature.c); a `hull build --with=gpu` build links a STRONG override
+ * returning the wgpu backend. Mirrors hl_db_feature_backends. */
+const HlGpuBackend *const *hl_gpu_feature_backends(size_t *count);
 
+#ifdef HL_ENABLE_GPU
+/* The wgpu backend vtable (defined in gpu_wgpu.c). Present only in a monolithic
+ * HL_ENABLE_GPU build or the gpu feature archive. */
+extern const HlGpuBackend hl_gpu_backend_wgpu;
 #endif /* HL_ENABLE_GPU */
+
 #endif /* HL_CAP_GPU_H */

--- a/src/hull/cap/gpu_feature.c
+++ b/src/hull/cap/gpu_feature.c
@@ -1,0 +1,21 @@
+/*
+ * cap/gpu_feature.c — composable-feature hook for the GPU backend.
+ *
+ * Base-resident weak default: a base build carries no GPU backend, so this
+ * returns none. A `hull build --with=gpu` build links a STRONG override (a
+ * generated registry) that returns the wgpu backend; serve.c then hands it to
+ * hl_cap_gpu_init. Mirrors hl_db_feature_backends in cap/db_select.c. Always
+ * compiled (picked up by the cap-directory wildcard) so the symbol always resolves
+ * whether or not GPU is present.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "hull/cap/gpu.h"
+
+__attribute__((weak))
+const HlGpuBackend *const *hl_gpu_feature_backends(size_t *count)
+{
+    if (count) *count = 0;
+    return NULL;
+}


### PR DESCRIPTION
Prerequisite for composing GPU as a build feature: unlike DuckDB (whose
db_select.c hook home was already base-resident since SQLite is default-on), the
entire GPU cap layer sits behind #ifdef HL_ENABLE_GPU, so a base build has no GPU
types or hook at all. This lands the minimal base-resident seam:

- include/hull/cap/gpu.h: un-gate the HlGpu* types + the generic cap prototypes
  (always declared); keep ONLY the concrete `hl_gpu_backend_wgpu` extern under
  #ifdef HL_ENABLE_GPU. Declare the composable-feature hook
  `hl_gpu_feature_backends` (mirrors hl_db_feature_backends).
- src/hull/cap/gpu_feature.c (new): the base-resident WEAK default returning no
  backend. Picked up by the cap/*.c wildcard, so no Makefile change; a
  `hull build --with=gpu` build will link a STRONG override returning wgpu.

No behavior change: gpu.c / mod_gpu.c / serve.c stay #ifdef-gated (the hook is
dormant), so both build configs are byte-compatible in behavior. Two facts that
de-risk the rest of Phase 0: limits/gpu.h uses #ifndef guards (constants always
available), and CAP_SRCS is a wildcard (the new TU is auto-compiled).

Verified locally:
- Base build (GPU off): links clean; hl_gpu_feature_backends is now base-resident
  (nm shows `T hl_gpu_feature_backends`) with no GPU backend present.
- Monolithic build (HL_ENABLE_GPU=1, WGPU_LIB_DIR=vendor/wgpu): builds + runs;
  existing GPU intact (weak hook coexists with the compiled wgpu backend).

Phase 0.2 (gpu.c/mod_gpu.c base-resident, serve.c rewire to the hook, Makefile,
sandbox-unveil gating on runtime feature presence) follows.

Signed-off-by: Mark Farkas <mark@artalis.io>
