### PR TITLE
feat(tls): complete the HMAC hook + build libhull_feature-tls.a (a2 prep)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3101,6 +3101,22 @@ feature-image-js: $(BUILDDIR)/libhull_feature-image-js.a
 $(BUILDDIR)/libhull_feature-image-js.a: $(BUILDDIR)/js_mod_image.o | $(BUILDDIR)
 	$(call AR_FEATURE_LIB,$(BUILDDIR)/js_mod_image.o)
 
+# libhull_feature-tls.a: the mbedTLS transport + crypto backends as a composable
+# feature (docs/tls_feature.md, a2). Bundles the mbedTLS-consuming TUs -- the two
+# crypto mbedTLS backends (strong overrides of the weak hl_crypto_*_active_backend
+# hooks), the outbound TLS client (smtp/pg/mysql sslmode), the serve TLS ctx setup
+# (a1), and the vendored mbedTLS (~1 MB) -- so a TLS-less app-build base drops them
+# and composes them back when the app needs TLS. References Keel's tls_mbedtls.o
+# (resolved from the base's KEEL_LIB at compose) + base crypto/vfs symbols, so the
+# compose whole-archives it inside a --start-group. Built at HL_LINK_TLS=1 (the
+# default HTTP build already compiles all members).
+FEATURE_TLS_OBJS := $(BUILDDIR)/cap_crypto_hmac_mbedtls.o $(BUILDDIR)/cap_crypto_asym_mbedtls.o \
+                    $(BUILDDIR)/tls_client.o $(BUILDDIR)/tls_transport.o $(MBEDTLS_OBJS)
+feature-tls: $(BUILDDIR)/libhull_feature-tls.a
+.PHONY: feature-tls
+$(BUILDDIR)/libhull_feature-tls.a: $(FEATURE_TLS_OBJS) | $(BUILDDIR)
+	$(call AR_FEATURE_LIB,$(FEATURE_TLS_OBJS))
+
 # Gate the image archives behind HL_ENABLE_IMAGE: on the subtractive image-less
 # flavor (make HL_ENABLE_IMAGE=0) cap_image.o + stb aren't built, so the archives
 # can't (and needn't) build. These vars resolve empty there so FEATURE_ARCHIVES /

--- a/src/hull/cap/crypto.c
+++ b/src/hull/cap/crypto.c
@@ -726,11 +726,14 @@ int hl_cap_crypto_random(void *buf, size_t len)
 __attribute__((weak))
 const HlCryptoHmacBackend *hl_crypto_hmac_active_backend(void)
 {
-#ifdef HL_ENABLE_HTTP
-    return &hl_crypto_hmac_backend_mbedtls;
-#else
+    /* Base default: the always-present portable backend. The mbedTLS HMAC TU
+     * (cap/crypto_hmac_mbedtls.c), when linked or composed into a TLS feature,
+     * provides a STRONG override returning the mbedTLS backend. Output is
+     * byte-identical either way, so this is transparent to callers. Returning
+     * portable (not &hl_crypto_hmac_backend_mbedtls) keeps crypto.o free of a
+     * hard reference to the mbedTLS HMAC TU so a TLS-less base links -- same
+     * shape as the asym accessor. */
     return &hl_crypto_hmac_backend_portable;
-#endif
 }
 
 /* ── Asymmetric verify backend selection (TLS feature Phase 1b) ─────────

--- a/src/hull/cap/crypto_hmac_mbedtls.c
+++ b/src/hull/cap/crypto_hmac_mbedtls.c
@@ -16,6 +16,7 @@
  */
 
 #include "hull/cap/crypto.h"
+#include "hull/tls_feature.h"   /* hl_crypto_hmac_active_backend (strong override) */
 
 #include <stddef.h>
 #include <stdint.h>
@@ -90,3 +91,15 @@ const HlCryptoHmacBackend hl_crypto_hmac_backend_mbedtls = {
     .supports = mbedtls_supports,
     .compute  = mbedtls_compute,
 };
+
+#ifdef HL_ENABLE_HTTP
+/* STRONG override of the base's weak hl_crypto_hmac_active_backend() (cap/crypto.c):
+ * when this real mbedTLS HMAC TU is linked (or composed into libhull_feature-tls.a),
+ * HMAC uses mbedTLS. Absent on a TLS-less base (this branch compiled out), where
+ * the weak default returns the portable backend. Mirrors the asym override in
+ * cap/crypto_asym_mbedtls.c. See docs/tls_feature.md. */
+const HlCryptoHmacBackend *hl_crypto_hmac_active_backend(void)
+{
+    return &hl_crypto_hmac_backend_mbedtls;
+}
+#endif


### PR DESCRIPTION
Safe, additive prep for the a2 base-drop — two changes that make the crypto layer fully feature-ready and stage the TLS archive, without touching the base.

## 1. Complete the HMAC hook (mirrors asym from #141)

The HMAC weak hook still hard-referenced `hl_crypto_hmac_backend_mbedtls` under `#ifdef HL_ENABLE_HTTP` — which would break a TLS-less base (the TU is dropped). Now the weak default in `crypto.c` returns the **portable** backend unconditionally, and the real mbedTLS HMAC TU provides a **strong** `hl_crypto_hmac_active_backend()` override (only under `HL_ENABLE_HTTP`).

**Dormant + byte-identical:** HTTP builds still HMAC via mbedTLS (strong override); pure-compute via portable — exactly as before. This closes the last gap keeping `crypto.o` from being asym-TU/HMAC-TU-independent.

## 2. Build `libhull_feature-tls.a`

Bundles the mbedTLS-consuming TUs (`cap_crypto_{hmac,asym}_mbedtls.o` + `tls_client.o` + `tls_transport.o`) + vendored mbedTLS (~488 KB). Provides the strong crypto/tls overrides; carries 9 undefined `kl_tls_mbedtls` refs resolved from the base's `KEEL_LIB` at compose (whole-archived inside `--start-group`).

**Additive:** new target, not yet composed; base unchanged.

## Why split here

The base-drop + compose (`HL_TLS_FEATURE` + `HL_APP_BASE_TLSLESS` + `build.lua`/`feature_compose`/`build_assets` + R1b toolchain split + release/signing + `e2e_feature_tls.sh`) is the **non-dormant, image-feature-scale** structural step touching signed release artifacts. Keeping it separate = reviewable, revertable, and doesn't mix safe + risky.

## Validation

- `test_crypto` 58/58, `test_asym` 21/21, full suite **60/60**
- HTTP build still selects mbedTLS HMAC via the strong override (`nm`-verified)
- `libhull_feature-tls.a` builds (488 KB) with the expected symbols