### PR TITLE
ci(tls): release-wire TLS + switch app-base to SLIM (a2 part 3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,7 @@ jobs:
             feature-wasm feature-wasm-lua feature-wasm-js
             feature-sqlite feature-sqlite-lua feature-sqlite-js
             feature-image feature-image-lua feature-image-js
+            feature-tls
       - name: Build embedded feature archives (macOS)
         if: runner.os == 'macOS'
         run: >
@@ -85,6 +86,7 @@ jobs:
           feature-wasm feature-wasm-lua feature-wasm-js
           feature-sqlite feature-sqlite-lua feature-sqlite-js
           feature-image feature-image-lua feature-image-js
+          feature-tls
       - name: Upload embedded feature archives
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
@@ -106,6 +108,7 @@ jobs:
             build/libhull_feature-image.a
             build/libhull_feature-image-lua.a
             build/libhull_feature-image-js.a
+            build/libhull_feature-tls.a
 
       # Per-flavor platform libs for `hull build --flavor` + `hull platform
       # install`. Each native platform-<flavor> target builds into its own obj
@@ -117,13 +120,14 @@ jobs:
         if: runner.os == 'Linux'
         uses: ./.github/actions/hull-build-container
         with:
-          # `sqliteless` is not a --flavor preset: it is the Phase D app-build
-          # base (docs/sqlite_feature.md), built by the `platform-sqliteless`
-          # target (HL_SQLITE_FEATURE=1 sub-build) and embedded by stage 3 when
-          # HL_APP_BASE_SQLITELESS=1. It shares this step's obj-dir isolation +
+          # `slim` is not a --flavor preset: it is the combined app-build base
+          # (SQLite-less + TLS-less; docs/sqlite_feature.md + docs/tls_feature.md),
+          # built by the `platform-slim` target (HL_SQLITE_FEATURE=1 HL_TLS_FEATURE=1
+          # sub-build) and embedded by stage 3 when HL_APP_BASE_SQLITELESS=1 AND
+          # HL_APP_BASE_TLSLESS=1. It shares this step's obj-dir isolation +
           # arch-qualified naming.
           run: |
-            for f in pure-compute sqliteless; do
+            for f in pure-compute slim; do
               make "platform-$f"
               mv "build/libhull_platform-$f.a" \
                  "build/libhull_platform-$f-${{ matrix.name }}.a"
@@ -131,7 +135,7 @@ jobs:
       - name: Build platform flavors (macOS)
         if: runner.os == 'macOS'
         run: |
-          for f in pure-compute sqliteless; do
+          for f in pure-compute slim; do
             make "platform-$f"
             mv "build/libhull_platform-$f.a" \
                "build/libhull_platform-$f-${{ matrix.name }}.a"
@@ -276,20 +280,20 @@ jobs:
         run: |
           set -eu
           {
-            # The native arch entry hashes the EMBEDDED app-build base. Phase D
-            # (docs/sqlite_feature.md): stage 3 embeds the SQLite-LESS base
-            # (HL_APP_BASE_SQLITELESS=1), so verify_platform checks it against
-            # THIS hash -- hash the sqlite-less base, not the sqlite-full one.
-            # Cosmo keeps SQLite in-base (no Phase D), so its entries are the
-            # sqlite-full cosmo archives.
+            # The native arch entry hashes the EMBEDDED app-build base. Stage 3
+            # embeds the SLIM base (SQLite-less + TLS-less; docs/sqlite_feature.md
+            # + docs/tls_feature.md, via HL_APP_BASE_SQLITELESS=1 HL_APP_BASE_TLSLESS=1),
+            # so verify_platform checks it against THIS hash -- hash the slim base,
+            # not the full one. Cosmo keeps both in-base (no drop), so its entries
+            # are the full cosmo archives.
             sha256sum \
-              platforms/platform-flavors-linux-x86_64/libhull_platform-sqliteless-linux-x86_64.a \
+              platforms/platform-flavors-linux-x86_64/libhull_platform-slim-linux-x86_64.a \
               | awk '{print $1"  linux-x86_64"}'
             sha256sum \
-              platforms/platform-flavors-linux-aarch64/libhull_platform-sqliteless-linux-aarch64.a \
+              platforms/platform-flavors-linux-aarch64/libhull_platform-slim-linux-aarch64.a \
               | awk '{print $1"  linux-aarch64"}'
             sha256sum \
-              platforms/platform-flavors-darwin-arm64/libhull_platform-sqliteless-darwin-arm64.a \
+              platforms/platform-flavors-darwin-arm64/libhull_platform-slim-darwin-arm64.a \
               | awk '{print $1"  darwin-arm64"}'
             sha256sum \
               platforms/platform-cosmo/libhull_platform.x86_64-cosmo.a \
@@ -302,9 +306,10 @@ jobs:
             # asset name that build.lua records in package.sig.gethull.composed
             # and that the runtime §5c looks up: "libhull_feature-<stem>.<arch>.a".
             # `sqlite` = the engine (Phase D), `sqlite-lua`/`sqlite-js` = the udf
-            # bridges (Phase C.2b).
+            # bridges (Phase C.2b). `tls` = the mbedTLS + crypto/transport backends
+            # (docs/tls_feature.md, a2; one archive, no per-runtime bridge).
             for arch in linux-x86_64 linux-aarch64 darwin-arm64; do
-              for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js sqlite sqlite-lua sqlite-js image image-lua image-js; do
+              for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js sqlite sqlite-lua sqlite-js image image-lua image-js tls; do
                 f="platforms/platform-features-$arch/libhull_feature-$stem.a"
                 sha256sum "$f" \
                   | awk -v n="libhull_feature-$stem.$arch.a" '{print $1"  "n}'
@@ -555,17 +560,17 @@ jobs:
           name: platform-features-${{ matrix.name }}
           path: build/
 
-      # Phase D (docs/sqlite_feature.md): the SQLite-LESS app-build base. Land it
-      # at build/libhull_platform-sqliteless.a (the name the Makefile's
-      # SQLITELESS_PLATFORM_LIB + TRUST_PLATFORM_LIB expect) so HL_APP_BASE_SQLITELESS=1
-      # embeds these exact signed bytes.
-      - name: Download SQLite-less app-build base (this arch)
+      # The SLIM app-build base (SQLite-less + TLS-less; docs/sqlite_feature.md +
+      # docs/tls_feature.md). Land it at build/libhull_platform-slim.a (the name
+      # the Makefile's SLIM_PLATFORM_LIB + TRUST_PLATFORM_LIB expect) so
+      # HL_APP_BASE_SQLITELESS=1 HL_APP_BASE_TLSLESS=1 embeds these exact signed bytes.
+      - name: Download SLIM app-build base (this arch)
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: platform-flavors-${{ matrix.name }}
           path: build/flavors/
-      - name: Stage SQLite-less base
-        run: cp build/flavors/libhull_platform-sqliteless-${{ matrix.name }}.a build/libhull_platform-sqliteless.a
+      - name: Stage SLIM base
+        run: cp build/flavors/libhull_platform-slim-${{ matrix.name }}.a build/libhull_platform-slim.a
 
       - name: Download signed manifest header
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
@@ -579,27 +584,27 @@ jobs:
         # See same step in build-cosmo for rationale.
         run: |
           set -eu
-          # Phase D: the native arch entry hashes the SQLite-LESS base (what stage
-          # 3 embeds via HL_APP_BASE_SQLITELESS=1), so verify THAT against it.
-          actual=$(sha256sum build/libhull_platform-sqliteless.a | awk '{print $1}')
+          # The native arch entry hashes the SLIM base (what stage 3 embeds via
+          # HL_APP_BASE_SQLITELESS=1 HL_APP_BASE_TLSLESS=1), so verify THAT against it.
+          actual=$(sha256sum build/libhull_platform-slim.a | awk '{print $1}')
           expected=$(awk -v a="${{ matrix.name }}" '$2==a {print $1}' build/platform-manifest.txt)
           if [ -z "$expected" ]; then
             echo "::error::arch '${{ matrix.name }}' not in signed manifest"
             exit 1
           fi
           if [ "$actual" != "$expected" ]; then
-            echo "::error::SQLite-less base SHA mismatch"
+            echo "::error::SLIM base SHA mismatch"
             echo "  expected (signed manifest): $expected"
             echo "  actual   (downloaded .a):   $actual"
             exit 1
           fi
-          echo "✓ ${{ matrix.name }} SQLite-less base SHA matches signed manifest: $actual"
+          echo "✓ ${{ matrix.name }} SLIM base SHA matches signed manifest: $actual"
           # Same cross-check for each embedded feature archive: its downloaded
           # bytes MUST match the signed-manifest entry keyed by the composed asset
           # name (libhull_feature-<stem>.<arch>.a), or the runtime §5c check on
           # every app this hull builds would fail. Includes the SQLite engine
-          # (sqlite) + udf bridges (sqlite-lua/sqlite-js).
-          for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js sqlite sqlite-lua sqlite-js image image-lua image-js; do
+          # (sqlite) + udf bridges (sqlite-lua/sqlite-js) + the TLS backends (tls).
+          for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js sqlite sqlite-lua sqlite-js image image-lua image-js tls; do
             fa="build/libhull_feature-$stem.a"
             name="libhull_feature-$stem.${{ matrix.name }}.a"
             fact=$(sha256sum "$fa" | awk '{print $1}')
@@ -637,12 +642,12 @@ jobs:
         with:
           user: host
           run: |
-            make EMBED_PLATFORM=1 HL_APP_BASE_SQLITELESS=1 TRUST_PLATFORM_LIB=1 TRUST_FEATURE_LIBS=1
+            make EMBED_PLATFORM=1 HL_APP_BASE_SQLITELESS=1 HL_APP_BASE_TLSLESS=1 TRUST_PLATFORM_LIB=1 TRUST_FEATURE_LIBS=1
             make hardening
             make check-hardening
       - name: Build hull with embedded platform (macOS)
         if: runner.os == 'macOS'
-        run: make EMBED_PLATFORM=1 HL_APP_BASE_SQLITELESS=1 TRUST_PLATFORM_LIB=1 TRUST_FEATURE_LIBS=1
+        run: make EMBED_PLATFORM=1 HL_APP_BASE_SQLITELESS=1 HL_APP_BASE_TLSLESS=1 TRUST_PLATFORM_LIB=1 TRUST_FEATURE_LIBS=1
       - name: Hardening summary (macOS)
         if: runner.os == 'macOS'
         run: make hardening

--- a/docs/sqlite_feature.md
+++ b/docs/sqlite_feature.md
@@ -226,20 +226,26 @@ WASM). `HL_ENABLE_SQLITE` stays the compile switch; the feature is the
     `libhull_feature-sqlite.<arch>.a`, §5c FATAL, like the runtime/wasm cores);
     an externally-installed engine keeps the **release** domain.
   - **Release wiring (release.yml).** ✅ WIRED (validate via a dry-run
-    pre-release tag before a real release). Stage 1 builds the sqlite-less base
-    (`platform-sqliteless`, published `libhull_platform-sqliteless-<arch>.a`) + the
-    engine + the C.2b udf bridges (`feature-sqlite{,-lua,-js}`). Stage 2's signed
-    platform manifest hashes the **sqlite-less** base for each native arch entry
-    (what stage 3 embeds) and adds the `sqlite`/`sqlite-lua`/`sqlite-js` feature
-    stems (the latter two also closed a C.2b manifest gap). Stage 3 downloads the
-    sqlite-less base + engine/bridges, SHA-verifies them against the signed
-    manifest, and builds with `HL_APP_BASE_SQLITELESS=1 TRUST_PLATFORM_LIB=1
-    TRUST_FEATURE_LIBS=1` (the Makefile's `SQLITELESS_PLATFORM_LIB` honours
-    `TRUST_PLATFORM_LIB`, embedding the exact signed bytes). No new keys — same
-    platform-key trust chain as the runtime/http/wasm cores. Cosmo arch entries
-    stay sqlite-full. The shipped `HL_PLATFORM_PUBKEY_HEX` is still the placeholder
-    (the whole §5b/§5c layer is skipped at runtime), so this is future-correct;
-    the produced-app payoff (drop SQLite) is already live regardless.
+    pre-release tag before a real release). **Superseded by the combined SLIM
+    base once TLS shipped** (docs/tls_feature.md, a2 part 3): the embedded
+    app-build base is now `slim` (SQLite-less **and** TLS-less) rather than
+    `sqliteless`, so the release drops both by default and composes each back
+    per app. Stage 1 builds `platform-slim` (published
+    `libhull_platform-slim-<arch>.a`) + the engine + the C.2b udf bridges + the
+    TLS backends (`feature-sqlite{,-lua,-js}`, `feature-tls`). Stage 2's signed
+    platform manifest hashes the **slim** base for each native arch entry (what
+    stage 3 embeds) and adds the `sqlite`/`sqlite-lua`/`sqlite-js`/`tls` feature
+    stems. Stage 3 downloads the slim base + engine/bridges/tls, SHA-verifies
+    them against the signed manifest, and builds with `HL_APP_BASE_SQLITELESS=1
+    HL_APP_BASE_TLSLESS=1 TRUST_PLATFORM_LIB=1 TRUST_FEATURE_LIBS=1` (the
+    Makefile's `SLIM_PLATFORM_LIB` honours `TRUST_PLATFORM_LIB`, embedding the
+    exact signed bytes). No new keys — same platform-key trust chain as the
+    runtime/http/wasm cores. Cosmo arch entries stay full (sqlite + TLS
+    in-base). The shipped `HL_PLATFORM_PUBKEY_HEX` is still the placeholder (the
+    whole §5b/§5c layer is skipped at runtime), so this is future-correct; the
+    produced-app payoff (drop SQLite) is already live regardless. The
+    standalone `platform-sqliteless` target + `HL_APP_BASE_SQLITELESS`-only path
+    remain for a SQLite-only drop.
   - **Cosmo** keeps SQLite in-base (a fat APE can't force-load a native archive);
     `HL_APP_BASE_SQLITELESS` is native-only.
 

--- a/docs/tls_feature.md
+++ b/docs/tls_feature.md
@@ -202,12 +202,22 @@ Keel, so this is one deliberate relocation. Because Keel isolates TLS in a singl
 - **Validate:** `e2e_build_flavor.sh` updated; release-pipeline dry-run
   (hyphenated pre-release tag, per [[project_release_dryrun_prerelease_tag]]).
 
-### Phase 5 — Release + signing
-- Add the `tls` stem to `release.yml` (build + sign into the platform manifest,
-  embed via `TRUST_FEATURE_LIBS`), landing it in the `platform_domain` of
-  `package.sig.gethull.composed` (platform-key attested, runtime §5c FATAL) — the
-  same trust chain as the runtime/HTTP/WASM/image archives
+### Phase 5 — Release + signing — **DONE (a2 part 3)**
+- The `tls` stem is wired into `release.yml`: `feature-tls` is built + uploaded
+  with the other embedded feature archives, hashed into the signed platform
+  manifest (native-arch feature stems), SHA-verified in stage 3, and embedded
+  via `TRUST_FEATURE_LIBS`. It lands in the `platform_domain` of
+  `package.sig.gethull.composed` (platform-key attested, runtime §5c FATAL) —
+  the same trust chain as the runtime/HTTP/WASM/image archives
   ([docs/composed_feature_signing.md](composed_feature_signing.md)).
+- The embedded **app-build base** for a release is now the combined **SLIM**
+  base (`platform-slim` = `HL_SQLITE_FEATURE=1 HL_TLS_FEATURE=1`), embedded via
+  `HL_APP_BASE_SQLITELESS=1 HL_APP_BASE_TLSLESS=1`, replacing the SQLite-only
+  `sqliteless` base. So a stock `hull build` drops **both** SQLite and mbedTLS
+  and composes each back per app. Cosmo stays full (fat APE can't force-load).
+  Validate via a dry-run pre-release tag before a real release (the shipped
+  `HL_PLATFORM_PUBKEY_HEX` placeholder means §5c is skipped at runtime today, so
+  this is future-correct; the produced-app size payoff is already live).
 
 ## Risks + open questions
 


### PR DESCRIPTION
Completes the TLS composable-feature arc: wires `tls` into the **signed release pipeline** and makes the released app-build base drop mbedTLS by default. Builds on the auto-compose from #146.

## release.yml
- **Build + upload** the embedded `feature-tls` archive alongside the other auto-composed cores (runtime/http/wasm/sqlite/image).
- **Sign + verify**: hash `tls` into the signed platform manifest's native-arch feature stems and SHA-verify it in stage 3, so an embedded-composed TLS backend is attested in the `platform_domain` of `package.sig.gethull.composed` (platform-key, runtime §5c FATAL) — same trust chain as the other embedded cores, **no new keys**.
- **App-base → SLIM**: switch the embedded app-build base from the SQLite-only `sqliteless` base to the combined **`slim`** base (`platform-slim` = `HL_SQLITE_FEATURE=1 HL_TLS_FEATURE=1`), embedded via `HL_APP_BASE_SQLITELESS=1 HL_APP_BASE_TLSLESS=1`. A stock `hull build` now drops **both** SQLite and mbedTLS and composes each back per app. Cosmo stays full in-base (a fat APE can't force-load a native archive).

## Why this is low-risk
The Makefile already carried the entire combined path (the `APP_BASE_LIB` 4-case → `SLIM_PLATFORM_LIB`; the `EMBEDDED_{SQLITE,TLS}_H` engine embeds gated on the two app-base flags, landed in #146). This PR only feeds it the signed pre-built archives via the `TRUST_*` flags — a faithful mirror of the proven SQLite Phase D wiring, extended to the `tls` stem.

## Verification (local, from source, no TRUST shortcut)
- `platform-slim`: 0 `mbedtls_ssl_handshake`, 0 `sqlite3_open`.
- A hull with the SLIM app-base embedded → a **db+https** app composes both back (7 mbedTLS + 1 sqlite, `db.query` returns 42, exit 0); a **plaintext** app drops both (0/0) and runs.
- YAML lint clean; `make` default restored.

The full signed round-trip only exercises on a tagged release; validate with a dry-run pre-release tag before the next real release (the shipped `HL_PLATFORM_PUBKEY_HEX` placeholder means §5c is skipped at runtime today, so this is future-correct; the produced-app size payoff is already live).

## Docs
- `docs/tls_feature.md` Phase 5 marked done.
- `docs/sqlite_feature.md` release-wiring section updated: the SLIM base supersedes the `sqliteless` embed.

## Remaining (Phase 4, separate)
Retire `pure-compute` into a `build.lua` feature preset and drop the per-flavor base matrix now that both SQLite and TLS compose.