### PR TITLE
ci(release): build/embed/sign the SQLite-less base + engine (Phase D release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,12 +75,14 @@ jobs:
             make feature-lua feature-js feature-http feature-http-lua
             feature-http-js feature-tui-lua feature-tui-js
             feature-wasm feature-wasm-lua feature-wasm-js
+            feature-sqlite feature-sqlite-lua feature-sqlite-js
       - name: Build embedded feature archives (macOS)
         if: runner.os == 'macOS'
         run: >
           make feature-lua feature-js feature-http feature-http-lua
           feature-http-js feature-tui-lua feature-tui-js
           feature-wasm feature-wasm-lua feature-wasm-js
+          feature-sqlite feature-sqlite-lua feature-sqlite-js
       - name: Upload embedded feature archives
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
@@ -96,6 +98,9 @@ jobs:
             build/libhull_feature-wasm.a
             build/libhull_feature-wasm-lua.a
             build/libhull_feature-wasm-js.a
+            build/libhull_feature-sqlite.a
+            build/libhull_feature-sqlite-lua.a
+            build/libhull_feature-sqlite-js.a
 
       # Per-flavor platform libs for `hull build --flavor` + `hull platform
       # install`. Each native platform-<flavor> target builds into its own obj
@@ -107,8 +112,13 @@ jobs:
         if: runner.os == 'Linux'
         uses: ./.github/actions/hull-build-container
         with:
+          # `sqliteless` is not a --flavor preset: it is the Phase D app-build
+          # base (docs/sqlite_feature.md), built by the `platform-sqliteless`
+          # target (HL_SQLITE_FEATURE=1 sub-build) and embedded by stage 3 when
+          # HL_APP_BASE_SQLITELESS=1. It shares this step's obj-dir isolation +
+          # arch-qualified naming.
           run: |
-            for f in pure-compute; do
+            for f in pure-compute sqliteless; do
               make "platform-$f"
               mv "build/libhull_platform-$f.a" \
                  "build/libhull_platform-$f-${{ matrix.name }}.a"
@@ -116,7 +126,7 @@ jobs:
       - name: Build platform flavors (macOS)
         if: runner.os == 'macOS'
         run: |
-          for f in pure-compute; do
+          for f in pure-compute sqliteless; do
             make "platform-$f"
             mv "build/libhull_platform-$f.a" \
                "build/libhull_platform-$f-${{ matrix.name }}.a"
@@ -261,14 +271,20 @@ jobs:
         run: |
           set -eu
           {
+            # The native arch entry hashes the EMBEDDED app-build base. Phase D
+            # (docs/sqlite_feature.md): stage 3 embeds the SQLite-LESS base
+            # (HL_APP_BASE_SQLITELESS=1), so verify_platform checks it against
+            # THIS hash -- hash the sqlite-less base, not the sqlite-full one.
+            # Cosmo keeps SQLite in-base (no Phase D), so its entries are the
+            # sqlite-full cosmo archives.
             sha256sum \
-              platforms/platform-linux-x86_64/libhull_platform.a \
+              platforms/platform-flavors-linux-x86_64/libhull_platform-sqliteless-linux-x86_64.a \
               | awk '{print $1"  linux-x86_64"}'
             sha256sum \
-              platforms/platform-linux-aarch64/libhull_platform.a \
+              platforms/platform-flavors-linux-aarch64/libhull_platform-sqliteless-linux-aarch64.a \
               | awk '{print $1"  linux-aarch64"}'
             sha256sum \
-              platforms/platform-darwin-arm64/libhull_platform.a \
+              platforms/platform-flavors-darwin-arm64/libhull_platform-sqliteless-darwin-arm64.a \
               | awk '{print $1"  darwin-arm64"}'
             sha256sum \
               platforms/platform-cosmo/libhull_platform.x86_64-cosmo.a \
@@ -276,12 +292,14 @@ jobs:
             sha256sum \
               platforms/platform-cosmo/libhull_platform.aarch64-cosmo.a \
               | awk '{print $1"  cosmo-aarch64"}'
-            # Embedded feature archives (issue #114), native arches only (cosmo
-            # composes nothing). Name column is the COMPOSED asset name that
-            # build.lua records in package.sig.gethull.composed and that the
-            # runtime §5c looks up: "libhull_feature-<stem>.<arch>.a".
+            # Embedded feature archives (issue #114 + SQLite Phase C.2b/D), native
+            # arches only (cosmo composes nothing). Name column is the COMPOSED
+            # asset name that build.lua records in package.sig.gethull.composed
+            # and that the runtime §5c looks up: "libhull_feature-<stem>.<arch>.a".
+            # `sqlite` = the engine (Phase D), `sqlite-lua`/`sqlite-js` = the udf
+            # bridges (Phase C.2b).
             for arch in linux-x86_64 linux-aarch64 darwin-arm64; do
-              for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js; do
+              for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js sqlite sqlite-lua sqlite-js; do
                 f="platforms/platform-features-$arch/libhull_feature-$stem.a"
                 sha256sum "$f" \
                   | awk -v n="libhull_feature-$stem.$arch.a" '{print $1"  "n}'
@@ -532,6 +550,18 @@ jobs:
           name: platform-features-${{ matrix.name }}
           path: build/
 
+      # Phase D (docs/sqlite_feature.md): the SQLite-LESS app-build base. Land it
+      # at build/libhull_platform-sqliteless.a (the name the Makefile's
+      # SQLITELESS_PLATFORM_LIB + TRUST_PLATFORM_LIB expect) so HL_APP_BASE_SQLITELESS=1
+      # embeds these exact signed bytes.
+      - name: Download SQLite-less app-build base (this arch)
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: platform-flavors-${{ matrix.name }}
+          path: build/flavors/
+      - name: Stage SQLite-less base
+        run: cp build/flavors/libhull_platform-sqliteless-${{ matrix.name }}.a build/libhull_platform-sqliteless.a
+
       - name: Download signed manifest header
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
@@ -544,24 +574,27 @@ jobs:
         # See same step in build-cosmo for rationale.
         run: |
           set -eu
-          actual=$(sha256sum build/libhull_platform.a | awk '{print $1}')
+          # Phase D: the native arch entry hashes the SQLite-LESS base (what stage
+          # 3 embeds via HL_APP_BASE_SQLITELESS=1), so verify THAT against it.
+          actual=$(sha256sum build/libhull_platform-sqliteless.a | awk '{print $1}')
           expected=$(awk -v a="${{ matrix.name }}" '$2==a {print $1}' build/platform-manifest.txt)
           if [ -z "$expected" ]; then
             echo "::error::arch '${{ matrix.name }}' not in signed manifest"
             exit 1
           fi
           if [ "$actual" != "$expected" ]; then
-            echo "::error::libhull_platform.a SHA mismatch"
+            echo "::error::SQLite-less base SHA mismatch"
             echo "  expected (signed manifest): $expected"
             echo "  actual   (downloaded .a):   $actual"
             exit 1
           fi
-          echo "✓ ${{ matrix.name }} .a SHA matches signed manifest: $actual"
+          echo "✓ ${{ matrix.name }} SQLite-less base SHA matches signed manifest: $actual"
           # Same cross-check for each embedded feature archive: its downloaded
           # bytes MUST match the signed-manifest entry keyed by the composed asset
           # name (libhull_feature-<stem>.<arch>.a), or the runtime §5c check on
-          # every app this hull builds would fail.
-          for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js; do
+          # every app this hull builds would fail. Includes the SQLite engine
+          # (sqlite) + udf bridges (sqlite-lua/sqlite-js).
+          for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js sqlite sqlite-lua sqlite-js; do
             fa="build/libhull_feature-$stem.a"
             name="libhull_feature-$stem.${{ matrix.name }}.a"
             fact=$(sha256sum "$fa" | awk '{print $1}')
@@ -599,12 +632,12 @@ jobs:
         with:
           user: host
           run: |
-            make EMBED_PLATFORM=1 TRUST_PLATFORM_LIB=1 TRUST_FEATURE_LIBS=1
+            make EMBED_PLATFORM=1 HL_APP_BASE_SQLITELESS=1 TRUST_PLATFORM_LIB=1 TRUST_FEATURE_LIBS=1
             make hardening
             make check-hardening
       - name: Build hull with embedded platform (macOS)
         if: runner.os == 'macOS'
-        run: make EMBED_PLATFORM=1 TRUST_PLATFORM_LIB=1 TRUST_FEATURE_LIBS=1
+        run: make EMBED_PLATFORM=1 HL_APP_BASE_SQLITELESS=1 TRUST_PLATFORM_LIB=1 TRUST_FEATURE_LIBS=1
       - name: Hardening summary (macOS)
         if: runner.os == 'macOS'
         run: make hardening

--- a/Makefile
+++ b/Makefile
@@ -2766,10 +2766,19 @@ platform-pure-compute: platform-%:
 # EMBED_PLATFORM path xxd's this instead of the sqlite-full libhull_platform.a
 # when HL_APP_BASE_SQLITELESS=1. See docs/sqlite_feature.md.
 SQLITELESS_PLATFORM_LIB := $(BUILDDIR)/libhull_platform-sqliteless.a
+ifeq ($(TRUST_PLATFORM_LIB),1)
+# Release stage 3: the SQLite-less base was downloaded from build-platform-native
+# (the exact bytes sign-platform-manifest hashed). Trust it as-is, like
+# $(PLATFORM_LIB) above; never sub-build over the signed artifact.
+$(SQLITELESS_PLATFORM_LIB): | $(BUILDDIR)
+	@test -f $@ || (echo "ERROR: TRUST_PLATFORM_LIB=1 but $@ is missing"; exit 1)
+	@echo "$@: trusting pre-built artifact (TRUST_PLATFORM_LIB=1)"
+else
 $(SQLITELESS_PLATFORM_LIB):
 	$(MAKE) platform BUILDDIR=$(BUILDDIR)/sqliteless HL_SQLITE_FEATURE=1
 	cp $(BUILDDIR)/sqliteless/libhull_platform.a $@
 	@echo "built $@ (SQLite-less app-build base)"
+endif
 .PHONY: platform-sqliteless
 platform-sqliteless: $(SQLITELESS_PLATFORM_LIB)
 

--- a/docs/sqlite_feature.md
+++ b/docs/sqlite_feature.md
@@ -221,10 +221,22 @@ WASM). `HL_ENABLE_SQLITE` stays the compile switch; the feature is the
   - **Signing.** An embedded-resolved engine is recorded in the composed
     attestation under the **platform** domain (embedded-asset name
     `libhull_feature-sqlite.<arch>.a`, §5c FATAL, like the runtime/wasm cores);
-    an externally-installed engine keeps the **release** domain. release.yml must
-    (a) build + embed the SQLite-less base + engine, (b) sign the SQLite-less base
-    into `embedded_platform_sig.h` so `verify_platform` passes, and (c) add the
-    engine hash to the platform manifest so §5c can verify it. **(pending)**
+    an externally-installed engine keeps the **release** domain.
+  - **Release wiring (release.yml).** ✅ WIRED (validate via a dry-run
+    pre-release tag before a real release). Stage 1 builds the sqlite-less base
+    (`platform-sqliteless`, published `libhull_platform-sqliteless-<arch>.a`) + the
+    engine + the C.2b udf bridges (`feature-sqlite{,-lua,-js}`). Stage 2's signed
+    platform manifest hashes the **sqlite-less** base for each native arch entry
+    (what stage 3 embeds) and adds the `sqlite`/`sqlite-lua`/`sqlite-js` feature
+    stems (the latter two also closed a C.2b manifest gap). Stage 3 downloads the
+    sqlite-less base + engine/bridges, SHA-verifies them against the signed
+    manifest, and builds with `HL_APP_BASE_SQLITELESS=1 TRUST_PLATFORM_LIB=1
+    TRUST_FEATURE_LIBS=1` (the Makefile's `SQLITELESS_PLATFORM_LIB` honours
+    `TRUST_PLATFORM_LIB`, embedding the exact signed bytes). No new keys — same
+    platform-key trust chain as the runtime/http/wasm cores. Cosmo arch entries
+    stay sqlite-full. The shipped `HL_PLATFORM_PUBKEY_HEX` is still the placeholder
+    (the whole §5b/§5c layer is skipped at runtime), so this is future-correct;
+    the produced-app payoff (drop SQLite) is already live regardless.
   - **Cosmo** keeps SQLite in-base (a fat APE can't force-load a native archive);
     `HL_APP_BASE_SQLITELESS` is native-only.
 


### PR DESCRIPTION
## What

Wires the Phase D core (gated `HL_APP_BASE_SQLITELESS`, #131 merged) into the release pipeline, so **published native `hull` binaries produce SQLite-dropping apps out of the box**: a db-free app links zero `sqlite3.*`; a db app auto-composes the embedded engine. Same platform-key trust chain as the runtime/http/wasm cores — **no new keys**. Cosmo stays SQLite-in-base.

## release.yml

- **Stage 1** (build-platform-native): build the SQLite-less base via `platform-sqliteless` (published `libhull_platform-sqliteless-<arch>.a`, sharing the flavor step's obj-dir isolation) + the engine + the C.2b udf bridges (`feature-sqlite{,-lua,-js}`), uploaded with the embedded feature archives.
- **Stage 2** (sign-platform-manifest): each **native** arch entry now hashes the **SQLite-less** base (what stage 3 embeds, so `verify_platform` matches); the feature stems gain `sqlite`/`sqlite-lua`/`sqlite-js` — the two bridges also close a **C.2b manifest gap** (they were embedded but never signed). Cosmo entries stay sqlite-full.
- **Stage 3** (build-native): download the SQLite-less base + engine/bridges, SHA-verify against the signed manifest, build with `HL_APP_BASE_SQLITELESS=1 TRUST_PLATFORM_LIB=1 TRUST_FEATURE_LIBS=1`.

## Makefile

`SQLITELESS_PLATFORM_LIB` honours `TRUST_PLATFORM_LIB` (embed the exact downloaded signed bytes in stage 3; sub-build from source otherwise), mirroring `$(PLATFORM_LIB)`.

## Consistency (traced)

- `verify_platform` hashes the embedded base (now sqlite-less) vs the embedded manifest arch entry (now sqlite-less) → match.
- §5c verifies the app-recorded platform-domain assets (engine + bridges) vs the same embedded manifest (now lists them) → match. The C side has **no hardcoded feature-stem list**.
- The shipped `HL_PLATFORM_PUBKEY_HEX` is still the placeholder, so §5b/§5c are **skipped at runtime** — this is future-correct; the produced-app payoff is already live regardless.

## ⚠️ Validation

`release.yml` runs **only on a tag**, so PR CI (ci.yml) does **not** exercise these changes — it only validates the Makefile (default build unaffected). **Validate via a dry-run pre-release tag** (hyphenated → auto `--prerelease`, teardown after) before a real release. YAML + Makefile rules were parse-checked locally, and the whole gated core was validated end-to-end via `make EMBED_PLATFORM=1 HL_APP_BASE_SQLITELESS=1` (#131).