### PR TITLE
fix(sandbox): grant tty pledge promise when stdout is a terminal (CLI app.main crash)

### DIFF
--- a/src/hull/sandbox.c
+++ b/src/hull/sandbox.c
@@ -29,6 +29,7 @@
 #include <strings.h>   /* strncasecmp (DSN scheme match) */
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <unistd.h>    /* isatty / STDIN_FILENO (tty-promise probe below) */
 
 /* Buffer size for cross-platform path resolution. Big enough to
  * hold any realpath() output (PATH_MAX-bound) and any reasonable
@@ -896,10 +897,19 @@ int hl_sandbox_apply(const HlSandboxPolicy *policy, const char *app_dir,
         if (n > 0) plen += n;
     }
     /* `tty` covers tcsetattr / tcgetattr / TIOCGWINSZ / ioctl on the
-     * controlling terminal. Required for TUI's raw-mode toggle and
-     * size queries; rejected silently if the app never asks for it. */
-    if (plen > 0 && policy->tui &&
-        (size_t)plen < sizeof(promises)) {
+     * controlling terminal. Required for TUI's raw-mode toggle and size
+     * queries, AND for the buffering probe glibc stdio runs on first use
+     * of a terminal-connected fd: writing to stdout/stderr calls
+     * isatty(), i.e. ioctl(TCGETS), which pledge routes through `tty`.
+     * Without it a plain CLI app.main that prints to a terminal is killed
+     * by the seccomp filter (Linux) the moment it writes. We grant it when
+     * the app is a TUI OR any of stdin/stdout/stderr is an actual terminal.
+     * Piped/redirected fds (the production/server case) are not terminals,
+     * so this grants nothing extra there. The probe runs before pledge(),
+     * so the isatty() ioctls themselves are unrestricted. */
+    if (plen > 0 && (size_t)plen < sizeof(promises) &&
+        (policy->tui || isatty(STDIN_FILENO) || isatty(STDOUT_FILENO) ||
+         isatty(STDERR_FILENO))) {
         int n = snprintf(promises + plen, sizeof(promises) - (size_t)plen,
                          " tty");
         if (n > 0) plen += n;

--- a/tests/e2e_sandbox.sh
+++ b/tests/e2e_sandbox.sh
@@ -446,6 +446,49 @@ else
     fi
 fi
 
+# ── Test 7: CLI app.main writing to a real TTY under the sandbox ──────
+#
+# glibc stdio runs isatty() -> ioctl(TCGETS) on first write to a
+# character device (a real terminal). Pre-fix, the sandbox granted the
+# `tty` pledge promise only to TUI apps, so a plain app.main that printed
+# to a terminal was killed by the seccomp filter the moment it wrote. The
+# bug is invisible under a pipe (glibc skips the isatty probe for
+# non-char-device fds), which is why it escaped CI - so this test drives
+# hull under a PTY. Native-Linux-only: macOS seatbelt returns EPERM from
+# isatty (no crash, just "not a tty"), cosmo/OpenBSD pledge differ.
+
+echo ""
+echo "=== Test 7: CLI app.main writes to a TTY under the sandbox ==="
+
+if [ "$UNAME_S" != "Linux" ] || [ "${IS_COSMO:-0}" = "1" ]; then
+    skip "TTY-write regression — native Linux only"
+elif ! command -v python3 >/dev/null 2>&1; then
+    skip "TTY-write regression — python3 (pty) unavailable"
+else
+    cat > "$WORKDIR/cli.lua" << 'EOF'
+app.manifest({ modules = {} })
+app.main(function(ctx)
+    ctx.stdout:write("cli-tty-ok\n")
+    return 0
+end)
+EOF
+    # Allocate a PTY so isatty(stdout) is true, exercising the char-device
+    # path. pty.spawn copies the child's tty output onto our stdout and
+    # returns its wait status; a seccomp SIGKILL surfaces as !WIFEXITED.
+    TTY_OUT=$(python3 - "$HULL" "$WORKDIR/cli.lua" <<'PY' 2>&1
+import os, pty, sys
+status = pty.spawn([sys.argv[1], sys.argv[2]])
+sys.exit(os.WEXITSTATUS(status) if os.WIFEXITED(status) else 1)
+PY
+)
+    RC=$?
+    if [ "$RC" = "0" ] && printf '%s' "$TTY_OUT" | grep -q "cli-tty-ok"; then
+        pass "app.main stdout under a PTY not killed by the sandbox"
+    else
+        fail "app.main under a PTY failed (exit $RC): $TTY_OUT"
+    fi
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## The bug
A plain CLI `app.main` that prints to a **terminal** was killed by the Linux seccomp filter the moment it wrote. glibc stdio runs `isatty()` → `ioctl(TCGETS)` on first write to a **character device** (a real tty) to choose line- vs full-buffering. The sandbox granted the `tty` pledge promise (which covers that ioctl) **only to TUI apps**, so the ioctl tripped the filter for a non-TUI CLI.

## Why it escaped CI + production
The probe is invisible under a **pipe** — glibc skips `isatty` for non-char-device fds. So piped/redirected fds (all of CI, and any server/production deployment) never hit it. It only bites an **interactive terminal session** on native-Linux pledge. (macOS seatbelt returns `EPERM` from `isatty` → graceful "not a tty", no crash; cosmo/OpenBSD differ.)

## Fix
Grant `tty` when `policy->tui` **OR** any of stdin/stdout/stderr is an actual terminal. The `isatty()` probe runs **before** `pledge()`, so it's itself unrestricted; piped/redirected fds are not terminals, so a server/production process's promise set is **unchanged** — the grant is scoped exactly to the interactive case that needs it. (`tty` in pledge does not include the dangerous `TIOCSTI`.) Adds `unistd.h` unconditionally (was OpenBSD-only) for `isatty`/`STDIN_FILENO`.

## Regression test
`e2e_sandbox.sh` **Test 7** drives `hull` under a **PTY** (so `isatty(stdout)` is true, reproducing the char-device path) and asserts an `app.main` writing to stdout exits 0 with its output. Native-Linux-only (the sole platform that SIGKILLs). Pre-fix it fails; post-fix it passes — and it's a genuine reproduction, not a proxy, since a pipe can't trigger the bug.

## Validation
- Darwin build clean; PTY harness mechanics validated locally (exit 0, output captured, full `app.main` lifecycle).
- cosmocc not local — CI covers the cosmo/Linux build + the new PTY regression on the Linux runner.

From the tracked follow-up in `project_cli_stdout_pledge_ioctl_abort.md`.