### PR TITLE
fix(stdlib): audit follow-ups — health.js ReferenceError + parity hardening

### DIFF
--- a/stdlib/js/hull/csv.js
+++ b/stdlib/js/hull/csv.js
@@ -102,7 +102,10 @@ function parse(text, opts) {
         const headers = rows[0];
         const result = [];
         for (let r = 1; r < rows.length; r++) {
-            const obj = {};
+            // Null-prototype: a header cell named "__proto__" / "constructor"
+            // is then an ordinary data key, not a prototype-chain write
+            // (parity with form.parse; matches Lua, which has no prototype).
+            const obj = Object.create(null);
             for (let c = 0; c < headers.length; c++) {
                 const key = headers[c];
                 if (typeof key !== "string" || key.length === 0) continue;

--- a/stdlib/js/hull/web/auth-flows.js
+++ b/stdlib/js/hull/web/auth-flows.js
@@ -844,7 +844,14 @@ async function handlePasswordResetConfirm(req, res) {
     // body: `(req, res, user) => session.destroyAll(user.id)`.
     emitEvent(result[0].sub, "password_reset_completed", req);
     if (_state.onPasswordReset) {
-        try { _state.onPasswordReset(req, res, user); } catch (_e) {}
+        // Log rather than fully swallow: the recommended body revokes all
+        // sessions (session.destroyAll), so a throw here means a suspected-
+        // compromise cleanup silently didn't run, so an operator must see it.
+        try {
+            _state.onPasswordReset(req, res, user);
+        } catch (e) {
+            log.warn("auth-flows: onPasswordReset threw: " + (e && e.message ? e.message : e));
+        }
     }
     gcExpired();
     res.json({ ok: true });

--- a/stdlib/js/hull/web/middleware/health.js
+++ b/stdlib/js/hull/web/middleware/health.js
@@ -157,7 +157,12 @@ function middleware(opts) {
                 uptime,
             };
 
-            if (server && httpServer.stats) {
+            // Include server stats if available. Pre-fix used `server`
+            // (an undeclared identifier — a ReferenceError the moment
+            // httpServer.stats existed), so the docstring's promised stats
+            // block never reached /ready responses. Mirrors the Lua fix in
+            // health.lua.
+            if (httpServer && httpServer.stats) {
                 body.stats = httpServer.stats();
             }
 

--- a/stdlib/lua/hull/web/auth-flows.lua
+++ b/stdlib/lua/hull/web/auth-flows.lua
@@ -1189,7 +1189,13 @@ local function handle_password_reset_confirm(req, res)
     -- out via session.destroy_others instead.
     emit_event(env.sub, "password_reset_completed", req)
     if _state.on_password_reset then
-        pcall(_state.on_password_reset, req, res, user)
+        -- Log rather than fully swallow: the recommended body revokes all
+        -- sessions (session.destroy_all), so a throw here means a suspected-
+        -- compromise cleanup silently didn't run -- an operator must see it.
+        local ok, cb_err = pcall(_state.on_password_reset, req, res, user)
+        if not ok then
+            require("hull.log").warn("auth-flows: on_password_reset failed: " .. tostring(cb_err))
+        end
     end
     gc_expired()
     res:json({ ok = true })


### PR DESCRIPTION
From the JS/Lua stdlib audit (no Critical/High found; these are the actionable
items):

- web/middleware/health.js: `/ready` referenced an undeclared `server` (it should
  be the imported `httpServer`), so the moment `httpServer.stats` existed the
  handler threw a ReferenceError and the documented stats block never reached the
  response. The Lua sibling was already fixed; this brings JS to parity. Verified
  live: /ready now returns the stats block.
- csv.js: header-mode rows are built with Object.create(null) so a header cell
  named "__proto__" / "constructor" is an ordinary data key, not a prototype
  write (parity with form.parse; Lua needs none — no prototype chain).
- web/auth-flows.{js,lua}: on_password_reset / onPasswordReset was fully swallowed
  on throw. The recommended body revokes all sessions after a reset
  (session.destroy_all), so a throw meant a suspected-compromise cleanup silently
  didn't run. Now logged via log.warn, matching the swallow-logging already used
  for user_sanitize / session.login_handler.

Verified: build clean; JS 151 + Lua 169 runtime tests pass.

Signed-off-by: Mark Farkas <mark@artalis.io>
