### PR TITLE
build(gpu): make feature-gpu — composable wgpu feature archive + base backend filter-out

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1464,6 +1464,17 @@ ifneq ($(HL_ENABLE_DUCKDB),1)
       $(SRCDIR)/hull/cap/db_duckdb.c, \
       $(CAP_SRCS))
 endif
+ifneq ($(HL_ENABLE_GPU),1)
+  # wgpu-native backend vtable (defines hl_gpu_backend_wgpu). Off by default.
+  # Filtered out of the base entirely -- like db_duckdb.c -- NOT stub-compiled,
+  # so the composable gpu feature (make feature-gpu) can supply the real
+  # cap_gpu_wgpu.o without a base stub shadowing it at the compose link. The
+  # generic gpu dispatch layer (cap/gpu.c) stays base-resident; only this
+  # concrete backend is feature-gated.
+  CAP_SRCS := $(filter-out \
+      $(SRCDIR)/hull/cap/gpu_wgpu.c, \
+      $(CAP_SRCS))
+endif
 ifeq ($(HL_ENABLE_HTTP_CLIENT),0)
   # CLIENT-only capability sources — http.fetch sync + async + SMTP send.
   CAP_SRCS := $(filter-out \
@@ -2438,6 +2449,35 @@ $(BUILDDIR)/libhull_feature-duckdb.a: $(BUILDDIR)/cap_db_duckdb.o $(DUCKDB_ARCHI
 	@rm -f $@
 	$(AR) rcs $@ $(BUILDDIR)/cap_db_duckdb.o
 	@tmproot=$$(mktemp -d); n=0; for a in $(DUCKDB_ARCHIVES); do \
+		mkdir -p $$tmproot/$$n && ( cd $$tmproot/$$n && $(AR) x $(CURDIR)/$$a ) && \
+		$(AR) rcs $(CURDIR)/$@ $$tmproot/$$n/*.o && n=$$((n+1)); \
+	done; rm -rf $$tmproot
+	@echo "built $@ ($$(du -h $@ | cut -f1))"
+
+# ── GPU feature archive (composable feature: hull build --with=gpu) ──
+# libhull_feature-gpu.a bundles the wgpu backend object (cap_gpu_wgpu.o, which
+# defines hl_gpu_backend_wgpu) + the wgpu-native static lib into ONE archive,
+# mirroring feature-duckdb. Merging into a single archive keeps the
+# cap_gpu_wgpu.o <-> libwgpu_native.a refs intra-archive, so the composing link
+# needs no --start-group.
+#
+# Unlike DuckDB (whose libs embed a clashing second mbedTLS that must be renamed),
+# wgpu-native shares no symbols with Hull: the monolithic HL_ENABLE_GPU=1 build
+# links wgpu + mbedTLS + SQLite + Lua together cleanly, and `nm` shows wgpu
+# exports none of those names. So this archive is a straight bundle, no isolation.
+# The platform link libs (-framework Metal ... on macOS / -lvulkan on Linux)
+# cannot live inside a .a; they are recorded in build.lua's FEATURE_SPECS.gpu and
+# emitted at the composing link. Native only (wgpu is not cosmo-compatible).
+# `feature-gpu` re-invokes make with HL_ENABLE_GPU=1 so cap_gpu_wgpu.o (compiled
+# as the real backend, not the base stub) + WGPU_LIB are in scope.
+feature-gpu:
+	$(MAKE) $(BUILDDIR)/libhull_feature-gpu.a HL_ENABLE_GPU=1
+.PHONY: feature-gpu
+
+$(BUILDDIR)/libhull_feature-gpu.a: $(BUILDDIR)/cap_gpu_wgpu.o $(WGPU_LIB) | $(BUILDDIR)
+	@rm -f $@
+	$(AR) rcs $@ $(BUILDDIR)/cap_gpu_wgpu.o
+	@tmproot=$$(mktemp -d); n=0; for a in $(WGPU_LIB); do \
 		mkdir -p $$tmproot/$$n && ( cd $$tmproot/$$n && $(AR) x $(CURDIR)/$$a ) && \
 		$(AR) rcs $(CURDIR)/$@ $$tmproot/$$n/*.o && n=$$((n+1)); \
 	done; rm -rf $$tmproot


### PR DESCRIPTION
Adds the `make feature-gpu` target and the compose-critical base filter so the GPU
backend becomes a side-loadable feature (hull build --with=gpu), mirroring the
DuckDB feature archive.

feature-gpu: re-invokes make with HL_ENABLE_GPU=1 and bundles the wgpu backend
object (cap_gpu_wgpu.o, defines hl_gpu_backend_wgpu) + the wgpu-native static lib
into ONE self-contained archive, libhull_feature-gpu.a. Merging into a single
archive keeps the cap_gpu_wgpu.o <-> libwgpu_native.a refs intra-archive, so the
composing link needs no --start-group (same technique as feature-duckdb).

Unlike DuckDB (whose libs embed a second mbedTLS that must be symbol-isolated),
wgpu-native shares no symbols with Hull: the monolithic HL_ENABLE_GPU=1 build
links wgpu + mbedTLS + SQLite + Lua cleanly, and `nm` confirms wgpu exports none
of those names. So the archive is a straight bundle, no isolation. The platform
link libs (-framework Metal/QuartzCore/CoreGraphics/Foundation on macOS,
-lvulkan on Linux) cannot live inside a .a; build.lua's FEATURE_SPECS.gpu records
them for the composing link.

Compose-critical: cap/gpu_wgpu.c is now filtered OUT of the base build (like
db_duckdb.c) instead of stub-compiled. A base stub would put a symbol-less
cap_gpu_wgpu.o into the platform lib and shadow the feature archive's real
backend at the compose link (the linker won't pull the archive member when the
base already defines the object), leaving hl_gpu_backend_wgpu unresolved. The
generic dispatch layer (cap/gpu.c) stays base-resident; only this concrete
backend is feature-gated.

Verified: archive builds complete (542/542 wgpu members, no dup-name clobber,
hl_gpu_backend_wgpu present); base builds without cap_gpu_wgpu.o and runs (gpu
inert); monolithic builds with the real backend; and a hand-composed link (base
platform compiled flag=0 + libhull_feature-gpu.a + a strong hl_gpu_feature_backends
hook + frameworks) links with zero undefined/duplicate symbols and boots to
"[hull:gpu] wgpu: 1 device(s), default=Apple M1 Max" -- a base hull gaining GPU
purely through the composed feature. cosmo base + full unit suite green.

Follow-up (next phase, needed before a gpu app runs on a composed binary): the
resolver gate for hull/gpu (allow when feature-composed, not HL_ENABLE_GPU-only),
uncommenting build.lua's FEATURE_SPECS.gpu, `hull feature install gpu`, and the
release job.

Signed-off-by: Mark Farkas <mark@artalis.io>
