### PR TITLE
feat(keel): compose the Keel event loop onto a Keel-less base (Phase 4.2b)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3187,6 +3187,23 @@ feature-http: $(BUILDDIR)/libhull_feature-http.a
 $(BUILDDIR)/libhull_feature-http.a: $(FEATURE_HTTP_OBJS) | $(BUILDDIR)
 	$(call AR_FEATURE_LIB,$(FEATURE_HTTP_OBJS))
 
+# libhull_feature-keel.a: the Keel EVENT LOOP as a composable feature
+# (docs/keel_feature.md, Phase 4.2b). The event-loop objects a Keel-less base
+# (HL_KEEL_FEATURE=1) drops -- serve.o (the KlServer serve loop + strong
+# hull_serve), async_keel.o (strong hl_async_backend), net_keel.o (strong
+# hl_net_op_*), plus the server-only hull_static.o / agent_api.o / test_runner.o.
+# Composed (whole-archived) at `hull build` on needs_http, but ONLY onto a
+# Keel-less base (build.lua nm-probes for an ABSENT strong hull_serve, so a full
+# base -- which already carries these -- never double-composes them). Built from
+# the default (HTTP_SERVER=1, HL_KEEL_FEATURE=0) objects, i.e. the real server.
+FEATURE_KEEL_OBJS := $(BUILDDIR)/serve.o $(BUILDDIR)/async_keel.o \
+                     $(BUILDDIR)/net_keel.o $(BUILDDIR)/hull_static.o \
+                     $(BUILDDIR)/agent_api.o $(BUILDDIR)/test_runner.o
+feature-keel: $(BUILDDIR)/libhull_feature-keel.a
+.PHONY: feature-keel
+$(BUILDDIR)/libhull_feature-keel.a: $(FEATURE_KEEL_OBJS) | $(BUILDDIR)
+	$(call AR_FEATURE_LIB,$(FEATURE_KEEL_OBJS))
+
 # libhull_feature-wasm.a: the runtime-agnostic WASM CORE (docs/wasm_feature.md,
 # Phase 1). Bundles the wasm caps + worker_wasm + the vendored WAMR objects
 # (the ~256 KB that leaves the base). Composed back at `hull build` and embedded

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1991,6 +1991,44 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
             end
             print("hull build: composed HTTP feature")
 
+            -- Compose the Keel event loop (docs/keel_feature.md, Phase 4.2b) when
+            -- the base is Keel-less. Sentinel: hl_async_backend_keel (async_keel.o's
+            -- vtable) is fully ABSENT from a Keel-less base (HL_KEEL_FEATURE=1 drops
+            -- async/keel.c) and present in a Keel-full base. It is a cleaner probe
+            -- than hull_serve, which serve_cli.o defines WEAK -- and macOS plain `nm`
+            -- prints a weak def as `T`, indistinguishable from a strong one. When the
+            -- sentinel is absent, compose libhull_feature-keel.a (serve.o + async_keel
+            -- + net_keel + the server-only static/agent/test objects); a full base,
+            -- which already carries them, never double-composes (no duplicate
+            -- hull_serve). The composed serve.o's kl_* refs pull libkeel from the base
+            -- .a on demand.
+            local base_has_keel = false
+            local serve_nm = tool.spawn_read({ "nm", platform_lib })
+            if serve_nm and serve_nm:find("hl_async_backend_keel") then
+                base_has_keel = true
+            end
+            if not base_has_keel then
+                local keel_lib = "libhull_feature-keel.a"
+                local keel_path, keel_from = fcompose.resolve_keel_lib(tmpdir,
+                                             { hull_dir = rt_hull_dir, plat = rt_plat })
+                if not keel_path then
+                    tool.stderr("hull build: the Keel feature lib "
+                        .. "(libhull_feature-keel.a) was not found "
+                        .. (keel_from == "cache-verify-failed"
+                            and "(cache re-verify failed)\n" or "(normally embedded in hull)\n"))
+                    tool.stderr("hint: build it from source with `make feature-keel`\n")
+                    tool.rmdir(tmpdir); tool.exit(1)
+                end
+                local keel_dest = tmpdir .. "/" .. keel_lib
+                if keel_path ~= keel_dest then tool.copy(keel_path, keel_dest) end
+                record_composed("libhull_feature-keel." .. (rt_plat or "") .. ".a",
+                                keel_dest, "platform")
+                for _, f in ipairs(fcompose.whole_archive_flags(keel_dest, is_darwin)) do
+                    feature_libs[#feature_libs + 1] = f
+                end
+                print("hull build: composed Keel event loop (Keel-less base)")
+            end
+
             -- Phase C: the per-runtime web bindings (routes/dispatch/res:*/ws/sse/
             -- http-client/smtp) live in libhull_feature-http-<rt>.a, not the pure
             -- runtime archive. Whole-archive it too (its strong defs override the

--- a/stdlib/cli/lua/hull/feature_compose.lua
+++ b/stdlib/cli/lua/hull/feature_compose.lua
@@ -185,6 +185,19 @@ function M.resolve_http_lib(tmpdir, ctx)
     return M.resolve_lib(libname, asset, ctx)
 end
 
+--- Resolve the Keel event-loop feature archive (libhull_feature-keel.a),
+--- composed onto a Keel-less base on needs_http (docs/keel_feature.md, Phase
+--- 4.2b). Embedded-in-hull first (once wired), else the local build dir / cache.
+function M.resolve_keel_lib(tmpdir, ctx)
+    local libname = "libhull_feature-keel.a"
+    if tool.extract_feature_keel and tool.extract_feature_keel(tmpdir)
+       and file_exists(tmpdir .. "/" .. libname) then
+        return tmpdir .. "/" .. libname, "embedded"
+    end
+    local asset = ctx.plat and ("libhull_feature-keel-" .. ctx.plat .. ".a") or nil
+    return M.resolve_lib(libname, asset, ctx)
+end
+
 --- Resolve the per-runtime web-bindings archive (libhull_feature-http-<rt>.a),
 --- trying the embedded-in-hull copy first (issue #114, Phase C).
 --


### PR DESCRIPTION
The **compose half** of the Keel base-drop ([docs/keel_feature.md](../blob/main/docs/keel_feature.md), Phase 4.2b). #151 dropped Keel from the base; this composes it back for http apps, so http apps keep a real server while compute apps stay Keel-free.

## What
- **`libhull_feature-keel.a`** (`make feature-keel`): `serve.o` (KlServer loop + strong `hull_serve`) + `async_keel.o` (strong `hl_async_backend`) + `net_keel.o` (strong `hl_net_op_*`) + the server-only `hull_static.o`/`agent_api.o`/`test_runner.o`. Built from the default HTTP_SERVER=1 objects (the real server).
- **`build.lua`** composes it inside the `needs_http` block, whole-archived, **only when the base is Keel-less**. Probe: `hl_async_backend_keel` (async_keel.o's vtable) is absent from a Keel-less base, present in a Keel-full one. (A cleaner sentinel than `hull_serve` — `serve_cli.o` defines it **weak**, and macOS plain `nm` prints a weak def as `T`, indistinguishable from strong.) A Keel-full base already carries these objects, so the gate skips → no duplicate `hull_serve`.
- **`feature_compose.lua`** `resolve_keel_lib`: embedded-in-hull first (once wired), then the local build dir / signed cache. The composed `serve.o`'s `kl_*` refs pull `libkeel` from the base `.a` on demand.

## Proven
- **HTTP app on a Keel-less base:** composes the event loop (`kl_server_run` present, builds).
- **Compute app on the same base:** composes **no Keel** (`composed Keel = 0`).
- **Default (Keel-full) base:** the gate skips, so plain `hull build` is **byte-identical** — `make test` **60/60**. Dormant until the app-build base goes Keel-less.

## Next
Embed `libhull_feature-keel.a` in hull + flip the app-build base to Keel-less (fold into SLIM) + release wiring, then the `pure-compute` preset (4.3). Together those activate the win end to end: a stock `hull build` of a compute app links zero Keel.