### PR TITLE
runtime: HlRuntimeKind vtable discriminator (Phase 1, Change 3)

### DIFF
--- a/include/hull/runtime.h
+++ b/include/hull/runtime.h
@@ -68,6 +68,17 @@ typedef void (*HlMiddlewareCb)(void *user,
                                const char *method, const char *pattern,
                                const char *phase);
 
+/*
+ * Runtime discriminator, carried in the vtable. Lets consumers branch on the
+ * concrete runtime (rt->vt->kind == HL_RT_LUA) WITHOUT taking the address of a
+ * concrete runtime symbol (&hl_lua_vtable), so base-lib code links cleanly
+ * against a build that composes only one runtime. See docs/runtime_feature_phase1.md.
+ */
+typedef enum {
+    HL_RT_LUA = 1,
+    HL_RT_JS  = 2,
+} HlRuntimeKind;
+
 typedef struct HlRuntimeVtable {
     int   (*init)(HlRuntime *rt, const void *config);
     int   (*load_app)(HlRuntime *rt, const char *filename);
@@ -102,6 +113,11 @@ typedef struct HlRuntimeVtable {
 
     void  (*destroy)(HlRuntime *rt);
     const char *name;
+
+    /* Runtime discriminator (HL_RT_LUA / HL_RT_JS). Consumers branch on this
+     * instead of `rt->vt == &hl_<rt>_vtable` so no base TU references a concrete
+     * runtime symbol (the precondition for a runtime-slim link). */
+    HlRuntimeKind kind;
 
     /* Glob pattern for test files in this runtime (e.g. "test_*.lua").
      * Used by the shared test runner — avoids switching on rt->vt->name

--- a/src/hull/agent/capabilities.c
+++ b/src/hull/agent/capabilities.c
@@ -189,7 +189,7 @@ int hl_agent_capabilities_ctx(HlAppContext *ctx, ShJsonBuf *out)
 
     int is_lua = 0;
 #ifdef HL_ENABLE_LUA
-    if (rt->vt == &hl_lua_vtable) is_lua = 1;
+    if (rt->vt->kind == HL_RT_LUA) is_lua = 1;
 #endif
 
     /* Extract the declared manifest */

--- a/src/hull/agent/eval.c
+++ b/src/hull/agent/eval.c
@@ -182,14 +182,14 @@ int hl_agent_eval_ctx(HlAppContext *ctx, const char *code, ShJsonBuf *out)
     if (!rt || !rt->vt) return hl_agent_write_error(out, "no runtime");
 
 #ifdef HL_ENABLE_LUA
-    if (rt->vt == &hl_lua_vtable) {
+    if (rt->vt->kind == HL_RT_LUA) {
         HlLua *lua = hl_app_context_lua(ctx);
         if (!lua) return hl_agent_write_error(out, "no lua state");
         return eval_lua(lua, code, out);
     }
 #endif
 #ifdef HL_ENABLE_JS
-    if (rt->vt == &hl_js_vtable) {
+    if (rt->vt->kind == HL_RT_JS) {
         HlJS *js = hl_app_context_js(ctx);
         if (!js) return hl_agent_write_error(out, "no js state");
         return eval_js(js, code, out);

--- a/src/hull/agent/manifest.c
+++ b/src/hull/agent/manifest.c
@@ -182,13 +182,13 @@ int hl_agent_manifest_ctx(HlAppContext *ctx, ShJsonBuf *out)
     const char *runtime_name = NULL;
 
 #ifdef HL_ENABLE_LUA
-    if (rt->vt == &hl_lua_vtable) {
+    if (rt->vt->kind == HL_RT_LUA) {
         runtime_name = "lua";
         rc = rt->vt->extract_manifest(rt, &m);
     }
 #endif
 #ifdef HL_ENABLE_JS
-    if (rt->vt == &hl_js_vtable) {
+    if (rt->vt->kind == HL_RT_JS) {
         runtime_name = "js";
         rc = rt->vt->extract_manifest(rt, &m);
     }

--- a/src/hull/agent/modules.c
+++ b/src/hull/agent/modules.c
@@ -91,11 +91,11 @@ int hl_agent_modules_ctx(HlAppContext *ctx, ShJsonBuf *out)
 
     HlManifest m = {0};
 #ifdef HL_ENABLE_LUA
-    if (rt->vt == &hl_lua_vtable)
+    if (rt->vt->kind == HL_RT_LUA)
         rt->vt->extract_manifest(rt, &m);
 #endif
 #ifdef HL_ENABLE_JS
-    if (rt->vt == &hl_js_vtable)
+    if (rt->vt->kind == HL_RT_JS)
         rt->vt->extract_manifest(rt, &m);
 #endif
 

--- a/src/hull/agent/overview.c
+++ b/src/hull/agent/overview.c
@@ -254,13 +254,13 @@ int hl_agent_overview_ctx(HlAppContext *ctx, ShJsonBuf *out)
     HlManifest m = {0};
     int have_manifest = 0;
 #ifdef HL_ENABLE_LUA
-    if (rt && rt->vt == &hl_lua_vtable && rt->vt->extract_manifest) {
+    if (rt && rt->vt->kind == HL_RT_LUA && rt->vt->extract_manifest) {
         rt->vt->extract_manifest(rt, &m);
         have_manifest = 1;
     }
 #endif
 #ifdef HL_ENABLE_JS
-    if (rt && rt->vt == &hl_js_vtable && rt->vt->extract_manifest) {
+    if (rt && rt->vt->kind == HL_RT_JS && rt->vt->extract_manifest) {
         rt->vt->extract_manifest(rt, &m);
         have_manifest = 1;
     }

--- a/src/hull/agent/overview.c
+++ b/src/hull/agent/overview.c
@@ -254,13 +254,13 @@ int hl_agent_overview_ctx(HlAppContext *ctx, ShJsonBuf *out)
     HlManifest m = {0};
     int have_manifest = 0;
 #ifdef HL_ENABLE_LUA
-    if (rt && rt->vt->kind == HL_RT_LUA && rt->vt->extract_manifest) {
+    if (rt && rt->vt && rt->vt->kind == HL_RT_LUA && rt->vt->extract_manifest) {
         rt->vt->extract_manifest(rt, &m);
         have_manifest = 1;
     }
 #endif
 #ifdef HL_ENABLE_JS
-    if (rt && rt->vt->kind == HL_RT_JS && rt->vt->extract_manifest) {
+    if (rt && rt->vt && rt->vt->kind == HL_RT_JS && rt->vt->extract_manifest) {
         rt->vt->extract_manifest(rt, &m);
         have_manifest = 1;
     }

--- a/src/hull/agent/perf.c
+++ b/src/hull/agent/perf.c
@@ -36,10 +36,10 @@ int hl_agent_perf_ctx(HlAppContext *ctx, ShJsonBuf *out)
     if (rt && rt->vt) {
         const char *name = rt->vt->name ? rt->vt->name : "unknown";
 #ifdef HL_ENABLE_LUA
-        if (rt->vt == &hl_lua_vtable) name = "lua";
+        if (rt->vt->kind == HL_RT_LUA) name = "lua";
 #endif
 #ifdef HL_ENABLE_JS
-        if (rt->vt == &hl_js_vtable) name = "js";
+        if (rt->vt->kind == HL_RT_JS) name = "js";
 #endif
         sh_json_write_kv_string(&w, "runtime", name);
     }

--- a/src/hull/agent/routes.c
+++ b/src/hull/agent/routes.c
@@ -63,8 +63,8 @@ int hl_agent_routes_ctx(HlAppContext *ctx, ShJsonBuf *out)
     }
 
     sh_json_write_kv_string(&w, "runtime",
-        rt->vt == &hl_lua_vtable ? "lua" :
-        rt->vt == &hl_js_vtable  ? "js"  : rt->vt->name);
+        rt->vt->kind == HL_RT_LUA ? "lua" :
+        rt->vt->kind == HL_RT_JS  ? "js"  : rt->vt->name);
 
     sh_json_write_key(&w, "routes");
     sh_json_write_array_start(&w);

--- a/src/hull/agent/template.c
+++ b/src/hull/agent/template.c
@@ -172,14 +172,14 @@ int hl_agent_template_ctx(HlAppContext *ctx, const char *template_name,
     if (!rt || !rt->vt) return hl_agent_write_error(out, "no runtime");
 
 #ifdef HL_ENABLE_LUA
-    if (rt->vt == &hl_lua_vtable) {
+    if (rt->vt->kind == HL_RT_LUA) {
         HlLua *lua = hl_app_context_lua(ctx);
         if (!lua) return hl_agent_write_error(out, "no lua state");
         return render_lua(lua, template_name, data_json, out);
     }
 #endif
 #ifdef HL_ENABLE_JS
-    if (rt->vt == &hl_js_vtable) {
+    if (rt->vt->kind == HL_RT_JS) {
         HlJS *js = hl_app_context_js(ctx);
         if (!js) return hl_agent_write_error(out, "no js state");
         return render_js(js, template_name, data_json, out);

--- a/src/hull/agent/test.c
+++ b/src/hull/agent/test.c
@@ -102,8 +102,8 @@ int hl_agent_test_ctx(HlAppContext *ctx, ShJsonBuf *out)
     HlRuntime *rt = hl_app_context_runtime(ctx);
     if (rt && rt->vt && rt->vt->name)
         sh_json_write_kv_string(&w, "runtime",
-            rt->vt == &hl_lua_vtable ? "lua" :
-            rt->vt == &hl_js_vtable  ? "js"  : rt->vt->name);
+            rt->vt->kind == HL_RT_LUA ? "lua" :
+            rt->vt->kind == HL_RT_JS  ? "js"  : rt->vt->name);
 
     sh_json_write_key(&w, "files");
     sh_json_write_array_start(&w);

--- a/src/hull/app_context.c
+++ b/src/hull/app_context.c
@@ -413,8 +413,9 @@ HlStmtCache *hl_app_context_stmt_cache(HlAppContext *ctx)
 int hl_app_context_is_lua(HlAppContext *ctx)
 {
     /* Identify via the factory pointer — avoids a stored is_lua flag.
-     * &hl_lua_vtable / &hl_js_vtable comparisons would also work but
-     * the factory pointer is the canonical source of truth post-K. */
+     * A `rt->vt->kind == HL_RT_LUA` check also works once rt is created; the
+     * factory pointer is the canonical source of truth post-K and is valid even
+     * before rt exists. */
 #ifdef HL_ENABLE_LUA
     extern const HlRuntimeFactory hl_lua_factory;
     return (ctx && ctx->factory == &hl_lua_factory) ? 1 : 0;

--- a/src/hull/runtime/js/runtime.c
+++ b/src/hull/runtime/js/runtime.c
@@ -1711,6 +1711,7 @@ const HlRuntimeVtable hl_js_vtable = {
     .run_test_file        = vt_js_run_test_file,
     .destroy              = vt_js_destroy,
     .name                 = "QuickJS",
+    .kind                 = HL_RT_JS,
     .test_file_pattern    = "test_*.js",
     .has_main             = vt_js_has_main,
     .has_server_handlers  = vt_js_has_server_handlers,

--- a/src/hull/runtime/lua/runtime.c
+++ b/src/hull/runtime/lua/runtime.c
@@ -912,6 +912,7 @@ const HlRuntimeVtable hl_lua_vtable = {
     .run_test_file       = vt_lua_run_test_file,
     .destroy             = vt_lua_destroy,
     .name                = "Lua",
+    .kind                = HL_RT_LUA,
     .test_file_pattern   = "test_*.lua",
     .has_main            = vt_lua_has_main,
     .has_server_handlers = vt_lua_has_server_handlers,


### PR DESCRIPTION
First implementation slice of the runtime-as-feature epic (docs/runtime_feature_phase1.md). Pure decoupling refactor, **zero behavior change**.

- Adds an `HlRuntimeKind` enum (`HL_RT_LUA`/`HL_RT_JS`) carried in `HlRuntimeVtable`, set in each runtime's vtable literal.
- Replaces the **17** `rt->vt == &hl_<rt>_vtable` comparisons in `agent/*.c` (9 files) with `rt->vt->kind == HL_RT_<RT>`.
- After this, no `PLATFORM_OBJS` non-runtime TU takes the address of a concrete runtime vtable — the precondition for a runtime-slim link in Phase 2. Runtime-local `&hl_<rt>_vtable` refs in `runtime/*/factory.c` and the vtable definitions are intentionally unchanged (they travel with the runtime).

**Verification:** build clean, 60/60 unit tests (`test_lua`/`test_js` included), `hull agent overview/routes` reports the correct runtime for both Lua and JS entries via the new `->kind` branch, and `grep -rn '== &hl_.*_vtable' src/hull/agent/` is empty.

Next: Changes 1+2 (weak `hl_runtime_feature_factories` hook + base-union-features collector).