### PR TITLE
feat(tui): move the TUI subsystem to a composable feature (Phase 1.2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1552,6 +1552,14 @@ ifeq ($(HL_ENABLE_HTTP_SERVER),0)
       $(SRCDIR)/hull/runtime/js/bindings.c, \
       $(JS_RT_SRCS))
 endif
+ifeq ($(HL_ENABLE_TUI),0)
+  # The tui native bridge moves to libhull_feature-tui.a (composed feature) —
+  # drop it from the base (which keeps only the weak feature hooks in
+  # cap/tui_feature.c). Pairs with the cap/tui.c + tui_input.c filter above.
+  JS_RT_SRCS := $(filter-out \
+      $(SRCDIR)/hull/runtime/js/mod_tui.c, \
+      $(JS_RT_SRCS))
+endif
 JS_RT_OBJS := $(patsubst $(SRCDIR)/hull/runtime/js/%.c,$(BUILDDIR)/js_%.o,$(JS_RT_SRCS))
 
 # Lua runtime sources
@@ -1582,6 +1590,14 @@ ifeq ($(HL_ENABLE_HTTP_SERVER),0)
       $(SRCDIR)/hull/runtime/lua/timers.c \
       $(SRCDIR)/hull/runtime/lua/mod_request.c \
       $(SRCDIR)/hull/runtime/lua/bindings.c, \
+      $(LUA_RT_SRCS))
+endif
+ifeq ($(HL_ENABLE_TUI),0)
+  # The tui native bridge moves to libhull_feature-tui.a (composed feature) —
+  # drop it from the base, which carries only the weak feature hooks
+  # (cap/tui_feature.c). Pairs with the cap/tui.c + tui_input.c filter above.
+  LUA_RT_SRCS := $(filter-out \
+      $(SRCDIR)/hull/runtime/lua/mod_tui.c, \
       $(LUA_RT_SRCS))
 endif
 LUA_RT_OBJS := $(patsubst $(SRCDIR)/hull/runtime/lua/%.c,$(BUILDDIR)/lua_rt_%.o,$(LUA_RT_SRCS))
@@ -2481,6 +2497,30 @@ $(BUILDDIR)/libhull_feature-gpu.a: $(BUILDDIR)/cap_gpu_wgpu.o $(WGPU_LIB) | $(BU
 		mkdir -p $$tmproot/$$n && ( cd $$tmproot/$$n && $(AR) x $(CURDIR)/$$a ) && \
 		$(AR) rcs $(CURDIR)/$@ $$tmproot/$$n/*.o && n=$$((n+1)); \
 	done; rm -rf $$tmproot
+	@echo "built $@ ($$(du -h $@ | cut -f1))"
+
+# ── TUI feature archive (composable feature: hull build --with=tui) ──
+# libhull_feature-tui.a bundles the whole TUI subsystem: the cap layer
+# (cap_tui.o + cap_tui_input.o) and both runtime bridges (lua_rt_mod_tui.o +
+# js_mod_tui.o). Those objects carry the STRONG overrides of the base's weak
+# feature hooks (hl_tui_feature_present in cap/tui.c; hl_tui_feature_register_lua
+# / _js in the mod_tui.c files), so composing the archive lights TUI up. Unlike
+# a backend feature (duckdb/gpu) there is no single entry symbol, so the compose
+# link must whole-archive / -force_load this lib to pull every member (wired in
+# build.lua's FEATURE_SPECS.tui, Phase 1.3). No vendored lib and no extra link
+# libs (TUI is pure POSIX termios). cap_tui_width.o (data table) and
+# cap_tui_feature.o (weak base hooks) intentionally stay in the base.
+# `feature-tui` re-invokes make with HL_ENABLE_TUI=1 so the subsystem objects
+# (filtered out of a base build) are in scope.
+feature-tui:
+	$(MAKE) $(BUILDDIR)/libhull_feature-tui.a HL_ENABLE_TUI=1
+.PHONY: feature-tui
+
+$(BUILDDIR)/libhull_feature-tui.a: $(BUILDDIR)/cap_tui.o $(BUILDDIR)/cap_tui_input.o \
+                                   $(BUILDDIR)/lua_rt_mod_tui.o $(BUILDDIR)/js_mod_tui.o | $(BUILDDIR)
+	@rm -f $@
+	$(AR) rcs $@ $(BUILDDIR)/cap_tui.o $(BUILDDIR)/cap_tui_input.o \
+	            $(BUILDDIR)/lua_rt_mod_tui.o $(BUILDDIR)/js_mod_tui.o
 	@echo "built $@ ($$(du -h $@ | cut -f1))"
 
 # Multi-arch cosmo platform: build x86_64 and aarch64 archives

--- a/include/hull/cap/tui.h
+++ b/include/hull/cap/tui.h
@@ -295,6 +295,16 @@ int hl_cap_tui_enable_kitty_kbd(HlTuiCtx *ctx, int on);
  */
 int hl_tui_feature_present(void);
 
+/* Per-runtime registration hooks for the composed tui feature. The base ships
+ * weak no-ops (cap/tui_feature.c); libhull_feature-tui.a provides strong
+ * overrides that register the native tui bridge (hull._tui / hull:tui). These
+ * take runtime types (lua_State* / JSContext* + HlJS*), so the strong overrides
+ * live in the feature archive (compiled with full runtime includes), NOT in the
+ * generated feature registry. Declared here as void* to avoid pulling lua.h /
+ * quickjs.h into every consumer of tui.h; the impl casts back. */
+void hl_tui_feature_register_lua(void *lua_state);
+int  hl_tui_feature_register_js(void *js_ctx, void *hl_js);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/hull/cap/tui.c
+++ b/src/hull/cap/tui.c
@@ -1082,3 +1082,14 @@ int hl_cap_tui_enable_kitty_kbd(HlTuiCtx *ctx, int on)
     ctx->kitty_kbd_on = !!on;
     return 0;
 }
+
+/* ── Composable-feature seam (strong overrides) ─────────────────────
+ * This TU compiles only when the TUI subsystem is present (a monolithic
+ * HL_ENABLE_TUI build, or bundled into libhull_feature-tui.a). Its very
+ * presence is the signal, so the strong hl_tui_feature_present overrides the
+ * base weak default (cap/tui_feature.c) and reports the tui cap to the resolver.
+ * The per-runtime register hooks are strong-overridden in the mod_tui.c files. */
+int hl_tui_feature_present(void)
+{
+    return 1;
+}

--- a/src/hull/cap/tui_feature.c
+++ b/src/hull/cap/tui_feature.c
@@ -24,3 +24,19 @@ int hl_tui_feature_present(void)
 {
     return 0;
 }
+
+/* Weak no-op registration hooks: a base build registers no tui bridge. The
+ * feature archive's strong overrides do the real per-runtime registration. */
+__attribute__((weak))
+void hl_tui_feature_register_lua(void *lua_state)
+{
+    (void)lua_state;
+}
+
+__attribute__((weak))
+int hl_tui_feature_register_js(void *js_ctx, void *hl_js)
+{
+    (void)js_ctx;
+    (void)hl_js;
+    return 0;
+}

--- a/src/hull/commands/dev.c
+++ b/src/hull/commands/dev.c
@@ -159,6 +159,14 @@ static const char *dev_detect_entry(void)
 }
 
 /* ── Dev state singleton (used by `hull dev --tui`) ──────────────── */
+/* The whole dev-state machinery exists solely for `hull dev --tui`: the
+ * singleton is only ever initialized by run_dev_tui, and its sole consumers are
+ * the tool.dev_* bindings that back the dev_tui Lua tool. So the entire block is
+ * TUI-only — the tool.dev_* bindings in tool_orchestration.c carry the matching
+ * HL_ENABLE_TUI gate. On a TUI-off build (including a base that composes TUI as
+ * a feature) it's all excluded, avoiding both unused-function (-Werror) and the
+ * "g_dev_state_inited always false" tautology (cppcheck). */
+#ifdef HL_ENABLE_TUI
 
 static HlDevState g_dev_state;
 static int        g_dev_state_inited = 0;
@@ -375,6 +383,8 @@ static int run_dev_tui(int argc, char **argv,
     g_dev_state_inited = 0;
     return rc;
 }
+
+#endif /* HL_ENABLE_TUI */
 
 /* ── Main ─────────────────────────────────────────────────────────── */
 

--- a/src/hull/runtime/js/mod_tui.c
+++ b/src/hull/runtime/js/mod_tui.c
@@ -549,4 +549,13 @@ int hl_js_init_tui_module(JSContext *ctx, HlJS *js)
     return 0;
 }
 
+/* Strong override of the base weak hl_tui_feature_register_js
+ * (cap/tui_feature.c): register the hull:_tui native module. Called
+ * unconditionally from js/modules.c; in a base build with no tui feature the
+ * weak no-op runs. void* params keep JS types out of tui.h. */
+int hl_tui_feature_register_js(void *js_ctx, void *hl_js)
+{
+    return hl_js_init_tui_module((JSContext *)js_ctx, (HlJS *)hl_js);
+}
+
 #endif /* HL_ENABLE_TUI */

--- a/src/hull/runtime/js/modules.c
+++ b/src/hull/runtime/js/modules.c
@@ -10,6 +10,7 @@
 
 #include "mod_buffer.h"
 #include "internal.h"  /* hl_js_request_register, hl_js_sse_register_class */
+#include "hull/cap/tui.h"  /* hl_tui_feature_register_js (composed-feature seam) */
 
 /* ════════════════════════════════════════════════════════════════════
  * Module registry — called by hl_js_init() to register all
@@ -117,12 +118,13 @@ int hl_js_register_modules(HlJS *js)
             return -1;
     }
 
-#ifdef HL_ENABLE_TUI
-    /* Register hull:tui module — gated at use time by the resolver
-     * (requires HL_ENABLE_TUI + manifest.tui). */
-    if (hl_js_init_tui_module(js->ctx, js) != 0)
+    /* TUI native module — registered by the tui feature (monolithic
+     * HL_ENABLE_TUI or a composed --with=tui). Base ships a weak no-op; the
+     * feature's strong override calls hl_js_init_tui_module. Gated at use time
+     * by the resolver (requires the tui cap + manifest.tui). Unconditional so a
+     * composed binary picks it up without HL_ENABLE_TUI. */
+    if (hl_tui_feature_register_js(js->ctx, js) != 0)
         return -1;
-#endif
 
 #ifdef HL_ENABLE_HTTP_SERVER
     /* hull:web:ws-server + hull:web:ws-client (now in mod_ws_server.c +

--- a/src/hull/runtime/lua/mod_tui.c
+++ b/src/hull/runtime/lua/mod_tui.c
@@ -585,4 +585,15 @@ int luaopen_hull_tui(lua_State *L)
     return 1;
 }
 
+/* Strong override of the base weak hl_tui_feature_register_lua
+ * (cap/tui_feature.c): register the hull._tui native bridge. Called
+ * unconditionally from lua/modules.c; in a base build with no tui feature the
+ * weak no-op runs instead. void* param keeps lua types out of tui.h. */
+void hl_tui_feature_register_lua(void *lua_state)
+{
+    lua_State *L = (lua_State *)lua_state;
+    luaL_requiref(L, "hull._tui", luaopen_hull_tui, 0);
+    lua_pop(L, 1); /* drop the module value luaL_requiref left on the stack */
+}
+
 #endif /* HL_ENABLE_TUI */

--- a/src/hull/runtime/lua/modules.c
+++ b/src/hull/runtime/lua/modules.c
@@ -15,6 +15,7 @@
 
 #include "mod_buffer.h"
 #include "internal.h"  /* hl_lua_request_register, hl_lua_sse_register_mt */
+#include "hull/cap/tui.h"  /* hl_tui_feature_register_lua (composed-feature seam) */
 
 /* Register a native module so `require("hull.X")` finds it via the
  * _LOADED bridge in hl_lua_require, but do NOT set it as a global. */
@@ -106,13 +107,12 @@ int hl_lua_register_modules(HlLua *lua)
     if (lua->base.gpu_ctx)
         register_native_module(L, "hull.gpu", luaopen_hull_gpu);
 
-#ifdef HL_ENABLE_TUI
-    /* Native bridge — the user-facing module is the stdlib Lua file
-     * at stdlib/lua/hull/tui.lua, which `require`s the bridge below
-     * and layers tui.run / tui.list / tui.confirm on top. Underscore
-     * prefix keeps it out of the public module registry. */
-    register_native_module(L, "hull._tui", luaopen_hull_tui);
-#endif
+    /* TUI native bridge — registered by the tui feature (a monolithic
+     * HL_ENABLE_TUI build or a composed --with=tui). The base ships a weak
+     * no-op; the feature's strong override registers hull._tui (the underscore
+     * bridge that stdlib/lua/hull/tui.lua layers tui.run/list/confirm on top
+     * of). Unconditional so a composed binary picks it up without HL_ENABLE_TUI. */
+    hl_tui_feature_register_lua(L);
 
 #ifdef HL_ENABLE_HTTP_SERVER
     /* SSE stream metatable (used by app.sse handler dispatch). */

--- a/src/hull/tool_orchestration.c
+++ b/src/hull/tool_orchestration.c
@@ -449,9 +449,11 @@ static int l_tool_modules_available(lua_State *L)
 /* All dev_* accessors consult hl_dev_state(), which is a no-op
  * (returns nil / safe defaults) when hull dev --tui isn't running.
  * That lets the stdlib's *_tui modules load cleanly in tests too.
- * hl_dev_state lives in the inbound-HTTP-server set (it backs `hull dev`),
- * so these bindings ship only when HL_ENABLE_HTTP_SERVER is on. */
-#ifdef HL_ENABLE_HTTP_SERVER
+ * The dev-state machinery (commands/dev.c) exists solely for `hull dev --tui`,
+ * so it — and these bindings — need BOTH the inbound-HTTP server (hull dev) and
+ * the TUI subsystem. On a TUI-off build (base composing TUI as a feature) they
+ * drop out together with the dev-state singleton. */
+#if defined(HL_ENABLE_HTTP_SERVER) && defined(HL_ENABLE_TUI)
 
 static int l_tool_dev_status(lua_State *L)
 {
@@ -523,7 +525,7 @@ static int l_tool_dev_reload(lua_State *L)
     return 1;
 }
 
-#endif /* HL_ENABLE_HTTP_SERVER */
+#endif /* HL_ENABLE_HTTP_SERVER && HL_ENABLE_TUI */
 
 /* ── Registration ──────────────────────────────────────────────────── */
 
@@ -547,7 +549,7 @@ void hl_lua_tool_register_orchestration(lua_State *L)
 #endif
         { "agent_context",          l_tool_agent_context },
         { "modules_available",      l_tool_modules_available },
-#ifdef HL_ENABLE_HTTP_SERVER
+#if defined(HL_ENABLE_HTTP_SERVER) && defined(HL_ENABLE_TUI)
         { "dev_status",             l_tool_dev_status },
         { "dev_drain",              l_tool_dev_drain },
         { "dev_recent_lines",       l_tool_dev_recent_lines },


### PR DESCRIPTION
Completes making TUI a composable feature: the base can now build WITHOUT the
TUI subsystem (HL_ENABLE_TUI=0), and `make feature-tui` bundles it into
libhull_feature-tui.a to compose back in. Proven end to end: a TUI=0 base binary
+ the feature archive (force_load) admits hull/tui and registers the working
hull.tui module.

The registration seam (TUI has no backend vtable and no serve.c init, unlike GPU,
so the whole cap+bindings move):
- cap/tui_feature.c: extend the base weak hooks — hl_tui_feature_register_lua /
  _js (no-ops) alongside hl_tui_feature_present (0).
- Strong overrides live where the subsystem does, compiled only under
  HL_ENABLE_TUI: hl_tui_feature_present in cap/tui.c; register_lua in
  runtime/lua/mod_tui.c (luaL_requiref hull._tui); register_js in
  runtime/js/mod_tui.c. In a monolithic build the strong defs win over the weak
  base defs; in a base build the weak no-ops run.
- runtime/{lua,js}/modules.c: call the register hook unconditionally (no
  #ifdef), so a composed binary registers tui without HL_ENABLE_TUI.

Makefile:
- Filter the mod_tui runtime bridges (lua/mod_tui.c, js/mod_tui.c) out of the
  base under HL_ENABLE_TUI=0, matching the existing cap/tui.c + tui_input.c
  filter. cap/tui_width.c (data table) and cap/tui_feature.c (weak hooks) stay
  base-resident.
- New `make feature-tui` -> libhull_feature-tui.a (cap_tui.o + cap_tui_input.o +
  lua_rt_mod_tui.o + js_mod_tui.o). No vendored lib, no extra link libs (pure
  POSIX termios). A subsystem feature has no single entry symbol, so the compose
  link must whole-archive / -force_load it (wired in Phase 1.3's FEATURE_SPECS).

Also fixes a pre-existing HL_ENABLE_TUI=0 build break: commands/dev.c
run_dev_tui was unused-function under -Werror when TUI is off. Guarded just that
function (the dev-state accessors stay compiled — the tool layer's tool.dev_*
bindings consume them regardless of TUI). That config wasn't CI-tested.

Verified: default monolithic build + full unit suite; HL_ENABLE_TUI=0 base
builds (~40 KB smaller) and correctly rejects a tui app / runs a plain app;
cosmo builds; make feature-tui archive + composed binary runs a tui app.

Phase 1.3 (next): FEATURES[]/FEATURE_SPECS.tui (subsystem shape with force_load)
+ resolver auto-compose from a declared hull/tui + feature install + release job,
then --flavor=auto can drop TUI for apps that don't use it.

Signed-off-by: Mark Farkas <mark@artalis.io>
