### PR TITLE
harden: post-audit fixes (H1/H2/H3/M2/M3 + Lows) across tool plugins, stdlib, cap layer

### DIFF
--- a/src/hull/build_assets.c
+++ b/src/hull/build_assets.c
@@ -44,7 +44,8 @@
  * on the embedded-platform macros. */
 #if defined(HL_BUILD_EMBEDDED) || defined(HL_BUILD_EMBEDDED_MULTIARCH) \
     || defined(HL_BUILD_EMBEDDED_RUNTIME) || defined(HL_BUILD_EMBEDDED_HTTP) \
-    || defined(HL_BUILD_EMBEDDED_TUI) || defined(HL_BUILD_EMBEDDED_WASM)
+    || defined(HL_BUILD_EMBEDDED_TUI) || defined(HL_BUILD_EMBEDDED_WASM) \
+    || defined(HL_BUILD_EMBEDDED_SQLITE) || defined(HL_BUILD_EMBEDDED_SQLITE_RT)
 static int write_blob(const char *path, const unsigned char *data, size_t len)
 {
     FILE *f = fopen(path, "wb");

--- a/src/hull/cap/fs.c
+++ b/src/hull/cap/fs.c
@@ -312,7 +312,13 @@ HlMappedBuffer *hl_cap_fs_mmap(const HlFsConfig *cfg, const char *path,
     }
 
     struct stat st;
-    if (fstat(fd, &st) != 0 || st.st_size <= 0) {
+    if (fstat(fd, &st) != 0) {
+        /* Do NOT read st here — it is uninitialized when fstat fails. */
+        close(fd);
+        if (err_msg) *err_msg = "mmap_failed";
+        goto audit;
+    }
+    if (st.st_size <= 0) {
         close(fd);
         if (err_msg) *err_msg = st.st_size == 0 ? "empty_file" : "mmap_failed";
         goto audit;

--- a/src/hull/runtime/js/mod_db_udf.c
+++ b/src/hull/runtime/js/mod_db_udf.c
@@ -486,6 +486,10 @@ static JSValue js_db_udf_unregister(JSContext *ctx, JSValueConst this_val,
         JS_FreeCString(ctx, sql_name);
         return JS_ThrowInternalError(ctx, "database not available");
     }
+    /* NOTE: SQLite keys functions by (name, nargs); nargs = -1 removes only a
+     * VARIADIC registration. A udf registered with a specific arity (opts.args
+     * = N) is not removed here (register arity is not tracked). register
+     * defaults to variadic, matching the common case. */
     int rc = sqlite3_create_function_v2(
         raw_db, sql_name, -1, SQLITE_UTF8,
         NULL, NULL, NULL, NULL, NULL);

--- a/src/hull/runtime/js/mod_http_client.c
+++ b/src/hull/runtime/js/mod_http_client.c
@@ -153,7 +153,9 @@ static JSValue js_http_request(JSContext *ctx, JSValueConst this_val,
         JS_FreeValue(ctx, hdrs_val);
     }
 
-    KlClientResponse resp;
+    KlClientResponse resp = {0}; /* zero-init: resp.error is read on the rc!=0
+                                  * path; don't depend on the cap layer's
+                                  * internal memset ordering. */
     int rc = hl_cap_http_request(js->base.http_cfg, method, url,
                                     headers, num_headers, body, body_len, &resp);
 
@@ -196,7 +198,9 @@ static JSValue js_http_get(JSContext *ctx, JSValueConst this_val,
         JS_FreeValue(ctx, hdrs_val);
     }
 
-    KlClientResponse resp;
+    KlClientResponse resp = {0}; /* zero-init: resp.error is read on the rc!=0
+                                  * path; don't depend on the cap layer's
+                                  * internal memset ordering. */
     int rc = hl_cap_http_request(js->base.http_cfg, "GET", url,
                                     headers, num_headers, NULL, 0, &resp);
     JS_FreeCString(ctx, url);
@@ -240,7 +244,9 @@ static JSValue js_http_body_method(JSContext *ctx, int argc, JSValueConst *argv,
         JS_FreeValue(ctx, hdrs_val);
     }
 
-    KlClientResponse resp;
+    KlClientResponse resp = {0}; /* zero-init: resp.error is read on the rc!=0
+                                  * path; don't depend on the cap layer's
+                                  * internal memset ordering. */
     int rc = hl_cap_http_request(js->base.http_cfg, method_name, url,
                                     headers, num_headers, body, body_len, &resp);
     JS_FreeCString(ctx, url);
@@ -293,7 +299,9 @@ static JSValue js_http_del(JSContext *ctx, JSValueConst this_val,
         JS_FreeValue(ctx, hdrs_val);
     }
 
-    KlClientResponse resp;
+    KlClientResponse resp = {0}; /* zero-init: resp.error is read on the rc!=0
+                                  * path; don't depend on the cap layer's
+                                  * internal memset ordering. */
     int rc = hl_cap_http_request(js->base.http_cfg, "DELETE", url,
                                     headers, num_headers, NULL, 0, &resp);
     JS_FreeCString(ctx, url);

--- a/src/hull/runtime/lua/mod_db_udf.c
+++ b/src/hull/runtime/lua/mod_db_udf.c
@@ -417,7 +417,13 @@ static int lua_db_udf_unregister(lua_State *L)
         return luaL_error(L, "db.udf.unregister: failed");
 #else
     /* Fall back to direct sqlite3 call when WASM (and the UDF cap helper)
-     * is compiled out — Lua/JS callback UDFs still work without WASM. */
+     * is compiled out — Lua/JS callback UDFs still work without WASM.
+     * NOTE: SQLite keys functions by (name, nargs); passing nargs = -1 removes
+     * only a VARIADIC registration. A udf registered with a specific arity
+     * (opts.args = N) is not removed by this path (the register arity is not
+     * tracked here). db.udf.register defaults to variadic, so this matches the
+     * common case; register with an explicit arity implies unregister is a
+     * no-op for it. */
     sqlite3 *raw_db = hl_db_sqlite_raw(conn);
     if (!raw_db)
         return luaL_error(L, "database not available");

--- a/src/hull/runtime/lua/mod_http_client.c
+++ b/src/hull/runtime/lua/mod_http_client.c
@@ -150,7 +150,9 @@ static int lua_http_request(lua_State *L)
         lua_pop(L, 1);
     }
 
-    KlClientResponse resp;
+    KlClientResponse resp = {0}; /* zero-init: resp.error is read on the rc!=0
+                                  * path; don't depend on the cap layer's
+                                  * internal memset ordering. */
     int rc = hl_cap_http_request(lua->base.http_cfg, method, url,
                                     headers, num_headers, body, body_len, &resp);
     if (rc != 0)
@@ -183,7 +185,9 @@ static int lua_http_get(lua_State *L)
         lua_pop(L, 1);
     }
 
-    KlClientResponse resp;
+    KlClientResponse resp = {0}; /* zero-init: resp.error is read on the rc!=0
+                                  * path; don't depend on the cap layer's
+                                  * internal memset ordering. */
     int rc = hl_cap_http_request(lua->base.http_cfg, "GET", url,
                                     headers, num_headers, NULL, 0, &resp);
     if (rc != 0)
@@ -220,7 +224,9 @@ static int lua_http_body_method(lua_State *L, const char *method)
         lua_pop(L, 1);
     }
 
-    KlClientResponse resp;
+    KlClientResponse resp = {0}; /* zero-init: resp.error is read on the rc!=0
+                                  * path; don't depend on the cap layer's
+                                  * internal memset ordering. */
     int rc = hl_cap_http_request(lua->base.http_cfg, method, url,
                                     headers, num_headers, body, body_len, &resp);
     if (rc != 0)
@@ -257,7 +263,9 @@ static int lua_http_delete(lua_State *L)
         lua_pop(L, 1);
     }
 
-    KlClientResponse resp;
+    KlClientResponse resp = {0}; /* zero-init: resp.error is read on the rc!=0
+                                  * path; don't depend on the cap layer's
+                                  * internal memset ordering. */
     int rc = hl_cap_http_request(lua->base.http_cfg, "DELETE", url,
                                     headers, num_headers, NULL, 0, &resp);
     if (rc != 0)

--- a/stdlib/cli/lua/hull/deploy.lua
+++ b/stdlib/cli/lua/hull/deploy.lua
@@ -148,6 +148,14 @@ local function parse_args()
             tool.stderr("hull deploy: " .. label .. " cannot start with '-': '" .. value .. "'\n")
             tool.exit(1)
         end
+        -- Reject '..' segments: the charset permits '.'+'/', so without this a
+        -- --data-dir / --install-dir like `/var/lib/hull/../..` would retarget
+        -- the systemd ExecStart / ReadWritePaths / install.sh mkdir paths.
+        if value == ".." or value:find("^%.%./") or value:find("/%.%./")
+           or value:find("/%.%.$") then
+            tool.stderr("hull deploy: " .. label .. " must not contain '..': '" .. value .. "'\n")
+            tool.exit(1)
+        end
     end
     if opts.user then validate_ident(opts.user, "--user") end
     validate_ident(opts.name, "--name")
@@ -211,14 +219,32 @@ local function introspect_app(app_dir)
                 local m = app.get_manifest()
                 if m then
                     info.manifest = m
+                    -- The manifest is UNTRUSTED third-party input that gets
+                    -- interpolated into the generated Dockerfile / fly.toml /
+                    -- systemd unit. Validate each entry so a value containing a
+                    -- newline (or shell/TOML metachars) can't inject directives;
+                    -- skip + warn on anything malformed rather than emitting it.
                     if m.env then
                         for _, v in ipairs(m.env) do
-                            info.env_vars[#info.env_vars + 1] = v
+                            if type(v) == "string" and v:find("^[A-Za-z_][A-Za-z0-9_]*$") then
+                                info.env_vars[#info.env_vars + 1] = v
+                            else
+                                tool.stderr("hull deploy: skipping invalid env name in manifest: "
+                                            .. tostring(v) .. "\n")
+                            end
                         end
                     end
                     if m.hosts then
                         for _, h in ipairs(m.hosts) do
-                            info.hosts[#info.hosts + 1] = h
+                            -- hostname / '*.suffix' glob / IPv4 / CIDR; no
+                            -- whitespace, quotes, or shell/TOML metacharacters.
+                            if type(h) == "string" and h ~= ""
+                               and h:find("^[%w%.%*%-/:]+$") then
+                                info.hosts[#info.hosts + 1] = h
+                            else
+                                tool.stderr("hull deploy: skipping invalid host in manifest: "
+                                            .. tostring(h) .. "\n")
+                            end
                         end
                     end
                 end

--- a/stdlib/cli/lua/hull/eject.lua
+++ b/stdlib/cli/lua/hull/eject.lua
@@ -442,15 +442,29 @@ local function main()
     -- Copy app files, preserving directory structure
     for _, path in ipairs(files) do
         local rel = path:sub(#opts.app_dir + 2)
-        local dest = dir .. "/app/" .. rel
 
-        -- Create parent directories
-        local parent = dest:match("(.*/)")
-        if parent then
-            tool.mkdir(parent)
+        -- Path-traversal defense (mirrors verify.lua): a crafted app tree with a
+        -- `..`-escaping or absolute relative path would otherwise write outside
+        -- the output dir.
+        if rel:find("%.%.") or rel:sub(1, 1) == "/" then
+            tool.stderr("hull eject: skipping suspicious app path: " .. rel .. "\n")
+            goto continue_files
         end
 
-        tool.copy(path, dest)
+        local dest = dir .. "/app/" .. rel
+
+        -- Never copy a file onto itself (tool.copy opens dest "wb" before reading
+        -- src, so src==dest 0-bytes the source). Guards `hull eject . -o .`-style
+        -- output/app-dir overlaps.
+        if dest ~= path then
+            -- Create parent directories
+            local parent = dest:match("(.*/)")
+            if parent then
+                tool.mkdir(parent)
+            end
+            tool.copy(path, dest)
+        end
+        ::continue_files::
     end
 
     print("hull eject: created " .. dir .. "/")

--- a/stdlib/cli/lua/hull/migrate.lua
+++ b/stdlib/cli/lua/hull/migrate.lua
@@ -39,7 +39,7 @@ end
 -- ── Helpers ──────────────────────────────────────────────────────────
 
 local function find_next_sequence(dir)
-    local files = tool.find_files(dir, "*.sql")
+    local files = tool.find_files(dir, "*.sql") or {}
     local max_seq = 0
 
     for _, path in ipairs(files) do

--- a/stdlib/cli/lua/hull/new.lua
+++ b/stdlib/cli/lua/hull/new.lua
@@ -225,17 +225,10 @@ local function main()
         tool.stderr("Usage: hull new <name> [--runtime lua|js] [--cli]\n")
         tool.exit(1)
     end
-    -- The name becomes a directory that gets mkdir'd + written into. Reject
-    -- absolute paths and '..' segments so `hull new` can only scaffold under the
-    -- current directory (defense in depth: keeps a stray name from writing
-    -- elsewhere on the filesystem).
-    if opts.name:sub(1, 1) == "/" or opts.name == ".."
-       or opts.name:find("^%.%./") or opts.name:find("/%.%./")
-       or opts.name:find("/%.%.$") then
-        tool.stderr("hull new: project name must be a relative path without "
-                    .. "'..' segments: '" .. opts.name .. "'\n")
-        tool.exit(1)
-    end
+    -- Note: the name IS the target directory and may be relative OR absolute
+    -- (like `git init <path>` / `cargo new <path>`); the user explicitly chooses
+    -- where to scaffold, and the file_exists gate below refuses to clobber, so
+    -- no path restriction is imposed here.
 
     local runtime = opts.runtime
     if runtime ~= "lua" and runtime ~= "js" then

--- a/stdlib/cli/lua/hull/new.lua
+++ b/stdlib/cli/lua/hull/new.lua
@@ -225,6 +225,17 @@ local function main()
         tool.stderr("Usage: hull new <name> [--runtime lua|js] [--cli]\n")
         tool.exit(1)
     end
+    -- The name becomes a directory that gets mkdir'd + written into. Reject
+    -- absolute paths and '..' segments so `hull new` can only scaffold under the
+    -- current directory (defense in depth: keeps a stray name from writing
+    -- elsewhere on the filesystem).
+    if opts.name:sub(1, 1) == "/" or opts.name == ".."
+       or opts.name:find("^%.%./") or opts.name:find("/%.%./")
+       or opts.name:find("/%.%.$") then
+        tool.stderr("hull new: project name must be a relative path without "
+                    .. "'..' segments: '" .. opts.name .. "'\n")
+        tool.exit(1)
+    end
 
     local runtime = opts.runtime
     if runtime ~= "lua" and runtime ~= "js" then

--- a/stdlib/cli/lua/hull/sign_platform.lua
+++ b/stdlib/cli/lua/hull/sign_platform.lua
@@ -76,17 +76,19 @@ local function detect_arch(dir, filename)
     if cc_data then
         local cc = cc_data:match("^%s*(.-)%s*$")
         if cc:find("cosmocc") then
-            -- Detect host architecture for cosmo builds
-            local uname = tool.spawn_read({"uname", "-m"})
-            if uname then
-                uname = uname:match("^%s*(.-)%s*$")
-                if uname == "x86_64" or uname == "amd64" then
-                    return "x86_64-cosmo"
-                elseif uname == "aarch64" or uname == "arm64" then
-                    return "aarch64-cosmo"
-                end
+            -- Detect host CPU arch from the in-process platform name (bound in
+            -- C) rather than spawning `uname` (not in the tool sandbox's spawn
+            -- allowlist, so it returned nil and silently mislabeled an aarch64
+            -- host's signed artifact as x86_64-cosmo).
+            local plat = tool.platform_name and tool.platform_name() or ""
+            if plat:find("x86_64") or plat:find("amd64") then
+                return "x86_64-cosmo"
+            elseif plat:find("aarch64") or plat:find("arm64") then
+                return "aarch64-cosmo"
             end
-            return "x86_64-cosmo" -- fallback
+            tool.stderr("hull sign-platform: cannot determine cosmo host arch "
+                        .. "from platform name '" .. plat .. "'\n")
+            tool.exit(1)
         end
     end
 

--- a/stdlib/cli/lua/hull/verify.lua
+++ b/stdlib/cli/lua/hull/verify.lua
@@ -50,37 +50,37 @@ local function read_file(path)
     return tool.read_file(path)
 end
 
--- Cap the HTTPS key fetch at 4 KiB. A pubkey is 64 hex chars; even
--- with surrounding whitespace, comments, or PEM-armor headers an
--- honest key file is well under this. Defends against a misbehaving
--- key URL (intentional or not) streaming megabytes through the
--- verifier on an opt-in CLI flag.
-local KEY_FETCH_MAX_BYTES = 4096
-
+-- Resolve a key SOURCE to its hex pubkey. Returns nil ONLY when no source was
+-- given (the caller then legitimately skips that key check). A source that IS
+-- given but cannot be read is a HARD ERROR (fail-closed): silently returning nil
+-- there would skip the operator-intended key pin (a fail-open security bypass).
 local function read_key(source)
     if not source then return nil end
 
-    -- URL fetch
-    -- WARNING: HTTPS key fetch trusts system CA store. Use local key files for high-security verification.
-    if source:sub(1, 8) == "https://" then
-        local data = tool.spawn_read({
-            "curl", "-sfL",
-            "--proto", "=https",
-            "--max-filesize", tostring(KEY_FETCH_MAX_BYTES),
-            source,
-        })
-        if data then
-            return data:match("^(%x+)")
-        end
-        return nil
+    -- URL fetch is not supported: the tool sandbox's spawn allowlist has no
+    -- network client (curl et al. are not permitted), so a `https://` source
+    -- could only ever fail. Error clearly instead of failing open.
+    if source:sub(1, 8) == "https://" or source:sub(1, 7) == "http://" then
+        tool.stderr("hull verify: URL key sources are not supported "
+                    .. "(no network client in the tool sandbox).\n"
+                    .. "Download the key and pass a local file path instead: "
+                    .. source .. "\n")
+        tool.exit(1)
     end
 
     -- File path
     local data = read_file(source)
-    if data then
-        return data:match("^(%x+)")
+    if not data then
+        tool.stderr("hull verify: cannot read key file: " .. source .. "\n")
+        tool.exit(1)
     end
-    return nil
+    local hex = data:match("^(%x+)")
+    if not hex then
+        tool.stderr("hull verify: key file has no valid hex public key: "
+                    .. source .. "\n")
+        tool.exit(1)
+    end
+    return hex
 end
 
 local function parse_args()

--- a/stdlib/js/hull/jwt.js
+++ b/stdlib/js/hull/jwt.js
@@ -92,6 +92,9 @@ function sign(payload, secret) {
         throw new Error("payload must be an object");
     if (!secret || typeof secret !== "string")
         throw new Error("secret is required");
+    // SECURITY: use a 32+ byte random HMAC key. A short (<16 byte) HS256 secret
+    // is brute-forceable. Not hard-rejected here (would break existing apps),
+    // but strongly recommended; oauth.init enforces >=16 for its state secret.
 
     const p = Object.create(null);
     for (const k of Object.keys(payload)) p[k] = payload[k];

--- a/stdlib/js/hull/search.js
+++ b/stdlib/js/hull/search.js
@@ -223,6 +223,22 @@ function query(name, q, opts) {
         throw new Error("query string is required");
 
     const o = opts || {};
+
+    // Bound the FTS5 MATCH expression (mirrors search.lua). The query is safely
+    // `?`-parameterized (no injection), but a pathological expression (thousands
+    // of OR terms, deeply nested NEAR/parens) is a CPU-amplification DoS when a
+    // public search box forwards untrusted input verbatim.
+    const maxLen = o.maxQueryLen !== undefined ? o.maxQueryLen : 1024;
+    const maxTerms = o.maxQueryTerms !== undefined ? o.maxQueryTerms : 64;
+    if (q.length > maxLen)
+        throw new Error("query too long (" + q.length + " > " + maxLen + ")");
+    const complexity =
+        (q.match(/[()]/g) || []).length +
+        (q.match(/\bOR\b/g) || []).length +
+        (q.match(/\bNEAR\b/g) || []).length;
+    if (complexity > maxTerms)
+        throw new Error("query too complex (>" + maxTerms +
+                        " operators/groups); bound untrusted input");
     const table = ftsTable(name);
     let limit = o.limit !== undefined ? o.limit : 20;
     let offset = o.offset !== undefined ? o.offset : 0;

--- a/stdlib/js/hull/web/auth-health.js
+++ b/stdlib/js/hull/web/auth-health.js
@@ -24,6 +24,12 @@ function tableExists(name) {
 }
 
 function rowCount(name) {
+    // All callers pass hardcoded `_hull_*` literals, but this interpolates the
+    // name into SQL (SQLite can't parameterize identifiers), so fail closed on
+    // anything that isn't a plain identifier -- a future variable table name can
+    // never become an injection vector (mirrors auth-health.lua).
+    if (typeof name !== "string" || !/^[A-Za-z0-9_]+$/.test(name))
+        throw new Error("auth-health.rowCount: table name must be a plain identifier");
     if (!tableExists(name)) return 0;
     const rows = db.query("SELECT count(*) AS n FROM " + name);
     return (rows && rows[0] && rows[0].n) || 0;

--- a/stdlib/js/hull/web/middleware/auth.js
+++ b/stdlib/js/hull/web/middleware/auth.js
@@ -133,6 +133,8 @@ function jwtMiddleware(opts) {
 
     if (!secret)
         throw new Error("jwtMiddleware requires opts.secret");
+    // SECURITY: opts.secret should be a 32+ byte random key; a short secret is
+    // brute-forceable. Not hard-rejected (back-compat), but strongly recommended.
 
     return function jwtMw(req, res) {
         // Check if path is excluded

--- a/stdlib/js/hull/web/middleware/csrf.js
+++ b/stdlib/js/hull/web/middleware/csrf.js
@@ -155,6 +155,8 @@ function middleware(opts) {
 
     if (!secret)
         throw new Error("csrf.middleware requires opts.secret");
+    // SECURITY: opts.secret should be a 32+ byte random key; a short secret is
+    // brute-forceable. Not hard-rejected (back-compat), but strongly recommended.
 
     // Resolve session id with the same precedence as the Lua sibling:
     // prefer req.ctx[sessionKey] (set by upstream session middleware

--- a/stdlib/lua/hull/jwt.lua
+++ b/stdlib/lua/hull/jwt.lua
@@ -90,6 +90,9 @@ function jwt.sign(payload, secret)
     if not payload or not secret then
         return nil, "payload and secret are required"
     end
+    -- SECURITY: use a 32+ byte random HMAC key. A short (<16 byte) HS256 secret
+    -- is brute-forceable. Not hard-rejected here (would break existing apps),
+    -- but strongly recommended; oauth.init enforces >=16 for its state secret.
 
     local claims = {}
     for k, v in pairs(payload) do claims[k] = v end

--- a/stdlib/lua/hull/search.lua
+++ b/stdlib/lua/hull/search.lua
@@ -234,6 +234,25 @@ function search.query(name, query, opts)
     end
     opts = opts or {}
 
+    -- Bound the FTS5 MATCH expression. The query is safely `?`-parameterized
+    -- (no SQL injection), but a pathological expression (thousands of OR terms,
+    -- deeply nested NEAR/parentheses) is a CPU-amplification DoS when a public
+    -- search box forwards untrusted `req.query.q` verbatim. Cap length and
+    -- boolean-operator/paren count; callers that legitimately need more can
+    -- raise opts.max_query_len / opts.max_query_terms.
+    local max_len = opts.max_query_len or 1024
+    local max_terms = opts.max_query_terms or 64
+    if #query > max_len then
+        error("search.query: query too long (" .. #query .. " > " .. max_len .. ")")
+    end
+    local _, term_count = query:gsub("[%(%)]", "")           -- parentheses
+    local _, or_count = query:gsub("%f[%w]OR%f[%W]", "")     -- OR operators
+    local _, near_count = query:gsub("%f[%w]NEAR%f[%W]", "") -- NEAR operators
+    if term_count + or_count + near_count > max_terms then
+        error("search.query: query too complex (>" .. max_terms
+              .. " operators/groups); bound untrusted input")
+    end
+
     local tbl = fts_table(name)
     local limit = opts.limit or 20
     local offset = opts.offset or 0

--- a/stdlib/lua/hull/web/auth-health.lua
+++ b/stdlib/lua/hull/web/auth-health.lua
@@ -58,6 +58,13 @@ end
 
 -- Helper: how many rows in a table (0 if table missing).
 local function row_count(name)
+    -- All callers pass hardcoded `_hull_*` literals, but this interpolates the
+    -- name into SQL (SQLite can't parameterize identifiers), so fail closed on
+    -- anything that isn't a plain identifier -- a future variable table name
+    -- can never become an injection vector.
+    if type(name) ~= "string" or not name:find("^[%w_]+$") then
+        error("auth-health.row_count: table name must be a plain identifier")
+    end
     if not table_exists(name) then return 0 end
     local rows = db.query("SELECT count(*) AS n FROM " .. name)
     return (rows and rows[1] and rows[1].n) or 0

--- a/stdlib/lua/hull/web/middleware/auth.lua
+++ b/stdlib/lua/hull/web/middleware/auth.lua
@@ -63,7 +63,7 @@ function auth.session_middleware(opts)
         end
 
         -- Parse cookies from request
-        local cookies = cookie.parse(req.headers["cookie"])
+        local cookies = cookie.parse(req.headers["cookie"] or "")
         local session_id = cookies[cookie_name]
         local stale = false
 
@@ -124,6 +124,8 @@ function auth.jwt_middleware(opts)
     if not opts.secret then
         error("auth.jwt_middleware requires opts.secret")
     end
+    -- SECURITY: opts.secret should be a 32+ byte random key; a short secret is
+    -- brute-forceable. Not hard-rejected (back-compat), but strongly recommended.
 
     local secret = opts.secret
     local optional = opts.optional or false
@@ -190,6 +192,12 @@ end
 --                   Mirrors the JS option.
 --
 -- @treturn string  Newly-created session id (hex).
+--
+-- NOTE: this legacy helper creates a fresh session but does NOT rotate/destroy
+-- any pre-existing session id, so it does not defend against session fixation.
+-- Prefer `session.login_handler(cookie)` (from hull/web/middleware/session),
+-- which rotates by default (opts.rotate = true) and wires the Set-Cookie +
+-- response in one line. Keep this only for simple flows with no prior session.
 -- @usage
 -- app.post("/login", function(req, res)
 --     local user = authenticate(req)

--- a/stdlib/lua/hull/web/middleware/csrf.lua
+++ b/stdlib/lua/hull/web/middleware/csrf.lua
@@ -151,6 +151,8 @@ function csrf.middleware(opts)
     if not opts or not opts.secret then
         error("csrf.middleware requires opts.secret")
     end
+    -- SECURITY: opts.secret should be a 32+ byte random key; a short secret is
+    -- brute-forceable. Not hard-rejected (back-compat), but strongly recommended.
 
     local secret = opts.secret
     local session_key = opts.session_key or "session_id"

--- a/stdlib/lua/hull/web/middleware/idempotency.lua
+++ b/stdlib/lua/hull/web/middleware/idempotency.lua
@@ -246,15 +246,10 @@ function idempotency.middleware(opts)
             else
                 -- Fingerprint comparison. Fingerprints are SHA-256(public
                 -- inputs) — not secrets — so timing leaks are not exploitable.
-                -- We still use a constant-time loop for consistency with jwt.lua
-                -- and csrf.lua so the comparison contract is the same everywhere
-                -- in the stdlib.
-                local diff = (row.fingerprint and #row.fingerprint or 0) == #fingerprint and 0 or 1
-                local n = math.min(#fingerprint, row.fingerprint and #row.fingerprint or 0)
-                for i = 1, n do
-                    diff = diff | (string.byte(row.fingerprint, i) ~ string.byte(fingerprint, i))
-                end
-                if diff ~= 0 then
+                -- We still use the C constant-time compare (crypto.constant_time_eq)
+                -- for consistency with jwt.lua/csrf.lua so the comparison contract
+                -- is one audited implementation everywhere in the stdlib.
+                if not crypto.constant_time_eq(row.fingerprint or "", fingerprint) then
                     res:status(409):json({
                         error = "idempotency key already used with different request body"
                     })

--- a/stdlib/lua/hull/web/middleware/totp.lua
+++ b/stdlib/lua/hull/web/middleware/totp.lua
@@ -370,12 +370,10 @@ end
 -- the per-comparison side-channel uniform.
 local function ct_eq(a, b)
     if type(a) ~= "string" or type(b) ~= "string" then return false end
-    if #a ~= #b then return false end
-    local diff = 0
-    for i = 1, #a do
-        diff = diff | (string.byte(a, i) ~ string.byte(b, i))
-    end
-    return diff == 0
+    -- Delegate to the C constant-time compare (the same primitive jwt/csrf use)
+    -- so the whole stdlib shares one audited implementation rather than a
+    -- per-module hand-rolled loop.
+    return crypto.constant_time_eq(a, b)
 end
 
 -- At-rest encryption: versioned NaCl secretbox.


### PR DESCRIPTION
Follow-up to the comprehensive `/c-audit` `/js-audit` `/lua-audit` pass. Fixes the confirmed High/Medium/Low findings **outside** the SQLite-feature scope. The one Critical (a udf-register double-free) shipped separately in #134. No happy-path behavior change — every fix is an input guard or defensive init.

## Tool plugins (Lua)
- **H1** `eject.lua`: reject `..`/absolute app paths before copy (path traversal, mirrors `verify.lua`) + never copy a file onto itself (output/app-dir overlap).
- **H2** `deploy.lua`: validate manifest env names + hosts before interpolating them into the generated Dockerfile/fly.toml/systemd (untrusted-manifest injection); skip + warn on malformed entries.
- **M4** `deploy.lua`: reject `..` in `--install-dir`/`--data-dir`.
- **M2** `verify.lua`: **fail closed** on an unreadable key source. A URL source is now a hard error (no network client in the tool sandbox) instead of silently returning nil — which skipped the operator's key pin (a **fail-open bypass**). Drops the dead `curl` branch.
- **M3** `sign_platform.lua`: derive the cosmo host arch from `tool.platform_name()` instead of spawning `uname` (not allowlisted → nil → **mislabeled signed artifact**).
- **L5** `migrate.lua`: nil-guard `tool.find_files`. **L7** `new.lua`: reject `..`/absolute project names (`init.lua`'s explicit dir target stays unrestricted, like `git init <path>`).

## stdlib (Lua + JS parity)
- **H3** `search.{lua,js}`: bound the FTS5 MATCH expression (length + operator/paren count) → stops a CPU-amplification DoS from untrusted query text.
- **M6** `auth-health.{lua,js}`: fail closed unless the `row_count` table name is a plain identifier.
- **L6** `totp.lua`/`idempotency.lua`: route hand-rolled constant-time loops through the C `crypto.constant_time_eq`.
- **L2** `auth.lua`: document `auth.login` as superseded by `session.login_handler` (no session-fixation rotation).
- **L1** jwt/csrf/auth (both runtimes): **documented** the ≥16-byte HMAC-secret recommendation rather than hard-enforcing it — a rejecting floor is a breaking change for existing apps (23 files + real apps use shorter secrets), disproportionate to a Low. `oauth.init` keeps its hard requirement (newer API, no back-compat burden).
- **L4**: already defended — `cap/smtp.c` `has_crlf` covers subject/cc/reply_to/from/to (no change needed).

## Cap layer (C)
- **M1** `build_assets.c`: add `HL_BUILD_EMBEDDED_SQLITE{,_RT}` to the `write_blob` gate (latent build break).
- **C-L2** `fs.c`: don't read `struct stat` when `fstat` fails (uninitialized read).
- **C-L3** `mod_http_client.c` (both runtimes): zero-init `KlClientResponse` so `resp.error` never depends on the cap layer's memset ordering.
- **C-L1** `mod_db_udf.c` (both runtimes): document `udf.unregister` (nargs=-1) removes only variadic registrations.

## Validation
`make test` 60/60; `e2e_cli` 14/14; `e2e_auth_flows` 48/0; `search` cap smoke (normal works, oversize/complex rejected); `test_fs` 21/21. The JS stdlib audit found it otherwise clean.

**Note (pre-existing, not from this PR):** `e2e_deploy` has 1 failing assertion (`agent hello: manifest present`) — confirmed identical on pristine `main` (a stale expectation: `examples/hello` moved `db.default()` to module top-level, which the tool-VM manifest extraction can't resolve pre-manifest). Orthogonal to this hardening.