### PR TITLE
feat(crypto): route asym-verify backend through a weak hook (TLS feature Phase 1b)

### DIFF
--- a/include/hull/cap/crypto.h
+++ b/include/hull/cap/crypto.h
@@ -474,10 +474,13 @@ typedef struct HlCryptoAsymBackend {
                   const void *sig,  size_t sig_len);
 } HlCryptoAsymBackend;
 
-/** Built-in mbedTLS backend. Always present in builds that link
- *  mbedTLS (any build with `HL_ENABLE_HTTP_CLIENT=1` or
- *  `HL_ENABLE_HTTP_SERVER=1`). On builds without mbedTLS the symbol
- *  still exists but its `verify` returns -2 (input error).
+/** Built-in mbedTLS asym backend. Present only in builds that link mbedTLS
+ *  (any build with `HL_ENABLE_HTTP_CLIENT=1` or `HL_ENABLE_HTTP_SERVER=1`, or a
+ *  composed TLS feature). On a TLS-less base the symbol is ABSENT; the active
+ *  backend is then a fail-closed stub whose `verify` returns -2. Prefer
+ *  `hl_crypto_asym_active_backend()` (hull/tls_feature.h) /
+ *  `hl_cap_crypto_asym_verify_default()` over referencing this symbol directly,
+ *  so code links on both TLS and TLS-less bases. See docs/tls_feature.md.
  */
 extern const HlCryptoAsymBackend hl_crypto_asym_backend_mbedtls;
 

--- a/include/hull/tls_feature.h
+++ b/include/hull/tls_feature.h
@@ -28,7 +28,7 @@
 #ifndef HL_TLS_FEATURE_H
 #define HL_TLS_FEATURE_H
 
-#include "hull/cap/crypto.h"   /* HlCryptoHmacBackend */
+#include "hull/cap/crypto.h"   /* HlCryptoHmacBackend, HlCryptoAsymBackend */
 
 /**
  * Return the active HMAC backend.
@@ -40,5 +40,18 @@
  * produce identical output, so the choice is transparent to callers.
  */
 const HlCryptoHmacBackend *hl_crypto_hmac_active_backend(void);
+
+/**
+ * Return the active asymmetric-verify backend (RSA / ECDSA over PEM keys).
+ *
+ * WEAK in the base (cap/crypto.c): the default returns a FAIL-CLOSED stub (every
+ * verify returns -2), so an asym verify on a TLS-less base fails closed rather
+ * than crashing. A build that links the mbedTLS asym TU (`HL_ENABLE_HTTP`), or a
+ * composed TLS feature, provides a STRONG override returning the real mbedTLS
+ * backend. `hl_cap_crypto_asym_verify_default` dispatches through this so callers
+ * (JWT-RS256, OAuth JWKS) transparently pick up mbedTLS when present. Keeps
+ * cap/crypto.o independent of the asym TU (the base link-granularity invariant).
+ */
+const HlCryptoAsymBackend *hl_crypto_asym_active_backend(void);
 
 #endif /* HL_TLS_FEATURE_H */

--- a/src/hull/cap/crypto.c
+++ b/src/hull/cap/crypto.c
@@ -733,6 +733,63 @@ const HlCryptoHmacBackend *hl_crypto_hmac_active_backend(void)
 #endif
 }
 
+/* ── Asymmetric verify backend selection (TLS feature Phase 1b) ─────────
+ *
+ * Base-resident FAIL-CLOSED asym stub + weak accessor. The mbedTLS asym backend
+ * (cap/crypto_asym_mbedtls.c) provides a STRONG override of the accessor when it
+ * is linked (HL_ENABLE_HTTP) or composed (a future libhull_feature-tls.a), so a
+ * TLS-less base fails closed (verify -> -2) while a TLS build uses mbedTLS -- no
+ * behavior change today. The two dispatchers below live here (not in the asym TU)
+ * so cap/crypto.o stays independent of that TU: some test link sets pull crypto.o
+ * without the asym TU, and the accessor's weak default references only this
+ * file-local stub. See docs/tls_feature.md. */
+static int asym_stub_supports(HlCryptoAsymAlg alg) { (void)alg; return 0; }
+static int asym_stub_verify(const void *pk, size_t plen, HlCryptoAsymAlg alg,
+                            const void *d, size_t dlen, const void *s, size_t slen)
+{
+    (void)pk; (void)plen; (void)alg;
+    (void)d;  (void)dlen; (void)s;  (void)slen;
+    return -2;   /* fail closed */
+}
+static const HlCryptoAsymBackend hl_crypto_asym_backend_stub = {
+    .supports = asym_stub_supports,
+    .verify   = asym_stub_verify,
+};
+
+__attribute__((weak))
+const HlCryptoAsymBackend *hl_crypto_asym_active_backend(void)
+{
+    return &hl_crypto_asym_backend_stub;   /* fail-closed; mbedTLS TU overrides */
+}
+
+/* Generic asym-verify dispatcher (backend-agnostic). Relocated here from
+ * cap/crypto_asym_mbedtls.c so it is base-resident. */
+int hl_cap_crypto_asym_verify(const HlCryptoAsymBackend *backend,
+                       const void *pubkey_pem, size_t pubkey_len,
+                       HlCryptoAsymAlg alg,
+                       const void *data, size_t data_len,
+                       const void *sig,  size_t sig_len)
+{
+    if (!backend || !backend->verify) return -2;
+    if (alg == HL_CRYPTO_ASYM_NONE) return -2;
+    if (!backend->supports || !backend->supports(alg)) return -2;
+    return backend->verify(pubkey_pem, pubkey_len, alg,
+                           data, data_len, sig, sig_len);
+}
+
+/* Convenience wrapper: verify via the active asym backend (mbedTLS when linked/
+ * composed, else the fail-closed stub). Relocated here from the asym TU + now
+ * dispatches through the hook instead of hard-wiring hl_crypto_asym_backend_mbedtls. */
+int hl_cap_crypto_asym_verify_default(const void *pubkey_pem, size_t pubkey_len,
+                                      HlCryptoAsymAlg alg,
+                                      const void *data, size_t data_len,
+                                      const void *sig,  size_t sig_len)
+{
+    return hl_cap_crypto_asym_verify(hl_crypto_asym_active_backend(),
+                                     pubkey_pem, pubkey_len,
+                                     alg, data, data_len, sig, sig_len);
+}
+
 /* ── HMAC-SHA256 (vtable-dispatched) ───────────────────────────────── */
 
 int hl_cap_crypto_hmac_sha256(const uint8_t *key, size_t key_len,

--- a/src/hull/cap/crypto_asym_mbedtls.c
+++ b/src/hull/cap/crypto_asym_mbedtls.c
@@ -17,6 +17,7 @@
  */
 
 #include "hull/cap/crypto.h"
+#include "hull/tls_feature.h"   /* hl_crypto_asym_active_backend (strong override) */
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -302,6 +303,15 @@ const HlCryptoAsymBackend hl_crypto_asym_backend_mbedtls = {
     .verify   = mbed_verify,
 };
 
+/* STRONG override of the base's weak hl_crypto_asym_active_backend() (cap/crypto.c):
+ * when this mbedTLS TU is linked, asym verify uses the real backend. Absent on a
+ * TLS-less base (this whole #ifdef is compiled out), where the weak fail-closed
+ * stub wins. A composed libhull_feature-tls.a provides the same override. */
+const HlCryptoAsymBackend *hl_crypto_asym_active_backend(void)
+{
+    return &hl_crypto_asym_backend_mbedtls;
+}
+
 /* ── X.509 -> SPKI PEM (for OIDC JWKS x5c entries) ───────────────── */
 
 int hl_cap_crypto_x509_pubkey_pem(const void *der, size_t der_len,
@@ -393,20 +403,12 @@ done:
 
 #else /* !HL_ENABLE_HTTP - mbedTLS is not linked */
 
-static int stub_supports(HlCryptoAsymAlg alg) { (void)alg; return 0; }
-static int stub_verify(const void *pk, size_t plen,
-                       HlCryptoAsymAlg alg,
-                       const void *d, size_t dlen,
-                       const void *s, size_t slen)
-{
-    (void)pk; (void)plen; (void)alg;
-    (void)d;  (void)dlen; (void)s;  (void)slen;
-    return -2;
-}
-const HlCryptoAsymBackend hl_crypto_asym_backend_mbedtls = {
-    .supports = stub_supports,
-    .verify   = stub_verify,
-};
+/* The mbedTLS asym backend (hl_crypto_asym_backend_mbedtls) + its
+ * hl_crypto_asym_active_backend() override are NOT defined here: on a TLS-less
+ * base the weak fail-closed stub + accessor in cap/crypto.c win, and nothing
+ * references the mbedTLS backend symbol. Only x509_pubkey_pem keeps a base stub
+ * (a direct cap fn, not routed through the asym vtable; a later phase moves it
+ * behind the feature too). See docs/tls_feature.md. */
 
 int hl_cap_crypto_x509_pubkey_pem(const void *der, size_t der_len,
                                   char *out_pem, size_t out_size,
@@ -458,25 +460,7 @@ const char *hl_crypto_asym_alg_to_string(HlCryptoAsymAlg alg)
     }
 }
 
-int hl_cap_crypto_asym_verify(const HlCryptoAsymBackend *backend,
-                       const void *pubkey_pem, size_t pubkey_len,
-                       HlCryptoAsymAlg alg,
-                       const void *data, size_t data_len,
-                       const void *sig,  size_t sig_len)
-{
-    if (!backend || !backend->verify) return -2;
-    if (alg == HL_CRYPTO_ASYM_NONE) return -2;
-    if (!backend->supports || !backend->supports(alg)) return -2;
-    return backend->verify(pubkey_pem, pubkey_len, alg,
-                           data, data_len, sig, sig_len);
-}
-
-int hl_cap_crypto_asym_verify_default(const void *pubkey_pem, size_t pubkey_len,
-                               HlCryptoAsymAlg alg,
-                               const void *data, size_t data_len,
-                               const void *sig,  size_t sig_len)
-{
-    return hl_cap_crypto_asym_verify(&hl_crypto_asym_backend_mbedtls,
-                              pubkey_pem, pubkey_len,
-                              alg, data, data_len, sig, sig_len);
-}
+/* hl_cap_crypto_asym_verify (generic dispatcher) + hl_cap_crypto_asym_verify_default
+ * moved to cap/crypto.c (base-resident) so they no longer tie those symbols to this
+ * mbedTLS TU. verify_default now dispatches through hl_crypto_asym_active_backend(),
+ * whose STRONG override lives below (HL_ENABLE_HTTP only). See docs/tls_feature.md. */


### PR DESCRIPTION
Completes the crypto weak-hook slice of **[TLS as a composable feature](../blob/main/docs/tls_feature.md)**, pairing with the HMAC hook (#140). This is the asym half.

Moves the asymmetric-verify backend (RSA/ECDSA over PEM keys — JWT-RS256 + OAuth JWKS) selection from a compile-time `#ifdef HL_ENABLE_HTTP` to the runtime weak accessor `hl_crypto_asym_active_backend()`.

## Shape

- **Base (`cap/crypto.c`):** a fail-closed asym stub (`verify → -2`) + the weak accessor default returning it, plus the two dispatchers (`hl_cap_crypto_asym_verify` + `hl_cap_crypto_asym_verify_default`) **relocated here** so they're base-resident and `verify_default` dispatches through the hook.
- **mbedTLS TU (`cap/crypto_asym_mbedtls.c`, `HL_ENABLE_HTTP` only):** a **strong override** returning the real mbedTLS backend; its old `#else` stub of `hl_crypto_asym_backend_mbedtls` is dropped (the base stub replaces it).

Keeps `cap/crypto.o` **independent of the asym TU** (the weak default references only a file-local stub) — the same link-granularity invariant that reshaped #140 away from a combined struct hook, now proven by `test_sbom` (links `crypto.o` without the asym TU) staying green.

## Additive + dormant

HTTP builds still verify via mbedTLS (strong override); TLS-less builds fail closed exactly as before. One visible change: on a TLS-less base the `hl_crypto_asym_backend_mbedtls` symbol is now **absent** rather than a `-2` stub — callers should use `hl_cap_crypto_asym_verify_default` (crypto.h updated to say so).

## Validation

- `test_crypto` 58/58, `test_asym` 21/21, full suite **60/60** (incl. `test_sbom`)
- pure-compute (`HL_ENABLE_HTTP=0`) links with **no mbedTLS asym symbol** and runs through the fail-closed stub
- HTTP-full selects the mbedTLS asym backend via the strong override (`nm`-verified)

After this, crypto-core is fully mbedTLS-optional behind runtime hooks (HMAC + asym) — the foundation for Phase 2 (transport seam) + Phase 3 (the tls archive).