### PR TITLE
feat(db): SQLite feature Phase B.3 — the compose (SQLite-less base + archive runs a DB app)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1980,6 +1980,18 @@ AGENT_LIB_SRCS := $(wildcard $(SRCDIR)/hull/agent/*.c)
 ifeq ($(HL_ENABLE_DB),0)
   AGENT_LIB_SRCS := $(filter-out $(SRCDIR)/hull/agent/db.c,$(AGENT_LIB_SRCS))
 endif
+ifneq ($(HL_ENABLE_SQLITE),1)
+  # SQLite-only agent introspection (raw sqlite3 API): drop from the base and
+  # ship in libhull_feature-sqlite.a (docs/sqlite_feature.md, Phase B). The base
+  # keeps agent/db_stub.c's weak entry points (A.2). Covers the postgres/mysql
+  # base builds too, where these compiled to empty TUs before.
+  AGENT_LIB_SRCS := $(filter-out \
+      $(SRCDIR)/hull/agent/db.c \
+      $(SRCDIR)/hull/agent/sql.c \
+      $(SRCDIR)/hull/agent/schema_diff.c \
+      $(SRCDIR)/hull/agent/db_open.c, \
+      $(AGENT_LIB_SRCS))
+endif
 ifeq ($(HL_ENABLE_HTTP_SERVER),0)
   # agent/test.c calls hl_test_runner_run + the in-process HTTP harness;
   # agent/request.c, agent/eval.c, agent/perf.c, agent/endpoint.c also
@@ -2809,9 +2821,11 @@ $(BUILDDIR)/libhull_feature-mysql.a: $(BUILDDIR)/cap_db_mysql.o $(BUILDDIR)/cap_
 # override is generated at compose (merges with any --with backends), not baked
 # into the archive. agent/db.c references hl_agent_open_app_db + hl_agent_write_error
 # from the base today; Phase B.2 splits agent/helpers.c so the opener moves here.
-FEATURE_SQLITE_OBJS := $(SQLITE_OBJ) $(BUILDDIR)/cap_db_sqlite.o \
+FEATURE_SQLITE_OBJS := $(SQLITE_OBJ) $(BUILDDIR)/cap_db.o \
+                       $(BUILDDIR)/cap_db_sqlite.o \
                        $(BUILDDIR)/cap_db_udf.o $(BUILDDIR)/agent_db.o \
-                       $(BUILDDIR)/agent_sql.o $(BUILDDIR)/agent_schema_diff.o
+                       $(BUILDDIR)/agent_sql.o $(BUILDDIR)/agent_schema_diff.o \
+                       $(BUILDDIR)/agent_db_open.o
 feature-sqlite:
 	$(MAKE) $(BUILDDIR)/libhull_feature-sqlite.a HL_ENABLE_SQLITE=1
 .PHONY: feature-sqlite
@@ -4290,6 +4304,10 @@ e2e-feature-runtime: $(BUILDDIR)/hull
 .PHONY: e2e-feature-wasm
 e2e-feature-wasm: $(BUILDDIR)/hull
 	sh tests/e2e_feature_wasm.sh
+
+.PHONY: e2e-feature-sqlite
+e2e-feature-sqlite: $(BUILDDIR)/hull
+	sh tests/e2e_feature_sqlite.sh
 
 e2e-multipart: $(BUILDDIR)/hull
 	RUNTIME=$(RUNTIME) sh tests/e2e_multipart.sh

--- a/src/hull/agent/db_open.c
+++ b/src/hull/agent/db_open.c
@@ -1,0 +1,65 @@
+/*
+ * agent/db_open.c — SQLite app-DB opener for agent introspection.
+ *
+ * Split out of agent/helpers.c so it moves into libhull_feature-sqlite.a with
+ * the rest of the SQLite agent code (SQLite as a composable feature,
+ * docs/sqlite_feature.md, Phase B). hl_agent_open_app_db is the raw sqlite3
+ * opener the SQLite agent impls (agent/db.c, sql.c, schema_diff.c) call; keeping
+ * it here lets a SQLite-less base drop it (the composed feature supplies it)
+ * while helpers.c retains the backend-agnostic hl_agent_write_error /
+ * hl_agent_detect_entry.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifdef HL_ENABLE_SQLITE
+
+#include "internal.h"
+#include "hull/app_context.h"
+#include "hull/entry.h"
+#include "hull/vfs.h"
+#include "hull/cap/db.h"
+#include "hull/cap/db_backend.h"
+#include "hull/cap/db_sqlite.h"   /* hl_db_sqlite_wrap/_unwrap */
+#include "hull/migrate.h"
+#include <sqlite3.h>
+
+#include <limits.h>
+#include <stdio.h>
+#include <unistd.h>
+
+sqlite3 *hl_agent_open_app_db(const char *app_dir, const char *db_path)
+{
+    sqlite3 *db = NULL;
+    char default_path[PATH_MAX];
+
+    if (!db_path) {
+        snprintf(default_path, sizeof(default_path), "%s/data.db", app_dir);
+        if (access(default_path, F_OK) == 0)
+            db_path = default_path;
+    }
+
+    if (db_path) {
+        if (sqlite3_open_v2(db_path, &db, SQLITE_OPEN_READONLY, NULL) != SQLITE_OK) {
+            if (db) sqlite3_close(db);
+            return NULL;
+        }
+    } else {
+        if (sqlite3_open(":memory:", &db) != SQLITE_OK)
+            return NULL;
+        hl_cap_db_init(db);
+
+        extern const HlEntry hl_app_entries[];
+        HlVfs app_vfs;
+        hl_vfs_init(&app_vfs, hl_app_entries, app_dir);
+        HlDbHandle tmp_handle;
+        if (hl_db_sqlite_wrap(&tmp_handle, db) == 0) {
+            hl_migrate_run(&tmp_handle, &app_vfs);
+            hl_db_sqlite_unwrap(&tmp_handle);
+        }
+    }
+
+    return db;
+}
+
+#endif /* HL_ENABLE_SQLITE */

--- a/src/hull/agent/helpers.c
+++ b/src/hull/agent/helpers.c
@@ -1,25 +1,17 @@
 /*
- * agent/helpers.c — Shared agent_lib helpers (DB opener + error JSON).
+ * agent/helpers.c — Shared agent_lib helpers (error JSON + entry detection).
+ *
+ * Backend-agnostic, so it stays in the base even when SQLite is composed as a
+ * feature (docs/sqlite_feature.md). The SQLite app-DB opener moved to
+ * agent/db_open.c so it can travel into libhull_feature-sqlite.a.
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 #include "internal.h"
-#include "hull/app_context.h"
-#include "hull/entry.h"
-#include "hull/vfs.h"
-
-#ifdef HL_ENABLE_SQLITE
-#include "hull/cap/db.h"
-#include "hull/cap/db_backend.h"
-#include "hull/cap/db_sqlite.h"   /* hl_db_sqlite_wrap/_unwrap */
-#include "hull/migrate.h"
-#include <sqlite3.h>
-#endif
 
 #include <sh_json.h>
 
-#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
@@ -33,42 +25,6 @@ int hl_agent_write_error(ShJsonBuf *out, const char *msg)
     sh_json_write_object_end(&w);
     return -1;
 }
-
-#ifdef HL_ENABLE_SQLITE
-sqlite3 *hl_agent_open_app_db(const char *app_dir, const char *db_path)
-{
-    sqlite3 *db = NULL;
-    char default_path[PATH_MAX];
-
-    if (!db_path) {
-        snprintf(default_path, sizeof(default_path), "%s/data.db", app_dir);
-        if (access(default_path, F_OK) == 0)
-            db_path = default_path;
-    }
-
-    if (db_path) {
-        if (sqlite3_open_v2(db_path, &db, SQLITE_OPEN_READONLY, NULL) != SQLITE_OK) {
-            if (db) sqlite3_close(db);
-            return NULL;
-        }
-    } else {
-        if (sqlite3_open(":memory:", &db) != SQLITE_OK)
-            return NULL;
-        hl_cap_db_init(db);
-
-        extern const HlEntry hl_app_entries[];
-        HlVfs app_vfs;
-        hl_vfs_init(&app_vfs, hl_app_entries, app_dir);
-        HlDbHandle tmp_handle;
-        if (hl_db_sqlite_wrap(&tmp_handle, db) == 0) {
-            hl_migrate_run(&tmp_handle, &app_vfs);
-            hl_db_sqlite_unwrap(&tmp_handle);
-        }
-    }
-
-    return db;
-}
-#endif /* HL_ENABLE_SQLITE */
 
 const char *hl_agent_detect_entry(const char *app_dir, const char *ext,
                                   char *buf, size_t buf_size)

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1342,6 +1342,23 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
     -- `libs` (extra link libs). Adding a feature is one row here + a
     -- `make feature-<name>` archive + a release-pipeline entry.
     local FEATURE_SPECS = {
+        -- sqlite: the vendored SQLite engine + backend + UDF + agent
+        -- introspection in libhull_feature-sqlite.a (`make feature-sqlite`),
+        -- filling the same hl_db_feature_backends hook. Unlike the others,
+        -- SQLite is Hull's DEFAULT backend composed onto a SQLite-less DB-core
+        -- base (built HL_SQLITE_FEATURE=1); docs/sqlite_feature.md, Phase B.
+        -- `base_group = true` because the archive references base symbols
+        -- (db_registry, the _hull_* guard, agent write_error, vfs, migrate) and
+        -- the base's generated override references the archive's backend, so the
+        -- compose wraps platform lib + archive in --start-group for GNU ld.
+        sqlite = {
+            backend    = "hl_db_backend_sqlite",
+            type       = "HlDbBackend",
+            hook       = "hl_db_feature_backends",
+            cxx        = false,
+            base_group = true,
+            libs       = { darwin = {}, other = {} },
+        },
         duckdb = {
             backend = "hl_db_backend_duckdb",
             type    = "HlDbBackend",

--- a/tests/e2e_feature_sqlite.sh
+++ b/tests/e2e_feature_sqlite.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# e2e_feature_sqlite.sh — SQLite as a composable feature (docs/sqlite_feature.md).
+#
+# Proves the Phase B compose end to end: a SQLite-less DB-core base
+# (HL_SQLITE_FEATURE=1: the vtable + selector + generic db.* caps + the weak
+# hl_db_feature_backends hook, ZERO compiled backend) plus libhull_feature-sqlite.a,
+# joined by `hull build --with=sqlite`, runs a real db.query through the composed
+# backend. The base carries no sqlite; the produced app gets it from the archive.
+#
+# The build dances across two config-sentinel states (SQLite=1 for the archive,
+# SQLite=0 for the base), so it stashes + restores build/hull + the platform lib
+# and leaves build/ as it found it. Heavy (two clean rebuilds); its own CI job.
+set -eu
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$ROOT"
+HULL="$ROOT/build/hull"
+[ -x "$HULL" ] || { echo "SKIP: build/hull not built"; exit 0; }
+case "$(file "$HULL" 2>/dev/null || true)" in
+    *cosmo*|*"APE"*) echo "SKIP: cosmo keeps SQLite in-base (fat APE can't force-load)"; exit 0;;
+esac
+
+W=""
+STASH=$(mktemp -d)
+cp "$HULL" "$STASH/hull"                                   # the default toolchain
+[ -f build/libhull_platform.a ] && cp build/libhull_platform.a "$STASH/plat.a" || true
+cleanup() {
+    # Restore build/ to the default toolchain + platform lib we started with.
+    cp "$STASH/hull" build/hull 2>/dev/null || true
+    [ -f "$STASH/plat.a" ] && cp "$STASH/plat.a" build/libhull_platform.a 2>/dev/null || true
+    rm -rf "$STASH"
+    [ -n "$W" ] && rm -rf "$W" || true
+}
+trap cleanup EXIT
+fail() { echo "FAIL: $1"; exit 1; }
+
+# 1. The feature archive (SQLite=1 config).
+make feature-sqlite >/dev/null 2>&1 || fail "make feature-sqlite"
+cp build/libhull_feature-sqlite.a "$STASH/feat.a"
+
+# 2. The SQLite-less DB-core base (SQLite=0). The sentinel clean wipes build/hull.
+make platform HL_SQLITE_FEATURE=1 >/dev/null 2>&1 || fail "make platform HL_SQLITE_FEATURE=1"
+if command -v nm >/dev/null 2>&1; then
+    n=$(nm build/libhull_platform.a 2>/dev/null | grep -cE ' [Tt] _?sqlite3_open$' || true)
+    [ "$n" = 0 ] || fail "base is not SQLite-less ($n sqlite3_open symbols)"
+    nm build/libhull_platform.a 2>/dev/null | grep -q hl_db_backend_select || fail "base lost the DB core"
+fi
+echo "ok  SQLite-less DB-core base builds (0 sqlite3_open, DB core intact)"
+
+# 3. Assemble: default toolchain hull + the SQLite-less base + the archive.
+cp "$STASH/hull" build/hull
+cp "$STASH/feat.a" build/libhull_feature-sqlite.a
+
+# 4. Compose an app and run it: db.query must return through the composed backend.
+W=$(mktemp -d)
+mkdir -p "$W/app"
+printf 'local db = require("hull.db").default()\napp.manifest({ modules = { "hull/db@1" } })\napp.main(function()\n  db.exec("CREATE TABLE t(x INTEGER)")\n  db.exec("INSERT INTO t VALUES(42)")\n  local r = db.query("SELECT x FROM t")\n  return (r[1] and r[1].x == 42) and 0 or 3\nend)\n' > "$W/app/app.lua"
+
+"$HULL" build --with=sqlite --no-verify-platform "$W/app" -o "$W/app/bin" >/dev/null 2>&1 \
+    || fail "hull build --with=sqlite (compose onto the SQLite-less base)"
+
+if command -v nm >/dev/null 2>&1; then
+    w=$(nm "$W/app/bin" 2>/dev/null | grep -cE ' [Tt] _?sqlite3_open$' || true)
+    [ "$w" -ge 1 ] || fail "composed app has no SQLite (should come from the archive)"
+fi
+rc=0; "$W/app/bin" -d ":memory:" >/dev/null 2>&1 || rc=$?
+[ "$rc" = 0 ] || fail "composed db app: db.query should return 42 (exit 0), got $rc"
+echo "ok  hull build --with=sqlite: SQLite-less base + archive -> db.query runs (exit 0)"
+
+# 5. A plain app on the SAME SQLite-less base without --with=sqlite fails closed
+#    (no default backend for its :memory: DSN) — proves the base really has none.
+mkdir -p "$W/plain"
+printf 'local db = require("hull.db").default()\napp.manifest({ modules = { "hull/db@1" } })\napp.main(function()\n  local ok = pcall(function() db.exec("CREATE TABLE t(x)") end)\n  return ok and 5 or 0\nend)\n' > "$W/plain/app.lua"
+if "$HULL" build --no-verify-platform "$W/plain" -o "$W/plain/bin" >/dev/null 2>&1; then
+    rc=0; "$W/plain/bin" -d ":memory:" >/dev/null 2>&1 || rc=$?
+    [ "$rc" = 0 ] || fail "uncomposed app on a SQLite-less base should fail closed on db use (exit 0 from pcall-guard), got $rc"
+    echo "ok  uncomposed app on the SQLite-less base has no backend (db use fails closed)"
+fi
+
+echo "PASS: e2e_feature_sqlite (SQLite-less base + libhull_feature-sqlite.a composes + runs)"


### PR DESCRIPTION
**The payoff of Phase B.** A SQLite-less DB-core base + `libhull_feature-sqlite.a`, joined by `hull build --with=sqlite`, runs a real `db.query` through the composed backend. The base carries **zero** SQLite; the produced app gets the engine + backend from the archive. No change to the default build.

Builds on #124/#125 (the A seams) and #126 (B.1 archive + B.2 SQLite-less base).

## What
- **Split `agent/helpers.c`** → new `agent/db_open.c`: `hl_agent_open_app_db` (the raw sqlite3 opener) moves into the archive; `helpers.c` keeps the backend-agnostic `hl_agent_write_error` / `hl_agent_detect_entry`.
- **Makefile**: `FEATURE_SQLITE_OBJS` gains `cap_db.o` (the SQLite stmt-cache/query engine defining `hl_cap_db_query` / `hl_stmt_cache_*` — the link symbols the first compose attempt was missing) and `agent_db_open.o`. Filter the SQLite-only agent TUs (`agent/db.c`, `sql.c`, `schema_diff.c`, `db_open.c`) out of the base when SQLite's off (they ship in the archive; the base keeps `agent/db_stub.c`'s A.2 weak stubs).
- **`build.lua`**: a `sqlite` `FEATURE_SPECS` entry (`base_group=true`) so the compose generates the strong `hl_db_feature_backends` override and `--start-group`-wraps the base↔archive cross-refs. Slots beside postgres/mysql/duckdb (all merge into one override).

## Validation — `tests/e2e_feature_sqlite.sh` (`make e2e-feature-sqlite`)
Builds the archive (SQLite=1) + a SQLite-less base (`HL_SQLITE_FEATURE=1`: `nm` → **0** `sqlite3_open`, DB core intact), composes `hull build --with=sqlite`, and runs a `db.query` returning **42** through the composed backend (the base had no backend at all). The app binary carries SQLite from the archive.
- Default `make` + `make test` **60/60** unaffected; default base still has SQLite; `agent db schema` still works.

## Remaining
- **B.4** — toolchain force-load so a SQLite-less `hull` itself runs `hull test` (`:memory:`) + the agent DB commands (the `HL_TUI_TOOLCHAIN` pattern).
- **Phase C/D** — `needs_sqlite` auto-compose (so a plain `hull build` composes it without `--with`) + embed/publish.

Note: the e2e is heavy (two clean rebuilds across the two config-sentinel states) and stashes/restores `build/`, so it warrants its own CI job rather than the default matrix.