### PR TITLE
feat(mysql): ship MySQL/MariaDB as a composable feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -942,6 +942,17 @@ jobs:
         timeout-minutes: 15
         run: sh tests/e2e_feature_postgres.sh
 
+  mysql-feature:
+    name: MySQL feature build (Linux)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+      - name: Compose the MySQL feature into an app binary (e2e)
+        timeout-minutes: 15
+        run: sh tests/e2e_feature_mysql.sh
+
   coverage:
     name: Code Coverage
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -932,10 +932,49 @@ jobs:
           name: feature-postgres-${{ matrix.name }}
           path: libhull_feature-postgres-${{ matrix.name }}.a
 
+  build-feature-mysql:
+    # Composable MySQL/MariaDB feature archive (libhull_feature-mysql-<arch>.a),
+    # pulled by `hull feature install mysql` -> `hull build --with=mysql`. One
+    # backend for mysql:// + mariadb://. Pure C (~4 KB wire client, no vendored
+    # engine), like postgres. `make feature-mysql` re-invokes make with
+    # HL_ENABLE_MYSQL=1. Native-only.
+    name: Build feature mysql (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            os: ubuntu-24.04
+          - name: linux-aarch64
+            os: ubuntu-24.04-arm
+          - name: darwin-arm64
+            os: macos-15
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+
+      - name: Write VERSION file
+        run: echo "${GITHUB_REF_NAME#v}" > VERSION
+
+      - name: Build MySQL feature archive
+        run: make feature-mysql
+
+      - name: Rename artifact (arch-qualified)
+        run: mv build/libhull_feature-mysql.a libhull_feature-mysql-${{ matrix.name }}.a
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: feature-mysql-${{ matrix.name }}
+          path: libhull_feature-mysql-${{ matrix.name }}.a
+
   release:
     name: Create Release
     runs-on: ubuntu-24.04
-    needs: [build-cosmo, build-native, build-wamrc, build-tcc, build-platform-cosmo-flavors, build-feature-native, build-feature-gpu, build-feature-tui, build-feature-postgres]
+    needs: [build-cosmo, build-native, build-wamrc, build-tcc, build-platform-cosmo-flavors, build-feature-native, build-feature-gpu, build-feature-tui, build-feature-postgres, build-feature-mysql]
     permissions:
       contents: write       # publish GitHub release + assets
       id-token: write       # SLSA: OIDC for Sigstore signing
@@ -1002,6 +1041,12 @@ jobs:
           mv artifacts/feature-postgres-linux-x86_64/*.a   dist/
           mv artifacts/feature-postgres-linux-aarch64/*.a  dist/
           mv artifacts/feature-postgres-darwin-arm64/*.a   dist/
+          # Composable MySQL/MariaDB feature archives (libhull_feature-mysql-<arch>.a),
+          # native-only. Pulled by `hull feature install mysql`. Covered by the
+          # libhull_feature-*.a glob in the SHA-256 + publish steps below.
+          mv artifacts/feature-mysql-linux-x86_64/*.a   dist/
+          mv artifacts/feature-mysql-linux-aarch64/*.a  dist/
+          mv artifacts/feature-mysql-darwin-arm64/*.a   dist/
 
       - name: Make binaries executable
         run: chmod +x dist/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ Hull's distribution is one binary; what's compiled into it is controlled by a sm
 | `HL_EMBED_CA_BUNDLE` | 1 | Drop Mozilla CA bundle (~200 KB, breaks HTTPS without system store) |
 | `HL_ENABLE_SQLITE` | 1 | Drop the SQLite backend (`cap/db_sqlite.c`, `cap/db_udf.c`, vendored `sqlite3.c`). A SQLite file path or `:memory:` DSN then has no backend. |
 | `HL_ENABLE_POSTGRES` | 0 | (Off by default.) On compiles the pure-C PostgreSQL wire backend (`cap/pgwire.c` + `cap/pg_conn.c` + `cap/db_postgres.c`; no libpq) into the base. A `postgres://` / `postgresql://` DSN selects it. Links the shared TLS client (`HL_LINK_TLS`) for SSL connections. Normally composed via the `postgres` **feature** (`hull build --with=postgres`) rather than set directly; the flag is the monolithic path and what `make feature-postgres` builds the archive with. See "Composable features" above and "PostgreSQL + multi-backend DB" below. |
-| `HL_ENABLE_MYSQL` | 0 | (Off by default.) On enables the pure-C MySQL / MariaDB wire backend (`cap/mysqlwire.c` + `cap/mysql_conn.c` + `cap/db_mysql.c`; no libmysql/libmariadb). A `mysql://` / `mariadb://` DSN selects it. Links the shared TLS client (`HL_LINK_TLS`). See "MySQL/MariaDB specifics" below. |
+| `HL_ENABLE_MYSQL` | 0 | (Off by default.) On compiles the pure-C MySQL / MariaDB wire backend (`cap/mysqlwire.c` + `cap/mysql_conn.c` + `cap/db_mysql.c`; no libmysql/libmariadb) into the base. A `mysql://` / `mariadb://` DSN selects it. Links the shared TLS client (`HL_LINK_TLS`). Normally composed via the `mysql` **feature** (`hull build --with=mysql`) rather than set directly; the flag is the monolithic path and what `make feature-mysql` builds the archive with. See "Composable features" above and "MySQL/MariaDB specifics" below. |
 | `HL_ENABLE_DB` | 1 | **Umbrella, derived** from the three granular flags: defined iff `HL_ENABLE_SQLITE`, `HL_ENABLE_POSTGRES`, or `HL_ENABLE_MYSQL` is on. Off (all granular off) drops `db.*` + `migrate.*` + worker-DB + the connection registry + DB-backed stdlib (session, ratelimit, idempotency, outbox, inbox, rbac, search). ~1.4 MB smaller. See "Compute-only builds" below. |
 | `HL_ENABLE_HTTP_SERVER` | 1 | Drop the inbound HTTP server: serve.c (KlServer setup), routing, body reader, WebSocket server (cap/ws), middleware, SSE, in-process test harness (cap/test, test_runner), and `hull dev/test/agent/mcp` commands. Apps must use `app.main(fn)` and may not declare `hull/http-server`, `hull/web/ws-server`, `hull/web/ws-client`, `hull/web/sse`, or any `hull/web/middleware/*`. See "HTTP build flavors" below. |
 | `HL_ENABLE_HTTP_CLIENT` | 1 | Drop the outbound HTTP/HTTPS client: `http.fetch` (cap/http + cap/http_async), SMTP send (cap/smtp), and `hull update` (which uses Keel's HTTPS client). Apps may not declare `hull/http-client`, `hull/smtp`, or `hull/email`. |
@@ -193,27 +193,32 @@ bolts a subsystem on. They compose (`M` flavors + `N` features publish `M+N`
 libs but build any of `M×N` combos). Design + rationale:
 [docs/features_and_flavors.md](docs/features_and_flavors.md).
 
-Four features ship today, all **native-only (no cosmo)**, published for all
+Five features ship today, all **native-only (no cosmo)**, published for all
 three native platforms (`linux-x86_64`, `linux-aarch64`, `darwin-arm64`):
 
 | Feature | What | Reached via |
 |---------|------|-------------|
 | `duckdb` | embedded DuckDB OLAP backend (~58 MB, C++) | a `duckdb://` DSN on `hull/db` |
 | `postgres` | pure-C PostgreSQL wire backend (~4 KB, no libpq) | a `postgres://` / `postgresql://` DSN on `hull/db` |
+| `mysql` | pure-C MySQL / MariaDB wire backend (~4 KB, no libmysql) | a `mysql://` / `mariadb://` DSN on `hull/db` |
 | `gpu` | wgpu-native GPU compute | `gpu.*` (the base ships the generic dispatch layer; the feature fills the concrete wgpu backend) |
 | `tui` | terminal UI subsystem (`hull.tui`) | `hull/tui` module (auto-inferred; force-loaded — see [docs/features_and_flavors.md](docs/features_and_flavors.md)) |
 
-`duckdb` and `postgres` are **backend features**: both fill the same weak
+`duckdb`, `postgres`, and `mysql` are **backend features**: all fill the same weak
 `hl_db_feature_backends` hook (DSN-scheme-selected via the `HlDbBackend` vtable),
-so `--with=duckdb --with=postgres` compose together into one generated collector.
-`postgres` is pure C (no vendored engine), so its archive is tiny; because its
-backend references base `tls_client` (sslmode) that a DB-only app doesn't
-otherwise pull, `hull build` wraps the platform lib + the pg archive in a GNU-ld
-`--start-group` at compose (Linux only; macOS ld64 rescans natively). Like
-DuckDB, the backend is reached by DSN and carries no module gate, so selection is
-**explicit `--with=postgres`** (DSNs are often `$VAR` env-refs, invisible at build
-time) rather than auto-inferred; a `postgres://` DSN on a plain base fails with a
-`hull feature install postgres` hint.
+so `--with=duckdb --with=postgres --with=mysql` compose together into one
+generated collector. `postgres` and `mysql` are pure C (no vendored engine), so
+their archives are tiny (~48 KB); because a wire backend references base
+`tls_client` (sslmode) + crypto (auth) that a DB-only app doesn't otherwise pull,
+`hull build` wraps the platform lib + the archive in a GNU-ld `--start-group` at
+compose (`base_group` in FEATURE_SPECS; Linux only — macOS ld64 rescans natively
+and rejects the flag). Like DuckDB, the backend is reached by DSN and carries no
+module gate, so selection is **explicit `--with=<name>`** (DSNs are often `$VAR`
+env-refs, invisible at build time) rather than auto-inferred; e.g. a `mysql://`
+DSN on a plain base fails with a `hull feature install mysql` hint. The kernel
+sandbox grants `network_outbound` for a declared network DB connection
+(`databases.named` net-DSN / env-ref, `databases.dynamic` net scheme, or a `-d`
+net DSN), so a sandboxed DB-only app can reach its database.
 
 **Install (end users):** `hull feature install <name>` / `hull feature list` /
 `hull feature uninstall <name>` fetch + Ed25519-verify + cache the signed lib to
@@ -894,7 +899,7 @@ The live install path is intentionally not tested in CI (it would need the just-
 
 **`hull flavor install <flavor> [--repo=ORG/NAME]` / `flavor list`**. Fetch the per-flavor platform library (`libhull_platform-<flavor>.a`) for `hull build --flavor` so end users do not build it from source. Same trust chain as `hull tools install` / `hull update`, via the shared `hl_release_io_fetch_verified_manifest`: download `hull.sha256` + `.sig` from the release matching this hull's version, verify the Ed25519 release signature against the embedded `HL_RELEASE_PUBKEY_HEX`, then for each asset look up its SHA-256 in the verified manifest, download, constant-time-compare the hash, and atomic-write to `$HOME/.hull/platform/`. Native platforms fetch one `libhull_platform-<flavor>-<arch>.a`; cosmo fetches the dual-arch pair `libhull_platform-<flavor>.{x86_64,aarch64}-cosmo.a`. `flavor list` shows each flavor as `embedded` (full), `installed`, or `not installed`. `hull build --flavor` then finds the cached lib automatically (see "Build flavors" above). Pure C, HTTP-client-gated (`src/hull/commands/flavor.c`); the `~/.hull/platform/` store is a signed durable store like `~/.hull/tools/`, not a prunable cache. Full design: [docs/build_flavors.md](docs/build_flavors.md).
 
-**`hull feature install <name> [--repo=ORG/NAME]` / `feature list` / `feature uninstall <name>`**. Fetch the per-feature composable library (`libhull_feature-<name>-<arch>.a`) for `hull build --with=<name>` so end users do not build it from source. Same trust chain as `hull flavor install` (the shared `hl_release_io_fetch_verified_manifest`: verify the Ed25519 signature on `hull.sha256` against the embedded `HL_RELEASE_PUBKEY_HEX`, then per asset look up its SHA-256 in the verified manifest, download, constant-time-compare, atomic-write to `$HOME/.hull/feature/`). Four features today: `duckdb`, `postgres`, `gpu`, `tui`, all native-only (features are static archives; cosmo is never published). `feature list` shows each as `not installed` / `installed` for this platform. Registry is the `FEATURES[]` table in `src/hull/commands/feature.c` (one row per feature). Pure C, HTTP-client-gated. See "Composable features" above and [docs/features_and_flavors.md](docs/features_and_flavors.md).
+**`hull feature install <name> [--repo=ORG/NAME]` / `feature list` / `feature uninstall <name>`**. Fetch the per-feature composable library (`libhull_feature-<name>-<arch>.a`) for `hull build --with=<name>` so end users do not build it from source. Same trust chain as `hull flavor install` (the shared `hl_release_io_fetch_verified_manifest`: verify the Ed25519 signature on `hull.sha256` against the embedded `HL_RELEASE_PUBKEY_HEX`, then per asset look up its SHA-256 in the verified manifest, download, constant-time-compare, atomic-write to `$HOME/.hull/feature/`). Five features today: `duckdb`, `postgres`, `mysql`, `gpu`, `tui`, all native-only (features are static archives; cosmo is never published). `feature list` shows each as `not installed` / `installed` for this platform. Registry is the `FEATURES[]` table in `src/hull/commands/feature.c` (one row per feature). Pure C, HTTP-client-gated. See "Composable features" above and [docs/features_and_flavors.md](docs/features_and_flavors.md).
 
 **`hull cache list|prune|clear|verify`**. Inspect and manage the runtime cache pool (`$HOME/.hull/blobs/runtime/` by default — set `HULL_CACHE_DIR=/abs/path` to redirect for per-app isolation). Full reference: [docs/cache.md](docs/cache.md). Six registered kinds today: `lua-bytecode` (Lua source → bytecode), `js-bytecode` (QuickJS module bytecode), `compute-aot` (WASM AOT artifacts), `templates` (compiled Lua template render functions), `js-templates` (compiled JS template render functions), `tools` (signed side-loaded tool binaries; system store, not pruned by default). `list` enumerates every kind with entry count + total size + on-disk path; `--json` for machine output. `prune [--kind=K] [--max-size=N] [--max-age=N] [--strategy=lru|fifo] [--dry-run]` runs LRU/FIFO eviction over runtime caches; system stores are preserved unless `--kind=tools` is named. `--max-size` accepts `K`/`M`/`G` suffixes (binary, 1024-based; trailing `B` optional, so `100M` and `100MB` are equivalent); `--max-age` accepts `s`/`m`/`h`/`d`/`w`/`y` suffixes (bare numbers = seconds for back-compat). Bad units are rejected with an example. `clear --yes` wipes runtime caches entirely (iter + delete, not policy-based — so even sub-second-old files go). `verify [--kind=K] [--repair] [--json]` walks every entry and flags corruption: for CAS-mode kinds (`tools`) it recomputes `sha256(contents)` and compares to filename; for keyed-mode runtime caches it does a structural check (regular file, non-empty, readable). `--repair` unlinks corrupt entries — safe because the next compile/install repopulates from source. Exits non-zero on corruption unless `--repair` was able to fix it. Cache registry (`include/hull/cache_registry.h`) is the single source of truth for cache kinds, also consumed by `hull doctor` (Caches section), `hull inspect` (runtime-caches disclosure), and `hull cache verify` (CAS vs keyed mode dispatch via `is_cas` field). Adding a new cache kind = one entry in `REGISTRY[]` and the new consumer auto-shows up in list / prune / clear / verify / doctor / inspect.
 

--- a/Makefile
+++ b/Makefile
@@ -2558,6 +2558,23 @@ $(BUILDDIR)/libhull_feature-postgres.a: $(BUILDDIR)/cap_db_postgres.o $(BUILDDIR
 	$(AR) rcs $@ $(BUILDDIR)/cap_db_postgres.o $(BUILDDIR)/cap_pg_conn.o $(BUILDDIR)/cap_pgwire.o
 	@echo "built $@ ($$(du -h $@ | cut -f1))"
 
+# ── MySQL/MariaDB feature archive (composable feature: hull build --with=mysql) ──
+# Bundles the pure-C MySQL/MariaDB wire client (cap_db_mysql.o + cap_mysql_conn.o
+# + cap_mysqlwire.o, defining hl_db_backend_mysql) into ONE archive. One backend
+# serves both mysql:// and mariadb://. Same shape as feature-postgres: pure C, no
+# vendored engine, references base crypto (native/caching_sha2 auth) + tls_client
+# (sslmode) resolved from the platform lib at compose, so build.lua wraps them in
+# --start-group (base_group). Native only. `feature-mysql` re-invokes make with
+# HL_ENABLE_MYSQL=1 so the wire objects (filtered out of a base build) are in scope.
+feature-mysql:
+	$(MAKE) $(BUILDDIR)/libhull_feature-mysql.a HL_ENABLE_MYSQL=1
+.PHONY: feature-mysql
+
+$(BUILDDIR)/libhull_feature-mysql.a: $(BUILDDIR)/cap_db_mysql.o $(BUILDDIR)/cap_mysql_conn.o $(BUILDDIR)/cap_mysqlwire.o | $(BUILDDIR)
+	@rm -f $@
+	$(AR) rcs $@ $(BUILDDIR)/cap_db_mysql.o $(BUILDDIR)/cap_mysql_conn.o $(BUILDDIR)/cap_mysqlwire.o
+	@echo "built $@ ($$(du -h $@ | cut -f1))"
+
 # ── GPU feature archive (composable feature: hull build --with=gpu) ──
 # libhull_feature-gpu.a bundles the wgpu backend object (cap_gpu_wgpu.o, which
 # defines hl_gpu_backend_wgpu) + the wgpu-native static lib into ONE archive,

--- a/docs/features_and_flavors.md
+++ b/docs/features_and_flavors.md
@@ -4,10 +4,11 @@ Status: **shipped.** Introduces **features** as a third distribution concept
 alongside **flavors** and **tools**, so Hull can absorb multiple large,
 orthogonal optional libraries without a combinatorial explosion of published
 build artifacts. Re-scopes the DuckDB side-load (roadmap "DuckDB epic" #4) from a
-one-off `full-duckdb` flavor to **DuckDB as the first composable feature**. Four
+one-off `full-duckdb` flavor to **DuckDB as the first composable feature**. Five
 features ship today: **`duckdb`** (embedded OLAP, `duckdb://`), **`postgres`**
-(pure-C PostgreSQL wire backend, `postgres://`), **`gpu`** (wgpu-native compute),
-and **`tui`** (terminal UI) - all native-only, installed with
+(pure-C PostgreSQL wire backend, `postgres://`), **`mysql`** (pure-C MySQL/MariaDB
+wire backend, `mysql://` / `mariadb://`), **`gpu`** (wgpu-native compute), and
+**`tui`** (terminal UI) - all native-only, installed with
 `hull feature install <name>` and composed with `hull build --with=<name>`. The
 command surface (`hull feature install / list / uninstall`), the `make
 feature-<name>` archive targets, the `--with=` build path, and the `?`

--- a/src/hull/cap/db_select.c
+++ b/src/hull/cap/db_select.c
@@ -73,8 +73,8 @@ static const struct { const char *scheme; const char *msg; } RESERVED[] = {
     { "sqlite",     "sqlite:// requires a build with HL_ENABLE_SQLITE" },
     { "file",       "file: URIs require a build with HL_ENABLE_SQLITE" },
     { "duckdb",     "duckdb:// needs the DuckDB feature: run 'hull feature install duckdb', then build the app with 'hull build --with=duckdb'" },
-    { "mysql",      "the MySQL/MariaDB backend (mysql://) is not available in this build" },
-    { "mariadb",    "the MySQL/MariaDB backend (mariadb://) is not available in this build" },
+    { "mysql",      "mysql:// needs the MySQL feature: run 'hull feature install mysql', then build the app with 'hull build --with=mysql'" },
+    { "mariadb",    "mariadb:// needs the MySQL feature: run 'hull feature install mysql', then build the app with 'hull build --with=mysql'" },
 };
 
 static int scheme_in(const char *const *list, const char *scheme)

--- a/src/hull/commands/feature.c
+++ b/src/hull/commands/feature.c
@@ -59,6 +59,7 @@ typedef struct {
 static const HlFeatureSpec FEATURES[] = {
     { "duckdb",   "DuckDB embedded OLAP SQL backend (duckdb://)", 1, 1, 1 },
     { "postgres", "PostgreSQL wire backend (postgres:// / postgresql://)", 1, 1, 1 },
+    { "mysql",    "MySQL / MariaDB wire backend (mysql:// / mariadb://)", 1, 1, 1 },
     { "gpu",      "GPU compute via wgpu-native (Vulkan/Metal)",   1, 1, 1 },
     { "tui",      "Terminal UI (hull.tui: full-screen, input, cell-diff)", 1, 1, 1 },
 };

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1329,6 +1329,19 @@ int main(int argc, char **argv) { return hull_main(argc, argv); }
             base_group = true,
             libs       = { darwin = {}, other = {} },
         },
+        -- mysql: pure-C MySQL/MariaDB wire backend in libhull_feature-mysql.a
+        -- (`make feature-mysql`), one backend serving both mysql:// and
+        -- mariadb://. Identical shape to postgres — fills hl_db_feature_backends,
+        -- references base crypto (native/caching_sha2 auth) + tls_client
+        -- (sslmode), so base_group = true (--start-group at compose on GNU ld).
+        mysql = {
+            backend    = "hl_db_backend_mysql",
+            type       = "HlDbBackend",
+            hook       = "hl_db_feature_backends",
+            cxx        = false,
+            base_group = true,
+            libs       = { darwin = {}, other = {} },
+        },
         -- gpu: wgpu-native backend, isolated in libhull_feature-gpu.a
         -- (`make feature-gpu`). Base ships the generic gpu dispatch layer +
         -- the weak hl_gpu_feature_backends hook; this fills it. C (no cxx). The

--- a/tests/e2e_feature_mysql.sh
+++ b/tests/e2e_feature_mysql.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# e2e_feature_mysql.sh — MySQL/MariaDB as a composable feature, end to end.
+#
+# Builds a BASE hull (EMBED_PLATFORM=1, no MySQL compiled in) + the MySQL feature
+# archive, then `hull build --with=mysql` an app and boots it. Proves that
+# `hull build` composes libhull_feature-mysql.a + a generated registry (filling
+# the hl_db_feature_backends hook, like Postgres/DuckDB) into the app binary, so a
+# base-built hull gains the mysql:// backend purely from the feature. One backend
+# serves both mysql:// and mariadb://.
+#
+# This is a BUILD-only e2e (no live server): the app connects to an unreachable
+# host and asserts the error is a CONNECTION failure, not a "needs the MySQL
+# feature" scheme rejection — i.e. the backend is registered and live. A real
+# connect + auth + query is covered by the monolithic e2e_mysql.sh job.
+#
+# Runs under the REAL kernel sandbox: the manifest declares a network database
+# (databases.named my), so hl_sandbox_policy_from_manifest grants network_outbound
+# and the connect is allowed to attempt + fail gracefully. This also exercises the
+# GNU-ld --start-group compose link (the mysql backend references base tls_client +
+# crypto that a DB-only app doesn't otherwise pull). --compiler=system.
+#
+# Must run on a fresh build tree (no prior HL_ENABLE_MYSQL=1 objects); its own CI
+# job. Native only.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+cd "$(dirname "$0")/.."
+
+echo "=== build base hull (EMBED_PLATFORM=1; base has no mysql backend) ==="
+make EMBED_PLATFORM=1 >/dev/null
+# Stash the base hull: `make feature-mysql` re-invokes make with HL_ENABLE_MYSQL=1
+# and the build-config sentinel cleans build/ on the flip.
+cp build/hull /tmp/hull_base_my_e2e
+
+echo "=== build the MySQL feature archive ==="
+make feature-mysql >/dev/null
+ls -la build/libhull_feature-mysql.a
+nm build/libhull_feature-mysql.a 2>/dev/null | grep -qE '[ _]hl_db_backend_mysql$' \
+    || { echo "FAIL: feature archive lacks hl_db_backend_mysql"; exit 1; }
+
+HULL=/tmp/hull_base_my_e2e
+APP=$(mktemp -d)
+PLAIN=$(mktemp -d)
+trap 'rm -rf "$APP" "$PLAIN" /tmp/hull_base_my_e2e' EXIT
+
+cat > "$APP/app.lua" <<'LUA'
+app.manifest({
+    modules = { "hull/db@1" },
+    -- Unreachable host + short timeout: the connect must FAIL, and the failure
+    -- proves the backend routed mysql:// (a scheme rejection would fire first).
+    databases = { named = { my = "mysql://u:p@10.255.255.1:3306/db?connect_timeout=1" } },
+})
+app.main(function()
+    local ok, err = pcall(function()
+        require("hull.db").connect("my").query("SELECT 1")
+    end)
+    assert(not ok, "expected the unreachable connect to fail")
+    if tostring(err):find("feature") then
+        print("MYSQL BACKEND MISSING: " .. tostring(err))
+    else
+        print("MYSQL FEATURE APP OK")  -- backend registered; failed on connect
+    end
+    return 0
+end)
+LUA
+
+echo "=== hull build --with=mysql (exercises the GNU-ld --start-group link) ==="
+BUILD_OUT=$("$HULL" build --compiler=system --with=mysql --no-verify-platform -o "$APP/bin" "$APP" 2>&1) || true
+echo "$BUILD_OUT"
+echo "$BUILD_OUT" | grep -q "composed feature 'mysql'" || { echo "FAIL: feature not composed"; exit 1; }
+test -x "$APP/bin" || { echo "FAIL: no composed binary produced"; exit 1; }
+
+echo "=== boot the composed binary (expect a connection error, not a feature error) ==="
+RUN_OUT=$("$APP/bin" 2>&1) || true
+echo "$RUN_OUT" | grep -q "MYSQL FEATURE APP OK" || {
+    echo "$RUN_OUT"
+    echo "FAIL: mysql backend not registered in the composed binary"; exit 1
+}
+echo "ok  --with=mysql composed + backend live"
+
+echo "=== negative: a plain app must NOT compose mysql ==="
+printf 'app.manifest({modules={}})\napp.main(function() print("PLAIN OK") return 0 end)\n' \
+    > "$PLAIN/app.lua"
+PLAIN_OUT=$("$HULL" build --no-verify-platform -o "$PLAIN/bin" "$PLAIN" 2>&1) || true
+if echo "$PLAIN_OUT" | grep -q "composed feature"; then
+    echo "$PLAIN_OUT"; echo "FAIL: composed a feature for a plain app"; exit 1
+fi
+"$PLAIN/bin" 2>&1 | grep -q "PLAIN OK" || { echo "FAIL: plain app did not run"; exit 1; }
+echo "ok  plain app stayed mysql-free"
+
+echo "PASS: MySQL feature composed into an app binary; base stays mysql-free"

--- a/tests/e2e_mysql.sh
+++ b/tests/e2e_mysql.sh
@@ -210,7 +210,7 @@ end)
 LUA
 
 echo "=== running app against mysql (native auth, plaintext) ==="
-./build/hull -d "$DSN" --no-sandbox -p "$PORT" "$APPDIR/app.lua" >"$APPDIR/serve.log" 2>&1 &
+./build/hull -d "$DSN" -p "$PORT" "$APPDIR/app.lua" >"$APPDIR/serve.log" 2>&1 &
 SVR=$!
 wait_for_server "$APPDIR/serve.log" || exit 1
 
@@ -299,7 +299,7 @@ app.main(function(ctx)
 end)
 LUA
 
-DYN_OUT=$(./build/hull --no-sandbox "$APPDIR_DYN/app.lua" -- "$DSN" 2>&1 || true)
+DYN_OUT=$(./build/hull "$APPDIR_DYN/app.lua" -- "$DSN" 2>&1 || true)
 echo "$DYN_OUT" | grep -qE "allow_count=3" || { echo "::error db.open allowed host did not query"; echo "$DYN_OUT"; exit 1; }
 echo "$DYN_OUT" | grep -qE "deny_host=denied" || { echo "::error db.open out-of-CIDR host not rejected"; echo "$DYN_OUT"; exit 1; }
 echo "$DYN_OUT" | grep -qE "deny_scheme=denied" || { echo "::error db.open disallowed scheme not rejected"; echo "$DYN_OUT"; exit 1; }
@@ -328,7 +328,7 @@ end)
 LUA
 
 echo "=== running app over TLS (sslmode=require + caching_sha2 full auth) ==="
-./build/hull -d "$DSN_TLS" --no-sandbox -p "$PORT" "$APPDIR_TLS/app.lua" >"$APPDIR_TLS/serve.log" 2>&1 &
+./build/hull -d "$DSN_TLS" -p "$PORT" "$APPDIR_TLS/app.lua" >"$APPDIR_TLS/serve.log" 2>&1 &
 SVR=$!
 wait_for_server "$APPDIR_TLS/serve.log" || exit 1
 

--- a/tests/hull/cap/test_db_select.c
+++ b/tests/hull/cap/test_db_select.c
@@ -56,8 +56,8 @@ UTEST(db_select, postgres_scheme)
 #endif
 }
 
-/* "mysql://" / "mariadb://" route to the MySQL backend when compiled, else a
- * build-flag hint. Both schemes share the one backend. */
+/* "mysql://" / "mariadb://" route to the MySQL backend when compiled, else point
+ * at the composable MySQL feature. Both schemes share the one backend. */
 UTEST(db_select, mysql_scheme)
 {
     const char *err = NULL;
@@ -68,7 +68,10 @@ UTEST(db_select, mysql_scheme)
     b = hl_db_backend_select("mariadb://u@h/db", &err);
     ASSERT_TRUE(b); ASSERT_STREQ(b->name, "mysql");
 #else
-    ASSERT_FALSE(b); ASSERT_TRUE(err); ASSERT_TRUE(strstr(err, "MySQL") != NULL);
+    ASSERT_FALSE(b); ASSERT_TRUE(err);
+    ASSERT_TRUE(strstr(err, "feature install mysql") != NULL);
+    b = hl_db_backend_select("mariadb://u@h/db", &err);
+    ASSERT_FALSE(b); ASSERT_TRUE(strstr(err, "feature install mysql") != NULL);
 #endif
 }
 


### PR DESCRIPTION
Ships **MySQL/MariaDB as a composable feature** — the near-mechanical repeat of the Postgres feature (#102), completing the DB-backend feature set. One backend (`hl_db_backend_mysql`) serves both `mysql://` and `mariadb://`. The stock binary (which can't touch MySQL today) gains it via `hull feature install mysql` → `hull build --with=mysql`, **zero regression**.

## How it works
Fills the same weak `hl_db_feature_backends` hook as `duckdb`/`postgres` (DSN-scheme-selected via the `HlDbBackend` vtable), so all three compose together into one generated collector. Same shape as postgres: pure-C wire client (`cap_db_mysql` + `cap_mysql_conn` + `cap_mysqlwire`, ~48 KB archive, no vendored engine), `base_group = true` → the compose wraps the platform lib + archive in a GNU-ld `--start-group` (the backend references base `tls_client` for sslmode + crypto for native/caching_sha2 auth; Linux only, macOS ld64 rescans natively). Selection is explicit `--with=mysql`; a `mysql://`/`mariadb://` DSN on a plain base points at `hull feature install mysql`.

## Sandbox
The `network_outbound` grant from #102 already covers the mysql/mariadb schemes, so a sandboxed MySQL app reaches its database — **both** the feature e2e **and** the monolithic `e2e_mysql.sh` now run under the **real sandbox** (dropped their `--no-sandbox`).

## Changes
- `Makefile`: `feature-mysql` archive target.
- `feature.c` FEATURES[] + `build.lua` FEATURE_SPECS.mysql (`base_group`).
- `db_select.c`: repoint the `mysql://`/`mariadb://` reserved hints.
- Release pipeline: `build-feature-mysql` job (3 native platforms), covered by the signed `hull.sha256` `libhull_feature-*.a` glob.
- `ci.yml`: `mysql-feature` job → `e2e_feature_mysql.sh`.
- `test_db_select`: mysql_scheme asserts the feature hint (+ mariadb).
- Docs: CLAUDE.md feature table (now five) + flag row; features doc.

## Validation
macOS: archive builds, composes, links, backend **live under the real sandbox**; **60/60** unit suites; YAML valid. Linux-only bits (`--start-group` link, pledge grant, real MySQL 8 connect) validated by the **mysql-feature** + **MySQL e2e** CI jobs.
