### PR TITLE
fix(agent): extract the manifest for apps that top-level-require the DB (fixes e2e_deploy)

### DIFF
--- a/src/hull/agent/deploy.c
+++ b/src/hull/agent/deploy.c
@@ -73,12 +73,21 @@ int hl_agent_deploy(const char *app_dir, ShJsonBuf *out)
     if (!entry_point)
         return hl_agent_write_error(out, "no entry point found (app.lua or app.js)");
 
-    /* Initialize app context to extract manifest */
+    /* Initialize app context to extract manifest. Register the hull.db module
+     * (backed by an in-memory DB) rather than running in no_db mode: apps
+     * commonly acquire the connection at module top level
+     * (`local db = require("hull.db").default()`), which would otherwise fail
+     * manifest extraction with "module not found: hull.db" and wrongly report
+     * no manifest. no_migrate keeps this read-only introspection from running
+     * the app's migrations; db_path stays NULL (-> :memory:), so there is no
+     * file side effect and the connection is discarded when the context is
+     * freed. */
     HlAppContext *ctx = NULL;
     HlAppContextOpts opts = {
         .app_dir = app_dir,
         .entry_point = entry_point,
-        .no_db = 1,
+        .no_db = 0,
+        .no_migrate = 1,
     };
 
     HlManifest manifest;


### PR DESCRIPTION
## What

`hull agent deploy` initialized its manifest-extraction context with `no_db=1`, so the `hull.db` module was never registered (`modules.c` registers it only when a DB registry exists). Apps that acquire the connection at **module top level** — the now-common `local db = require("hull.db").default()` pattern (examples updated in `1cf17e8f`) — failed extraction with `module not found: hull.db` and were wrongly reported as having **no manifest** (`"present": false`), despite declaring `app.manifest({...})`.

This is the pre-existing `e2e_deploy` failure (`agent hello: manifest present` — confirmed identical on a pristine-`main` worktree build during the audit pass).

## Fix

Run extraction against an **in-memory** DB (`no_db=0`, `db_path` stays `NULL` → `:memory:`) so the module is requirable, with `no_migrate=1` so this read-only introspection never runs the app's migrations. The `:memory:` connection has **no file side effect** and is discarded when the context is freed (verified: the deploy path creates no `data.db`).

## Validation

- `hull agent deploy examples/hello` → `"present": true` (was `false`)
- **`tests/e2e_deploy.sh` 43/0** (was 42/1)
- `make test` 60/60; non-db apps (hello_cli) still report correctly; no db file created

## Known remaining limitation (out of scope)

An app that does DB *work* at module top level (e.g. `examples/todo` indexes via `hull/search` against a not-yet-migrated schema) still fails extraction — its chunk errors *after* `app.manifest()`. The tool-VM path (`hull deploy`) tolerates this via nop stubs; making the runtime's `extract_manifest` equally robust (capture-on-error / stub) is a broader, separate change. No regression: `todo` was `present:false` before and after.