### PR TITLE
feat(tui): hull build --with=tui + feature install + release (Phase 1.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -916,6 +916,21 @@ jobs:
         timeout-minutes: 15
         run: sh tests/e2e_feature_gpu.sh
 
+  # TUI as a composable FEATURE. Own fresh build tree. Builds a TUI-free base
+  # (EMBED_PLATFORM=1 HL_ENABLE_TUI=0) + the tui feature archive, then
+  # `hull build --with=tui` an app and boots it (asserts hull.tui registered).
+  # Pure C, no vendored lib and no extra link libs, so no install step.
+  tui-feature:
+    name: TUI feature build (Linux)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+      - name: Compose the TUI feature into an app binary (e2e)
+        timeout-minutes: 15
+        run: sh tests/e2e_feature_tui.sh
+
   coverage:
     name: Code Coverage
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -809,10 +809,51 @@ jobs:
           name: feature-gpu-${{ matrix.name }}
           path: libhull_feature-gpu-${{ matrix.name }}.a
 
+  build-feature-tui:
+    # Composable TUI feature archive (libhull_feature-tui-<arch>.a), pulled by
+    # `hull feature install tui` -> `hull build --with=tui`. TUI is a
+    # whole_archive feature (the compose force-loads it); pure C, no vendored lib
+    # and no extra link libs (POSIX termios), so this is the simplest feature
+    # job: no fetch, no toolchain install, no symbol isolation. `make
+    # feature-tui` re-invokes make with HL_ENABLE_TUI=1. Native-only; covered by
+    # the release signature only. See docs/features_and_flavors.md.
+    name: Build feature tui (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            os: ubuntu-24.04
+          - name: linux-aarch64
+            os: ubuntu-24.04-arm
+          - name: darwin-arm64
+            os: macos-15
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+
+      - name: Write VERSION file
+        run: echo "${GITHUB_REF_NAME#v}" > VERSION
+
+      - name: Build TUI feature archive
+        run: make feature-tui
+
+      - name: Rename artifact (arch-qualified)
+        run: mv build/libhull_feature-tui.a libhull_feature-tui-${{ matrix.name }}.a
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: feature-tui-${{ matrix.name }}
+          path: libhull_feature-tui-${{ matrix.name }}.a
+
   release:
     name: Create Release
     runs-on: ubuntu-24.04
-    needs: [build-cosmo, build-native, build-wamrc, build-platform-cosmo-flavors, build-feature-native, build-feature-gpu]
+    needs: [build-cosmo, build-native, build-wamrc, build-platform-cosmo-flavors, build-feature-native, build-feature-gpu, build-feature-tui]
     permissions:
       contents: write       # publish GitHub release + assets
       id-token: write       # SLSA: OIDC for Sigstore signing
@@ -865,6 +906,12 @@ jobs:
           mv artifacts/feature-gpu-linux-x86_64/*.a   dist/
           mv artifacts/feature-gpu-linux-aarch64/*.a  dist/
           mv artifacts/feature-gpu-darwin-arm64/*.a   dist/
+          # Composable TUI feature archives (libhull_feature-tui-<arch>.a),
+          # native-only. Pulled by `hull feature install tui`. Covered by the
+          # libhull_feature-*.a glob in the SHA-256 + publish steps below.
+          mv artifacts/feature-tui-linux-x86_64/*.a   dist/
+          mv artifacts/feature-tui-linux-aarch64/*.a  dist/
+          mv artifacts/feature-tui-darwin-arm64/*.a   dist/
 
       - name: Make binaries executable
         run: chmod +x dist/*

--- a/Makefile
+++ b/Makefile
@@ -1493,12 +1493,18 @@ ifeq ($(HL_ENABLE_HTTP_SERVER),0)
       $(CAP_SRCS))
 endif
 ifeq ($(HL_ENABLE_TUI),0)
-  # Drop the TUI capability when disabled. cap/tui_width.c stays
-  # compiled regardless — it's a pure data-table lookup with no
-  # platform deps, useful elsewhere.
+  # Drop the TUI capability when disabled. cap/tui_width.c is dropped too: its
+  # symbols (hl_tui_cp_width / hl_tui_utf8_decode) are used ONLY by cap/tui.c +
+  # cap/tui_input.c, so it's dead weight in a TUI-free base and, crucially, must
+  # travel WITH the tui feature archive so a whole-archive compose resolves those
+  # references internally (GNU ld can't satisfy a force-loaded archive's refs from
+  # an already-processed base lib). It's bundled into libhull_feature-tui.a below.
+  # cap/tui_feature.c (the weak base hooks) is NOT dropped -- it stays
+  # base-resident so hl_tui_feature_present always resolves.
   CAP_SRCS := $(filter-out \
       $(SRCDIR)/hull/cap/tui.c \
-      $(SRCDIR)/hull/cap/tui_input.c, \
+      $(SRCDIR)/hull/cap/tui_input.c \
+      $(SRCDIR)/hull/cap/tui_width.c, \
       $(CAP_SRCS))
 endif
 CAP_OBJS := $(patsubst $(SRCDIR)/hull/cap/%.c,$(BUILDDIR)/cap_%.o,$(CAP_SRCS))
@@ -2501,25 +2507,29 @@ $(BUILDDIR)/libhull_feature-gpu.a: $(BUILDDIR)/cap_gpu_wgpu.o $(WGPU_LIB) | $(BU
 
 # ── TUI feature archive (composable feature: hull build --with=tui) ──
 # libhull_feature-tui.a bundles the whole TUI subsystem: the cap layer
-# (cap_tui.o + cap_tui_input.o) and both runtime bridges (lua_rt_mod_tui.o +
-# js_mod_tui.o). Those objects carry the STRONG overrides of the base's weak
-# feature hooks (hl_tui_feature_present in cap/tui.c; hl_tui_feature_register_lua
-# / _js in the mod_tui.c files), so composing the archive lights TUI up. Unlike
-# a backend feature (duckdb/gpu) there is no single entry symbol, so the compose
-# link must whole-archive / -force_load this lib to pull every member (wired in
-# build.lua's FEATURE_SPECS.tui, Phase 1.3). No vendored lib and no extra link
-# libs (TUI is pure POSIX termios). cap_tui_width.o (data table) and
-# cap_tui_feature.o (weak base hooks) intentionally stay in the base.
-# `feature-tui` re-invokes make with HL_ENABLE_TUI=1 so the subsystem objects
-# (filtered out of a base build) are in scope.
+# (cap_tui.o + cap_tui_input.o + cap_tui_width.o) and both runtime bridges
+# (lua_rt_mod_tui.o + js_mod_tui.o). Those objects carry the STRONG overrides of
+# the base's weak feature hooks (hl_tui_feature_present in cap/tui.c;
+# hl_tui_feature_register_lua / _js in the mod_tui.c files), so composing the
+# archive lights TUI up. Unlike a backend feature (duckdb/gpu) there is no single
+# entry symbol, so the compose link must whole-archive / -force_load this lib to
+# pull every member (wired in build.lua's FEATURE_SPECS.tui). The archive is
+# SELF-CONTAINED: cap_tui_width.o (used only by the tui trio) travels with it so
+# a GNU-ld whole-archive compose resolves its refs internally. No vendored lib
+# and no extra link libs (TUI is pure POSIX termios). cap_tui_feature.o (weak
+# base hooks) stays base-resident. `feature-tui` re-invokes make with
+# HL_ENABLE_TUI=1 so the subsystem objects (filtered out of a base build) are in
+# scope.
 feature-tui:
 	$(MAKE) $(BUILDDIR)/libhull_feature-tui.a HL_ENABLE_TUI=1
 .PHONY: feature-tui
 
 $(BUILDDIR)/libhull_feature-tui.a: $(BUILDDIR)/cap_tui.o $(BUILDDIR)/cap_tui_input.o \
+                                   $(BUILDDIR)/cap_tui_width.o \
                                    $(BUILDDIR)/lua_rt_mod_tui.o $(BUILDDIR)/js_mod_tui.o | $(BUILDDIR)
 	@rm -f $@
 	$(AR) rcs $@ $(BUILDDIR)/cap_tui.o $(BUILDDIR)/cap_tui_input.o \
+	            $(BUILDDIR)/cap_tui_width.o \
 	            $(BUILDDIR)/lua_rt_mod_tui.o $(BUILDDIR)/js_mod_tui.o
 	@echo "built $@ ($$(du -h $@ | cut -f1))"
 

--- a/src/hull/cap/tool.c
+++ b/src/hull/cap/tool.c
@@ -176,6 +176,15 @@ int hl_tool_validate_args(const char *const argv[])
                 "--no-entry", "--export=", "--export-all", "--allow-undefined",
                 "--initial-memory=", "--max-memory=", "--stack-first",
                 "--import-memory", "--export-memory", "--shared-memory",
+                /* Composable-feature whole-archive linking (`hull build
+                 * --with=<feature>` for a whole_archive feature like tui). These
+                 * only control WHICH members of an archive are pulled -- no
+                 * plugin load, no codegen, no code execution (contrast the
+                 * blocked -load / -Xlinker / @response). build.lua emits them
+                 * solely for the trusted FEATURE_SPECS feature archive, whose
+                 * path it controls; the build sandbox's unveil bounds the path. */
+                "-force_load,",       /* macOS ld64: -Wl,-force_load,<archive> */
+                "--whole-archive", "--no-whole-archive",  /* GNU ld / lld bracket */
                 NULL
             };
             const char *wl_arg = a + 4;

--- a/src/hull/commands/feature.c
+++ b/src/hull/commands/feature.c
@@ -59,6 +59,7 @@ typedef struct {
 static const HlFeatureSpec FEATURES[] = {
     { "duckdb", "DuckDB embedded OLAP SQL backend (duckdb://)", 1, 1, 1 },
     { "gpu",    "GPU compute via wgpu-native (Vulkan/Metal)",   1, 1, 1 },
+    { "tui",    "Terminal UI (hull.tui: full-screen, input, cell-diff)", 1, 1, 1 },
 };
 
 static const HlFeatureSpec *feature_find(const char *name)

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1234,12 +1234,18 @@ int main(int argc, char **argv) { return hull_main(argc, argv); }
     -- extract_app_manifest EXECUTES app.lua and re-running it corrupts the sign
     -- flow; a side-effect-free manifest read is a tracked follow-up.)
     --
-    -- FEATURE_SPECS is the single source of truth for the codegen: per feature,
-    -- the backend symbol its archive exports, that backend's vtable type, the
-    -- base weak hook it fills, whether it is C++ (needs a system compiler + C++
-    -- runtime), and its extra link libs. Adding a feature is one row here + a
-    -- `make feature-<name>` archive + a release-pipeline entry -- and, for a NEW
-    -- subsystem kind, a weak hook in that (always-base-resident) cap layer.
+    -- FEATURE_SPECS is the single source of truth per feature. A feature that
+    -- contributes a backend to a base hook that returns an ARRAY (so several
+    -- features could feed one hook) carries { backend, type, hook }: the compose
+    -- step generates one strong collector filling that hook. A feature whose
+    -- base hooks each have exactly one provider carries no backend/hook; instead
+    -- `whole_archive = true` tells the compose step to force-load its archive so
+    -- the strong overrides (spread across its object files, with no single
+    -- backend symbol to anchor on) all get pulled. `whole_archive` is a plain
+    -- per-feature LINK attribute, sibling to `cxx` -- not a second kind of
+    -- feature. Other fields: `cxx` (needs a system compiler + C++ runtime) and
+    -- `libs` (extra link libs). Adding a feature is one row here + a
+    -- `make feature-<name>` archive + a release-pipeline entry.
     local FEATURE_SPECS = {
         duckdb = {
             backend = "hl_db_backend_duckdb",
@@ -1258,6 +1264,17 @@ int main(int argc, char **argv) { return hull_main(argc, argv); }
             libs = { darwin = { "-framework", "Metal", "-framework", "QuartzCore",
                                 "-framework", "CoreGraphics", "-framework", "Foundation" },
                      other  = { "-lvulkan" } },
+        },
+        -- tui: the whole TUI subsystem (cap + both runtime bridges) in
+        -- libhull_feature-tui.a (`make feature-tui`). Its base hooks
+        -- (hl_tui_feature_present / register_lua / register_js) each have one
+        -- provider, and the strong overrides live across several object files
+        -- with no single backend symbol, so the archive is whole-archive-linked
+        -- (force_load) rather than pull-by-backend-symbol. Pure C, no extra libs
+        -- (POSIX termios).
+        tui = {
+            whole_archive = true, cxx = false,
+            libs = { darwin = {}, other = {} },
         },
     }
     local features_needed = {}
@@ -1319,17 +1336,34 @@ int main(int argc, char **argv) { return hull_main(argc, argv); }
             end
             local dest = tmpdir .. "/" .. libname
             tool.copy(lib, dest)
-            feature_libs[#feature_libs + 1] = dest
+            local is_darwin = plat and plat:sub(1, 6) == "darwin"
+
+            if spec.whole_archive then
+                -- Force-load the whole archive: its strong overrides of the
+                -- base weak hooks are spread across several object files with no
+                -- single backend symbol to anchor a selective pull. macOS uses
+                -- -force_load <lib>; the GNU ld / lld path uses the
+                -- --whole-archive ... --no-whole-archive bracket.
+                if is_darwin then
+                    feature_libs[#feature_libs + 1] = "-Wl,-force_load," .. dest
+                else
+                    feature_libs[#feature_libs + 1] = "-Wl,--whole-archive"
+                    feature_libs[#feature_libs + 1] = dest
+                    feature_libs[#feature_libs + 1] = "-Wl,--no-whole-archive"
+                end
+            else
+                -- Backend feature: linked plainly; the generated registry's
+                -- extern-&backend reference pulls the backend object.
+                feature_libs[#feature_libs + 1] = dest
+                by_hook[spec.hook] = by_hook[spec.hook] or { type = spec.type, backends = {} }
+                local g = by_hook[spec.hook]
+                g.backends[#g.backends + 1] = spec.backend
+            end
 
             -- Per-feature link libs (C++ runtime / native frameworks / -lvulkan).
-            local platlibs = (plat and plat:sub(1, 6) == "darwin")
-                             and (spec.libs.darwin or {}) or (spec.libs.other or {})
+            local platlibs = is_darwin and (spec.libs.darwin or {})
+                                        or  (spec.libs.other or {})
             for _, l in ipairs(platlibs) do feature_libs[#feature_libs + 1] = l end
-
-            -- Group this backend under its base hook (subsystem kind).
-            by_hook[spec.hook] = by_hook[spec.hook] or { type = spec.type, backends = {} }
-            local g = by_hook[spec.hook]
-            g.backends[#g.backends + 1] = spec.backend
 
             print("hull build: composed feature '" .. fname .. "'"
                   .. (from_cache and " (~/.hull/feature)" or " (local)"))
@@ -1346,37 +1380,42 @@ int main(int argc, char **argv) { return hull_main(argc, argv); }
             tool.rmdir(tmpdir); tool.exit(1)
         end
 
-        -- Generate ONE registry filling each base weak hook with the STRONG
-        -- override returning that kind's composed backends. Self-contained (no
-        -- <stddef.h>: these files compile with a bare include path; size_t comes
-        -- from the compiler builtin, ABI-exact under tcc/gcc/clang).
-        local reg = {
-            "/* Auto-generated by hull build — do not edit. */",
-            "typedef __SIZE_TYPE__ size_t;",
-        }
-        for hook, g in pairs(by_hook) do
-            reg[#reg + 1] = "typedef struct " .. g.type .. " " .. g.type .. ";"
-            local addrs = {}
-            for i, b in ipairs(g.backends) do
-                reg[#reg + 1] = "extern const " .. g.type .. " " .. b .. ";"
-                addrs[i] = "&" .. b
+        -- Generate ONE registry filling each aggregating base hook with the
+        -- STRONG override returning that kind's composed backends. Only backend
+        -- features populate `by_hook`; a compose of only whole_archive features
+        -- (e.g. --with=tui alone) needs no registry (its strong overrides come
+        -- straight from the force-loaded archive). Self-contained (no <stddef.h>:
+        -- these files compile with a bare include path; size_t comes from the
+        -- compiler builtin, ABI-exact under tcc/gcc/clang).
+        if next(by_hook) then
+            local reg = {
+                "/* Auto-generated by hull build — do not edit. */",
+                "typedef __SIZE_TYPE__ size_t;",
+            }
+            for hook, g in pairs(by_hook) do
+                reg[#reg + 1] = "typedef struct " .. g.type .. " " .. g.type .. ";"
+                local addrs = {}
+                for i, b in ipairs(g.backends) do
+                    reg[#reg + 1] = "extern const " .. g.type .. " " .. b .. ";"
+                    addrs[i] = "&" .. b
+                end
+                local arr = "HL_FEAT_" .. hook
+                reg[#reg + 1] = "static const " .. g.type .. " *const " .. arr
+                                .. "[] = { " .. table.concat(addrs, ", ") .. " };"
+                reg[#reg + 1] = "const " .. g.type .. " *const *" .. hook .. "(size_t *count) {"
+                reg[#reg + 1] = "    if (count) *count = " .. #g.backends .. ";"
+                reg[#reg + 1] = "    return " .. arr .. ";"
+                reg[#reg + 1] = "}"
             end
-            local arr = "HL_FEAT_" .. hook
-            reg[#reg + 1] = "static const " .. g.type .. " *const " .. arr
-                            .. "[] = { " .. table.concat(addrs, ", ") .. " };"
-            reg[#reg + 1] = "const " .. g.type .. " *const *" .. hook .. "(size_t *count) {"
-            reg[#reg + 1] = "    if (count) *count = " .. #g.backends .. ";"
-            reg[#reg + 1] = "    return " .. arr .. ";"
-            reg[#reg + 1] = "}"
+            reg[#reg + 1] = ""
+            write_file(tmpdir .. "/feature_registry.c", table.concat(reg, "\n"))
+            if not tool.compiler.compile(tmpdir .. "/feature_registry.c",
+                                         tmpdir .. "/feature_registry.o", nil) then
+                tool.stderr("hull build: compilation failed (feature_registry.c)\n")
+                tool.rmdir(tmpdir); tool.exit(1)
+            end
+            feature_objs[#feature_objs + 1] = tmpdir .. "/feature_registry.o"
         end
-        reg[#reg + 1] = ""
-        write_file(tmpdir .. "/feature_registry.c", table.concat(reg, "\n"))
-        if not tool.compiler.compile(tmpdir .. "/feature_registry.c",
-                                     tmpdir .. "/feature_registry.o", nil) then
-            tool.stderr("hull build: compilation failed (feature_registry.c)\n")
-            tool.rmdir(tmpdir); tool.exit(1)
-        end
-        feature_objs[#feature_objs + 1] = tmpdir .. "/feature_registry.o"
     end
 
     -- Link

--- a/tests/e2e_feature_tui.sh
+++ b/tests/e2e_feature_tui.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# e2e_feature_tui.sh - TUI as a composable feature, end to end.
+#
+# Builds a BASE hull with a TUI-FREE platform (EMBED_PLATFORM=1 HL_ENABLE_TUI=0)
+# + the TUI feature archive, then `hull build --with=tui` an app and boots it.
+# Proves that `hull build` whole-archive-links libhull_feature-tui.a into the app
+# so the resolver admits hull/tui and the runtime registers the module, while a
+# plain app stays TUI-free and a base build (no --with=tui) rejects a tui app.
+#
+# Unlike GPU/DuckDB (backend features with a generated collector), TUI is a
+# whole_archive feature: its strong overrides of the base weak hooks
+# (hl_tui_feature_present / register_lua / register_js) are spread across the
+# archive's object files with no single backend symbol, so build.lua force-loads
+# the archive (FEATURE_SPECS.tui: whole_archive = true). No dispatch to check
+# (tui.run needs a real tty), so the app asserts the module registered
+# (require + tui.run is a function). --compiler=system: the whole-archive link
+# flag isn't reliably supported by the embedded TinyCC.
+#
+# Must run on a fresh build tree. Native only. In its own CI job.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+cd "$(dirname "$0")/.."
+
+echo "=== build base hull (EMBED_PLATFORM=1 HL_ENABLE_TUI=0; base is TUI-free) ==="
+make EMBED_PLATFORM=1 HL_ENABLE_TUI=0 >/dev/null
+# Stash the base hull: `make feature-tui` re-invokes make with HL_ENABLE_TUI=1
+# and the build-config sentinel cleans build/ on the flag flip.
+cp build/hull /tmp/hull_base_tui_e2e
+
+echo "=== build the TUI feature archive ==="
+make feature-tui >/dev/null
+ls -la build/libhull_feature-tui.a
+# Strong overrides present? (macOS nm prefixes a leading '_', Linux doesn't.)
+nm build/libhull_feature-tui.a 2>/dev/null | grep -qE '[ _]hl_tui_feature_present$' \
+    || { echo "FAIL: feature archive lacks hl_tui_feature_present"; exit 1; }
+
+HULL=/tmp/hull_base_tui_e2e
+APP=$(mktemp -d)
+PLAIN=$(mktemp -d)
+trap 'rm -rf "$APP" "$PLAIN" /tmp/hull_base_tui_e2e' EXIT
+
+cat > "$APP/app.lua" <<'LUA'
+app.manifest({ tui = true, modules = { "hull/tui@1" } })
+app.main(function()
+    -- The composed feature admits hull/tui and registers the native bridge that
+    -- stdlib/lua/hull/tui.lua layers tui.run/list/confirm on top of. No tty here,
+    -- so assert registration (require + tui.run is a function), not a full run.
+    local ok, tui = pcall(require, "hull.tui")
+    assert(ok and tui, "hull.tui not registered: " .. tostring(tui))
+    assert(type(tui.run) == "function", "tui.run missing")
+    print("TUI FEATURE APP OK")
+    return 0
+end)
+LUA
+
+echo "=== hull build --with=tui ==="
+BUILD_OUT=$("$HULL" build --compiler=system --with=tui --no-verify-platform -o "$APP/bin" "$APP" 2>&1) || true
+echo "$BUILD_OUT"
+echo "$BUILD_OUT" | grep -q "composed feature 'tui'" || { echo "FAIL: feature not composed"; exit 1; }
+test -x "$APP/bin" || { echo "FAIL: no composed binary produced"; exit 1; }
+
+echo "=== boot the composed binary ==="
+RUN_OUT=$("$APP/bin" 2>&1) || true
+echo "$RUN_OUT"
+echo "$RUN_OUT" | grep -q "TUI FEATURE APP OK" || {
+    echo "--- boot failed; diagnostics ---"
+    file "$APP/bin" 2>/dev/null || true
+    echo "FAIL: composed tui binary did not boot"; exit 1
+}
+echo "ok  --with=tui composed + booted"
+
+echo "=== negative: a plain app must NOT compose tui ==="
+printf 'app.manifest({modules={}})\napp.main(function() print("PLAIN OK") return 0 end)\n' \
+    > "$PLAIN/app.lua"
+PLAIN_OUT=$("$HULL" build --no-verify-platform -o "$PLAIN/bin" "$PLAIN" 2>&1) || true
+if echo "$PLAIN_OUT" | grep -q "composed feature"; then
+    echo "$PLAIN_OUT"; echo "FAIL: composed a feature for a plain app"; exit 1
+fi
+"$PLAIN/bin" 2>&1 | grep -q "PLAIN OK" || { echo "FAIL: plain app did not run"; exit 1; }
+echo "ok  plain app stayed TUI-free"
+
+# NOTE: the "base build (no --with=tui) rejects a tui app at load" case is
+# covered deterministically by the module_resolver unit tests
+# (tui_rejected_when_compiled_out). It is intentionally NOT re-asserted here: TUI
+# is on by default, so which platform `hull build` links for a bare rebuild is
+# build-state-dependent, making an e2e version of that assertion flaky (unlike
+# GPU, which is off by default so its base is reliably GPU-free).
+
+echo "PASS: TUI feature composed into an app binary; base stays TUI-free"


### PR DESCRIPTION
Wires the TUI composable feature end to end: `hull build --with=tui` composes
libhull_feature-tui.a into an app, `hull feature install tui` fetches it, and the
release pipeline builds + signs it. Proven: a TUI-free base (EMBED_PLATFORM=1
HL_ENABLE_TUI=0) + --with=tui admits hull/tui and registers the module; a plain
app stays TUI-free; a base build rejects a tui app at load.

TUI generalizes the feature model to a "whole_archive" feature WITHOUT a second
concept -- one FEATURE_SPECS table, one --with pipeline, one install/release path.
The only difference is a per-feature LINK attribute (sibling to the existing
`cxx`): a backend feature (duckdb/gpu) contributes to a hook that returns an
array, so the compose generates one collector; a whole_archive feature's strong
overrides are spread across its archive with no single backend symbol, so the
compose force-loads the archive instead. FEATURE_SPECS.tui carries
`whole_archive = true`.

- build.lua: branch the compose on `spec.whole_archive` -- force-load the archive
  (`-Wl,-force_load,<a>` on macOS ld64; `-Wl,--whole-archive .. --no-whole-archive`
  on GNU ld/lld) and skip the collector codegen (only backend features populate
  `by_hook`; guard the registry generation on `next(by_hook)`).
- cap/tool.c: allowlist the whole-archive linker flags in hl_tool_validate_args.
  They only control WHICH archive members are pulled -- no plugin load, no
  codegen, no code execution (contrast the still-blocked -load / -Xlinker /
  @response) -- and build.lua emits them solely for the trusted FEATURE_SPECS
  archive whose path it controls, bounded by the build sandbox's unveil.
- feature.c: FEATURES[] += tui (hull feature install/list tui).
- release.yml: a build-feature-tui matrix job (3 native platforms; no fetch, no
  toolchain install, no symbol isolation -- pure C) + flatten; covered by the
  existing libhull_feature-*.a SHA-256 + publish globs.
- ci.yml + tests/e2e_feature_tui.sh: a tui-feature job that builds the TUI-free
  base + archive, composes --with=tui, and asserts the app registers hull.tui.

Verified: default build + full suite (60/60); make lint-lua + cppcheck clean;
e2e_feature_tui.sh PASS locally; `hull feature list` shows tui.

Follow-on (Phase 1.4, a product decision): flip the default to HL_ENABLE_TUI=0 +
auto-compose tui from a declared hull/tui so `--flavor=auto` drops it for apps
that don't use it -- the actual leanness payoff, which changes the stock binary.

Signed-off-by: Mark Farkas <mark@artalis.io>
