### PR TITLE
feat(keel): embed the Keel feature + Keel-less SLIM app-base (Phase 4.2b activation)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
             feature-sqlite feature-sqlite-lua feature-sqlite-js
             feature-image feature-image-lua feature-image-js
             feature-tls
+            feature-keel
       - name: Build embedded feature archives (macOS)
         if: runner.os == 'macOS'
         run: >
@@ -87,6 +88,7 @@ jobs:
           feature-sqlite feature-sqlite-lua feature-sqlite-js
           feature-image feature-image-lua feature-image-js
           feature-tls
+          feature-keel
       - name: Upload embedded feature archives
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
@@ -109,6 +111,7 @@ jobs:
             build/libhull_feature-image-lua.a
             build/libhull_feature-image-js.a
             build/libhull_feature-tls.a
+            build/libhull_feature-keel.a
 
       # Per-flavor platform libs for `hull build --flavor` + `hull platform
       # install`. Each native platform-<flavor> target builds into its own obj
@@ -309,7 +312,7 @@ jobs:
             # bridges (Phase C.2b). `tls` = the mbedTLS + crypto/transport backends
             # (docs/tls_feature.md, a2; one archive, no per-runtime bridge).
             for arch in linux-x86_64 linux-aarch64 darwin-arm64; do
-              for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js sqlite sqlite-lua sqlite-js image image-lua image-js tls; do
+              for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js sqlite sqlite-lua sqlite-js image image-lua image-js tls keel; do
                 f="platforms/platform-features-$arch/libhull_feature-$stem.a"
                 sha256sum "$f" \
                   | awk -v n="libhull_feature-$stem.$arch.a" '{print $1"  "n}'
@@ -604,7 +607,7 @@ jobs:
           # name (libhull_feature-<stem>.<arch>.a), or the runtime §5c check on
           # every app this hull builds would fail. Includes the SQLite engine
           # (sqlite) + udf bridges (sqlite-lua/sqlite-js) + the TLS backends (tls).
-          for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js sqlite sqlite-lua sqlite-js image image-lua image-js tls; do
+          for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js sqlite sqlite-lua sqlite-js image image-lua image-js tls keel; do
             fa="build/libhull_feature-$stem.a"
             name="libhull_feature-$stem.${{ matrix.name }}.a"
             fact=$(sha256sum "$fa" | awk '{print $1}')

--- a/Makefile
+++ b/Makefile
@@ -2950,11 +2950,11 @@ platform-keelless: $(KEELLESS_PLATFORM_LIB)
 		echo "FAIL: Keel-less base is missing the serve_cli.o entry"; exit 1; fi
 	@echo "ok  Keel-less base drops serve.o + async_keel.o + net_keel.o (4.2b base-drop verified)"
 
-# ── Combined SQLite-less + TLS-less app-build base ─────────────────────
-# When a release drops BOTH SQLite and TLS from the app base, they must share one
-# sub-build (the embedded base is a single platform lib). HL_SQLITE_FEATURE=1 +
-# HL_TLS_FEATURE=1 together. Used only when HL_APP_BASE_SQLITELESS=1 AND
-# HL_APP_BASE_TLSLESS=1.
+# ── Combined SLIM app-build base: SQLite-less + TLS-less + Keel-less ────
+# The release's minimal app-build base: every composable subsystem dropped, each
+# composed back per app. One shared sub-build (the embedded base is a single
+# platform lib): HL_SQLITE_FEATURE=1 + HL_TLS_FEATURE=1 + HL_KEEL_FEATURE=1. Used
+# when HL_APP_BASE_SQLITELESS=1 AND HL_APP_BASE_TLSLESS=1 (the release sets both).
 SLIM_PLATFORM_LIB := $(BUILDDIR)/libhull_platform-slim.a
 ifeq ($(TRUST_PLATFORM_LIB),1)
 $(SLIM_PLATFORM_LIB): | $(BUILDDIR)
@@ -2962,9 +2962,9 @@ $(SLIM_PLATFORM_LIB): | $(BUILDDIR)
 	@echo "$@: trusting pre-built artifact (TRUST_PLATFORM_LIB=1)"
 else
 $(SLIM_PLATFORM_LIB):
-	$(MAKE) platform BUILDDIR=$(BUILDDIR)/slim HL_SQLITE_FEATURE=1 HL_TLS_FEATURE=1
+	$(MAKE) platform BUILDDIR=$(BUILDDIR)/slim HL_SQLITE_FEATURE=1 HL_TLS_FEATURE=1 HL_KEEL_FEATURE=1
 	cp $(BUILDDIR)/slim/libhull_platform.a $@
-	@echo "built $@ (SQLite-less + TLS-less app-build base)"
+	@echo "built $@ (SQLite-less + TLS-less + Keel-less app-build base)"
 endif
 .PHONY: platform-slim
 platform-slim: $(SLIM_PLATFORM_LIB)
@@ -3644,6 +3644,20 @@ $(EMBEDDED_TLS_H): $(BUILDDIR)/libhull_feature-tls.a | $(BUILDDIR)
 	@xxd -i $(BUILDDIR)/libhull_feature-tls.a | sed 's/build_libhull_feature_tls_a/hl_embedded_feature_tls_a/g' | $(XXD_CONST_PIPE) >> $@
 CFLAGS += -DHL_BUILD_EMBEDDED_TLS
 $(BUILD_ASSET_OBJ): $(EMBEDDED_TLS_H)
+endif
+
+# Keel feature archive embed (Phase 4.2b): keel is folded into the SLIM base, so
+# when the app-build base is SLIM (SQLITELESS + TLSLESS both set) it is also
+# Keel-less -- embed libhull_feature-keel.a (serve.o + async_keel + net_keel +
+# the server-only static/agent/test objects) so an http app auto-composes the
+# Keel event loop with no `hull feature install`. Only pulled for the SLIM base.
+ifeq ($(HL_APP_BASE_SQLITELESS)$(HL_APP_BASE_TLSLESS),11)
+EMBEDDED_KEEL_H := $(BUILDDIR)/embedded_keel.h
+$(EMBEDDED_KEEL_H): $(BUILDDIR)/libhull_feature-keel.a | $(BUILDDIR)
+	@echo "/* Auto-generated - do not edit */" > $@
+	@xxd -i $(BUILDDIR)/libhull_feature-keel.a | sed 's/build_libhull_feature_keel_a/hl_embedded_feature_keel_a/g' | $(XXD_CONST_PIPE) >> $@
+CFLAGS += -DHL_BUILD_EMBEDDED_KEEL
+$(BUILD_ASSET_OBJ): $(EMBEDDED_KEEL_H)
 endif
 endif
 

--- a/include/hull/build_assets.h
+++ b/include/hull/build_assets.h
@@ -72,6 +72,7 @@ int hl_build_extract_feature_wasm_rt(const char *dir, const char *rt);
 int hl_build_extract_feature_sqlite_rt(const char *dir, const char *rt);
 int hl_build_extract_feature_sqlite(const char *dir);
 int hl_build_extract_feature_tls(const char *dir);
+int hl_build_extract_feature_keel(const char *dir);
 int hl_build_extract_feature_image(const char *dir);
 int hl_build_extract_feature_image_rt(const char *dir, const char *rt);
 

--- a/src/hull/build_assets.c
+++ b/src/hull/build_assets.c
@@ -38,6 +38,9 @@
 #ifdef HL_BUILD_EMBEDDED_TLS
 #include "embedded_tls.h"       /* hl_embedded_feature_tls_a[] (mbedTLS + crypto/tls) */
 #endif
+#ifdef HL_BUILD_EMBEDDED_KEEL
+#include "embedded_keel.h"      /* hl_embedded_feature_keel_a[] (serve.o + Keel event loop) */
+#endif
 #ifdef HL_BUILD_EMBEDDED_IMAGE
 #include "embedded_image.h"     /* hl_embedded_feature_image{,_lua,_js}_a[] */
 #endif
@@ -52,7 +55,8 @@
     || defined(HL_BUILD_EMBEDDED_RUNTIME) || defined(HL_BUILD_EMBEDDED_HTTP) \
     || defined(HL_BUILD_EMBEDDED_TUI) || defined(HL_BUILD_EMBEDDED_WASM) \
     || defined(HL_BUILD_EMBEDDED_SQLITE) || defined(HL_BUILD_EMBEDDED_SQLITE_RT) \
-    || defined(HL_BUILD_EMBEDDED_IMAGE) || defined(HL_BUILD_EMBEDDED_TLS)
+    || defined(HL_BUILD_EMBEDDED_IMAGE) || defined(HL_BUILD_EMBEDDED_TLS) \
+    || defined(HL_BUILD_EMBEDDED_KEEL)
 static int write_blob(const char *path, const unsigned char *data, size_t len)
 {
     FILE *f = fopen(path, "wb");
@@ -260,6 +264,23 @@ int hl_build_extract_feature_tls(const char *dir)
         return -1;
     return write_blob(path, hl_embedded_feature_tls_a,
                       hl_embedded_feature_tls_a_len);
+#else
+    (void)dir;
+    return -1;
+#endif
+}
+
+int hl_build_extract_feature_keel(const char *dir)
+{
+#ifdef HL_BUILD_EMBEDDED_KEEL
+    if (!dir)
+        return -1;
+    char path[1024];
+    int n = snprintf(path, sizeof(path), "%s/libhull_feature-keel.a", dir);
+    if (n < 0 || (size_t)n >= sizeof(path))
+        return -1;
+    return write_blob(path, hl_embedded_feature_keel_a,
+                      hl_embedded_feature_keel_a_len);
 #else
     (void)dir;
     return -1;

--- a/src/hull/runtime/lua/mod_tool.c
+++ b/src/hull/runtime/lua/mod_tool.c
@@ -555,6 +555,14 @@ static int l_tool_extract_feature_tls(lua_State *L)
     return 1;
 }
 
+static int l_tool_extract_feature_keel(lua_State *L)
+{
+    const char *dir = luaL_checkstring(L, 1);
+    int rc = hl_build_extract_feature_keel(dir);
+    lua_pushboolean(L, rc == 0);
+    return 1;
+}
+
 /* ── tool.extract_feature_image(dir) / _image_rt(dir, rt) → bool ────── */
 
 static int l_tool_extract_feature_image(lua_State *L)
@@ -1299,6 +1307,7 @@ static const luaL_Reg tool_funcs[] = {
     { "extract_feature_sqlite_rt", l_tool_extract_feature_sqlite_rt },
     { "extract_feature_sqlite", l_tool_extract_feature_sqlite },
     { "extract_feature_tls",    l_tool_extract_feature_tls },
+    { "extract_feature_keel",   l_tool_extract_feature_keel },
     { "extract_feature_image",  l_tool_extract_feature_image },
     { "extract_feature_image_rt", l_tool_extract_feature_image_rt },
     { "extract_platform_cosmo", l_tool_extract_platform_cosmo },


### PR DESCRIPTION
**Activates the Keel base-drop end to end.** #151 dropped Keel from the base and #152 composed it back; this makes the *distributed* binary do it by default — folds `HL_KEEL_FEATURE=1` into the SLIM app-build base and embeds `libhull_feature-keel.a` in hull.

## What
- **SLIM base gains `HL_KEEL_FEATURE=1`** → the release's minimal app-base is now SQLite-less **+ TLS-less + Keel-less** (drops `serve.o`/`async_keel`/`net_keel` alongside SQLite + mbedTLS).
- **`EMBEDDED_KEEL_H`** (gated on the SLIM condition — both `HL_APP_BASE_*` flags) xxd's `libhull_feature-keel.a` into hull with `-DHL_BUILD_EMBEDDED_KEEL`. Embed chain mirrors TLS a2: `build_assets.c` `hl_build_extract_feature_keel` + header + `mod_tool.c` `tool.extract_feature_keel` (which `resolve_keel_lib` already prefers).
- **`release.yml`**: build + upload `feature-keel` with the other embedded features, and add the `keel` stem to the signed platform manifest + stage-3 verify, so the embedded Keel archive is **platform-domain attested (§5c)** like the rest. Keeps the release consistent (the SLIM base already drops Keel via the folded flag).

## Proven end to end (embedded SLIM-app-base hull)
- **COMPUTE app:** a stock `hull build` links **0 Keel + 0 mbedTLS** — **~2.1 MB** (was ~3.7 MB).
- **HTTP app:** composes the Keel event loop back from the embedded feature (`kl_server_run` present, builds).
- Default (non-SLIM) build **byte-identical**, `make test` **60/60**.

## Notes
- `make platform-slim` is recipe-only, so after changing the sub-build flags you must force-rebuild (`rm -rf build/slim build/libhull_platform-slim.a`). CI/release build fresh so this only bites local iteration.
- ci.yml doesn't build the SLIM-embed path (release-only), so this PR is CI-safe; the release wiring is included so no future tag breaks.

## Next — Phase 4.3
`pure-compute` becomes a `build.lua` preset (compose nothing), now that a compute app on the *default* composable base is genuinely Keel/mbedTLS/SQLite-free. Delete `platform-pure-compute` + `hull flavor install pure-compute` + the per-flavor base matrix. That's the original "flavors become feature presets" payoff.