### PR TITLE
feat(build): OR the net-DB signal into needs_tls (compose TLS for postgres/mysql)

### DIFF
--- a/src/hull/tool_orchestration.c
+++ b/src/hull/tool_orchestration.c
@@ -262,10 +262,10 @@ static int l_tool_modules_resolve(lua_State *L)
      * switch (any HTTP half OR a network DB backend), moved to compose time. Here
      * we report the module-inferable part: HTTP (which also covers hull/smtp, an
      * http-client module, and hull/http-client's https fetches). `hull build`
-     * will OR in the network-DB signal (a postgres/mysql --with or net DSN, the
-     * same signal those backend features use) when the TLS archive lands (the
-     * Keel move). DORMANT today: nothing composes on it yet -- the base still
-     * links mbedTLS + Keel; this is Phase-0 scaffolding for the compose gate. */
+     * ORs in the network-DB signal (a postgres/mysql --with, whose wire backend
+     * links the shared tls_client for sslmode) at compose time. ACTIVE: on a
+     * TLS-less base (the release SLIM base) an HTTP or net-DB app composes
+     * libhull_feature-tls.a; a plaintext app links zero mbedTLS. */
     lua_pushboolean(L, (req_caps & HL_MOD_CAP_HTTP) ? 1 : 0);
     lua_setfield(L, -2, "needs_tls");
 

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1755,6 +1755,16 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
                     if r.ok and r.needs_tls then needs_tls = true end
                 end
             end
+            -- OR in the network-DB signal (the piece tool_orchestration.c's
+            -- needs_tls left to build time): the postgres/mysql wire backends link
+            -- the shared tls_client (which the a2 TLS feature now owns) for
+            -- sslmode, so composing either onto a TLS-less base needs the TLS
+            -- feature too -- regardless of the DSN's sslmode, since the archive's
+            -- tls_client refs must resolve. These are explicit --with=/inferred
+            -- (opts.with), the same signal the backend features compose on.
+            if opts.with and (opts.with.postgres or opts.with.mysql) then
+                needs_tls = true
+            end
 
             write_file(tmpdir .. "/app_feature_registry.c",
                        fcompose.gen_app_registry_c(app_rt))


### PR DESCRIPTION
Closes the **last composable-feature compose gate**. `tool_orchestration.c`'s `needs_tls` reported only the module-inferable HTTP part and left a comment that `hull build` would OR in the network-DB signal *"when the TLS archive lands (the Keel move)"* — now done.

## The gap
A `--with=postgres` / `--with=mysql` app on the release's **TLS-less SLIM base** would fail to link: the pure-C wire backends reference the shared `tls_client` (which the a2 TLS feature now owns) for `sslmode`, but nothing composed the TLS feature to resolve those refs.

## Fix
`build.lua` now sets `needs_tls` when `opts.with.postgres` or `opts.with.mysql` is composed — regardless of the DSN's `sslmode` (the archive's `tls_client` refs must resolve either way), the same `--with` signal those backend features compose on. Comment in `tool_orchestration.c` updated (ACTIVE, not dormant).

## Validated
- A `--with=postgres` app (`postgres://…?sslmode=require`) on a `HL_TLS_FEATURE=1` base now **composes the TLS feature** (7 `mbedtls_ssl_handshake` + the postgres backend, links clean).
- A plaintext app on the same base still **drops TLS** (0 mbedTLS).
- `make test` 60/60.

With this, every composable subsystem's compose gate is complete — the feature/flavor arc's last functional piece.