### PR TITLE
feat(gpu): hull feature install gpu + release job for libhull_feature-gpu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -755,10 +755,64 @@ jobs:
           name: feature-duckdb-${{ matrix.name }}
           path: libhull_feature-duckdb-${{ matrix.name }}.a
 
+  build-feature-gpu:
+    # Composable GPU feature archive (libhull_feature-gpu-<arch>.a), shipped as a
+    # release asset and pulled by `hull feature install gpu` -> `hull build
+    # --with=gpu`. See docs/features_and_flavors.md.
+    #
+    # Built bare (not in the reproducible container): `make fetch-wgpu` needs
+    # network, and the archive is covered by the release signature only (not the
+    # platform-sig cross-check), so it need not be byte-reproducible. Its SHA-256
+    # lands in the signed hull.sha256 and `hull feature install` re-verifies.
+    #
+    # Unlike duckdb, wgpu needs NO symbol isolation (no objcopy / LLVM): it shares
+    # no symbols with Hull. The macOS frameworks (Metal/QuartzCore/CoreGraphics/
+    # Foundation) and Linux -lvulkan are link-time deps that build.lua emits at
+    # app-compose time; the feature archive only `ar`s cap_gpu_wgpu.o +
+    # libwgpu_native.a members (no linking), so no framework / vulkan-dev install
+    # is needed here.
+    #
+    # No cosmo feature: GPU is native-only.
+    name: Build feature gpu (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            os: ubuntu-24.04
+          - name: linux-aarch64
+            os: ubuntu-24.04-arm
+          - name: darwin-arm64
+            os: macos-15
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+
+      - name: Write VERSION file
+        run: echo "${GITHUB_REF_NAME#v}" > VERSION
+
+      - name: Fetch wgpu-native static lib
+        run: make fetch-wgpu
+
+      - name: Build GPU feature archive
+        run: make feature-gpu
+
+      - name: Rename artifact (arch-qualified)
+        run: mv build/libhull_feature-gpu.a libhull_feature-gpu-${{ matrix.name }}.a
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: feature-gpu-${{ matrix.name }}
+          path: libhull_feature-gpu-${{ matrix.name }}.a
+
   release:
     name: Create Release
     runs-on: ubuntu-24.04
-    needs: [build-cosmo, build-native, build-wamrc, build-platform-cosmo-flavors, build-feature-native]
+    needs: [build-cosmo, build-native, build-wamrc, build-platform-cosmo-flavors, build-feature-native, build-feature-gpu]
     permissions:
       contents: write       # publish GitHub release + assets
       id-token: write       # SLSA: OIDC for Sigstore signing
@@ -805,6 +859,12 @@ jobs:
           mv artifacts/feature-duckdb-linux-x86_64/*.a   dist/
           mv artifacts/feature-duckdb-linux-aarch64/*.a  dist/
           mv artifacts/feature-duckdb-darwin-arm64/*.a   dist/
+          # Composable GPU feature archives (libhull_feature-gpu-<arch>.a),
+          # native-only. Pulled by `hull feature install gpu`. Covered by the
+          # libhull_feature-*.a glob in the SHA-256 + publish steps below.
+          mv artifacts/feature-gpu-linux-x86_64/*.a   dist/
+          mv artifacts/feature-gpu-linux-aarch64/*.a  dist/
+          mv artifacts/feature-gpu-darwin-arm64/*.a   dist/
 
       - name: Make binaries executable
         run: chmod +x dist/*
@@ -889,7 +949,7 @@ jobs:
                     libhull_platform-*.a \
                     libhull-linux-x86_64.a libhull-linux-aarch64.a libhull-darwin-arm64.a \
                     libhull.x86_64-cosmo.a libhull.aarch64-cosmo.a \
-                    libhull_feature-duckdb-*.a \
+                    libhull_feature-*.a \
                     > hull.sha256
           cat hull.sha256
 

--- a/src/hull/commands/dispatch.c
+++ b/src/hull/commands/dispatch.c
@@ -89,7 +89,7 @@ static const HlCommand commands[] = {
     { "update",         hl_cmd_update },
     { "tools",          hl_cmd_tools },
     { "flavor",         hl_cmd_flavor },   /* installs published build flavors ("platform" = build target, not this) */
-    { "feature",        hl_cmd_feature },  /* installs composable feature libs (e.g. duckdb) */
+    { "feature",        hl_cmd_feature },  /* installs composable feature libs (e.g. duckdb, gpu) */
 #endif
     { "sign-release",   hl_cmd_sign_release },
     { "verify-release", hl_cmd_verify_release },

--- a/src/hull/commands/feature.c
+++ b/src/hull/commands/feature.c
@@ -58,6 +58,7 @@ typedef struct {
 
 static const HlFeatureSpec FEATURES[] = {
     { "duckdb", "DuckDB embedded OLAP SQL backend (duckdb://)", 1, 1, 1 },
+    { "gpu",    "GPU compute via wgpu-native (Vulkan/Metal)",   1, 1, 1 },
 };
 
 static const HlFeatureSpec *feature_find(const char *name)

--- a/src/hull/commands/help.c
+++ b/src/hull/commands/help.c
@@ -95,7 +95,7 @@ int hl_cmd_help(int argc, char **argv, const HlCommandEnv *env)
     row(f, "update",        "self-update hull from GitHub releases");
     row(f, "tools",         "install / list / uninstall side-loaded tools (e.g. wamrc)");
     row(f, "flavor",        "install / list published build flavors for hull build --flavor");
-    row(f, "feature",       "install / list composable feature libs (e.g. duckdb) for hull build");
+    row(f, "feature",       "install / list composable feature libs (e.g. duckdb, gpu) for hull build");
     row(f, "cache",         "list / prune / clear runtime cache pool (HULL_CACHE_DIR)");
 #else
     section(f, "Self-management");


### PR DESCRIPTION
Ships the GPU feature archive as a signed release asset so end users can
`hull feature install gpu` -> `hull build --with=gpu` without building it from
source, mirroring the DuckDB feature. (The build.lua --with=gpu path and the
`make feature-gpu` archive already exist; this wires distribution.)

feature.c: one row in the FEATURES[] registry ({ "gpu", ..., 1,1,1 } -- published
for all three native platforms, native-only like duckdb). Everything else derives
automatically: feature_asset() names libhull_feature-gpu-<platform>.a,
feature list / install / uninstall iterate the registry, and the signed-manifest
fetch + SHA-256 re-verify in install_asset() is asset-name-agnostic.

release.yml: a build-feature-gpu matrix job (linux-x86_64 / linux-aarch64 /
darwin-arm64) that fetch-wgpu + make feature-gpu + uploads
libhull_feature-gpu-<arch>.a; added to the release job's needs; flattened into
dist/; and the signed hull.sha256 glob broadened from libhull_feature-duckdb-*.a
to libhull_feature-*.a (publish already globs libhull_feature-*.a). Unlike
duckdb, GPU needs NO llvm-objcopy step: wgpu shares no symbols with Hull, so
there is no isolation pass; and the frameworks / -lvulkan are app-compose link
deps, not needed to `ar` the archive.

help.c / dispatch.c: the "e.g. duckdb" hints now read "e.g. duckdb, gpu".

Verified: `hull feature list` shows gpu ("not installed"); release.yml is valid
YAML; unit suite green. Live install is validated by the release dry-run (a
pre-release tag builds + signs the gpu archives), same as duckdb.

Signed-off-by: Mark Farkas <mark@artalis.io>
