### PR TITLE
feat(agent): tolerate top-level app errors during manifest extraction

### DIFF
--- a/include/hull/app_context.h
+++ b/include/hull/app_context.h
@@ -65,6 +65,16 @@ typedef struct HlAppContextOpts {
      * Use hl_app_context_load() to load app code later. */
     int           no_load;
 
+    /* Tolerate a top-level error while loading the app (read-only extraction
+     * paths only). app.manifest() stores the manifest the moment it is called,
+     * so an app that errors LATER in its top-level code (e.g. does DB work at
+     * module scope against an unmigrated :memory: schema) still has an
+     * extractable manifest. With this set, load_app's failure is logged but not
+     * fatal: init succeeds, app_loaded stays 0, gate_modules is skipped, and the
+     * caller can still call extract_manifest. Consumers that RUN the app
+     * (serve/test) leave this 0 so a broken app fails loudly. */
+    int           tolerate_load_error;
+
     /* Module-system gating:
      *   1 = run the resolver after manifest extraction and wire the
      *       result onto rt->module_set so require/import enforce the

--- a/src/hull/agent/deploy.c
+++ b/src/hull/agent/deploy.c
@@ -88,6 +88,10 @@ int hl_agent_deploy(const char *app_dir, ShJsonBuf *out)
         .entry_point = entry_point,
         .no_db = 0,
         .no_migrate = 1,
+        /* Read-only introspection: if the app errors LATE in its top-level code
+         * (e.g. does DB work at module scope against the unmigrated :memory:
+         * schema), still recover the manifest app.manifest() already stored. */
+        .tolerate_load_error = 1,
     };
 
     HlManifest manifest;

--- a/src/hull/app_context.c
+++ b/src/hull/app_context.c
@@ -279,10 +279,15 @@ int hl_app_context_init(HlAppContext **out, const HlAppContextOpts *opts)
     ctx->rt_init = 1;
 
     if (!opts->no_load) {
-        if (load_app_code(ctx, entry) != 0) {
+        int load_rc = load_app_code(ctx, entry);
+        if (load_rc != 0 && !opts->tolerate_load_error) {
             hl_app_context_free(ctx);
             return -1;
         }
+        /* On a tolerated load error the app is only PARTIALLY loaded: skip
+         * module gating (no reliable module surface) but keep the context so the
+         * caller can still extract whatever manifest app.manifest() stored
+         * before the error. load_app_code left app_loaded = 0. */
 
         /* Module-system gating (opt-in via opts.gate_modules).
          *
@@ -296,7 +301,7 @@ int hl_app_context_init(HlAppContext **out, const HlAppContextOpts *opts)
          *
          * The set lives in HlAppContext (lifetime matches the runtime).
          * Resolver failure is fatal — caller sees init failure. */
-        if (opts->gate_modules) {
+        if (load_rc == 0 && opts->gate_modules) {
             HlManifest m = {0};
             if (ctx->rt->vt->extract_manifest(ctx->rt, &m) == 0) {
                 char err[HL_MODULE_RESOLVER_ERR_MAX] = {0};

--- a/tests/e2e_deploy.sh
+++ b/tests/e2e_deploy.sh
@@ -216,6 +216,11 @@ AGENT_OUT=$("$HULL" agent deploy "$SRCDIR/examples/todo" 2>/dev/null)
 check_contains "agent: runtime" "$AGENT_OUT" '"runtime"'
 check_contains "agent: lua" "$AGENT_OUT" '"lua"'
 check_contains "agent: manifest" "$AGENT_OUT" '"manifest"'
+# todo acquires the DB at module top level AND does DB work there (search
+# reindex against the unmigrated :memory: schema). The manifest must still be
+# recovered: app.manifest() stored it before the top-level error, and the
+# extraction context tolerates the load error (regression: tolerate_load_error).
+check_contains "agent todo: manifest present (top-level DB work)" "$AGENT_OUT" '"present":true'
 check_contains "agent: configs" "$AGENT_OUT" '"configs"'
 check_contains "agent: files" "$AGENT_OUT" '"files"'
 check_contains "agent: recommendations" "$AGENT_OUT" '"recommendations"'


### PR DESCRIPTION
## What

The broader `extract_manifest` robustness follow-up to #136. `hull agent deploy` extracts an app's manifest by loading it and reading what `app.manifest()` stored. #136 made the DB module requirable so apps that acquire a connection at module top level extract correctly — but an app that does DB **work** at module top level (e.g. `examples/todo` runs `hull/search` reindex against the fresh, unmigrated `:memory:` schema) still errored partway through its top-level code, *after* `app.manifest()` had run, and the load failure discarded the whole context → no manifest.

## Fix

Add `HlAppContextOpts.tolerate_load_error`: a read-only extraction consumer opts in so a top-level load error is **logged but not fatal**. `app.manifest()` stores the manifest the instant it's called, so init still succeeds (`app_loaded` stays 0, module gating skipped) and the caller can extract the already-stored manifest. Consumers that **run** the app (serve/test) leave the flag 0 → a broken app still fails loudly. The fix sits above the runtime vtable, so it covers **Lua and JS**.

## Validation

- `hull agent deploy examples/todo` → `"present": true` (top-level search work; was false)
- A **JS** app that errors on a top-level `db.query` after `app.manifest()` also extracts
- A genuinely broken app (syntax error / error *before* `app.manifest()`) correctly stays `"present": false`
- The **serve** path still exits non-zero on a broken app (flag defaults 0)
- `make test` 60/60; **`e2e_deploy` 44/0** (new regression asserts todo's manifest is recovered)

Closes the extract-manifest robustness gap noted in #136: agent deploy now correctly reports the manifest for apps regardless of what they do at module top level.