### PR TITLE
feat(db): SQLite-less app-build base as the default (Phase D core, gated)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -435,6 +435,17 @@ ifeq ($(HL_SQLITE_FEATURE),1)
 override HL_ENABLE_SQLITE := 0
 endif
 
+# HL_APP_BASE_SQLITELESS=1 (Phase D, docs/sqlite_feature.md): the distributed
+# hull embeds a SQLite-LESS platform lib as the app-build base (built in a
+# HL_SQLITE_FEATURE=1 sub-build) plus the SQLite engine archive, so a stock
+# `hull build` produces SQLite-DROPPING apps (a db-free app links zero sqlite3.*;
+# a db app auto-composes the engine via the Phase C nm-probe gate). The hull
+# binary ITSELF stays SQLite-full (it links SQLITE_OBJ for its own toolchain:
+# hull test / agent). Only the EMBED_PLATFORM path honours this; a plain dev
+# `make` is unaffected. Default 0 so the default distributed behaviour is
+# unchanged until release.yml opts in. Cosmo ignores it (SQLite stays in-base).
+HL_APP_BASE_SQLITELESS ?= 0
+
 # Keel (KlTls) + mbedTLS are linked when an HTTP half OR PostgreSQL OR MySQL is
 # enabled (MySQL's caching_sha2_password full-auth + ed25519 need TLS + crypto).
 # HTTP still owns the -DHL_ENABLE_HTTP macro (above), so a DB-only build links
@@ -2748,6 +2759,20 @@ platform-pure-compute: platform-%:
 	cp $(BUILDDIR)/flavor-$*/libhull_platform.a $(BUILDDIR)/libhull_platform-$*.a
 	@echo "built $(BUILDDIR)/libhull_platform-$*.a"
 
+# ── SQLite-less app-build base (Phase D, HL_APP_BASE_SQLITELESS=1) ──────
+# The platform lib the distributed hull embeds as the DEFAULT app-build base.
+# Built in a dedicated object dir at HL_SQLITE_FEATURE=1 (SQLite dropped, DB core
+# intact) so it never clobbers the main sqlite-full build or build/hull. The
+# EMBED_PLATFORM path xxd's this instead of the sqlite-full libhull_platform.a
+# when HL_APP_BASE_SQLITELESS=1. See docs/sqlite_feature.md.
+SQLITELESS_PLATFORM_LIB := $(BUILDDIR)/libhull_platform-sqliteless.a
+$(SQLITELESS_PLATFORM_LIB):
+	$(MAKE) platform BUILDDIR=$(BUILDDIR)/sqliteless HL_SQLITE_FEATURE=1
+	cp $(BUILDDIR)/sqliteless/libhull_platform.a $@
+	@echo "built $@ (SQLite-less app-build base)"
+.PHONY: platform-sqliteless
+platform-sqliteless: $(SQLITELESS_PLATFORM_LIB)
+
 # ── DuckDB feature archive (composable feature: hull build --with=duckdb) ──
 # libhull_feature-duckdb.a bundles the DuckDB backend object (cap_db_duckdb.o,
 # which defines hl_db_backend_duckdb) + the isolated DuckDB static libs into ONE
@@ -3221,9 +3246,17 @@ CFLAGS += -DHL_BUILD_EMBEDDED -DHL_BUILD_EMBEDDED_MULTIARCH
 $(BUILD_ASSET_OBJ): $(EMBEDDED_PLATFORM_H) $(EMBEDDED_TEMPLATES_H)
 
 else ifneq ($(EMBED_PLATFORM),)
-# Single-arch embedding (existing behavior)
-$(EMBEDDED_PLATFORM_H): $(PLATFORM_LIB) | $(BUILDDIR)
-	xxd -i $< | sed 's/build_libhull_platform_a/hl_embedded_platform_a/g' | $(XXD_CONST_PIPE) > $@
+# Single-arch embedding (existing behavior). The app-build base is the
+# sqlite-full platform lib by default; HL_APP_BASE_SQLITELESS=1 (Phase D) swaps
+# in the SQLite-less sub-build so produced apps drop SQLite. Either way the hull
+# binary itself stays sqlite-full (it links its own objects, not this archive).
+ifeq ($(HL_APP_BASE_SQLITELESS),1)
+APP_BASE_LIB := $(SQLITELESS_PLATFORM_LIB)
+else
+APP_BASE_LIB := $(PLATFORM_LIB)
+endif
+$(EMBEDDED_PLATFORM_H): $(APP_BASE_LIB) | $(BUILDDIR)
+	xxd -i $< | sed 's/build_libhull_platform\(_sqliteless\)\{0,1\}_a/hl_embedded_platform_a/g' | $(XXD_CONST_PIPE) > $@
 
 $(EMBEDDED_TEMPLATES_H): templates/app_main.c templates/entry.h | $(BUILDDIR)
 	@echo "/* Auto-generated — do not edit */" > $@
@@ -3283,6 +3316,20 @@ $(EMBEDDED_SQLITE_RT_H): $(BUILDDIR)/libhull_feature-sqlite-lua.a $(BUILDDIR)/li
 
 CFLAGS += -DHL_BUILD_EMBEDDED -DHL_BUILD_EMBEDDED_RUNTIME -DHL_BUILD_EMBEDDED_HTTP -DHL_BUILD_EMBEDDED_TUI -DHL_BUILD_EMBEDDED_WASM -DHL_BUILD_EMBEDDED_SQLITE_RT
 $(BUILD_ASSET_OBJ): $(EMBEDDED_PLATFORM_H) $(EMBEDDED_TEMPLATES_H) $(EMBEDDED_RUNTIME_H) $(EMBEDDED_HTTP_H) $(EMBEDDED_TUI_H) $(EMBEDDED_WASM_H) $(EMBEDDED_SQLITE_RT_H)
+
+# Phase D: when the app-build base is SQLite-less, embed the SQLite ENGINE
+# archive (cap/db_sqlite + vendored sqlite3 + FTS5 + udf cap + sqlite agent) so a
+# db app auto-composes it with no `hull feature install sqlite`. Mirrors the WASM
+# core embed. Only pulled when HL_APP_BASE_SQLITELESS=1 (else the engine is
+# in-base and this would be ~2 MB of dormant bloat).
+ifeq ($(HL_APP_BASE_SQLITELESS),1)
+EMBEDDED_SQLITE_H := $(BUILDDIR)/embedded_sqlite.h
+$(EMBEDDED_SQLITE_H): $(BUILDDIR)/libhull_feature-sqlite.a | $(BUILDDIR)
+	@echo "/* Auto-generated - do not edit */" > $@
+	@xxd -i $(BUILDDIR)/libhull_feature-sqlite.a | sed 's/build_libhull_feature_sqlite_a/hl_embedded_feature_sqlite_a/g' | $(XXD_CONST_PIPE) >> $@
+CFLAGS += -DHL_BUILD_EMBEDDED_SQLITE
+$(BUILD_ASSET_OBJ): $(EMBEDDED_SQLITE_H)
+endif
 endif
 
 # Hull binary

--- a/docs/sqlite_feature.md
+++ b/docs/sqlite_feature.md
@@ -203,11 +203,30 @@ WASM). `HL_ENABLE_SQLITE` stays the compile switch; the feature is the
       pre-existing `JS_FreeRuntime` GC-leak assertion (reproduces on pre-C.2
       `main`; the DB isn't closed before the runtime is freed). Tracked
       separately; unrelated to the bridge split.
-- **Phase D — embed + publish.** Embed the SQLite-less base + the archive in the
-  distributed `hull` so a stock install produces SQLite-dropping apps, add the
-  composed-feature signing entry (platform domain, like the runtime archives),
-  and make the SQLite-less base the default app-build target. Cosmo keeps SQLite
-  in-base (fat APE can't force-load a native archive).
+- **Phase D — embed the SQLite-less base as the default app-build target.**
+  🚧 CORE landed (gated), release wiring pending.
+  - **Model.** The `hull` binary stays SQLite-full (it links `SQLITE_OBJ` for its
+    own toolchain: `hull test`, `hull agent db`). Only the **embedded app-build
+    base** goes SQLite-less, so a stock `hull build` produces SQLite-dropping
+    apps: a db-free app links zero `sqlite3.*`; a db app auto-composes the engine
+    (Phase C nm-probe) + the udf bridge (C.2b).
+  - **Gate.** `make HL_APP_BASE_SQLITELESS=1` (in the `EMBED_PLATFORM` path). The
+    embedded base is built in a dedicated `HL_SQLITE_FEATURE=1` sub-build
+    (`platform-sqliteless` → `build/sqliteless/`) so it never clobbers the main
+    sqlite-full build or `build/hull`; `EMBEDDED_PLATFORM_H` xxd's that instead of
+    the sqlite-full lib. The engine `libhull_feature-sqlite.a` is embedded too
+    (`EMBEDDED_SQLITE_H`, `HL_BUILD_EMBEDDED_SQLITE`) and resolved **embedded-first**
+    (`fcompose.resolve_sqlite_lib`, mirrors the wasm core). Default `0` keeps the
+    distributed behaviour unchanged until release.yml opts in.
+  - **Signing.** An embedded-resolved engine is recorded in the composed
+    attestation under the **platform** domain (embedded-asset name
+    `libhull_feature-sqlite.<arch>.a`, §5c FATAL, like the runtime/wasm cores);
+    an externally-installed engine keeps the **release** domain. release.yml must
+    (a) build + embed the SQLite-less base + engine, (b) sign the SQLite-less base
+    into `embedded_platform_sig.h` so `verify_platform` passes, and (c) add the
+    engine hash to the platform manifest so §5c can verify it. **(pending)**
+  - **Cosmo** keeps SQLite in-base (a fat APE can't force-load a native archive);
+    `HL_APP_BASE_SQLITELESS` is native-only.
 
 ## Testing
 

--- a/include/hull/build_assets.h
+++ b/include/hull/build_assets.h
@@ -70,6 +70,7 @@ int hl_build_extract_feature_tui_rt(const char *dir, const char *rt);
 int hl_build_extract_feature_wasm(const char *dir);
 int hl_build_extract_feature_wasm_rt(const char *dir, const char *rt);
 int hl_build_extract_feature_sqlite_rt(const char *dir, const char *rt);
+int hl_build_extract_feature_sqlite(const char *dir);
 
 /*
  * Get the list of embedded platform archives (multi-arch builds).

--- a/src/hull/build_assets.c
+++ b/src/hull/build_assets.c
@@ -32,6 +32,9 @@
 #ifdef HL_BUILD_EMBEDDED_SQLITE_RT
 #include "embedded_sqlite_rt.h" /* hl_embedded_feature_sqlite_{lua,js}_a[] */
 #endif
+#ifdef HL_BUILD_EMBEDDED_SQLITE
+#include "embedded_sqlite.h"    /* hl_embedded_feature_sqlite_a[] (engine) */
+#endif
 
 /* ── Helper: write data to a file ──────────────────────────────────── */
 
@@ -217,6 +220,23 @@ int hl_build_extract_feature_tui_rt(const char *dir, const char *rt)
     return write_blob(path, data, len);
 #else
     (void)dir; (void)rt;
+    return -1;
+#endif
+}
+
+int hl_build_extract_feature_sqlite(const char *dir)
+{
+#ifdef HL_BUILD_EMBEDDED_SQLITE
+    if (!dir)
+        return -1;
+    char path[1024];
+    int n = snprintf(path, sizeof(path), "%s/libhull_feature-sqlite.a", dir);
+    if (n < 0 || (size_t)n >= sizeof(path))
+        return -1;
+    return write_blob(path, hl_embedded_feature_sqlite_a,
+                      hl_embedded_feature_sqlite_a_len);
+#else
+    (void)dir;
     return -1;
 #endif
 }

--- a/src/hull/runtime/lua/mod_tool.c
+++ b/src/hull/runtime/lua/mod_tool.c
@@ -539,6 +539,14 @@ static int l_tool_extract_feature_sqlite_rt(lua_State *L)
     return 1;
 }
 
+static int l_tool_extract_feature_sqlite(lua_State *L)
+{
+    const char *dir = luaL_checkstring(L, 1);
+    int rc = hl_build_extract_feature_sqlite(dir);
+    lua_pushboolean(L, rc == 0);
+    return 1;
+}
+
 /* ── tool.extract_platform_cosmo(dir) → bool ───────────────────────── */
 /*
  * Extract both arch-specific archives and set up the .aarch64/ directory
@@ -1262,6 +1270,7 @@ static const luaL_Reg tool_funcs[] = {
     { "extract_feature_wasm",   l_tool_extract_feature_wasm },
     { "extract_feature_wasm_rt", l_tool_extract_feature_wasm_rt },
     { "extract_feature_sqlite_rt", l_tool_extract_feature_sqlite_rt },
+    { "extract_feature_sqlite", l_tool_extract_feature_sqlite },
     { "extract_platform_cosmo", l_tool_extract_platform_cosmo },
     { "platform_archs",         l_tool_platform_archs },
     /* Orchestration entries (modules_resolve, doctor_json, agent_*,

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1525,8 +1525,18 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
             -- embedded release pubkey).
             local libname = "libhull_feature-" .. fname .. ".a"
             local asset = plat and ("libhull_feature-" .. fname .. "-" .. plat .. ".a") or nil
-            local lib, from = fcompose.resolve_lib(libname, asset,
-                                                   { hull_dir = hull_dir, plat = plat })
+            local lib, from
+            if fname == "sqlite" then
+                -- Phase D: the SQLite engine ships EMBEDDED in an
+                -- HL_APP_BASE_SQLITELESS hull, so resolve it embedded-first (like
+                -- the wasm core). Falls back to the local build dir / installed
+                -- feature cache on a pre-Phase-D hull.
+                lib, from = fcompose.resolve_sqlite_lib(tmpdir,
+                                                        { hull_dir = hull_dir, plat = plat })
+            else
+                lib, from = fcompose.resolve_lib(libname, asset,
+                                                 { hull_dir = hull_dir, plat = plat })
+            end
             if not lib then
                 if from == "cache-verify-failed" then
                     tool.stderr("hull build: cached " .. fname .. " feature lib could not "
@@ -1550,10 +1560,23 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
             end
             local from_cache = (from == "cache")
             local dest = tmpdir .. "/" .. libname
-            tool.copy(lib, dest)
-            -- Externally-installed feature: attested by the release-key
-            -- hull.sha256 under its release asset name (libhull_feature-<n>-<arch>.a).
-            record_composed(asset or libname, dest, "release")
+            -- An embedded-resolved engine (Phase D: resolve_sqlite_lib extracts
+            -- straight into tmpdir) is already at `dest`; copying a file onto
+            -- itself truncates it to 0 bytes, so guard like the wasm compose.
+            if lib ~= dest then tool.copy(lib, dest) end
+            -- Attestation domain (docs/composed_feature_signing.md): an archive
+            -- resolved EMBEDDED (Phase D: the SQLite engine on an
+            -- HL_APP_BASE_SQLITELESS hull) ships INSIDE hull, so it is attested by
+            -- the platform-key manifest (§5c FATAL) under the embedded-asset name
+            -- `libhull_feature-<n>.<arch>.a`, exactly like the runtime/wasm cores.
+            -- An externally-installed feature keeps the release domain + its
+            -- release-asset name `libhull_feature-<n>-<arch>.a`.
+            if from == "embedded" then
+                record_composed("libhull_feature-" .. fname .. "."
+                                .. (plat or "") .. ".a", dest, "platform")
+            else
+                record_composed(asset or libname, dest, "release")
+            end
             local is_darwin = plat and plat:sub(1, 6) == "darwin"
 
             if spec.whole_archive then
@@ -1608,7 +1631,8 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
             for _, l in ipairs(platlibs) do feature_libs[#feature_libs + 1] = l end
 
             print("hull build: composed feature '" .. fname .. "'"
-                  .. (from_cache and " (~/.hull/feature)" or " (local)"))
+                  .. (from == "embedded" and " (embedded)"
+                      or from_cache and " (~/.hull/feature)" or " (local)"))
         end
 
         -- A C++ feature archive cannot be linked by the embedded TinyCC (it links

--- a/stdlib/cli/lua/hull/feature_compose.lua
+++ b/stdlib/cli/lua/hull/feature_compose.lua
@@ -259,6 +259,22 @@ function M.resolve_wasm_rt_lib(rt, tmpdir, ctx)
     return M.resolve_lib(libname, asset, ctx)
 end
 
+--- Resolve the SQLite ENGINE archive (libhull_feature-sqlite.a: cap/db_sqlite +
+--- vendored sqlite3 + FTS5 + udf cap + sqlite agent), embedded first (Phase D).
+--- On an HL_APP_BASE_SQLITELESS distributed hull the engine ships embedded, so a
+--- db app auto-composes it with no `hull feature install sqlite`; otherwise this
+--- falls back to the local build dir / installed feature cache (the pre-Phase-D
+--- path). Mirrors resolve_wasm_lib.
+function M.resolve_sqlite_lib(tmpdir, ctx)
+    local libname = "libhull_feature-sqlite.a"
+    if tool.extract_feature_sqlite and tool.extract_feature_sqlite(tmpdir)
+       and file_exists(tmpdir .. "/" .. libname) then
+        return tmpdir .. "/" .. libname, "embedded"
+    end
+    local asset = ctx.plat and ("libhull_feature-sqlite-" .. ctx.plat .. ".a") or nil
+    return M.resolve_lib(libname, asset, ctx)
+end
+
 --- Resolve the per-runtime SQLite UDF bridge (libhull_feature-sqlite-<rt>.a),
 --- embedded first. Holds mod_db_udf (the db.udf bindings); composed for the
 --- app's runtime whenever the app uses a udf-capable DB, so the runtime archive


### PR DESCRIPTION
## What

A stock `hull build` now produces **SQLite-dropping apps**: a db-free app links **zero** `sqlite3.*`, a db app auto-composes the engine, a db+udf app also composes the udf bridge. This is the end-user payoff of the SQLite-feature epic (A/B/C/C.2 already merged).

Crucially, the **`hull` binary itself stays SQLite-full** (it links `SQLITE_OBJ` for its own toolchain — `hull test`, `hull agent db`). Only the *embedded app-build base* goes SQLite-less.

## Gated (zero blast radius until release.yml opts in)

Everything is behind `HL_APP_BASE_SQLITELESS=1` (the `EMBED_PLATFORM` path), default `0`, so the default distributed behaviour is byte-identical:

- **Makefile:** a `platform-sqliteless` sub-build (`HL_SQLITE_FEATURE=1` in a dedicated object dir, never clobbering the main sqlite-full build or `build/hull`); `EMBEDDED_PLATFORM_H` xxd's that as the app-build base when the flag is on. The engine `libhull_feature-sqlite.a` is embedded too (`EMBEDDED_SQLITE_H`), mirroring the WASM-core embed.
- **build_assets + mod_tool:** `hl_build_extract_feature_sqlite` / `tool.extract_feature_sqlite`.
- **feature_compose:** `resolve_sqlite_lib` (embedded-first, mirrors `resolve_wasm_lib`).
- **build.lua:** the engine resolves embedded-first; an embedded-resolved engine is recorded in the composed attestation under the **platform** domain (embedded-asset name `libhull_feature-sqlite.<arch>.a`, §5c FATAL, like the runtime/wasm cores); an installed engine keeps the **release** domain. Also fixes a self-copy truncation (embedded resolve returns a path already inside `tmpdir`; the loop's unconditional `tool.copy(lib, dest)` emptied it — guarded like the wasm compose).

## Validation

Local `make EMBED_PLATFORM=1 HL_APP_BASE_SQLITELESS=1`:
- **db-free app → 0 `sqlite3_open`** (the payoff)
- db app → composes the **embedded** engine (`(embedded)`) + runs (`sqlite3_open=1`)
- db+udf app → engine + bridge + `db.udf` runs
- the `hull` binary keeps `sqlite3_open` (**stays SQLite-full**)

Default build (flag off): behaviour unchanged, `make test` 60/60, `e2e_feature_sqlite.sh` green (existing local-resolve compose path intact).

## Remaining (release.yml follow-up)

Documented in `docs/sqlite_feature.md` Phase D:
1. release.yml builds + embeds the SQLite-less base + engine (sets `HL_APP_BASE_SQLITELESS=1`).
2. Sign the SQLite-less base into `embedded_platform_sig.h` so `verify_platform` passes.
3. Add the engine hash to the platform manifest so the runtime **§5c FATAL** check verifies the platform-domain engine.
4. (Optional) a lightweight CI guard for the gated path.

Cosmo keeps SQLite in-base (a fat APE can't force-load a native archive); the flag is native-only.