### PR TITLE
feat(keel): route serve_cli's HTTPS-client allocator through Hull (Phase 4.2a)

### DIFF
--- a/src/hull/serve_cli.c
+++ b/src/hull/serve_cli.c
@@ -29,6 +29,7 @@
 
 #include "hull/app_context.h"
 #include "hull/entry.h"        /* HlEntry / hl_app_entries[] (embedded apps) */
+#include "hull/utils/alloc.h"  /* HlAllocator + hl_alloc_kl (Keel-free KlAllocator) */
 #include "hull/shared/async_backend.h"
 #include "hull/shared/log_lock.h"
 #include "hull/shared/thread_affinity.h"
@@ -276,7 +277,17 @@ int hull_serve(int argc, char **argv)
      * matches the resolution order in serve.c minus the system-store
      * probe (which adds platform-specific cruft we don't need for CLI). */
     HlHttpConfig http_cfg = {0};
-    KlAllocator kalloc    = kl_allocator_default();
+    /* Hull's tracking allocator (uncapped: limit 0 = track, no cap), bridged to
+     * a KlAllocator for the composed HTTPS client. Mirrors serve.c's
+     * `s->kl_alloc = hl_alloc_kl(&s->alloc)`. This replaces kl_allocator_default(),
+     * which lives in libkeel.a: routing the base app.main runner through Hull's
+     * own allocator (hl_alloc_kl references only the KlAllocator *type*, no kl_*
+     * symbol) keeps serve_cli.o Keel-free, the prerequisite for a Keel-less base
+     * (docs/keel_feature.md, Phase 4.2). http_alloc must outlive tls_ctx; both are
+     * function-scope and live for the whole app.main run. */
+    HlAllocator http_alloc;
+    hl_alloc_init(&http_alloc, 0);
+    KlAllocator kalloc    = hl_alloc_kl(&http_alloc);
     KlTlsConfig tls_cfg   = {0};
     KlTlsCtx *tls_ctx     = NULL;
 


### PR DESCRIPTION
Phase 4.2a of the event-loop-composable epic ([docs/keel_feature.md](../blob/main/docs/keel_feature.md)) — resolve the base's one real compute-path Keel residual so the `app.main` runner links zero Keel.

## What
`serve_cli.c` is the base app.main runner (`SERVE_OBJ` when `HL_ENABLE_HTTP_SERVER=0`). Its `#ifdef HL_ENABLE_HTTP_CLIENT` block called `kl_allocator_default()` for the composed HTTPS client's allocator — **the one remaining direct Keel reference** (the TLS ctx already goes through the a1 `hl_tls_*` seam).

Replace it with Hull's own tracking allocator via `hl_alloc_kl(&http_alloc)` (`hl_alloc_init(..., 0)` = track, no cap), mirroring `serve.c`'s `s->kl_alloc = hl_alloc_kl(&s->alloc)`.

**Not a bare malloc/free swap** — it routes through Hull's unified allocator (which honours `realloc` `old_size` for accounting), and `hl_alloc_kl` references only the `KlAllocator` *type* (a header struct), no `kl_*` symbol. So `serve_cli.o` becomes fully Keel-free.

## Why
This is the base's one real compute-path Keel coupling (`shared/async.c`'s `kl_async_complete` is a comment; the worker TUs use only the `KlAsyncOp` type). With it fixed, the base app.main runner links zero Keel — the prerequisite for a Keel-less composable base where `pure-compute` genuinely drops Keel. Dormant: no behavior change on any current build.

## Verification
- Default build + `make test` **60/60** (byte-identical behavior — Hull's uncapped tracker is correctness-equivalent to stdlib here).
- An `HL_ENABLE_HTTP_SERVER=0` build produces `serve_cli.o` with **zero** undefined `kl_*` symbols (was 1: `kl_allocator_default`).

Next (4.2b): the base-drop — move `serve.o`/`async_keel`/`static.o`/`libkeel` into the http feature, build the base Keel-free, compose Keel back on `needs_http`.