### PR TITLE
fix(build,flavor): audit fixes — Keel compose probe default + NULL-safe flavor asset

### DIFF
--- a/src/hull/commands/flavor.c
+++ b/src/hull/commands/flavor.c
@@ -180,7 +180,7 @@ static int cmd_install(const char *flavor, const char *repo)
                         "nothing to install.\n");
         return 0;
     }
-    if (f->asset[0] == '\0') {
+    if (!f->asset || f->asset[0] == '\0') {
         fprintf(stdout, "hull platform: '%s' is a preset flavor -- it builds on "
                         "the default composable base (which drops HTTP/TLS/Keel "
                         "and composes each back per app); nothing to install.\n",
@@ -263,7 +263,7 @@ static int cmd_list(void)
             fprintf(stdout, "  %-14s embedded\n", all[i].name);
             continue;
         }
-        if (all[i].asset[0] == '\0') {
+        if (!all[i].asset || all[i].asset[0] == '\0') {
             fprintf(stdout, "  %-14s preset (default base)\n", all[i].name);
             continue;
         }

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -2006,10 +2006,16 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
             -- which already carries them, never double-composes (no duplicate
             -- hull_serve). The composed serve.o's kl_* refs pull libkeel from the base
             -- .a on demand.
-            local base_has_keel = false
+            -- Default to "present" (skip compose), flipping to compose only on a
+            -- CONFIRMED nm result lacking the sentinel -- mirrors the sqlite/tls
+            -- probes. If nm is absent or errors (serve_nm == nil), skipping is the
+            -- safe no-op for the common Keel-FULL base: composing there would
+            -- duplicate serve.o's strong hull_serve / hl_async_backend and fail the
+            -- link. The Keel-less release base is only built where nm exists.
+            local base_has_keel = true
             local serve_nm = tool.spawn_read({ "nm", platform_lib })
-            if serve_nm and serve_nm:find("hl_async_backend_keel") then
-                base_has_keel = true
+            if serve_nm and not serve_nm:find("hl_async_backend_keel") then
+                base_has_keel = false
             end
             if not base_has_keel then
                 local keel_lib = "libhull_feature-keel.a"
@@ -2027,6 +2033,7 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
                 if keel_path ~= keel_dest then tool.copy(keel_path, keel_dest) end
                 record_composed("libhull_feature-keel." .. (rt_plat or "") .. ".a",
                                 keel_dest, "platform")
+                needs_base_group = true  -- keel archive refs base + libkeel symbols
                 for _, f in ipairs(fcompose.whole_archive_flags(keel_dest, is_darwin)) do
                     feature_libs[#feature_libs + 1] = f
                 end


### PR DESCRIPTION
Fixes from the **/c-audit + /lua-audit** of this session's composability work (TLS/Keel/pure-compute). The /js-audit found no findings (all seams are runtime-agnostic; Lua↔JS parity intact).

## Fixes
- **build.lua (lua-audit Medium):** the Keel-compose `nm`-probe defaulted `base_has_keel=false`, so if `nm` is absent/errors it would compose `libhull_feature-keel.a` onto a possibly-Keel-full base → duplicate `serve.o` strong `hull_serve`/`hl_async_backend` → link failure. The sqlite/tls probes default to *present* (skip) precisely so an `nm` failure is a safe no-op for the common full base. Match them: default `true`, flip to `false` only on a **confirmed** `nm` result lacking the `hl_async_backend_keel` sentinel.
- **build.lua (lua-audit Low):** the Keel compose block now sets `needs_base_group=true` like the TLS block (the keel archive's `kl_*` refs into the base `.a` need `--start-group`) — removes a latent ordering dependency.
- **flavor.c (c-audit Low):** NULL-safe the preset check (`!f->asset || f->asset[0]=='\0'`) at the install + list sites, so a future `BUILD_FLAVORS` entry with a `NULL` asset can't NULL-deref.

## Validated
Full base still **skips** keel compose (no duplicate); a `HL_KEEL_FEATURE=1` base still **composes** it; `make test` **60/60**.

## Audit summary
- **c-audit:** clean (weak/strong seams safe, vtables `const`, runtime db_path probe side-effect-free, allocator lifetimes correct, buffer bounds OK) — only the one Low above.
- **lua-audit:** the Medium + Low above; no injection (fixed argv, hull-controlled paths), TLS probe robust (`mbedtls_ssl_handshake` is a strong def), preset change correct.
- **js-audit:** no findings — no JS stdlib changed; every new seam is runtime-agnostic C or a runtime-agnostic feature archive, so a JS app composes identically to a Lua app.