### PR TITLE
feat(gpu): base-resident generic GPU layer; serve inits from the feature hook (Phase 0.2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1301,7 +1301,7 @@ ifeq ($(HL_ENABLE_GPU),1)
   endif
   WORKER_GPU_OBJ := $(BUILDDIR)/worker_gpu.o
 else
-  WORKER_GPU_OBJ :=
+  WORKER_GPU_OBJ := $(BUILDDIR)/worker_gpu.o
   WGPU_LIB :=
   WGPU_FRAMEWORKS :=
 endif
@@ -2750,11 +2750,10 @@ $(WORKER_DB_OBJ): $(SRCDIR)/hull/worker_db.c | $(BUILDDIR)
 $(WORKER_WASM_OBJ): $(SRCDIR)/hull/worker_wasm.c | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) $(WAMR_CFLAGS) -c -o $@ $<
 
-# Worker GPU (runtime-agnostic GPU thread pool dispatch)
-ifeq ($(HL_ENABLE_GPU),1)
+# Worker GPU (runtime-agnostic GPU thread pool dispatch — base-resident,
+# like worker_db/worker_wasm; the wgpu backend itself stays feature/HL_ENABLE_GPU).
 $(WORKER_GPU_OBJ): $(SRCDIR)/hull/worker_gpu.c | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
-endif
 
 # Manifest — split into shared helpers + per-runtime extractors (item G).
 # Each per-runtime .c compiles to an empty TU when its runtime is disabled,

--- a/include/hull/runtime.h
+++ b/include/hull/runtime.h
@@ -206,9 +206,8 @@ struct HlRuntime {
         uint64_t max_output;
     } wasm_config;                     /* three-tier resolved limits (CLI > manifest > defaults) */
 #endif
-#ifdef HL_ENABLE_GPU
-    HlGpuCtx *gpu_ctx;                /* GPU compute context (NULL if disabled) */
-#endif
+    HlGpuCtx *gpu_ctx;                /* GPU compute context; NULL when no backend
+                                        * (base build without a composed gpu feature) */
     /* Phase gate for the `app.X` registration bindings (app.get / use /
      * use_post / ws / sse / every / daily).  Set to 1 by serve.c
      * (hl_serve_wire_routes) after the route registry has been flushed

--- a/include/hull/worker_gpu.h
+++ b/include/hull/worker_gpu.h
@@ -10,7 +10,6 @@
 #ifndef HL_WORKER_GPU_H
 #define HL_WORKER_GPU_H
 
-#ifdef HL_ENABLE_GPU
 
 #include "hull/cap/gpu.h"
 #include "hull/limits/core.h"  /* HL_WORKER_ERR_SIZE (HL_GPU_NAME_MAX via cap/gpu.h) */
@@ -75,5 +74,4 @@ void hl_worker_gpu_op_free_all(void *ptr);
 /* KlAsyncOp on_cancel handler for gpu.async operations. */
 void hl_worker_gpu_async_cancel(KlAsyncOp *op, void *user_data);
 
-#endif /* HL_ENABLE_GPU */
 #endif /* HL_WORKER_GPU_H */

--- a/src/hull/cap/gpu.c
+++ b/src/hull/cap/gpu.c
@@ -8,7 +8,11 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#ifdef HL_ENABLE_GPU
+/* Base-resident: the generic dispatch layer is always compiled (it drives any
+ * HlGpuBackend vtable and never touches a concrete backend). A base build with
+ * no backend simply has ctx->backend == NULL and reports GPU unavailable; a
+ * `hull build --with=gpu` feature (or an HL_ENABLE_GPU monolithic build)
+ * supplies the wgpu backend via hl_gpu_feature_backends() / serve.c. */
 
 #include "hull/cap/gpu.h"
 #include "hull/cap/audit.h"
@@ -689,8 +693,3 @@ int hl_cap_gpu_buffer_copy(HlGpuCtx *ctx, int device,
 
     return rc;
 }
-
-#else /* !HL_ENABLE_GPU */
-/* ISO C requires a translation unit to contain at least one declaration. */
-typedef int hl_cap_gpu_disabled;
-#endif /* HL_ENABLE_GPU */

--- a/src/hull/runtime/js/mod_buffer.h
+++ b/src/hull/runtime/js/mod_buffer.h
@@ -89,9 +89,7 @@ int hl_js_init_image_module(JSContext *ctx, HlJS *js);
 int hl_js_init_compute_module(JSContext *ctx, HlJS *js);
 #endif
 
-#ifdef HL_ENABLE_GPU
 int hl_js_init_gpu_module(JSContext *ctx, HlJS *js);
-#endif
 
 #ifdef HL_ENABLE_TUI
 int hl_js_init_tui_module(JSContext *ctx, HlJS *js);

--- a/src/hull/runtime/js/mod_gpu.c
+++ b/src/hull/runtime/js/mod_gpu.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#ifdef HL_ENABLE_GPU
 
 #include "mod_buffer.h"
 #include "hull/cap/gpu.h"
@@ -1655,7 +1654,3 @@ int hl_js_init_gpu_module(JSContext *ctx, HlJS *js)
     JS_AddModuleExport(ctx, m, "gpu");
     return 0;
 }
-#else /* !HL_ENABLE_GPU */
-/* ISO C requires a translation unit to contain at least one declaration. */
-typedef int hl_js_mod_gpu_disabled;
-#endif /* HL_ENABLE_GPU */

--- a/src/hull/runtime/js/modules.c
+++ b/src/hull/runtime/js/modules.c
@@ -110,13 +110,12 @@ int hl_js_register_modules(HlJS *js)
     }
 #endif
 
-#ifdef HL_ENABLE_GPU
-    /* Register hull:gpu module (only if GPU context is available) */
+    /* hull:gpu registers only when a GPU backend is present (monolithic
+     * HL_ENABLE_GPU build or a composed --with=gpu feature). */
     if (js->base.gpu_ctx) {
         if (hl_js_init_gpu_module(js->ctx, js) != 0)
             return -1;
     }
-#endif
 
 #ifdef HL_ENABLE_TUI
     /* Register hull:tui module — gated at use time by the resolver

--- a/src/hull/runtime/lua/mod_buffer.h
+++ b/src/hull/runtime/lua/mod_buffer.h
@@ -77,9 +77,7 @@ struct HlWasmBuffer;
 void lua_push_wasm_buffer(lua_State *L, struct HlWasmBuffer *buf);
 #endif
 
-#ifdef HL_ENABLE_GPU
 int luaopen_hull_gpu(lua_State *L);
-#endif
 
 #ifdef HL_ENABLE_TUI
 int luaopen_hull_tui(lua_State *L);

--- a/src/hull/runtime/lua/mod_gpu.c
+++ b/src/hull/runtime/lua/mod_gpu.c
@@ -915,9 +915,14 @@ static int parse_pipeline_stages(lua_State *L, int tbl_idx,
 
     for (int s = 0; s < stage_count; s++) {
         lua_rawgeti(L, tbl_idx, s + 1);
-        if (!lua_istable(L, -1)) { lua_pop(L, 1); continue; }
 
+        /* Zero-init every counted stage BEFORE the type check. A non-table
+         * entry takes the `continue` below, but the caller still iterates all
+         * stage_count entries; leaving this one uninitialized reads garbage
+         * (stages[s].shader) downstream. */
         memset(&stages[s], 0, sizeof(stages[s]));
+
+        if (!lua_istable(L, -1)) { lua_pop(L, 1); continue; }
 
         /* shader (required) */
         lua_getfield(L, -1, "shader");

--- a/src/hull/runtime/lua/mod_gpu.c
+++ b/src/hull/runtime/lua/mod_gpu.c
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#ifdef HL_ENABLE_GPU
 
 #include "mod_buffer.h"
 #include "hull/cap/gpu.h"
@@ -1364,7 +1363,3 @@ int luaopen_hull_gpu(lua_State *L)
     return 1;
 }
 
-#else /* !HL_ENABLE_GPU */
-/* ISO C requires a translation unit to contain at least one declaration. */
-typedef int hl_lua_mod_gpu_disabled;
-#endif /* HL_ENABLE_GPU */

--- a/src/hull/runtime/lua/modules.c
+++ b/src/hull/runtime/lua/modules.c
@@ -101,10 +101,10 @@ int hl_lua_register_modules(HlLua *lua)
         register_native_module(L, "hull.compute", luaopen_hull_compute);
 #endif
 
-#ifdef HL_ENABLE_GPU
+    /* hull.gpu registers only when a GPU backend is present (monolithic
+     * HL_ENABLE_GPU build or a composed --with=gpu feature). */
     if (lua->base.gpu_ctx)
         register_native_module(L, "hull.gpu", luaopen_hull_gpu);
-#endif
 
 #ifdef HL_ENABLE_TUI
     /* Native bridge — the user-facing module is the stdlib Lua file

--- a/src/hull/serve.c
+++ b/src/hull/serve.c
@@ -74,9 +74,7 @@
 #ifdef HL_ENABLE_WASM
 #include "hull/cap/wasm.h"
 #endif
-#ifdef HL_ENABLE_GPU
 #include "hull/cap/gpu.h"
-#endif
 
 #include <keel/cors.h>
 #include <keel/keel.h>
@@ -183,10 +181,10 @@ static void free_route_allocs(HlAllocator *a)
 static HlWasmCache wasm_cache;
 static int wasm_cache_ok = 0;
 #endif
-#ifdef HL_ENABLE_GPU
+/* Base-resident: the GPU context is populated from a composed feature
+ * backend (or a monolithic HL_ENABLE_GPU build); unavailable otherwise. */
 static HlGpuCtx gpu_ctx;
 static int gpu_ctx_ok = 0;
-#endif
 
 /* ── Runtime selection ──────────────────────────────────────────────── */
 
@@ -541,7 +539,6 @@ static int hl_parse_serve_args(int argc, char **argv, HlServeConfig *cfg)
                 return -1;
             }
             cfg->wasm_max_output = v;
-#ifdef HL_ENABLE_GPU
         } else if (strcmp(argv[i], "--gpu-device") == 0 && i + 1 < argc) {
             char *end;
             long v = strtol(argv[++i], &end, 10);
@@ -550,7 +547,6 @@ static int hl_parse_serve_args(int argc, char **argv, HlServeConfig *cfg)
                 return -1;
             }
             cfg->gpu_device = (int)v;
-#endif
         } else if (strcmp(argv[i], "-h") == 0) {
             usage(argv[0]);
             return 1; /* signal help shown, exit 0 */
@@ -979,19 +975,29 @@ static int hl_serve_init_app_context(HlServerState *s)
     }
 #endif
 
-#ifdef HL_ENABLE_GPU
-    /* Initialize GPU compute runtime (static cache persists across calls). */
+    /* Initialize GPU compute from the composable-feature hook: a
+     * `hull build --with=gpu` build links a STRONG override returning the wgpu
+     * backend; a monolithic HL_ENABLE_GPU build falls back to the compiled-in
+     * backend. No backend -> gpu.* stays unavailable (static cache persists). */
     if (!gpu_ctx_ok) {
-        if (hl_cap_gpu_init(&gpu_ctx, &hl_gpu_backend_wgpu) == HL_GPU_OK
+        const HlGpuBackend *gpu_be = NULL;
+        size_t gpu_nfeat = 0;
+        const HlGpuBackend *const *gpu_feats = hl_gpu_feature_backends(&gpu_nfeat);
+        if (gpu_nfeat > 0 && gpu_feats)
+            gpu_be = gpu_feats[0];
+#ifdef HL_ENABLE_GPU
+        if (!gpu_be)
+            gpu_be = &hl_gpu_backend_wgpu;
+#endif
+        if (gpu_be && hl_cap_gpu_init(&gpu_ctx, gpu_be) == HL_GPU_OK
             && hl_cap_gpu_available(&gpu_ctx)) {
             if (s->cfg.gpu_device >= 0 && s->cfg.gpu_device < gpu_ctx.device_count)
                 gpu_ctx.default_device = s->cfg.gpu_device;
             gpu_ctx_ok = 1;
-        } else {
+        } else if (gpu_be) {
             log_info("[hull:c] GPU compute unavailable — gpu.* disabled");
         }
     }
-#endif
 
     HlAppContextOpts app_opts = {
         .app_dir           = s->app_dir,
@@ -1011,10 +1017,8 @@ static int hl_serve_init_app_context(HlServerState *s)
 #ifdef HL_ENABLE_WASM
         .wasm_cache        = wasm_cache_ok ? &wasm_cache : NULL,
 #endif
-#ifdef HL_ENABLE_GPU
         .gpu_ctx           = gpu_ctx_ok ? &gpu_ctx : NULL,
         .gpu_device        = s->cfg.gpu_device,
-#endif
     };
 
     if (hl_app_context_init(&s->app, &app_opts) != 0) {
@@ -1398,8 +1402,7 @@ static int hl_serve_wire_caps(HlServerState *s)
     hl_resolve_wasm_config(rt, &s->manifest, &s->cfg);
 #endif
 
-#ifdef HL_ENABLE_GPU
-    /* GPU gating mirrors the WASM rule above. */
+    /* GPU gating mirrors the WASM rule above (runtime, on gpu_ctx_ok). */
     if (gpu_ctx_ok) {
         int admit;
         if (s->manifest.modules_declared)
@@ -1424,7 +1427,6 @@ static int hl_serve_wire_caps(HlServerState *s)
         log_info("[hull:c] gpu device restriction: %d of %d devices allowed",
                  s->manifest.gpu_device_count, gpu_ctx.device_count);
     }
-#endif
 
     /* Wire fs_cfg from manifest (if app declares fs.read OR fs.write
      * paths — both blob.* and fs.mmap need the cfg). */

--- a/src/hull/worker_gpu.c
+++ b/src/hull/worker_gpu.c
@@ -9,7 +9,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-#ifdef HL_ENABLE_GPU
 
 #include "hull/worker_gpu.h"
 #include "hull/utils/alloc.h"
@@ -195,4 +194,3 @@ void hl_worker_gpu_async_cancel(KlAsyncOp *kl_op, void *user_data)
     }
 }
 
-#endif /* HL_ENABLE_GPU */


### PR DESCRIPTION
Completes the GPU cap-layer base/feature split. The generic GPU dispatch layer,
its runtime bindings, and the async worker now compile into every binary and sit
INERT without a backend; only the concrete wgpu backend + wgpu lib stay gated on
HL_ENABLE_GPU (monolithic) / the future --with=gpu feature archive.

Un-gated (removed the outer #ifdef HL_ENABLE_GPU; kept nested feature ifdefs):
- cap/gpu.c (generic dispatch), runtime/{lua,js}/mod_gpu.c (the `gpu` bindings),
  worker_gpu.c (async dispatch) -- all backend-agnostic (drive the HlGpuBackend
  vtable; no wgpu headers).
- The header types/decls they need: worker_gpu.h (HlWorkerGpuOp), runtime.h
  (HlRuntime.gpu_ctx field; HlGpuCtx was already fwd-declared), and the
  registration prototypes in {lua,js}/mod_buffer.h.
- The two registration sites (runtime/{lua,js}/modules.c) keep their runtime
  `if (base.gpu_ctx)` guard -- so `gpu` registers only when a backend is present.
- Makefile: worker_gpu.o compiles unconditionally (like worker_db/worker_wasm);
  WGPU_LIB + the wgpu backend object stay HL_ENABLE_GPU-gated.

serve.c rewire: GPU init now pulls the backend from hl_gpu_feature_backends()
(the composable-feature hook); a monolithic HL_ENABLE_GPU build falls back to the
compiled-in &hl_gpu_backend_wgpu. gpu statics / --gpu-device / app-context
config-pass / module-admit + device-restriction are un-gated (all runtime-gated
on gpu_ctx_ok). The only remaining #ifdef HL_ENABLE_GPU in serve.c is the wgpu
fallback reference. The sandbox GPU unveils were already gated on the manifest
`policy->gpu` flag (not the compile flag), so they need no change -- correct for
the feature model (contrast the DuckDB /proc/self/cgroup miss).

Verified: native base builds (gpu-declaring app rejected by the resolver -- no
backend; plain app unaffected); native monolithic builds + real gpu.dispatch
works (wgpu inits Apple M1 Max via the serve fallback); cosmo base builds
(cosmocc, generic layer now always-compiled); full unit suite 60/60.

Deferred to the --with=gpu wiring phase (needs the feature archive): the resolver
gate for hull/gpu (currently still HL_ENABLE_GPU-only, so base rejects it), the
`make feature-gpu` archive + wgpu isolation, and the FEATURE_SPECS.gpu row.

Signed-off-by: Mark Farkas <mark@artalis.io>
