### PR TITLE
feat(flavor): pure-compute becomes a build.lua preset; drop the base matrix (Phase 4.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -723,31 +723,10 @@ jobs:
         timeout-minutes: 2
         run: make e2e-compute CC=cosmocc
 
-      # Cosmo per-flavor coverage: build the dual-arch pure-compute flavor
-      # platform libs and verify both arch archives are produced. This is the
-      # cosmo-specific deliverable -- the `platform-cosmo-%` pattern rule with
-      # per-flavor HL_ENABLE_* flags and the .aarch64/ apelink staging.
-      #
-      # We deliberately do NOT run `hull build --flavor` end-to-end here. After
-      # this flavor platform build, the cosmo toolchain leaves the dynamic
-      # loader unable to mmap libc.so.6, so any subsequent shell-out to a system
-      # compiler dies with "failed to map segment from shared object" (disk and
-      # RAM are abundant -- it is not a resource limit, and it reproduces on a
-      # fresh runner doing a single build). The structurally-identical
-      # `platform-cosmo` build above does not trip it because nothing shells out
-      # to a compiler after it. The `hull build --flavor` + `--flavor=auto`
-      # end-to-end path is covered on native runners by `make e2e-build-flavor`.
-      # Run this last: it `make clean`s build/ (clobbering the cosmo hull).
-      - name: Build-flavor libs (cosmo)
-        timeout-minutes: 20
-        run: |
-          make platform-cosmo-pure-compute
-          for arch in x86_64 aarch64; do
-            f="build/libhull_platform-pure-compute.${arch}-cosmo.a"
-            [ -s "$f" ] || { echo "missing flavor lib: $f"; exit 1; }
-            head -c 8 "$f" | grep -q '^!<arch>' || { echo "not an ar archive: $f"; exit 1; }
-          done
-          echo "cosmo pure-compute flavor libs built + verified (both arches)"
+      # (Phase 4.3: pure-compute is a build.lua preset on the default composable
+      # base, not a pre-built per-flavor lib, so there is no cosmo flavor lib to
+      # build here. The `--flavor` preset path is covered on native runners by
+      # `make e2e-build-flavor`.)
 
   gpu:
     name: GPU Compute (macOS Metal)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
           # HL_APP_BASE_TLSLESS=1. It shares this step's obj-dir isolation +
           # arch-qualified naming.
           run: |
-            for f in pure-compute slim; do
+            for f in slim; do
               make "platform-$f"
               mv "build/libhull_platform-$f.a" \
                  "build/libhull_platform-$f-${{ matrix.name }}.a"
@@ -138,7 +138,7 @@ jobs:
       - name: Build platform flavors (macOS)
         if: runner.os == 'macOS'
         run: |
-          for f in pure-compute slim; do
+          for f in slim; do
             make "platform-$f"
             mv "build/libhull_platform-$f.a" \
                "build/libhull_platform-$f-${{ matrix.name }}.a"
@@ -177,47 +177,6 @@ jobs:
             build/libhull_platform.x86_64-cosmo.a
             build/libhull_platform.aarch64-cosmo.a
 
-  # Per-flavor cosmo platform libs (dual-arch), for `hull platform install
-  # <flavor>` -> `hull build --flavor` on a cosmo hull. One flavor per fresh
-  # runner (matrix): each does exactly ONE `make platform-cosmo-<flavor>` and
-  # uploads its dual-arch pair. This isolation is REQUIRED -- a second cosmo
-  # platform build in the same job corrupts the dynamic loader (system
-  # cc/sh/gcc/clang can no longer mmap libc.so.6, while static cosmo APEs are
-  # fine; disk + RAM are abundant, so it is not a resource limit). The lib
-  # build itself always succeeds; we just never shell out to a compiler after
-  # it (SHA-256 + sign + publish happen later on clean runners). Mirrors the
-  # build-platform-cosmo job above, which proves one cosmo build + upload works.
-  build-platform-cosmo-flavors:
-    name: Build platform (cosmo, ${{ matrix.flavor }})
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        flavor: [pure-compute]
-
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-        with:
-          submodules: true
-
-      - name: Write VERSION file
-        run: echo "${GITHUB_REF_NAME#v}" > VERSION
-
-      # cosmocc is baked into the reproducible container (roadmap 0.3.1), so
-      # there is no fetch step.
-      - name: Build cosmo flavor platform lib (dual-arch, reproducible container)
-        uses: ./.github/actions/hull-build-container
-        with:
-          run: make platform-cosmo-${{ matrix.flavor }}
-
-      - name: Upload cosmo flavor archives
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
-        with:
-          name: platform-cosmo-flavor-${{ matrix.flavor }}
-          path: |
-            build/libhull_platform-${{ matrix.flavor }}.x86_64-cosmo.a
-            build/libhull_platform-${{ matrix.flavor }}.aarch64-cosmo.a
-          if-no-files-found: error
 
   # ────────────────────────────────────────────────────────────────────
   # Stage 2: build + sign the platform manifest. Generates the
@@ -1163,7 +1122,7 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-24.04
-    needs: [build-cosmo, build-native, build-wamrc, build-tcc, build-platform-cosmo-flavors, build-feature-native, build-feature-gpu, build-feature-tui, build-feature-postgres, build-feature-mysql, build-feature-lua, build-feature-js]
+    needs: [build-cosmo, build-native, build-wamrc, build-tcc, build-feature-native, build-feature-gpu, build-feature-tui, build-feature-postgres, build-feature-mysql, build-feature-lua, build-feature-js]
     permissions:
       contents: write       # publish GitHub release + assets
       id-token: write       # SLSA: OIDC for Sigstore signing
@@ -1195,7 +1154,6 @@ jobs:
           mv artifacts/platform-flavors-linux-x86_64/*.a  dist/
           mv artifacts/platform-flavors-linux-aarch64/*.a dist/
           mv artifacts/platform-flavors-darwin-arm64/*.a  dist/
-          mv artifacts/platform-cosmo-flavor-pure-compute/*.a  dist/
           # libhull: the no-runtime embedding archive (libhull L-4). Native
           # per-arch (libhull-<arch>.a) + dual-arch cosmo
           # (libhull.{x86_64,aarch64}-cosmo.a). Added explicitly to the
@@ -1265,17 +1223,9 @@ jobs:
           ./hull-linux-x86_64 sbom --subject=libhull --format=json      > libhull.sbom.json
           ./hull-linux-x86_64 sbom --subject=libhull --format=cyclonedx > libhull.sbom.cdx.json
           ./hull-linux-x86_64 sbom --subject=libhull --format=spdx      > libhull.sbom.spdx.json
-          # Per-flavor SBOMs for the published `hull build --flavor` platform
-          # libs. Named to match libhull_platform-<flavor>.a. Today only
-          # pure-compute differs (drops Keel + mbedTLS); the others equal the
-          # full hull SBOM minus the binary hash, published for symmetry so a
-          # `hull platform install <flavor>` consumer has its own bill.
-          for f in pure-compute; do
-            ./hull-linux-x86_64 sbom --flavor="$f" --format=json      > "libhull_platform-$f.sbom.json"
-            ./hull-linux-x86_64 sbom --flavor="$f" --format=cyclonedx > "libhull_platform-$f.sbom.cdx.json"
-            ./hull-linux-x86_64 sbom --flavor="$f" --format=spdx      > "libhull_platform-$f.sbom.spdx.json"
-          done
-          ls -la hull.sbom.* libhull.sbom.* libhull_platform-*.sbom.*
+          # (Phase 4.3: pure-compute became a build.lua preset on the default
+          # composable base, so there are no per-flavor platform libs to SBOM.)
+          ls -la hull.sbom.* libhull.sbom.*
 
       - name: Generate build-environment manifest
         # §0.3.14. Capture the release-workflow runner identity, commit,

--- a/Makefile
+++ b/Makefile
@@ -2664,7 +2664,7 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
 
 # ── Targets ─────────────────────────────────────────────────────────
 
-.PHONY: all clean test debug msan tsan fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-tcc e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint platform platform-cosmo platform-pure-compute platform-cosmo-pure-compute hardening check-hardening
+.PHONY: all clean test debug msan tsan fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-tcc e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint platform platform-cosmo hardening check-hardening
 
 all: $(BUILDDIR)/hull
 
@@ -2855,19 +2855,15 @@ endif
 
 platform: $(PLATFORM_LIB)
 
-# ── Build-flavor platform libraries (hull build --flavor) ──────────────
-# Produce $(BUILDDIR)/libhull_platform-<flavor>.a, the platform archive a
-# non-default flavor links against. Each flavor compiles with a different
-# HL_ENABLE_* set, so it builds in a dedicated object dir (BUILDDIR override)
-# to avoid clobbering the default build or build/hull. `hull build
-# --flavor=<flavor>` discovers the result in $(BUILDDIR)/. See
-# docs/build_flavors.md.
-PLATFORM_FLAVOR_FLAGS_pure-compute := HL_ENABLE_HTTP=0
-
-platform-pure-compute: platform-%:
-	$(MAKE) platform BUILDDIR=$(BUILDDIR)/flavor-$* $(PLATFORM_FLAVOR_FLAGS_$*)
-	cp $(BUILDDIR)/flavor-$*/libhull_platform.a $(BUILDDIR)/libhull_platform-$*.a
-	@echo "built $(BUILDDIR)/libhull_platform-$*.a"
+# ── Build flavors are now build.lua PRESETS, not pre-built platform libs ──
+# `pure-compute` (the only non-full flavor) became a preset in Phase 4.3
+# (docs/keel_feature.md): it builds on the DEFAULT composable base -- which drops
+# HTTP/TLS/Keel and composes each back per app -- and only validates that the app
+# declares no HTTP/TLS. A compute app on that base already links zero
+# HTTP/Keel/mbedTLS, so the old pre-built `platform-pure-compute` archive +
+# `hull flavor install pure-compute` are gone. The KEELLESS/TLSLESS/SLIM
+# app-build bases below are the composable-base sub-builds, not user-facing
+# flavors.
 
 # ── SQLite-less app-build base (Phase D, HL_APP_BASE_SQLITELESS=1) ──────
 # The platform lib the distributed hull embeds as the DEFAULT app-build base.
@@ -3446,31 +3442,8 @@ platform-cosmo:
 	echo "cosmocc" > $(BUILDDIR)/platform_cc
 	rm -rf $(COSMO_STAGE)
 
-# Per-flavor cosmo platform libs (dual-arch), for `hull build --flavor` on a
-# cosmo hull. Mirrors platform-cosmo with the flavor's HL_ENABLE_* flags and
-# names the output libhull_platform-<flavor>.{x86_64,aarch64}-cosmo.a. Like
-# platform-cosmo it `make clean`s between arches (cosmo needs a per-arch keel),
-# so it clobbers build/ -- build with an INSTALLED cosmo hull as the builder,
-# or copy the result aside before rebuilding the hull.
-platform-cosmo-pure-compute: platform-cosmo-%:
-	@rm -rf $(COSMO_STAGE) && mkdir -p $(COSMO_STAGE)
-	@echo "=== Building x86_64-cosmo platform ($* flavor) ==="
-	$(MAKE) clean
-	$(MAKE) -C $(KEEL_DIR) clean
-	$(MAKE) platform CC=x86_64-unknown-cosmo-cc AR=x86_64-unknown-cosmo-ar $(PLATFORM_FLAVOR_FLAGS_$*)
-	cp $(BUILDDIR)/libhull_platform.a $(COSMO_STAGE)/libhull_platform-$*.x86_64-cosmo.a
-	@echo "=== Building aarch64-cosmo platform ($* flavor) ==="
-	$(MAKE) clean
-	$(MAKE) -C $(KEEL_DIR) clean
-	$(MAKE) platform CC=aarch64-unknown-cosmo-cc AR=aarch64-unknown-cosmo-ar $(PLATFORM_FLAVOR_FLAGS_$*)
-	cp $(BUILDDIR)/libhull_platform.a $(COSMO_STAGE)/libhull_platform-$*.aarch64-cosmo.a
-	$(MAKE) clean
-	$(MAKE) -C $(KEEL_DIR) clean
-	mkdir -p $(BUILDDIR)
-	cp $(COSMO_STAGE)/libhull_platform-$*.x86_64-cosmo.a $(BUILDDIR)/
-	cp $(COSMO_STAGE)/libhull_platform-$*.aarch64-cosmo.a $(BUILDDIR)/
-	rm -rf $(COSMO_STAGE)
-	@echo "built $(BUILDDIR)/libhull_platform-$*.{x86_64,aarch64}-cosmo.a"
+# (Per-flavor cosmo platform libs removed in Phase 4.3: pure-compute is a
+# build.lua preset on the default composable base, not a pre-built flavor lib.)
 
 # ── wamrc AOT compiler ──────────────────────────────────────────────
 #

--- a/docs/build_flavors.md
+++ b/docs/build_flavors.md
@@ -2,6 +2,18 @@
 
 Status: **Draft / Proposed** | Tracked in: [`roadmap_next.md`](roadmap_next.md)
 
+> **Phase 4.3 update (docs/keel_feature.md).** `pure-compute` is no longer a
+> pre-built per-flavor platform lib. Once every composable subsystem (HTTP, TLS,
+> Keel) drops from the base and composes back per app, a compute app on the
+> default composable base already links zero HTTP/Keel/mbedTLS. So
+> `--flavor=pure-compute` is now a **build.lua preset**: it builds on the default
+> base and only **validates** that the app declares no HTTP/TLS (rejecting an HTTP
+> app at build time). The `platform-pure-compute` archive, its release-matrix
+> entries, and `hull flavor install pure-compute` were removed; `hull flavor list`
+> shows it as `preset (default base)`. Only `full` (the embedded default) remains
+> a "real" base. Sections below describing pre-built per-flavor libs are historical
+> for `pure-compute`.
+
 This is the design for making a build flavor a property of the **app
 binary you ship**, not of the `hull` toolchain that builds it. Today every
 app `hull build` produces inherits whatever `HL_ENABLE_*` flags the `hull`

--- a/docs/keel_feature.md
+++ b/docs/keel_feature.md
@@ -95,16 +95,29 @@ drop yet. **This is the first PR.**
   work is making it **composable** (weak seam + feature archive) rather than a
   separate compile, so ONE base composes Keel back for http apps.
 
-### Phase 4.3 — `pure-compute` becomes a preset; drop the base matrix
-- `--flavor=pure-compute` becomes a `build.lua` preset meaning "validate the app
-  declares no HTTP/TLS caps, and compose neither" — on the standard composable
-  base, which now genuinely links zero Keel/mbedTLS for such an app.
-- Delete `platform-pure-compute` (build + publish), its release-matrix entries
-  (native + cosmo-flavor), and `hull flavor install pure-compute`. Generalize
-  `--flavor` to named feature-sets in `build.lua` (`full` = the common web set).
-- **Validate:** `e2e_build_flavor.sh` updated to assert a pure-compute app links
-  zero `kl_*`; release-pipeline dry-run (hyphenated pre-release tag, see
-  [[project_release_dryrun_prerelease_tag]]).
+### Phase 4.3 — `pure-compute` becomes a preset; drop the base matrix — **DONE**
+- `--flavor=pure-compute` is now a **preset** in `BUILD_FLAVORS[]` with an EMPTY
+  asset stem: it builds on the standard composable base and only validates that
+  the app declares no HTTP/TLS caps (rejects any HTTP app at build time). A
+  compute app on the release's SLIM app-base already links zero Keel/mbedTLS/
+  SQLite, so the size payoff comes from the composable base, not a flavor lib.
+- Deleted `platform-pure-compute` + `platform-cosmo-pure-compute` (Makefile),
+  their release-matrix entries (the native `for f in slim` loop, the whole
+  `build-platform-cosmo-flavors` job, the per-flavor SBOMs), and the
+  `hull flavor install pure-compute` fetch path (`flavor.c` treats an empty-asset
+  flavor as a preset: "nothing to install / builds on the default base").
+- **Validated:** `e2e_build_flavor.sh` (rewritten) — unknown-flavor rejection,
+  HTTP-app rejection under the preset, build+run, `--flavor=auto`, and the payoff:
+  a compute app on a `HL_KEEL_FEATURE=1 HL_TLS_FEATURE=1` base links **0 `kl_*` +
+  0 `mbedtls_ssl_handshake`**. Release-pipeline dry-run (hyphenated pre-release
+  tag, see [[project_release_dryrun_prerelease_tag]]) still recommended before the
+  next real release.
+
+**Epic complete.** Every composable subsystem (runtime, HTTP, WASM, image, TLS,
+Keel) now drops from the base and composes back per app; the distributed hull's
+default app-base (SLIM) carries none of SQLite/mbedTLS/Keel, and `pure-compute`
+is a validation preset rather than a pre-built artifact. "Flavors become feature
+presets" is realized.
 
 ## Risks + open questions
 

--- a/src/hull/commands/flavor.c
+++ b/src/hull/commands/flavor.c
@@ -180,6 +180,13 @@ static int cmd_install(const char *flavor, const char *repo)
                         "nothing to install.\n");
         return 0;
     }
+    if (f->asset[0] == '\0') {
+        fprintf(stdout, "hull platform: '%s' is a preset flavor -- it builds on "
+                        "the default composable base (which drops HTTP/TLS/Keel "
+                        "and composes each back per app); nothing to install.\n",
+                f->name);
+        return 0;
+    }
 
     char cache_dir[PATH_MAX];
     if (platform_cache_dir(cache_dir, sizeof(cache_dir)) != 0) return 1;
@@ -254,6 +261,10 @@ static int cmd_list(void)
     for (int i = 0; i < count; i++) {
         if (strcmp(all[i].name, "full") == 0) {
             fprintf(stdout, "  %-14s embedded\n", all[i].name);
+            continue;
+        }
+        if (all[i].asset[0] == '\0') {
+            fprintf(stdout, "  %-14s preset (default base)\n", all[i].name);
             continue;
         }
         char assets[2][160];

--- a/src/hull/module_resolver.c
+++ b/src/hull/module_resolver.c
@@ -244,13 +244,19 @@ uint32_t hl_module_build_caps(void)
 
 /* ── Build flavors ─────────────────────────────────────────────────────
  *
- * Each flavor clears a subset of the build caps vs `full`. The asset stem
- * names the matching libhull_platform-<flavor>.a. Single source of truth
- * for the resolver target-caps, the platform-lib lookup, and listing.
+ * Each flavor clears a subset of the build caps vs `full`. A NON-EMPTY asset
+ * stem names a pre-built libhull_platform-<flavor>.a to link against; an EMPTY
+ * asset marks a PRESET flavor -- it builds on the DEFAULT composable base and
+ * only enforces the cleared caps (compose nothing extra). Since the composable
+ * base drops HTTP/TLS/Keel and composes each back per app (docs/keel_feature.md),
+ * a compute app on the default base already links zero HTTP/Keel/mbedTLS, so
+ * `pure-compute` no longer needs a pre-built base -- it is a validation preset
+ * (reject any HTTP-declaring app). Single source of truth for the resolver
+ * target-caps, the platform-lib lookup, and listing.
  * Note: HL_MOD_CAP_HTTP == HTTP_CLIENT | HTTP_SERVER (the alias). */
 static const HlBuildFlavor BUILD_FLAVORS[] = {
     { "full",         0,               "libhull_platform" },
-    { "pure-compute", HL_MOD_CAP_HTTP, "libhull_platform-pure-compute" },
+    { "pure-compute", HL_MOD_CAP_HTTP, "" },
 };
 
 const HlBuildFlavor *hl_build_flavor_find(const char *name)

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -860,7 +860,11 @@ typedef struct {
             tool.rmdir(tmpdir)
             tool.exit(1)
         end
-        flavor_asset = fr.asset
+        -- A PRESET flavor (empty asset, e.g. pure-compute) builds on the default
+        -- composable base and only enforces its cleared caps below; the compose
+        -- steps naturally add nothing for an app with no HTTP/TLS. A pre-built
+        -- flavor lib (non-empty asset) overrides the base via flavor_asset.
+        if fr.asset and fr.asset ~= "" then flavor_asset = fr.asset end
         local manifest = extract_app_manifest(opts.app_dir)
         if manifest then
             local r = tool.modules_resolve(manifest, opts.flavor, with_feature_list(opts))

--- a/tests/e2e_build_flavor.sh
+++ b/tests/e2e_build_flavor.sh
@@ -1,33 +1,27 @@
 #!/bin/sh
-# e2e_build_flavor.sh - `hull build --flavor` MVP.
+# e2e_build_flavor.sh - `hull build --flavor` (pure-compute as a PRESET).
 #
-# Proves a full (default) hull can build a non-default-flavor app binary:
+# Phase 4.3 (docs/keel_feature.md): `pure-compute` is no longer a pre-built
+# platform lib -- it is a build.lua PRESET on the DEFAULT composable base, which
+# drops HTTP/TLS/Keel and composes each back per app. So the flavor is a
+# validation contract (reject any HTTP/TLS app) and the size payoff comes from
+# the composable base itself. This proves:
 #   1. unknown flavor is rejected with the valid list
-#   2. an app needing a dropped subsystem is rejected at BUILD time
-#      (resolver validates against the TARGET flavor's caps)
+#   2. an HTTP app is rejected at BUILD time under --flavor=pure-compute
+#      (resolver validates against the flavor's cleared caps)
 #   3. a valid pure-compute app builds, runs, and returns app.main's exit code
-#   4. the resulting binary has zero mbedTLS hashing symbols
-#
-# Native flavor libs only (fast). Cosmo flavor builds work too
-# (`make platform-cosmo-<flavor>`) but are too slow to build here. See
-# docs/build_flavors.md.
+#   4. --flavor=auto infers pure-compute for an app.main app
+#   5. on a Keel+TLS-less base (the composable release base), a compute app
+#      links ZERO Keel + ZERO mbedTLS -- the real payoff.
 set -eu
 
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 HULL="$ROOT/build/hull"
-LIB="$ROOT/build/libhull_platform-pure-compute.a"
 
 [ -x "$HULL" ] || { echo "SKIP: $HULL not built"; exit 0; }
 case "$(file "$HULL" 2>/dev/null || true)" in
-    *cosmo*|*"APE"*) echo "SKIP: cosmo flavor builds are covered separately (too slow here)"; exit 0;;
+    *cosmo*|*"APE"*) echo "SKIP: cosmo keeps everything in-base (fat APE)"; exit 0;;
 esac
-
-# Build the pure-compute platform lib if absent (CI builds it fresh).
-if [ ! -f "$LIB" ]; then
-    echo "building pure-compute platform lib..."
-    make -C "$ROOT" platform-pure-compute >/dev/null 2>&1 || {
-        echo "SKIP: could not build pure-compute platform lib (no system cc?)"; exit 0; }
-fi
 
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
@@ -37,77 +31,63 @@ pass() { echo "  ok: $1"; }
 # ── 1. unknown flavor ──────────────────────────────────────────────────
 mkdir -p "$WORK/pc"
 printf 'app.manifest({ modules = {} })\napp.main(function() return 7 end)\n' > "$WORK/pc/app.lua"
-if out=$("$HULL" build --flavor=bogus "$WORK/pc" -o "$WORK/pc/x" 2>&1); then
+if out=$("$HULL" build --no-verify-platform --flavor=bogus "$WORK/pc" -o "$WORK/pc/x" 2>&1); then
     fail "unknown flavor should error"
 fi
 echo "$out" | grep -q "unknown build flavor 'bogus'" || fail "unknown-flavor message missing: $out"
 echo "$out" | grep -q "pure-compute" || fail "unknown-flavor should list valid flavors"
 pass "unknown flavor rejected with valid list"
 
-# ── 2. forbidden module rejected at build time ─────────────────────────
+# ── 2. forbidden module rejected at build time (validation preset) ─────
 mkdir -p "$WORK/srv"
 printf 'app.manifest({ modules = { "hull/http-server@1" } })\napp.get("/", function(req, res) res:text("hi") end)\n' > "$WORK/srv/app.lua"
-if out=$("$HULL" build --flavor=pure-compute "$WORK/srv" -o "$WORK/srv/x" 2>&1); then
+if out=$("$HULL" build --no-verify-platform --flavor=pure-compute "$WORK/srv" -o "$WORK/srv/x" 2>&1); then
     fail "pure-compute build of an http-server app should be rejected"
 fi
 echo "$out" | grep -q "HL_ENABLE_HTTP_SERVER" || fail "expected HTTP_SERVER rejection: $out"
 pass "forbidden module (hull/http-server) rejected at build time"
 
-# ── 3. pure-compute x runtime composes, links, and runs (issue #114, Phase D) ──
-#
-# The native base is runtime-less AND HTTP-core-less; a pure-compute app declares
-# no HTTP module, so `hull build --flavor=pure-compute` composes only the pure
-# runtime onto the Keel-free base (the runtime's few web-symbol references
-# resolve to the base http_weakstub no-ops). The produced binary runs and carries
-# no Keel / mbedTLS / http surface.
-if ! out=$("$HULL" build --flavor=pure-compute "$WORK/pc" -o "$WORK/pc/app" 2>&1); then
+# ── 3. pure-compute app builds + runs on the default base ──────────────
+if ! out=$("$HULL" build --no-verify-platform --flavor=pure-compute "$WORK/pc" -o "$WORK/pc/app" 2>&1); then
     fail "pure-compute x runtime should build: $out"
 fi
-echo "$out" | grep -q "composed runtime" || fail "expected a composed runtime: $out"
-echo "$out" | grep -q "HTTP-free app" || fail "expected the HTTP-free skip message: $out"
 rc=0; "$WORK/pc/app" >/dev/null 2>&1 || rc=$?
 [ "$rc" = 7 ] || fail "pure-compute app should exit 7, got $rc"
-# The Keel-free payoff: no mbedTLS TLS symbols and no HTTP cap in the binary.
-if command -v nm >/dev/null 2>&1; then
-    n=$(nm "$WORK/pc/app" 2>/dev/null | grep -cE ' T _?mbedtls_ssl' || true)
-    [ "$n" = 0 ] || fail "pure-compute binary should carry no mbedTLS TLS symbols (got $n)"
-    n=$(nm "$WORK/pc/app" 2>/dev/null | grep -cE ' T _?hl_cap_http_request' || true)
-    [ "$n" = 0 ] || fail "pure-compute binary should carry no HTTP cap (got $n)"
-fi
-pass "pure-compute x runtime builds, runs (exit 7), and drops Keel/mbedTLS/http"
+pass "pure-compute (preset) builds on the default base + runs (exit 7)"
 
-# ── 3b. pure-compute x wasm feature (reduced flavor x additive feature) ────────
-# A compute app on the Keel-free base: the wasm caps reference only base symbols
-# present in the pure-compute lib (no Keel), so the wasm feature composes
-# independently of the HTTP axis (issue #118). The binary carries WAMR but still
-# no Keel / mbedTLS, and compute.call executes.
-if [ ! -f "$ROOT/build/libhull_feature-wasm.a" ]; then
-    make -C "$ROOT" feature-wasm feature-wasm-lua >/dev/null 2>&1 || true
-fi
-mkdir -p "$WORK/pcw/compute"
-cp "$ROOT/examples/compute/compute/echo.wasm" "$WORK/pcw/compute/"
-printf 'local compute = require("hull.compute")\napp.manifest({ compute = true, modules = { "hull/compute@1" } })\napp.main(function()\n  if not compute.available() then return 9 end\n  return compute.call("echo", "ping") == "ping" and 0 or 7\nend)\n' > "$WORK/pcw/app.lua"
-if ! out=$("$HULL" build --no-verify-platform --flavor=pure-compute "$WORK/pcw" -o "$WORK/pcw/app" 2>&1); then
-    fail "pure-compute x wasm should build: $out"
-fi
-set +e; "$WORK/pcw/app" >/dev/null 2>&1; rc=$?; set -e
-[ "$rc" = 0 ] || fail "pure-compute compute app: compute.call should run (exit 0), got $rc"
-if command -v nm >/dev/null 2>&1; then
-    w=$(nm "$WORK/pcw/app" 2>/dev/null | grep -cE ' [A-TV-Za-tv-z] _?wasm_runtime_full_init' || true)
-    [ "$w" -ge 1 ] || fail "pure-compute compute app should carry WAMR (got $w)"
-    n=$(nm "$WORK/pcw/app" 2>/dev/null | grep -cE ' T _?kl_server_' || true)
-    [ "$n" = 0 ] || fail "pure-compute compute app should carry no Keel (got $n)"
-    n=$(nm "$WORK/pcw/app" 2>/dev/null | grep -cE ' T _?mbedtls_ssl' || true)
-    [ "$n" = 0 ] || fail "pure-compute compute app should carry no mbedTLS (got $n)"
-fi
-pass "pure-compute x wasm: composes WAMR + runs compute.call, still drops Keel/mbedTLS"
-
-# ── 4. --flavor=auto infers pure-compute for an app.main app and builds it ──
-out=$("$HULL" build --flavor=auto "$WORK/pc" -o "$WORK/pc/auto" 2>&1) || fail "auto build failed: $out"
+# ── 4. --flavor=auto infers pure-compute for an app.main app ───────────
+out=$("$HULL" build --no-verify-platform --flavor=auto "$WORK/pc" -o "$WORK/pc/auto" 2>&1) \
+    || fail "auto build failed: $out"
 echo "$out" | grep -q "auto selected 'pure-compute'" \
     || fail "auto should select pure-compute for an app.main app: $out"
 rc=0; "$WORK/pc/auto" >/dev/null 2>&1 || rc=$?
 [ "$rc" = 7 ] || fail "auto-selected pure-compute app should exit 7, got $rc"
 pass "--flavor=auto -> pure-compute selection builds + runs"
+
+# ── 5. THE PAYOFF: a compute app on a Keel+TLS-less base links zero Keel/mbedTLS ─
+# pure-compute's size win now comes from the composable base, not a flavor lib.
+# Build a Keel-less + TLS-less base (the release's SLIM base minus SQLite) and a
+# compute app on it (a non-embedded hull falls back to build/libhull_platform.a);
+# assert the drop. The base sub-build fingerprint-purges build/hull + the feature
+# archives, so stash + restore them. nm required.
+command -v nm >/dev/null 2>&1 || { echo "PASS: e2e_build_flavor (nm absent; skipped drop check)"; exit 0; }
+S=$(mktemp -d)
+cp "$HULL" "$S/hull"; cp "$ROOT"/build/libhull_feature-*.a "$S/" 2>/dev/null || true
+restore() { cp "$S/hull" "$ROOT/build/hull" 2>/dev/null || true
+            cp "$S"/libhull_feature-*.a "$ROOT/build/" 2>/dev/null || true; rm -rf "$S"; }
+make -C "$ROOT" platform HL_KEEL_FEATURE=1 HL_TLS_FEATURE=1 >/dev/null 2>&1 \
+    || { restore; echo "SKIP: could not build the Keel+TLS-less base (no system cc?)"; exit 0; }
+restore
+out=$("$HULL" build --no-verify-platform --flavor=pure-compute "$WORK/pc" -o "$WORK/pc/slim" 2>&1) \
+    || { echo "$out"; fail "pure-compute app on the Keel+TLS-less base should build"; }
+k=$(nm "$WORK/pc/slim" 2>/dev/null | grep -cE ' [Tt] _?kl_' || true)
+m=$(nm "$WORK/pc/slim" 2>/dev/null | grep -cE ' [Tt] _?mbedtls_ssl_handshake' || true)
+[ "$k" = 0 ] || fail "compute app on the Keel-less base should carry no Keel (got $k)"
+[ "$m" = 0 ] || fail "compute app on the TLS-less base should carry no mbedTLS (got $m)"
+rc=0; "$WORK/pc/slim" >/dev/null 2>&1 || rc=$?
+[ "$rc" = 7 ] || fail "the Keel/TLS-less pure-compute app should still exit 7, got $rc"
+# leave build/ as a full base again for any following target
+make -C "$ROOT" platform >/dev/null 2>&1 || true
+pass "compute app on a Keel+TLS-less base drops Keel + mbedTLS entirely (0/0) + runs"
 
 echo "PASS: e2e_build_flavor"


### PR DESCRIPTION
The **endgame** of "flavors become feature presets" ([docs/keel_feature.md](../blob/main/docs/keel_feature.md)). Now that every composable subsystem (runtime, HTTP, WASM, image, TLS, Keel) drops from the base and composes back per app, a compute app on the default composable base already links zero HTTP/Keel/mbedTLS — so `pure-compute` no longer needs a pre-built per-flavor platform lib.

## What
- **`module_resolver.c`**: `pure-compute`'s `BUILD_FLAVORS` asset stem is now **empty**, marking it a **preset**. `build.lua` only overrides the base with a pre-built flavor lib when the asset is non-empty; a preset builds on the default composable base and just enforces its cleared caps (reject any HTTP/TLS app at build time).
- **`flavor.c`**: `hull flavor install pure-compute` → *"preset flavor, nothing to install"*; `hull flavor list` shows `preset (default base)`.
- **Deleted the pre-built base matrix**: `platform-pure-compute` + `platform-cosmo-pure-compute` (Makefile), and the release wiring (the native `for f in slim` loop no longer builds pure-compute, the whole `build-platform-cosmo-flavors` job, the cosmo-flavor artifact `mv`, the per-flavor SBOM loop, and the dangling `needs:` ref).
- **`e2e_build_flavor.sh` rewritten**: unknown-flavor rejection, HTTP-app rejection under the preset, build+run, `--flavor=auto`, and **the payoff** — a compute app on a `HL_KEEL_FEATURE=1 HL_TLS_FEATURE=1` base links **0 `kl_*` + 0 `mbedtls_ssl_handshake`**.

## Result
`full` (the embedded default) is now the **only** "real" base; every reduction is a composable feature or a preset. `make test` **60/60**; the rewritten `e2e_build_flavor.sh` passes all 5 checks locally.

## Docs
`docs/keel_feature.md` Phase 4.3 marked done (epic complete); `docs/build_flavors.md` noted. A fuller docs sweep of the other flavor-mentioning files is a follow-up.

**This completes the Keel epic and the "flavors become feature presets" program.**