### PR TITLE
feat(db): SQLite feature Phase B.1+B.2 — feature archive + SQLite-less DB-core base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -423,6 +423,18 @@ HL_ENABLE_POSTGRES ?= 0
 HL_ENABLE_MYSQL    ?= 0
 HL_ENABLE_DUCKDB   ?= 0
 
+# HL_SQLITE_FEATURE=1 builds a SQLite-as-a-composable-feature base
+# (docs/sqlite_feature.md, Phase B): SQLite leaves the base object set (composed
+# back from libhull_feature-sqlite.a) but the DB CORE stays on. It forces
+# HL_ENABLE_SQLITE off here; the umbrella below keeps HL_ENABLE_DB on so the
+# vtable + selector + generic db.* caps + weak hl_db_feature_backends remain,
+# with zero compiled backend. Orthogonal to the postgres/mysql flags (those may
+# still be composed alongside). Native only; the default (0) is unchanged.
+HL_SQLITE_FEATURE  ?= 0
+ifeq ($(HL_SQLITE_FEATURE),1)
+override HL_ENABLE_SQLITE := 0
+endif
+
 # Keel (KlTls) + mbedTLS are linked when an HTTP half OR PostgreSQL OR MySQL is
 # enabled (MySQL's caching_sha2_password full-auth + ed25519 need TLS + crypto).
 # HTTP still owns the -DHL_ENABLE_HTTP macro (above), so a DB-only build links
@@ -545,8 +557,20 @@ endif
 # contradictory HL_ENABLE_DB=1 was passed with all backends off (resolves
 # to a coherent "no backend" rather than a broken half-build). The
 # back-compat check above already read the caller's HL_ENABLE_DB=0 intent.
+#
+# Exception: HL_SQLITE_FEATURE=1 is exactly the "DB core, backend composed" case
+# (docs/sqlite_feature.md, Phase B). No backend is compiled into the base, but
+# the umbrella stays ON so the vtable + selector + generic db.* caps + the weak
+# hl_db_feature_backends hook remain; the backend arrives from the composed
+# libhull_feature-sqlite.a. This is NOT the broken half-build the override guards
+# against -- it is the composable base.
 ifeq ($(HL_ENABLE_SQLITE)$(HL_ENABLE_POSTGRES)$(HL_ENABLE_MYSQL)$(HL_ENABLE_DUCKDB),0000)
+ifeq ($(HL_SQLITE_FEATURE),1)
+override HL_ENABLE_DB := 1
+CFLAGS += -DHL_ENABLE_DB
+else
 override HL_ENABLE_DB := 0
+endif
 else
 override HL_ENABLE_DB := 1
 CFLAGS += -DHL_ENABLE_DB

--- a/Makefile
+++ b/Makefile
@@ -2774,6 +2774,29 @@ $(BUILDDIR)/libhull_feature-mysql.a: $(BUILDDIR)/cap_db_mysql.o $(BUILDDIR)/cap_
 	$(AR) rcs $@ $(BUILDDIR)/cap_db_mysql.o $(BUILDDIR)/cap_mysql_conn.o $(BUILDDIR)/cap_mysqlwire.o
 	@echo "built $@ ($$(du -h $@ | cut -f1))"
 
+# ── SQLite feature archive (SQLite as a composable feature, Phase B) ──
+# docs/sqlite_feature.md. Bundles the vendored SQLite engine + the SQLite
+# backend + UDF bridge + the SQLite-only agent introspection into ONE archive
+# so the base can become SQLite-less (Phase B.2) and compose it back (Phase
+# B.3). Unlike postgres/mysql (installable, off-by-default, filtered out of the
+# base), SQLite is still in the default base today, so this target just packages
+# the same objects into the archive as the additive first step; the base-flip +
+# auto-compose land in later Phase B increments. The strong hl_db_feature_backends
+# override is generated at compose (merges with any --with backends), not baked
+# into the archive. agent/db.c references hl_agent_open_app_db + hl_agent_write_error
+# from the base today; Phase B.2 splits agent/helpers.c so the opener moves here.
+FEATURE_SQLITE_OBJS := $(SQLITE_OBJ) $(BUILDDIR)/cap_db_sqlite.o \
+                       $(BUILDDIR)/cap_db_udf.o $(BUILDDIR)/agent_db.o \
+                       $(BUILDDIR)/agent_sql.o $(BUILDDIR)/agent_schema_diff.o
+feature-sqlite:
+	$(MAKE) $(BUILDDIR)/libhull_feature-sqlite.a HL_ENABLE_SQLITE=1
+.PHONY: feature-sqlite
+
+$(BUILDDIR)/libhull_feature-sqlite.a: $(FEATURE_SQLITE_OBJS) | $(BUILDDIR)
+	@rm -f $@
+	$(AR) rcs $@ $(FEATURE_SQLITE_OBJS)
+	@echo "built $@ ($$(du -h $@ | cut -f1))"
+
 # ── GPU feature archive (composable feature: hull build --with=gpu) ──
 # libhull_feature-gpu.a bundles the wgpu backend object (cap_gpu_wgpu.o, which
 # defines hl_gpu_backend_wgpu) + the wgpu-native static lib into ONE archive,

--- a/src/hull/cap/db_select.c
+++ b/src/hull/cap/db_select.c
@@ -57,6 +57,14 @@ static const HlDbBackend *const BACKENDS[] = {
 #ifdef HL_ENABLE_DUCKDB
     &hl_db_backend_duckdb,
 #endif
+#if !defined(HL_ENABLE_SQLITE) && !defined(HL_ENABLE_POSTGRES) && \
+    !defined(HL_ENABLE_MYSQL) && !defined(HL_ENABLE_DUCKDB)
+    /* No backend compiled into the base (HL_SQLITE_FEATURE: SQLite composed as a
+     * feature, docs/sqlite_feature.md). A lone NULL keeps the array non-empty
+     * for ISO C (no zero-length array under -Wpedantic); backend_for_scheme
+     * skips NULL entries and the real backend arrives via hl_db_feature_backends. */
+    NULL,
+#endif
 };
 
 /* Schemes Hull recognizes but may not have compiled: a helpful, specific error
@@ -98,7 +106,7 @@ static int scheme_in(const char *const *list, const char *scheme)
 static const HlDbBackend *backend_for_scheme(const char *scheme)
 {
     for (size_t i = 0; i < sizeof BACKENDS / sizeof BACKENDS[0]; i++)
-        if (scheme_in(BACKENDS[i]->schemes, scheme))
+        if (BACKENDS[i] && scheme_in(BACKENDS[i]->schemes, scheme))
             return BACKENDS[i];
     size_t fcount = 0;
     const HlDbBackend *const *feats = hl_db_feature_backends(&fcount);


### PR DESCRIPTION
Two Phase B increments of the SQLite-as-a-feature epic (design: `docs/sqlite_feature.md`; builds on the A.1/A.2 seams in #124/#125). Together they produce the two halves the compose (B.3) will join: **the archive** and **a base that can go SQLite-less**. The default/shipped build is byte-identical.

## B.1 — `make feature-sqlite` → `libhull_feature-sqlite.a`
Packages the SQLite engine + backend + agent introspection (`sqlite3.o` + `cap_db_sqlite.o` + `cap_db_udf.o` + `agent_db.o` + `agent_sql.o` + `agent_schema_diff.o`, ~1.7 MB). Mirrors `feature-postgres`/`feature-mysql`. The strong `hl_db_feature_backends` override is generated at compose (so `sqlite + --with=postgres` merges), not baked in.

## B.2 — SQLite-less DB-core base (umbrella decouple)
- New **`HL_SQLITE_FEATURE`** flag (default 0). `=1` forces `HL_ENABLE_SQLITE` off and decouples the umbrella so `HL_ENABLE_DB` stays **on** with zero compiled backend — the "DB core, backend composed" case, distinct from the genuine no-DB build.
- `db_select.c`: `BACKENDS[]` gets a lone `NULL` sentinel when no backend is compiled (dodges a zero-length array under `-Wpedantic`); `backend_for_scheme` skips `NULL`. The scheme-less default already routes via the feature hook (A.1), so a backend-less base sends `db.*` to whatever backend the feature composes.

The heavy lifting was already proven by the CI **postgres-only** flavor (`HL_ENABLE_SQLITE=0 HL_ENABLE_DB=1`): `mod_db`/`app_context`/`migrate`/`worker_db` all compile+link SQLite-free there. B.2's only delta is an **empty** `BACKENDS[]` + the umbrella allowing it.

## Validation
- `make platform HL_SQLITE_FEATURE=1` → SQLite-less base: `nm` shows **0** `sqlite3_open`, **0** `hl_db_backend_sqlite`, the weak `hl_db_feature_backends` present, `db_select` present (DB core on).
- **Default byte-identical**: `make test` **60/60**; default base still carries SQLite (`sqlite3_open=1`); a `:memory:` db app still runs.
- `db_select.c` compiles clean under postgres-only (non-empty `BACKENDS`) *and* the backend-less base (`NULL` sentinel, no zero-length-array warning).
- The archive contains `sqlite3_open`, `hl_db_backend_sqlite`, a strong `hl_agent_db_schema` (overrides the A.2 weak stub), and UDF.

## Remaining Phase B
- **B.3** — the compose: generate the strong `hl_db_feature_backends` override, split `agent/helpers.c` (move `hl_agent_open_app_db` into the archive), link a SQLite-less base + archive into a working app, `needs_sqlite` gate.
- **B.4** — toolchain force-load (`hull test` / agent) + e2e.