### PR TITLE
feat(gpu): resolver gate + FEATURE_SPECS.gpu — hull build --with=gpu runs GPU end to end

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3368,8 +3368,10 @@ $(BUILDDIR)/test_module_registry: $(TESTDIR)/hull/test_module_registry.c $(MODUL
 	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(MODULE_REGISTRY_OBJ)
 
 # Module resolver — needs the registry plus the manifest types
-$(BUILDDIR)/test_module_resolver: $(TESTDIR)/hull/test_module_resolver.c $(MODULE_OBJ) | $(BUILDDIR)
-	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(MODULE_OBJ)
+# cap_gpu_feature.o supplies the weak hl_gpu_feature_backends the resolver now
+# consults (composed-feature GPU cap). It's base-resident, so always available.
+$(BUILDDIR)/test_module_resolver: $(TESTDIR)/hull/test_module_resolver.c $(MODULE_OBJ) $(BUILDDIR)/cap_gpu_feature.o | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(MODULE_OBJ) $(BUILDDIR)/cap_gpu_feature.o
 
 # CA bundle test — links against cacert.o and mbedTLS for parse verification
 $(BUILDDIR)/test_cacert: $(TESTDIR)/hull/test_cacert.c $(CACERT_OBJ) $(MBEDTLS_OBJS) | $(BUILDDIR)

--- a/include/hull/module_resolver.h
+++ b/include/hull/module_resolver.h
@@ -107,6 +107,15 @@ int hl_module_resolver_resolve(const HlManifest *manifest,
 uint32_t hl_module_build_caps(void);
 
 /*
+ * Build cap an optional composable feature provides (HL_MOD_CAP_* or 0).
+ * `hull build --with=<feature>` passes its composed features here so the base
+ * build-tool's resolver admits the modules the feature will supply. Only
+ * features that carry a module-gated capability map to a nonzero cap (today:
+ * "gpu" -> HL_MOD_CAP_GPU; "duckdb" -> 0, it rides on the always-present hull/db).
+ */
+uint32_t hl_module_feature_cap(const char *name);
+
+/*
  * Resolve against an EXPLICIT build-cap set instead of this binary's
  * compiled-in flags. Used by `hull build --flavor`, which must validate an
  * app's manifest against the TARGET flavor's caps (e.g. reject hull/web/

--- a/src/hull/app_context.c
+++ b/src/hull/app_context.c
@@ -41,9 +41,7 @@ typedef struct HlJS HlJS;
 #ifdef HL_ENABLE_WASM
 #include "hull/cap/wasm.h"
 #endif
-#ifdef HL_ENABLE_GPU
-#include "hull/cap/gpu.h"
-#endif
+#include "hull/cap/gpu.h"  /* base-resident: gpu_ctx propagates for composed feature too */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -253,9 +251,11 @@ int hl_app_context_init(HlAppContext **out, const HlAppContextOpts *opts)
     if (ctx->wasm_ok)
         base.wasm_cache = opts->wasm_cache ? opts->wasm_cache : &ctx->wasm_cache;
 #endif
-#ifdef HL_ENABLE_GPU
+    /* Base-resident: NULL without a backend (plain base), the live ctx with a
+     * monolithic HL_ENABLE_GPU build or a composed --with=gpu feature. The
+     * runtime registers hull.gpu only when this is non-NULL, so gpu stays
+     * unexposed when there's no GPU. */
     base.gpu_ctx = opts->gpu_ctx;
-#endif
 
     /* Init runtime via the factory — table-driven, single-path. */
     if (ctx->factory->create(&ctx->rt, opts, &base) != 0) {

--- a/src/hull/module_resolver.c
+++ b/src/hull/module_resolver.c
@@ -19,6 +19,7 @@
 #include "hull/module_resolver.h"
 #include "hull/manifest.h"
 #include "hull/runtime.h"  /* HlRuntime — import_tracker fields */
+#include "hull/cap/gpu.h"  /* hl_gpu_feature_backends — composed-feature GPU cap */
 
 #include <stdio.h>
 #include <string.h>
@@ -120,7 +121,33 @@ static uint32_t build_provided_caps(void)
 #ifdef HL_ENABLE_TUI
     caps |= HL_MOD_CAP_TUI;
 #endif
+    /* A composed gpu feature (`hull build --with=gpu`) fills the base's weak
+     * hl_gpu_feature_backends hook with a strong override returning the wgpu
+     * backend. Report GPU at runtime so THIS composed binary admits hull/gpu at
+     * app load even though HL_ENABLE_GPU was never compiled into the base. In a
+     * plain base the hook is the weak default (0) and this adds nothing; in a
+     * monolithic HL_ENABLE_GPU build the bit is already set above. */
+    {
+        size_t nfeat = 0;
+        if (hl_gpu_feature_backends(&nfeat) && nfeat > 0)
+            caps |= HL_MOD_CAP_GPU;
+    }
     return caps;
+}
+
+/*
+ * Map a composable-feature name to the build cap it provides, or 0 if the
+ * feature contributes no module-gated capability. Lets `hull build --with=<f>`
+ * tell the (base) build-tool resolver to admit modules the feature will supply,
+ * even though the build-tool itself wasn't compiled with that subsystem. Today
+ * only the gpu feature carries a module cap; duckdb rides on the always-present
+ * hull/db (a DSN scheme, no module gate) so it maps to 0.
+ */
+uint32_t hl_module_feature_cap(const char *name)
+{
+    if (name && strcmp(name, "gpu") == 0)
+        return HL_MOD_CAP_GPU;
+    return 0;
 }
 
 /* Human-readable name for a capability bit (for error messages). */

--- a/src/hull/runtime/js/factory.c
+++ b/src/hull/runtime/js/factory.c
@@ -39,9 +39,9 @@ static int js_create(HlRuntime **out, const HlAppContextOpts *opts,
 #ifdef HL_ENABLE_WASM
         js->base.wasm_cache     = base->wasm_cache;
 #endif
-#ifdef HL_ENABLE_GPU
+        /* Base-resident: propagate the GPU context (monolithic or composed
+         * --with=gpu feature); NULL when no backend is present. */
         js->base.gpu_ctx        = base->gpu_ctx;
-#endif
     }
     if (!js->base.alloc && opts->alloc) js->base.alloc = opts->alloc;
 

--- a/src/hull/runtime/lua/factory.c
+++ b/src/hull/runtime/lua/factory.c
@@ -42,9 +42,10 @@ static int lua_create(HlRuntime **out, const HlAppContextOpts *opts,
 #ifdef HL_ENABLE_WASM
         lua->base.wasm_cache     = base->wasm_cache;
 #endif
-#ifdef HL_ENABLE_GPU
+        /* Base-resident: propagate the GPU context whether it came from a
+         * monolithic HL_ENABLE_GPU build or a composed --with=gpu feature.
+         * NULL (no backend) is the inert case. */
         lua->base.gpu_ctx        = base->gpu_ctx;
-#endif
     }
     /* opts->alloc is honoured separately if base->alloc isn't set. */
     if (!lua->base.alloc && opts->alloc) lua->base.alloc = opts->alloc;

--- a/src/hull/tool_orchestration.c
+++ b/src/hull/tool_orchestration.c
@@ -150,6 +150,20 @@ static int l_tool_modules_resolve(lua_State *L)
         caps = hl_build_flavor_caps(f, caps);
     }
 
+    /* Optional arg 3: an array of composed feature names (hull build --with=X).
+     * Admit the build caps those features supply, so the base build-tool's
+     * resolver accepts modules the feature will fill into the produced app
+     * binary (e.g. --with=gpu admits hull/gpu even though this hull, and the
+     * base platform lib, were not compiled with HL_ENABLE_GPU). */
+    if (lua_gettop(L) >= 3 && lua_istable(L, 3)) {
+        lua_pushnil(L);
+        while (lua_next(L, 3) != 0) {
+            if (lua_isstring(L, -1))
+                caps |= hl_module_feature_cap(lua_tostring(L, -1));
+            lua_pop(L, 1);
+        }
+    }
+
     HlResolvedModuleSet set;
     char err[HL_MODULE_RESOLVER_ERR_MAX] = {0};
     int rc = hl_module_resolver_resolve_caps(&m, &set, caps, err, sizeof(err));

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -430,6 +430,15 @@ local function sign_fail(msg, tmpdir, output)
     tool.exit(1)
 end
 
+-- Composed features (--with) as a plain array, for tool.modules_resolve's 3rd
+-- arg: admits the build caps those features supply (e.g. gpu -> hull/gpu) so
+-- the base build-tool resolver accepts modules the feature fills in the app.
+local function with_feature_list(opts)
+    local t = {}
+    if opts.with then for f in pairs(opts.with) do t[#t + 1] = f end end
+    return t
+end
+
 local function sign_app(app_dir, key_file, sign_ctx, files, tmpdir, output)
     local key_data = read_file(key_file)
     if not key_data then
@@ -474,7 +483,7 @@ local function sign_app(app_dir, key_file, sign_ctx, files, tmpdir, output)
     -- this field, so tampering invalidates the package.
     local modules_resolved = nil
     if manifest then
-        local r = tool.modules_resolve(manifest, sign_ctx.flavor)
+        local r = tool.modules_resolve(manifest, sign_ctx.flavor, sign_ctx.features)
         if r.ok then
             modules_resolved = r.modules
         else
@@ -735,7 +744,7 @@ typedef struct {
         local picked = "full"
         local manifest = extract_app_manifest(opts.app_dir)
         if manifest then
-            local r = tool.modules_resolve(manifest)
+            local r = tool.modules_resolve(manifest, nil, with_feature_list(opts))
             if r.ok and r.auto and r.auto.name then
                 picked = r.auto.name
             end
@@ -761,7 +770,7 @@ typedef struct {
         flavor_asset = fr.asset
         local manifest = extract_app_manifest(opts.app_dir)
         if manifest then
-            local r = tool.modules_resolve(manifest, opts.flavor)
+            local r = tool.modules_resolve(manifest, opts.flavor, with_feature_list(opts))
             if not r.ok then
                 tool.stderr("hull build: --flavor=" .. opts.flavor .. ": "
                             .. tostring(r.error) .. "\n")
@@ -1239,17 +1248,17 @@ int main(int argc, char **argv) { return hull_main(argc, argv); }
             cxx     = true,
             libs    = { darwin = { "-lc++" }, other = { "-lstdc++", "-ldl" } },
         },
-        -- gpu (scoped, not yet buildable -- needs the gpu cap layer split into a
-        -- base-resident generic half + a weak hl_gpu_feature_backends hook, with
-        -- wgpu isolated into libhull_feature-gpu.a). The codegen below already
-        -- handles it; only the spec row + the base hook + the archive are absent:
-        -- gpu = {
-        --     backend = "hl_gpu_backend_wgpu", type = "HlGpuBackend",
-        --     hook = "hl_gpu_feature_backends", cxx = false,
-        --     libs = { darwin = { "-framework", "Metal", "-framework", "QuartzCore",
-        --                         "-framework", "CoreGraphics", "-framework", "Foundation" },
-        --              other  = { "-lvulkan" } },
-        -- },
+        -- gpu: wgpu-native backend, isolated in libhull_feature-gpu.a
+        -- (`make feature-gpu`). Base ships the generic gpu dispatch layer +
+        -- the weak hl_gpu_feature_backends hook; this fills it. C (no cxx). The
+        -- frameworks / -lvulkan can't live in the .a so they're emitted here.
+        gpu = {
+            backend = "hl_gpu_backend_wgpu", type = "HlGpuBackend",
+            hook = "hl_gpu_feature_backends", cxx = false,
+            libs = { darwin = { "-framework", "Metal", "-framework", "QuartzCore",
+                                "-framework", "CoreGraphics", "-framework", "Foundation" },
+                     other  = { "-lvulkan" } },
+        },
     }
     local features_needed = {}
     if opts.with then for f in pairs(opts.with) do features_needed[f] = true end end
@@ -1432,6 +1441,7 @@ int main(int argc, char **argv) { return hull_main(argc, argv); }
         local sign_ctx = {
             cc = cc,
             flavor = opts.flavor,
+            features = with_feature_list(opts),
             binary_hash = nil,
             trampoline_hash = crypto.sha256(app_main),
             platform_sig_path = platform_sig_path,

--- a/tests/hull/test_module_resolver.c
+++ b/tests/hull/test_module_resolver.c
@@ -410,7 +410,35 @@ UTEST(module_resolver, gpu_rejected_when_compiled_out)
     ASSERT_EQ(rc, -1);
     ASSERT_NE(strstr(err, "HL_ENABLE_GPU"), NULL);
 }
+
+UTEST(module_resolver, gpu_admitted_with_composed_feature_cap)
+{
+    /* `hull build --with=gpu` (and the resulting composed binary) supplies
+     * HL_MOD_CAP_GPU at runtime even though HL_ENABLE_GPU was never compiled.
+     * Resolving with that cap ORed in admits hull/gpu where the plain resolver
+     * (previous test) rejects it. This is the resolver half of the gpu feature. */
+    HlManifest m;
+    clear_manifest(&m);
+    m.gpu = 1;
+    add_module(&m, "gpu", 1);
+
+    HlResolvedModuleSet s = {0};
+    char err[256] = {0};
+    int rc = hl_module_resolver_resolve_caps(
+        &m, &s, hl_module_build_caps() | HL_MOD_CAP_GPU, err, sizeof(err));
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(err[0], '\0');
+}
 #endif
+
+UTEST(module_resolver, feature_cap_maps_gpu_only)
+{
+    /* Only features carrying a module-gated capability map nonzero. */
+    ASSERT_EQ(hl_module_feature_cap("gpu"), (uint32_t)HL_MOD_CAP_GPU);
+    ASSERT_EQ(hl_module_feature_cap("duckdb"), (uint32_t)0);
+    ASSERT_EQ(hl_module_feature_cap("nope"), (uint32_t)0);
+    ASSERT_EQ(hl_module_feature_cap(NULL), (uint32_t)0);
+}
 
 #ifdef HL_ENABLE_TUI
 UTEST(module_resolver, tui_admitted_when_both_build_and_manifest_set)


### PR DESCRIPTION
Makes the gpu feature actually usable: `hull build --with=gpu` composes the wgpu
backend into an app and the produced binary runs gpu.dispatch, while a plain base
still rejects gpu. Completes the wiring on top of the base/feature split
(Phase 0.2) and the feature archive (make feature-gpu).

Resolver gate (the module cap must reflect gpu availability, not just
HL_ENABLE_GPU):
- build_provided_caps() now also reports HL_MOD_CAP_GPU when the base-resident
  hl_gpu_feature_backends hook returns >0. So a COMPOSED binary self-admits
  hull/gpu at app load even though HL_ENABLE_GPU was never compiled; a plain base
  (weak hook -> 0) still rejects it; a monolithic build already had the bit.
- New hl_module_feature_cap(name): maps a composed feature to the build cap it
  supplies ("gpu" -> HL_MOD_CAP_GPU; "duckdb" -> 0, it rides on the always-present
  hull/db). tool.modules_resolve gains an optional 3rd arg (composed feature
  names) that ORs these in, so the BASE build-tool admits hull/gpu under
  --with=gpu even though the tool itself has no GPU. build.lua passes the --with
  set to all three resolve sites (threaded via sign_ctx.features).

gpu_ctx propagation (four #ifdef HL_ENABLE_GPU that Phase 0.2 missed): the runtime
factories (lua/js) and app_context did not copy gpu_ctx into the runtime unless
compiled with HL_ENABLE_GPU, so a composed binary inited the backend but never
registered hull.gpu. Un-gated (the fields are base-resident); hull.gpu now
registers whenever a backend is present. The registration guard stays
`if (base.gpu_ctx)`, so the design holds: GPU present -> hull.gpu exists; GPU
absent -> it doesn't (module presence is the capability probe, like conn.udf).

FEATURE_SPECS.gpu: uncommented in build.lua (the generic codegen already emitted
the strong hl_gpu_feature_backends). --with=gpu now resolves the archive, links
the frameworks (-framework Metal/... on macOS, -lvulkan on Linux), and generates
the strong hook.

Tests: two new module_resolver cases (composed-feature GPU admission via
resolve_caps; hl_module_feature_cap mapping). test_module_resolver links
cap_gpu_feature.o now (the weak hook it consults).

Verified: composed binary (base flag=0 + feature archive + strong hook) runs a
real shader -> DISPATCH_OUT=2,4,6,8 on Apple M1 Max, gpu.available()=true; plain
base rejects a gpu app; monolithic + cosmo base + unit suite (35 resolver, 60/60)
all green.

Follow-up: optional-module declarations for graceful "GPU if present else CPU"
(today declaring hull/gpu hard-requires a GPU-capable binary), and a build-only
e2e for --with=gpu (dispatch e2e needs a GPU device CI lacks).

Signed-off-by: Mark Farkas <mark@artalis.io>
