### PR TITLE
fix(gpu/js): resolve HlJS via JS_GetContextOpaque, not a phantom __hull_js global

### DIFF
--- a/src/hull/runtime/js/mod_gpu.c
+++ b/src/hull/runtime/js/mod_gpu.c
@@ -26,11 +26,11 @@ static int js_parse_texture_descs(JSContext *ctx, JSValueConst arr,
 
 static HlGpuCtx *js_get_gpu_ctx(JSContext *ctx)
 {
-    JSValue global = JS_GetGlobalObject(ctx);
-    JSValue hull_opaque = JS_GetPropertyStr(ctx, global, "__hull_js");
-    HlJS *js = (HlJS *)JS_GetOpaque(hull_opaque, 1);
-    JS_FreeValue(ctx, hull_opaque);
-    JS_FreeValue(ctx, global);
+    /* HlJS is stashed as the context opaque (runtime.c: JS_SetContextOpaque),
+     * the same idiom every other JS cap module uses. The old code read a
+     * `__hull_js` global that is never set, so this always returned NULL and
+     * every gpu.* call failed (compile surfaced as a misleading "shader_error"). */
+    HlJS *js = (HlJS *)JS_GetContextOpaque(ctx);
     return js ? js->base.gpu_ctx : NULL;
 }
 


### PR DESCRIPTION
js_get_gpu_ctx() looked up HlJS from a JS global named `__hull_js` that is set
nowhere in the codebase, so it always returned NULL. With a NULL gpu_ctx every
JS gpu.* call failed: gpu.available() returned false and gpu.compile() surfaced
NULL-ctx as a misleading "shader_error" (the WGSL was fine -- Lua compiled the
identical source). The entire JS gpu.* surface (available/devices/compile/load/
dispatch) was dead for callers.

Fix: obtain HlJS via JS_GetContextOpaque(ctx) -- the exact idiom every other JS
cap module (env, blob, compute, db, async) already uses, matching the
JS_SetContextOpaque(js->ctx, js) set at runtime init. One helper, and the whole
JS gpu path works: gpu.compile + gpu.dispatch on real hardware returns 2,4,6,8
for a doubling shader over [1,2,3,4] on Apple M1 Max.

The Lua side was never affected (it reads __hull_lua from the Lua registry,
which IS populated).

Signed-off-by: Mark Farkas <mark@artalis.io>
