### PR TITLE
feat(db): SQLite feature Phase A.2 — agent introspection weak-stub seam

### DIFF
--- a/src/hull/agent/db_stub.c
+++ b/src/hull/agent/db_stub.c
@@ -1,0 +1,111 @@
+/*
+ * agent/db_stub.c — weak fallbacks for the SQLite-backed agent DB introspection
+ * (SQLite as a composable feature, docs/sqlite_feature.md, Phase A).
+ *
+ * The `hull agent db|migrate|sql|schema-diff` entry points are implemented
+ * against the raw sqlite3 API in agent/{db,sql,schema_diff}.c, which are
+ * SQLite-only. Phase B moves those TUs into libhull_feature-sqlite.a; this TU
+ * (always compiled into the base whenever the DB umbrella is on) provides WEAK
+ * defaults for every public entry point so the base's agent dispatch, in-process
+ * agent API, and MCP server link even when the SQLite backend is not composed.
+ *
+ * The strong definitions in agent/{db,sql,schema_diff}.c override these when
+ * SQLite is present (Phase A: compiled into the base -> byte-identical; Phase B:
+ * supplied by the composed feature archive). When absent, each weak stub emits a
+ * clear `{"error": ...}` and returns -1 (hl_agent_write_error's convention), so
+ * `hull agent db schema` on, say, a Postgres-only build fails closed with a
+ * useful message instead of the command being compiled out.
+ *
+ * Mirrors http_weakstub.c / wasm_weakstub.c. Guarded on HL_ENABLE_DB (matches
+ * where agent_lib.h declares these entry points); a compute-only HL_ENABLE_DB=0
+ * build has no agent DB commands at all, so no stub is needed.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifdef HL_ENABLE_DB
+
+#include "internal.h"            /* hl_agent_write_error */
+#include "hull/agent_lib.h"      /* the entry-point prototypes */
+#include "hull/app_context.h"    /* HlAppContext */
+
+#include <sh_json.h>
+
+/* One message for the whole surface: the introspection is SQLite-specific
+ * (sqlite_master / PRAGMA), so it needs the SQLite backend regardless of which
+ * DB the app actually uses. */
+#define HL_AGENT_DB_ABSENT_MSG \
+    "agent database introspection requires the SQLite backend " \
+    "(not composed in this build)"
+
+__attribute__((weak))
+int hl_agent_db_schema_ctx(HlAppContext *ctx, const char *db_path, ShJsonBuf *out)
+{
+    (void)ctx; (void)db_path;
+    return hl_agent_write_error(out, HL_AGENT_DB_ABSENT_MSG);
+}
+
+__attribute__((weak))
+int hl_agent_db_schema(const char *app_dir, const char *db_path, ShJsonBuf *out)
+{
+    (void)app_dir; (void)db_path;
+    return hl_agent_write_error(out, HL_AGENT_DB_ABSENT_MSG);
+}
+
+__attribute__((weak))
+int hl_agent_db_query_ctx(HlAppContext *ctx, const char *db_path,
+                          const char *sql, ShJsonBuf *out)
+{
+    (void)ctx; (void)db_path; (void)sql;
+    return hl_agent_write_error(out, HL_AGENT_DB_ABSENT_MSG);
+}
+
+__attribute__((weak))
+int hl_agent_db_query(const char *app_dir, const char *db_path,
+                      const char *sql, ShJsonBuf *out)
+{
+    (void)app_dir; (void)db_path; (void)sql;
+    return hl_agent_write_error(out, HL_AGENT_DB_ABSENT_MSG);
+}
+
+__attribute__((weak))
+int hl_agent_migrate_status_ctx(HlAppContext *ctx, const char *db_path,
+                                ShJsonBuf *out)
+{
+    (void)ctx; (void)db_path;
+    return hl_agent_write_error(out, HL_AGENT_DB_ABSENT_MSG);
+}
+
+__attribute__((weak))
+int hl_agent_migrate_status(const char *app_dir, const char *db_path,
+                            ShJsonBuf *out)
+{
+    (void)app_dir; (void)db_path;
+    return hl_agent_write_error(out, HL_AGENT_DB_ABSENT_MSG);
+}
+
+__attribute__((weak))
+int hl_agent_schema_diff_ctx(HlAppContext *ctx, const char *db_path,
+                             ShJsonBuf *out)
+{
+    (void)ctx; (void)db_path;
+    return hl_agent_write_error(out, HL_AGENT_DB_ABSENT_MSG);
+}
+
+__attribute__((weak))
+int hl_agent_schema_diff(const char *app_dir, const char *db_path,
+                         ShJsonBuf *out)
+{
+    (void)app_dir; (void)db_path;
+    return hl_agent_write_error(out, HL_AGENT_DB_ABSENT_MSG);
+}
+
+__attribute__((weak))
+int hl_agent_sql_named_ctx(HlAppContext *ctx, const char *query_name,
+                           const char *params_json, ShJsonBuf *out)
+{
+    (void)ctx; (void)query_name; (void)params_json;
+    return hl_agent_write_error(out, HL_AGENT_DB_ABSENT_MSG);
+}
+
+#endif /* HL_ENABLE_DB */

--- a/src/hull/agent_api.c
+++ b/src/hull/agent_api.c
@@ -35,7 +35,7 @@ static int agent_api_middleware(KlRequest *req, KlResponse *res, void *user_data
 
     if (strcmp(endpoint, "routes") == 0) {
         hl_agent_routes(ctx->app_dir, &out);
-#ifdef HL_ENABLE_SQLITE
+#ifdef HL_ENABLE_DB
     } else if (strcmp(endpoint, "schema") == 0) {
         hl_agent_db_schema(ctx->app_dir, ctx->db_path, &out);
 #endif
@@ -43,7 +43,7 @@ static int agent_api_middleware(KlRequest *req, KlResponse *res, void *user_data
         hl_agent_status(ctx->app_dir, 0, &out);
     } else if (strcmp(endpoint, "errors") == 0) {
         hl_agent_errors(ctx->app_dir, &out);
-#ifdef HL_ENABLE_SQLITE
+#ifdef HL_ENABLE_DB
     } else if (strcmp(endpoint, "migrate") == 0) {
         hl_agent_migrate_status(ctx->app_dir, ctx->db_path, &out);
 #endif

--- a/src/hull/commands/agent.c
+++ b/src/hull/commands/agent.c
@@ -59,7 +59,7 @@ static int cmd_routes(int argc, char **argv)
     return output_result(&out, rc);
 }
 
-#ifdef HL_ENABLE_SQLITE
+#ifdef HL_ENABLE_DB
 static int cmd_db_schema(int argc, char **argv)
 {
     const char *app_dir = ".";
@@ -119,7 +119,7 @@ static int cmd_db(int argc, char **argv)
     fprintf(stderr, "hull agent db: unknown subcommand '%s'\n", argv[0]);
     return 1;
 }
-#endif /* HL_ENABLE_SQLITE */
+#endif /* HL_ENABLE_DB */
 
 static int cmd_request(int argc, char **argv)
 {
@@ -357,7 +357,7 @@ static int cmd_deploy(int argc, char **argv)
     return output_result(&out, rc);
 }
 
-#ifdef HL_ENABLE_SQLITE
+#ifdef HL_ENABLE_DB
 static int cmd_migrate(int argc, char **argv)
 {
     const char *app_dir = ".";
@@ -650,7 +650,7 @@ static int cmd_compute_call(int argc, char **argv)
     return output_result(&out, rc);
 }
 
-#ifdef HL_ENABLE_SQLITE
+#ifdef HL_ENABLE_DB
 static int cmd_schema_diff(int argc, char **argv)
 {
     const char *app_dir = ".";
@@ -748,7 +748,7 @@ int hl_cmd_agent(int argc, char **argv, const HlCommandEnv *env)
 
     if (strcmp(sub, "routes") == 0)
         return cmd_routes(sub_argc, sub_argv);
-#ifdef HL_ENABLE_SQLITE
+#ifdef HL_ENABLE_DB
     if (strcmp(sub, "db") == 0)
         return cmd_db(sub_argc, sub_argv);
 #endif
@@ -764,7 +764,7 @@ int hl_cmd_agent(int argc, char **argv, const HlCommandEnv *env)
         return cmd_test(sub_argc, sub_argv, env);
     if (strcmp(sub, "context") == 0)
         return cmd_context(sub_argc, sub_argv, env);
-#ifdef HL_ENABLE_SQLITE
+#ifdef HL_ENABLE_DB
     if (strcmp(sub, "migrate") == 0)
         return cmd_migrate(sub_argc, sub_argv);
 #endif
@@ -798,7 +798,7 @@ int hl_cmd_agent(int argc, char **argv, const HlCommandEnv *env)
     }
     /* Composite project summary — one call to orient an agent. */
     if (strcmp(sub, "overview") == 0)     return cmd_overview(sub_argc, sub_argv);
-#ifdef HL_ENABLE_SQLITE
+#ifdef HL_ENABLE_DB
     if (strcmp(sub, "schema-diff") == 0)  return cmd_schema_diff(sub_argc, sub_argv);
     if (strcmp(sub, "sql") == 0)          return cmd_sql(sub_argc, sub_argv);
 #endif


### PR DESCRIPTION
Second seam of the SQLite-as-a-feature epic (design: `docs/sqlite_feature.md` from #123; follows Phase A.1 in #124). **No behavior change on a standard SQLite build.**

## What
Routes the agent DB introspection (`hull agent db|migrate|sql|schema-diff`) through a weak-stub seam so the base's agent dispatch, in-process agent API, and (later) MCP server link even when the SQLite-only implementations are not composed — the prerequisite for moving `agent/{db,sql,schema_diff}.c` into `libhull_feature-sqlite.a` in Phase B.

- **New `src/hull/agent/db_stub.c`**: weak defaults for all 9 public agent-DB entry points (`hl_agent_db_schema{,_ctx}`, `_db_query{,_ctx}`, `_migrate_status{,_ctx}`, `_schema_diff{,_ctx}`, `_sql_named_ctx`), each emitting a clear `{"error": ...}` via `hl_agent_write_error`. Guarded on `HL_ENABLE_DB` (where `agent_lib.h` declares them), auto-picked-up by the `AGENT_LIB_SRCS` wildcard. Mirrors `http_weakstub.c` / `wasm_weakstub.c`.
- The **strong** impls in `agent/{db,sql,schema_diff}.c` override the weak stubs when SQLite is present. Phase A: compiled into the base → strong wins → byte-identical. Phase B: supplied by the composed feature archive.
- **Retarget** the guards in `commands/agent.c` + `agent_api.c` from `HL_ENABLE_SQLITE` → `HL_ENABLE_DB`: the agent-DB commands are now present whenever a DB backend exists (routing to the strong impl on SQLite, else the stub's "requires the SQLite backend" error) instead of being compiled out. A compute-only `HL_ENABLE_DB=0` build still has no agent-DB commands.
- `mcp.c`'s db-tool advertisement guards are **intentionally deferred** (they carry the separate "advertise db tools on a non-SQLite base" product question); leaving them `HL_ENABLE_SQLITE`-gated is harmless here.

## Behavior-change note
Confined to the **non-shipped** postgres/mysql-only edge build: `hull agent db schema` there now returns a graceful `"requires the SQLite backend"` error instead of being an unknown subcommand. An improvement.

## Validation
- `make test` **60/60**; `e2e_agent` **61/61**; `e2e_agent_api` **7/7**
- `hull agent db schema` / `migrate` produce real output — the strong impl wins → byte-identical
- The three touched TUs **compile SQLite-free** (DB on, SQLite off) with all 9 weak entry points present — proving the base links without `agent/db.c` for Phase B

Independent of #124 (different files/seams); both are Phase A prerequisites for the Phase B extraction.