### PR TITLE
WASM as a composable feature (design + epic)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,10 @@ jobs:
         timeout-minutes: 3
         run: make e2e-feature-runtime
 
+      - name: WASM feature E2E test (compute-free app drops WAMR; needs_wasm gate)
+        timeout-minutes: 4
+        run: make e2e-feature-wasm
+
       - name: Attachment E2E tests
         timeout-minutes: 2
         run: make e2e-attachment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,11 +74,13 @@ jobs:
           run: >
             make feature-lua feature-js feature-http feature-http-lua
             feature-http-js feature-tui-lua feature-tui-js
+            feature-wasm feature-wasm-lua feature-wasm-js
       - name: Build embedded feature archives (macOS)
         if: runner.os == 'macOS'
         run: >
           make feature-lua feature-js feature-http feature-http-lua
           feature-http-js feature-tui-lua feature-tui-js
+          feature-wasm feature-wasm-lua feature-wasm-js
       - name: Upload embedded feature archives
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
@@ -91,6 +93,9 @@ jobs:
             build/libhull_feature-http-js.a
             build/libhull_feature-tui-lua.a
             build/libhull_feature-tui-js.a
+            build/libhull_feature-wasm.a
+            build/libhull_feature-wasm-lua.a
+            build/libhull_feature-wasm-js.a
 
       # Per-flavor platform libs for `hull build --flavor` + `hull platform
       # install`. Each native platform-<flavor> target builds into its own obj
@@ -276,7 +281,7 @@ jobs:
             # build.lua records in package.sig.gethull.composed and that the
             # runtime §5c looks up: "libhull_feature-<stem>.<arch>.a".
             for arch in linux-x86_64 linux-aarch64 darwin-arm64; do
-              for stem in lua js http http-lua http-js tui-lua tui-js; do
+              for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js; do
                 f="platforms/platform-features-$arch/libhull_feature-$stem.a"
                 sha256sum "$f" \
                   | awk -v n="libhull_feature-$stem.$arch.a" '{print $1"  "n}'
@@ -556,7 +561,7 @@ jobs:
           # bytes MUST match the signed-manifest entry keyed by the composed asset
           # name (libhull_feature-<stem>.<arch>.a), or the runtime §5c check on
           # every app this hull builds would fail.
-          for stem in lua js http http-lua http-js tui-lua tui-js; do
+          for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js; do
             fa="build/libhull_feature-$stem.a"
             name="libhull_feature-$stem.${{ matrix.name }}.a"
             fact=$(sha256sum "$fa" | awk '{print $1}')

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,7 +140,7 @@ Hull's distribution is one binary; what's compiled into it is controlled by a sm
 |------|---------|-----------------|
 | `HL_ENABLE_LUA` | 1 | Drop the Lua 5.4 runtime; QuickJS-only build |
 | `HL_ENABLE_JS` | 1 | Drop QuickJS; Lua-only build |
-| `HL_ENABLE_WASM` | 1 | Drop WAMR (`compute.*` unavailable, ~256 KB) |
+| `HL_ENABLE_WASM` | 1 | Compile-time drop of WAMR (`compute.*` unavailable, ~256 KB): base + no wasm archive. Orthogonal to the auto-composed axis — with the default `=1`, the native base is still **compute-less** and composes WASM only for apps that need it (see "Composable runtime + HTTP base"). Cosmo keeps WASM in-base. |
 | `HL_ENABLE_GPU` | 0 | (Off by default.) On enables wgpu-native (`gpu.*`). Normally composed via the `gpu` **feature** (`hull build --with=gpu`) rather than set directly; see "Composable features" below. Native-only (no cosmo). |
 | `HL_ENABLE_DUCKDB` | 0 | (Off by default.) On enables the embedded DuckDB OLAP backend (`cap/db_duckdb.c` + fetched static libs via `make fetch-duckdb`). A `duckdb://` DSN selects it. Native-only (no cosmo). Normally composed via the `duckdb` **feature** (`hull build --with=duckdb`) rather than set directly; see "Composable features" below. |
 | `HL_ENABLE_TCC` | 1 Linux / 0 macOS+cosmo | Compile the tcc backend for `hull build --compiler=tcc`. tcc is **not embedded** (~400 KB lighter binary) — it's a side-loaded tool (`hull tools install tcc`), resolved at build time from `~/.hull/tools` → `dirname(hull)` → `$PATH`. Off on macOS (Mach-O) / cosmo (APE archives), where tcc's ELF output is unusable and the system compiler is used instead. |
@@ -258,12 +258,12 @@ CI lacks).
 
 `--with=` features above are the **optional, additive** axis. There is a second,
 **mandatory** composition axis that a plain `hull build` drives automatically:
-the native base platform library is **runtime-less AND HTTP-core-less**, and the
-produced app composes back exactly what it uses. Unlike a `--with=` feature, you
-never install or flag these — they are **embedded in the distributed `hull`** and
-auto-composed. (Issues #113 runtime, #114 HTTP; cosmo is exempt — a fat APE
-can't force-load native feature archives, so its base keeps both runtimes + HTTP
-compiled in.)
+the native base platform library is **runtime-less AND HTTP-core-less AND
+compute-less**, and the produced app composes back exactly what it uses. Unlike a
+`--with=` feature, you never install or flag these — they are **embedded in the
+distributed `hull`** and auto-composed. (Issues #113 runtime, #114 HTTP, #118
+WASM; cosmo is exempt — a fat APE can't force-load native feature archives, so its
+base keeps both runtimes + HTTP + WASM compiled in.)
 
 What the native base **drops** and what composes it back at `hull build`:
 
@@ -272,6 +272,8 @@ What the native base **drops** and what composes it back at `hull build`:
 | both interpreters (Lua VM, QuickJS) | `libhull_feature-{lua,js}.a` | exactly one, auto-inferred from the entry extension (`app.lua` → lua, `app.js` → js). Mandatory: an app must have a runtime to run. |
 | the HTTP core caps (`cap/http` + async, `ws`, `smtp`, `body`) | `libhull_feature-http.a` | only when the app needs HTTP |
 | the per-runtime web bindings (routes, dispatch, `res:*` helpers, `mod_http_*`/`mod_ws_*`/`sse`/`mod_smtp`, the in-process test harness, timers) | `libhull_feature-http-<rt>.a` | with the http core, only when the app needs HTTP |
+| the WASM caps + WAMR (`cap/wasm*`, `worker_wasm`, ~256 KB of vendored WAMR) | `libhull_feature-wasm.a` | only when the app needs compute (the `needs_wasm` gate below) |
+| the per-runtime compute binding (`mod_compute` — `compute.*` + the `WasmBuffer` userdata) | `libhull_feature-wasm-<rt>.a` | with the wasm core, only when the app needs compute |
 | the per-runtime tui bridge | `libhull_feature-tui-<rt>.a` (the tui cap core stays the installable `--with=tui` asset) | with `--with=tui`, only the app's runtime's bridge |
 
 **The seam.** Each dropped piece leaves a **weak no-op default** in the base that
@@ -279,10 +281,15 @@ a **strong override** in the composed archive replaces (mirrors the gpu/tui
 feature hooks). The HTTP seam is `include/hull/http_feature.h` (weak defaults in
 `cap/http_feature.c`); a base TU `src/hull/http_weakstub.c` carries weak
 real-signature stubs so the pure runtime's few references to the web bindings
-link even when HTTP is not composed. The archives are whole-archived at compose
-(no single anchor symbol), inside a GNU-ld `--start-group` (native) / `-force_load`
-(ld64) with the platform lib + Keel, since the caps reference base symbols + Keel
-and the web bindings reference the caps.
+link even when HTTP is not composed. The WASM seam is weak-stubs-only (no hook
+header): `src/hull/wasm_weakstub.c` carries weak `hl_cap_wasm_*` / `hl_wasm_buffer_*`
+defaults (referenced by `db_udf` / `mod_buffer` / `mod_image` / `mod_gpu` /
+`app_context` / `serve`) plus the per-runtime compute-binding stubs — so a WASM-free
+app links; a function `db.udf` still works while a WASM-backed one fails closed.
+The archives are whole-archived at compose (no single anchor symbol), inside a
+GNU-ld `--start-group` (native) / `-force_load` (ld64) with the platform lib + Keel,
+since the caps reference base symbols + Keel and the web/compute bindings reference
+the caps.
 
 **"Needs HTTP" is resolved, not guessed.** `hull build` composes the http core +
 web bindings only when the resolved manifest trips an HTTP cap
@@ -294,16 +301,31 @@ links only the pure runtime; on a `--flavor=pure-compute` base it also drops Kee
 + mbedTLS (~785 KB smaller than a full-flavor CLI). The base defines **zero** HTTP
 caps (verifiable: `nm libhull_platform.a | grep hl_cap_http_request` → empty).
 
+**"Needs WASM" is a two-signal gate** (docs/wasm_feature.md). WASM is harder than
+HTTP because it is not cleanly module-inferable: `db.udf` can be WASM-backed
+(`cap/db_udf.c` calls `hl_cap_wasm_instance_*`) without any module declaration. So
+`hull build` composes the wasm core + compute bridge iff **S1 or S2**: `S1` = a
+declared WASM cap (`hull/compute`, `req_caps & HL_MOD_CAP_WASM`, exposed as
+`needs_wasm` from `tool.modules_resolve`, mirrors `needs_http`); `S2` = the app
+ships `compute/*.wasm` (catches the WASM-backed `db.udf`). A genuinely compute-free
+app links **zero** WAMR (~256 KB smaller; verifiable: `nm app | grep
+wasm_runtime_full_init` → empty). The base defines zero wasm caps (`nm
+libhull_platform.a | grep hl_cap_wasm_init` → only the weak stub).
+
 **Where it's wired.** The archives + embed live in the Makefile (`FEATURE_*_OBJS`,
-`libhull_feature-*.a`, `embedded_{runtime,http,tui}.h`, `RUNTIME_FEATURE_LIBS`);
+`libhull_feature-*.a`, `embedded_{runtime,http,tui,wasm}.h`, `RUNTIME_FEATURE_LIBS`);
 the compose + embedded-first resolve ladder is shared by `hull build` and
 `hull eject` via `stdlib/cli/lua/hull/feature_compose.lua`
 (`resolve_runtime_lib` / `resolve_http_lib` / `resolve_http_rt_lib` /
-`resolve_tui_rt_lib`) + `build_assets.c` (`hl_build_extract_feature_*`). Design:
-[docs/http_feature_phase1.md](docs/http_feature_phase1.md). Covered by
+`resolve_tui_rt_lib` / `resolve_wasm_lib` / `resolve_wasm_rt_lib`) +
+`build_assets.c` (`hl_build_extract_feature_*`). Design:
+[docs/http_feature_phase1.md](docs/http_feature_phase1.md),
+[docs/wasm_feature.md](docs/wasm_feature.md). Covered by
 `tests/e2e_feature_runtime.sh` (runtime slim, both runtimes),
 `tests/e2e_build_flavor.sh` (pure-compute × runtime, symbol-level Keel/http drop),
-and `tests/e2e_feature_tui.sh` (tui × runtime, both runtimes).
+`tests/e2e_feature_tui.sh` (tui × runtime, both runtimes), and
+`tests/e2e_feature_wasm.sh` (compute-free drops WAMR + the needs_wasm gate + a
+composed `compute.call`, both runtimes).
 
 ### Extension taxonomy: feature vs flavor vs tool vs stdlib
 

--- a/Makefile
+++ b/Makefile
@@ -1956,6 +1956,13 @@ ENTRY_OBJ      := $(BUILDDIR)/entry.o
 # HTTP_SERVER is off (the whole body is guarded).
 HTTP_WEAKSTUB_OBJ := $(BUILDDIR)/http_weakstub.o
 
+# WASM-as-a-feature seam (docs/wasm_feature.md, Phase 0). Weak, fail-closed
+# defaults for the eleven runtime-agnostic wasm cap symbols base objects
+# (db_udf / mod_buffer / mod_image / mod_gpu / app_context / serve) reference, so
+# a future compute-less base still links. Additive + dormant today: the strong
+# cap_wasm* defs win while WAMR is still compiled in (the base flip is Phase 1).
+WASM_WEAKSTUB_OBJ := $(BUILDDIR)/wasm_weakstub.o
+
 # ── Stdlib embedding (xxd) ──────────────────────────────────────────
 #
 # Two Lua source trees feed the embedded stdlib registry:
@@ -2576,7 +2583,7 @@ else
   # HTTP core caps move to libhull_feature-http.a; the app composes it back.
   PLATFORM_CAP_OBJS      := $(filter-out $(FEATURE_HTTP_OBJS),$(CAP_OBJS))
 endif
-PLATFORM_OBJS := $(PLATFORM_CAP_OBJS) $(CAP_TOOL_OBJ) $(CAP_TEST_OBJ) $(CMD_OBJS) $(PLATFORM_RT_OBJS) $(ALLOC_OBJ) $(ASYNC_OBJ) $(COMPRESS_OBJ) $(MINIZ_OBJ) $(WORKER_DB_OBJ) $(WORKER_WASM_OBJ) $(WORKER_GPU_OBJ) $(PLATFORM_MANIFEST_OBJ) $(MODULE_OBJ) $(ASYNC_BACKEND_OBJS) $(NET_BACKEND_OBJS) $(SANDBOX_OBJ) $(SANDBOX_TOOL_OBJ) $(SIG_OBJ) $(RELEASE_OBJ) $(RELEASE_IO_OBJ) $(TOOLS_INSTALL_OBJ) $(PLATFORM_SIG_OBJ) $(EMBEDDED_PLATFORM_SIG_OBJ) $(TEST_RUNNER_OBJ) $(RUNTIME_FACTORY_OBJ) $(STATIC_OBJ) $(MIGRATE_OBJ) $(VFS_OBJ) $(PATH_NORM_OBJ) $(THREAD_AFFINITY_OBJ) $(CACHE_DIR_OBJ) $(BLOB_STORE_OBJ) $(CACHE_REGISTRY_OBJ) $(CACERT_OBJ) $(TLS_CLIENT_OBJ) $(CSP_OBJ) $(SBOM_OBJ) $(STDLIB_FEATURE_OBJ) $(APP_CONTEXT_OBJ) $(APP_CONTEXT_RT_OBJ) $(AGENT_LIB_OBJ) $(AGENT_API_OBJ) $(MAIN_OBJ) $(SERVE_OBJ) $(APP_RUNNER_OBJ) $(HTTP_WEAKSTUB_OBJ) $(TOOL_OBJ) $(BUILD_ASSET_STUB_OBJ) $(STDLIB_REGISTRY_O) $(PLATFORM_RUNTIME_EXTRA) $(WAMR_OBJS) $(MBEDTLS_OBJS) \
+PLATFORM_OBJS := $(PLATFORM_CAP_OBJS) $(CAP_TOOL_OBJ) $(CAP_TEST_OBJ) $(CMD_OBJS) $(PLATFORM_RT_OBJS) $(ALLOC_OBJ) $(ASYNC_OBJ) $(COMPRESS_OBJ) $(MINIZ_OBJ) $(WORKER_DB_OBJ) $(WORKER_WASM_OBJ) $(WORKER_GPU_OBJ) $(PLATFORM_MANIFEST_OBJ) $(MODULE_OBJ) $(ASYNC_BACKEND_OBJS) $(NET_BACKEND_OBJS) $(SANDBOX_OBJ) $(SANDBOX_TOOL_OBJ) $(SIG_OBJ) $(RELEASE_OBJ) $(RELEASE_IO_OBJ) $(TOOLS_INSTALL_OBJ) $(PLATFORM_SIG_OBJ) $(EMBEDDED_PLATFORM_SIG_OBJ) $(TEST_RUNNER_OBJ) $(RUNTIME_FACTORY_OBJ) $(STATIC_OBJ) $(MIGRATE_OBJ) $(VFS_OBJ) $(PATH_NORM_OBJ) $(THREAD_AFFINITY_OBJ) $(CACHE_DIR_OBJ) $(BLOB_STORE_OBJ) $(CACHE_REGISTRY_OBJ) $(CACERT_OBJ) $(TLS_CLIENT_OBJ) $(CSP_OBJ) $(SBOM_OBJ) $(STDLIB_FEATURE_OBJ) $(APP_CONTEXT_OBJ) $(APP_CONTEXT_RT_OBJ) $(AGENT_LIB_OBJ) $(AGENT_API_OBJ) $(MAIN_OBJ) $(SERVE_OBJ) $(APP_RUNNER_OBJ) $(HTTP_WEAKSTUB_OBJ) $(WASM_WEAKSTUB_OBJ) $(TOOL_OBJ) $(BUILD_ASSET_STUB_OBJ) $(STDLIB_REGISTRY_O) $(PLATFORM_RUNTIME_EXTRA) $(WAMR_OBJS) $(MBEDTLS_OBJS) \
 	$(SQLITE_OBJ) $(LOG_OBJ) $(LOG_LOCK_OBJ) $(SH_ARENA_OBJ) $(SH_JSON_OBJ) $(TWEETNACL_OBJ) $(STB_OBJ) $(PLEDGE_OBJS) \
 	$(COMPILER_OBJ) $(COMPILER_TCC_OBJ)
 
@@ -3495,6 +3502,9 @@ $(APP_RUNNER_OBJ): $(SRCDIR)/hull/app_runner.c | $(BUILDDIR)
 
 # Weak no-op defaults for the per-runtime web bindings (issue #114, Phase C).
 $(HTTP_WEAKSTUB_OBJ): $(SRCDIR)/hull/http_weakstub.c | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
+
+$(WASM_WEAKSTUB_OBJ): $(SRCDIR)/hull/wasm_weakstub.c | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
 
 # Serve-cli (CLI counterpart, used when HL_ENABLE_HTTP_SERVER=0)

--- a/Makefile
+++ b/Makefile
@@ -2571,6 +2571,14 @@ check-hardening: $(BUILDDIR)/hull
 # `hull build`. The feature-http archive target below reuses this list.
 FEATURE_HTTP_OBJS := $(BUILDDIR)/cap_http.o $(BUILDDIR)/cap_http_async.o \
                      $(BUILDDIR)/cap_ws.o $(BUILDDIR)/cap_smtp.o $(BUILDDIR)/cap_body.o
+
+# WASM as a composable feature (docs/wasm_feature.md, Phase 1). The runtime-
+# AGNOSTIC wasm caps move into libhull_feature-wasm.a (with worker_wasm + the
+# vendored WAMR objects) and compose back at `hull build`; the per-runtime
+# compute BINDING (mod_compute) moves into libhull_feature-wasm-<rt>.a. The base
+# keeps the wasm_weakstub.c weak defaults (Phase 0) so a compute-less app links.
+FEATURE_WASM_OBJS := $(BUILDDIR)/cap_wasm.o $(BUILDDIR)/cap_wasm_buffer.o \
+                     $(BUILDDIR)/cap_wasm_data.o $(BUILDDIR)/cap_wasm_stream.o
 ifdef COSMO
   PLATFORM_RT_OBJS       := $(RT_OBJS)
   PLATFORM_MANIFEST_OBJ  := $(MANIFEST_OBJ)
@@ -2855,6 +2863,29 @@ feature-http: $(BUILDDIR)/libhull_feature-http.a
 .PHONY: feature-http
 $(BUILDDIR)/libhull_feature-http.a: $(FEATURE_HTTP_OBJS) | $(BUILDDIR)
 	$(call AR_FEATURE_LIB,$(FEATURE_HTTP_OBJS))
+
+# libhull_feature-wasm.a: the runtime-agnostic WASM CORE (docs/wasm_feature.md,
+# Phase 1). Bundles the wasm caps + worker_wasm + the vendored WAMR objects
+# (the ~256 KB that leaves the base). Composed back at `hull build` and embedded
+# in hull (embedded_wasm.h). The per-runtime compute binding (mod_compute) is a
+# separate archive below, like the http web bindings.
+FEATURE_WASM_CORE := $(FEATURE_WASM_OBJS) $(WORKER_WASM_OBJ) $(WAMR_OBJS)
+feature-wasm: $(BUILDDIR)/libhull_feature-wasm.a
+.PHONY: feature-wasm
+$(BUILDDIR)/libhull_feature-wasm.a: $(FEATURE_WASM_CORE) | $(BUILDDIR)
+	$(call AR_FEATURE_LIB,$(FEATURE_WASM_CORE))
+
+# Per-runtime compute-binding bridges (mod_compute). Tiny (one object each);
+# embedded in hull + composed for the app's runtime alongside the wasm core.
+feature-wasm-lua: $(BUILDDIR)/libhull_feature-wasm-lua.a
+.PHONY: feature-wasm-lua
+$(BUILDDIR)/libhull_feature-wasm-lua.a: $(BUILDDIR)/lua_rt_mod_compute.o | $(BUILDDIR)
+	$(call AR_FEATURE_LIB,$(BUILDDIR)/lua_rt_mod_compute.o)
+
+feature-wasm-js: $(BUILDDIR)/libhull_feature-wasm-js.a
+.PHONY: feature-wasm-js
+$(BUILDDIR)/libhull_feature-wasm-js.a: $(BUILDDIR)/js_mod_compute.o | $(BUILDDIR)
+	$(call AR_FEATURE_LIB,$(BUILDDIR)/js_mod_compute.o)
 
 # libhull_feature-lua.a / -js.a: a runtime as a composable feature archive.
 # Bundles the runtime objects, its vendored VM, its manifest extractor, and its

--- a/Makefile
+++ b/Makefile
@@ -4197,6 +4197,10 @@ e2e-http: $(BUILDDIR)/hull
 e2e-feature-runtime: $(BUILDDIR)/hull
 	sh tests/e2e_feature_runtime.sh
 
+.PHONY: e2e-feature-wasm
+e2e-feature-wasm: $(BUILDDIR)/hull
+	sh tests/e2e_feature_wasm.sh
+
 e2e-multipart: $(BUILDDIR)/hull
 	RUNTIME=$(RUNTIME) sh tests/e2e_multipart.sh
 

--- a/Makefile
+++ b/Makefile
@@ -2588,10 +2588,12 @@ else
   PLATFORM_RT_OBJS       := $(RUNTIME_CACHE_COMMON_OBJ)  # runtime-agnostic; VMs dropped
   PLATFORM_MANIFEST_OBJ  := $(BUILDDIR)/manifest.o       # runtime-agnostic
   PLATFORM_RUNTIME_EXTRA :=
-  # HTTP core caps move to libhull_feature-http.a; the app composes it back.
-  PLATFORM_CAP_OBJS      := $(filter-out $(FEATURE_HTTP_OBJS),$(CAP_OBJS))
+  # HTTP core caps move to libhull_feature-http.a; the wasm caps move to
+  # libhull_feature-wasm.a (docs/wasm_feature.md, Phase 1). Both compose back at
+  # `hull build`; the base keeps the weak stubs (http_weakstub / wasm_weakstub).
+  PLATFORM_CAP_OBJS      := $(filter-out $(FEATURE_HTTP_OBJS) $(FEATURE_WASM_OBJS),$(CAP_OBJS))
 endif
-PLATFORM_OBJS := $(PLATFORM_CAP_OBJS) $(CAP_TOOL_OBJ) $(CAP_TEST_OBJ) $(CMD_OBJS) $(PLATFORM_RT_OBJS) $(ALLOC_OBJ) $(ASYNC_OBJ) $(COMPRESS_OBJ) $(MINIZ_OBJ) $(WORKER_DB_OBJ) $(WORKER_WASM_OBJ) $(WORKER_GPU_OBJ) $(PLATFORM_MANIFEST_OBJ) $(MODULE_OBJ) $(ASYNC_BACKEND_OBJS) $(NET_BACKEND_OBJS) $(SANDBOX_OBJ) $(SANDBOX_TOOL_OBJ) $(SIG_OBJ) $(RELEASE_OBJ) $(RELEASE_IO_OBJ) $(TOOLS_INSTALL_OBJ) $(PLATFORM_SIG_OBJ) $(EMBEDDED_PLATFORM_SIG_OBJ) $(TEST_RUNNER_OBJ) $(RUNTIME_FACTORY_OBJ) $(STATIC_OBJ) $(MIGRATE_OBJ) $(VFS_OBJ) $(PATH_NORM_OBJ) $(THREAD_AFFINITY_OBJ) $(CACHE_DIR_OBJ) $(BLOB_STORE_OBJ) $(CACHE_REGISTRY_OBJ) $(CACERT_OBJ) $(TLS_CLIENT_OBJ) $(CSP_OBJ) $(SBOM_OBJ) $(STDLIB_FEATURE_OBJ) $(APP_CONTEXT_OBJ) $(APP_CONTEXT_RT_OBJ) $(AGENT_LIB_OBJ) $(AGENT_API_OBJ) $(MAIN_OBJ) $(SERVE_OBJ) $(APP_RUNNER_OBJ) $(HTTP_WEAKSTUB_OBJ) $(WASM_WEAKSTUB_OBJ) $(TOOL_OBJ) $(BUILD_ASSET_STUB_OBJ) $(STDLIB_REGISTRY_O) $(PLATFORM_RUNTIME_EXTRA) $(WAMR_OBJS) $(MBEDTLS_OBJS) \
+PLATFORM_OBJS := $(PLATFORM_CAP_OBJS) $(CAP_TOOL_OBJ) $(CAP_TEST_OBJ) $(CMD_OBJS) $(PLATFORM_RT_OBJS) $(ALLOC_OBJ) $(ASYNC_OBJ) $(COMPRESS_OBJ) $(MINIZ_OBJ) $(WORKER_DB_OBJ) $(WORKER_GPU_OBJ) $(PLATFORM_MANIFEST_OBJ) $(MODULE_OBJ) $(ASYNC_BACKEND_OBJS) $(NET_BACKEND_OBJS) $(SANDBOX_OBJ) $(SANDBOX_TOOL_OBJ) $(SIG_OBJ) $(RELEASE_OBJ) $(RELEASE_IO_OBJ) $(TOOLS_INSTALL_OBJ) $(PLATFORM_SIG_OBJ) $(EMBEDDED_PLATFORM_SIG_OBJ) $(TEST_RUNNER_OBJ) $(RUNTIME_FACTORY_OBJ) $(STATIC_OBJ) $(MIGRATE_OBJ) $(VFS_OBJ) $(PATH_NORM_OBJ) $(THREAD_AFFINITY_OBJ) $(CACHE_DIR_OBJ) $(BLOB_STORE_OBJ) $(CACHE_REGISTRY_OBJ) $(CACERT_OBJ) $(TLS_CLIENT_OBJ) $(CSP_OBJ) $(SBOM_OBJ) $(STDLIB_FEATURE_OBJ) $(APP_CONTEXT_OBJ) $(APP_CONTEXT_RT_OBJ) $(AGENT_LIB_OBJ) $(AGENT_API_OBJ) $(MAIN_OBJ) $(SERVE_OBJ) $(APP_RUNNER_OBJ) $(HTTP_WEAKSTUB_OBJ) $(WASM_WEAKSTUB_OBJ) $(TOOL_OBJ) $(BUILD_ASSET_STUB_OBJ) $(STDLIB_REGISTRY_O) $(PLATFORM_RUNTIME_EXTRA) $(MBEDTLS_OBJS) \
 	$(SQLITE_OBJ) $(LOG_OBJ) $(LOG_LOCK_OBJ) $(SH_ARENA_OBJ) $(SH_JSON_OBJ) $(TWEETNACL_OBJ) $(STB_OBJ) $(PLEDGE_OBJS) \
 	$(COMPILER_OBJ) $(COMPILER_TCC_OBJ)
 
@@ -2909,9 +2911,9 @@ FEATURE_HTTP_RT_NAMES := mod_ws_server mod_ws_client mod_http_server mod_sse \
 FEATURE_HTTP_LUA_OBJS := $(addprefix $(BUILDDIR)/lua_rt_,$(addsuffix .o,$(FEATURE_HTTP_RT_NAMES)))
 FEATURE_HTTP_JS_OBJS  := $(addprefix $(BUILDDIR)/js_,$(addsuffix .o,$(FEATURE_HTTP_RT_NAMES)))
 
-FEATURE_LUA_OBJS := $(filter-out $(BUILDDIR)/lua_rt_mod_tui.o $(BUILDDIR)/lua_rt_mod_tool.o $(FEATURE_HTTP_LUA_OBJS),$(LUA_RT_OBJS)) \
+FEATURE_LUA_OBJS := $(filter-out $(BUILDDIR)/lua_rt_mod_tui.o $(BUILDDIR)/lua_rt_mod_tool.o $(BUILDDIR)/lua_rt_mod_compute.o $(FEATURE_HTTP_LUA_OBJS),$(LUA_RT_OBJS)) \
                     $(LUA_OBJS) $(BUILDDIR)/manifest_lua.o $(STDLIB_LUA_REGISTRY_O)
-FEATURE_JS_OBJS  := $(filter-out $(BUILDDIR)/js_mod_tui.o $(FEATURE_HTTP_JS_OBJS),$(JS_RT_OBJS)) \
+FEATURE_JS_OBJS  := $(filter-out $(BUILDDIR)/js_mod_tui.o $(BUILDDIR)/js_mod_compute.o $(FEATURE_HTTP_JS_OBJS),$(JS_RT_OBJS)) \
                     $(QJS_OBJS) $(BUILDDIR)/manifest_js.o $(STDLIB_JS_REGISTRY_O)
 
 feature-lua: $(BUILDDIR)/libhull_feature-lua.a
@@ -2948,8 +2950,14 @@ FEATURE_ARCHIVES := $(BUILDDIR)/libhull_feature-lua.a $(BUILDDIR)/libhull_featur
                     $(BUILDDIR)/libhull_feature-http.a \
                     $(BUILDDIR)/libhull_feature-http-lua.a $(BUILDDIR)/libhull_feature-http-js.a \
                     $(BUILDDIR)/libhull_feature-tui.a \
-                    $(BUILDDIR)/libhull_feature-tui-lua.a $(BUILDDIR)/libhull_feature-tui-js.a
+                    $(BUILDDIR)/libhull_feature-tui-lua.a $(BUILDDIR)/libhull_feature-tui-js.a \
+                    $(BUILDDIR)/libhull_feature-wasm.a \
+                    $(BUILDDIR)/libhull_feature-wasm-lua.a $(BUILDDIR)/libhull_feature-wasm-js.a
 $(FEATURE_ARCHIVES): Makefile
+# The base platform lib is built from an object LIST (PLATFORM_OBJS); a Phase-1
+# change to that list (wasm caps + WAMR removed) must retrigger the ar, which an
+# mtime check alone misses (docs/wasm_feature.md). Same guard as the features.
+$(PLATFORM_LIB): Makefile
 
 # Runtime feature archives a native `hull build` needs to compose a runnable
 # app. The native base is runtime-less, so `hull build` resolves the runtime
@@ -2964,14 +2972,20 @@ $(FEATURE_ARCHIVES): Makefile
 # HTTP in the base and composes no http feature.
 ifndef COSMO
 ifeq ($(RUNTIME),js)
-  RUNTIME_FEATURE_LIBS := $(BUILDDIR)/libhull_feature-js.a $(BUILDDIR)/libhull_feature-http-js.a
+  RUNTIME_FEATURE_LIBS := $(BUILDDIR)/libhull_feature-js.a $(BUILDDIR)/libhull_feature-http-js.a \
+                          $(BUILDDIR)/libhull_feature-wasm-js.a
 else ifeq ($(RUNTIME),lua)
-  RUNTIME_FEATURE_LIBS := $(BUILDDIR)/libhull_feature-lua.a $(BUILDDIR)/libhull_feature-http-lua.a
+  RUNTIME_FEATURE_LIBS := $(BUILDDIR)/libhull_feature-lua.a $(BUILDDIR)/libhull_feature-http-lua.a \
+                          $(BUILDDIR)/libhull_feature-wasm-lua.a
 else
   RUNTIME_FEATURE_LIBS := $(BUILDDIR)/libhull_feature-lua.a $(BUILDDIR)/libhull_feature-http-lua.a \
-                          $(BUILDDIR)/libhull_feature-js.a $(BUILDDIR)/libhull_feature-http-js.a
+                          $(BUILDDIR)/libhull_feature-wasm-lua.a \
+                          $(BUILDDIR)/libhull_feature-js.a $(BUILDDIR)/libhull_feature-http-js.a \
+                          $(BUILDDIR)/libhull_feature-wasm-js.a
 endif
-  RUNTIME_FEATURE_LIBS += $(BUILDDIR)/libhull_feature-http.a
+  # HTTP + WASM core feature archives (runtime-agnostic), composed for every
+  # full-flavor app (docs/wasm_feature.md, Phase 1 composes wasm always).
+  RUNTIME_FEATURE_LIBS += $(BUILDDIR)/libhull_feature-http.a $(BUILDDIR)/libhull_feature-wasm.a
 else
   RUNTIME_FEATURE_LIBS :=
 endif
@@ -3123,8 +3137,18 @@ $(EMBEDDED_TUI_H): $(BUILDDIR)/libhull_feature-tui-lua.a $(BUILDDIR)/libhull_fea
 	@xxd -i $(BUILDDIR)/libhull_feature-tui-lua.a | sed 's/build_libhull_feature_tui_lua_a/hl_embedded_feature_tui_lua_a/g' | $(XXD_CONST_PIPE) >> $@
 	@xxd -i $(BUILDDIR)/libhull_feature-tui-js.a  | sed 's/build_libhull_feature_tui_js_a/hl_embedded_feature_tui_js_a/g'   | $(XXD_CONST_PIPE) >> $@
 
-CFLAGS += -DHL_BUILD_EMBEDDED -DHL_BUILD_EMBEDDED_RUNTIME -DHL_BUILD_EMBEDDED_HTTP -DHL_BUILD_EMBEDDED_TUI
-$(BUILD_ASSET_OBJ): $(EMBEDDED_PLATFORM_H) $(EMBEDDED_TEMPLATES_H) $(EMBEDDED_RUNTIME_H) $(EMBEDDED_HTTP_H) $(EMBEDDED_TUI_H)
+# Embed the WASM feature archives too (docs/wasm_feature.md, Phase 1). The native
+# base is compute-less; the default distributed hull composes the wasm core + the
+# app's runtime compute bridge back for every full-flavor app with no install.
+EMBEDDED_WASM_H := $(BUILDDIR)/embedded_wasm.h
+$(EMBEDDED_WASM_H): $(BUILDDIR)/libhull_feature-wasm.a $(BUILDDIR)/libhull_feature-wasm-lua.a $(BUILDDIR)/libhull_feature-wasm-js.a | $(BUILDDIR)
+	@echo "/* Auto-generated - do not edit */" > $@
+	@xxd -i $(BUILDDIR)/libhull_feature-wasm.a     | sed 's/build_libhull_feature_wasm_a/hl_embedded_feature_wasm_a/g'         | $(XXD_CONST_PIPE) >> $@
+	@xxd -i $(BUILDDIR)/libhull_feature-wasm-lua.a | sed 's/build_libhull_feature_wasm_lua_a/hl_embedded_feature_wasm_lua_a/g' | $(XXD_CONST_PIPE) >> $@
+	@xxd -i $(BUILDDIR)/libhull_feature-wasm-js.a  | sed 's/build_libhull_feature_wasm_js_a/hl_embedded_feature_wasm_js_a/g'   | $(XXD_CONST_PIPE) >> $@
+
+CFLAGS += -DHL_BUILD_EMBEDDED -DHL_BUILD_EMBEDDED_RUNTIME -DHL_BUILD_EMBEDDED_HTTP -DHL_BUILD_EMBEDDED_TUI -DHL_BUILD_EMBEDDED_WASM
+$(BUILD_ASSET_OBJ): $(EMBEDDED_PLATFORM_H) $(EMBEDDED_TEMPLATES_H) $(EMBEDDED_RUNTIME_H) $(EMBEDDED_HTTP_H) $(EMBEDDED_TUI_H) $(EMBEDDED_WASM_H)
 endif
 
 # Hull binary

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -156,10 +156,16 @@ flavor.
 | **`hull/query` builder + `hull/query/schema`** | **stdlib** | Designed + requested; the C keystone already shipped (`HlDbDialect` descriptor + `conn.dialect`, commit `234c8dc`). A thin, injection-safe compile-to-`(sql, params)` layer over `conn.query` (values bound, identifiers dialect-quoted), NOT an ORM. Resolves 5 DB-API-review findings (portable upsert / `RETURNING` / async terminals / raw composition / dialect leakage). Cheaper than any feature (no C, no release pipeline; offline `to_sql()` matrix tests). See [roadmap_next.md](roadmap_next.md) "Out of scope" note under the backend-onboarding checklist. |
 | **Object storage / S3, most integration clients** | **stdlib** | Buildable on `http.fetch` + `crypto` (SigV4). No C archive. The canonical "reach for stdlib before a feature" case. |
 
-**Deliberately kept core (never a feature):** the WASM *interpreter* (WAMR,
-~256 KB - the compute pillar; `db.udf` leans on it; its heavy half, the AOT
-*compiler* `wamrc`, is already correctly a tool), and `crypto` / SHA / HMAC (the
-trust substrate under signatures, sessions, JWT).
+**WASM featurified (#118, docs/wasm_feature.md).** The WASM *interpreter* (WAMR,
+~256 KB) was the last "kept core" candidate; it is now an embedded, auto-composed
+feature (like the runtimes / HTTP core) — the native base is compute-less and a
+compute-free app links zero WAMR. It stays *embedded + auto-composed*, not
+`hull feature install`, because compute is a pillar and the `db.udf` coupling
+needs the two-signal `needs_wasm` gate rather than a manual `--with`. Its heavy
+half, the AOT *compiler* `wamrc`, remains correctly a tool.
+
+**Deliberately kept core (never a feature):** `crypto` / SHA / HMAC (the trust
+substrate under signatures, sessions, JWT), and the default SQLite backend.
 
 ### Next. Distribution: hull.com Downloadable Tool
 

--- a/docs/wasm_feature.md
+++ b/docs/wasm_feature.md
@@ -1,0 +1,205 @@
+# WASM as a composable feature — design
+
+**Status:** design (not implemented). The last large vendored engine still
+compiled into the base by default. Finishes the base-subtraction axis begun by
+#113 (runtimes) and #114 (HTTP core). Sequenced as its **own epic** after a
+release cut, because it is materially harder than the runtime/HTTP splits (see
+"Why this is harder" below).
+
+Related: [docs/http_feature_phase1.md](http_feature_phase1.md) (the seam +
+whole-archive pattern this reuses), [docs/features_and_flavors.md](features_and_flavors.md)
+(the taxonomy), [docs/composed_feature_signing.md](composed_feature_signing.md)
+(which covers this feature for free — see "Signing").
+
+## The gap
+
+Today WAMR (~256 KB) is a **compile-time flag** (`HL_ENABLE_WASM`, default 1):
+one binary either has `compute.*` or it doesn't. Like the runtime and HTTP work,
+we want it to be a **composition decision of the produced app** instead — a
+single distributed `hull` builds both compute apps and compute-free apps, and a
+compute-free app links **zero** WAMR (~256 KB smaller, smaller attack surface,
+no `wasm_*` symbols).
+
+This mirrors the mandatory auto-composed axis: the native base becomes
+**compute-less**, and `hull build` composes `libhull_feature-wasm.a` back only
+when the app needs it. Like the runtimes and HTTP core (and unlike `--with=gpu`),
+the archive is **embedded in `hull`** and **auto-composed** — never
+`hull feature install`. Cosmo (fat APE) keeps WASM compiled in.
+
+## Why this is harder than #113 / #114
+
+The runtime split inferred from the entry extension (`.lua`/`.js`); the HTTP
+split inferred from a resolved cap (`HL_MOD_CAP_HTTP`) tripped by module-
+conditional `app.get`/etc. decorations. WASM has **three** entanglements that
+neither of those had:
+
+1. **Not cleanly module-inferable.** `hull/compute` declares `HL_MOD_CAP_WASM`,
+   so the *direct* `compute.*` path is inferable exactly like HTTP. But WAMR is
+   **also** reachable through a path that carries no module declaration:
+2. **`db.udf` is WASM-backed.** `cap/db_udf.c` (part of the always-present base
+   DB layer) calls `hl_cap_wasm_instance_create/call/destroy` directly:
+   `db.udf.register(name, "wasm_module")` runs a compute module inside SQLite.
+   That app may declare only `hull/db` and never `hull/compute`. So the base DB
+   layer references WASM cap symbols, and "needs WASM" cannot be read from
+   `hull/compute` alone.
+3. **The unified buffer protocol touches `WasmBuffer`.** `compute.buffer(...)`
+   and the zero-copy `WasmBuffer` userdata (`cap/wasm_buffer.c`) are woven into
+   `mod_buffer` / `mod_compute` and the GPU path. Dropping WASM must leave the
+   buffer protocol coherent (a `WasmBuffer` simply cannot be created).
+
+These are exactly why roadmap.md still lists the WASM *interpreter* under
+"deliberately kept core" for the near term, while roadmap_next.md carries the
+"WASM follows the same model (separate epic)" long-term plan. Both are true: it
+is the last featurify target, and it is a distinct, later epic.
+
+## Resolving "needs WASM" (the two-signal gate)
+
+`hull build` composes the WASM feature iff **either** build-time signal fires
+(the roadmap's "two signals", realized at build time):
+
+| Signal | Source | Catches |
+|--------|--------|---------|
+| **S1: compute cap declared** | `hl_module_set_required_caps & HL_MOD_CAP_WASM` (an app declaring `hull/compute`), exposed from `tool.modules_resolve` as `needs_wasm` — identical plumbing to `needs_http`. | the direct `compute.*` path |
+| **S2: app ships `compute/*.wasm`** | `build.lua` already discovers + embeds `compute/*.wasm` (and AOT-compiles them). A non-empty compute set is the signal. | the WASM-backed `db.udf` path (a wasm UDF needs a `.wasm` to register), even when only `hull/db` is declared |
+
+`needs_wasm = S1 or S2`. If **neither** fires, the app links no WAMR. S2 is the
+critical difference from HTTP: a UDF-only app trips S2 (it ships the `.wasm`)
+without S1, so it keeps the runtime it needs. Conservative by construction: a
+declared-but-unused `hull/compute`, or a stray `compute/*.wasm`, composes WASM
+(correct, just not minimal). A compute-free app is the common case and gets the
+slim binary.
+
+**Edge to document:** a Lua/JS-function `db.udf` (not WASM-backed) needs no WAMR;
+it must keep working on a WASM-free base (see the seam below). Only
+`db.udf.register(name, "module")` (WASM-backed) requires the feature, and that
+app ships the `.wasm` → S2.
+
+## The seam
+
+Mirror the HTTP seam (`http_feature.h` weak defaults in `cap/http_feature.c`,
+strong overrides whole-archived from the feature lib).
+
+**Moves into `libhull_feature-wasm.a`:**
+- `cap/wasm.c`, `cap/wasm_buffer.c`, `cap/wasm_data.c`, `cap/wasm_stream.c`
+- `worker_wasm.o` (the async compute worker)
+- `WAMR_OBJS` (the vendored WAMR archive, the ~256 KB)
+
+**Stays in the base, gains a weak seam** (`include/hull/wasm_feature.h`,
+weak no-ops in `cap/wasm_feature.c`, real-signature weak stubs in a base TU
+`src/hull/wasm_weakstub.c` for the symbols base objects reference):
+
+- **`cap/db_udf.c`** (base DB layer) references `hl_cap_wasm_instance_*`. On a
+  WASM-free base those resolve to weak stubs that fail closed:
+  `db.udf.register(name, <lua/js fn>)` (scalar/aggregate function UDFs) still
+  works — that path never calls WASM; `db.udf.register(name, "module")`
+  (WASM-backed) returns a clear "WASM feature not composed" error. This is the
+  central seam: the DB layer stays whole, only the wasm-backed branch degrades.
+- **`compute.*` runtime bindings.** Two options, decide in Phase 0:
+  - **(a) weak-seam in place (simpler).** `mod_compute.o` stays in the runtime
+    archive and calls `hl_cap_wasm_*` through the seam; on a WASM-free base
+    `compute.available()` → false and every `compute.call/async/instance/segment/
+    stream/buffer` returns "not_available". No new per-runtime archive.
+  - **(b) per-runtime bridge (parallels HTTP-C).** `mod_compute.o` moves into
+    `libhull_feature-wasm-<rt>.a`, composed with the core when `needs_wasm`. The
+    pure runtime keeps weak stubs for the few `mod_compute` symbols `modules.o`
+    references. Cleaner symbol separation, one more archive per runtime.
+  Recommendation: **(a)** — the `compute.*` binding surface is small and the
+  buffer-protocol coupling (`WasmBuffer`) makes a clean per-runtime extraction
+  fiddlier than it was for the web bindings. Prove with an `nm` assertion that a
+  compute-free app has zero `wasm_*`/WAMR symbols regardless.
+- **`compute.buffer` / `WasmBuffer`.** On a WASM-free base, `compute.buffer(...)`
+  fails ("WASM feature not composed"); a `WasmBuffer` cannot be created, so the
+  unified buffer protocol's other producers (`fs.mmap` → `MappedBuffer`,
+  `ArrayBuffer`) are unaffected. Verify GPU + image paths still accept the
+  remaining buffer types.
+
+Whole-archive at compose (`-force_load` ld64 / `--whole-archive` +
+`--start-group` GNU-ld), inside the platform-lib group — WAMR references libc/pthread
+and the caps reference base symbols, same as the HTTP core.
+
+## Composition + Makefile
+
+- `libhull_feature-wasm.a`: `make feature-wasm` (ar over the wasm caps +
+  worker_wasm + WAMR_OBJS). Add to `EMBEDDED_*` (a new `embedded_wasm.h` via the
+  `XXD_CONST_PIPE` pattern) and `RUNTIME_FEATURE_LIBS`, gated so the base drops
+  the WAMR objects from `PLATFORM_OBJS`.
+- `build.lua` composes it (embedded-first resolve ladder, like the runtime/http
+  libs) when `needs_wasm`, via `feature_compose.lua` (`resolve_wasm_lib`) +
+  `build_assets.c` (`hl_build_extract_feature_wasm`).
+- Cosmo exempt: the fat APE keeps WASM in-base (a fat APE can't force-load a
+  native feature archive), same carve-out as the runtimes and HTTP core.
+
+## Signing (free)
+
+Because the WASM feature is an **embedded, auto-composed** archive (not
+`hull feature install`), it lands in the `platform_domain` of
+`package.sig.gethull.composed`. The composed-feature signing already shipped
+([docs/composed_feature_signing.md](composed_feature_signing.md)) covers it with
+**no new mechanism**: add `libhull_feature-wasm` as the 8th embedded archive in
+`release.yml`'s `platform-features-<arch>` set, one line in the signed platform
+manifest, and one entry in the `TRUST_FEATURE_LIBS` list. `build.lua`
+`record_composed(...)` already tags any composed archive; the runtime §5c check
+attests it automatically.
+
+## Phase plan
+
+- **Phase 0 — seam (additive, no base-flip).** Add `wasm_feature.h` +
+  `cap/wasm_feature.c` weak defaults + `wasm_weakstub.c`; route `cap/db_udf.c`
+  and `mod_compute` through the seam. Base still compiles WAMR in. Prove the seam
+  with the existing `test_wasm` / `test_wasm_buffer` unchanged. Decide (a) vs (b).
+- **Phase 1 — base-flip + embed.** Drop `WAMR_OBJS` + wasm caps + `worker_wasm`
+  from `PLATFORM_OBJS` into `libhull_feature-wasm.a`; embed it; base is
+  compute-less. `make` composes it always (behavior-identical), then gate on
+  `needs_wasm`. `nm` assertion: a compute-free app has zero WAMR symbols.
+- **Phase 2 — the two-signal gate.** Wire `needs_wasm = S1 or S2` (`S1` from
+  `tool.modules_resolve`, `S2` from the discovered `compute/*.wasm` set). E2E:
+  (i) `compute.*` app composes; (ii) WASM-backed-`db.udf`-only app (only
+  `hull/db`, ships a `.wasm`) composes via S2; (iii) function-`db.udf` app with
+  no `.wasm` stays WASM-free and its UDF still runs; (iv) plain web app is
+  WASM-free and ~256 KB smaller.
+- **Phase 3 — signing + release wire-up.** Extend `release.yml`
+  `platform-features` + the signed manifest + `TRUST_FEATURE_LIBS`. Extend
+  `e2e_composed_sig.sh`'s manifest to the 8th archive.
+- **Phase 4 — docs + flavor interplay.** `--flavor=pure-compute` × WASM (the
+  reduced-flavor × feature orthogonality now that #114 landed); update
+  CLAUDE.md, AGENTS.md, the taxonomy tables.
+
+## Testing
+
+- Seam unit tests: a WASM-free base build links; `compute.available()` → false;
+  a function-`db.udf` runs; a WASM-backed `db.udf.register` fails with the clear
+  "feature not composed" message.
+- `nm` symbol assertion: a compute-free app exports no `wasm_*` / WAMR / iwasm
+  symbols (the base-flip invariant), and the buffer protocol still resolves.
+- `tests/e2e_feature_wasm.sh`: compose WASM (both runtimes), the four Phase-2
+  scenarios, and a slim-binary size assertion (~256 KB delta).
+- `e2e_composed_sig.sh`: the 8th embedded archive is attested; tamper fatal.
+- Regression: existing `test_wasm` (55), `test_wasm_buffer` (12), `e2e_compute*`
+  unchanged when WASM is composed.
+
+## Non-goals
+
+- `hull feature install wasm` (WASM is embedded + auto-composed, not
+  install-on-demand — same as the runtimes/HTTP).
+- Cosmo WASM slim (the universal APE keeps WAMR in-base).
+- Featurizing `wamrc` (already correctly a **tool**), or the AOT path itself.
+- Making `crypto`/SHA/HMAC or the default SQLite DB a feature (out of scope;
+  crypto is the trust substrate, SQLite is the default backend).
+
+## Risks
+
+- **db.udf seam correctness (highest).** The failure mode is a wasm-backed UDF
+  silently mis-degrading or a function-UDF regressing. Cover both branches
+  explicitly; the wasm-backed branch must fail *loud and closed*.
+- **Buffer-protocol coherence.** `WasmBuffer` disappearing must not break the
+  `MappedBuffer`/`ArrayBuffer` paths into GPU/image. Test the cross-buffer
+  matrix on a WASM-free base.
+- **S2 false-negative.** An app that loads a compute module by a path build.lua
+  doesn't discover would miss S2 and link no WAMR. Today all compute modules come
+  from `compute/*.wasm` (embedded), so the discovery is complete — assert there
+  is no other module source, and document that dynamic/out-of-tree `.wasm` is
+  unsupported (as it already is).
+- **Effort/risk vs payoff.** ~256 KB on a base that ships far larger vendored
+  pieces (mbedTLS, SQLite). Worth it for the compute-free web/CLI app and to
+  finish the axis, but lower leverage than a new additive feature (e.g. the
+  Redis/Valkey client). Sequence accordingly.

--- a/docs/wasm_feature.md
+++ b/docs/wasm_feature.md
@@ -1,10 +1,11 @@
 # WASM as a composable feature — design
 
-**Status:** design (not implemented). The last large vendored engine still
-compiled into the base by default. Finishes the base-subtraction axis begun by
-#113 (runtimes) and #114 (HTTP core). Sequenced as its **own epic** after a
-release cut, because it is materially harder than the runtime/HTTP splits (see
-"Why this is harder" below).
+**Status:** implemented (native builds), PR #118. Finishes the base-subtraction
+axis begun by #113 (runtimes) and #114 (HTTP core) — the last large vendored
+engine (WAMR, ~256 KB) moves out of the base. Phases 0-4 landed; the native base
+is compute-less and a produced compute-free app links zero WAMR. Cosmo keeps WASM
+in-base. The "why this is harder than #113/#114" analysis below held up: the
+`db.udf` seam and the two-signal `needs_wasm` gate were the crux.
 
 Related: [docs/http_feature_phase1.md](http_feature_phase1.md) (the seam +
 whole-archive pattern this reuses), [docs/features_and_flavors.md](features_and_flavors.md)

--- a/docs/wasm_feature.md
+++ b/docs/wasm_feature.md
@@ -84,9 +84,12 @@ strong overrides whole-archived from the feature lib).
 - `worker_wasm.o` (the async compute worker)
 - `WAMR_OBJS` (the vendored WAMR archive, the ~256 KB)
 
-**Stays in the base, gains a weak seam** (`include/hull/wasm_feature.h`,
-weak no-ops in `cap/wasm_feature.c`, real-signature weak stubs in a base TU
-`src/hull/wasm_weakstub.c` for the symbols base objects reference):
+**Stays in the base, gains a weak seam.** Unlike the GPU/TUI features (which use
+a `hl_*_feature_backends` hook indirection), the spike showed WASM needs **only
+real-signature weak stubs** for the existing `hl_cap_wasm_*` / `hl_wasm_buffer_*`
+symbols that base objects call directly — a single base TU `src/hull/wasm_weakstub.c`
+(the exact `http_weakstub.c` pattern), no new `wasm_feature.h` hook header. The
+composed `libhull_feature-wasm.a` whole-archives its strong definitions over them:
 
 - **`cap/db_udf.c`** (base DB layer) references `hl_cap_wasm_instance_*`. On a
   WASM-free base those resolve to weak stubs that fail closed:
@@ -94,19 +97,48 @@ weak no-ops in `cap/wasm_feature.c`, real-signature weak stubs in a base TU
   works — that path never calls WASM; `db.udf.register(name, "module")`
   (WASM-backed) returns a clear "WASM feature not composed" error. This is the
   central seam: the DB layer stays whole, only the wasm-backed branch degrades.
-- **`compute.*` runtime bindings.** Two options, decide in Phase 0:
-  - **(a) weak-seam in place (simpler).** `mod_compute.o` stays in the runtime
-    archive and calls `hl_cap_wasm_*` through the seam; on a WASM-free base
-    `compute.available()` → false and every `compute.call/async/instance/segment/
-    stream/buffer` returns "not_available". No new per-runtime archive.
-  - **(b) per-runtime bridge (parallels HTTP-C).** `mod_compute.o` moves into
-    `libhull_feature-wasm-<rt>.a`, composed with the core when `needs_wasm`. The
-    pure runtime keeps weak stubs for the few `mod_compute` symbols `modules.o`
-    references. Cleaner symbol separation, one more archive per runtime.
-  Recommendation: **(a)** — the `compute.*` binding surface is small and the
-  buffer-protocol coupling (`WasmBuffer`) makes a clean per-runtime extraction
-  fiddlier than it was for the web bindings. Prove with an `nm` assertion that a
-  compute-free app has zero `wasm_*`/WAMR symbols regardless.
+- **`compute.*` runtime bindings → decision: (b) per-runtime bridge.** The
+  Phase-0 spike (`nm` symbol map, below) resolved the (a)/(b) fork in favor of
+  **(b)**: `mod_compute.o` moves into `libhull_feature-wasm-<rt>.a`, composed
+  with the core when `needs_wasm`. The spike showed the extraction is clean —
+  `mod_compute.o` defines only two globals (`luaopen_hull_compute`,
+  `lua_push_wasm_buffer`), so the base needs just two per-runtime weak stubs, and
+  the (a)-vs-(b) *difference* is only those two symbols (the real seam — the
+  cap-symbol weak stubs — is identical either way). (b) gets the honest win: a
+  compute-free app's runtime archive is genuinely `mod_compute`-free (zero
+  WasmBuffer/compute binding code), which makes the "no `wasm_*` symbols" `nm`
+  assertion trivially true rather than a claim about dead-but-linked code.
+
+### Phase 0 spike findings (symbol map)
+
+The seam is entirely **weak stubs for existing cap symbols** (like
+`http_weakstub.c`), not a new hook indirection — base objects call
+`hl_cap_wasm_*` / `hl_wasm_buffer_*` directly. Two symbol tiers:
+
+**Tier 1 — the core cap-seam (11 symbols, identical for (a) and (b)).** Base
+objects that STAY reference these; `wasm_weakstub.c` provides weak no-ops that
+the composed `libhull_feature-wasm.a` overrides:
+
+| Symbol(s) | Referenced by (stays in base) | Degrades to |
+|---|---|---|
+| `hl_cap_wasm_init` / `_destroy` | `app_context.o`, `serve.o` (cache lifecycle) | no-op init, `available()` false |
+| `hl_cap_wasm_load` / `_instance_create` / `_call` / `_destroy` | `cap_db_udf.o` (WASM-backed UDF) | wasm-backed `db.udf` errors closed; **function UDFs unaffected** |
+| `hl_wasm_buffer_data` / `_len` | `mod_buffer` (unified buffer protocol) | `WasmBuffer` type absent; other buffer types unaffected |
+| `hl_wasm_buffer_borrow` / `_release` | `mod_image` (`image.from_buffer` borrow) | can't borrow a `WasmBuffer` (none exist) |
+| `hl_wasm_buffer_create_adopted` | `mod_gpu` (GPU result → `WasmBuffer`) | GPU returns string/`ArrayBuffer`, not a `WasmBuffer` |
+
+**Tier 2 — the two (b)-specific per-runtime stubs.** Because `mod_compute.o`
+leaves the runtime archive under (b):
+
+| Symbol | Referenced by (stays) | Weak stub degrades to |
+|---|---|---|
+| `luaopen_hull_compute` (+ js) | `modules.o` (module registry) | the resolver already returns nil for an absent optional cap; the stub just satisfies the link (exact `http_weakstub` pattern) |
+| `lua_push_wasm_buffer` (+ js) | `mod_gpu.o` (GPU chaining a result as a `WasmBuffer`) | can't push a `WasmBuffer` without WAMR — the correct degradation |
+
+Note `lua_push_wasm_buffer` + the `WasmBuffer` userdata belong **with** the wasm
+feature (they wrap WAMR-backed memory), so keeping them in `mod_compute.o`/the
+bridge and weak-stubbing the GPU reference is semantically right — a WASM-free
+base genuinely cannot produce a `WasmBuffer`. No relocation needed.
 - **`compute.buffer` / `WasmBuffer`.** On a WASM-free base, `compute.buffer(...)`
   fails ("WASM feature not composed"); a `WasmBuffer` cannot be created, so the
   unified buffer protocol's other producers (`fs.mmap` → `MappedBuffer`,
@@ -143,10 +175,12 @@ attests it automatically.
 
 ## Phase plan
 
-- **Phase 0 — seam (additive, no base-flip).** Add `wasm_feature.h` +
-  `cap/wasm_feature.c` weak defaults + `wasm_weakstub.c`; route `cap/db_udf.c`
-  and `mod_compute` through the seam. Base still compiles WAMR in. Prove the seam
-  with the existing `test_wasm` / `test_wasm_buffer` unchanged. Decide (a) vs (b).
+- **Phase 0 — spike (done) + seam (additive, no base-flip).** ✅ Spike done: the
+  `nm` symbol map resolved (a)/(b) → **(b)** and enumerated the exact seam surface
+  (11 core cap stubs + 2 per-runtime stubs, tables above). Remaining Phase-0 work:
+  add `src/hull/wasm_weakstub.c` with those weak stubs (base still compiles WAMR
+  in, so the strong defs win and behavior is identical), and confirm `test_wasm` /
+  `test_wasm_buffer` are unchanged. No `wasm_feature.h` hook header needed.
 - **Phase 1 — base-flip + embed.** Drop `WAMR_OBJS` + wasm caps + `worker_wasm`
   from `PLATFORM_OBJS` into `libhull_feature-wasm.a`; embed it; base is
   compute-less. `make` composes it always (behavior-identical), then gate on

--- a/include/hull/build_assets.h
+++ b/include/hull/build_assets.h
@@ -62,6 +62,15 @@ int hl_build_extract_feature_http_rt(const char *dir, const char *rt);
 int hl_build_extract_feature_tui_rt(const char *dir, const char *rt);
 
 /*
+ * Extract the embedded WASM core (`dir/libhull_feature-wasm.a`) and per-runtime
+ * compute bridge (`dir/libhull_feature-wasm-<rt>.a`, rt = "lua" | "js"), composed
+ * for every full-flavor app (docs/wasm_feature.md, Phase 1). Return 0 on success,
+ * -1 if not embedded / unknown rt.
+ */
+int hl_build_extract_feature_wasm(const char *dir);
+int hl_build_extract_feature_wasm_rt(const char *dir, const char *rt);
+
+/*
  * Get the list of embedded platform archives (multi-arch builds).
  * Sets *out to the sentinel-terminated array.
  * Returns the count (excluding sentinel), or 0 if not multi-arch.

--- a/src/hull/build_assets.c
+++ b/src/hull/build_assets.c
@@ -26,6 +26,9 @@
 #ifdef HL_BUILD_EMBEDDED_TUI
 #include "embedded_tui.h"       /* hl_embedded_feature_tui_{lua,js}_a[] */
 #endif
+#ifdef HL_BUILD_EMBEDDED_WASM
+#include "embedded_wasm.h"      /* hl_embedded_feature_wasm{,_lua,_js}_a[] */
+#endif
 
 /* ── Helper: write data to a file ──────────────────────────────────── */
 
@@ -35,7 +38,7 @@
  * on the embedded-platform macros. */
 #if defined(HL_BUILD_EMBEDDED) || defined(HL_BUILD_EMBEDDED_MULTIARCH) \
     || defined(HL_BUILD_EMBEDDED_RUNTIME) || defined(HL_BUILD_EMBEDDED_HTTP) \
-    || defined(HL_BUILD_EMBEDDED_TUI)
+    || defined(HL_BUILD_EMBEDDED_TUI) || defined(HL_BUILD_EMBEDDED_WASM)
 static int write_blob(const char *path, const unsigned char *data, size_t len)
 {
     FILE *f = fopen(path, "wb");
@@ -206,6 +209,48 @@ int hl_build_extract_feature_tui_rt(const char *dir, const char *rt)
     }
     char path[1024];
     int n = snprintf(path, sizeof(path), "%s/libhull_feature-tui-%s.a", dir, rt);
+    if (n < 0 || (size_t)n >= sizeof(path))
+        return -1;
+    return write_blob(path, data, len);
+#else
+    (void)dir; (void)rt;
+    return -1;
+#endif
+}
+
+int hl_build_extract_feature_wasm(const char *dir)
+{
+#ifdef HL_BUILD_EMBEDDED_WASM
+    if (!dir)
+        return -1;
+    char path[1024];
+    int n = snprintf(path, sizeof(path), "%s/libhull_feature-wasm.a", dir);
+    if (n < 0 || (size_t)n >= sizeof(path))
+        return -1;
+    return write_blob(path, hl_embedded_feature_wasm_a,
+                      hl_embedded_feature_wasm_a_len);
+#else
+    (void)dir;
+    return -1;
+#endif
+}
+
+int hl_build_extract_feature_wasm_rt(const char *dir, const char *rt)
+{
+#ifdef HL_BUILD_EMBEDDED_WASM
+    if (!dir || !rt)
+        return -1;
+    const unsigned char *data = NULL;
+    unsigned int len = 0;
+    if (strcmp(rt, "lua") == 0) {
+        data = hl_embedded_feature_wasm_lua_a; len = hl_embedded_feature_wasm_lua_a_len;
+    } else if (strcmp(rt, "js") == 0) {
+        data = hl_embedded_feature_wasm_js_a;  len = hl_embedded_feature_wasm_js_a_len;
+    } else {
+        return -1;
+    }
+    char path[1024];
+    int n = snprintf(path, sizeof(path), "%s/libhull_feature-wasm-%s.a", dir, rt);
     if (n < 0 || (size_t)n >= sizeof(path))
         return -1;
     return write_blob(path, data, len);

--- a/src/hull/runtime/lua/mod_tool.c
+++ b/src/hull/runtime/lua/mod_tool.c
@@ -511,6 +511,25 @@ static int l_tool_extract_feature_tui_rt(lua_State *L)
     return 1;
 }
 
+/* ── tool.extract_feature_wasm(dir) / _wasm_rt(dir, rt) → bool ──────── */
+
+static int l_tool_extract_feature_wasm(lua_State *L)
+{
+    const char *dir = luaL_checkstring(L, 1);
+    int rc = hl_build_extract_feature_wasm(dir);
+    lua_pushboolean(L, rc == 0);
+    return 1;
+}
+
+static int l_tool_extract_feature_wasm_rt(lua_State *L)
+{
+    const char *dir = luaL_checkstring(L, 1);
+    const char *rt  = luaL_checkstring(L, 2);
+    int rc = hl_build_extract_feature_wasm_rt(dir, rt);
+    lua_pushboolean(L, rc == 0);
+    return 1;
+}
+
 /* ── tool.extract_platform_cosmo(dir) → bool ───────────────────────── */
 /*
  * Extract both arch-specific archives and set up the .aarch64/ directory
@@ -1231,6 +1250,8 @@ static const luaL_Reg tool_funcs[] = {
     { "extract_feature_http",   l_tool_extract_feature_http },
     { "extract_feature_http_rt", l_tool_extract_feature_http_rt },
     { "extract_feature_tui_rt", l_tool_extract_feature_tui_rt },
+    { "extract_feature_wasm",   l_tool_extract_feature_wasm },
+    { "extract_feature_wasm_rt", l_tool_extract_feature_wasm_rt },
     { "extract_platform_cosmo", l_tool_extract_platform_cosmo },
     { "platform_archs",         l_tool_platform_archs },
     /* Orchestration entries (modules_resolve, doctor_json, agent_*,

--- a/src/hull/tool.c
+++ b/src/hull/tool.c
@@ -355,6 +355,16 @@ int hull_tool(const char *module, int argc, char **argv, const char *hull_exe)
         lua_setglobal(L, "__hull_exe");
     }
 
+    /* Record which module the tool VM is DISPATCHING (the entry command), so a
+     * command script can tell "I was invoked as `hull <cmd>`" from "I was
+     * require()'d as a dependency". Without this, an app that legitimately does
+     * require("hull.compute") during manifest extraction pulls in the CLI
+     * compute.lua command, whose bottom-of-file main() then self-executes
+     * against the *build* argv (`hull compute: unknown command '.'`). Command
+     * scripts guard their trailing main() with `__hull_tool_entry == "hull.X"`. */
+    lua_pushstring(L, module);
+    lua_setglobal(L, "__hull_tool_entry");
+
     /* Load and run the stdlib module */
     char code[256];
     snprintf(code, sizeof(code), "require('%s')", module);

--- a/src/hull/tool_orchestration.c
+++ b/src/hull/tool_orchestration.c
@@ -229,6 +229,15 @@ static int l_tool_modules_resolve(lua_State *L)
     lua_pushboolean(L, (req_caps & HL_MOD_CAP_HTTP) ? 1 : 0);
     lua_setfield(L, -2, "needs_http");
 
+    /* needs_wasm (S1 of the two-signal gate, docs/wasm_feature.md, Phase 2) =
+     * does the resolved set declare a WASM cap (hull/compute)? Drives `hull
+     * build`'s decision to compose the wasm core + the per-runtime compute
+     * bridge. This is only S1: an app that runs a WASM-backed db.udf carries no
+     * module declaration, so build.lua ORs this with S2 (the app ships
+     * compute/*.wasm) before deciding. */
+    lua_pushboolean(L, (req_caps & HL_MOD_CAP_WASM) ? 1 : 0);
+    lua_setfield(L, -2, "needs_wasm");
+
     /* auto = the minimal build flavor that still satisfies this app's
      * declared modules (drives `hull build --flavor=auto`). Computed from
      * the resolved set's aggregate required-caps. */

--- a/src/hull/wasm_weakstub.c
+++ b/src/hull/wasm_weakstub.c
@@ -1,0 +1,130 @@
+/*
+ * wasm_weakstub.c — weak no-op defaults for the WASM cap seam (WASM as a
+ * composable feature, docs/wasm_feature.md).
+ *
+ * The plan moves WAMR + the wasm caps (cap/wasm*.c, worker_wasm.c, WAMR_OBJS)
+ * out of the base into an embedded, auto-composed libhull_feature-wasm.a. Base
+ * objects that STAY reference a small set of cap symbols directly:
+ *
+ *   app_context.o, serve.o     -> hl_cap_wasm_init / _destroy   (cache lifecycle)
+ *   cap_db_udf.o               -> hl_cap_wasm_load / _instance_* (WASM-backed UDF)
+ *   mod_buffer (per runtime)   -> hl_wasm_buffer_data / _len     (buffer protocol)
+ *   mod_image  (per runtime)   -> hl_wasm_buffer_borrow / _release
+ *   mod_gpu    (per runtime)   -> hl_wasm_buffer_create_adopted  (GPU -> WasmBuffer)
+ *
+ * The Phase-0 spike (an `nm` map over these objects) enumerated exactly these
+ * eleven runtime-AGNOSTIC symbols as the core seam; this TU provides weak,
+ * fail-closed defaults for them. When libhull_feature-wasm.a is composed it is
+ * whole-archived, so the linker takes its strong definitions; when it is NOT
+ * composed (a genuinely compute-free app, once the base is flipped in Phase 1)
+ * these weak no-ops satisfy the link, `compute.available()` reads false, a
+ * WASM-backed `db.udf` fails closed (function UDFs are untouched — they never
+ * call these), and no `WasmBuffer` can exist (the other buffer-protocol types
+ * are unaffected).
+ *
+ * This mirrors http_weakstub.c: real prototypes (the base already sees the cap
+ * headers) so the definitions are ODR/LTO-clean against the strong ones. It is
+ * additive and dormant while WAMR is still compiled into the base (Phase 0):
+ * the strong cap definitions win, so behavior is byte-identical.
+ *
+ * The two per-RUNTIME references the spike also found (luaopen_hull_compute from
+ * modules.o, lua_push_wasm_buffer from mod_gpu.o, + the JS twins) are deferred
+ * to Phase 1: they only need stubbing once mod_compute actually moves into the
+ * per-runtime bridge, and their degraded semantics (require("hull.compute") ->
+ * nil) are part of the resolver integration there, not this cap seam.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include <stddef.h>
+
+#include "hull/cap/wasm.h"
+#include "hull/cap/wasm_buffer.h"
+
+/* ── Module cache lifecycle (app_context.o, serve.o) ─────────────────── */
+
+__attribute__((weak)) int hl_cap_wasm_init(HlWasmCache *cache)
+{
+    (void)cache;
+    return -1;   /* no runtime -> init "fails"; available() stays false */
+}
+
+__attribute__((weak)) void hl_cap_wasm_destroy(HlWasmCache *cache)
+{
+    (void)cache;
+}
+
+/* ── WASM-backed db.udf (cap_db_udf.o) ───────────────────────────────── */
+
+__attribute__((weak)) int hl_cap_wasm_load(HlWasmCache *cache, const char *name,
+                                           const struct HlVfs *app_vfs,
+                                           const char *app_dir)
+{
+    (void)cache; (void)name; (void)app_vfs; (void)app_dir;
+    return -1;
+}
+
+__attribute__((weak))
+HlWasmInstance *hl_cap_wasm_instance_create(HlWasmCache *cache, const char *name,
+                                            const HlWasmCallOpts *opts,
+                                            const struct HlVfs *app_vfs,
+                                            const char *app_dir,
+                                            HlAllocator *alloc,
+                                            const char **err_msg)
+{
+    (void)cache; (void)name; (void)opts; (void)app_vfs; (void)app_dir;
+    (void)alloc;
+    if (err_msg) *err_msg = "WASM feature not composed";
+    return NULL;
+}
+
+__attribute__((weak))
+int hl_cap_wasm_instance_call(HlWasmInstance *inst,
+                              const void *input, size_t input_len,
+                              void **output, size_t *output_len,
+                              const HlWasmCallOpts *opts,
+                              HlWasmCallbackFn cb_fn, void *cb_ctx,
+                              HlAllocator *alloc, const char **err_msg)
+{
+    (void)inst; (void)input; (void)input_len; (void)output; (void)output_len;
+    (void)opts; (void)cb_fn; (void)cb_ctx; (void)alloc;
+    if (err_msg) *err_msg = "WASM feature not composed";
+    return -1;
+}
+
+__attribute__((weak)) void hl_cap_wasm_instance_destroy(HlWasmInstance *inst)
+{
+    (void)inst;
+}
+
+/* ── Unified buffer protocol: the WasmBuffer type (mod_buffer / image / gpu) ── */
+
+__attribute__((weak)) const void *hl_wasm_buffer_data(const HlWasmBuffer *buf)
+{
+    (void)buf;
+    return NULL;
+}
+
+__attribute__((weak)) size_t hl_wasm_buffer_len(const HlWasmBuffer *buf)
+{
+    (void)buf;
+    return 0;
+}
+
+__attribute__((weak)) void hl_wasm_buffer_borrow(HlWasmBuffer *buf)
+{
+    (void)buf;
+}
+
+__attribute__((weak)) void hl_wasm_buffer_release(void *buf)
+{
+    (void)buf;
+}
+
+__attribute__((weak))
+HlWasmBuffer *hl_wasm_buffer_create_adopted(void *data, size_t len,
+                                            HlAllocator *alloc)
+{
+    (void)data; (void)len; (void)alloc;
+    return NULL;
+}

--- a/src/hull/wasm_weakstub.c
+++ b/src/hull/wasm_weakstub.c
@@ -27,11 +27,13 @@
  * additive and dormant while WAMR is still compiled into the base (Phase 0):
  * the strong cap definitions win, so behavior is byte-identical.
  *
- * The two per-RUNTIME references the spike also found (luaopen_hull_compute from
- * modules.o, lua_push_wasm_buffer from mod_gpu.o, + the JS twins) are deferred
- * to Phase 1: they only need stubbing once mod_compute actually moves into the
- * per-runtime bridge, and their degraded semantics (require("hull.compute") ->
- * nil) are part of the resolver integration there, not this cap seam.
+ * The two per-RUNTIME references the spike found (luaopen_hull_compute from
+ * modules.o, lua_push_wasm_buffer from mod_gpu.o, + the JS init twin) are the
+ * per-runtime section below: needed once the needs_wasm gate (Phase 2) can skip
+ * composing the compute bridge, so a compute-free app's pure runtime still links.
+ * Neither weak body is ever REACHED on a compute-free app — modules.c gates the
+ * compute-module register on wasm_cache (NULL without the feature) — they only
+ * satisfy the link.
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -128,3 +130,38 @@ HlWasmBuffer *hl_wasm_buffer_create_adopted(void *data, size_t len,
     (void)data; (void)len; (void)alloc;
     return NULL;
 }
+
+/* ── Per-runtime compute-binding refs (Phase 2) ──────────────────────────
+ * The pure runtime archive references these from modules.o (the compute module
+ * register) and mod_gpu.o (a GPU result pushed as a WasmBuffer). When the wasm
+ * bridge is composed its strong defs win; when it is NOT (needs_wasm false),
+ * these weak no-ops satisfy the link. Real prototypes via the runtime headers,
+ * mirroring http_weakstub.c. */
+
+#ifdef HL_ENABLE_LUA
+#include "hull/runtime/lua.h"   /* lua_State (type only) */
+
+__attribute__((weak)) int luaopen_hull_compute(lua_State *L)
+{
+    (void)L;
+    return 0;   /* not registered without wasm_cache; only satisfies the link */
+}
+
+/* Pure no-op — never REACHED without the feature (a WasmBuffer can't exist, so
+ * mod_gpu never pushes one), so it deliberately calls no Lua-VM function: this
+ * TU is also linked into a JS-only app, where lua_pushnil() would be undefined. */
+__attribute__((weak)) void lua_push_wasm_buffer(lua_State *L, struct HlWasmBuffer *buf)
+{
+    (void)L; (void)buf;
+}
+#endif /* HL_ENABLE_LUA */
+
+#ifdef HL_ENABLE_JS
+#include "hull/runtime/js.h"    /* HlJS, JSContext */
+
+__attribute__((weak)) int hl_js_init_compute_module(JSContext *ctx, HlJS *js)
+{
+    (void)ctx; (void)js;
+    return -1;
+}
+#endif /* HL_ENABLE_JS */

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1694,6 +1694,50 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
             end
             print("hull build: composed runtime '" .. app_rt .. "'")
 
+            -- Compose the WASM feature (docs/wasm_feature.md, Phase 1). The native
+            -- base is compute-less: the wasm caps + WAMR live in
+            -- libhull_feature-wasm.a and the compute.* binding (mod_compute) in
+            -- libhull_feature-wasm-<rt>.a. Phase 1 composes both for EVERY app
+            -- (behavior-identical to the pre-flip base; the needs_wasm two-signal
+            -- gate is Phase 2). Whole-archive both inside the --start-group.
+            local wasm_lib = "libhull_feature-wasm.a"
+            local wasm_path, wasm_from = fcompose.resolve_wasm_lib(tmpdir,
+                                         { hull_dir = rt_hull_dir, plat = rt_plat })
+            if not wasm_path then
+                tool.stderr("hull build: the WASM feature lib (libhull_feature-wasm.a) "
+                    .. "was not found "
+                    .. (wasm_from == "cache-verify-failed"
+                        and "(cache re-verify failed)\n" or "(normally embedded in hull)\n"))
+                tool.stderr("hint: build it from source with `make feature-wasm`\n")
+                tool.rmdir(tmpdir); tool.exit(1)
+            end
+            local wasm_dest = tmpdir .. "/" .. wasm_lib
+            if wasm_path ~= wasm_dest then tool.copy(wasm_path, wasm_dest) end
+            record_composed("libhull_feature-wasm." .. (rt_plat or "") .. ".a",
+                            wasm_dest, "platform")
+            for _, f in ipairs(fcompose.whole_archive_flags(wasm_dest, is_darwin)) do
+                feature_libs[#feature_libs + 1] = f
+            end
+
+            local wasmrt_lib = "libhull_feature-wasm-" .. app_rt .. ".a"
+            local wasmrt_path, wasmrt_from = fcompose.resolve_wasm_rt_lib(app_rt, tmpdir,
+                                             { hull_dir = rt_hull_dir, plat = rt_plat })
+            if not wasmrt_path then
+                tool.stderr("hull build: the compute-bindings feature lib (" .. wasmrt_lib
+                    .. ") was not found "
+                    .. (wasmrt_from == "cache-verify-failed"
+                        and "(cache re-verify failed)\n" or "(normally embedded in hull)\n"))
+                tool.rmdir(tmpdir); tool.exit(1)
+            end
+            local wasmrt_dest = tmpdir .. "/" .. wasmrt_lib
+            if wasmrt_path ~= wasmrt_dest then tool.copy(wasmrt_path, wasmrt_dest) end
+            record_composed("libhull_feature-wasm-" .. app_rt .. "."
+                            .. (rt_plat or "") .. ".a", wasmrt_dest, "platform")
+            for _, f in ipairs(fcompose.whole_archive_flags(wasmrt_dest, is_darwin)) do
+                feature_libs[#feature_libs + 1] = f
+            end
+            print("hull build: composed WASM feature + compute bridge '" .. app_rt .. "'")
+
             if needs_http then
             -- Compose the HTTP feature (issue #114, Phase B). The native base is
             -- HTTP-CORE-LESS: serve.c + the runtime's web-module bindings

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1639,11 +1639,19 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
             -- Fail safe: if resolution is unavailable, compose HTTP (never
             -- under-compose and silently break serving).
             local needs_http = true
+            -- needs_wasm two-signal gate (docs/wasm_feature.md, Phase 2):
+            --   S2 = the app ships compute/*.wasm (catches a WASM-backed db.udf
+            --        that declares no compute module — invisible to the resolver);
+            --   S1 = a declared WASM cap (hull/compute), from modules_resolve.
+            -- Compose the wasm feature iff either fires; a genuinely compute-free
+            -- app then links zero WAMR (~256 KB smaller).
+            local needs_wasm = (#compute_files > 0)
             do
                 local mf = extract_app_manifest(opts.app_dir)
                 if mf then
                     local r = tool.modules_resolve(mf, opts.flavor, with_feature_list(opts))
                     if r.ok and r.needs_http ~= nil then needs_http = r.needs_http end
+                    if r.ok and r.needs_wasm then needs_wasm = true end
                 end
             end
 
@@ -1694,12 +1702,13 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
             end
             print("hull build: composed runtime '" .. app_rt .. "'")
 
-            -- Compose the WASM feature (docs/wasm_feature.md, Phase 1). The native
+            -- Compose the WASM feature (docs/wasm_feature.md, Phase 2). The native
             -- base is compute-less: the wasm caps + WAMR live in
             -- libhull_feature-wasm.a and the compute.* binding (mod_compute) in
-            -- libhull_feature-wasm-<rt>.a. Phase 1 composes both for EVERY app
-            -- (behavior-identical to the pre-flip base; the needs_wasm two-signal
-            -- gate is Phase 2). Whole-archive both inside the --start-group.
+            -- libhull_feature-wasm-<rt>.a. Composed only when needs_wasm (S1 or S2,
+            -- above); a genuinely compute-free app links zero WAMR. Whole-archive
+            -- both inside the --start-group.
+            if needs_wasm then
             local wasm_lib = "libhull_feature-wasm.a"
             local wasm_path, wasm_from = fcompose.resolve_wasm_lib(tmpdir,
                                          { hull_dir = rt_hull_dir, plat = rt_plat })
@@ -1737,6 +1746,10 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
                 feature_libs[#feature_libs + 1] = f
             end
             print("hull build: composed WASM feature + compute bridge '" .. app_rt .. "'")
+            else
+                print("hull build: compute-free app (no hull/compute, no "
+                    .. "compute/*.wasm) - skipped the WASM feature (~256 KB smaller)")
+            end
 
             if needs_http then
             -- Compose the HTTP feature (issue #114, Phase B). The native base is

--- a/stdlib/cli/lua/hull/compute.lua
+++ b/stdlib/cli/lua/hull/compute.lua
@@ -677,4 +677,10 @@ local function main()
     end
 end
 
-main()
+-- Only self-dispatch when invoked AS the `hull compute` command. When an app
+-- legitimately require("hull.compute")s during manifest extraction in the tool
+-- VM, this module is pulled in as a dependency and must NOT run main() against
+-- the surrounding command's argv (see __hull_tool_entry in src/hull/tool.c).
+if __hull_tool_entry == "hull.compute" then
+    main()
+end

--- a/stdlib/cli/lua/hull/feature_compose.lua
+++ b/stdlib/cli/lua/hull/feature_compose.lua
@@ -232,4 +232,31 @@ function M.resolve_tui_rt_lib(rt, tmpdir, ctx)
     return M.resolve_lib(libname, asset, ctx)
 end
 
+--- Resolve the WASM core feature archive (libhull_feature-wasm.a), embedded
+--- first (docs/wasm_feature.md, Phase 1). Mirrors resolve_http_lib: the native
+--- base is compute-less and the default hull embeds the wasm core, so a
+--- full-flavor app composes it back with no `hull feature install`.
+function M.resolve_wasm_lib(tmpdir, ctx)
+    local libname = "libhull_feature-wasm.a"
+    if tool.extract_feature_wasm and tool.extract_feature_wasm(tmpdir)
+       and file_exists(tmpdir .. "/" .. libname) then
+        return tmpdir .. "/" .. libname, "embedded"
+    end
+    local asset = ctx.plat and ("libhull_feature-wasm-" .. ctx.plat .. ".a") or nil
+    return M.resolve_lib(libname, asset, ctx)
+end
+
+--- Resolve the per-runtime compute bridge (libhull_feature-wasm-<rt>.a),
+--- embedded first. Holds mod_compute (the compute.* binding); composed alongside
+--- the wasm core for the app's runtime, like the http web bindings.
+function M.resolve_wasm_rt_lib(rt, tmpdir, ctx)
+    local libname = "libhull_feature-wasm-" .. rt .. ".a"
+    if tool.extract_feature_wasm_rt and tool.extract_feature_wasm_rt(tmpdir, rt)
+       and file_exists(tmpdir .. "/" .. libname) then
+        return tmpdir .. "/" .. libname, "embedded"
+    end
+    local asset = ctx.plat and ("libhull_feature-wasm-" .. rt .. "-" .. ctx.plat .. ".a") or nil
+    return M.resolve_lib(libname, asset, ctx)
+end
+
 return M

--- a/tests/e2e_composed_sig.sh
+++ b/tests/e2e_composed_sig.sh
@@ -94,7 +94,7 @@ echo "-- signing the extended manifest with the test key --"
 MAN="$WORK/manifest.txt"
 {
     $SHA build/libhull_platform.a | awk -v a="$ARCH" '{print $1"  "a}'
-    for f in lua js http http-lua http-js tui-lua tui-js; do
+    for f in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js; do
         A="build/libhull_feature-$f.a"
         [ -f "$A" ] || continue
         $SHA "$A" | awk -v n="libhull_feature-$f.$ARCH.a" '{print $1"  "n}'

--- a/tests/e2e_feature_wasm.sh
+++ b/tests/e2e_feature_wasm.sh
@@ -1,0 +1,132 @@
+#!/bin/sh
+# e2e_feature_wasm.sh — WASM as a composable feature: the compute-free slim
+# invariant + the needs_wasm two-signal gate (docs/wasm_feature.md).
+#
+# Proves:
+#   - the base platform lib is COMPUTE-LESS (0 WAMR symbols);
+#   - a compute-free app skips the WASM feature (binary has 0 WAMR symbols) and
+#     still runs;
+#   - a compute app (S1: declares hull/compute) composes WASM and compute.call
+#     actually executes in the produced binary;
+#   - a .wasm-only app (S2: ships compute/*.wasm, declares no compute module)
+#     composes WASM via the second signal;
+#   - both runtimes behave symmetrically.
+# Locks in the base-flip + gate so they can't silently regress.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+cd "$(dirname "$0")/.."
+
+HULL=./build/hull
+ECHO_WASM=examples/compute/compute/echo.wasm
+
+echo "=== build hull + the compute-less platform lib + the wasm archives ==="
+make >/dev/null
+make platform >/dev/null
+# The base is compute-less: a produced compute app composes the wasm core +
+# its runtime's compute bridge, so hull build needs them in build/ (found by
+# build.lua). The distributed hull embeds them instead.
+make feature-wasm feature-wasm-lua feature-wasm-js >/dev/null
+
+# Count DEFINED symbols matching $2 (exclude undefined 'U'/'u' refs). Mach-O
+# prefixes an underscore; ELF does not. We assert what a binary DEFINES.
+count_syms() { nm "$1" 2>/dev/null | grep -cE " [A-TV-Za-tv-z] _?$2" || true; }
+
+echo "=== the base platform lib is COMPUTE-LESS (0 WAMR symbols) ==="
+base_wamr=$(count_syms build/libhull_platform.a "wasm_runtime_full_init")
+echo "libhull_platform.a: WAMR=$base_wamr"
+[ "$base_wamr" -eq 0 ] || { echo "FAIL: base platform lib still carries WAMR"; exit 1; }
+echo "ok  base platform lib carries no WASM runtime"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# ── fixtures ────────────────────────────────────────────────────────────
+# Lua: compute app (S1), compute-free, and .wasm-only (S2).
+mkdir -p "$WORK/lua_compute/compute" "$WORK/lua_free" "$WORK/lua_s2/compute"
+cp "$ECHO_WASM" "$WORK/lua_compute/compute/"
+cp "$ECHO_WASM" "$WORK/lua_s2/compute/"
+cat > "$WORK/lua_compute/app.lua" <<'LUA'
+local compute = require("hull.compute")
+app.manifest({ compute = true, modules = { "hull/compute@1" } })
+app.main(function()
+    if not compute.available() then return 9 end
+    local out = compute.call("echo", "ping")
+    return out == "ping" and 0 or 7
+end)
+LUA
+cat > "$WORK/lua_free/app.lua" <<'LUA'
+app.manifest({ modules = {} })
+app.main(function() return 4 end)
+LUA
+# S2: ships compute/*.wasm but declares NO compute module (the WASM-backed-udf
+# shape). The gate must still compose WASM.
+cat > "$WORK/lua_s2/app.lua" <<'LUA'
+app.manifest({ modules = {} })
+app.main(function() return 0 end)
+LUA
+
+# JS: compute app + compute-free.
+mkdir -p "$WORK/js_compute/compute" "$WORK/js_free"
+cp "$ECHO_WASM" "$WORK/js_compute/compute/"
+cat > "$WORK/js_compute/app.js" <<'JS'
+import { app } from "hull:app";
+import { compute } from "hull:compute";
+app.manifest({ compute: true, modules: ["hull/compute@1"] });
+app.main(() => {
+    if (!compute.available()) return 9;
+    const o = compute.call("echo", "ping");
+    return (o && o.byteLength === 4) ? 0 : 7;   // "ping" = 4 bytes
+});
+JS
+cat > "$WORK/js_free/app.js" <<'JS'
+import { app } from "hull:app";
+app.manifest({ modules: [] });
+app.main(() => 5);
+JS
+
+build() { "$HULL" build --no-verify-platform --compiler=system -o "$1/bin" "$1" >/tmp/wasm_build.log 2>&1; }
+
+# ── 1. compute app (S1): composes WASM + compute.call runs ──────────────
+echo "=== Lua compute app (S1) composes WASM + compute.call executes ==="
+build "$WORK/lua_compute" || { cat /tmp/wasm_build.log; echo "FAIL: lua compute build"; exit 1; }
+w=$(count_syms "$WORK/lua_compute/bin" "wasm_runtime_full_init")
+[ "$w" -ge 1 ] || { echo "FAIL: lua compute app has no WAMR ($w)"; exit 1; }
+set +e; "$WORK/lua_compute/bin" >/dev/null 2>&1; rc=$?; set -e
+[ "$rc" -eq 0 ] || { echo "FAIL: lua compute.call did not return 'ping' (exit $rc)"; exit 1; }
+echo "ok  lua compute app: WAMR composed + compute.call('echo','ping')=='ping'"
+
+# ── 2. compute-free app: skips WASM (0 WAMR), still runs ────────────────
+echo "=== Lua compute-free app skips WASM (0 WAMR) ==="
+build "$WORK/lua_free" || { cat /tmp/wasm_build.log; echo "FAIL: lua free build"; exit 1; }
+w=$(count_syms "$WORK/lua_free/bin" "wasm_runtime_full_init")
+[ "$w" -eq 0 ] || { echo "FAIL: compute-free lua app still has WAMR ($w)"; exit 1; }
+set +e; "$WORK/lua_free/bin" >/dev/null 2>&1; rc=$?; set -e
+[ "$rc" -eq 4 ] || { echo "FAIL: compute-free lua app did not run (exit $rc)"; exit 1; }
+echo "ok  lua compute-free app: 0 WAMR symbols + runs"
+
+# ── 3. .wasm-only app (S2): composes WASM via the second signal ─────────
+echo "=== Lua .wasm-only app (S2, no hull/compute) composes WASM ==="
+build "$WORK/lua_s2" || { cat /tmp/wasm_build.log; echo "FAIL: lua S2 build"; exit 1; }
+w=$(count_syms "$WORK/lua_s2/bin" "wasm_runtime_full_init")
+[ "$w" -ge 1 ] || { echo "FAIL: S2 app (ships .wasm) did not compose WASM ($w)"; exit 1; }
+echo "ok  S2 app composed WASM from compute/*.wasm alone"
+
+# ── 4. JS symmetric ─────────────────────────────────────────────────────
+echo "=== JS compute app composes WASM + compute.call executes ==="
+build "$WORK/js_compute" || { cat /tmp/wasm_build.log; echo "FAIL: js compute build"; exit 1; }
+w=$(count_syms "$WORK/js_compute/bin" "wasm_runtime_full_init")
+[ "$w" -ge 1 ] || { echo "FAIL: js compute app has no WAMR ($w)"; exit 1; }
+set +e; "$WORK/js_compute/bin" >/dev/null 2>&1; rc=$?; set -e
+[ "$rc" -eq 0 ] || { echo "FAIL: js compute.call did not return 4 bytes (exit $rc)"; exit 1; }
+echo "ok  js compute app: WAMR composed + compute.call executes"
+
+echo "=== JS compute-free app skips WASM (0 WAMR) ==="
+build "$WORK/js_free" || { cat /tmp/wasm_build.log; echo "FAIL: js free build"; exit 1; }
+w=$(count_syms "$WORK/js_free/bin" "wasm_runtime_full_init")
+[ "$w" -eq 0 ] || { echo "FAIL: compute-free js app still has WAMR ($w)"; exit 1; }
+set +e; "$WORK/js_free/bin" >/dev/null 2>&1; rc=$?; set -e
+[ "$rc" -eq 5 ] || { echo "FAIL: compute-free js app did not run (exit $rc)"; exit 1; }
+echo "ok  js compute-free app: 0 WAMR symbols + runs"
+
+echo "PASS: e2e_feature_wasm (base compute-less; needs_wasm gate; compute.call in composed apps, both runtimes)"


### PR DESCRIPTION
Finishes the base-subtraction axis begun by #113 (runtimes) and #114 (HTTP core): move WAMR (~256 KB) from the `HL_ENABLE_WASM` compile flag to an **embedded, auto-composed feature**, so a single `hull` builds both compute apps and compute-free apps (a compute-free app links zero WAMR).

**This PR (so far):** the design doc only — `docs/wasm_feature.md`. No code yet; it's the epic's starting point.

## Why WASM is harder than #113 / #114
1. **Not cleanly module-inferable** — `hull/compute` gives the direct path, but…
2. **`db.udf` is WASM-backed** — `cap/db_udf.c` (base DB layer) calls `hl_cap_wasm_instance_*`; a WASM-backed-UDF app may declare only `hull/db`.
3. **Unified buffer protocol touches `WasmBuffer`** — must degrade cleanly.

## The crux — two-signal gate
`needs_wasm = S1 or S2`:
- **S1** = resolved caps `& HL_MOD_CAP_WASM` (same plumbing as `needs_http`)
- **S2** = the app ships `compute/*.wasm` (catches the WASM-backed-UDF app S1 misses)

## Signing is free
It lands as an embedded `platform_domain` archive, so the composed-feature signing shipped in **v0.8.0** attests it with one manifest line + one `TRUST_FEATURE_LIBS` entry.

## Phases
0 (seam, additive) → 1 (base-flip + embed) → 2 (two-signal gate) → 3 (signing/release wire-up) → 4 (docs + flavor interplay). Full seam design, testing, and risks in `docs/wasm_feature.md`.

## Open decision (Phase 0)
Compute bindings: **(a)** weak-seam-in-place (`mod_compute` stays in the runtime archive, calls through the seam) vs **(b)** per-runtime bridge `libhull_feature-wasm-<rt>.a` (parallels HTTP-C). Doc recommends **(a)** — smaller surface, and the `WasmBuffer` coupling makes a clean per-runtime extraction fiddlier than the web bindings were.