### PR TITLE
harden: two Low findings from the post-feature C/Lua/JS audit

### DIFF
--- a/src/hull/sandbox.c
+++ b/src/hull/sandbox.c
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>   /* strncasecmp (DSN scheme match) */
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -958,10 +959,13 @@ static int sandbox_dsn_is_network(const char *dsn)
 {
     if (!dsn || !*dsn) return 0;
     if (dsn[0] == '$') return 1;                 /* env-ref: assume network */
-    return strncmp(dsn, "postgres://",   11) == 0
-        || strncmp(dsn, "postgresql://", 13) == 0
-        || strncmp(dsn, "mysql://",       8) == 0
-        || strncmp(dsn, "mariadb://",    10) == 0;
+    /* Case-insensitive to match the DSN backend selector (db_select.c) and
+     * serve.c's db_dsn_is_network — else an uppercase-scheme named DSN would
+     * be classified non-network and the app SIGKILLed on connect. */
+    return strncasecmp(dsn, "postgres://",   11) == 0
+        || strncasecmp(dsn, "postgresql://", 13) == 0
+        || strncasecmp(dsn, "mysql://",       8) == 0
+        || strncasecmp(dsn, "mariadb://",    10) == 0;
 }
 
 /* True if the manifest declares any database connection that may dial the

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1412,9 +1412,11 @@ int main(int argc, char **argv) { return hull_main(argc, argv); }
                     if file_exists(cache .. "/" .. asset) then
                         -- Re-verify a cache-sourced lib against its signed
                         -- manifest (embedded release pubkey) before linking.
-                        if tool.platform_verify and not tool.platform_verify(cache, asset) then
-                            tool.stderr("hull build: cached " .. fname .. " feature lib failed "
-                                .. "re-verification; run `hull feature install " .. fname .. "` again\n")
+                        -- Fail CLOSED: a missing platform_verify binding must
+                        -- abort a cache-sourced lib, not link it unverified.
+                        if not tool.platform_verify or not tool.platform_verify(cache, asset) then
+                            tool.stderr("hull build: cached " .. fname .. " feature lib could not "
+                                .. "be re-verified; run `hull feature install " .. fname .. "` again\n")
                             tool.rmdir(tmpdir); tool.exit(1)
                         end
                         lib = cache .. "/" .. asset; from_cache = true


### PR DESCRIPTION
Follow-up to the tui/tcc/postgres/mysql composable-feature work (#99–#103).
A comprehensive C + Lua + JS audit found **zero Critical/High**; this PR is
the two actionable **Low** findings, both in security-relevant trust paths.

## Findings

**L1 — `sandbox.c`: case-sensitive DSN scheme match (self-DoS, fails closed)**
`sandbox_dsn_is_network` matched schemes with `strncmp`, while
`serve.c::db_dsn_is_network` and the `db_select.c` backend selector are
case-insensitive. An uppercase-scheme named connection (`Postgres://…`) with no
`http` hosts would be classified non-network → `network_outbound` withheld → the
app SIGKILLed by pledge on connect. Switch to `strncasecmp` to align with the
selector.

**L2 — `build.lua`: cache-sourced feature-lib verify fail-open**
The re-verification fired only `if tool.platform_verify and not
tool.platform_verify(...)`, so a *missing* `platform_verify` binding would link
an **unverified** cache lib rather than fail closed. Make it abort when the
binding is absent (a cache-sourced signed lib must be re-verifiable). On a
version-matched binary the binding is always present, so this is defense in
depth on the signed-lib trust path.

The **JS audit was clean** — no changes. The DB-feature work is backend-agnostic
C selected C-side by DSN scheme; `hull:db` is unchanged.

## Verification
- `make` clean, `60/60` unit suites.
- `e2e_feature_postgres.sh` green **under the real kernel sandbox** (exercises
  the `network_outbound` grant the L1 fix touches).
