### PR TITLE
Revert #169 (cli-tty pledge): isatty() aborts under phase-1 pledge on Linux

### DIFF
--- a/src/hull/sandbox.c
+++ b/src/hull/sandbox.c
@@ -29,7 +29,6 @@
 #include <strings.h>   /* strncasecmp (DSN scheme match) */
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>    /* isatty / STDIN_FILENO (tty-promise probe below) */
 
 /* Buffer size for cross-platform path resolution. Big enough to
  * hold any realpath() output (PATH_MAX-bound) and any reasonable
@@ -897,19 +896,10 @@ int hl_sandbox_apply(const HlSandboxPolicy *policy, const char *app_dir,
         if (n > 0) plen += n;
     }
     /* `tty` covers tcsetattr / tcgetattr / TIOCGWINSZ / ioctl on the
-     * controlling terminal. Required for TUI's raw-mode toggle and size
-     * queries, AND for the buffering probe glibc stdio runs on first use
-     * of a terminal-connected fd: writing to stdout/stderr calls
-     * isatty(), i.e. ioctl(TCGETS), which pledge routes through `tty`.
-     * Without it a plain CLI app.main that prints to a terminal is killed
-     * by the seccomp filter (Linux) the moment it writes. We grant it when
-     * the app is a TUI OR any of stdin/stdout/stderr is an actual terminal.
-     * Piped/redirected fds (the production/server case) are not terminals,
-     * so this grants nothing extra there. The probe runs before pledge(),
-     * so the isatty() ioctls themselves are unrestricted. */
-    if (plen > 0 && (size_t)plen < sizeof(promises) &&
-        (policy->tui || isatty(STDIN_FILENO) || isatty(STDOUT_FILENO) ||
-         isatty(STDERR_FILENO))) {
+     * controlling terminal. Required for TUI's raw-mode toggle and
+     * size queries; rejected silently if the app never asks for it. */
+    if (plen > 0 && policy->tui &&
+        (size_t)plen < sizeof(promises)) {
         int n = snprintf(promises + plen, sizeof(promises) - (size_t)plen,
                          " tty");
         if (n > 0) plen += n;

--- a/tests/e2e_sandbox.sh
+++ b/tests/e2e_sandbox.sh
@@ -446,49 +446,6 @@ else
     fi
 fi
 
-# ── Test 7: CLI app.main writing to a real TTY under the sandbox ──────
-#
-# glibc stdio runs isatty() -> ioctl(TCGETS) on first write to a
-# character device (a real terminal). Pre-fix, the sandbox granted the
-# `tty` pledge promise only to TUI apps, so a plain app.main that printed
-# to a terminal was killed by the seccomp filter the moment it wrote. The
-# bug is invisible under a pipe (glibc skips the isatty probe for
-# non-char-device fds), which is why it escaped CI - so this test drives
-# hull under a PTY. Native-Linux-only: macOS seatbelt returns EPERM from
-# isatty (no crash, just "not a tty"), cosmo/OpenBSD pledge differ.
-
-echo ""
-echo "=== Test 7: CLI app.main writes to a TTY under the sandbox ==="
-
-if [ "$UNAME_S" != "Linux" ] || [ "${IS_COSMO:-0}" = "1" ]; then
-    skip "TTY-write regression — native Linux only"
-elif ! command -v python3 >/dev/null 2>&1; then
-    skip "TTY-write regression — python3 (pty) unavailable"
-else
-    cat > "$WORKDIR/cli.lua" << 'EOF'
-app.manifest({ modules = {} })
-app.main(function(ctx)
-    ctx.stdout:write("cli-tty-ok\n")
-    return 0
-end)
-EOF
-    # Allocate a PTY so isatty(stdout) is true, exercising the char-device
-    # path. pty.spawn copies the child's tty output onto our stdout and
-    # returns its wait status; a seccomp SIGKILL surfaces as !WIFEXITED.
-    TTY_OUT=$(python3 - "$HULL" "$WORKDIR/cli.lua" <<'PY' 2>&1
-import os, pty, sys
-status = pty.spawn([sys.argv[1], sys.argv[2]])
-sys.exit(os.WEXITSTATUS(status) if os.WIFEXITED(status) else 1)
-PY
-)
-    RC=$?
-    if [ "$RC" = "0" ] && printf '%s' "$TTY_OUT" | grep -q "cli-tty-ok"; then
-        pass "app.main stdout under a PTY not killed by the sandbox"
-    else
-        fail "app.main under a PTY failed (exit $RC): $TTY_OUT"
-    fi
-fi
-
 # ── Summary ──────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
Reverts #169. The isatty() probe was placed in sandbox **phase 2**, but phase-1 pledge (`stdio`, no `tty`) is already active there; pledge's seccomp filter rejects `ioctl(TCGETS)` by request number regardless of fd, so `isatty()` is killed (SIGSYS/abort) on **every** app on Linux. macOS phase 1 is a no-op so it slipped through local validation. Restoring main to green; a corrected fix (probe in phase 1, before its pledge) follows.