### PR TITLE
feat(modules): optional module declarations ("hull/gpu@1?") for graceful fallback

### DIFF
--- a/include/hull/manifest.h
+++ b/include/hull/manifest.h
@@ -50,6 +50,10 @@ typedef struct HlAllocator HlAllocator;
 typedef struct HlManifestModule {
     const char *name;       /* allocator-owned copy */
     uint8_t     api_major;  /* parsed from version string (e.g. "1" → 1) */
+    uint8_t     optional;   /* trailing '?' in the spec ("hull/gpu@1?"): if the
+                             * module needs a build cap this binary lacks, the
+                             * resolver SKIPS it (no error) and require/import
+                             * yields nil/null so the app can fall back. */
 } HlManifestModule;
 
 /* One declared named database connection:

--- a/include/hull/module_resolver.h
+++ b/include/hull/module_resolver.h
@@ -56,6 +56,11 @@ typedef struct HlManifest HlManifest;
  */
 typedef struct HlResolvedModuleSet {
     uint64_t bits[HL_MODULE_BITSET_WORDS];
+    /* Modules declared optional ("hull/gpu@1?") that were SKIPPED because a
+     * build cap is absent. Distinct from `bits` (admitted) and from "never
+     * declared" (in neither): the require/import gate consults this to return
+     * nil/null gracefully instead of erroring. Parallel-indexed to `bits`. */
+    uint64_t optional_absent[HL_MODULE_BITSET_WORDS];
 } HlResolvedModuleSet;
 
 /* ── Set operations ────────────────────────────────────────────────── */
@@ -74,6 +79,15 @@ bool hl_module_set_contains_name(const HlResolvedModuleSet *set,
 /* True iff a short or canonical name is in the set. */
 bool hl_module_set_contains_short(const HlResolvedModuleSet *set,
                                    const char *name);
+
+/* True iff `spec` was declared optional but skipped (build cap absent). NULL →
+ * false. The require/import gate uses this to yield nil/null instead of an error. */
+bool hl_module_set_optional_absent_spec(const HlResolvedModuleSet *set,
+                                         const HlModuleSpec *spec);
+
+/* Same, by canonical name. NULL → false. */
+bool hl_module_set_optional_absent_name(const HlResolvedModuleSet *set,
+                                         const char *canonical_name);
 
 /* Number of bits set. */
 int hl_module_set_count(const HlResolvedModuleSet *set);
@@ -114,6 +128,16 @@ uint32_t hl_module_build_caps(void);
  * "gpu" -> HL_MOD_CAP_GPU; "duckdb" -> 0, it rides on the always-present hull/db).
  */
 uint32_t hl_module_feature_cap(const char *name);
+
+/*
+ * True iff `spec` requires a build-time subsystem cap (DB/WASM/GPU/HTTP/TUI)
+ * that THIS binary lacks — compiled out and not composed as a feature. The JS
+ * loader uses it to tell a build-cap-optional top-level import (return a null
+ * stub, defer the decision to the resolver + import tracker) from a genuine
+ * unresolvable import (throw now): a module absent for OTHER reasons (e.g. a db
+ * runtime not configured) still errors at import.
+ */
+bool hl_module_needs_absent_build_cap(const HlModuleSpec *spec);
 
 /*
  * Resolve against an EXPLICIT build-cap set instead of this binary's

--- a/src/hull/manifest_js.c
+++ b/src/hull/manifest_js.c
@@ -249,11 +249,17 @@ int hl_manifest_extract_js(JSContext *ctx, HlManifest *out, HlAllocator *alloc)
             if (JS_IsString(elem)) {
                 const char *spec = JS_ToCString(ctx, elem);
                 if (spec) {
+                    /* Trailing '?' marks the module optional (skip, not error,
+                     * when its build cap is absent); sits after the major. */
+                    size_t speclen = strlen(spec);
+                    int optional = (speclen > 0 && spec[speclen - 1] == '?');
                     const char *at = strchr(spec, '@');
                     if (at && at != spec) {
                         char *end = NULL;
                         long v = strtol(at + 1, &end, 10);
-                        if (end != at + 1 && *end == '\0' &&
+                        int end_ok = (*end == '\0') ||
+                                     (optional && end[0] == '?' && end[1] == '\0');
+                        if (end != at + 1 && end_ok &&
                             v >= 1 && v <= 255) {
                             size_t nlen = (size_t)(at - spec);
                             char *namebuf = hl_alloc_malloc(alloc, nlen + 1);
@@ -262,6 +268,7 @@ int hl_manifest_extract_js(JSContext *ctx, HlManifest *out, HlAllocator *alloc)
                                 namebuf[nlen] = '\0';
                                 out->modules[out->modules_count].name      = namebuf;
                                 out->modules[out->modules_count].api_major = (uint8_t)v;
+                                out->modules[out->modules_count].optional  = (uint8_t)optional;
                                 out->modules_count++;
                             }
                         } else {
@@ -297,6 +304,8 @@ int hl_manifest_extract_js(JSContext *ctx, HlManifest *out, HlAllocator *alloc)
                 if (alias && JS_IsString(v_val)) {
                     const char *spec = JS_ToCString(ctx, v_val);
                     if (spec) {
+                        size_t speclen = strlen(spec);
+                        int optional = (speclen > 0 && spec[speclen - 1] == '?');
                         const char *at = strchr(spec, '@');
                         if (!at || at == spec) {
                             log_warn("[manifest] modules.%s = %s — expected "
@@ -305,7 +314,9 @@ int hl_manifest_extract_js(JSContext *ctx, HlManifest *out, HlAllocator *alloc)
                         } else {
                             char *end = NULL;
                             long v = strtol(at + 1, &end, 10);
-                            if (end == at + 1 || *end != '\0' ||
+                            int end_ok = (*end == '\0') ||
+                                         (optional && end[0] == '?' && end[1] == '\0');
+                            if (end == at + 1 || !end_ok ||
                                 v < 1 || v > 255) {
                                 log_warn("[manifest] modules.%s = %s — invalid "
                                          "major version, ignored", alias, spec);
@@ -317,6 +328,7 @@ int hl_manifest_extract_js(JSContext *ctx, HlManifest *out, HlAllocator *alloc)
                                     namebuf[nlen] = '\0';
                                     out->modules[out->modules_count].name      = namebuf;
                                     out->modules[out->modules_count].api_major = (uint8_t)v;
+                                    out->modules[out->modules_count].optional  = (uint8_t)optional;
                                     out->modules_count++;
                                 }
                             }

--- a/src/hull/manifest_lua.c
+++ b/src/hull/manifest_lua.c
@@ -224,6 +224,11 @@ int hl_manifest_extract_lua(lua_State *L, HlManifest *out, HlAllocator *alloc)
                 lua_rawgeti(L, modules_idx, i);
                 if (lua_type(L, -1) == LUA_TSTRING) {
                     const char *spec = lua_tostring(L, -1);
+                    /* Trailing '?' marks the module optional (skip, not error,
+                     * when its build cap is absent). It sits after the major,
+                     * so the name length (before '@') is unaffected. */
+                    size_t speclen = strlen(spec);
+                    int optional = (speclen > 0 && spec[speclen - 1] == '?');
                     const char *at   = strchr(spec, '@');
                     if (!at || at == spec) {
                         log_warn("[manifest] modules[%lld] = %s — expected "
@@ -232,7 +237,9 @@ int hl_manifest_extract_lua(lua_State *L, HlManifest *out, HlAllocator *alloc)
                     } else {
                         char *end = NULL;
                         long v = strtol(at + 1, &end, 10);
-                        if (end == at + 1 || *end != '\0' ||
+                        int end_ok = (*end == '\0') ||
+                                     (optional && end[0] == '?' && end[1] == '\0');
+                        if (end == at + 1 || !end_ok ||
                             v < 1 || v > 255) {
                             log_warn("[manifest] modules[%lld] = %s — "
                                      "invalid major version, ignored",
@@ -245,6 +252,7 @@ int hl_manifest_extract_lua(lua_State *L, HlManifest *out, HlAllocator *alloc)
                                 namebuf[nlen] = '\0';
                                 out->modules[out->modules_count].name      = namebuf;
                                 out->modules[out->modules_count].api_major = (uint8_t)v;
+                                out->modules[out->modules_count].optional  = (uint8_t)optional;
                                 out->modules_count++;
                             }
                         }
@@ -271,6 +279,8 @@ int hl_manifest_extract_lua(lua_State *L, HlManifest *out, HlAllocator *alloc)
                     }
                     const char *alias = lua_tostring(L, -2);
                     const char *spec  = lua_tostring(L, -1);
+                    size_t speclen = strlen(spec);
+                    int optional = (speclen > 0 && spec[speclen - 1] == '?');
                     const char *at    = strchr(spec, '@');
                     if (!at || at == spec) {
                         log_warn("[manifest] modules.%s = %s — expected "
@@ -279,7 +289,9 @@ int hl_manifest_extract_lua(lua_State *L, HlManifest *out, HlAllocator *alloc)
                     } else {
                         char *end = NULL;
                         long v = strtol(at + 1, &end, 10);
-                        if (end == at + 1 || *end != '\0' ||
+                        int end_ok = (*end == '\0') ||
+                                     (optional && end[0] == '?' && end[1] == '\0');
+                        if (end == at + 1 || !end_ok ||
                             v < 1 || v > 255) {
                             log_warn("[manifest] modules.%s = %s — invalid "
                                      "major version, ignored", alias, spec);
@@ -291,6 +303,7 @@ int hl_manifest_extract_lua(lua_State *L, HlManifest *out, HlAllocator *alloc)
                                 namebuf[nlen] = '\0';
                                 out->modules[out->modules_count].name      = namebuf;
                                 out->modules[out->modules_count].api_major = (uint8_t)v;
+                                out->modules[out->modules_count].optional  = (uint8_t)optional;
                                 out->modules_count++;
                             }
                         }

--- a/src/hull/module_resolver.c
+++ b/src/hull/module_resolver.c
@@ -42,6 +42,18 @@ static bool get_bit(const HlResolvedModuleSet *s, int i)
     return (s->bits[BIT_WORD(i)] & BIT_MASK(i)) != 0;
 }
 
+static void set_optional_absent_bit(HlResolvedModuleSet *s, int i)
+{
+    if (i < 0 || i >= (int)MAX_BITS) return;
+    s->optional_absent[BIT_WORD(i)] |= BIT_MASK(i);
+}
+
+static bool get_optional_absent_bit(const HlResolvedModuleSet *s, int i)
+{
+    if (!s || i < 0 || i >= (int)MAX_BITS) return false;
+    return (s->optional_absent[BIT_WORD(i)] & BIT_MASK(i)) != 0;
+}
+
 void hl_module_set_clear(HlResolvedModuleSet *s)
 {
     if (s) memset(s, 0, sizeof(*s));
@@ -68,6 +80,19 @@ bool hl_module_set_contains_short(const HlResolvedModuleSet *s,
                                    const char *name)
 {
     return hl_module_set_contains_spec(s, hl_module_registry_find_short(name));
+}
+
+bool hl_module_set_optional_absent_spec(const HlResolvedModuleSet *s,
+                                         const HlModuleSpec *spec)
+{
+    return get_optional_absent_bit(s, hl_module_registry_index(spec));
+}
+
+bool hl_module_set_optional_absent_name(const HlResolvedModuleSet *s,
+                                         const char *canonical_name)
+{
+    return get_optional_absent_bit(
+        s, hl_module_registry_index(hl_module_registry_find(canonical_name)));
 }
 
 int hl_module_set_count(const HlResolvedModuleSet *s)
@@ -148,6 +173,15 @@ uint32_t hl_module_feature_cap(const char *name)
     if (name && strcmp(name, "gpu") == 0)
         return HL_MOD_CAP_GPU;
     return 0;
+}
+
+bool hl_module_needs_absent_build_cap(const HlModuleSpec *spec)
+{
+    if (!spec) return false;
+    const uint32_t build_cap_mask = HL_MOD_CAP_DB | HL_MOD_CAP_WASM
+                                    | HL_MOD_CAP_GPU | HL_MOD_CAP_HTTP
+                                    | HL_MOD_CAP_TUI;
+    return (spec->required_caps & build_cap_mask & ~build_provided_caps()) != 0;
 }
 
 /* Human-readable name for a capability bit (for error messages). */
@@ -396,6 +430,14 @@ int hl_module_resolver_resolve_caps(const HlManifest *manifest,
             uint32_t bit = 1u << bi;
             if (!(need_build & bit)) continue;
             if (!(prov_build & bit)) {
+                /* Optional ("hull/gpu@1?"): the build lacks this cap, so SKIP
+                 * the module (record it absent) instead of failing the whole
+                 * resolve. require/import will yield nil/null for graceful
+                 * fallback. A non-optional module here is still a hard error. */
+                if (m->optional) {
+                    set_optional_absent_bit(out, idx);
+                    goto next_module;
+                }
                 ERR2("module '%s' requires %s, but it is disabled in "
                      "this hull build",
                      spec->name, cap_label(bit));
@@ -410,12 +452,17 @@ int hl_module_resolver_resolve_caps(const HlManifest *manifest,
          * resolve time so apps see the error before reaching cap
          * code. */
         if ((spec->required_caps & HL_MOD_CAP_TUI) && !manifest->tui) {
+            if (m->optional) {
+                set_optional_absent_bit(out, idx);
+                goto next_module;
+            }
             ERR1("module '%s' requires the 'tui' capability in the "
                  "manifest (add `tui = true`)", spec->name);
             return -1;
         }
 
         set_bit(out, idx);
+    next_module:;
     }
 
     /* Pass 2: auto-admit transitive deps of every admitted module.
@@ -520,7 +567,10 @@ int hl_import_tracker_validate(const HlRuntime *rt,
     const char *first_missing = NULL;
     for (int i = 0; i < rt->import_tracker_count; i++) {
         const char *name = rt->import_tracker_names[i];
-        if (!hl_module_set_contains_name(set, name)) {
+        /* Optional-absent counts as satisfied: a top-level import of an
+         * optional module the build lacks is allowed (it yields nil/null). */
+        if (!hl_module_set_contains_name(set, name) &&
+            !hl_module_set_optional_absent_name(set, name)) {
             if (!first_missing) first_missing = name;
             missing_count++;
         }

--- a/src/hull/runtime/js/runtime.c
+++ b/src/hull/runtime/js/runtime.c
@@ -188,6 +188,37 @@ int hl_js_check_module_declared(JSContext *ctx,
     return 0;
 }
 
+/* Build-cap-optional module ("hull/gpu@1?") the build lacks: synthesize a stub
+ * whose single conventional export — the last ':' segment, which matches the
+ * native module's export name (hull:gpu -> `gpu`, hull:compute -> `compute`) —
+ * is null. So `import { gpu } from "hull:gpu"` binds null on a base binary and
+ * the real object on a GPU binary, letting the app branch on it. */
+static const char *hl_js_module_last_seg(const char *module_name)
+{
+    const char *seg = strrchr(module_name, ':');
+    return seg ? seg + 1 : module_name;
+}
+
+static int hl_js_optional_stub_init(JSContext *ctx, JSModuleDef *m)
+{
+    JSAtom nm = JS_GetModuleName(ctx, m);
+    const char *mn = JS_AtomToCString(ctx, nm);
+    JS_FreeAtom(ctx, nm);
+    if (mn) {
+        JS_SetModuleExport(ctx, m, hl_js_module_last_seg(mn), JS_NULL);
+        JS_FreeCString(ctx, mn);
+    }
+    return 0;
+}
+
+static JSModuleDef *hl_js_optional_stub(JSContext *ctx, const char *module_name)
+{
+    JSModuleDef *m = JS_NewCModule(ctx, module_name, hl_js_optional_stub_init);
+    if (!m) return NULL;
+    JS_AddModuleExport(ctx, m, hl_js_module_last_seg(module_name));
+    return m;
+}
+
 /*
  * Module loader. Handles:
  * 1. hull:* prefix → built-in modules (registered at init time)
@@ -218,6 +249,13 @@ static JSModuleDef *hl_js_module_loader(JSContext *ctx,
         if (spec) {
             if (js->base.module_set) {
                 if (!hl_module_set_contains_spec(js->base.module_set, spec)) {
+                    /* Optional module the build lacks ("hull/gpu@1?"): return a
+                     * null-export stub so `import { gpu } from "hull:gpu"` binds
+                     * null and the app can fall back, instead of throwing. */
+                    if (hl_module_set_optional_absent_spec(js->base.module_set,
+                                                           spec))
+                        return hl_js_optional_stub(ctx, module_name);
+
                     char deps_buf[128];
                     hl_module_registry_format_deps(spec, deps_buf, sizeof(deps_buf));
                     char deps_part[160] = {0};
@@ -255,6 +293,20 @@ static JSModuleDef *hl_js_module_loader(JSContext *ctx,
                 return m;
             }
         }
+        /* A registry-KNOWN hull:* module that needs a build-time cap this
+         * binary lacks (compiled out / not composed, e.g. hull:gpu on a
+         * non-GPU binary) and that reached here with no native reg + no VFS
+         * entry: at top-of-file import time the module_set isn't wired yet, so
+         * we can't tell if it was declared optional. Return a null-export stub
+         * and defer the decision — the resolver + import tracker run right after
+         * manifest extraction and still REJECT a non-optional or undeclared
+         * import, while an optional one ("hull/gpu@1?") resolves to null so the
+         * app can fall back. Scoped to build-cap-absent modules so a module
+         * missing for other reasons (unconfigured runtime) still throws here. */
+        if (spec && !js->base.module_set &&
+            hl_module_needs_absent_build_cap(spec))
+            return hl_js_optional_stub(ctx, module_name);
+
         /* "hull:something" that isn't a known native and isn't in the
          * VFS stdlib — almost always a typo. Probe the registry for a
          * near match and surface "did you mean?" if anything is close. */

--- a/src/hull/runtime/lua/mod_fs.c
+++ b/src/hull/runtime/lua/mod_fs.c
@@ -412,6 +412,13 @@ static int hl_lua_require(lua_State *L)
         if (spec) {
             if (lua->base.module_set) {
                 if (!hl_module_set_contains_spec(lua->base.module_set, spec)) {
+                    /* Optional module the build lacks ("hull/gpu@1?"): return
+                     * nil so the app can fall back, instead of erroring. */
+                    if (hl_module_set_optional_absent_spec(lua->base.module_set,
+                                                           spec)) {
+                        lua_pushnil(L);
+                        return 1;
+                    }
                     char deps_buf[128];
                     hl_module_registry_format_deps(spec, deps_buf, sizeof(deps_buf));
                     char deps_part[160] = {0};

--- a/src/hull/tool_orchestration.c
+++ b/src/hull/tool_orchestration.c
@@ -103,8 +103,14 @@ static int l_tool_modules_resolve(lua_State *L)
                 const char *spec = NULL;
                 size_t nlen = 0;
                 long v = 0;
+                int optional = 0;
                 if (is_spec) {
                     spec = val;
+                    /* Trailing '?' marks the module optional; it's after the
+                     * major so the name (before '@') is unaffected, and strtol
+                     * with a NULL end already stops at the '?'. */
+                    size_t sl = strlen(spec);
+                    optional = (sl > 0 && spec[sl - 1] == '?');
                     const char *at = strchr(spec, '@');
                     nlen = at ? (size_t)(at - spec) : strlen(spec);
                     v = at ? strtol(at + 1, NULL, 10) : 1;
@@ -121,6 +127,7 @@ static int l_tool_modules_resolve(lua_State *L)
                         owned_names[owned_count] = copy;
                         m.modules[m.modules_count].name = copy;
                         m.modules[m.modules_count].api_major = (uint8_t)v;
+                        m.modules[m.modules_count].optional = (uint8_t)optional;
                         m.modules_count++;
                         owned_count++;
                     }

--- a/tests/hull/test_module_resolver.c
+++ b/tests/hull/test_module_resolver.c
@@ -429,6 +429,40 @@ UTEST(module_resolver, gpu_admitted_with_composed_feature_cap)
     ASSERT_EQ(rc, 0);
     ASSERT_EQ(err[0], '\0');
 }
+
+UTEST(module_resolver, optional_module_skipped_when_cap_absent)
+{
+    /* "hull/gpu@1?" on a non-GPU build: SKIP, don't error. Not admitted, but
+     * recorded optional-absent so require/import yields nil/null for fallback. */
+    HlManifest m;
+    clear_manifest(&m);
+    add_module(&m, "gpu", 1);
+    m.modules[m.modules_count - 1].optional = 1;
+
+    HlResolvedModuleSet s = {0};
+    char err[256] = {0};
+    int rc = hl_module_resolver_resolve(&m, &s, err, sizeof(err));
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(err[0], '\0');
+
+    const HlModuleSpec *gpu = hl_module_registry_find_short("gpu");
+    ASSERT_FALSE(hl_module_set_contains_spec(&s, gpu));
+    ASSERT_TRUE(hl_module_set_optional_absent_spec(&s, gpu));
+}
+
+UTEST(module_resolver, non_optional_still_rejected_when_cap_absent)
+{
+    /* Regression guard: without the '?', the hard rejection stays. */
+    HlManifest m;
+    clear_manifest(&m);
+    add_module(&m, "gpu", 1);  /* optional defaults to 0 */
+
+    HlResolvedModuleSet s = {0};
+    char err[256] = {0};
+    int rc = hl_module_resolver_resolve(&m, &s, err, sizeof(err));
+    ASSERT_EQ(rc, -1);
+    ASSERT_NE(strstr(err, "HL_ENABLE_GPU"), NULL);
+}
 #endif
 
 UTEST(module_resolver, feature_cap_maps_gpu_only)


### PR DESCRIPTION
A trailing '?' on a manifest spec marks the module OPTIONAL: if it needs a
build cap this binary lacks, the resolver SKIPS it (instead of rejecting the
whole app) and require/import yields nil/null, so an app can use a capability
when present and fall back when not:

    -- Lua                              // JS
    modules = { "hull/gpu@1?" }         modules: ["hull/gpu@1?"]
    local gpu = require("hull.gpu")     import { gpu } from "hull:gpu";
    if gpu then gpu.dispatch(...)       if (gpu) gpu.dispatch(...);
    else cpu_path() end                 else cpu();

Only the ABSENT case changes; a present optional module is gated exactly as
before (full resolver + per-call cap layer), so this grants zero new authority.
A NON-optional declaration ("hull/gpu@1") still hard-rejects on a build that
lacks the cap, and an undeclared import is still caught by the import tracker.
Generalizes to every build-cap module (db/wasm/gpu/http/tui), not just gpu.

Mechanics:
- HlManifestModule gains an `optional` bit; all four manifest parse sites
  (Lua/JS x array/legacy) strip the trailing '?' (which sits after the major,
  so the name is unaffected) and set it. tool_orchestration carries it so the
  build-time resolve matches runtime.
- HlResolvedModuleSet gains a parallel `optional_absent[]` bitset (auto-seals
  with the existing set; no new runtime fields, no resolver signature change).
  Pass 1: an optional module missing a build cap (or the tui manifest flag) is
  recorded optional-absent and skipped; a non-optional one still errors. The
  import tracker treats optional-absent as satisfied.
- Lua require: optional-absent -> lua_pushnil.
- JS loader: optional-absent (and, pre-manifest, a registry-known module that
  needs a build cap this binary lacks — since module_set isn't wired yet at
  top-of-file import time) returns a synthesized stub whose single conventional
  export (the last ':' segment, matching the native module's export name, e.g.
  hull:gpu -> `gpu`) is null. The resolver + tracker run right after and still
  reject a non-optional or undeclared import, so the stub can't mask an error.
  Scoped via hl_module_needs_absent_build_cap() to build-cap-absent modules, so
  a module missing for OTHER reasons (e.g. an unconfigured db runtime) still
  throws at import exactly as before.

Verified: base binary + "hull/gpu@1?" -> require nil (Lua) / import null (JS),
app runs the CPU path (exit 0); "hull/gpu@1" (no '?') -> still rejected; imported
-but-undeclared -> tracker reject; GPU binary + "hull/gpu@1?" -> real module.
37 resolver tests (+2), full suite (60/60) + monolithic + cosmo all green.

Signed-off-by: Mark Farkas <mark@artalis.io>
