### PR TITLE
feat(db): SQLite feature Phase A.1 — default-backend seam (no behavior change)

### DIFF
--- a/src/hull/cap/db_select.c
+++ b/src/hull/cap/db_select.c
@@ -85,6 +85,29 @@ static int scheme_in(const char *const *list, const char *scheme)
     return 0;
 }
 
+/* The scheme a scheme-less DSN (a bare path, ":memory:", a "file:" URI) routes
+ * to. This is the DEFAULT backend. Today the base SQLite backend claims it; once
+ * SQLite becomes a composable feature (docs/sqlite_feature.md) it fills the same
+ * slot via hl_db_feature_backends, so resolving the default by scheme keeps this
+ * correct without the selector naming hl_db_backend_sqlite directly. */
+#define HL_DB_DEFAULT_SCHEME "sqlite"
+
+/* Resolve the backend claiming @p scheme among the base backends compiled into
+ * this binary, then any feature backends composed in at build time. NULL if
+ * none. Shared by the explicit-scheme path and the scheme-less default. */
+static const HlDbBackend *backend_for_scheme(const char *scheme)
+{
+    for (size_t i = 0; i < sizeof BACKENDS / sizeof BACKENDS[0]; i++)
+        if (scheme_in(BACKENDS[i]->schemes, scheme))
+            return BACKENDS[i];
+    size_t fcount = 0;
+    const HlDbBackend *const *feats = hl_db_feature_backends(&fcount);
+    for (size_t i = 0; i < fcount; i++)
+        if (feats && feats[i] && scheme_in(feats[i]->schemes, scheme))
+            return feats[i];
+    return NULL;
+}
+
 /* Weak default: a base build has no composed feature backends. A feature build
  * (`hull build --with=<feature>`) links a generated STRONG override — a const
  * table referencing each composed feature's backend — which the linker prefers
@@ -106,18 +129,10 @@ const HlDbBackend *hl_db_backend_select(const char *dsn, const char **err)
     size_t slen = dsn_scheme(dsn, scheme, sizeof scheme);
 
     if (slen > 0) {
-        /* Explicit "<scheme>://": route to the backend that claims it. First the
-         * base backends compiled into this binary. */
-        for (size_t i = 0; i < sizeof BACKENDS / sizeof BACKENDS[0]; i++)
-            if (scheme_in(BACKENDS[i]->schemes, scheme))
-                return BACKENDS[i];
-        /* Then feature backends composed in at build time (empty in a base
-         * build; a generated registry fills this in a `--with=<feature>` build). */
-        size_t fcount = 0;
-        const HlDbBackend *const *feats = hl_db_feature_backends(&fcount);
-        for (size_t i = 0; i < fcount; i++)
-            if (feats && feats[i] && scheme_in(feats[i]->schemes, scheme))
-                return feats[i];
+        /* Explicit "<scheme>://": route to the backend that claims it (base
+         * backends first, then feature backends composed at build time). */
+        const HlDbBackend *be = backend_for_scheme(scheme);
+        if (be) return be;
         /* A scheme Hull knows but this build lacks: specific hint. */
         for (size_t i = 0; i < sizeof RESERVED / sizeof RESERVED[0]; i++)
             if (strcmp(RESERVED[i].scheme, scheme) == 0) {
@@ -130,15 +145,16 @@ const HlDbBackend *hl_db_backend_select(const char *dsn, const char **err)
         return NULL;
     }
 
-    /* No scheme: a bare path, ":memory:", or an sqlite "file:" URI -> SQLite. */
-#ifdef HL_ENABLE_SQLITE
-    return &hl_db_backend_sqlite;
-#else
+    /* No scheme: a bare path, ":memory:", or an sqlite "file:" URI -> the
+     * default backend, resolved by scheme rather than by a hardcoded symbol so
+     * this stays correct when SQLite moves behind hl_db_feature_backends. Today
+     * the base SQLite backend claims HL_DB_DEFAULT_SCHEME. */
+    const HlDbBackend *def = backend_for_scheme(HL_DB_DEFAULT_SCHEME);
+    if (def) return def;
     if (err)
-        *err = "this hull has no SQLite backend for a scheme-less DSN; use an "
-               "explicit scheme (e.g. postgres:// or duckdb://)";
+        *err = "this hull has no default (SQLite) backend for a scheme-less "
+               "DSN; use an explicit scheme (e.g. postgres:// or duckdb://)";
     return NULL;
-#endif
 }
 
 /* hl_cap_db_check_namespace (the backend-agnostic _hull_* guard) moved to


### PR DESCRIPTION
Kicks off the SQLite-as-a-feature epic (design: `docs/sqlite_feature.md`, from #123). This is **Phase A, seam 1 of 2** — the de-risking refactor with **zero behavior change**.

## What
Routes the scheme-less DSN default through the backend registry instead of naming `hl_db_backend_sqlite` directly, so the selector is ready for SQLite to move behind `hl_db_feature_backends` in Phase B.

- Add `backend_for_scheme(scheme)`: resolves the backend claiming a scheme among the base `BACKENDS[]` then the composed feature backends (the same order the explicit-scheme path already used — now shared by both paths).
- The scheme-less default (bare path / `:memory:` / `file:` URI) now resolves via `backend_for_scheme(HL_DB_DEFAULT_SCHEME = "sqlite")` instead of returning `&hl_db_backend_sqlite` under `#ifdef HL_ENABLE_SQLITE`. Byte-identical today (the base SQLite backend claims that scheme and is in `BACKENDS[]`); when SQLite becomes a feature it fills the same slot via the hook, so the default keeps resolving without the selector naming the symbol.
- **No SQLite is moved yet.** `BACKENDS[]` still registers it (Phase B relocates that to the feature hook). The selector *logic* no longer references `hl_db_backend_sqlite`; only the registration line + comments do — which is exactly the Phase A verify criterion in the design doc.

## Validation (byte-identical)
- `make test` **60/60**
- `test_db_select` / `test_db` / `test_db_backend` / `test_db_registry` / `test_db_dynamic` all pass (73 cases)
- `e2e_named_connections` **6/6** on both runtimes — exercises the scheme-less default → SQLite through the real selector

## Next in Phase A
Seam 2: the **agent-introspection weak-stub seam** (`hl_agent_db_*` / `hl_agent_sql_*` gain base weak stubs so the base links without `agent/db.c`; the SQLite impls become strong overrides). It's a meatier refactor that pairs naturally with the Phase B extraction, so it's split out for reviewability.

Depends conceptually on #123 (the design doc) but is independent code-wise.