### PR TITLE
feat(keel): hull_serve app-entry weak seam (Phase 4.2b R1)

### DIFF
--- a/src/hull/serve_cli.c
+++ b/src/hull/serve_cli.c
@@ -105,6 +105,14 @@ static int cli_parse_args(int argc, char **argv,
     return entry_idx;
 }
 
+/* Weak default: the Keel-free app.main runner. serve.c provides a STRONG
+ * hull_serve() (the full KlServer serve loop) that wins whenever serve.o is
+ * linked -- in the http feature, composed on needs_http (docs/keel_feature.md,
+ * Phase 4.2). A compute app links only this weak runner and never touches Keel.
+ * hull_serve is the ONLY external symbol serve.c and serve_cli.c share, so the
+ * weak/strong pick is unambiguous. Byte-identical today (only one of serve.o /
+ * serve_cli.o is built per config; a lone weak def resolves like a strong one). */
+__attribute__((weak))
 int hull_serve(int argc, char **argv)
 {
     int app_argc = 0;


### PR DESCRIPTION
R1 of the Keel base-drop ([docs/keel_feature.md](../blob/main/docs/keel_feature.md), Phase 4.2) — the app-entry seam that finishes the `serve.c` decouple #114 deferred.

## What
`hull_serve()` (the app entry) is defined in **both** `serve.c` (the full KlServer serve loop) and `serve_cli.c` (the Keel-free `app.main` runner); the Makefile picks one via `SERVE_OBJ`. Verified it's the **only** external symbol the two TUs share (`nm` comm of their defined externals = just `_hull_serve`), so it's a clean weak/strong seam.

Make `serve_cli.c`'s `hull_serve` the **weak default**; `serve.c`'s stays **strong**. A Keel-less base can then carry `serve_cli.o` (weak) as the app entry while the composed http feature carries `serve.o` (strong, whole-archived on `needs_http`) — strong wins when composed, the weak Keel-free runner stands otherwise. Same pattern as the a1/4.1 seams.

**Byte-identical / dormant today:** only one of `serve.o` / `serve_cli.o` is built per config, and a lone weak def resolves exactly like a strong one. Combined with **4.1** (async-backend weak seam) + **4.2a** (serve_cli allocator through Hull), the base compute-path is now fully seam-ready for the drop.

## Verification
- Default build links `serve.o`'s strong `hull_serve` (`make test` **60/60**).
- `HL_ENABLE_HTTP_SERVER=0`: `serve_cli.o`'s `hull_serve` = `weak external`, `serve.o`'s = strong `external`.

## Remaining (the base-drop itself — next focused PR)
Move `serve.o`/`async_keel.o`/`hull_static.o`/`agent_api.o`/`test_runner.o` into the http feature (compiled HTTP_SERVER=1); the app-build base uses `serve_cli.o`; `libkeel` stays merged in the base `.a` (pulled on-demand — a compute app references no `kl_*` so it isn't pulled, an http app's composed `serve.o` force-loads it). The genuine complexity is the **multi-config compile** (base `serve_cli.o` coexisting with a composed `serve.o`), which is why the seam lands first. Then release wiring + the pure-compute preset (4.3).