### PR TITLE
feat(tui): base-resident presence seam for TUI-as-a-feature (Phase 1.1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3368,10 +3368,11 @@ $(BUILDDIR)/test_module_registry: $(TESTDIR)/hull/test_module_registry.c $(MODUL
 	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(MODULE_REGISTRY_OBJ)
 
 # Module resolver — needs the registry plus the manifest types
-# cap_gpu_feature.o supplies the weak hl_gpu_feature_backends the resolver now
-# consults (composed-feature GPU cap). It's base-resident, so always available.
-$(BUILDDIR)/test_module_resolver: $(TESTDIR)/hull/test_module_resolver.c $(MODULE_OBJ) $(BUILDDIR)/cap_gpu_feature.o | $(BUILDDIR)
-	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(MODULE_OBJ) $(BUILDDIR)/cap_gpu_feature.o
+# cap_gpu_feature.o / cap_tui_feature.o supply the weak hl_gpu_feature_backends /
+# hl_tui_feature_present the resolver now consults (composed-feature GPU + TUI
+# caps). Both are base-resident, so always available.
+$(BUILDDIR)/test_module_resolver: $(TESTDIR)/hull/test_module_resolver.c $(MODULE_OBJ) $(BUILDDIR)/cap_gpu_feature.o $(BUILDDIR)/cap_tui_feature.o | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(MODULE_OBJ) $(BUILDDIR)/cap_gpu_feature.o $(BUILDDIR)/cap_tui_feature.o
 
 # CA bundle test — links against cacert.o and mbedTLS for parse verification
 $(BUILDDIR)/test_cacert: $(TESTDIR)/hull/test_cacert.c $(CACERT_OBJ) $(MBEDTLS_OBJS) | $(BUILDDIR)

--- a/include/hull/cap/tui.h
+++ b/include/hull/cap/tui.h
@@ -281,6 +281,20 @@ int hl_cap_tui_enable_focus(HlTuiCtx *ctx, int on);
 /* Toggle Kitty keyboard protocol (richer modifier reporting). */
 int hl_cap_tui_enable_kitty_kbd(HlTuiCtx *ctx, int on);
 
+/* ── Composable-feature seam ────────────────────────────────────────
+ *
+ * TUI is a "subsystem feature": the whole cap layer + runtime bindings
+ * live in libhull_feature-tui.a rather than the base platform lib. The
+ * base ships only this weak presence hook (default 0, in cap/tui_feature.c);
+ * `hull build --with=tui` composes the feature, whose strong override
+ * returns 1. The resolver consults it (build_provided_caps) so a composed
+ * binary admits hull/tui at app load even though HL_ENABLE_TUI was never
+ * compiled into the base. A monolithic HL_ENABLE_TUI build reports TUI via
+ * the compile flag instead; a plain base returns 0 and hull/tui is rejected.
+ * (Parallels hl_gpu_feature_backends / hl_db_feature_backends.)
+ */
+int hl_tui_feature_present(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/hull/cap/tui_feature.c
+++ b/src/hull/cap/tui_feature.c
@@ -1,0 +1,26 @@
+/*
+ * cap/tui_feature.c — composable-feature presence hook for the TUI subsystem.
+ *
+ * Base-resident weak default: a base build carries no TUI cap layer, so this
+ * returns 0 (not present). A `hull build --with=tui` build links a STRONG
+ * override (in libhull_feature-tui.a) that returns 1; the resolver's
+ * build_provided_caps then reports HL_MOD_CAP_TUI so a composed binary admits
+ * hull/tui at app load even though HL_ENABLE_TUI was never compiled into the
+ * base. A monolithic HL_ENABLE_TUI build reports TUI via the compile flag.
+ *
+ * TUI is a "subsystem feature", not a "backend feature": there is no backend
+ * vtable (contrast HlGpuBackend / HlDbBackend), so the seam is a single
+ * presence hook plus the per-runtime registration hooks the feature provides.
+ * Always compiled (picked up by the cap-directory wildcard) so the symbol
+ * always resolves whether or not TUI is present.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "hull/cap/tui.h"
+
+__attribute__((weak))
+int hl_tui_feature_present(void)
+{
+    return 0;
+}

--- a/src/hull/module_resolver.c
+++ b/src/hull/module_resolver.c
@@ -20,6 +20,7 @@
 #include "hull/manifest.h"
 #include "hull/runtime.h"  /* HlRuntime — import_tracker fields */
 #include "hull/cap/gpu.h"  /* hl_gpu_feature_backends — composed-feature GPU cap */
+#include "hull/cap/tui.h"  /* hl_tui_feature_present — composed-feature TUI cap */
 
 #include <stdio.h>
 #include <string.h>
@@ -157,6 +158,12 @@ static uint32_t build_provided_caps(void)
         if (hl_gpu_feature_backends(&nfeat) && nfeat > 0)
             caps |= HL_MOD_CAP_GPU;
     }
+    /* Same shape for the composed tui feature: its strong override of the
+     * base's weak hl_tui_feature_present (default 0) returns 1, so a
+     * `hull build --with=tui` binary admits hull/tui at app load. Plain base
+     * -> 0 (adds nothing); monolithic HL_ENABLE_TUI -> already set above. */
+    if (hl_tui_feature_present())
+        caps |= HL_MOD_CAP_TUI;
     return caps;
 }
 


### PR DESCRIPTION
First step of making TUI a composable feature (docs/features_and_flavors.md),
so `--flavor=auto` can drop the ~29 KB TUI subsystem from apps that declare no
hull/tui. Mirrors the GPU base/feature split.

TUI is a "subsystem feature", not a "backend feature": there's no backend vtable
(contrast HlGpuBackend / HlDbBackend) and no serve.c init to rewire (TUI is
lazily acquired via tui.run). So the base seam is a single weak presence hook:

- include/hull/cap/tui.h: declare hl_tui_feature_present().
- src/hull/cap/tui_feature.c (new, base-resident, auto-compiled via the cap
  wildcard): the weak default returns 0 (no TUI). A future `hull build --with=tui`
  links a strong override (in libhull_feature-tui.a) returning 1.
- module_resolver.c build_provided_caps(): report HL_MOD_CAP_TUI when the hook
  returns 1, so a composed binary admits hull/tui at app load even though
  HL_ENABLE_TUI was never compiled into the base. Same shape as the GPU hook.
  A monolithic HL_ENABLE_TUI build still reports TUI via the compile flag; a
  plain base returns 0 and hull/tui is rejected (unchanged).
- Makefile: test_module_resolver links cap_tui_feature.o (the weak symbol it
  now references), alongside cap_gpu_feature.o.

No behavior change: base + monolithic (HL_ENABLE_TUI=1) build identically; the
hook is inert (0) in the base. Verified: base + monolithic build; resolver
suite 37/37; full unit suite 60/60.

Phase 1.2 (next) does the actual subsystem move: filter the mod_tui runtime
bindings out of the base (they currently break an HL_ENABLE_TUI=0 link),
route module registration through a per-runtime feature hook, add
`make feature-tui` + FEATURES[]/FEATURE_SPECS + the resolver/auto-compose, and
fix a pre-existing HL_ENABLE_TUI=0 build break (commands/dev.c run_dev_tui
unused-function under -Werror).

Signed-off-by: Mark Farkas <mark@artalis.io>
