### PR TITLE
feat(build): HL_ENABLE_IMAGE flavor knob (drop image codecs + stb)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,11 @@ jobs:
             flags: HL_ENABLE_MYSQL=1
           - name: mysql-only (no sqlite)
             flags: HL_ENABLE_SQLITE=0 HL_ENABLE_MYSQL=1
+          # image-less: drops cap/image + stb (image's sole consumer). Guards
+          # the HL_ENABLE_IMAGE=0 link (mod_image/mod_gpu image paths gated) and
+          # that stb is fully unlinked.
+          - name: image-less (no image codecs)
+            flags: HL_ENABLE_IMAGE=0
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,7 @@ Hull's distribution is one binary; what's compiled into it is controlled by a sm
 | `HL_ENABLE_TCC` | 1 Linux / 0 macOS+cosmo | Compile the tcc backend for `hull build --compiler=tcc`. tcc is **not embedded** (~400 KB lighter binary) — it's a side-loaded tool (`hull tools install tcc`), resolved at build time from `~/.hull/tools` → `dirname(hull)` → `$PATH`. Off on macOS (Mach-O) / cosmo (APE archives), where tcc's ELF output is unusable and the system compiler is used instead. |
 | `HL_EMBED_CA_BUNDLE` | 1 | Drop Mozilla CA bundle (~200 KB, breaks HTTPS without system store) |
 | `HL_ENABLE_SQLITE` | 1 | Drop the SQLite backend (`cap/db_sqlite.c`, `cap/db_udf.c`, vendored `sqlite3.c`). A SQLite file path or `:memory:` DSN then has no backend. |
+| `HL_ENABLE_IMAGE` | 1 | Drop the image codec subsystem (`cap/image.c`, `cap/image_stb.c`, per-runtime `mod_image`, and vendored `stb_image` — image's **sole** consumer, ~146 KB). Subtractive knob like `HL_ENABLE_DB` (on by default: web apps want avatars/thumbnails). `hull/image` then fails module resolution unless declared optional (`"hull/image@1?"` → `require` returns nil). The GPU texture paths that take/return an `HlImage` (`gpu.texture(img)`, `gpu.texture_read`/`textureRead`) are gated out too, so a `GPU=1 IMAGE=0` build keeps raw-byte textures but not the image bridge. See "Image-less builds" below. |
 | `HL_ENABLE_POSTGRES` | 0 | (Off by default.) On compiles the pure-C PostgreSQL wire backend (`cap/pgwire.c` + `cap/pg_conn.c` + `cap/db_postgres.c`; no libpq) into the base. A `postgres://` / `postgresql://` DSN selects it. Links the shared TLS client (`HL_LINK_TLS`) for SSL connections. Normally composed via the `postgres` **feature** (`hull build --with=postgres`) rather than set directly; the flag is the monolithic path and what `make feature-postgres` builds the archive with. See "Composable features" above and "PostgreSQL + multi-backend DB" below. |
 | `HL_ENABLE_MYSQL` | 0 | (Off by default.) On compiles the pure-C MySQL / MariaDB wire backend (`cap/mysqlwire.c` + `cap/mysql_conn.c` + `cap/db_mysql.c`; no libmysql/libmariadb) into the base. A `mysql://` / `mariadb://` DSN selects it. Links the shared TLS client (`HL_LINK_TLS`). Normally composed via the `mysql` **feature** (`hull build --with=mysql`) rather than set directly; the flag is the monolithic path and what `make feature-mysql` builds the archive with. See "Composable features" above and "MySQL/MariaDB specifics" below. |
 | `HL_ENABLE_DB` | 1 | **Umbrella, derived** from the three granular flags: defined iff `HL_ENABLE_SQLITE`, `HL_ENABLE_POSTGRES`, or `HL_ENABLE_MYSQL` is on. Off (all granular off) drops `db.*` + `migrate.*` + worker-DB + the connection registry + DB-backed stdlib (session, ratelimit, idempotency, outbox, inbox, rbac, search). ~1.4 MB smaller. See "Compute-only builds" below. |
@@ -422,6 +423,39 @@ What still works:
 - `hull build`, `hull dev`, `hull test`, `hull agent` (minus the `db`/`migrate` subcommands)
 
 Binary size on arm64 Darwin: ~3.66 MB vs ~5.06 MB with DB (about 28% smaller).
+
+### Image-less builds (`HL_ENABLE_IMAGE=0`)
+
+`make HL_ENABLE_IMAGE=0` produces a hull binary without the image codec
+subsystem. Use for a compute / CLI / signing binary that never decodes or
+encodes images (a WASM/GPU transform pipeline, an air-gapped batch job, a data
+tool). Image is **on by default** (web apps want avatars / thumbnails), so this
+is a subtractive flavor knob like `HL_ENABLE_DB=0` — a make-level switch, not a
+`hull build --with=` feature and not exposed as a `--flavor` preset.
+
+What's removed:
+- `src/hull/cap/image.c`, `cap/image_stb.c` (the codec vtable + stb backend)
+- `runtime/{lua,js}/mod_image.c` (the `image` module bindings)
+- `vendor/stb/stb_impl.c` (stb_image + stb_image_write — image is its **only**
+  consumer, so it drops entirely; ~146 KB smaller on arm64 Darwin)
+
+What's unavailable to app code:
+- The `hull/image` module (`image.new/decode/encode/from_buffer`, the `HlImage`
+  userdata). A non-optional `"hull/image@1"` declaration is a hard app-load
+  error (`requires HL_ENABLE_IMAGE (build-time)`); declare it optional
+  (`"hull/image@1?"`) to have `require("hull.image")` return nil / `import`
+  bind null and fall back gracefully.
+- On a `HL_ENABLE_GPU=1 HL_ENABLE_IMAGE=0` build only the **image bridge** of the
+  GPU texture API drops: `gpu.texture(img)` no longer accepts an `HlImage` (raw
+  bytes + `{width,height,format}` still work) and `gpu.texture_read` /
+  `textureRead` (which return an `HlImage`) are compiled out. `gpu.buffer_read`
+  and the rest of `gpu.*` are unaffected.
+
+What still works: everything else — Lua/JS runtimes, `db.*`, `http.*`,
+`compute.*`, `gpu.*` (buffers/dispatch/pipeline), `crypto.*`, `fs.*`, templates,
+CSV, i18n, `hull build/dev/test/agent`. The image-less link is CI-covered by the
+`flavors` matrix (`HL_ENABLE_IMAGE=0`); combine with `HL_ENABLE_DB=0` /
+`HL_ENABLE_HTTP=0` for a minimal compute runtime.
 
 ### PostgreSQL + multi-backend DB
 

--- a/Makefile
+++ b/Makefile
@@ -647,14 +647,35 @@ TWEETNACL_DIR    := $(VENDDIR)/tweetnacl
 TWEETNACL_OBJ    := $(BUILDDIR)/tweetnacl.o
 TWEETNACL_CFLAGS := -std=c11 -O2 -w
 
+# ── HL_ENABLE_IMAGE (image codecs, on by default) ─────────────────────
+# The image decode/encode subsystem: cap/image.c + cap/image_stb.c + the
+# per-runtime mod_image bindings + vendored stb_image. On by default (web apps
+# want avatars / thumbnails), so slimming it out is SUBTRACTIVE -- a flavor knob
+# like HL_ENABLE_DB, not a `--with=` feature. `make HL_ENABLE_IMAGE=0` drops the
+# codec subsystem and stb entirely for a compute / CLI / signing binary that
+# never touches images; `hull/image` then needs an optional `"hull/image@1?"`
+# declaration to resolve on such a build (a non-optional decl is a hard error,
+# the HL_ENABLE_DB/GPU pattern). stb_image is image's ONLY consumer, so it goes
+# too. See CLAUDE.md "Image-less builds".
+HL_ENABLE_IMAGE ?= 1
+ifeq ($(HL_ENABLE_IMAGE),1)
+CFLAGS += -DHL_ENABLE_IMAGE
+endif
+
 # ── stb_image (image decode/encode) ──────────────────────────────────
 
 STB_DIR     := $(VENDDIR)/stb
-STB_OBJ     := $(BUILDDIR)/stb_impl.o
 STB_CFLAGS  := -std=c11 -O2 -w
+
+ifeq ($(HL_ENABLE_IMAGE),1)
+STB_OBJ     := $(BUILDDIR)/stb_impl.o
 
 $(STB_OBJ): $(STB_DIR)/stb_impl.c | $(BUILDDIR)
 	$(CC) $(STB_CFLAGS) -I$(STB_DIR) -c -o $@ $<
+else
+# Image codecs disabled: no stb object linked (image's sole consumer).
+STB_OBJ     :=
+endif
 
 # ── Unicode tables (TUI cell-width lookup) ──────────────────────────
 #
@@ -1499,6 +1520,15 @@ PLEDGE_OBJS ?=
 # Runtime-layer test bindings live in runtime/{lua,js}/mod_test.c (picked
 # up via the JS_RT_SRCS / LUA_RT_SRCS globs below).
 CAP_SRCS := $(filter-out $(SRCDIR)/hull/cap/tool.c $(SRCDIR)/hull/cap/test.c,$(wildcard $(SRCDIR)/hull/cap/*.c))
+ifeq ($(HL_ENABLE_IMAGE),0)
+  # Image codecs off: drop the codec vtable + stb backend (stb obj already
+  # emptied above). The per-runtime mod_image bindings are dropped from the
+  # runtime sources below.
+  CAP_SRCS := $(filter-out \
+      $(SRCDIR)/hull/cap/image.c \
+      $(SRCDIR)/hull/cap/image_stb.c, \
+      $(CAP_SRCS))
+endif
 ifeq ($(HL_ENABLE_DB),0)
   # Umbrella off (no backend): drop the shared query surface + selector +
   # the connection registry too.
@@ -1603,6 +1633,9 @@ endif
 
 # JS runtime sources
 JS_RT_SRCS := $(wildcard $(SRCDIR)/hull/runtime/js/*.c)
+ifeq ($(HL_ENABLE_IMAGE),0)
+  JS_RT_SRCS := $(filter-out $(SRCDIR)/hull/runtime/js/mod_image.c,$(JS_RT_SRCS))
+endif
 ifeq ($(HL_ENABLE_DB),0)
   JS_RT_SRCS := $(filter-out \
       $(SRCDIR)/hull/runtime/js/mod_db.c \
@@ -1648,6 +1681,9 @@ JS_RT_OBJS := $(patsubst $(SRCDIR)/hull/runtime/js/%.c,$(BUILDDIR)/js_%.o,$(JS_R
 
 # Lua runtime sources
 LUA_RT_SRCS := $(wildcard $(SRCDIR)/hull/runtime/lua/*.c)
+ifeq ($(HL_ENABLE_IMAGE),0)
+  LUA_RT_SRCS := $(filter-out $(SRCDIR)/hull/runtime/lua/mod_image.c,$(LUA_RT_SRCS))
+endif
 ifeq ($(HL_ENABLE_DB),0)
   LUA_RT_SRCS := $(filter-out \
       $(SRCDIR)/hull/runtime/lua/mod_db.c \
@@ -2441,6 +2477,7 @@ BUILD_FINGERPRINT := \
   TCC=$(HL_ENABLE_TCC)|\
   TUI=$(HL_ENABLE_TUI)|\
   TUI_TC=$(HL_TUI_TOOLCHAIN)|\
+  IMAGE=$(HL_ENABLE_IMAGE)|\
   CA=$(HL_EMBED_CA_BUNDLE)|\
   JS=$(HL_ENABLE_JS)|\
   LUA=$(HL_ENABLE_LUA)|\
@@ -3675,6 +3712,12 @@ ifeq ($(HL_ENABLE_DB),0)
       %/test_db.c %/test_db_backend.c %/test_db_select.c %/test_db_dynamic.c \
       %/test_js.c %/test_lua.c, \
       $(TEST_SRCS))
+endif
+
+# Drop the image codec test when the image subsystem is compiled out; it
+# exercises hl_cap_image_* / stb directly and would fail to link.
+ifeq ($(HL_ENABLE_IMAGE),0)
+  TEST_SRCS := $(filter-out %/test_image.c,$(TEST_SRCS))
 endif
 
 # Flatten test paths to build/ binaries: tests/hull/cap/test_body.c → build/test_body

--- a/include/hull/module_registry.h
+++ b/include/hull/module_registry.h
@@ -56,6 +56,7 @@
 #define HL_MOD_CAP_HTTP_CLIENT (1u << 6)  /* requires HL_ENABLE_HTTP_CLIENT at build */
 #define HL_MOD_CAP_HTTP_SERVER (1u << 7)  /* requires HL_ENABLE_HTTP_SERVER at build */
 #define HL_MOD_CAP_TUI         (1u << 8)  /* requires HL_ENABLE_TUI + tui:true */
+#define HL_MOD_CAP_IMAGE       (1u << 9)  /* requires HL_ENABLE_IMAGE at build */
 /* Back-compat: HL_MOD_CAP_HTTP means "any HTTP" (server OR client).
  * Existing module specs that haven't been classified yet still use
  * this; new specs should pick CLIENT or SERVER. */

--- a/src/hull/commands/modules.c
+++ b/src/hull/commands/modules.c
@@ -47,6 +47,7 @@ static const struct {
     { HL_MOD_CAP_HTTP_CLIENT, "build:http-client" },
     { HL_MOD_CAP_HTTP_SERVER, "build:http-server" },
     { HL_MOD_CAP_TUI,         "build:tui"        },
+    { HL_MOD_CAP_IMAGE,       "build:image"      },
     { 0, NULL }
 };
 

--- a/src/hull/module_registry.c
+++ b/src/hull/module_registry.c
@@ -164,7 +164,7 @@ static const HlModuleSpec REGISTRY[] = {
     {
         .name = "hull/image",
         .api_major = 1, .intrinsic = 0, .pure = 0,
-        .required_caps = 0, .deps = {0},
+        .required_caps = HL_MOD_CAP_IMAGE, .deps = {0},
     },
     {
         .name = "hull/inspect",

--- a/src/hull/module_resolver.c
+++ b/src/hull/module_resolver.c
@@ -154,6 +154,9 @@ static uint32_t build_compile_caps(void)
 #ifdef HL_ENABLE_TUI
     caps |= HL_MOD_CAP_TUI;
 #endif
+#ifdef HL_ENABLE_IMAGE
+    caps |= HL_MOD_CAP_IMAGE;
+#endif
     return caps;
 }
 
@@ -206,7 +209,7 @@ bool hl_module_needs_absent_build_cap(const HlModuleSpec *spec)
     if (!spec) return false;
     const uint32_t build_cap_mask = HL_MOD_CAP_DB | HL_MOD_CAP_WASM
                                     | HL_MOD_CAP_GPU | HL_MOD_CAP_HTTP
-                                    | HL_MOD_CAP_TUI;
+                                    | HL_MOD_CAP_TUI | HL_MOD_CAP_IMAGE;
     return (spec->required_caps & build_cap_mask & ~build_provided_caps()) != 0;
 }
 
@@ -224,6 +227,7 @@ static const char *cap_label(uint32_t cap)
     case HL_MOD_CAP_HTTP_SERVER: return "HL_ENABLE_HTTP_SERVER (build-time)";
     case HL_MOD_CAP_HTTP:        return "HL_ENABLE_HTTP (build-time)";
     case HL_MOD_CAP_TUI:         return "HL_ENABLE_TUI (build-time)";
+    case HL_MOD_CAP_IMAGE:       return "HL_ENABLE_IMAGE (build-time)";
     default:                     return "unknown";
     }
 }
@@ -344,7 +348,7 @@ int hl_module_resolver_resolve_caps(const HlManifest *manifest,
     const uint32_t prov_build    = build_caps;
     const uint32_t build_cap_mask = HL_MOD_CAP_DB | HL_MOD_CAP_WASM
                                     | HL_MOD_CAP_GPU | HL_MOD_CAP_HTTP
-                                    | HL_MOD_CAP_TUI;
+                                    | HL_MOD_CAP_TUI | HL_MOD_CAP_IMAGE;
 
     /* Pass 1: look up each declared module + admit it. Detect unknown
      * names, version mismatches, duplicates, missing capabilities. */

--- a/src/hull/runtime/js/mod_gpu.c
+++ b/src/hull/runtime/js/mod_gpu.c
@@ -584,6 +584,7 @@ static JSValue js_gpu_texture(JSContext *ctx, JSValueConst this_val,
     const char *str_data = NULL;
     int str_needs_free = 0;
 
+#ifdef HL_ENABLE_IMAGE
     /* Check if arg 1 is an HlImage object */
     HlImage *img = JS_GetOpaque(argv[1], js_image_class_id);
     if (img) {
@@ -592,7 +593,9 @@ static JSValue js_gpu_texture(JSContext *ctx, JSValueConst this_val,
         format = (HlGpuTexFormat)img->format;
         pixels = img->pixels;
         pixel_len = img->pixel_len;
-    } else {
+    } else
+#endif
+    {
         /* Get data from buffer protocol */
         HlBufferView bv;
         if (js_get_buffer(ctx, argv[1], &bv, &str_data, &str_needs_free)) {
@@ -600,7 +603,11 @@ static JSValue js_gpu_texture(JSContext *ctx, JSValueConst this_val,
             pixel_len = bv.len;
         } else {
             JS_FreeCString(ctx, name);
-            return JS_ThrowTypeError(ctx, "gpu.texture: data must be HlImage, ArrayBuffer, or string");
+            return JS_ThrowTypeError(ctx, "gpu.texture: data must be "
+#ifdef HL_ENABLE_IMAGE
+                                     "HlImage, "
+#endif
+                                     "ArrayBuffer, or string");
         }
     }
 
@@ -671,6 +678,7 @@ static JSValue js_gpu_texture(JSContext *ctx, JSValueConst this_val,
 
 /* ── gpu.textureRead(name, opts?) → HlImage ──────────────────────── */
 
+#ifdef HL_ENABLE_IMAGE
 static JSValue js_gpu_texture_read(JSContext *ctx, JSValueConst this_val,
                                     int argc, JSValueConst *argv)
 {
@@ -712,6 +720,7 @@ static JSValue js_gpu_texture_read(JSContext *ctx, JSValueConst this_val,
     JS_SetOpaque(obj, img);
     return obj;
 }
+#endif /* HL_ENABLE_IMAGE */
 
 /* ── JS texture desc parsing helper ──────────────────────────────── */
 
@@ -1630,8 +1639,10 @@ static int js_gpu_module_init(JSContext *ctx, JSModuleDef *m)
                       JS_NewCFunction(ctx, js_gpu_buffer_copy, "bufferCopy", 3));
     JS_SetPropertyStr(ctx, gpu, "texture",
                       JS_NewCFunction(ctx, js_gpu_texture, "texture", 3));
+#ifdef HL_ENABLE_IMAGE
     JS_SetPropertyStr(ctx, gpu, "textureRead",
                       JS_NewCFunction(ctx, js_gpu_texture_read, "textureRead", 1));
+#endif
 
     /* gpu.async sub-object */
     JSValue async_obj = JS_NewObject(ctx);

--- a/src/hull/runtime/js/modules.c
+++ b/src/hull/runtime/js/modules.c
@@ -84,9 +84,11 @@ int hl_js_register_modules(HlJS *js)
     if (hl_js_init_mime_module(js->ctx, js) != 0)
         return -1;
 
-    /* Register hull:image module — always available */
+#ifdef HL_ENABLE_IMAGE
+    /* Register hull:image module (dropped on a HL_ENABLE_IMAGE=0 build). */
     if (hl_js_init_image_module(js->ctx, js) != 0)
         return -1;
+#endif
 
 #ifdef HL_ENABLE_WASM
     /* Register hull:compute module (only if WASM runtime is available) */

--- a/src/hull/runtime/lua/mod_gpu.c
+++ b/src/hull/runtime/lua/mod_gpu.c
@@ -467,10 +467,12 @@ static HlGpuTexFormat lua_parse_tex_format(const char *s)
     return HL_GPU_TEX_RGBA8;
 }
 
+#ifdef HL_ENABLE_IMAGE
 static HlGpuTexFormat image_format_to_gpu(HlImageFormat fmt)
 {
     return (HlGpuTexFormat)fmt;  /* safe: enum values match */
 }
+#endif
 
 /* ── gpu.texture(name, data_or_nil, opts?) ────────────────────────── */
 
@@ -497,6 +499,7 @@ static int l_gpu_texture(lua_State *L)
     const void *pixels = NULL;
     size_t pixel_len = 0;
 
+#ifdef HL_ENABLE_IMAGE
     /* Check if arg 2 is an HlImage userdata */
     HlImage **imgp = (HlImage **)luaL_testudata(L, 2, HL_IMAGE_MT);
     if (imgp && *imgp) {
@@ -506,11 +509,17 @@ static int l_gpu_texture(lua_State *L)
         format = image_format_to_gpu(img->format);
         pixels = img->pixels;
         pixel_len = img->pixel_len;
-    } else {
+    } else
+#endif
+    {
         /* Buffer data: require opts with width, height, format */
         HlBufferView bv;
         if (!lua_get_buffer(L, 2, &bv))
-            return luaL_error(L, "gpu.texture: data must be HlImage, string, or buffer");
+            return luaL_error(L, "gpu.texture: data must be "
+#ifdef HL_ENABLE_IMAGE
+                              "HlImage, "
+#endif
+                              "string, or buffer");
         pixels = bv.data;
         pixel_len = bv.len;
     }
@@ -581,6 +590,7 @@ static int l_gpu_texture(lua_State *L)
 
 /* ── gpu.texture_read(name, opts?) → HlImage ─────────────────────── */
 
+#ifdef HL_ENABLE_IMAGE
 static int l_gpu_texture_read(lua_State *L)
 {
     HlGpuCtx *ctx = lua_get_gpu_ctx(L);
@@ -619,6 +629,7 @@ static int l_gpu_texture_read(lua_State *L)
     lua_setmetatable(L, -2);
     return 1;
 }
+#endif /* HL_ENABLE_IMAGE */
 
 /* ── Texture desc parsing helper (used by dispatch + pipeline) ────── */
 
@@ -657,6 +668,7 @@ static int lua_parse_texture_descs(lua_State *L, int tbl_idx,
             lua_pop(L, 1);
 
             /* data: pixel bytes or HlImage */
+#ifdef HL_ENABLE_IMAGE
             lua_getfield(L, -1, "image");
             HlImage **imgp2 = (HlImage **)luaL_testudata(L, -1, HL_IMAGE_MT);
             if (imgp2 && *imgp2) {
@@ -668,6 +680,7 @@ static int lua_parse_texture_descs(lua_State *L, int tbl_idx,
                 descs[i].format = image_format_to_gpu(img->format);
             }
             lua_pop(L, 1);
+#endif
 
             if (!descs[i].data) {
                 lua_getfield(L, -1, "data");
@@ -1350,7 +1363,9 @@ static const luaL_Reg gpu_funcs[] = {
     {"buffer_read",   l_gpu_buffer_read},
     {"buffer_copy",   l_gpu_buffer_copy},
     {"texture",       l_gpu_texture},
+#ifdef HL_ENABLE_IMAGE
     {"texture_read",  l_gpu_texture_read},
+#endif
     {NULL, NULL}
 };
 

--- a/src/hull/runtime/lua/modules.c
+++ b/src/hull/runtime/lua/modules.c
@@ -80,7 +80,9 @@ int hl_lua_register_modules(HlLua *lua)
     register_native_module(L, "hull.fs",     luaopen_hull_fs);
     register_native_module(L, "hull.blob",   luaopen_hull_blob);
     register_native_module(L, "hull.mime",   luaopen_hull_mime);
+#ifdef HL_ENABLE_IMAGE
     register_native_module(L, "hull.image",  luaopen_hull_image);
+#endif
 
     /* Internal bridge used by the hull.template stdlib — name starts
      * with underscore so it's not exposed as a first-party module via

--- a/src/hull/tool_orchestration.c
+++ b/src/hull/tool_orchestration.c
@@ -457,6 +457,7 @@ static int l_tool_modules_available(lua_State *L)
             { HL_MOD_CAP_HTTP_CLIENT, "http_client" },
             { HL_MOD_CAP_HTTP_SERVER, "http_server" },
             { HL_MOD_CAP_TUI,         "tui"         },
+            { HL_MOD_CAP_IMAGE,       "image"       },
         };
         for (size_t k = 0; k < sizeof map / sizeof map[0]; k++) {
             if (need & map[k].bit) {

--- a/tests/hull/runtime/js/test_js.c
+++ b/tests/hull/runtime/js/test_js.c
@@ -3988,6 +3988,7 @@ UTEST(js_runtime, import_gated_declared_native_module_succeeds)
     cleanup_js();
 }
 
+#ifdef HL_ENABLE_IMAGE
 UTEST(js_runtime, import_image_is_a_real_hull_module)
 {
     /* Phase 2c: image is no longer a global on globalThis — it must be
@@ -4015,6 +4016,7 @@ UTEST(js_runtime, import_image_is_a_real_hull_module)
     js.base.module_set = NULL;
     cleanup_js();
 }
+#endif /* HL_ENABLE_IMAGE */
 
 /* ── Async test-runner regression coverage ──────────────────────────
  *


### PR DESCRIPTION
Adds a subtractive build knob for the image codec subsystem, mirroring `HL_ENABLE_DB`: on by default (web apps want avatars / thumbnails), and `make HL_ENABLE_IMAGE=0` drops it for a compute / CLI / signing binary that never touches images. Removes `cap/image.c` + `cap/image_stb.c` + the per-runtime `mod_image` bindings + vendored `stb_image` (image's **sole** consumer, so stb goes too; ~146 KB smaller on arm64 Darwin).

Classified per the extension taxonomy as a **flavor knob** (subtractive, on-by-default), not a `--with=` feature — the roadmap's near-term-targets table calls this out.

## Wiring (the HL_ENABLE_DB pattern)
- **Makefile:** `HL_ENABLE_IMAGE` flag + `-DHL_ENABLE_IMAGE`; gate `STB_OBJ`; filter `image.c`/`image_stb.c` from `CAP_SRCS` and `mod_image.c` from the per-runtime sources; `IMAGE=` added to the config-sentinel fingerprint; drop `test_image` at 0.
- **Module gate:** new `HL_MOD_CAP_IMAGE` bit; `hull/image` carries it; the resolver's `build_compile_caps` / `build_cap_mask` / `cap_label` learn it — a non-optional `hull/image@1` hard-fails `requires HL_ENABLE_IMAGE (build-time)`, an optional `hull/image@1?` resolves to nil (identical to `hull/gpu@1?`).
- **Source guards:** `mod_image` registration (both runtimes) and the `mod_gpu` image bridge (the `HlImage` texture input + `gpu.texture_read`/`textureRead`, which call `hl_image_new`) behind `#ifdef HL_ENABLE_IMAGE`, so a `GPU=1 IMAGE=0` build keeps raw-byte textures but drops the image bridge. `mod_buffer` needs no guard (it only reads `HlImage` struct fields, which `image.h` still provides).
- **Display parity:** the `build:image` / `image` cap names in `modules.c` and `tool_orchestration.c`; guard the js `import_image` test at `IMAGE=0`.

## Validation
- default `make test` **60/60** (behavior byte-identical), `HL_ENABLE_IMAGE=0` `make test` **59/59** (`test_image` gated)
- the three module scenarios: no-image app runs; non-optional rejected; optional → nil
- stb fully unlinked (0 `stbi_` symbols), ~146 KB smaller
- CI `flavors` matrix gains an `HL_ENABLE_IMAGE=0` link+smoke entry

## Note for review
Built + tested natively (macOS); not yet run through `make CC=cosmocc`. The featurify axis is cosmo-exempt and no platform-branch code was touched, but a cosmo build check before merge would close that out.