### PR TITLE
feat(image): image codecs as a composable auto-composed feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,10 @@ jobs:
         timeout-minutes: 4
         run: make e2e-feature-wasm
 
+      - name: Image feature E2E test (image-free app drops stb; needs_image gate)
+        timeout-minutes: 4
+        run: make e2e-feature-image
+
       - name: Attachment E2E tests
         timeout-minutes: 2
         run: make e2e-attachment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
             feature-http-js feature-tui-lua feature-tui-js
             feature-wasm feature-wasm-lua feature-wasm-js
             feature-sqlite feature-sqlite-lua feature-sqlite-js
+            feature-image feature-image-lua feature-image-js
       - name: Build embedded feature archives (macOS)
         if: runner.os == 'macOS'
         run: >
@@ -83,6 +84,7 @@ jobs:
           feature-http-js feature-tui-lua feature-tui-js
           feature-wasm feature-wasm-lua feature-wasm-js
           feature-sqlite feature-sqlite-lua feature-sqlite-js
+          feature-image feature-image-lua feature-image-js
       - name: Upload embedded feature archives
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
@@ -101,6 +103,9 @@ jobs:
             build/libhull_feature-sqlite.a
             build/libhull_feature-sqlite-lua.a
             build/libhull_feature-sqlite-js.a
+            build/libhull_feature-image.a
+            build/libhull_feature-image-lua.a
+            build/libhull_feature-image-js.a
 
       # Per-flavor platform libs for `hull build --flavor` + `hull platform
       # install`. Each native platform-<flavor> target builds into its own obj
@@ -299,7 +304,7 @@ jobs:
             # `sqlite` = the engine (Phase D), `sqlite-lua`/`sqlite-js` = the udf
             # bridges (Phase C.2b).
             for arch in linux-x86_64 linux-aarch64 darwin-arm64; do
-              for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js sqlite sqlite-lua sqlite-js; do
+              for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js sqlite sqlite-lua sqlite-js image image-lua image-js; do
                 f="platforms/platform-features-$arch/libhull_feature-$stem.a"
                 sha256sum "$f" \
                   | awk -v n="libhull_feature-$stem.$arch.a" '{print $1"  "n}'
@@ -594,7 +599,7 @@ jobs:
           # name (libhull_feature-<stem>.<arch>.a), or the runtime §5c check on
           # every app this hull builds would fail. Includes the SQLite engine
           # (sqlite) + udf bridges (sqlite-lua/sqlite-js).
-          for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js sqlite sqlite-lua sqlite-js; do
+          for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js sqlite sqlite-lua sqlite-js image image-lua image-js; do
             fa="build/libhull_feature-$stem.a"
             name="libhull_feature-$stem.${{ matrix.name }}.a"
             fact=$(sha256sum "$fa" | awk '{print $1}')

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ Hull's distribution is one binary; what's compiled into it is controlled by a sm
 | `HL_ENABLE_TCC` | 1 Linux / 0 macOS+cosmo | Compile the tcc backend for `hull build --compiler=tcc`. tcc is **not embedded** (~400 KB lighter binary) — it's a side-loaded tool (`hull tools install tcc`), resolved at build time from `~/.hull/tools` → `dirname(hull)` → `$PATH`. Off on macOS (Mach-O) / cosmo (APE archives), where tcc's ELF output is unusable and the system compiler is used instead. |
 | `HL_EMBED_CA_BUNDLE` | 1 | Drop Mozilla CA bundle (~200 KB, breaks HTTPS without system store) |
 | `HL_ENABLE_SQLITE` | 1 | Drop the SQLite backend (`cap/db_sqlite.c`, `cap/db_udf.c`, vendored `sqlite3.c`). A SQLite file path or `:memory:` DSN then has no backend. |
-| `HL_ENABLE_IMAGE` | 1 | Drop the image codec subsystem (`cap/image.c`, `cap/image_stb.c`, per-runtime `mod_image`, and vendored `stb_image` — image's **sole** consumer, ~146 KB). Subtractive knob like `HL_ENABLE_DB` (on by default: web apps want avatars/thumbnails). `hull/image` then fails module resolution unless declared optional (`"hull/image@1?"` → `require` returns nil). The GPU texture paths that take/return an `HlImage` (`gpu.texture(img)`, `gpu.texture_read`/`textureRead`) are gated out too, so a `GPU=1 IMAGE=0` build keeps raw-byte textures but not the image bridge. See "Image-less builds" below. |
+| `HL_ENABLE_IMAGE` | 1 | Drop the image codec subsystem (`cap/image.c`, `cap/image_stb.c`, per-runtime `mod_image`, and vendored `stb_image` — image's **sole** consumer, ~146 KB). **Two-mode knob:** at the default `=1` the base is IMAGE-LESS and auto-composes the image feature (`libhull_feature-image.a` + `-image-<rt>.a`, embedded in hull) back for apps that declare `hull/image` (the `needs_image` gate; see "Composable runtime + HTTP base"). `=0` is the subtractive path — drops image entirely (no feature to compose, like `HL_ENABLE_DB=0`). `hull/image` then fails module resolution unless declared optional (`"hull/image@1?"` → `require` returns nil). The GPU texture paths that take/return an `HlImage` (`gpu.texture(img)`, `gpu.texture_read`/`textureRead`) stay `#ifdef HL_ENABLE_IMAGE`-gated, so a `GPU=1 IMAGE=0` build keeps raw-byte textures but not the image bridge. See "Image-less builds" below and [docs/image_feature.md](docs/image_feature.md). |
 | `HL_ENABLE_POSTGRES` | 0 | (Off by default.) On compiles the pure-C PostgreSQL wire backend (`cap/pgwire.c` + `cap/pg_conn.c` + `cap/db_postgres.c`; no libpq) into the base. A `postgres://` / `postgresql://` DSN selects it. Links the shared TLS client (`HL_LINK_TLS`) for SSL connections. Normally composed via the `postgres` **feature** (`hull build --with=postgres`) rather than set directly; the flag is the monolithic path and what `make feature-postgres` builds the archive with. See "Composable features" above and "PostgreSQL + multi-backend DB" below. |
 | `HL_ENABLE_MYSQL` | 0 | (Off by default.) On compiles the pure-C MySQL / MariaDB wire backend (`cap/mysqlwire.c` + `cap/mysql_conn.c` + `cap/db_mysql.c`; no libmysql/libmariadb) into the base. A `mysql://` / `mariadb://` DSN selects it. Links the shared TLS client (`HL_LINK_TLS`). Normally composed via the `mysql` **feature** (`hull build --with=mysql`) rather than set directly; the flag is the monolithic path and what `make feature-mysql` builds the archive with. See "Composable features" above and "MySQL/MariaDB specifics" below. |
 | `HL_ENABLE_DB` | 1 | **Umbrella, derived** from the three granular flags: defined iff `HL_ENABLE_SQLITE`, `HL_ENABLE_POSTGRES`, or `HL_ENABLE_MYSQL` is on. Off (all granular off) drops `db.*` + `migrate.*` + worker-DB + the connection registry + DB-backed stdlib (session, ratelimit, idempotency, outbox, inbox, rbac, search). ~1.4 MB smaller. See "Compute-only builds" below. |
@@ -276,6 +276,8 @@ What the native base **drops** and what composes it back at `hull build`:
 | the WASM caps + WAMR (`cap/wasm*`, `worker_wasm`, ~256 KB of vendored WAMR) | `libhull_feature-wasm.a` | only when the app needs compute (the `needs_wasm` gate below) |
 | the per-runtime compute binding (`mod_compute` — `compute.*` + the `WasmBuffer` userdata) | `libhull_feature-wasm-<rt>.a` | with the wasm core, only when the app needs compute |
 | the per-runtime tui bridge | `libhull_feature-tui-<rt>.a` (the tui cap core stays the installable `--with=tui` asset) | with `--with=tui`, only the app's runtime's bridge |
+| the image codec caps + vendored stb (`cap/image`, `cap/image_stb`, `stb_impl`, ~146 KB) | `libhull_feature-image.a` | only when the app declares `hull/image` (the `needs_image` gate below) |
+| the per-runtime image binding (`mod_image` — `image.*` + the `HlImage` userdata) | `libhull_feature-image-<rt>.a` | with the image core, only when the app declares `hull/image` |
 
 **The seam.** Each dropped piece leaves a **weak no-op default** in the base that
 a **strong override** in the composed archive replaces (mirrors the gpu/tui
@@ -287,10 +289,28 @@ header): `src/hull/wasm_weakstub.c` carries weak `hl_cap_wasm_*` / `hl_wasm_buff
 defaults (referenced by `db_udf` / `mod_buffer` / `mod_image` / `mod_gpu` /
 `app_context` / `serve`) plus the per-runtime compute-binding stubs — so a WASM-free
 app links; a function `db.udf` still works while a WASM-backed one fails closed.
+The IMAGE seam is weak-stubs-only too: `src/hull/image_weakstub.c` carries weak
+`hl_image_new`/`hl_image_free` (referenced by `mod_gpu`'s `gpu.texture_read`), and
+per-runtime `runtime/{lua,js}/image_stub.c` carry weak `luaopen_hull_image` /
+`hl_js_init_image_module` (referenced by `modules.c`'s registration) — so an
+image-free app links, and `HL_ENABLE_IMAGE` stays **defined** in the base
+(resolver keeps reporting the cap; `modules.c`/`mod_gpu` need no `#ifdef` change).
 The archives are whole-archived at compose (no single anchor symbol), inside a
 GNU-ld `--start-group` (native) / `-force_load` (ld64) with the platform lib + Keel,
 since the caps reference base symbols + Keel and the web/compute bindings reference
 the caps.
+
+**"Needs IMAGE" is module-inferred.** `hull build` composes the image codec core +
+the per-runtime image bridge only when the resolved manifest declares `hull/image`
+(`req_caps & HL_MOD_CAP_IMAGE`, exposed as `needs_image` from
+`tool.modules_resolve`, mirrors `needs_http`/`needs_wasm`). Unlike WASM this needs
+no second signal: the only reachable `HlImage` producer is the `image` module
+itself, so a declared `hull/image` is the whole gate. An image-free app links
+**zero** stb (~146 KB smaller; `nm app | grep stbi_load_from_memory` → empty). The
+subtractive `make HL_ENABLE_IMAGE=0` knob still exists (drops image entirely, no
+feature to compose); the composable path is the default `HL_ENABLE_IMAGE=1` base.
+See [docs/image_feature.md](docs/image_feature.md); covered by
+`tests/e2e_feature_image.sh`.
 
 **"Needs HTTP" is resolved, not guessed.** `hull build` composes the http core +
 web bindings only when the resolved manifest trips an HTTP cap

--- a/Makefile
+++ b/Makefile
@@ -2048,6 +2048,13 @@ HTTP_WEAKSTUB_OBJ := $(BUILDDIR)/http_weakstub.o
 # cap_wasm* defs win while WAMR is still compiled in (the base flip is Phase 1).
 WASM_WEAKSTUB_OBJ := $(BUILDDIR)/wasm_weakstub.o
 
+# IMAGE-as-a-feature seam (docs/image_feature.md). Weak, fail-closed defaults for
+# the two runtime-agnostic image cap symbols base objects reference (mod_gpu:
+# gpu.texture_read builds an HlImage, the paired free), so an image-less base
+# links. The strong cap_image defs win when the image feature is composed (or on
+# a cosmo full base). Mirrors WASM_WEAKSTUB_OBJ.
+IMAGE_WEAKSTUB_OBJ := $(BUILDDIR)/image_weakstub.o
+
 # ── Stdlib embedding (xxd) ──────────────────────────────────────────
 #
 # Two Lua source trees feed the embedded stdlib registry:
@@ -2665,22 +2672,31 @@ FEATURE_HTTP_OBJS := $(BUILDDIR)/cap_http.o $(BUILDDIR)/cap_http_async.o \
 # keeps the wasm_weakstub.c weak defaults (Phase 0) so a compute-less app links.
 FEATURE_WASM_OBJS := $(BUILDDIR)/cap_wasm.o $(BUILDDIR)/cap_wasm_buffer.o \
                      $(BUILDDIR)/cap_wasm_data.o $(BUILDDIR)/cap_wasm_stream.o
+# IMAGE as a composable feature (docs/image_feature.md). The runtime-AGNOSTIC
+# codec caps move into libhull_feature-image.a (with vendored stb) and compose
+# back at `hull build`; the per-runtime binding (mod_image) moves into
+# libhull_feature-image-<rt>.a. The base keeps image_weakstub.c so an image-less
+# app links. Mirrors FEATURE_WASM_OBJS.
+FEATURE_IMAGE_OBJS := $(BUILDDIR)/cap_image.o $(BUILDDIR)/cap_image_stb.o
 ifdef COSMO
   PLATFORM_RT_OBJS       := $(RT_OBJS)
   PLATFORM_MANIFEST_OBJ  := $(MANIFEST_OBJ)
   PLATFORM_RUNTIME_EXTRA := $(STDLIB_RT_REGISTRY_OBJS) $(STDLIB_TOOLCHAIN_REGISTRY_O) $(RUNTIME_TOOLCHAIN_REGISTRY_O) $(VEND_OBJS)
   PLATFORM_CAP_OBJS      := $(CAP_OBJS)                 # cosmo stays full (features native-only)
+  PLATFORM_STB_OBJ       := $(STB_OBJ)                  # cosmo base bundles stb (cap_image stays in-base)
 else
   PLATFORM_RT_OBJS       := $(RUNTIME_CACHE_COMMON_OBJ)  # runtime-agnostic; VMs dropped
   PLATFORM_MANIFEST_OBJ  := $(BUILDDIR)/manifest.o       # runtime-agnostic
   PLATFORM_RUNTIME_EXTRA :=
   # HTTP core caps move to libhull_feature-http.a; the wasm caps move to
-  # libhull_feature-wasm.a (docs/wasm_feature.md, Phase 1). Both compose back at
-  # `hull build`; the base keeps the weak stubs (http_weakstub / wasm_weakstub).
-  PLATFORM_CAP_OBJS      := $(filter-out $(FEATURE_HTTP_OBJS) $(FEATURE_WASM_OBJS),$(CAP_OBJS))
+  # libhull_feature-wasm.a (docs/wasm_feature.md, Phase 1); the image codec caps
+  # move to libhull_feature-image.a (docs/image_feature.md). All compose back at
+  # `hull build`; the base keeps the weak stubs (http/wasm/image_weakstub).
+  PLATFORM_CAP_OBJS      := $(filter-out $(FEATURE_HTTP_OBJS) $(FEATURE_WASM_OBJS) $(FEATURE_IMAGE_OBJS),$(CAP_OBJS))
+  PLATFORM_STB_OBJ       :=                              # stb moves into libhull_feature-image.a
 endif
-PLATFORM_OBJS := $(PLATFORM_CAP_OBJS) $(CAP_TOOL_OBJ) $(CAP_TEST_OBJ) $(CMD_OBJS) $(PLATFORM_RT_OBJS) $(ALLOC_OBJ) $(ASYNC_OBJ) $(COMPRESS_OBJ) $(MINIZ_OBJ) $(WORKER_DB_OBJ) $(WORKER_GPU_OBJ) $(PLATFORM_MANIFEST_OBJ) $(MODULE_OBJ) $(ASYNC_BACKEND_OBJS) $(NET_BACKEND_OBJS) $(SANDBOX_OBJ) $(SANDBOX_TOOL_OBJ) $(SIG_OBJ) $(RELEASE_OBJ) $(RELEASE_IO_OBJ) $(TOOLS_INSTALL_OBJ) $(PLATFORM_SIG_OBJ) $(EMBEDDED_PLATFORM_SIG_OBJ) $(TEST_RUNNER_OBJ) $(RUNTIME_FACTORY_OBJ) $(STATIC_OBJ) $(MIGRATE_OBJ) $(VFS_OBJ) $(PATH_NORM_OBJ) $(THREAD_AFFINITY_OBJ) $(CACHE_DIR_OBJ) $(BLOB_STORE_OBJ) $(CACHE_REGISTRY_OBJ) $(CACERT_OBJ) $(TLS_CLIENT_OBJ) $(CSP_OBJ) $(SBOM_OBJ) $(STDLIB_FEATURE_OBJ) $(APP_CONTEXT_OBJ) $(APP_CONTEXT_RT_OBJ) $(AGENT_LIB_OBJ) $(AGENT_API_OBJ) $(MAIN_OBJ) $(SERVE_OBJ) $(APP_RUNNER_OBJ) $(HTTP_WEAKSTUB_OBJ) $(WASM_WEAKSTUB_OBJ) $(TOOL_OBJ) $(BUILD_ASSET_STUB_OBJ) $(STDLIB_REGISTRY_O) $(PLATFORM_RUNTIME_EXTRA) $(MBEDTLS_OBJS) \
-	$(SQLITE_OBJ) $(LOG_OBJ) $(LOG_LOCK_OBJ) $(SH_ARENA_OBJ) $(SH_JSON_OBJ) $(TWEETNACL_OBJ) $(STB_OBJ) $(PLEDGE_OBJS) \
+PLATFORM_OBJS := $(PLATFORM_CAP_OBJS) $(CAP_TOOL_OBJ) $(CAP_TEST_OBJ) $(CMD_OBJS) $(PLATFORM_RT_OBJS) $(ALLOC_OBJ) $(ASYNC_OBJ) $(COMPRESS_OBJ) $(MINIZ_OBJ) $(WORKER_DB_OBJ) $(WORKER_GPU_OBJ) $(PLATFORM_MANIFEST_OBJ) $(MODULE_OBJ) $(ASYNC_BACKEND_OBJS) $(NET_BACKEND_OBJS) $(SANDBOX_OBJ) $(SANDBOX_TOOL_OBJ) $(SIG_OBJ) $(RELEASE_OBJ) $(RELEASE_IO_OBJ) $(TOOLS_INSTALL_OBJ) $(PLATFORM_SIG_OBJ) $(EMBEDDED_PLATFORM_SIG_OBJ) $(TEST_RUNNER_OBJ) $(RUNTIME_FACTORY_OBJ) $(STATIC_OBJ) $(MIGRATE_OBJ) $(VFS_OBJ) $(PATH_NORM_OBJ) $(THREAD_AFFINITY_OBJ) $(CACHE_DIR_OBJ) $(BLOB_STORE_OBJ) $(CACHE_REGISTRY_OBJ) $(CACERT_OBJ) $(TLS_CLIENT_OBJ) $(CSP_OBJ) $(SBOM_OBJ) $(STDLIB_FEATURE_OBJ) $(APP_CONTEXT_OBJ) $(APP_CONTEXT_RT_OBJ) $(AGENT_LIB_OBJ) $(AGENT_API_OBJ) $(MAIN_OBJ) $(SERVE_OBJ) $(APP_RUNNER_OBJ) $(HTTP_WEAKSTUB_OBJ) $(WASM_WEAKSTUB_OBJ) $(IMAGE_WEAKSTUB_OBJ) $(TOOL_OBJ) $(BUILD_ASSET_STUB_OBJ) $(STDLIB_REGISTRY_O) $(PLATFORM_RUNTIME_EXTRA) $(MBEDTLS_OBJS) \
+	$(SQLITE_OBJ) $(LOG_OBJ) $(LOG_LOCK_OBJ) $(SH_ARENA_OBJ) $(SH_JSON_OBJ) $(TWEETNACL_OBJ) $(PLATFORM_STB_OBJ) $(PLEDGE_OBJS) \
 	$(COMPILER_OBJ) $(COMPILER_TCC_OBJ)
 
 PLATFORM_LIB := $(BUILDDIR)/libhull_platform.a
@@ -3047,6 +3063,45 @@ feature-sqlite-js: $(BUILDDIR)/libhull_feature-sqlite-js.a
 $(BUILDDIR)/libhull_feature-sqlite-js.a: $(BUILDDIR)/js_mod_db_udf.o | $(BUILDDIR)
 	$(call AR_FEATURE_LIB,$(BUILDDIR)/js_mod_db_udf.o)
 
+# libhull_feature-image.a: the runtime-agnostic image CODEC core
+# (docs/image_feature.md). Bundles the codec vtable + stb backend + vendored stb
+# (~146 KB that leaves the base). Composed back at `hull build` and embedded in
+# hull (embedded_image.h). The per-runtime image binding (mod_image) is a
+# separate archive below, like the wasm compute bridge.
+FEATURE_IMAGE_CORE := $(FEATURE_IMAGE_OBJS) $(STB_OBJ)
+feature-image: $(BUILDDIR)/libhull_feature-image.a
+.PHONY: feature-image
+$(BUILDDIR)/libhull_feature-image.a: $(FEATURE_IMAGE_CORE) | $(BUILDDIR)
+	$(call AR_FEATURE_LIB,$(FEATURE_IMAGE_CORE))
+
+# Per-runtime image-binding bridges (mod_image). Tiny (one object each);
+# embedded in hull + composed for the app's runtime alongside the image core.
+feature-image-lua: $(BUILDDIR)/libhull_feature-image-lua.a
+.PHONY: feature-image-lua
+$(BUILDDIR)/libhull_feature-image-lua.a: $(BUILDDIR)/lua_rt_mod_image.o | $(BUILDDIR)
+	$(call AR_FEATURE_LIB,$(BUILDDIR)/lua_rt_mod_image.o)
+
+feature-image-js: $(BUILDDIR)/libhull_feature-image-js.a
+.PHONY: feature-image-js
+$(BUILDDIR)/libhull_feature-image-js.a: $(BUILDDIR)/js_mod_image.o | $(BUILDDIR)
+	$(call AR_FEATURE_LIB,$(BUILDDIR)/js_mod_image.o)
+
+# Gate the image archives behind HL_ENABLE_IMAGE: on the subtractive image-less
+# flavor (make HL_ENABLE_IMAGE=0) cap_image.o + stb aren't built, so the archives
+# can't (and needn't) build. These vars resolve empty there so FEATURE_ARCHIVES /
+# RUNTIME_FEATURE_LIBS / the embed don't pull them.
+ifeq ($(HL_ENABLE_IMAGE),1)
+IMG_FEATURE_CORE := $(BUILDDIR)/libhull_feature-image.a
+IMG_FEATURE_LUA  := $(BUILDDIR)/libhull_feature-image-lua.a
+IMG_FEATURE_JS   := $(BUILDDIR)/libhull_feature-image-js.a
+IMG_FEATURE_LIBS := $(IMG_FEATURE_CORE) $(IMG_FEATURE_LUA) $(IMG_FEATURE_JS)
+else
+IMG_FEATURE_CORE :=
+IMG_FEATURE_LUA  :=
+IMG_FEATURE_JS   :=
+IMG_FEATURE_LIBS :=
+endif
+
 # libhull_feature-lua.a / -js.a: a runtime as a composable feature archive.
 # Bundles the runtime objects, its vendored VM, its manifest extractor, and its
 # stdlib VFS array (hl_stdlib_<rt>_entries). The tui bridge (mod_tui) is excluded
@@ -3069,9 +3124,9 @@ FEATURE_HTTP_RT_NAMES := mod_ws_server mod_ws_client mod_http_server mod_sse \
 FEATURE_HTTP_LUA_OBJS := $(addprefix $(BUILDDIR)/lua_rt_,$(addsuffix .o,$(FEATURE_HTTP_RT_NAMES)))
 FEATURE_HTTP_JS_OBJS  := $(addprefix $(BUILDDIR)/js_,$(addsuffix .o,$(FEATURE_HTTP_RT_NAMES)))
 
-FEATURE_LUA_OBJS := $(filter-out $(BUILDDIR)/lua_rt_mod_tui.o $(BUILDDIR)/lua_rt_mod_tool.o $(BUILDDIR)/lua_rt_mod_compute.o $(BUILDDIR)/lua_rt_mod_db_udf.o $(FEATURE_HTTP_LUA_OBJS),$(LUA_RT_OBJS)) \
+FEATURE_LUA_OBJS := $(filter-out $(BUILDDIR)/lua_rt_mod_tui.o $(BUILDDIR)/lua_rt_mod_tool.o $(BUILDDIR)/lua_rt_mod_compute.o $(BUILDDIR)/lua_rt_mod_db_udf.o $(BUILDDIR)/lua_rt_mod_image.o $(FEATURE_HTTP_LUA_OBJS),$(LUA_RT_OBJS)) \
                     $(LUA_OBJS) $(BUILDDIR)/manifest_lua.o $(STDLIB_LUA_REGISTRY_O)
-FEATURE_JS_OBJS  := $(filter-out $(BUILDDIR)/js_mod_tui.o $(BUILDDIR)/js_mod_compute.o $(BUILDDIR)/js_mod_db_udf.o $(FEATURE_HTTP_JS_OBJS),$(JS_RT_OBJS)) \
+FEATURE_JS_OBJS  := $(filter-out $(BUILDDIR)/js_mod_tui.o $(BUILDDIR)/js_mod_compute.o $(BUILDDIR)/js_mod_db_udf.o $(BUILDDIR)/js_mod_image.o $(FEATURE_HTTP_JS_OBJS),$(JS_RT_OBJS)) \
                     $(QJS_OBJS) $(BUILDDIR)/manifest_js.o $(STDLIB_JS_REGISTRY_O)
 
 feature-lua: $(BUILDDIR)/libhull_feature-lua.a
@@ -3111,7 +3166,8 @@ FEATURE_ARCHIVES := $(BUILDDIR)/libhull_feature-lua.a $(BUILDDIR)/libhull_featur
                     $(BUILDDIR)/libhull_feature-tui-lua.a $(BUILDDIR)/libhull_feature-tui-js.a \
                     $(BUILDDIR)/libhull_feature-wasm.a \
                     $(BUILDDIR)/libhull_feature-wasm-lua.a $(BUILDDIR)/libhull_feature-wasm-js.a \
-                    $(BUILDDIR)/libhull_feature-sqlite-lua.a $(BUILDDIR)/libhull_feature-sqlite-js.a
+                    $(BUILDDIR)/libhull_feature-sqlite-lua.a $(BUILDDIR)/libhull_feature-sqlite-js.a \
+                    $(IMG_FEATURE_LIBS)
 $(FEATURE_ARCHIVES): Makefile
 # The base platform lib is built from an object LIST (PLATFORM_OBJS); a Phase-1
 # change to that list (wasm caps + WAMR removed) must retrigger the ar, which an
@@ -3132,19 +3188,25 @@ $(PLATFORM_LIB): Makefile
 ifndef COSMO
 ifeq ($(RUNTIME),js)
   RUNTIME_FEATURE_LIBS := $(BUILDDIR)/libhull_feature-js.a $(BUILDDIR)/libhull_feature-http-js.a \
-                          $(BUILDDIR)/libhull_feature-wasm-js.a $(BUILDDIR)/libhull_feature-sqlite-js.a
+                          $(BUILDDIR)/libhull_feature-wasm-js.a $(BUILDDIR)/libhull_feature-sqlite-js.a \
+                          $(IMG_FEATURE_JS)
 else ifeq ($(RUNTIME),lua)
   RUNTIME_FEATURE_LIBS := $(BUILDDIR)/libhull_feature-lua.a $(BUILDDIR)/libhull_feature-http-lua.a \
-                          $(BUILDDIR)/libhull_feature-wasm-lua.a $(BUILDDIR)/libhull_feature-sqlite-lua.a
+                          $(BUILDDIR)/libhull_feature-wasm-lua.a $(BUILDDIR)/libhull_feature-sqlite-lua.a \
+                          $(IMG_FEATURE_LUA)
 else
   RUNTIME_FEATURE_LIBS := $(BUILDDIR)/libhull_feature-lua.a $(BUILDDIR)/libhull_feature-http-lua.a \
                           $(BUILDDIR)/libhull_feature-wasm-lua.a $(BUILDDIR)/libhull_feature-sqlite-lua.a \
+                          $(IMG_FEATURE_LUA) \
                           $(BUILDDIR)/libhull_feature-js.a $(BUILDDIR)/libhull_feature-http-js.a \
-                          $(BUILDDIR)/libhull_feature-wasm-js.a $(BUILDDIR)/libhull_feature-sqlite-js.a
+                          $(BUILDDIR)/libhull_feature-wasm-js.a $(BUILDDIR)/libhull_feature-sqlite-js.a \
+                          $(IMG_FEATURE_JS)
 endif
-  # HTTP + WASM core feature archives (runtime-agnostic), composed for every
-  # full-flavor app (docs/wasm_feature.md, Phase 1 composes wasm always).
-  RUNTIME_FEATURE_LIBS += $(BUILDDIR)/libhull_feature-http.a $(BUILDDIR)/libhull_feature-wasm.a
+  # HTTP + WASM + IMAGE core feature archives (runtime-agnostic), composed for
+  # every full-flavor app (docs/wasm_feature.md, Phase 1 composes wasm always).
+  # IMG_FEATURE_CORE is empty on an image-less base (HL_ENABLE_IMAGE=0).
+  RUNTIME_FEATURE_LIBS += $(BUILDDIR)/libhull_feature-http.a $(BUILDDIR)/libhull_feature-wasm.a \
+                          $(IMG_FEATURE_CORE)
 else
   RUNTIME_FEATURE_LIBS :=
 endif
@@ -3323,8 +3385,19 @@ $(EMBEDDED_SQLITE_RT_H): $(BUILDDIR)/libhull_feature-sqlite-lua.a $(BUILDDIR)/li
 	@xxd -i $(BUILDDIR)/libhull_feature-sqlite-lua.a | sed 's/build_libhull_feature_sqlite_lua_a/hl_embedded_feature_sqlite_lua_a/g' | $(XXD_CONST_PIPE) >> $@
 	@xxd -i $(BUILDDIR)/libhull_feature-sqlite-js.a  | sed 's/build_libhull_feature_sqlite_js_a/hl_embedded_feature_sqlite_js_a/g'   | $(XXD_CONST_PIPE) >> $@
 
-CFLAGS += -DHL_BUILD_EMBEDDED -DHL_BUILD_EMBEDDED_RUNTIME -DHL_BUILD_EMBEDDED_HTTP -DHL_BUILD_EMBEDDED_TUI -DHL_BUILD_EMBEDDED_WASM -DHL_BUILD_EMBEDDED_SQLITE_RT
-$(BUILD_ASSET_OBJ): $(EMBEDDED_PLATFORM_H) $(EMBEDDED_TEMPLATES_H) $(EMBEDDED_RUNTIME_H) $(EMBEDDED_HTTP_H) $(EMBEDDED_TUI_H) $(EMBEDDED_WASM_H) $(EMBEDDED_SQLITE_RT_H)
+# Embed the image feature archives too (docs/image_feature.md). The native base
+# is image-less; the default distributed hull composes the image codec core + the
+# app's runtime image bridge back whenever the app declares hull/image, with no
+# install.
+EMBEDDED_IMAGE_H := $(BUILDDIR)/embedded_image.h
+$(EMBEDDED_IMAGE_H): $(BUILDDIR)/libhull_feature-image.a $(BUILDDIR)/libhull_feature-image-lua.a $(BUILDDIR)/libhull_feature-image-js.a | $(BUILDDIR)
+	@echo "/* Auto-generated - do not edit */" > $@
+	@xxd -i $(BUILDDIR)/libhull_feature-image.a     | sed 's/build_libhull_feature_image_a/hl_embedded_feature_image_a/g'         | $(XXD_CONST_PIPE) >> $@
+	@xxd -i $(BUILDDIR)/libhull_feature-image-lua.a | sed 's/build_libhull_feature_image_lua_a/hl_embedded_feature_image_lua_a/g' | $(XXD_CONST_PIPE) >> $@
+	@xxd -i $(BUILDDIR)/libhull_feature-image-js.a  | sed 's/build_libhull_feature_image_js_a/hl_embedded_feature_image_js_a/g'   | $(XXD_CONST_PIPE) >> $@
+
+CFLAGS += -DHL_BUILD_EMBEDDED -DHL_BUILD_EMBEDDED_RUNTIME -DHL_BUILD_EMBEDDED_HTTP -DHL_BUILD_EMBEDDED_TUI -DHL_BUILD_EMBEDDED_WASM -DHL_BUILD_EMBEDDED_SQLITE_RT -DHL_BUILD_EMBEDDED_IMAGE
+$(BUILD_ASSET_OBJ): $(EMBEDDED_PLATFORM_H) $(EMBEDDED_TEMPLATES_H) $(EMBEDDED_RUNTIME_H) $(EMBEDDED_HTTP_H) $(EMBEDDED_TUI_H) $(EMBEDDED_WASM_H) $(EMBEDDED_SQLITE_RT_H) $(EMBEDDED_IMAGE_H)
 
 # Phase D: when the app-build base is SQLite-less, embed the SQLite ENGINE
 # archive (cap/db_sqlite + vendored sqlite3 + FTS5 + udf cap + sqlite agent) so a
@@ -3750,6 +3823,9 @@ $(HTTP_WEAKSTUB_OBJ): $(SRCDIR)/hull/http_weakstub.c | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
 
 $(WASM_WEAKSTUB_OBJ): $(SRCDIR)/hull/wasm_weakstub.c | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
+
+$(IMAGE_WEAKSTUB_OBJ): $(SRCDIR)/hull/image_weakstub.c | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
 
 # Serve-cli (CLI counterpart, used when HL_ENABLE_HTTP_SERVER=0)
@@ -4400,6 +4476,10 @@ e2e-feature-wasm: $(BUILDDIR)/hull
 .PHONY: e2e-feature-sqlite
 e2e-feature-sqlite: $(BUILDDIR)/hull
 	sh tests/e2e_feature_sqlite.sh
+
+.PHONY: e2e-feature-image
+e2e-feature-image: $(BUILDDIR)/hull
+	sh tests/e2e_feature_image.sh
 
 e2e-multipart: $(BUILDDIR)/hull
 	RUNTIME=$(RUNTIME) sh tests/e2e_multipart.sh

--- a/docs/image_feature.md
+++ b/docs/image_feature.md
@@ -1,0 +1,97 @@
+# Image codecs as a composable feature
+
+The image codec subsystem (`hull/image`: decode/encode PNG/JPEG/BMP, raw pixel
+buffers, the `HlImage` userdata) is an **embedded, auto-composed feature** on the
+native base — the same mandatory-composition axis as the runtimes, HTTP, WASM, and
+the SQLite udf bridge (see CLAUDE.md "Composable runtime + HTTP base"). The native
+base platform lib is **image-less**; `hull build` composes the codec back only for
+apps that declare `hull/image`. You never `hull feature install` it — the archives
+ship inside the distributed `hull` and compose automatically.
+
+This is the [Step 1 slice](roadmap.md) of the broader "flavors become feature
+presets" direction: image was the cleanest remaining base-resident subsystem to
+extract, and it validates the auto-compose mechanism for a small, self-contained
+codec.
+
+## What moves where
+
+| Piece | From | To (composable archive) |
+|-------|------|-------------------------|
+| codec vtable + stb backend + vendored stb | base `libhull_platform.a` | `libhull_feature-image.a` (runtime-agnostic core) |
+| the `image.*` binding + `HlImage` userdata (`mod_image`) | the per-runtime base archive | `libhull_feature-image-<rt>.a` |
+
+Both are embedded in hull (`embedded_image.h`, via the Makefile's
+`EMBEDDED_IMAGE_H`) and extracted + whole-archived at `hull build`, exactly like
+the WASM core + compute bridge.
+
+## The seam
+
+`HL_ENABLE_IMAGE` stays **defined** in the base (like `HL_ENABLE_WASM`), so:
+
+- the resolver keeps reporting `HL_MOD_CAP_IMAGE` (an image app passes module
+  resolution on the base), and
+- `modules.c`'s registration + `mod_gpu`'s `#ifdef HL_ENABLE_IMAGE` texture paths
+  compile unchanged.
+
+The engine objects are filtered out of the base and replaced by weak stubs:
+
+- **cap-level** (`src/hull/image_weakstub.c`, runtime-agnostic, in the base
+  platform lib): weak `hl_image_new` / `hl_image_free`, referenced by
+  `mod_gpu`'s `gpu.texture_read` (which builds an `HlImage` to return). When the
+  image feature is composed the strong `cap/image.c` defs win; when not, the weak
+  no-ops satisfy the link (`gpu.texture_read` fails closed — returns nothing).
+- **per-runtime** (`src/hull/runtime/{lua,js}/image_stub.c`, in the runtime
+  feature archive): weak `luaopen_hull_image` (Lua) / `hl_js_init_image_module`
+  (JS), referenced by `modules.c`'s unconditional registration. The strong
+  `mod_image.o` (in the composed bridge) overrides.
+
+Mirrors `wasm_weakstub.c` + `runtime/{lua,js}/wasm_stub.c` exactly.
+
+## The gate
+
+`hull build` composes the image core + the per-runtime bridge iff the resolved
+manifest declares `hull/image` (`req_caps & HL_MOD_CAP_IMAGE`, exposed as
+`needs_image` from `tool.modules_resolve`, alongside `needs_http`/`needs_wasm`/
+`needs_sqlite`). Unlike WASM, no second signal is needed: the only reachable
+`HlImage` producer is the `image` module itself, so a declared `hull/image` is the
+whole gate.
+
+- A genuinely image-free app links **zero** stb (~146 KB smaller). Verify:
+  `nm app | grep stbi_load_from_memory` → empty.
+- The base defines zero image engine symbols. Verify:
+  `nm libhull_platform.a | grep stbi_load_from_memory` → empty (only the
+  `image_weakstub` weak `hl_image_new` remains).
+
+## `HL_ENABLE_IMAGE=0` (the subtractive knob) still works
+
+The composable path is the default `HL_ENABLE_IMAGE=1` base. `make
+HL_ENABLE_IMAGE=0` is the older **subtractive** flavor: it drops `cap/image` +
+stb + `mod_image` at compile time (there is no feature to compose), for a
+compute/CLI/signing binary that never touches images. `hull/image` then needs an
+optional `"hull/image@1?"` declaration to resolve (a non-optional decl is a hard
+load error). The image feature archives are gated out of the build under
+`HL_ENABLE_IMAGE=0` (`IMG_FEATURE_*` resolve empty), so `make HL_ENABLE_IMAGE=0`
+never tries to build them from the (filtered-out) `cap_image.o`.
+
+## Cosmo
+
+Cosmo can't force-load native feature archives, so its fat-APE base keeps the
+image codec compiled in (like the runtimes, HTTP, and WASM). The image-less base
++ compose model is native-only.
+
+## Composed-feature signing
+
+The three image archives ship inside the distributed `hull`, so they land in the
+`platform_domain` of `package.sig.gethull.composed` (platform-key attested,
+runtime §5c FATAL on tamper) — the same trust chain as the runtime/HTTP/WASM
+archives. `release.yml` builds + signs the `image` / `image-lua` / `image-js`
+stems into the platform manifest and embeds those exact bytes
+(`TRUST_FEATURE_LIBS=1`). See [docs/composed_feature_signing.md](composed_feature_signing.md).
+
+## Tests
+
+`tests/e2e_feature_image.sh` (`make e2e-feature-image`): asserts the base is
+image-less (0 stb symbols), an image app (Lua + JS) composes the feature and a
+create → encode-PNG → decode round-trip runs in the produced binary, and an
+image-free app links zero stb and still runs. The subtractive `HL_ENABLE_IMAGE=0`
+link is covered by the `flavors` CI matrix.

--- a/include/hull/build_assets.h
+++ b/include/hull/build_assets.h
@@ -71,6 +71,8 @@ int hl_build_extract_feature_wasm(const char *dir);
 int hl_build_extract_feature_wasm_rt(const char *dir, const char *rt);
 int hl_build_extract_feature_sqlite_rt(const char *dir, const char *rt);
 int hl_build_extract_feature_sqlite(const char *dir);
+int hl_build_extract_feature_image(const char *dir);
+int hl_build_extract_feature_image_rt(const char *dir, const char *rt);
 
 /*
  * Get the list of embedded platform archives (multi-arch builds).

--- a/src/hull/build_assets.c
+++ b/src/hull/build_assets.c
@@ -35,6 +35,9 @@
 #ifdef HL_BUILD_EMBEDDED_SQLITE
 #include "embedded_sqlite.h"    /* hl_embedded_feature_sqlite_a[] (engine) */
 #endif
+#ifdef HL_BUILD_EMBEDDED_IMAGE
+#include "embedded_image.h"     /* hl_embedded_feature_image{,_lua,_js}_a[] */
+#endif
 
 /* ── Helper: write data to a file ──────────────────────────────────── */
 
@@ -45,7 +48,8 @@
 #if defined(HL_BUILD_EMBEDDED) || defined(HL_BUILD_EMBEDDED_MULTIARCH) \
     || defined(HL_BUILD_EMBEDDED_RUNTIME) || defined(HL_BUILD_EMBEDDED_HTTP) \
     || defined(HL_BUILD_EMBEDDED_TUI) || defined(HL_BUILD_EMBEDDED_WASM) \
-    || defined(HL_BUILD_EMBEDDED_SQLITE) || defined(HL_BUILD_EMBEDDED_SQLITE_RT)
+    || defined(HL_BUILD_EMBEDDED_SQLITE) || defined(HL_BUILD_EMBEDDED_SQLITE_RT) \
+    || defined(HL_BUILD_EMBEDDED_IMAGE)
 static int write_blob(const char *path, const unsigned char *data, size_t len)
 {
     FILE *f = fopen(path, "wb");
@@ -275,6 +279,48 @@ int hl_build_extract_feature_wasm_rt(const char *dir, const char *rt)
     }
     char path[1024];
     int n = snprintf(path, sizeof(path), "%s/libhull_feature-wasm-%s.a", dir, rt);
+    if (n < 0 || (size_t)n >= sizeof(path))
+        return -1;
+    return write_blob(path, data, len);
+#else
+    (void)dir; (void)rt;
+    return -1;
+#endif
+}
+
+int hl_build_extract_feature_image(const char *dir)
+{
+#ifdef HL_BUILD_EMBEDDED_IMAGE
+    if (!dir)
+        return -1;
+    char path[1024];
+    int n = snprintf(path, sizeof(path), "%s/libhull_feature-image.a", dir);
+    if (n < 0 || (size_t)n >= sizeof(path))
+        return -1;
+    return write_blob(path, hl_embedded_feature_image_a,
+                      hl_embedded_feature_image_a_len);
+#else
+    (void)dir;
+    return -1;
+#endif
+}
+
+int hl_build_extract_feature_image_rt(const char *dir, const char *rt)
+{
+#ifdef HL_BUILD_EMBEDDED_IMAGE
+    if (!dir || !rt)
+        return -1;
+    const unsigned char *data = NULL;
+    unsigned int len = 0;
+    if (strcmp(rt, "lua") == 0) {
+        data = hl_embedded_feature_image_lua_a; len = hl_embedded_feature_image_lua_a_len;
+    } else if (strcmp(rt, "js") == 0) {
+        data = hl_embedded_feature_image_js_a;  len = hl_embedded_feature_image_js_a_len;
+    } else {
+        return -1;
+    }
+    char path[1024];
+    int n = snprintf(path, sizeof(path), "%s/libhull_feature-image-%s.a", dir, rt);
     if (n < 0 || (size_t)n >= sizeof(path))
         return -1;
     return write_blob(path, data, len);

--- a/src/hull/image_weakstub.c
+++ b/src/hull/image_weakstub.c
@@ -1,0 +1,34 @@
+/*
+ * image_weakstub.c — weak image-cap defaults for an image-less base.
+ *
+ * The image codec (cap/image.c + cap/image_stb.c + vendored stb) is a composable
+ * feature archive (libhull_feature-image.a, docs/image_feature.md). The base
+ * runtime archive still references two of its cap symbols from mod_gpu
+ * (gpu.texture_read builds an HlImage to return; the paired free), so these weak
+ * no-ops satisfy the link when the image feature is NOT composed (an image-free
+ * app). When it IS composed, the strong defs in cap/image.c win. Neither body is
+ * reached in a way that matters: gpu.texture_read only produces an image when the
+ * app declared hull/image (needs_image -> the image feature is composed), and
+ * hl_image_free(NULL) is a no-op.
+ *
+ * Mirrors wasm_weakstub.c (the WASM seam). Runtime-agnostic — lives in the base
+ * platform lib, linked into both Lua-only and JS-only apps.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "hull/cap/image.h"
+
+__attribute__((weak)) HlImage *hl_image_new(uint32_t w, uint32_t h,
+                                            HlImageFormat fmt,
+                                            const void *pixels, size_t pixel_len,
+                                            HlAllocator *alloc)
+{
+    (void)w; (void)h; (void)fmt; (void)pixels; (void)pixel_len; (void)alloc;
+    return NULL;   /* image feature not composed; only satisfies the link */
+}
+
+__attribute__((weak)) void hl_image_free(HlImage *img)
+{
+    (void)img;   /* no HlImage exists without the feature; NULL-free is a no-op */
+}

--- a/src/hull/runtime/js/image_stub.c
+++ b/src/hull/runtime/js/image_stub.c
@@ -1,0 +1,25 @@
+/*
+ * image_stub.c — weak per-runtime image-binding default (JS).
+ *
+ * The image.* binding (mod_image) is a composable feature archive
+ * (libhull_feature-image-js.a, docs/image_feature.md). The pure runtime archive
+ * still references hl_js_init_image_module (modules.c's module register). When
+ * the image bridge is composed its strong def wins; when it is NOT (an
+ * image-free app, needs_image false) this weak no-op satisfies the link.
+ *
+ * Not reached in a way that matters: the JS module loader gates hull:image on
+ * the resolved module set (optional-absent -> a synthesized null export;
+ * non-optional -> hard error before load), so no real module is expected here.
+ *
+ * Mirrors wasm_stub.c (the compute seam).
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "mod_buffer.h"   /* hl_js_init_image_module decl, JSContext, HlJS */
+
+__attribute__((weak)) int hl_js_init_image_module(JSContext *ctx, HlJS *js)
+{
+    (void)ctx; (void)js;
+    return 0;   /* not registered meaningfully without the feature; satisfies link */
+}

--- a/src/hull/runtime/lua/image_stub.c
+++ b/src/hull/runtime/lua/image_stub.c
@@ -1,0 +1,25 @@
+/*
+ * image_stub.c — weak per-runtime image-binding default (Lua).
+ *
+ * The image.* binding (mod_image) is a composable feature archive
+ * (libhull_feature-image-lua.a, docs/image_feature.md). The pure runtime archive
+ * still references luaopen_hull_image (modules.c's module register). When the
+ * image bridge is composed its strong def wins; when it is NOT (an image-free
+ * app, needs_image false) this weak no-op satisfies the link.
+ *
+ * Not reached in a way that matters: hl_lua_require gates hull.image on the
+ * resolved module set (optional-absent -> nil; non-optional -> hard error before
+ * load), so the empty module this would register is never handed to app code.
+ *
+ * Mirrors wasm_stub.c (the compute seam).
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "mod_buffer.h"   /* luaopen_hull_image decl, lua_State */
+
+__attribute__((weak)) int luaopen_hull_image(lua_State *L)
+{
+    (void)L;
+    return 0;   /* not registered meaningfully without the feature; satisfies link */
+}

--- a/src/hull/runtime/lua/mod_tool.c
+++ b/src/hull/runtime/lua/mod_tool.c
@@ -547,6 +547,25 @@ static int l_tool_extract_feature_sqlite(lua_State *L)
     return 1;
 }
 
+/* ── tool.extract_feature_image(dir) / _image_rt(dir, rt) → bool ────── */
+
+static int l_tool_extract_feature_image(lua_State *L)
+{
+    const char *dir = luaL_checkstring(L, 1);
+    int rc = hl_build_extract_feature_image(dir);
+    lua_pushboolean(L, rc == 0);
+    return 1;
+}
+
+static int l_tool_extract_feature_image_rt(lua_State *L)
+{
+    const char *dir = luaL_checkstring(L, 1);
+    const char *rt  = luaL_checkstring(L, 2);
+    int rc = hl_build_extract_feature_image_rt(dir, rt);
+    lua_pushboolean(L, rc == 0);
+    return 1;
+}
+
 /* ── tool.extract_platform_cosmo(dir) → bool ───────────────────────── */
 /*
  * Extract both arch-specific archives and set up the .aarch64/ directory
@@ -1271,6 +1290,8 @@ static const luaL_Reg tool_funcs[] = {
     { "extract_feature_wasm_rt", l_tool_extract_feature_wasm_rt },
     { "extract_feature_sqlite_rt", l_tool_extract_feature_sqlite_rt },
     { "extract_feature_sqlite", l_tool_extract_feature_sqlite },
+    { "extract_feature_image",  l_tool_extract_feature_image },
+    { "extract_feature_image_rt", l_tool_extract_feature_image_rt },
     { "extract_platform_cosmo", l_tool_extract_platform_cosmo },
     { "platform_archs",         l_tool_platform_archs },
     /* Orchestration entries (modules_resolve, doctor_json, agent_*,

--- a/src/hull/tool_orchestration.c
+++ b/src/hull/tool_orchestration.c
@@ -249,6 +249,14 @@ static int l_tool_modules_resolve(lua_State *L)
     lua_pushboolean(L, (req_caps & HL_MOD_CAP_DB) ? 1 : 0);
     lua_setfield(L, -2, "needs_sqlite");
 
+    /* needs_image (image as a composable feature, docs/image_feature.md) = does
+     * the resolved set declare the image cap (hull/image)? Drives `hull build`'s
+     * decision to compose the image codec core + the per-runtime image bridge.
+     * Cleanly module-inferable (unlike wasm): the only reachable HlImage producer
+     * is the image module itself, so a declared hull/image is the whole gate. */
+    lua_pushboolean(L, (req_caps & HL_MOD_CAP_IMAGE) ? 1 : 0);
+    lua_setfield(L, -2, "needs_image");
+
     /* auto = the minimal build flavor that still satisfies this app's
      * declared modules (drives `hull build --flavor=auto`). Computed from
      * the resolved set's aggregate required-caps. */

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1729,6 +1729,12 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
             -- base, or composed as the engine feature by the Phase C block above),
             -- so the bridge's sqlite3_* references always resolve.
             local needs_sqlite = false
+            -- needs_image (docs/image_feature.md): the app declares hull/image, so
+            -- compose the image codec core + the per-runtime image bridge, which the
+            -- native base no longer carries. Cleanly module-inferable (the resolver's
+            -- HL_MOD_CAP_IMAGE); a genuinely image-free app links zero stb (~146 KB
+            -- smaller).
+            local needs_image = false
             do
                 local mf = extract_app_manifest(opts.app_dir)
                 if mf then
@@ -1736,6 +1742,7 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
                     if r.ok and r.needs_http ~= nil then needs_http = r.needs_http end
                     if r.ok and r.needs_wasm then needs_wasm = true end
                     if r.ok and r.needs_sqlite then needs_sqlite = true end
+                    if r.ok and r.needs_image then needs_image = true end
                 end
             end
 
@@ -1859,6 +1866,52 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
                 feature_libs[#feature_libs + 1] = f
             end
             print("hull build: composed SQLite udf bridge '" .. app_rt .. "'")
+            end
+
+            -- Compose the IMAGE feature (docs/image_feature.md). The native base is
+            -- image-less: the codec caps + vendored stb live in
+            -- libhull_feature-image.a and the image.* binding (mod_image) in
+            -- libhull_feature-image-<rt>.a. Composed only when needs_image (the app
+            -- declared hull/image); a genuinely image-free app links zero stb
+            -- (~146 KB smaller). Whole-archive both inside the --start-group.
+            if needs_image then
+            local img_lib = "libhull_feature-image.a"
+            local img_path, img_from = fcompose.resolve_image_lib(tmpdir,
+                                       { hull_dir = rt_hull_dir, plat = rt_plat })
+            if not img_path then
+                tool.stderr("hull build: the image feature lib (libhull_feature-image.a) "
+                    .. "was not found "
+                    .. (img_from == "cache-verify-failed"
+                        and "(cache re-verify failed)\n" or "(normally embedded in hull)\n"))
+                tool.stderr("hint: build it from source with `make feature-image`\n")
+                tool.rmdir(tmpdir); tool.exit(1)
+            end
+            local img_dest = tmpdir .. "/" .. img_lib
+            if img_path ~= img_dest then tool.copy(img_path, img_dest) end
+            record_composed("libhull_feature-image." .. (rt_plat or "") .. ".a",
+                            img_dest, "platform")
+            for _, f in ipairs(fcompose.whole_archive_flags(img_dest, is_darwin)) do
+                feature_libs[#feature_libs + 1] = f
+            end
+
+            local imgrt_lib = "libhull_feature-image-" .. app_rt .. ".a"
+            local imgrt_path, imgrt_from = fcompose.resolve_image_rt_lib(app_rt, tmpdir,
+                                           { hull_dir = rt_hull_dir, plat = rt_plat })
+            if not imgrt_path then
+                tool.stderr("hull build: the image-bindings feature lib (" .. imgrt_lib
+                    .. ") was not found "
+                    .. (imgrt_from == "cache-verify-failed"
+                        and "(cache re-verify failed)\n" or "(normally embedded in hull)\n"))
+                tool.rmdir(tmpdir); tool.exit(1)
+            end
+            local imgrt_dest = tmpdir .. "/" .. imgrt_lib
+            if imgrt_path ~= imgrt_dest then tool.copy(imgrt_path, imgrt_dest) end
+            record_composed("libhull_feature-image-" .. app_rt .. "."
+                            .. (rt_plat or "") .. ".a", imgrt_dest, "platform")
+            for _, f in ipairs(fcompose.whole_archive_flags(imgrt_dest, is_darwin)) do
+                feature_libs[#feature_libs + 1] = f
+            end
+            print("hull build: composed image feature + image bridge '" .. app_rt .. "'")
             end
 
             if needs_http then

--- a/stdlib/cli/lua/hull/feature_compose.lua
+++ b/stdlib/cli/lua/hull/feature_compose.lua
@@ -289,4 +289,32 @@ function M.resolve_sqlite_rt_lib(rt, tmpdir, ctx)
     return M.resolve_lib(libname, asset, ctx)
 end
 
+--- Resolve the image CODEC core archive (libhull_feature-image.a: the codec
+--- vtable + stb backend + vendored stb), embedded first (docs/image_feature.md).
+--- The native base is image-less and the default hull embeds the image core, so
+--- an app declaring hull/image composes it back with no `hull feature install`.
+--- Mirrors resolve_wasm_lib.
+function M.resolve_image_lib(tmpdir, ctx)
+    local libname = "libhull_feature-image.a"
+    if tool.extract_feature_image and tool.extract_feature_image(tmpdir)
+       and file_exists(tmpdir .. "/" .. libname) then
+        return tmpdir .. "/" .. libname, "embedded"
+    end
+    local asset = ctx.plat and ("libhull_feature-image-" .. ctx.plat .. ".a") or nil
+    return M.resolve_lib(libname, asset, ctx)
+end
+
+--- Resolve the per-runtime image bridge (libhull_feature-image-<rt>.a), embedded
+--- first. Holds mod_image (the image.* binding); composed alongside the image
+--- core for the app's runtime, like the wasm compute bridge.
+function M.resolve_image_rt_lib(rt, tmpdir, ctx)
+    local libname = "libhull_feature-image-" .. rt .. ".a"
+    if tool.extract_feature_image_rt and tool.extract_feature_image_rt(tmpdir, rt)
+       and file_exists(tmpdir .. "/" .. libname) then
+        return tmpdir .. "/" .. libname, "embedded"
+    end
+    local asset = ctx.plat and ("libhull_feature-image-" .. rt .. "-" .. ctx.plat .. ".a") or nil
+    return M.resolve_lib(libname, asset, ctx)
+end
+
 return M

--- a/tests/e2e_feature_image.sh
+++ b/tests/e2e_feature_image.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+# e2e_feature_image.sh — image codecs as a composable feature: the image-less
+# base invariant + the needs_image gate (docs/image_feature.md).
+#
+# Proves:
+#   - the base platform lib is IMAGE-LESS (0 stb symbols);
+#   - an image-free app skips the image feature (binary has 0 stb symbols) and
+#     still runs;
+#   - an image app (declares hull/image) composes the codec core + its runtime's
+#     image bridge, and image.new actually works in the produced binary;
+#   - both runtimes behave symmetrically.
+# Locks in the base-flip + gate so they can't silently regress.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+cd "$(dirname "$0")/.."
+
+HULL=./build/hull
+
+echo "=== build hull + the image-less platform lib + the image archives ==="
+make >/dev/null
+make platform >/dev/null
+# The base is image-less: a produced image app composes the codec core +
+# its runtime's image bridge, so hull build needs them in build/ (found by
+# build.lua). The distributed hull embeds them instead.
+make feature-image feature-image-lua feature-image-js >/dev/null
+
+# Count DEFINED symbols matching $2 (exclude undefined 'U'/'u' refs). Mach-O
+# prefixes an underscore; ELF does not. We assert what a binary DEFINES.
+count_syms() { nm "$1" 2>/dev/null | grep -cE " [A-TV-Za-tv-z] _?$2" || true; }
+
+echo "=== the base platform lib is IMAGE-LESS (0 stb symbols) ==="
+base_stb=$(count_syms build/libhull_platform.a "stbi_load_from_memory")
+echo "libhull_platform.a: stb=$base_stb"
+[ "$base_stb" -eq 0 ] || { echo "FAIL: base platform lib still carries stb"; exit 1; }
+echo "ok  base platform lib carries no image codec"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# ── fixtures ────────────────────────────────────────────────────────────
+# Lua: image app + image-free.
+mkdir -p "$WORK/lua_image" "$WORK/lua_free"
+cat > "$WORK/lua_image/app.lua" <<'LUA'
+local image = require("hull.image")
+app.manifest({ modules = { "hull/image@1" } })
+app.main(function()
+    -- create -> encode PNG -> decode round-trip
+    local img = image.new(3, 3, "rgba8", string.rep("\255", 36))
+    if img:width() ~= 3 or img:height() ~= 3 then return 7 end
+    local png = image.encode(img, "png")
+    local back = image.decode(png)
+    return (back:width() == 3 and back:height() == 3) and 0 or 8
+end)
+LUA
+cat > "$WORK/lua_free/app.lua" <<'LUA'
+app.manifest({ modules = {} })
+app.main(function() return 4 end)
+LUA
+
+# JS: image app + image-free.
+mkdir -p "$WORK/js_image" "$WORK/js_free"
+cat > "$WORK/js_image/app.js" <<'JS'
+import { app } from "hull:app";
+import { image } from "hull:image";
+app.manifest({ modules: ["hull/image@1"] });
+app.main(() => {
+    const buf = new Uint8Array(36); buf.fill(255);
+    const img = image.new(3, 3, "rgba8", buf.buffer);
+    if (img.width !== 3 || img.height !== 3) return 7;
+    const png = image.encode(img, "png");
+    const back = image.decode(png);
+    return (back.width === 3 && back.height === 3) ? 0 : 8;
+});
+JS
+cat > "$WORK/js_free/app.js" <<'JS'
+import { app } from "hull:app";
+app.manifest({ modules: [] });
+app.main(() => 5);
+JS
+
+build() { "$HULL" build --no-verify-platform --compiler=system -o "$1/bin" "$1" >/tmp/image_build.log 2>&1; }
+
+# ── 1. image app: composes the feature + image.new runs ─────────────────
+for rt in lua js; do
+    echo "=== $rt image app composes the image feature + image round-trip runs ==="
+    build "$WORK/${rt}_image" || { cat /tmp/image_build.log; echo "FAIL: $rt image build"; exit 1; }
+    s=$(count_syms "$WORK/${rt}_image/bin" "stbi_load_from_memory")
+    [ "$s" -ge 1 ] || { echo "FAIL: $rt image app has no stb ($s)"; exit 1; }
+    set +e; "$WORK/${rt}_image/bin" >/dev/null 2>&1; rc=$?; set -e
+    [ "$rc" -eq 0 ] || { echo "FAIL: $rt image app exited $rc (image round-trip broken)"; exit 1; }
+    echo "ok  $rt image app: composed (stb=$s), round-trip exit 0"
+done
+
+# ── 2. image-free app: drops stb, still runs ────────────────────────────
+for rt in lua js; do
+    echo "=== $rt image-free app links ZERO stb + still runs ==="
+    build "$WORK/${rt}_free" || { cat /tmp/image_build.log; echo "FAIL: $rt free build"; exit 1; }
+    s=$(count_syms "$WORK/${rt}_free/bin" "stbi_load_from_memory")
+    [ "$s" -eq 0 ] || { echo "FAIL: $rt image-free app still carries stb ($s)"; exit 1; }
+    exp=4; [ "$rt" = "js" ] && exp=5
+    set +e; "$WORK/${rt}_free/bin" >/dev/null 2>&1; rc=$?; set -e
+    [ "$rc" -eq "$exp" ] || { echo "FAIL: $rt free app exited $rc (want $exp)"; exit 1; }
+    echo "ok  $rt image-free app: 0 stb, ran (exit $rc)"
+done
+
+echo ""
+echo "=== PASS: image is a composable feature (base image-less, composed on demand) ==="


### PR DESCRIPTION
## Step 1 of "flavors become feature presets"

Extract the image codec subsystem (`hull/image`) from the native base into embedded feature archives composed back at `hull build` only for apps that declare `hull/image`. Mirrors the WASM / SQLite-bridge pattern (the mandatory auto-composed axis): the base is **image-less**, and a genuinely image-free app links **zero stb** (~146 KB smaller); an image app auto-composes the codec with **no `hull feature install`**.

This is the low-risk warm-up validating the auto-compose mechanism for a small, self-contained subsystem, ahead of the larger TLS extraction that makes flavors collapse into feature presets.

## What moves

| Piece | To |
|-------|----|
| `cap/image` + `cap/image_stb` + vendored stb | `libhull_feature-image.a` (runtime-agnostic core) |
| `mod_image` (`image.*` + `HlImage`) | `libhull_feature-image-<rt>.a` (per-runtime bridge) |

Both embedded in hull (`embedded_image.h`), whole-archived at compose.

## The seam

`HL_ENABLE_IMAGE` stays **defined** in the base, so the resolver keeps reporting the cap and `modules.c`/`mod_gpu` need no `#ifdef` change. Engine objects are filtered out and replaced by weak stubs:
- `image_weakstub.c`: weak `hl_image_new`/`hl_image_free` (referenced by `mod_gpu`'s `gpu.texture_read`)
- `runtime/{lua,js}/image_stub.c`: weak `luaopen_hull_image` / `hl_js_init_image_module` (referenced by `modules.c`)

## The gate

Composed iff the resolved manifest declares `hull/image` (`needs_image` from `tool.modules_resolve`). No second signal needed — the only reachable `HlImage` producer is the `image` module itself.

## Compatibility

- `make HL_ENABLE_IMAGE=0` (subtractive knob, CI `image-less` flavor) still drops image entirely — the image feature archives are gated out (`IMG_FEATURE_*`), so it builds clean.
- Cosmo keeps image in-base (fat APE can't force-load native archives), like the runtimes/HTTP/WASM.

## Validation

- `tests/e2e_feature_image.sh` (`make e2e-feature-image`): base image-less (0 stb), both runtimes compose + create→encode-PNG→decode round-trip runs, image-free app drops stb. Wired into CI.
- `make test` 60/60; `make HL_ENABLE_IMAGE=0` builds clean (0 image symbols); manual Lua + JS end-to-end verified.
- release.yml builds + signs + embeds the `image`/`image-lua`/`image-js` stems (platform_domain, `TRUST_FEATURE_LIBS`).

Design: `docs/image_feature.md`.