### PR TITLE
Build modularization: platform axis (mk/platform/<os>.mk) + pledge -> linux.mk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,23 @@ endif
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
 
+# Platform axis: darwin | linux | cosmo (native Windows is future; Windows runs
+# via the cosmo APE today). Selects mk/platform/<PLATFORM>.mk, which holds the
+# OS-global build policy (currently just the sandbox backend: the pledge polyfill
+# is Linux-only). A vendor's or feature's per-OS wiring stays inline with its
+# vendor/feature fragment; only OS-GLOBAL policy lives in mk/platform/. See
+# docs/build_modularization.md ("Platform axis"). COSMO is checked first because
+# a cosmo build reports UNAME_S=Linux but must not pull the Linux pledge polyfill.
+ifdef COSMO
+PLATFORM := cosmo
+else ifeq ($(UNAME_S),Darwin)
+PLATFORM := darwin
+else ifeq ($(UNAME_S),Linux)
+PLATFORM := linux
+else
+PLATFORM := unknown
+endif
+
 # Retry knob for network fetches (toolchains + vendored assets). --retry-all-errors
 # also retries partial transfers (curl exit 18), the observed CI download flake.
 CURL_RETRY := --retry 3 --retry-all-errors --retry-delay 2
@@ -856,47 +873,14 @@ fetch-unicode:
 include mk/vendor/wgpu.mk
 # DuckDB static-libs config -> mk/vendor/duckdb.mk
 include mk/vendor/duckdb.mk
-# ── jart/pledge polyfill (Linux-only: seccomp + landlock) ──────────
+# ── Platform-specific policy (the sandbox backend) ─────────────────
 #
-# Provides real pledge()/unveil() on native Linux.
-# Cosmopolitan has these built-in; macOS uses no-op stubs.
-
-PLEDGE_DIR := $(VENDDIR)/pledge
-PLEDGE_CFLAGS := -std=c11 -O2 -w -D_GNU_SOURCE -I$(PLEDGE_DIR) $(DEPFLAGS)
-
-ifeq ($(UNAME_S),Linux)
-ifndef COSMO
-PLEDGE_SRCS := \
-	$(PLEDGE_DIR)/libc/calls/pledge.c \
-	$(PLEDGE_DIR)/libc/calls/pledge-linux.c \
-	$(PLEDGE_DIR)/libc/calls/unveil.c \
-	$(PLEDGE_DIR)/libc/calls/parsepromises.c \
-	$(PLEDGE_DIR)/libc/calls/landlock_add_rule.c \
-	$(PLEDGE_DIR)/libc/calls/landlock_create_ruleset.c \
-	$(PLEDGE_DIR)/libc/calls/landlock_restrict_self.c \
-	$(PLEDGE_DIR)/libc/calls/commandv.c \
-	$(PLEDGE_DIR)/libc/calls/getcpucount.c \
-	$(PLEDGE_DIR)/libc/calls/islinux.c \
-	$(PLEDGE_DIR)/libc/intrin/promises.c \
-	$(PLEDGE_DIR)/libc/intrin/pthread_setcancelstate.c \
-	$(PLEDGE_DIR)/libc/elf/checkelfaddress.c \
-	$(PLEDGE_DIR)/libc/elf/getelfsegmentheaderaddress.c \
-	$(PLEDGE_DIR)/libc/str/classifypath.c \
-	$(PLEDGE_DIR)/libc/str/endswith.c \
-	$(PLEDGE_DIR)/libc/str/isabspath.c \
-	$(PLEDGE_DIR)/libc/fmt/joinpaths.c \
-	$(PLEDGE_DIR)/libc/fmt/sizetol.c \
-	$(PLEDGE_DIR)/libc/runtime/isdynamicexecutable.c \
-	$(PLEDGE_DIR)/libc/sysv/calls/ioprio_set.c \
-	$(PLEDGE_DIR)/libc/x/xdie.c \
-	$(PLEDGE_DIR)/libc/x/xjoinpaths.c \
-	$(PLEDGE_DIR)/libc/x/xmalloc.c \
-	$(PLEDGE_DIR)/libc/x/xrealloc.c \
-	$(PLEDGE_DIR)/libc/x/xstrcat.c \
-	$(PLEDGE_DIR)/libc/x/xstrdup.c
-PLEDGE_OBJS := $(patsubst $(PLEDGE_DIR)/%.c,$(BUILDDIR)/pledge_%.o,$(PLEDGE_SRCS))
-endif
-endif
+# PLATFORM is computed near the top. mk/platform/linux.mk defines the
+# PLEDGE_* vars + compile rule (the Linux pledge/unveil polyfill);
+# darwin/cosmo are thin seams (their OS specifics live with their
+# vendor/feature). PLEDGE_OBJS defaults empty on non-Linux so the hull
+# link references it unconditionally.
+include mk/platform/$(PLATFORM).mk
 PLEDGE_OBJS ?=
 
 # ── Hull source files ───────────────────────────────────────────────
@@ -2893,10 +2877,6 @@ $(TWEETNACL_OBJ): $(TWEETNACL_DIR)/tweetnacl.c | $(BUILDDIR)
 	$(CC) $(TWEETNACL_CFLAGS) -I$(TWEETNACL_DIR) -c -o $@ $<
 
 # jart/pledge polyfill (vendored, Linux only, relaxed warnings)
-# Flatten libc/calls/pledge.c → build/pledge_libc_calls_pledge.o
-$(BUILDDIR)/pledge_%.o: $(PLEDGE_DIR)/%.c | $(BUILDDIR)
-	@mkdir -p $(dir $@)
-	$(CC) $(PLEDGE_CFLAGS) -c -o $@ $<
 
 # WAMR (vendored, relaxed warnings)
 # Flatten vendor/wamr/core/iwasm/... → build/wamr_core_iwasm_...

--- a/docs/build_modularization.md
+++ b/docs/build_modularization.md
@@ -271,28 +271,49 @@ configs) is *tidying*, not the feature/flavor axis - lower value, weaker gates.
 
 ## Platform axis (Darwin / Linux / Cosmopolitan / future Windows)
 
-Orthogonal to the feature axis. The ~22 platform conditionals split two ways,
-and the split dictates where each belongs:
+Orthogonal to the feature axis. Platform conditionals split two ways, and the
+split dictates where each belongs:
 
-- **Platform-GLOBAL policy → `mk/platform/<os>.mk`:** the sandbox backend
-  selection (Linux pledge/landlock, macOS seatbelt no-op, cosmo built-in), the
-  OS link flags (macOS `-framework ...`, Linux `-Wl,-z,relro` + `-ldl`), the ar
-  determinism envelope, and the cosmo fat-APE conventions (`.aarch64/`, poll
-  backend). Driver: a computed `PLATFORM := darwin|linux|cosmo` at the top +
+- **Platform-GLOBAL policy → `mk/platform/<os>.mk`:** OS build policy that is not
+  tied to any one vendor or feature - today just the **sandbox backend**. A
+  computed `PLATFORM := darwin|linux|cosmo` at the top of the Makefile (COSMO
+  checked first, since a cosmo build reports `UNAME_S=Linux`) selects
   `include mk/platform/$(PLATFORM).mk`.
-- **Feature-LOCAL platform choices → stay in the feature fragment:** gpu's
-  `WGPU_FRAMEWORKS` (Metal vs Vulkan), duckdb/tcc/tui cosmo-exclusion. Moving
-  these into a platform file would fragment feature cohesion - the Metal-vs-Vulkan
-  choice belongs *with* gpu, not in `darwin.mk`. **This is the key design call:
-  the platform file holds OS policy, not a feature's per-OS wiring.**
+- **Feature-LOCAL platform choices → stay in the feature/vendor fragment:** gpu's
+  `WGPU_FRAMEWORKS` (Metal vs Vulkan) in `mk/vendor/wgpu.mk`, tcc's ELF-only
+  exclusion, WAMR's per-OS `platform_init`, duckdb/tui cosmo-exclusion. Moving
+  these into a platform file would fragment cohesion - the Metal-vs-Vulkan choice
+  belongs *with* gpu, not in `darwin.mk`. **This is the key design call: the
+  platform file holds OS policy, not a feature's per-OS wiring.**
 
-`mk/platform/windows.mk` is a **stub today**: Hull already runs on Windows via
-the cosmo APE (one binary, no native build), so there is no native-Windows
-toolchain yet. The stub documents the seam a future native port fills - a Windows
-sandbox backend (Restricted Tokens / AppContainer), `VirtualAlloc`/`VirtualProtect`
-for the sealed arena (see docs/security.md §5b), and the MSVC/clang-cl link flags.
+**What the vendor/feature extraction already achieved.** By the time this axis
+landed, the earlier `mk/vendor/*` + `mk/features/*` work had *already* moved
+almost every platform conditional out of the root **with its concern** (WAMR
+per-OS wiring, wgpu frameworks, tcc ELF gate, TUI cosmo force-load). What
+remained platform-GLOBAL in the root was a single block: the **jart/pledge
+polyfill** (the Linux-only `pledge()`/`unveil()` implementation). There are no
+per-OS link libs left in the root (the hull link is the universal
+`-lm -lpthread`), and no darwin/cosmo-global blocks. So the axis is small by
+design - the modularization did the heavy lifting.
 
-**Status:** the platform axis is a scattered, order-sensitive extraction with an
-all-or-nothing coherence requirement (like the coarse sections). Designed here;
-the `windows.mk` stub lands now as the forward seam. The full `mk/platform/*.mk`
-rollout is a follow-up PR.
+Concretely:
+- **`mk/platform/linux.mk`** holds the `PLEDGE_*` vars + the `pledge_%.o` compile
+  rule (no `ifeq(Linux)/ifndef(COSMO)` guard - the file is only included when
+  `PLATFORM=linux`). `PLEDGE_OBJS ?=` in the root defaults it empty elsewhere, so
+  the hull link references it unconditionally.
+- **`mk/platform/{darwin,cosmo}.mk`** are thin seams: macOS uses seatbelt (applied
+  in `sandbox.c`, no compiled polyfill) and cosmo has pledge/unveil built in, so
+  neither needs Makefile content today. They document where any future OS-global
+  policy goes.
+- **`mk/platform/unknown.mk`** is the empty fallback for an unrecognized `uname`.
+
+`mk/platform/windows.mk` is a **stub**: Hull already runs on Windows via the
+cosmo APE (one binary, no native build), so there is no native-Windows toolchain
+yet. The stub documents the seam a future native port fills - a Windows sandbox
+backend (Restricted Tokens / AppContainer), `VirtualAlloc`/`VirtualProtect` for
+the sealed arena (see docs/security.md §5b), and the MSVC/clang-cl link flags.
+
+**Status: implemented.** `PLATFORM` detection + `include mk/platform/$(PLATFORM).mk`
+are live; pledge moved to `linux.mk` verbatim. Validated by resolved-value parity
+(PLATFORM + `PLEDGE_OBJS` identical to the old inline `ifeq` under simulated
+`UNAME_S=Linux`, `COSMO=1`, and native Darwin) plus the full CI matrix.

--- a/mk/platform/cosmo.mk
+++ b/mk/platform/cosmo.mk
@@ -1,0 +1,6 @@
+# mk/platform/cosmo.mk - Cosmopolitan (fat APE) platform policy.
+#
+# No OS-global Makefile content today: pledge/unveil are built into cosmo (no
+# polyfill), and the poll backend + fat-APE archive conventions (.aarch64/) live
+# with their concern (Keel's own Makefile, mk/libhull.mk's LIBHULL_COSMO_FAT, the
+# base sub-builds). This file is the seam for any future cosmo-global policy.

--- a/mk/platform/darwin.mk
+++ b/mk/platform/darwin.mk
@@ -1,0 +1,7 @@
+# mk/platform/darwin.mk - native macOS platform policy.
+#
+# No OS-global Makefile content today: the sandbox is seatbelt (applied in
+# sandbox.c, no compiled polyfill), the link is the universal -lm -lpthread, and
+# macOS-specific vendor wiring (wgpu Metal frameworks, WAMR darwin platform_init)
+# lives with its vendor in mk/vendor/*. This file is the seam for any future
+# macOS-global policy (ld64 link flags, notarization, ...).

--- a/mk/platform/linux.mk
+++ b/mk/platform/linux.mk
@@ -1,0 +1,44 @@
+# mk/platform/linux.mk - native Linux platform policy.
+#
+# The jart/pledge polyfill: real pledge()/unveil() via seccomp + landlock.
+# (macOS uses seatbelt, applied in sandbox.c with no compiled polyfill; cosmo
+# has pledge/unveil built in.) Included only when PLATFORM=linux, so the
+# original ifeq(Linux)/ifndef(COSMO) guard is no longer needed here.
+
+PLEDGE_DIR := $(VENDDIR)/pledge
+PLEDGE_CFLAGS := -std=c11 -O2 -w -D_GNU_SOURCE -I$(PLEDGE_DIR) $(DEPFLAGS)
+
+PLEDGE_SRCS := \
+	$(PLEDGE_DIR)/libc/calls/pledge.c \
+	$(PLEDGE_DIR)/libc/calls/pledge-linux.c \
+	$(PLEDGE_DIR)/libc/calls/unveil.c \
+	$(PLEDGE_DIR)/libc/calls/parsepromises.c \
+	$(PLEDGE_DIR)/libc/calls/landlock_add_rule.c \
+	$(PLEDGE_DIR)/libc/calls/landlock_create_ruleset.c \
+	$(PLEDGE_DIR)/libc/calls/landlock_restrict_self.c \
+	$(PLEDGE_DIR)/libc/calls/commandv.c \
+	$(PLEDGE_DIR)/libc/calls/getcpucount.c \
+	$(PLEDGE_DIR)/libc/calls/islinux.c \
+	$(PLEDGE_DIR)/libc/intrin/promises.c \
+	$(PLEDGE_DIR)/libc/intrin/pthread_setcancelstate.c \
+	$(PLEDGE_DIR)/libc/elf/checkelfaddress.c \
+	$(PLEDGE_DIR)/libc/elf/getelfsegmentheaderaddress.c \
+	$(PLEDGE_DIR)/libc/str/classifypath.c \
+	$(PLEDGE_DIR)/libc/str/endswith.c \
+	$(PLEDGE_DIR)/libc/str/isabspath.c \
+	$(PLEDGE_DIR)/libc/fmt/joinpaths.c \
+	$(PLEDGE_DIR)/libc/fmt/sizetol.c \
+	$(PLEDGE_DIR)/libc/runtime/isdynamicexecutable.c \
+	$(PLEDGE_DIR)/libc/sysv/calls/ioprio_set.c \
+	$(PLEDGE_DIR)/libc/x/xdie.c \
+	$(PLEDGE_DIR)/libc/x/xjoinpaths.c \
+	$(PLEDGE_DIR)/libc/x/xmalloc.c \
+	$(PLEDGE_DIR)/libc/x/xrealloc.c \
+	$(PLEDGE_DIR)/libc/x/xstrcat.c \
+	$(PLEDGE_DIR)/libc/x/xstrdup.c
+PLEDGE_OBJS := $(patsubst $(PLEDGE_DIR)/%.c,$(BUILDDIR)/pledge_%.o,$(PLEDGE_SRCS))
+
+# Flatten libc/calls/pledge.c -> build/pledge_libc_calls_pledge.o
+$(BUILDDIR)/pledge_%.o: $(PLEDGE_DIR)/%.c | $(BUILDDIR)
+	@mkdir -p $(dir $@)
+	$(CC) $(PLEDGE_CFLAGS) -c -o $@ $<

--- a/mk/platform/unknown.mk
+++ b/mk/platform/unknown.mk
@@ -1,0 +1,1 @@
+# mk/platform/unknown.mk - fallback for an unrecognized uname (no platform policy).


### PR DESCRIPTION
Completes the build-modularization **platform axis** (issue #167), the last piece after the feature fragments (#161), coarse hardening (#164), Phase 2 (#165), and libhull/tests/vendor (#166).

## What
A computed `PLATFORM := darwin|linux|cosmo` at the top of the Makefile (COSMO checked first — a cosmo build reports `UNAME_S=Linux`) selects `include mk/platform/$(PLATFORM).mk`, which holds **OS-global build policy**: today just the sandbox backend.

## The finding: this axis is small by design
The vendor/feature extraction had **already** moved almost every platform conditional out of the root *with its concern* — WAMR per-OS wiring (`mk/vendor/wamr.mk`), wgpu Metal/Vulkan frameworks (`mk/vendor/wgpu.mk`), tcc ELF gate, TUI cosmo force-load. What remained platform-GLOBAL in the root was **one block**: the jart/pledge polyfill (Linux-only `pledge()`/`unveil()`). There are no per-OS link libs left in root (the hull link is the universal `-lm -lpthread`) and no darwin/cosmo-global blocks.

## Files
- **`mk/platform/linux.mk`** — the `PLEDGE_*` vars + `pledge_%.o` compile rule, moved verbatim, minus the now-redundant `ifeq(Linux)/ifndef(COSMO)` guard (the file is included only when `PLATFORM=linux`). `PLEDGE_OBJS ?=` in root defaults it empty elsewhere so the hull link references it unconditionally.
- **`mk/platform/{darwin,cosmo}.mk`** — thin seams (macOS seatbelt lives in `sandbox.c` with no compiled polyfill; cosmo has pledge built in), documenting where future OS-global policy goes.
- **`mk/platform/unknown.mk`** — empty fallback for an unrecognized `uname`.
- `mk/platform/windows.mk` (from #165) stays the future-native-port stub.

## Design call
Feature-LOCAL platform choices (gpu Metal-vs-Vulkan, tcc ELF, WAMR per-OS) **stay** with their vendor/feature fragment. The platform file holds OS *policy*, not a feature's per-OS wiring.

## Validation
Resolved-value parity — `PLATFORM` + `PLEDGE_OBJS` are **identical** to the old inline `ifeq` under all three:
- simulated `UNAME_S=Linux` → `PLATFORM=linux`, 27 pledge objects
- `COSMO=1` → `PLATFORM=cosmo`, no pledge
- native Darwin → `PLATFORM=darwin`, `PLEDGE_OBJS` empty

Darwin build + full unit suite (60/60) green. cosmocc not available locally — CI covers the cosmo/Linux **build** (the actual pledge compile + link). Makefile 3374 → 3354.

Closes #167.