### PR TITLE
feat(db): SQLite feature Phase C — needs_sqlite auto-compose gate

### DIFF
--- a/docs/sqlite_feature.md
+++ b/docs/sqlite_feature.md
@@ -167,10 +167,22 @@ WASM). `HL_ENABLE_SQLITE` stays the compile switch; the feature is the
   `agent/helpers.c` so `hull build --with=sqlite` composes the SQLite-less base +
   archive into an app whose `db.query` runs through the composed backend
   (`tests/e2e_feature_sqlite.sh`). The architecture is PROVEN end to end.
-- **Phase C — the `needs_sqlite` auto-compose gate.** `hull build` composes the
-  archive iff S1/S2/S3 with **no** `--with=sqlite` (today the compose is explicit,
-  like a `--with` feature). No toolchain force-load — the `hull` binary keeps
-  SQLite in-base (see the gate section above); only produced apps go SQLite-less.
+- **Phase C — the `needs_sqlite` auto-compose gate.** ✅ SHIPPED (the gate).
+  `tool.modules_resolve` exposes `needs_sqlite` (= the app uses `HL_MOD_CAP_DB`,
+  mirroring `needs_wasm`); `hull build` auto-infers `--with=sqlite` when
+  `needs_sqlite` **and** the resolved base lacks the SQLite backend (probed with
+  `nm`, so it's a no-op on a stock SQLite-full base and only fires on a
+  `HL_SQLITE_FEATURE=1` base). A db app on a SQLite-less base composes SQLite and
+  runs with no explicit `--with` (`tests/e2e_feature_sqlite.sh`). No toolchain
+  force-load — the `hull` binary keeps SQLite in-base.
+  - **REMAINING (Phase C.2) — the per-runtime `mod_db`-udf bridge split.** The
+    embedded runtime archive (`libhull_feature-<rt>.a`) bundles `mod_db`'s SQLite
+    UDF bindings (`sqlite3_value_*`), so a whole-archived runtime drags SQLite
+    refs into EVERY app on a SQLite-less base — a **db-free** app then can't link
+    without the composed engine, so it can't yet DROP SQLite (the size payoff).
+    Split the UDF bindings out of `mod_db.o` into a `sqlite-<rt>` bridge that
+    ships in the SQLite feature archive (mirrors the wasm-`<rt>` / tui-`<rt>`
+    bridges); then a db-free app on a SQLite-less base links zero `sqlite3.*`.
 - **Phase D — embed + publish.** Embed the SQLite-less base + the archive in the
   distributed `hull` so a stock install produces SQLite-dropping apps, add the
   composed-feature signing entry (platform domain, like the runtime archives),

--- a/src/hull/cap/tool.c
+++ b/src/hull/cap/tool.c
@@ -133,6 +133,10 @@ int hl_tool_unveil_check(const HlToolUnveilCtx *ctx, const char *path, char need
 static const char *allowed_prefixes[] = {
     "cc", "gcc", "clang", "cosmocc", "cosmoar", "ar", "wamrc", "hull",
     "tcc", "ld",
+    /* nm: read-only symbol lister. `hull build` probes the resolved platform lib
+     * for hl_db_backend_sqlite to decide whether to auto-compose the SQLite
+     * feature onto a SQLite-less base (docs/sqlite_feature.md, Phase C). */
+    "nm",
     NULL
 };
 

--- a/src/hull/tool_orchestration.c
+++ b/src/hull/tool_orchestration.c
@@ -238,6 +238,17 @@ static int l_tool_modules_resolve(lua_State *L)
     lua_pushboolean(L, (req_caps & HL_MOD_CAP_WASM) ? 1 : 0);
     lua_setfield(L, -2, "needs_wasm");
 
+    /* needs_sqlite (SQLite as a composable feature, docs/sqlite_feature.md,
+     * Phase C) = does the resolved set use a DB (HL_MOD_CAP_DB)? SQLite is the
+     * DEFAULT backend, so any DB-using app MIGHT need it. build.lua only acts on
+     * this when the target base is actually SQLite-less (else the in-base backend
+     * already serves), so composing is a no-op on a SQLite-full base and a
+     * safe over-approximation (a postgres-only app on a SQLite-less base gets an
+     * unused ~2 MB until the DSN-scheme refinement lands). hull/search + a
+     * WASM-backed db.udf both imply DB, so this cap covers them. */
+    lua_pushboolean(L, (req_caps & HL_MOD_CAP_DB) ? 1 : 0);
+    lua_setfield(L, -2, "needs_sqlite");
+
     /* auto = the minimal build flavor that still satisfies this app's
      * declared modules (drives `hull build --flavor=auto`). Computed from
      * the resolved set's aggregate required-caps. */

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1416,6 +1416,42 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
             libs = { darwin = {}, other = {} },
         },
     }
+    -- SQLite auto-compose (docs/sqlite_feature.md, Phase C). SQLite is Hull's
+    -- DEFAULT backend, so a DB-using app auto-composes libhull_feature-sqlite.a
+    -- -- but ONLY when the target base is SQLite-less. A stock base carries the
+    -- SQLite backend in-lib; composing it there would double-define the backend,
+    -- so we gate on the base NOT already providing hl_db_backend_sqlite. Net:
+    -- a no-op on a stock (SQLite-full) base -> byte-identical; on a
+    -- HL_SQLITE_FEATURE=1 base a DB app composes SQLite and a DB-free app drops
+    -- it. Inferred (not a hand-typed --with=sqlite), like hull/tui.
+    if not (opts.with and opts.with.sqlite) then
+        local mf = extract_app_manifest(opts.app_dir)
+        local needs_sqlite = false
+        if mf then
+            local r = tool.modules_resolve(mf, opts.flavor, with_feature_list(opts))
+            if r.ok and r.needs_sqlite then needs_sqlite = true end
+        end
+        if needs_sqlite then
+            -- Probe the resolved base: a stock base defines hl_db_backend_sqlite,
+            -- a SQLite-less (HL_SQLITE_FEATURE=1) base does not. nm may be absent
+            -- (or the base unreadable); default to "has sqlite" so we never
+            -- wrongly compose onto a SQLite-full base.
+            local base_has_sqlite = true
+            local nm_out = tool.spawn_read({ "nm", platform_lib })
+            if nm_out and not nm_out:find("hl_db_backend_sqlite") then
+                base_has_sqlite = false
+            end
+            if not base_has_sqlite then
+                opts.with = opts.with or {}
+                opts.with.sqlite = true
+                opts.with_inferred = opts.with_inferred or {}
+                opts.with_inferred.sqlite = true
+                print("hull build: composing feature 'sqlite' "
+                      .. "(SQLite-less base + app uses db)")
+            end
+        end
+    end
+
     local features_needed = {}
     if opts.with then for f in pairs(opts.with) do features_needed[f] = true end end
     local feature_objs = {}

--- a/tests/e2e_feature_sqlite.sh
+++ b/tests/e2e_feature_sqlite.sh
@@ -56,25 +56,27 @@ W=$(mktemp -d)
 mkdir -p "$W/app"
 printf 'local db = require("hull.db").default()\napp.manifest({ modules = { "hull/db@1" } })\napp.main(function()\n  db.exec("CREATE TABLE t(x INTEGER)")\n  db.exec("INSERT INTO t VALUES(42)")\n  local r = db.query("SELECT x FROM t")\n  return (r[1] and r[1].x == 42) and 0 or 3\nend)\n' > "$W/app/app.lua"
 
-"$HULL" build --with=sqlite --no-verify-platform "$W/app" -o "$W/app/bin" >/dev/null 2>&1 \
-    || fail "hull build --with=sqlite (compose onto the SQLite-less base)"
-
+# Phase C: AUTO-INFERENCE — no --with=sqlite. `hull build` sees the app uses db
+# (needs_sqlite) + the base lacks SQLite, and composes libhull_feature-sqlite.a
+# on its own.
+out=$("$HULL" build --no-verify-platform "$W/app" -o "$W/app/bin" 2>&1) \
+    || fail "hull build (auto-infer sqlite onto the SQLite-less base): $out"
+echo "$out" | grep -qi "composing feature 'sqlite'" \
+    || fail "expected auto-inference to compose sqlite (no --with), got: $out"
 if command -v nm >/dev/null 2>&1; then
     w=$(nm "$W/app/bin" 2>/dev/null | grep -cE ' [Tt] _?sqlite3_open$' || true)
-    [ "$w" -ge 1 ] || fail "composed app has no SQLite (should come from the archive)"
+    [ "$w" -ge 1 ] || fail "auto-composed app has no SQLite (should come from the archive)"
 fi
 rc=0; "$W/app/bin" -d ":memory:" >/dev/null 2>&1 || rc=$?
-[ "$rc" = 0 ] || fail "composed db app: db.query should return 42 (exit 0), got $rc"
-echo "ok  hull build --with=sqlite: SQLite-less base + archive -> db.query runs (exit 0)"
+[ "$rc" = 0 ] || fail "auto-composed db app: db.query should return 42 (exit 0), got $rc"
+echo "ok  auto-inference: plain hull build on a SQLite-less base composes sqlite + db.query runs"
 
-# 5. A plain app on the SAME SQLite-less base without --with=sqlite fails closed
-#    (no default backend for its :memory: DSN) — proves the base really has none.
-mkdir -p "$W/plain"
-printf 'local db = require("hull.db").default()\napp.manifest({ modules = { "hull/db@1" } })\napp.main(function()\n  local ok = pcall(function() db.exec("CREATE TABLE t(x)") end)\n  return ok and 5 or 0\nend)\n' > "$W/plain/app.lua"
-if "$HULL" build --no-verify-platform "$W/plain" -o "$W/plain/bin" >/dev/null 2>&1; then
-    rc=0; "$W/plain/bin" -d ":memory:" >/dev/null 2>&1 || rc=$?
-    [ "$rc" = 0 ] || fail "uncomposed app on a SQLite-less base should fail closed on db use (exit 0 from pcall-guard), got $rc"
-    echo "ok  uncomposed app on the SQLite-less base has no backend (db use fails closed)"
-fi
+# NOTE — the db-free-app-drops-SQLite payoff is NOT yet reachable: the embedded
+# per-runtime runtime archive (libhull_feature-<rt>.a) bundles mod_db's SQLite
+# UDF bindings (referencing sqlite3_value_* etc.), so a whole-archived runtime
+# drags SQLite refs into EVERY app on a SQLite-less base -- a db-free app then
+# fails to link without the composed engine. Dropping SQLite from db-free apps
+# needs a per-runtime mod_db-udf bridge split (the sqlite-<rt> bridge, mirroring
+# wasm-<rt> / tui-<rt>). Tracked as the next Phase C step; see docs/sqlite_feature.md.
 
-echo "PASS: e2e_feature_sqlite (SQLite-less base + libhull_feature-sqlite.a composes + runs)"
+echo "PASS: e2e_feature_sqlite (SQLite-less base; needs_sqlite auto-composes for db apps)"


### PR DESCRIPTION
`hull build` now auto-composes the SQLite feature (**no explicit `--with=sqlite`**) when an app uses a DB and the target base lacks the SQLite backend. Builds on the A/B stack (#124–#128). **No behavior change on the stock (SQLite-full) base.**

## What
- **`needs_sqlite` signal** — `tool.modules_resolve` exposes it (`req_caps & HL_MOD_CAP_DB`), mirroring `needs_wasm`/`needs_http`.
- **Auto-inference** (`build.lua`) — when `needs_sqlite`, probe the resolved platform lib with `nm` for `hl_db_backend_sqlite`. Absent (a `HL_SQLITE_FEATURE=1` SQLite-less base) → auto-infer `--with=sqlite` (like `hull/tui`). Present (stock base) → skip. Composing onto a base that already has the backend would double-define it — hence the guard, which also makes it a **no-op / byte-identical** on the stock base.
- **`nm` allowlisted** in `cap/tool.c` for that read-only probe (the spawn allowlist already carries `ar`/`ld`).
- **e2e** — `e2e_feature_sqlite.sh` asserts a plain `hull build` on a SQLite-less base composes SQLite and `db.query` runs.

## Validation
- `make test` **60/60** (stock base unaffected); a db app on the stock base does **not** auto-compose (`nm` finds the in-base backend) → byte-identical.
- `e2e_feature_sqlite` passes: SQLite-less base auto-composes for a db app, no `--with`.

## Known limitation → Phase C.2 (documented in `docs/sqlite_feature.md`)
The embedded runtime archive's `mod_db.o` bundles the SQLite UDF bindings (`sqlite3_value_*`), so a whole-archived runtime drags SQLite refs into **every** app on a SQLite-less base — a **db-free** app can't yet *drop* SQLite (the size payoff). That needs a per-runtime **`mod_db`-udf bridge split** (a `sqlite-<rt>` bridge, mirroring wasm-`<rt>`/tui-`<rt>`). The gate here is the prerequisite; the split unlocks the drop.