### PR TITLE
Post-#118 fixes: command self-dispatch guard + WASM polish

### DIFF
--- a/include/hull/cap/wasm.h
+++ b/include/hull/cap/wasm.h
@@ -207,9 +207,16 @@ typedef struct HlWasmInstance {
 
 /* ── API ───────────────────────────────────────────────────────────── */
 
+/* hl_cap_wasm_init return codes. 0 = ok; a NEGATIVE value is a genuine WAMR
+ * init failure (worth warning about); the POSITIVE HL_CAP_WASM_ABSENT is
+ * returned by the base weak stub when the WASM feature was not composed
+ * (a compute-free app) — an expected, quiet state, not a failure. */
+#define HL_CAP_WASM_ABSENT 1
+
 /**
  * Initialize WAMR runtime and module cache.
- * Returns 0 on success, -1 on failure.
+ * Returns 0 on success, <0 on real failure, HL_CAP_WASM_ABSENT (>0) when the
+ * WASM feature is not composed.
  */
 int hl_cap_wasm_init(HlWasmCache *cache);
 

--- a/src/hull/serve.c
+++ b/src/hull/serve.c
@@ -968,10 +968,12 @@ static int hl_serve_init_app_context(HlServerState *s)
      * Wired to context via opts so module registration in init() can see it.
      * If the manifest later declares compute: false, we NULL it out. */
     if (!wasm_cache_ok) {
-        if (hl_cap_wasm_init(&wasm_cache) == 0)
+        int wrc = hl_cap_wasm_init(&wasm_cache);
+        if (wrc == 0)
             wasm_cache_ok = 1;
-        else
+        else if (wrc < 0)
             log_warn("[hull:c] WAMR init failed — compute.call() unavailable");
+        /* wrc > 0 (HL_CAP_WASM_ABSENT): WASM feature not composed — quiet. */
     }
 #endif
 

--- a/src/hull/wasm_weakstub.c
+++ b/src/hull/wasm_weakstub.c
@@ -48,7 +48,10 @@
 __attribute__((weak)) int hl_cap_wasm_init(HlWasmCache *cache)
 {
     (void)cache;
-    return -1;   /* no runtime -> init "fails"; available() stays false */
+    /* Positive sentinel: the feature is NOT COMPOSED (compute-free app), an
+     * expected/quiet state — distinct from a genuine WAMR init failure (<0), so
+     * serve.c doesn't log a misleading "WAMR init failed" on every such app. */
+    return HL_CAP_WASM_ABSENT;
 }
 
 __attribute__((weak)) void hl_cap_wasm_destroy(HlWasmCache *cache)

--- a/stdlib/cli/lua/hull/analyze.lua
+++ b/stdlib/cli/lua/hull/analyze.lua
@@ -351,4 +351,11 @@ local function main()
     if #undeclared > 0 then tool.exit(1) end
 end
 
-main()
+-- Only self-dispatch when invoked AS the `hull analyze` command. When this
+-- module is require()'d as a dependency (e.g. an app that require()s the
+-- matching stdlib module during manifest extraction in the tool VM), its
+-- main() must NOT run against the surrounding command's argv
+-- (see __hull_tool_entry in src/hull/tool.c).
+if __hull_tool_entry == "hull.analyze" then
+    main()
+end

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1931,4 +1931,11 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
     tool.rmdir(tmpdir)
 end
 
-main()
+-- Only self-dispatch when invoked AS the `hull build` command. When this
+-- module is require()'d as a dependency (e.g. an app that require()s the
+-- matching stdlib module during manifest extraction in the tool VM), its
+-- main() must NOT run against the surrounding command's argv
+-- (see __hull_tool_entry in src/hull/tool.c).
+if __hull_tool_entry == "hull.build" then
+    main()
+end

--- a/stdlib/cli/lua/hull/deploy.lua
+++ b/stdlib/cli/lua/hull/deploy.lua
@@ -553,4 +553,11 @@ local function main()
     targets[opts.target](opts, info)
 end
 
-main()
+-- Only self-dispatch when invoked AS the `hull deploy` command. When this
+-- module is require()'d as a dependency (e.g. an app that require()s the
+-- matching stdlib module during manifest extraction in the tool VM), its
+-- main() must NOT run against the surrounding command's argv
+-- (see __hull_tool_entry in src/hull/tool.c).
+if __hull_tool_entry == "hull.deploy" then
+    main()
+end

--- a/stdlib/cli/lua/hull/eject.lua
+++ b/stdlib/cli/lua/hull/eject.lua
@@ -479,4 +479,11 @@ local function main()
     print("  ./" .. out_name)
 end
 
-main()
+-- Only self-dispatch when invoked AS the `hull eject` command. When this
+-- module is require()'d as a dependency (e.g. an app that require()s the
+-- matching stdlib module during manifest extraction in the tool VM), its
+-- main() must NOT run against the surrounding command's argv
+-- (see __hull_tool_entry in src/hull/tool.c).
+if __hull_tool_entry == "hull.eject" then
+    main()
+end

--- a/stdlib/cli/lua/hull/init.lua
+++ b/stdlib/cli/lua/hull/init.lua
@@ -1801,4 +1801,11 @@ local function main()
     end
 end
 
-main()
+-- Only self-dispatch when invoked AS the `hull init` command. When this
+-- module is require()'d as a dependency (e.g. an app that require()s the
+-- matching stdlib module during manifest extraction in the tool VM), its
+-- main() must NOT run against the surrounding command's argv
+-- (see __hull_tool_entry in src/hull/tool.c).
+if __hull_tool_entry == "hull.init" then
+    main()
+end

--- a/stdlib/cli/lua/hull/inspect.lua
+++ b/stdlib/cli/lua/hull/inspect.lua
@@ -254,4 +254,11 @@ local function main()
     end
 end
 
-main()
+-- Only self-dispatch when invoked AS the `hull inspect` command. When this
+-- module is require()'d as a dependency (e.g. an app that require()s the
+-- matching stdlib module during manifest extraction in the tool VM), its
+-- main() must NOT run against the surrounding command's argv
+-- (see __hull_tool_entry in src/hull/tool.c).
+if __hull_tool_entry == "hull.inspect" then
+    main()
+end

--- a/stdlib/cli/lua/hull/manifest.lua
+++ b/stdlib/cli/lua/hull/manifest.lua
@@ -72,4 +72,11 @@ local function main()
     print(json.encode(m))
 end
 
-main()
+-- Only self-dispatch when invoked AS the `hull manifest` command. When this
+-- module is require()'d as a dependency (e.g. an app that require()s the
+-- matching stdlib module during manifest extraction in the tool VM), its
+-- main() must NOT run against the surrounding command's argv
+-- (see __hull_tool_entry in src/hull/tool.c).
+if __hull_tool_entry == "hull.manifest" then
+    main()
+end

--- a/stdlib/cli/lua/hull/migrate.lua
+++ b/stdlib/cli/lua/hull/migrate.lua
@@ -98,4 +98,11 @@ local function main()
     print("hull migrate: created " .. filepath)
 end
 
-main()
+-- Only self-dispatch when invoked AS the `hull migrate` command. When this
+-- module is require()'d as a dependency (e.g. an app that require()s the
+-- matching stdlib module during manifest extraction in the tool VM), its
+-- main() must NOT run against the surrounding command's argv
+-- (see __hull_tool_entry in src/hull/tool.c).
+if __hull_tool_entry == "hull.migrate" then
+    main()
+end

--- a/stdlib/cli/lua/hull/modules.lua
+++ b/stdlib/cli/lua/hull/modules.lua
@@ -92,4 +92,11 @@ local function main()
     end
 end
 
-main()
+-- Only self-dispatch when invoked AS the `hull modules` command. When this
+-- module is require()'d as a dependency (e.g. an app that require()s the
+-- matching stdlib module during manifest extraction in the tool VM), its
+-- main() must NOT run against the surrounding command's argv
+-- (see __hull_tool_entry in src/hull/tool.c).
+if __hull_tool_entry == "hull.modules" then
+    main()
+end

--- a/stdlib/cli/lua/hull/new.lua
+++ b/stdlib/cli/lua/hull/new.lua
@@ -348,4 +348,11 @@ local function main()
     end
 end
 
-main()
+-- Only self-dispatch when invoked AS the `hull new` command. When this
+-- module is require()'d as a dependency (e.g. an app that require()s the
+-- matching stdlib module during manifest extraction in the tool VM), its
+-- main() must NOT run against the surrounding command's argv
+-- (see __hull_tool_entry in src/hull/tool.c).
+if __hull_tool_entry == "hull.new" then
+    main()
+end

--- a/stdlib/cli/lua/hull/sign_platform.lua
+++ b/stdlib/cli/lua/hull/sign_platform.lua
@@ -251,4 +251,11 @@ local function main()
     print("wrote " .. sig_path)
 end
 
-main()
+-- Only self-dispatch when invoked AS the `hull sign platform` command. When this
+-- module is require()'d as a dependency (e.g. an app that require()s the
+-- matching stdlib module during manifest extraction in the tool VM), its
+-- main() must NOT run against the surrounding command's argv
+-- (see __hull_tool_entry in src/hull/tool.c).
+if __hull_tool_entry == "hull.sign_platform" then
+    main()
+end

--- a/stdlib/cli/lua/hull/verify.lua
+++ b/stdlib/cli/lua/hull/verify.lua
@@ -353,4 +353,11 @@ local function main()
     print("hull verify: OK — all checks passed")
 end
 
-main()
+-- Only self-dispatch when invoked AS the `hull verify` command. When this
+-- module is require()'d as a dependency (e.g. an app that require()s the
+-- matching stdlib module during manifest extraction in the tool VM), its
+-- main() must NOT run against the surrounding command's argv
+-- (see __hull_tool_entry in src/hull/tool.c).
+if __hull_tool_entry == "hull.verify" then
+    main()
+end

--- a/tests/e2e_build_flavor.sh
+++ b/tests/e2e_build_flavor.sh
@@ -76,6 +76,32 @@ if command -v nm >/dev/null 2>&1; then
 fi
 pass "pure-compute x runtime builds, runs (exit 7), and drops Keel/mbedTLS/http"
 
+# ── 3b. pure-compute x wasm feature (reduced flavor x additive feature) ────────
+# A compute app on the Keel-free base: the wasm caps reference only base symbols
+# present in the pure-compute lib (no Keel), so the wasm feature composes
+# independently of the HTTP axis (issue #118). The binary carries WAMR but still
+# no Keel / mbedTLS, and compute.call executes.
+if [ ! -f "$ROOT/build/libhull_feature-wasm.a" ]; then
+    make -C "$ROOT" feature-wasm feature-wasm-lua >/dev/null 2>&1 || true
+fi
+mkdir -p "$WORK/pcw/compute"
+cp "$ROOT/examples/compute/compute/echo.wasm" "$WORK/pcw/compute/"
+printf 'local compute = require("hull.compute")\napp.manifest({ compute = true, modules = { "hull/compute@1" } })\napp.main(function()\n  if not compute.available() then return 9 end\n  return compute.call("echo", "ping") == "ping" and 0 or 7\nend)\n' > "$WORK/pcw/app.lua"
+if ! out=$("$HULL" build --no-verify-platform --flavor=pure-compute "$WORK/pcw" -o "$WORK/pcw/app" 2>&1); then
+    fail "pure-compute x wasm should build: $out"
+fi
+set +e; "$WORK/pcw/app" >/dev/null 2>&1; rc=$?; set -e
+[ "$rc" = 0 ] || fail "pure-compute compute app: compute.call should run (exit 0), got $rc"
+if command -v nm >/dev/null 2>&1; then
+    w=$(nm "$WORK/pcw/app" 2>/dev/null | grep -cE ' [A-TV-Za-tv-z] _?wasm_runtime_full_init' || true)
+    [ "$w" -ge 1 ] || fail "pure-compute compute app should carry WAMR (got $w)"
+    n=$(nm "$WORK/pcw/app" 2>/dev/null | grep -cE ' T _?kl_server_' || true)
+    [ "$n" = 0 ] || fail "pure-compute compute app should carry no Keel (got $n)"
+    n=$(nm "$WORK/pcw/app" 2>/dev/null | grep -cE ' T _?mbedtls_ssl' || true)
+    [ "$n" = 0 ] || fail "pure-compute compute app should carry no mbedTLS (got $n)"
+fi
+pass "pure-compute x wasm: composes WAMR + runs compute.call, still drops Keel/mbedTLS"
+
 # ── 4. --flavor=auto infers pure-compute for an app.main app and builds it ──
 out=$("$HULL" build --flavor=auto "$WORK/pc" -o "$WORK/pc/auto" 2>&1) || fail "auto build failed: $out"
 echo "$out" | grep -q "auto selected 'pure-compute'" \


### PR DESCRIPTION
Three small fixes on top of the merged WASM-feature epic (#118).

## 1. Generalize the command self-dispatch guard (`b2bd76`)
#118 fixed `compute.lua` specifically: an app's `require("hull.compute")` during manifest extraction in the tool VM pulled in the CLI command module, whose bare `main()` self-ran against the *build* argv → `hull compute: unknown command '<flag value>'`. This generalizes the guard to **all twelve** command scripts (`analyze`/`build`/`deploy`/`eject`/`init`/`inspect`/`manifest`/`migrate`/`modules`/`new`/`sign_platform`/`verify`): each runs `main()` only when it is the *dispatched* command (`__hull_tool_entry == "hull.<cmd>"`), never when `require`'d as a dependency. `compute` is the only live collision today, but this makes the whole class impossible.

## 2. Quiet a misleading WARN (`3e20df`)
The base-flip left the base weak `hl_cap_wasm_init` returning `-1`, so `serve.c` logged `WAMR init failed — compute.call() unavailable` on **every** compute-free app. Added a positive `HL_CAP_WASM_ABSENT` return: the weak stub returns it, and `serve.c` warns only on a genuine failure (`<0`), staying quiet for the not-composed case.

## 3. Guard `--flavor=pure-compute × wasm` (`ee86ec`)
The deferred #118 Phase-4 interplay: a compute app on the Keel-free pure-compute base composes WASM (WAMR present) and `compute.call` runs, while still dropping Keel + mbedTLS — the subtractive-flavor × additive-feature axes are orthogonal. Extends `e2e_build_flavor.sh`.

All validated locally: 60/60 unit suites, `e2e_feature_wasm`, `e2e_build_flavor`, and a compute-app round-trip (build → `compute.call → ping`).