### PR TITLE
fix(gpu): destroy the GPU context on shutdown in composed --with=gpu builds

### DIFF
--- a/src/hull/serve.c
+++ b/src/hull/serve.c
@@ -1285,7 +1285,8 @@ static int hl_serve_wire_caps(HlServerState *s)
         }
 
         /* Resolve the module set BEFORE sealing the arena.  The
-         * resolver writes its 16-byte bitset to s->module_set as a
+         * resolver writes its module set (admitted + optional-absent
+         * bitsets) to s->module_set as a
          * scratch buffer, then we memdup it into the arena so the
          * sealed copy is what the runtime consults on every
          * require/import.  This closes the "manifest declared ->
@@ -1766,10 +1767,13 @@ static void hl_serve_teardown_after_serve(HlServerState *s)
     if (wasm_cache_ok)
         hl_cap_wasm_destroy(&wasm_cache);
 #endif
-#ifdef HL_ENABLE_GPU
+    /* Base-resident, symmetric with the init above: a composed --with=gpu app
+     * binary links the base serve.c (no HL_ENABLE_GPU) but still sets
+     * gpu_ctx_ok via the feature hook, so the destroy must NOT be
+     * #ifdef-gated or the GPU context leaks on shutdown. hl_cap_gpu_destroy
+     * lives in base-resident gpu.c and is NULL-safe + idempotent. */
     if (gpu_ctx_ok)
         hl_cap_gpu_destroy(&gpu_ctx);
-#endif
     if (s->client_tls_ctx) {
         kl_tls_mbedtls_ctx_destroy(s->client_tls_ctx);
         s->client_tls_ctx = NULL;

--- a/src/hull/tool_orchestration.c
+++ b/src/hull/tool_orchestration.c
@@ -112,7 +112,10 @@ static int l_tool_modules_resolve(lua_State *L)
                     size_t sl = strlen(spec);
                     optional = (sl > 0 && spec[sl - 1] == '?');
                     const char *at = strchr(spec, '@');
-                    nlen = at ? (size_t)(at - spec) : strlen(spec);
+                    /* When there's no '@', strip a trailing '?' from the name so
+                     * "hull/gpu?" resolves to "hull/gpu" (matches manifest_lua.c). */
+                    nlen = at ? (size_t)(at - spec)
+                              : (optional ? sl - 1 : sl);
                     v = at ? strtol(at + 1, NULL, 10) : 1;
                 } else if (lua_type(L, -2) == LUA_TSTRING) {
                     spec = lua_tostring(L, -2);


### PR DESCRIPTION
C-audit finding (Medium). Phase 0.2 made the GPU *init* in serve.c base-resident
(no HL_ENABLE_GPU guard on hl_cap_gpu_init — only the wgpu-backend fallback stays
#ifdef'd), so a `hull build --with=gpu` app binary links the base serve.c and
sets gpu_ctx_ok via the feature hook. But the teardown
`if (gpu_ctx_ok) hl_cap_gpu_destroy(&gpu_ctx)` was still wrapped in
`#ifdef HL_ENABLE_GPU`, so in a feature build it compiled out entirely: the GPU
context (per-device pthread mutexes + wgpu device/adapter/instance handles +
pipeline/buffer/texture caches, and the queue drain) leaked on clean shutdown.
Un-gate the destroy so it's driven by the runtime gpu_ctx_ok flag, symmetric
with the init. hl_cap_gpu_destroy is base-resident in cap/gpu.c and NULL-safe +
idempotent, so this is safe in every flavor.

Also from the audit:
- tool_orchestration.c: strip a trailing '?' from an optional spec that has no
  '@' ("hull/gpu?"), matching manifest_lua.c, so the build-tool resolver sees
  the bare name (was a harmless registry non-match, now consistent).
- serve.c: fix a stale comment ("16-byte bitset" -> the module set is now the
  admitted + optional-absent bitsets).

Verified: base + monolithic build; module_resolver suite 37/37.

Signed-off-by: Mark Farkas <mark@artalis.io>
