### PR TITLE
fix(runtime): close the DB before the runtime on teardown (JS udf abort)

### DIFF
--- a/docs/sqlite_feature.md
+++ b/docs/sqlite_feature.md
@@ -199,10 +199,13 @@ WASM). `HL_ENABLE_SQLITE` stays the compile switch; the feature is the
       (`nm app | grep sqlite3_open` → empty); a udf app composes the bridge and
       `db.udf` runs; a db app composes the engine and `db.query` runs. Covered by
       `tests/e2e_feature_sqlite.sh`.
-    - **Known-orthogonal:** a JS `app.main` + `db.udf` + clean-exit path trips a
-      pre-existing `JS_FreeRuntime` GC-leak assertion (reproduces on pre-C.2
-      `main`; the DB isn't closed before the runtime is freed). Tracked
-      separately; unrelated to the bridge split.
+    - **Fixed (was known-orthogonal):** a JS `app.main` + `db.udf` + clean-exit
+      path used to trip a pre-existing `JS_FreeRuntime` GC-leak assertion (the DB
+      was closed AFTER the runtime was freed, so the udf's dup'd closure leaked).
+      Fixed in `app_context.c::hl_app_context_free` by closing the DB **before**
+      destroying the runtime, so `sqlite3_close`'s udf `xDestroy` frees the
+      closure while the runtime is alive (WASM cache still destroyed after the
+      runtime). Regression-guarded by `tests/e2e_cli.sh` (both runtimes).
 - **Phase D — embed the SQLite-less base as the default app-build target.**
   🚧 CORE landed (gated), release wiring pending.
   - **Model.** The `hull` binary stays SQLite-full (it links `SQLITE_OBJ` for its

--- a/src/hull/app_context.c
+++ b/src/hull/app_context.c
@@ -348,19 +348,19 @@ void hl_app_context_free(HlAppContext *ctx)
 {
     if (!ctx) return;
 
-    if (ctx->rt_init && ctx->factory && ctx->factory->destroy) {
-        ctx->factory->destroy(ctx->rt);
-        ctx->rt = NULL;
-    }
-
-#ifdef HL_ENABLE_WASM
-    if (ctx->wasm_ok && !ctx->wasm_external)
-        hl_cap_wasm_destroy(&ctx->wasm_cache);
-#endif
-
 #ifdef HL_ENABLE_DB
-    /* The registry owns every connection, including the "default"; destroying
-     * it closes them all. ctx->db aliased the default's raw sqlite3*, so it
+    /* Close the DB BEFORE destroying the runtime. The registry owns every
+     * connection, including the "default"; destroying it runs sqlite3_close,
+     * which fires each registered udf's xDestroy callback. Those callbacks free
+     * the runtime-side closure the udf holds (a JS JS_DupValue ref / a Lua
+     * registry ref), and they can only do so while the runtime is still alive.
+     * Destroying the runtime first would trip QuickJS's JS_FreeRuntime
+     * gc_obj_list-empty assertion on the still-referenced udf closure (and
+     * silently leak the equivalent Lua ref). Connection-object finalizers run
+     * later during the runtime destroy are safe against this ordering: a
+     * borrowed conn's finalizer is a no-op (the registry owned the handle), and
+     * an owned (db.open) conn's finalizer closes only its own handle, which was
+     * never in the registry. ctx->db aliased the default's raw sqlite3*, so it
      * dangles after this. */
     if (ctx->db_registry) {
         hl_db_registry_destroy(ctx->db_registry);
@@ -368,6 +368,19 @@ void hl_app_context_free(HlAppContext *ctx)
     }
     ctx->db = NULL;
     ctx->db_open = 0;
+#endif
+
+    if (ctx->rt_init && ctx->factory && ctx->factory->destroy) {
+        ctx->factory->destroy(ctx->rt);
+        ctx->rt = NULL;
+    }
+
+    /* WASM cache AFTER the runtime destroy: the runtime's GC finalizers
+     * (WasmBuffer WASM-kind, WasmInstance) dereference WAMR, so it must outlive
+     * them. */
+#ifdef HL_ENABLE_WASM
+    if (ctx->wasm_ok && !ctx->wasm_external)
+        hl_cap_wasm_destroy(&ctx->wasm_cache);
 #endif
 
     ctx->rt = NULL;

--- a/tests/e2e_cli.sh
+++ b/tests/e2e_cli.sh
@@ -60,6 +60,49 @@ run_hello_cli() {
 run_hello_cli "lua" "lua"
 run_hello_cli "js"  "js"
 
+# run_udf_teardown <runtime> <ext>
+# Regression: a db.udf-registering app.main app must exit CLEANLY (0) after the
+# runtime is torn down. The udf holds a runtime-side closure (JS JS_DupValue /
+# Lua registry ref) freed by sqlite3_close's xDestroy; if the DB is closed AFTER
+# the runtime is freed, QuickJS's JS_FreeRuntime aborts (SIGABRT -> 134) on the
+# leaked closure. See app_context.c hl_app_context_free (DB closed before runtime).
+run_udf_teardown() {
+    runtime="$1"; ext="$2"
+    echo "--- db.udf teardown (${runtime}) ---"
+    d=$(mktemp -d)
+    if [ "$ext" = "lua" ]; then
+        cat > "${d}/app.lua" <<'LUA'
+local db = require("hull.db").default()
+app.manifest({ modules = { "hull/db@1" } })
+app.main(function()
+  db.udf.register("hull_double", function(x) return x * 2 end, { deterministic = true })
+  local r = db.query("SELECT hull_double(21) AS v")
+  return (r[1] and r[1].v == 42) and 0 or 3
+end)
+LUA
+    else
+        cat > "${d}/app.js" <<'JS'
+import { app } from "hull:app";
+import { db as dbmod } from "hull:db";
+app.manifest({ modules: ["hull/db@1"] });
+app.main(() => {
+  const db = dbmod.default();
+  db.udf.register("hull_double", (x) => x * 2, { deterministic: true });
+  const r = db.query("SELECT hull_double(21) AS v");
+  return (r[0] && r[0].v === 42) ? 0 : 3;
+});
+JS
+    fi
+    "${HULL_BIN}" "${d}/app.${ext}" -d ":memory:" >/dev/null 2>&1
+    rc=$?
+    # 0 = udf ran + clean teardown; 134 = the JS_FreeRuntime leak abort (regression).
+    expect_eq "${runtime} db.udf app.main clean exit (no teardown abort)" "0" "${rc}"
+    rm -rf "${d}"
+}
+
+run_udf_teardown "lua" "lua"
+run_udf_teardown "js"  "js"
+
 echo
 echo "${PASS}/$((PASS + FAIL)) CLI e2e tests passed"
 [ "${FAIL}" -eq 0 ]


### PR DESCRIPTION
## The bug

A JS `app.main` app that registered a `db.udf` and exited cleanly **aborted**:
```
Assertion failed: (list_empty(&rt->gc_obj_list)), function JS_FreeRuntime, file quickjs.c, line 1991.
```
The udf holds a runtime-side closure (JS `JS_DupValue` ref / Lua registry ref) that `sqlite3_close`'s `xDestroy` callback frees. `hl_app_context_free` destroyed the **runtime first** and closed the **DB second**, so `JS_FreeRuntime` saw the still-referenced closure and asserted. Lua leaked the ref silently (`lua_close` doesn't assert). Pre-existing — reproduced on unmodified `main`.

## The fix

Close the DB registry **before** destroying the runtime, so `xDestroy` frees the closure while the runtime's context is still alive.

Safe against the connection finalizers that run later during the runtime destroy (verified in the source):
- a **borrowed** conn's finalizer is a **no-op** (`handle owned by the registry; nothing to free`)
- an **owned** (`db.open`) conn's finalizer closes only its own `box->h`, which was never in the registry

The WASM cache is still destroyed **after** the runtime (its GC finalizers dereference WAMR — the one ordering constraint in the other direction).

## Validation

- JS repro now exits 0 (no assert); Lua still exits 0
- `make test` 60/60; `e2e_named_connections` 6/6
- real serve start → `SIGTERM` with a db+udf JS app shuts down clean
- **Regression-guarded** by `tests/e2e_cli.sh` (`db.udf` app.main clean-exit, both runtimes) — reverting the reorder flips the JS case to exit 134

Closes the last open thread from the SQLite-feature epic (it was surfaced during C.2 and confirmed pre-existing).