### PR TITLE
Build modularization Phase 2: macro-ify fragments + fix F5

### DIFF
--- a/docs/build_modularization.md
+++ b/docs/build_modularization.md
@@ -234,3 +234,65 @@ re-create the scattered-hunt problem the split exists to remove.
   order is load-bearing (see Validation). The existing tail `-include
   $(DEPS_ALL)` (the `.d` auto-deps) and `-include $(SANITIZER_STAMP)` stay in
   the root Makefile at their positions and coexist with the new includes.
+
+## What remains in the root Makefile (~4.7k lines) and why
+
+After the 13 feature fragments + `mk/{flags,feature,hardening}.mk`, the root
+Makefile is ~4.7k lines. It is NOT more feature-extractable - what is left is the
+BASE build machinery, which falls into three modularizability classes:
+
+| Lines | Bucket | Further modularizable? |
+|------:|--------|------------------------|
+| ~220  | toolchain / CFLAGS base / sanitizer / version / dirs | **No** - `CFLAGS :=`/`+=` accumulation root; everything downstream depends on order |
+| ~1140 | vendored-lib configs (QuickJS, Lua, Keel, mbedTLS, SQLite, log.c, sh_arena, sh_json, TweetNaCl, stb, unicode, **WAMR**, LTO, CFI, TinyCC, wgpu, DuckDB, pledge, CA-bundle, pwned, HTMX) | **Partly** - a `mk/vendor/<lib>.mk` per lib is possible, but each carries a `CFLAGS +=` so it's order-sensitive like the coarse sections |
+| ~550  | Hull source-file object lists (`CAP_OBJS`, `RT_OBJS`, all `*_OBJ`) + compile pattern rules (`%.o: %.c`) | **No** - the central object registry + the ~10 pattern rules every archive/link consumes |
+| ~440  | stdlib/context/asset/app embedding (xxd) + registries | Partly (a `mk/embed-stdlib.mk`), low value |
+| ~85   | include paths + build-flag fingerprint | No - tiny, central |
+| ~180  | **platform-lib composition + the `hull` link rule** | **No - this is the assembly point.** `PLATFORM_OBJS` and the single `cc -o build/hull ...` line reference *everything*; splitting them loses the one-place-to-see-the-link property |
+| ~295  | base variants (SQLite/TLS/Keel-less + SLIM) + wamrc | No - they re-invoke the base build with flag overrides; inherently central |
+| ~83   | embedded build assets (`embedded_platform.h`, `embedded_templates.h`) + `BUILD_ASSET_OBJ` | No - the aggregation point the feature embeds feed into |
+| ~500  | libhull no-runtime embedding library | Yes → a `mk/libhull.mk` (self-contained), a reasonable future extraction |
+| ~760  | debug / tests / msan / fuzz / e2e | Yes → `mk/tests.mk`, but weak gate (rules, no value-diff) + `TEST_COMMON_*` shared with bench |
+| ~445  | self-build / repro / check / analysis / bench / coverage / lint / fetch / docs / clean | Partly → `mk/dev.mk` (dev/CI targets), low value |
+
+**Why the core cannot shrink much further.** Three structural facts:
+1. **The `CFLAGS`/`LDFLAGS` accumulation is a single ordered pipeline.** Anything
+   touching it can only move as a whole block at its exact position (proven with
+   `flags.mk` / `hardening.mk`); you cannot scatter it into per-topic files
+   without a reorder hazard.
+2. **The link + platform-lib composition is an assembly point by nature.** Its
+   value is that one `PLATFORM_OBJS` list and one `hull` link line name every
+   object; fragmenting them trades legibility for file count.
+3. **The compile pattern rules + object registry are the shared substrate** every
+   fragment already references; they belong in one place.
+
+The genuinely-extractable remainder (`libhull.mk`, `tests.mk`, per-vendor
+configs) is *tidying*, not the feature/flavor axis - lower value, weaker gates.
+
+## Platform axis (Darwin / Linux / Cosmopolitan / future Windows)
+
+Orthogonal to the feature axis. The ~22 platform conditionals split two ways,
+and the split dictates where each belongs:
+
+- **Platform-GLOBAL policy → `mk/platform/<os>.mk`:** the sandbox backend
+  selection (Linux pledge/landlock, macOS seatbelt no-op, cosmo built-in), the
+  OS link flags (macOS `-framework ...`, Linux `-Wl,-z,relro` + `-ldl`), the ar
+  determinism envelope, and the cosmo fat-APE conventions (`.aarch64/`, poll
+  backend). Driver: a computed `PLATFORM := darwin|linux|cosmo` at the top +
+  `include mk/platform/$(PLATFORM).mk`.
+- **Feature-LOCAL platform choices → stay in the feature fragment:** gpu's
+  `WGPU_FRAMEWORKS` (Metal vs Vulkan), duckdb/tcc/tui cosmo-exclusion. Moving
+  these into a platform file would fragment feature cohesion - the Metal-vs-Vulkan
+  choice belongs *with* gpu, not in `darwin.mk`. **This is the key design call:
+  the platform file holds OS policy, not a feature's per-OS wiring.**
+
+`mk/platform/windows.mk` is a **stub today**: Hull already runs on Windows via
+the cosmo APE (one binary, no native build), so there is no native-Windows
+toolchain yet. The stub documents the seam a future native port fills - a Windows
+sandbox backend (Restricted Tokens / AppContainer), `VirtualAlloc`/`VirtualProtect`
+for the sealed arena (see docs/security.md §5b), and the MSVC/clang-cl link flags.
+
+**Status:** the platform axis is a scattered, order-sensitive extraction with an
+all-or-nothing coherence requirement (like the coarse sections). Designed here;
+the `windows.mk` stub lands now as the forward seam. The full `mk/platform/*.mk`
+rollout is a follow-up PR.

--- a/mk/feature.mk
+++ b/mk/feature.mk
@@ -26,3 +26,31 @@ feature-$(1): $$(BUILDDIR)/libhull_feature-$(1).a
 $$(BUILDDIR)/libhull_feature-$(1).a: $(2) | $$(BUILDDIR)
 	$$(call AR_FEATURE_LIB,$(2))
 endef
+
+# $(call define-feature-bundle,STEM,FIRST_OBJ,ARCHIVES_VAR): archive rule for a
+# vendored-engine --with feature (duckdb, gpu). Bundles FIRST_OBJ plus the
+# objects extracted from each vendored static lib named in the ARCHIVES_VAR
+# variable into libhull_feature-STEM.a. Each source archive is extracted into
+# its own subdir so same-named members from different archives coexist (ar
+# tolerates duplicate member names; ld pulls whichever resolves a needed symbol
+# via the index), which keeps the engine's circular refs intra-archive (no
+# --start-group at compose). Does NOT emit a feature-STEM phony: those are
+# sub-make targets (`$(MAKE) ... HL_ENABLE_<X>=1`) and stay hand-written in the
+# fragment. Raw ar by design - these are --with / release-domain assets
+# (hull.sha256), not the platform-key trust-embedded set, so AR_FEATURE_LIB /
+# TRUST_FEATURE_LIBS do not apply.
+#
+# ARCHIVES_VAR is the NAME of the variable (e.g. DUCKDB_ARCHIVES), not its value:
+# it is dereferenced with $($(3)) so the archive list expands at recipe-run time
+# (deferred), byte-identical to the hand-written duckdb/gpu recipes - it is only
+# populated in the HL_ENABLE_<X>=1 sub-make.
+define define-feature-bundle
+$$(BUILDDIR)/libhull_feature-$(1).a: $(2) $$($(3)) | $$(BUILDDIR)
+	@rm -f $$@
+	$$(AR) rcs $$@ $(2)
+	@tmproot=$$$$(mktemp -d); n=0; for a in $$($(3)); do \
+		mkdir -p $$$$tmproot/$$$$n && ( cd $$$$tmproot/$$$$n && $$(AR) x $$(CURDIR)/$$$$a ) && \
+		$$(AR) rcs $$(CURDIR)/$$@ $$$$tmproot/$$$$n/*.o && n=$$$$((n+1)); \
+	done; rm -rf $$$$tmproot
+	@echo "built $$@ ($$$$(du -h $$@ | cut -f1))"
+endef

--- a/mk/features/duckdb.mk
+++ b/mk/features/duckdb.mk
@@ -21,11 +21,4 @@ feature-duckdb:
 	$(MAKE) $(BUILDDIR)/libhull_feature-duckdb.a HL_ENABLE_DUCKDB=1
 .PHONY: feature-duckdb
 
-$(BUILDDIR)/libhull_feature-duckdb.a: $(BUILDDIR)/cap_db_duckdb.o $(DUCKDB_ARCHIVES) | $(BUILDDIR)
-	@rm -f $@
-	$(AR) rcs $@ $(BUILDDIR)/cap_db_duckdb.o
-	@tmproot=$$(mktemp -d); n=0; for a in $(DUCKDB_ARCHIVES); do \
-		mkdir -p $$tmproot/$$n && ( cd $$tmproot/$$n && $(AR) x $(CURDIR)/$$a ) && \
-		$(AR) rcs $(CURDIR)/$@ $$tmproot/$$n/*.o && n=$$((n+1)); \
-	done; rm -rf $$tmproot
-	@echo "built $@ ($$(du -h $@ | cut -f1))"
+$(eval $(call define-feature-bundle,duckdb,$(BUILDDIR)/cap_db_duckdb.o,DUCKDB_ARCHIVES))

--- a/mk/features/gpu.mk
+++ b/mk/features/gpu.mk
@@ -22,11 +22,4 @@ feature-gpu:
 	$(MAKE) $(BUILDDIR)/libhull_feature-gpu.a HL_ENABLE_GPU=1
 .PHONY: feature-gpu
 
-$(BUILDDIR)/libhull_feature-gpu.a: $(BUILDDIR)/cap_gpu_wgpu.o $(WGPU_LIB) | $(BUILDDIR)
-	@rm -f $@
-	$(AR) rcs $@ $(BUILDDIR)/cap_gpu_wgpu.o
-	@tmproot=$$(mktemp -d); n=0; for a in $(WGPU_LIB); do \
-		mkdir -p $$tmproot/$$n && ( cd $$tmproot/$$n && $(AR) x $(CURDIR)/$$a ) && \
-		$(AR) rcs $(CURDIR)/$@ $$tmproot/$$n/*.o && n=$$((n+1)); \
-	done; rm -rf $$tmproot
-	@echo "built $@ ($$(du -h $@ | cut -f1))"
+$(eval $(call define-feature-bundle,gpu,$(BUILDDIR)/cap_gpu_wgpu.o,WGPU_LIB))

--- a/mk/features/http.mk
+++ b/mk/features/http.mk
@@ -35,10 +35,7 @@ FEATURE_HTTP_OBJS := $(BUILDDIR)/cap_http.o $(BUILDDIR)/cap_http_async.o \
 # (FEATURE_HTTP_OBJS is defined earlier, above PLATFORM_OBJS, so the native app
 # base filters these caps out; the archive below and the base share one list.)
 
-feature-http: $(BUILDDIR)/libhull_feature-http.a
-.PHONY: feature-http
-$(BUILDDIR)/libhull_feature-http.a: $(FEATURE_HTTP_OBJS) | $(BUILDDIR)
-	$(call AR_FEATURE_LIB,$(FEATURE_HTTP_OBJS))
+$(eval $(call define-feature-archive,http,$(FEATURE_HTTP_OBJS)))
 
 # Per-runtime web bindings (issue #114, Phase C). This is the same set the
 # HL_ENABLE_HTTP_SERVER=0 + HL_ENABLE_HTTP_CLIENT=0 source filters enumerate -
@@ -53,15 +50,9 @@ FEATURE_HTTP_LUA_OBJS := $(addprefix $(BUILDDIR)/lua_rt_,$(addsuffix .o,$(FEATUR
 FEATURE_HTTP_JS_OBJS  := $(addprefix $(BUILDDIR)/js_,$(addsuffix .o,$(FEATURE_HTTP_RT_NAMES)))
 
 # Per-runtime web-bindings feature archives (issue #114, Phase C).
-feature-http-lua: $(BUILDDIR)/libhull_feature-http-lua.a
-.PHONY: feature-http-lua
-$(BUILDDIR)/libhull_feature-http-lua.a: $(FEATURE_HTTP_LUA_OBJS) | $(BUILDDIR)
-	$(call AR_FEATURE_LIB,$(FEATURE_HTTP_LUA_OBJS))
+$(eval $(call define-feature-archive,http-lua,$(FEATURE_HTTP_LUA_OBJS)))
 
-feature-http-js: $(BUILDDIR)/libhull_feature-http-js.a
-.PHONY: feature-http-js
-$(BUILDDIR)/libhull_feature-http-js.a: $(FEATURE_HTTP_JS_OBJS) | $(BUILDDIR)
-	$(call AR_FEATURE_LIB,$(FEATURE_HTTP_JS_OBJS))
+$(eval $(call define-feature-archive,http-js,$(FEATURE_HTTP_JS_OBJS)))
 
 # Embed the HTTP core feature archive too (issue #114). The native base is
 # HTTP-core-less; the default distributed hull composes this back for every

--- a/mk/features/keel.mk
+++ b/mk/features/keel.mk
@@ -23,10 +23,7 @@
 FEATURE_KEEL_OBJS := $(BUILDDIR)/serve.o $(BUILDDIR)/async_keel.o \
                      $(BUILDDIR)/net_keel.o $(BUILDDIR)/hull_static.o \
                      $(BUILDDIR)/agent_api.o $(BUILDDIR)/test_runner.o
-feature-keel: $(BUILDDIR)/libhull_feature-keel.a
-.PHONY: feature-keel
-$(BUILDDIR)/libhull_feature-keel.a: $(FEATURE_KEEL_OBJS) | $(BUILDDIR)
-	$(call AR_FEATURE_LIB,$(FEATURE_KEEL_OBJS))
+$(eval $(call define-feature-archive,keel,$(FEATURE_KEEL_OBJS)))
 
 # Keel feature archive embed (Phase 4.2b): keel is folded into the SLIM base, so
 # when the app-build base is SLIM (SQLITELESS + TLSLESS both set) it is also

--- a/mk/features/runtime.mk
+++ b/mk/features/runtime.mk
@@ -27,15 +27,9 @@ FEATURE_LUA_OBJS := $(filter-out $(BUILDDIR)/lua_rt_mod_tui.o $(BUILDDIR)/lua_rt
 FEATURE_JS_OBJS  := $(filter-out $(BUILDDIR)/js_mod_tui.o $(BUILDDIR)/js_mod_compute.o $(BUILDDIR)/js_mod_db_udf.o $(BUILDDIR)/js_mod_image.o $(FEATURE_HTTP_JS_OBJS),$(JS_RT_OBJS)) \
                     $(QJS_OBJS) $(BUILDDIR)/manifest_js.o $(STDLIB_JS_REGISTRY_O)
 
-feature-lua: $(BUILDDIR)/libhull_feature-lua.a
-.PHONY: feature-lua
-$(BUILDDIR)/libhull_feature-lua.a: $(FEATURE_LUA_OBJS) | $(BUILDDIR)
-	$(call AR_FEATURE_LIB,$(FEATURE_LUA_OBJS))
+$(eval $(call define-feature-archive,lua,$(FEATURE_LUA_OBJS)))
 
-feature-js: $(BUILDDIR)/libhull_feature-js.a
-.PHONY: feature-js
-$(BUILDDIR)/libhull_feature-js.a: $(FEATURE_JS_OBJS) | $(BUILDDIR)
-	$(call AR_FEATURE_LIB,$(FEATURE_JS_OBJS))
+$(eval $(call define-feature-archive,js,$(FEATURE_JS_OBJS)))
 
 # Embed both runtime feature archives so the runtime-less native base composes
 # one at build time with no `hull feature install` (the runtime is mandatory).

--- a/mk/features/sqlite.mk
+++ b/mk/features/sqlite.mk
@@ -34,9 +34,7 @@ feature-sqlite:
 .PHONY: feature-sqlite
 
 $(BUILDDIR)/libhull_feature-sqlite.a: $(FEATURE_SQLITE_OBJS) | $(BUILDDIR)
-	@rm -f $@
-	$(AR) rcs $@ $(FEATURE_SQLITE_OBJS)
-	@echo "built $@ ($$(du -h $@ | cut -f1))"
+	$(call AR_FEATURE_LIB,$(FEATURE_SQLITE_OBJS))
 
 feature-sqlite-lua: $(BUILDDIR)/libhull_feature-sqlite-lua.a
 .PHONY: feature-sqlite-lua

--- a/mk/features/sqlite.mk
+++ b/mk/features/sqlite.mk
@@ -36,15 +36,9 @@ feature-sqlite:
 $(BUILDDIR)/libhull_feature-sqlite.a: $(FEATURE_SQLITE_OBJS) | $(BUILDDIR)
 	$(call AR_FEATURE_LIB,$(FEATURE_SQLITE_OBJS))
 
-feature-sqlite-lua: $(BUILDDIR)/libhull_feature-sqlite-lua.a
-.PHONY: feature-sqlite-lua
-$(BUILDDIR)/libhull_feature-sqlite-lua.a: $(BUILDDIR)/lua_rt_mod_db_udf.o | $(BUILDDIR)
-	$(call AR_FEATURE_LIB,$(BUILDDIR)/lua_rt_mod_db_udf.o)
+$(eval $(call define-feature-archive,sqlite-lua,$(BUILDDIR)/lua_rt_mod_db_udf.o))
 
-feature-sqlite-js: $(BUILDDIR)/libhull_feature-sqlite-js.a
-.PHONY: feature-sqlite-js
-$(BUILDDIR)/libhull_feature-sqlite-js.a: $(BUILDDIR)/js_mod_db_udf.o | $(BUILDDIR)
-	$(call AR_FEATURE_LIB,$(BUILDDIR)/js_mod_db_udf.o)
+$(eval $(call define-feature-archive,sqlite-js,$(BUILDDIR)/js_mod_db_udf.o))
 
 # Embed the per-runtime SQLite UDF bridges too (Phase C.2b). The runtime archive
 # is SQLite-free; the default distributed hull composes the app's runtime bridge

--- a/mk/features/tls.mk
+++ b/mk/features/tls.mk
@@ -28,10 +28,7 @@ $(BUILDDIR)/keel_tls_mbedtls.o: $(KEEL_LIB) | $(BUILDDIR)
 FEATURE_TLS_OBJS := $(BUILDDIR)/cap_crypto_hmac_mbedtls.o $(BUILDDIR)/cap_crypto_asym_mbedtls.o \
                     $(BUILDDIR)/tls_client.o $(BUILDDIR)/tls_transport.o \
                     $(BUILDDIR)/keel_tls_mbedtls.o $(MBEDTLS_OBJS)
-feature-tls: $(BUILDDIR)/libhull_feature-tls.a
-.PHONY: feature-tls
-$(BUILDDIR)/libhull_feature-tls.a: $(FEATURE_TLS_OBJS) | $(BUILDDIR)
-	$(call AR_FEATURE_LIB,$(FEATURE_TLS_OBJS))
+$(eval $(call define-feature-archive,tls,$(FEATURE_TLS_OBJS)))
 
 # TLS feature archive embed (a2, HL_APP_BASE_TLSLESS=1): when the app-build base
 # is TLS-less, embed libhull_feature-tls.a (mbedTLS + the crypto/tls TUs) so an

--- a/mk/features/tui.mk
+++ b/mk/features/tui.mk
@@ -56,15 +56,9 @@ $(BUILDDIR)/libhull_feature-tui.a: $(BUILDDIR)/cap_tui.o $(BUILDDIR)/cap_tui_inp
 
 # Per-runtime tui bridge archives (issue #114, Phase D). Tiny (one object each);
 # embedded in hull + composed for the app's runtime alongside the cap core.
-feature-tui-lua: $(BUILDDIR)/libhull_feature-tui-lua.a
-.PHONY: feature-tui-lua
-$(BUILDDIR)/libhull_feature-tui-lua.a: $(BUILDDIR)/lua_rt_mod_tui.o | $(BUILDDIR)
-	$(call AR_FEATURE_LIB,$(BUILDDIR)/lua_rt_mod_tui.o)
+$(eval $(call define-feature-archive,tui-lua,$(BUILDDIR)/lua_rt_mod_tui.o))
 
-feature-tui-js: $(BUILDDIR)/libhull_feature-tui-js.a
-.PHONY: feature-tui-js
-$(BUILDDIR)/libhull_feature-tui-js.a: $(BUILDDIR)/js_mod_tui.o | $(BUILDDIR)
-	$(call AR_FEATURE_LIB,$(BUILDDIR)/js_mod_tui.o)
+$(eval $(call define-feature-archive,tui-js,$(BUILDDIR)/js_mod_tui.o))
 
 EMBEDDED_TUI_H := $(BUILDDIR)/embedded_tui.h
 $(EMBEDDED_TUI_H): $(BUILDDIR)/libhull_feature-tui-lua.a $(BUILDDIR)/libhull_feature-tui-js.a | $(BUILDDIR)

--- a/mk/features/wasm.mk
+++ b/mk/features/wasm.mk
@@ -24,22 +24,13 @@ FEATURE_WASM_OBJS := $(BUILDDIR)/cap_wasm.o $(BUILDDIR)/cap_wasm_buffer.o \
 # in hull (embedded_wasm.h). The per-runtime compute binding (mod_compute) is a
 # separate archive below, like the http web bindings.
 FEATURE_WASM_CORE := $(FEATURE_WASM_OBJS) $(WORKER_WASM_OBJ) $(WAMR_OBJS)
-feature-wasm: $(BUILDDIR)/libhull_feature-wasm.a
-.PHONY: feature-wasm
-$(BUILDDIR)/libhull_feature-wasm.a: $(FEATURE_WASM_CORE) | $(BUILDDIR)
-	$(call AR_FEATURE_LIB,$(FEATURE_WASM_CORE))
+$(eval $(call define-feature-archive,wasm,$(FEATURE_WASM_CORE)))
 
 # Per-runtime compute-binding bridges (mod_compute). Tiny (one object each);
 # embedded in hull + composed for the app's runtime alongside the wasm core.
-feature-wasm-lua: $(BUILDDIR)/libhull_feature-wasm-lua.a
-.PHONY: feature-wasm-lua
-$(BUILDDIR)/libhull_feature-wasm-lua.a: $(BUILDDIR)/lua_rt_mod_compute.o | $(BUILDDIR)
-	$(call AR_FEATURE_LIB,$(BUILDDIR)/lua_rt_mod_compute.o)
+$(eval $(call define-feature-archive,wasm-lua,$(BUILDDIR)/lua_rt_mod_compute.o))
 
-feature-wasm-js: $(BUILDDIR)/libhull_feature-wasm-js.a
-.PHONY: feature-wasm-js
-$(BUILDDIR)/libhull_feature-wasm-js.a: $(BUILDDIR)/js_mod_compute.o | $(BUILDDIR)
-	$(call AR_FEATURE_LIB,$(BUILDDIR)/js_mod_compute.o)
+$(eval $(call define-feature-archive,wasm-js,$(BUILDDIR)/js_mod_compute.o))
 
 # Embed the WASM feature archives too (docs/wasm_feature.md, Phase 1). The native
 # base is compute-less; the default distributed hull composes the wasm core + the

--- a/mk/platform/windows.mk
+++ b/mk/platform/windows.mk
@@ -1,0 +1,20 @@
+# mk/platform/windows.mk - native Windows platform policy (STUB / forward seam).
+#
+# Hull runs on Windows TODAY via the Cosmopolitan APE (`hull-cosmo`): one fat
+# binary, no native Windows toolchain, no code here. This file documents the
+# seam a future NATIVE Windows port (MSVC / clang-cl) would fill, so the platform
+# axis (mk/platform/{darwin,linux,cosmo,windows}.mk) is complete by construction.
+#
+# A native port fills in:
+#   - Sandbox backend: Restricted Tokens / AppContainer / Job Objects, behind the
+#     same hl_sandbox_apply seam Linux pledge/unveil and macOS seatbelt use.
+#   - Sealed arena (docs/security.md 5b): VirtualAlloc + VirtualProtect in place
+#     of mmap/mprotect (the hl_seal_arena _WIN32 branch noted in the c-audit skill).
+#   - Link flags: MSVC/clang-cl equivalents of the -Wl,-z,* hardening + the OS
+#     libs (ws2_32, bcrypt, ...), and the deterministic-archive envelope.
+#   - CA trust: the embedded Mozilla bundle already covers this (no system store
+#     dependency), so no work beyond linking it.
+#
+# Until then this file is intentionally empty: `include mk/platform/windows.mk`
+# on a hypothetical native-Windows build is a no-op that fails loudly only if the
+# port forgets to fill it in.


### PR DESCRIPTION
Phase 2 of the build modularization, on top of the 13 feature fragments (#161) and the coarse `mk/hardening.mk` (#164). Two things: a correctness fix and a DRY pass over the fragments.

## F5 fix (correctness) — `build(sqlite)`
The `sqlite` feature archive rule hand-wrote its recipe (`@rm; ar rcs; @echo`) instead of calling `AR_FEATURE_LIB`, so it **bypassed the `TRUST_FEATURE_LIBS=1` trust branch** every other embedded feature archive uses at release stage 3. Since `libhull_feature-sqlite.a` is embedded in the SLIM base and built with `TRUST_FEATURE_LIBS=1` in `release.yml`, a recompiled prereq at stage 3 would have rebuilt sqlite from source instead of trusting the signed pre-verified bytes.
- Routed through `AR_FEATURE_LIB` (else-branch byte-identical to the old recipe; archive membership unchanged). Verified: with a stale prereq, `TRUST_FEATURE_LIBS=1` now prints *"trusting pre-built artifact"* instead of rebuilding.
- Surfaced as review finding **F5** in the design.

## Macro-ify (DRY) — `define-feature-archive`
Collapse the hand-written archive scaffolding (phony + `.PHONY` + rule + `AR_FEATURE_LIB` recipe) to one `$(eval $(call define-feature-archive,<name>,<objs>))` per archive, using the macro proven on `image` in Phase 0. Converts **14 archives** across tls / keel / wasm / http / tui(bridges) / runtime / sqlite(bridges). Net **-42 lines**.

Left as-is by design: sqlite CORE (sub-make phony + the F5-fixed `AR_FEATURE_LIB`), tui CORE (raw `ar`, a `--with`/release-domain asset — not trust-embedded), and the gpu/duckdb bundle recipes + postgres/mysql raw multi-obj `ar` (a `define-feature-bundle` variant is an optional follow-up).

## Verified
`make` green (0 errors); **every affected archive's `ar` object-membership byte-identical** before/after (15 archives incl. sqlite core); `make e2e-feature-runtime` passes. Full CI on merge.