### PR TITLE
fix(db): don't double-free the udf ctx when sqlite3_create_function_v2 fails

### DIFF
--- a/src/hull/runtime/js/mod_db_udf.c
+++ b/src/hull/runtime/js/mod_db_udf.c
@@ -395,11 +395,13 @@ static JSValue js_db_udf_register(JSContext *ctx, JSValueConst this_val,
 
         JS_FreeCString(ctx, sql_name);
 
-        if (rc != SQLITE_OK) {
-            js_scalar_udf_destroy(udf_ctx);
+        if (rc != SQLITE_OK)
+            /* SQLite invokes the xDestroy (js_scalar_udf_destroy) ITSELF when
+             * create_function_v2 fails (the destructor runs when its nRef stays
+             * 0), freeing udf_ctx and JS_FreeValue-ing its func. Do NOT free
+             * again here -- that double-frees + corrupts the QuickJS refcount. */
             return JS_ThrowInternalError(ctx, "db.udf.register: %s",
                                          sqlite3_errmsg(raw_db));
-        }
     } else if (JS_IsObject(argv[1])) {
         /* ── JS aggregate UDF ({step, finalize}) ───────────────── */
         JSValue step_fn = JS_GetPropertyStr(ctx, argv[1], "step");
@@ -442,11 +444,11 @@ static JSValue js_db_udf_register(JSContext *ctx, JSValueConst this_val,
 
         JS_FreeCString(ctx, sql_name);
 
-        if (rc != SQLITE_OK) {
-            js_agg_udf_destroy(udf_ctx);
+        if (rc != SQLITE_OK)
+            /* SQLite already invoked the xDestroy (js_agg_udf_destroy) on
+             * failure -- do NOT free again (double-free + refcount corruption). */
             return JS_ThrowInternalError(ctx, "db.udf.register: %s",
                                          sqlite3_errmsg(raw_db));
-        }
     } else {
         JS_FreeCString(ctx, sql_name);
         return JS_ThrowTypeError(ctx,

--- a/src/hull/runtime/lua/mod_db_udf.c
+++ b/src/hull/runtime/lua/mod_db_udf.c
@@ -347,11 +347,13 @@ static int lua_db_udf_register(lua_State *L)
             raw_db, sql_name, nargs, encoding, udf_ctx,
             lua_scalar_udf_func, NULL, NULL,
             lua_scalar_udf_destroy);
-        if (rc != SQLITE_OK) {
-            lua_scalar_udf_destroy(udf_ctx);
+        if (rc != SQLITE_OK)
+            /* SQLite invokes the xDestroy (lua_scalar_udf_destroy) ITSELF when
+             * create_function_v2 fails (the destructor runs when its nRef stays
+             * 0), freeing udf_ctx and dropping its Lua ref. Do NOT free again
+             * here -- that double-frees udf_ctx + double-unrefs the closure. */
             return luaL_error(L, "db.udf.register: %s",
                               sqlite3_errmsg(raw_db));
-        }
     } else if (lua_istable(L, 2)) {
         /* ── Lua aggregate UDF (table with step + finalize) ──── */
         lua_getfield(L, 2, "step");
@@ -387,11 +389,11 @@ static int lua_db_udf_register(lua_State *L)
             raw_db, sql_name, nargs, encoding, udf_ctx,
             NULL, lua_agg_step_func, lua_agg_finalize_func,
             lua_agg_udf_destroy);
-        if (rc != SQLITE_OK) {
-            lua_agg_udf_destroy(udf_ctx);
+        if (rc != SQLITE_OK)
+            /* SQLite already invoked the xDestroy (lua_agg_udf_destroy) on
+             * failure -- do NOT free again (double-free + double-unref). */
             return luaL_error(L, "db.udf.register: %s",
                               sqlite3_errmsg(raw_db));
-        }
     } else {
         return luaL_error(L,
             "db.udf.register: impl must be a function, table, or string");

--- a/tests/e2e_cli.sh
+++ b/tests/e2e_cli.sh
@@ -61,14 +61,20 @@ run_hello_cli "lua" "lua"
 run_hello_cli "js"  "js"
 
 # run_udf_teardown <runtime> <ext>
-# Regression: a db.udf-registering app.main app must exit CLEANLY (0) after the
-# runtime is torn down. The udf holds a runtime-side closure (JS JS_DupValue /
-# Lua registry ref) freed by sqlite3_close's xDestroy; if the DB is closed AFTER
-# the runtime is freed, QuickJS's JS_FreeRuntime aborts (SIGABRT -> 134) on the
-# leaked closure. See app_context.c hl_app_context_free (DB closed before runtime).
+# Two db.udf regressions in one app.main run:
+#  (a) teardown ordering: the udf holds a runtime-side closure (JS JS_DupValue /
+#      Lua registry ref) freed by sqlite3_close's xDestroy. If the DB is closed
+#      AFTER the runtime is freed, QuickJS's JS_FreeRuntime aborts (SIGABRT->134)
+#      on the leaked closure. See app_context.c hl_app_context_free (DB closed
+#      before the runtime).
+#  (b) failed-register double-free: sqlite3_create_function_v2 invokes the udf's
+#      xDestroy ITSELF on failure (e.g. a >255-byte name), so the register paths
+#      must NOT free the ctx again. A regression double-frees + double-unrefs
+#      (heap corruption / QuickJS refcount corruption -> crash, esp. under ASan).
+# Either regression flips the clean exit (0) to a non-zero/abort.
 run_udf_teardown() {
     runtime="$1"; ext="$2"
-    echo "--- db.udf teardown (${runtime}) ---"
+    echo "--- db.udf teardown + failed-register (${runtime}) ---"
     d=$(mktemp -d)
     if [ "$ext" = "lua" ]; then
         cat > "${d}/app.lua" <<'LUA'
@@ -76,6 +82,12 @@ local db = require("hull.db").default()
 app.manifest({ modules = { "hull/db@1" } })
 app.main(function()
   db.udf.register("hull_double", function(x) return x * 2 end, { deterministic = true })
+  -- (b) a >255-byte name makes sqlite3_create_function_v2 fail; the error must be
+  -- raised cleanly (SQLite already ran xDestroy) with no double-free.
+  local ok = pcall(function()
+    db.udf.register("hull_" .. string.rep("x", 400), function(x) return x end)
+  end)
+  if ok then return 5 end
   local r = db.query("SELECT hull_double(21) AS v")
   return (r[1] and r[1].v == 42) and 0 or 3
 end)
@@ -88,6 +100,9 @@ app.manifest({ modules: ["hull/db@1"] });
 app.main(() => {
   const db = dbmod.default();
   db.udf.register("hull_double", (x) => x * 2, { deterministic: true });
+  let threw = false;
+  try { db.udf.register("hull_" + "x".repeat(400), (x) => x); } catch (e) { threw = true; }
+  if (!threw) return 5;
   const r = db.query("SELECT hull_double(21) AS v");
   return (r[0] && r[0].v === 42) ? 0 : 3;
 });
@@ -95,8 +110,9 @@ JS
     fi
     "${HULL_BIN}" "${d}/app.${ext}" -d ":memory:" >/dev/null 2>&1
     rc=$?
-    # 0 = udf ran + clean teardown; 134 = the JS_FreeRuntime leak abort (regression).
-    expect_eq "${runtime} db.udf app.main clean exit (no teardown abort)" "0" "${rc}"
+    # 0 = udf ran + failed-register handled + clean teardown; non-zero/134/139 = a
+    # teardown-leak abort or a failed-register double-free (regression).
+    expect_eq "${runtime} db.udf clean exit (teardown + failed-register safe)" "0" "${rc}"
     rm -rf "${d}"
 }
 


### PR DESCRIPTION
## The bug (Critical, found by /c-audit)

`sqlite3_create_function_v2` invokes the passed `xDestroy` **itself** on every failure path (`vendor/sqlite/sqlite3.c` `createFunctionApi`: `xDestroy(p)` on the OOM-before-destructor branch, and again in the `pArg->nRef==0` branch that runs on any registration failure). All four Hull register paths (Lua + JS, scalar + aggregate) **also** called their `*_udf_destroy(udf_ctx)` on the `rc != SQLITE_OK` branch → the destructor ran twice: `free(udf_ctx)` twice + a double `luaL_unref` / `JS_FreeValue` of the closure → heap corruption + QuickJS refcount corruption (later UAF).

**App-reachable:** a udf name that (after the enforced `hull_` prefix) exceeds 255 bytes → `SQLITE_MISUSE`; registering/replacing a udf while a statement is live → `SQLITE_BUSY`. Either triggered the double-free.

**Pre-existing** (predates the C.2 udf-bridge split — carried in verbatim), surfaced by the C audit.

## The fix

On the failure branch, raise the Lua/JS error **without** calling the destroy — SQLite already freed the ctx and dropped the closure ref exactly once. On success `nRef>0`, so `xDestroy` is correctly deferred to db close (no leak). Traced line-by-line against the vendored `createFunctionApi`.

## Validation

- The too-long-name error path exits cleanly **under ASan** (no double-free report) — definitive, since a double-free would abort under ASan
- `make test` 60/60 + `e2e_cli` 14/14 under ASan; udf still works
- `tests/e2e_cli.sh` db.udf regression now also exercises the **failed-register** path (both runtimes), so reverting the fix flips the clean exit to an abort

Part of a comprehensive /c-audit /js-audit /lua-audit pass; this was the only Critical.