### PR TITLE
fix(wasm): resolve two Low audit findings from the WASM-feature arc

### DIFF
--- a/src/hull/runtime/js/wasm_stub.c
+++ b/src/hull/runtime/js/wasm_stub.c
@@ -1,0 +1,20 @@
+/*
+ * wasm_stub.c — weak per-runtime compute-binding default (JS). See the Lua twin
+ * (src/hull/runtime/lua/wasm_stub.c) for the rationale.
+ *
+ * hl_js_init_compute_module is referenced by js_modules.c's module register; the
+ * strong def lives in the compute bridge (libhull_feature-wasm-js.a, mod_compute).
+ * This weak no-op satisfies the link for a compute-free JS app (never reached —
+ * modules.c gates the register on wasm_cache). It lives in the pure JS runtime
+ * archive so it's linked only into JS apps.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "mod_buffer.h"   /* hl_js_init_compute_module decl, JSContext, HlJS */
+
+__attribute__((weak)) int hl_js_init_compute_module(JSContext *ctx, HlJS *js)
+{
+    (void)ctx; (void)js;
+    return -1;
+}

--- a/src/hull/runtime/lua/wasm_stub.c
+++ b/src/hull/runtime/lua/wasm_stub.c
@@ -1,0 +1,34 @@
+/*
+ * wasm_stub.c — weak per-runtime compute-binding defaults (Lua).
+ *
+ * The compute.* binding (mod_compute) is a composable feature archive
+ * (libhull_feature-wasm-lua.a, docs/wasm_feature.md). The pure runtime archive
+ * still references two of its symbols: luaopen_hull_compute (modules.c's module
+ * register) and lua_push_wasm_buffer (mod_gpu.c, a GPU result pushed as a
+ * WasmBuffer). When the compute bridge is composed its strong defs win; when it
+ * is NOT (a compute-free app, needs_wasm false) these weak no-ops satisfy the
+ * link.
+ *
+ * These live in the PURE RUNTIME archive (where the Lua VM is linked), not the
+ * base wasm_weakstub.c, so lua_push_wasm_buffer can push a balanced nil — the
+ * base TU is also linked into a JS-only app, where lua_pushnil would be
+ * undefined. Neither body is reached without the feature (modules.c gates the
+ * compute register on wasm_cache, NULL when uncomposed; mod_gpu only pushes a
+ * WasmBuffer when one exists, which requires the feature).
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "mod_buffer.h"   /* luaopen_hull_compute + lua_push_wasm_buffer decls, lua_State */
+
+__attribute__((weak)) int luaopen_hull_compute(lua_State *L)
+{
+    (void)L;
+    return 0;   /* not registered without wasm_cache; only satisfies the link */
+}
+
+__attribute__((weak)) void lua_push_wasm_buffer(lua_State *L, struct HlWasmBuffer *buf)
+{
+    (void)buf;
+    lua_pushnil(L);   /* no WasmBuffer exists without the feature — balanced push */
+}

--- a/src/hull/tool.c
+++ b/src/hull/tool.c
@@ -355,20 +355,25 @@ int hull_tool(const char *module, int argc, char **argv, const char *hull_exe)
         lua_setglobal(L, "__hull_exe");
     }
 
-    /* Record which module the tool VM is DISPATCHING (the entry command), so a
-     * command script can tell "I was invoked as `hull <cmd>`" from "I was
-     * require()'d as a dependency". Without this, an app that legitimately does
-     * require("hull.compute") during manifest extraction pulls in the CLI
-     * compute.lua command, whose bottom-of-file main() then self-executes
-     * against the *build* argv (`hull compute: unknown command '.'`). Command
-     * scripts guard their trailing main() with `__hull_tool_entry == "hull.X"`. */
-    lua_pushstring(L, module);
-    lua_setglobal(L, "__hull_tool_entry");
-
-    /* Load and run the stdlib module */
+    /* Load the command module and run its entry. Each command script RETURNS
+     * its main() function; the dispatcher invokes it here rather than letting
+     * the script self-run at load time. This is the mechanism that keeps a
+     * command's main() from firing when the module is merely require()'d as a
+     * dependency: an app that legitimately does require("hull.compute") during
+     * manifest extraction pulls in the CLI compute.lua and gets its main
+     * function back, but only THIS dispatcher ever calls it. (Previously the
+     * script self-dispatched at the bottom of the file, so such a require ran
+     * main() against the *build* argv: `hull compute: unknown command '.'`.) */
     char code[256];
-    snprintf(code, sizeof(code), "require('%s')", module);
-    int rc = luaL_dostring(L, code);
+    snprintf(code, sizeof(code), "return require('%s')", module);
+    int rc = luaL_dostring(L, code);   /* leaves the module's return on the stack */
+    if (rc == LUA_OK) {
+        if (lua_isfunction(L, -1)) {
+            rc = lua_pcall(L, 0, 0, 0);   /* run main(); errors propagate below */
+        } else {
+            lua_pop(L, 1);                /* module returned no entry; nothing to run */
+        }
+    }
     if (rc != LUA_OK) {
         const char *err = lua_tostring(L, -1);
         fprintf(stderr, "hull %s: %s\n", module, err ? err : "unknown error");

--- a/src/hull/wasm_weakstub.c
+++ b/src/hull/wasm_weakstub.c
@@ -28,10 +28,11 @@
  * the strong cap definitions win, so behavior is byte-identical.
  *
  * The two per-RUNTIME references the spike found (luaopen_hull_compute from
- * modules.o, lua_push_wasm_buffer from mod_gpu.o, + the JS init twin) are the
- * per-runtime section below: needed once the needs_wasm gate (Phase 2) can skip
- * composing the compute bridge, so a compute-free app's pure runtime still links.
- * Neither weak body is ever REACHED on a compute-free app — modules.c gates the
+ * modules.o, lua_push_wasm_buffer from mod_gpu.o, + the JS init twin) do NOT
+ * live here: they are per-runtime and live in the pure runtime archives
+ * (src/hull/runtime/{lua,js}/wasm_stub.c), so lua_push_wasm_buffer can push a
+ * balanced nil and the Lua stub stays out of a JS-only app's link. Neither weak
+ * body is ever REACHED on a compute-free app — modules.c gates the
  * compute-module register on wasm_cache (NULL without the feature) — they only
  * satisfy the link.
  *
@@ -134,37 +135,8 @@ HlWasmBuffer *hl_wasm_buffer_create_adopted(void *data, size_t len,
     return NULL;
 }
 
-/* ── Per-runtime compute-binding refs (Phase 2) ──────────────────────────
- * The pure runtime archive references these from modules.o (the compute module
- * register) and mod_gpu.o (a GPU result pushed as a WasmBuffer). When the wasm
- * bridge is composed its strong defs win; when it is NOT (needs_wasm false),
- * these weak no-ops satisfy the link. Real prototypes via the runtime headers,
- * mirroring http_weakstub.c. */
-
-#ifdef HL_ENABLE_LUA
-#include "hull/runtime/lua.h"   /* lua_State (type only) */
-
-__attribute__((weak)) int luaopen_hull_compute(lua_State *L)
-{
-    (void)L;
-    return 0;   /* not registered without wasm_cache; only satisfies the link */
-}
-
-/* Pure no-op — never REACHED without the feature (a WasmBuffer can't exist, so
- * mod_gpu never pushes one), so it deliberately calls no Lua-VM function: this
- * TU is also linked into a JS-only app, where lua_pushnil() would be undefined. */
-__attribute__((weak)) void lua_push_wasm_buffer(lua_State *L, struct HlWasmBuffer *buf)
-{
-    (void)L; (void)buf;
-}
-#endif /* HL_ENABLE_LUA */
-
-#ifdef HL_ENABLE_JS
-#include "hull/runtime/js.h"    /* HlJS, JSContext */
-
-__attribute__((weak)) int hl_js_init_compute_module(JSContext *ctx, HlJS *js)
-{
-    (void)ctx; (void)js;
-    return -1;
-}
-#endif /* HL_ENABLE_JS */
+/* The two per-RUNTIME compute-binding refs (luaopen_hull_compute /
+ * lua_push_wasm_buffer + the JS init) live in the PURE RUNTIME archives, not
+ * here: src/hull/runtime/{lua,js}/wasm_stub.c. Placing them where the VM is
+ * linked lets lua_push_wasm_buffer push a balanced nil, and keeps the Lua stub
+ * out of a JS-only app's link (this base TU is shared by both). */

--- a/stdlib/cli/lua/hull/analyze.lua
+++ b/stdlib/cli/lua/hull/analyze.lua
@@ -351,11 +351,9 @@ local function main()
     if #undeclared > 0 then tool.exit(1) end
 end
 
--- Only self-dispatch when invoked AS the `hull analyze` command. When this
--- module is require()'d as a dependency (e.g. an app that require()s the
--- matching stdlib module during manifest extraction in the tool VM), its
--- main() must NOT run against the surrounding command's argv
--- (see __hull_tool_entry in src/hull/tool.c).
-if __hull_tool_entry == "hull.analyze" then
-    main()
-end
+-- The tool dispatcher (src/hull/tool.c) invokes the returned main() only when
+-- this module is the entry command it was asked to run. A module that is
+-- require()'d as a dependency (e.g. by an app during manifest extraction in
+-- the tool VM) hands its main() back but is never called, so it can't run
+-- against the wrong argv.
+return main

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1931,11 +1931,9 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
     tool.rmdir(tmpdir)
 end
 
--- Only self-dispatch when invoked AS the `hull build` command. When this
--- module is require()'d as a dependency (e.g. an app that require()s the
--- matching stdlib module during manifest extraction in the tool VM), its
--- main() must NOT run against the surrounding command's argv
--- (see __hull_tool_entry in src/hull/tool.c).
-if __hull_tool_entry == "hull.build" then
-    main()
-end
+-- The tool dispatcher (src/hull/tool.c) invokes the returned main() only when
+-- this module is the entry command it was asked to run. A module that is
+-- require()'d as a dependency (e.g. by an app during manifest extraction in
+-- the tool VM) hands its main() back but is never called, so it can't run
+-- against the wrong argv.
+return main

--- a/stdlib/cli/lua/hull/compute.lua
+++ b/stdlib/cli/lua/hull/compute.lua
@@ -677,10 +677,9 @@ local function main()
     end
 end
 
--- Only self-dispatch when invoked AS the `hull compute` command. When an app
--- legitimately require("hull.compute")s during manifest extraction in the tool
--- VM, this module is pulled in as a dependency and must NOT run main() against
--- the surrounding command's argv (see __hull_tool_entry in src/hull/tool.c).
-if __hull_tool_entry == "hull.compute" then
-    main()
-end
+-- The tool dispatcher (src/hull/tool.c) invokes the returned main() only when
+-- this module is the entry command it was asked to run. A module that is
+-- require()'d as a dependency (e.g. by an app during manifest extraction in
+-- the tool VM) hands its main() back but is never called, so it can't run
+-- against the wrong argv.
+return main

--- a/stdlib/cli/lua/hull/deploy.lua
+++ b/stdlib/cli/lua/hull/deploy.lua
@@ -553,11 +553,9 @@ local function main()
     targets[opts.target](opts, info)
 end
 
--- Only self-dispatch when invoked AS the `hull deploy` command. When this
--- module is require()'d as a dependency (e.g. an app that require()s the
--- matching stdlib module during manifest extraction in the tool VM), its
--- main() must NOT run against the surrounding command's argv
--- (see __hull_tool_entry in src/hull/tool.c).
-if __hull_tool_entry == "hull.deploy" then
-    main()
-end
+-- The tool dispatcher (src/hull/tool.c) invokes the returned main() only when
+-- this module is the entry command it was asked to run. A module that is
+-- require()'d as a dependency (e.g. by an app during manifest extraction in
+-- the tool VM) hands its main() back but is never called, so it can't run
+-- against the wrong argv.
+return main

--- a/stdlib/cli/lua/hull/eject.lua
+++ b/stdlib/cli/lua/hull/eject.lua
@@ -479,11 +479,9 @@ local function main()
     print("  ./" .. out_name)
 end
 
--- Only self-dispatch when invoked AS the `hull eject` command. When this
--- module is require()'d as a dependency (e.g. an app that require()s the
--- matching stdlib module during manifest extraction in the tool VM), its
--- main() must NOT run against the surrounding command's argv
--- (see __hull_tool_entry in src/hull/tool.c).
-if __hull_tool_entry == "hull.eject" then
-    main()
-end
+-- The tool dispatcher (src/hull/tool.c) invokes the returned main() only when
+-- this module is the entry command it was asked to run. A module that is
+-- require()'d as a dependency (e.g. by an app during manifest extraction in
+-- the tool VM) hands its main() back but is never called, so it can't run
+-- against the wrong argv.
+return main

--- a/stdlib/cli/lua/hull/init.lua
+++ b/stdlib/cli/lua/hull/init.lua
@@ -1801,11 +1801,9 @@ local function main()
     end
 end
 
--- Only self-dispatch when invoked AS the `hull init` command. When this
--- module is require()'d as a dependency (e.g. an app that require()s the
--- matching stdlib module during manifest extraction in the tool VM), its
--- main() must NOT run against the surrounding command's argv
--- (see __hull_tool_entry in src/hull/tool.c).
-if __hull_tool_entry == "hull.init" then
-    main()
-end
+-- The tool dispatcher (src/hull/tool.c) invokes the returned main() only when
+-- this module is the entry command it was asked to run. A module that is
+-- require()'d as a dependency (e.g. by an app during manifest extraction in
+-- the tool VM) hands its main() back but is never called, so it can't run
+-- against the wrong argv.
+return main

--- a/stdlib/cli/lua/hull/inspect.lua
+++ b/stdlib/cli/lua/hull/inspect.lua
@@ -254,11 +254,9 @@ local function main()
     end
 end
 
--- Only self-dispatch when invoked AS the `hull inspect` command. When this
--- module is require()'d as a dependency (e.g. an app that require()s the
--- matching stdlib module during manifest extraction in the tool VM), its
--- main() must NOT run against the surrounding command's argv
--- (see __hull_tool_entry in src/hull/tool.c).
-if __hull_tool_entry == "hull.inspect" then
-    main()
-end
+-- The tool dispatcher (src/hull/tool.c) invokes the returned main() only when
+-- this module is the entry command it was asked to run. A module that is
+-- require()'d as a dependency (e.g. by an app during manifest extraction in
+-- the tool VM) hands its main() back but is never called, so it can't run
+-- against the wrong argv.
+return main

--- a/stdlib/cli/lua/hull/manifest.lua
+++ b/stdlib/cli/lua/hull/manifest.lua
@@ -72,11 +72,9 @@ local function main()
     print(json.encode(m))
 end
 
--- Only self-dispatch when invoked AS the `hull manifest` command. When this
--- module is require()'d as a dependency (e.g. an app that require()s the
--- matching stdlib module during manifest extraction in the tool VM), its
--- main() must NOT run against the surrounding command's argv
--- (see __hull_tool_entry in src/hull/tool.c).
-if __hull_tool_entry == "hull.manifest" then
-    main()
-end
+-- The tool dispatcher (src/hull/tool.c) invokes the returned main() only when
+-- this module is the entry command it was asked to run. A module that is
+-- require()'d as a dependency (e.g. by an app during manifest extraction in
+-- the tool VM) hands its main() back but is never called, so it can't run
+-- against the wrong argv.
+return main

--- a/stdlib/cli/lua/hull/migrate.lua
+++ b/stdlib/cli/lua/hull/migrate.lua
@@ -98,11 +98,9 @@ local function main()
     print("hull migrate: created " .. filepath)
 end
 
--- Only self-dispatch when invoked AS the `hull migrate` command. When this
--- module is require()'d as a dependency (e.g. an app that require()s the
--- matching stdlib module during manifest extraction in the tool VM), its
--- main() must NOT run against the surrounding command's argv
--- (see __hull_tool_entry in src/hull/tool.c).
-if __hull_tool_entry == "hull.migrate" then
-    main()
-end
+-- The tool dispatcher (src/hull/tool.c) invokes the returned main() only when
+-- this module is the entry command it was asked to run. A module that is
+-- require()'d as a dependency (e.g. by an app during manifest extraction in
+-- the tool VM) hands its main() back but is never called, so it can't run
+-- against the wrong argv.
+return main

--- a/stdlib/cli/lua/hull/modules.lua
+++ b/stdlib/cli/lua/hull/modules.lua
@@ -92,11 +92,9 @@ local function main()
     end
 end
 
--- Only self-dispatch when invoked AS the `hull modules` command. When this
--- module is require()'d as a dependency (e.g. an app that require()s the
--- matching stdlib module during manifest extraction in the tool VM), its
--- main() must NOT run against the surrounding command's argv
--- (see __hull_tool_entry in src/hull/tool.c).
-if __hull_tool_entry == "hull.modules" then
-    main()
-end
+-- The tool dispatcher (src/hull/tool.c) invokes the returned main() only when
+-- this module is the entry command it was asked to run. A module that is
+-- require()'d as a dependency (e.g. by an app during manifest extraction in
+-- the tool VM) hands its main() back but is never called, so it can't run
+-- against the wrong argv.
+return main

--- a/stdlib/cli/lua/hull/new.lua
+++ b/stdlib/cli/lua/hull/new.lua
@@ -348,11 +348,9 @@ local function main()
     end
 end
 
--- Only self-dispatch when invoked AS the `hull new` command. When this
--- module is require()'d as a dependency (e.g. an app that require()s the
--- matching stdlib module during manifest extraction in the tool VM), its
--- main() must NOT run against the surrounding command's argv
--- (see __hull_tool_entry in src/hull/tool.c).
-if __hull_tool_entry == "hull.new" then
-    main()
-end
+-- The tool dispatcher (src/hull/tool.c) invokes the returned main() only when
+-- this module is the entry command it was asked to run. A module that is
+-- require()'d as a dependency (e.g. by an app during manifest extraction in
+-- the tool VM) hands its main() back but is never called, so it can't run
+-- against the wrong argv.
+return main

--- a/stdlib/cli/lua/hull/sign_platform.lua
+++ b/stdlib/cli/lua/hull/sign_platform.lua
@@ -251,11 +251,9 @@ local function main()
     print("wrote " .. sig_path)
 end
 
--- Only self-dispatch when invoked AS the `hull sign platform` command. When this
--- module is require()'d as a dependency (e.g. an app that require()s the
--- matching stdlib module during manifest extraction in the tool VM), its
--- main() must NOT run against the surrounding command's argv
--- (see __hull_tool_entry in src/hull/tool.c).
-if __hull_tool_entry == "hull.sign_platform" then
-    main()
-end
+-- The tool dispatcher (src/hull/tool.c) invokes the returned main() only when
+-- this module is the entry command it was asked to run. A module that is
+-- require()'d as a dependency (e.g. by an app during manifest extraction in
+-- the tool VM) hands its main() back but is never called, so it can't run
+-- against the wrong argv.
+return main

--- a/stdlib/cli/lua/hull/verify.lua
+++ b/stdlib/cli/lua/hull/verify.lua
@@ -353,11 +353,9 @@ local function main()
     print("hull verify: OK — all checks passed")
 end
 
--- Only self-dispatch when invoked AS the `hull verify` command. When this
--- module is require()'d as a dependency (e.g. an app that require()s the
--- matching stdlib module during manifest extraction in the tool VM), its
--- main() must NOT run against the surrounding command's argv
--- (see __hull_tool_entry in src/hull/tool.c).
-if __hull_tool_entry == "hull.verify" then
-    main()
-end
+-- The tool dispatcher (src/hull/tool.c) invokes the returned main() only when
+-- this module is the entry command it was asked to run. A module that is
+-- require()'d as a dependency (e.g. by an app during manifest extraction in
+-- the tool VM) hands its main() back but is never called, so it can't run
+-- against the wrong argv.
+return main


### PR DESCRIPTION
Fixes the two Low findings from the C/Lua audits of the WASM-as-a-feature arc (#118/#119). No behavior change on the default build; both are structural cleanups.

## C-L1 — Lua stub leaking into JS-only links
The shared base `wasm_weakstub.c` carried the per-runtime compute stubs. Because that TU links into *every* app (Lua and JS), `lua_push_wasm_buffer` had to be an unbalanced no-op to avoid referencing `lua_pushnil` in a JS-only link.

**Fix:** relocate the per-runtime stubs into the pure runtime archives (`runtime/lua/wasm_stub.c`, `runtime/js/wasm_stub.c`) where the VM is actually linked, so `lua_push_wasm_buffer` pushes a balanced `lua_pushnil` and the Lua stub stays out of a JS-only link entirely. The base keeps only the 11 runtime-agnostic cap stubs.

Verified by symbol placement: base 0, runtime archives weak, bridges strong; a compute-free JS binary carries **zero** lua-stub symbols.

## Lua-L1 — `__hull_tool_entry` magic global + 13 hardcoded-name guards
Each command script self-dispatched via `if __hull_tool_entry == "hull.<cmd>" then main() end` — copy the guard for a new command, forget to change the string, and `main()` silently never runs.

**Fix:** remove the global entirely. Each command script `return main`s and the C dispatcher (`tool.c`) invokes the returned function. The self-dispatch invariant is now structural: only the dispatcher calls `main`, so a module `require`'d as a dependency (e.g. by an app during manifest extraction) never runs it.

## Validation
- `make test` 60/60, `e2e_feature_wasm`, `e2e_build_flavor` all pass
- The original `hull compute: unknown command '.'` self-dispatch bug stays fixed
- Symbol placement confirmed (base 0, runtime archives weak, bridges strong)