### PR TITLE
feat(crypto): route HMAC backend through a weak hook (TLS feature Phase 1)

### DIFF
--- a/include/hull/tls_feature.h
+++ b/include/hull/tls_feature.h
@@ -1,0 +1,44 @@
+/**
+ * @file tls_feature.h
+ * @brief Composed-feature seam for the mbedTLS-backed crypto backends.
+ *
+ * Part of the "TLS as a composable feature" work (docs/tls_feature.md). The
+ * mbedTLS-backed crypto backends are selected at RUNTIME through weak accessor
+ * hooks instead of a compile-time `#ifdef`, so a future TLS-less base can
+ * default to the portable/fail-closed backends while a composed TLS feature
+ * swaps in the mbedTLS backends via a strong override (mirrors the gpu/tui
+ * feature hooks).
+ *
+ * Per-backend accessors (rather than one combined struct) on purpose: the base
+ * links crypto.o independently of the asym TU (some test link sets pull crypto.o
+ * + the HMAC TU without the asym TU), so a hook whose default referenced the
+ * asym symbol would break those links. Each accessor references only its own
+ * backend.
+ *
+ * Phase 1 (this seam) is additive + dormant: the weak default preserves the
+ * historical compile-time selection byte-for-byte. Later phases move mbedTLS out
+ * of the base and provide the strong override from libhull_feature-tls.a. The
+ * asym accessor lands with the asym slice of Phase 1.
+ *
+ * Stability: Tier 3 (internal seam).
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef HL_TLS_FEATURE_H
+#define HL_TLS_FEATURE_H
+
+#include "hull/cap/crypto.h"   /* HlCryptoHmacBackend */
+
+/**
+ * Return the active HMAC backend.
+ *
+ * WEAK in the base (cap/crypto.c): the default returns the mbedTLS HMAC backend
+ * when it is compiled in (the historical `HL_ENABLE_HTTP` selection) and the
+ * portable backend otherwise. A composed TLS feature provides a STRONG override
+ * returning the mbedTLS HMAC backend unconditionally. Portable and mbedTLS HMAC
+ * produce identical output, so the choice is transparent to callers.
+ */
+const HlCryptoHmacBackend *hl_crypto_hmac_active_backend(void);
+
+#endif /* HL_TLS_FEATURE_H */

--- a/src/hull/cap/crypto.c
+++ b/src/hull/cap/crypto.c
@@ -9,6 +9,7 @@
  */
 
 #include "hull/cap/crypto.h"
+#include "hull/tls_feature.h"
 #include "tweetnacl.h"
 /* SHA-1 is hand-rolled below (hl_cap_crypto_sha1) so it works in mbedtls-free
  * builds, same as the hand-rolled SHA-256 in this file. No mbedtls include. */
@@ -708,15 +709,29 @@ int hl_cap_crypto_random(void *buf, size_t len)
 #endif
 }
 
-/* Active HMAC backend. mbedTLS when it is linked (any build with an HTTP
- * half); the portable hand-rolled backend in the pure-compute flavor, where
- * mbedTLS is dropped. Both symbols always exist — this only picks which one
- * the cap entry points dispatch through. */
+/* Active HMAC backend, chosen at RUNTIME via the weak hl_crypto_hmac_active_backend()
+ * hook (hull/tls_feature.h) instead of the historical compile-time macro, so a
+ * future TLS-less base defaults to the portable backend while a composed TLS
+ * feature swaps in mbedTLS via a strong override (docs/tls_feature.md, Phase 1).
+ *
+ * Per-backend accessor (not a combined {hmac,asym} struct) on purpose: the base
+ * splits crypto.o from the asym TU (test link sets pull crypto.o + the HMAC TU
+ * without the asym TU), so a hook whose default referenced the asym symbol would
+ * break those links. Asym gets its own accessor in the asym follow-up.
+ *
+ * Phase 1 is dormant: this weak default preserves the historical selection
+ * byte-for-byte -- mbedTLS when it is linked (HL_ENABLE_HTTP), portable
+ * otherwise. Both symbols always exist today; portable and mbedTLS HMAC produce
+ * identical output. */
+__attribute__((weak))
+const HlCryptoHmacBackend *hl_crypto_hmac_active_backend(void)
+{
 #ifdef HL_ENABLE_HTTP
-#define HL_HMAC_BACKEND hl_crypto_hmac_backend_mbedtls
+    return &hl_crypto_hmac_backend_mbedtls;
 #else
-#define HL_HMAC_BACKEND hl_crypto_hmac_backend_portable
+    return &hl_crypto_hmac_backend_portable;
 #endif
+}
 
 /* ── HMAC-SHA256 (vtable-dispatched) ───────────────────────────────── */
 
@@ -735,8 +750,9 @@ int hl_cap_crypto_hmac_sha256(const uint8_t *key, size_t key_len,
      * reach the backend implementation. */
     if (!key || !msg || !out)
         return -1;
-    return HL_HMAC_BACKEND.compute(
-        &HL_HMAC_BACKEND,
+    const HlCryptoHmacBackend *b = hl_crypto_hmac_active_backend();
+    return b->compute(
+        b,
         HL_CRYPTO_HMAC_SHA256,
         key, key_len, msg, msg_len, out, 32);
 }
@@ -757,8 +773,9 @@ int hl_cap_crypto_hmac_sha1(const uint8_t *key, size_t key_len,
      * depth (the backend would reject too) but keeps the two
      * cap entry points symmetric. */
     if (!key || !msg || !out) return -1;
-    return HL_HMAC_BACKEND.compute(
-        &HL_HMAC_BACKEND,
+    const HlCryptoHmacBackend *b = hl_crypto_hmac_active_backend();
+    return b->compute(
+        b,
         HL_CRYPTO_HMAC_SHA1,
         key, key_len, msg, msg_len, out, 20);
 }
@@ -1228,8 +1245,8 @@ int hl_cap_crypto_sha1(const void *data, size_t len, uint8_t out[20])
 /* ── Portable HMAC backend (mbedtls-free) ─────────────────────────────
  *
  * HMAC per RFC 2104 over the in-tree hand-rolled hashes. Selected by the
- * cap layer (HL_HMAC_BACKEND, above) only in the pure-compute flavor where
- * mbedTLS is not linked; always compiled so test_crypto exercises it in
+ * cap layer (hl_crypto_hmac_active_backend, above) only in the pure-compute
+ * flavor where mbedTLS is not linked; always compiled so test_crypto exercises it in
  * every build. Block size is 64 for both SHA-1 and SHA-256. The ipad/opad
  * block and the message are absorbed incrementally — no heap, any message
  * length. HMAC-SHA512 is intentionally unsupported (no streaming SHA-512 in


### PR DESCRIPTION
First implementation slice of **[TLS as a composable feature](../blob/main/docs/tls_feature.md)** (design in #139).

Moves the HMAC backend selection from a compile-time `#ifdef HL_ENABLE_HTTP` macro to the runtime weak hook `hl_crypto_hmac_active_backend()` (`include/hull/tls_feature.h`) — so a future TLS-less base defaults to the portable backend while a composed TLS feature swaps in mbedTLS via a strong override (the gpu/tui hook pattern).

## Additive + dormant

The weak default preserves the historical selection **byte-for-byte**: mbedTLS when `HL_ENABLE_HTTP`, portable otherwise. Portable and mbedTLS HMAC produce identical output, so this is a no-op behaviorally — it just converts the *mechanism* from compile-time to a composable hook.

## Why a per-backend accessor (not a combined `{hmac, asym}` struct)

An initial combined-struct hook broke `test_sbom`, which links `crypto.o` + the HMAC TU **without** the asym TU (the historical design keeps `crypto.o` asym-independent). A struct hook whose default initializer referenced the asym symbol forced that cross-TU dependency. A per-backend accessor references only its own backend, respecting the existing link granularity. The asym accessor + relocating the base-resident asym dispatcher land in the **asym follow-up** (Phase 1b).

## Validation

- `test_crypto` 58/58, `test_asym` 21/21, full unit suite **60/60**
- pure-compute (`HL_ENABLE_HTTP=0`) links + runs through the hook's portable branch
- default (HTTP-full) selects mbedTLS via the hook — unchanged behavior

Scope: `include/hull/tls_feature.h` (new) + `cap/crypto.c` (hook + 2 call sites). +29/−12 in crypto.c.