### PR TITLE
fix(sandbox): grant tty pledge in BOTH phases when a terminal is present (corrected #169)

### DIFF
--- a/src/hull/sandbox.c
+++ b/src/hull/sandbox.c
@@ -29,6 +29,7 @@
 #include <strings.h>   /* strncasecmp (DSN scheme match) */
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <unistd.h>    /* isatty / STDIN_FILENO (controlling-terminal probe) */
 
 /* Buffer size for cross-platform path resolution. Big enough to
  * hold any realpath() output (PATH_MAX-bound) and any reasonable
@@ -540,8 +541,26 @@ static int sb_supported(void) { return 0; }
 
 /* ── Phase 1: pre-load pledge ──────────────────────────────────────── */
 
+/* Whether any of stdin/stdout/stderr is a controlling terminal, probed once
+ * in phase 1 BEFORE any pledge is applied. Read by phase 2 (which cannot probe
+ * itself: phase-1 pledge is already active there, and isatty()'s ioctl(TCGETS)
+ * is not permitted by the `stdio` promise). See the probe site below. */
+static int g_stdio_is_tty = 0;
+
 int hl_sandbox_apply_pledge(void)
 {
+    /* Probe the controlling terminal before ANY sandbox is installed. glibc
+     * stdio issues isatty() -> ioctl(TCGETS) on first write to a character
+     * device (a real tty) to pick line- vs full-buffering; that ioctl is
+     * covered by the `tty` promise, not `stdio`. Without this, a plain CLI
+     * app.main that prints to a terminal is killed by the seccomp filter the
+     * moment it writes. Probing here, unsandboxed, lets both phases grant
+     * `tty` when a terminal is present (seccomp can only restrict, not widen,
+     * so phase 1 must be a superset of phase 2). Piped/redirected fds are not
+     * terminals, so a server/CI process gets nothing extra. */
+    g_stdio_is_tty = (isatty(STDIN_FILENO) || isatty(STDOUT_FILENO) ||
+                      isatty(STDERR_FILENO)) ? 1 : 0;
+
     if (!sb_supported()) {
         log_info("[sandbox] kernel sandbox not available on this platform");
         return 0;
@@ -570,10 +589,16 @@ int hl_sandbox_apply_pledge(void)
      * futimes() via bump_atime_fd for LRU tracking. Without it the
      * JS / Lua runtime gets killed during stdlib module compilation. */
 #if defined(__linux__) && !defined(__COSMOPOLITAN__)
-    const char *phase1 = "stdio inet unix rpath wpath cpath flock fattr dns netlink unveil";
+    const char *phase1_base = "stdio inet unix rpath wpath cpath flock fattr dns netlink unveil";
 #else
-    const char *phase1 = "stdio inet rpath wpath cpath flock fattr dns unveil";
+    const char *phase1_base = "stdio inet rpath wpath cpath flock fattr dns unveil";
 #endif
+    /* Grant `tty` in phase 1 too when a terminal is present, so phase 2's
+     * `tty` (for TUI or a terminal-connected CLI) is actually effective -
+     * seccomp only restricts, so phase 1 must be a superset. */
+    char phase1[256];
+    snprintf(phase1, sizeof(phase1), "%s%s",
+             phase1_base, g_stdio_is_tty ? " tty" : "");
     if (pledge(phase1, NULL) != 0) {
         log_error("[sandbox] phase 1 pledge failed");
         return -1;
@@ -895,10 +920,16 @@ int hl_sandbox_apply(const HlSandboxPolicy *policy, const char *app_dir,
                          " inet");
         if (n > 0) plen += n;
     }
-    /* `tty` covers tcsetattr / tcgetattr / TIOCGWINSZ / ioctl on the
-     * controlling terminal. Required for TUI's raw-mode toggle and
-     * size queries; rejected silently if the app never asks for it. */
-    if (plen > 0 && policy->tui &&
+    /* `tty` covers tcsetattr / tcgetattr / TIOCGWINSZ / ioctl(TCGETS) on the
+     * controlling terminal. Required for TUI's raw-mode toggle and size
+     * queries, AND for the isatty()/buffering-probe ioctl glibc stdio runs on
+     * first write to a terminal-connected fd (so a plain CLI app.main that
+     * prints to a terminal is not killed). Granted when the app is a TUI OR a
+     * terminal is present (g_stdio_is_tty, probed unsandboxed in phase 1 -
+     * we must NOT call isatty() here, as phase-1 pledge already forbids that
+     * ioctl). Phase 1 grants the matching superset. Piped/redirected fds are
+     * not terminals, so a server/CI process's promise set is unchanged. */
+    if (plen > 0 && (policy->tui || g_stdio_is_tty) &&
         (size_t)plen < sizeof(promises)) {
         int n = snprintf(promises + plen, sizeof(promises) - (size_t)plen,
                          " tty");

--- a/tests/e2e_sandbox.sh
+++ b/tests/e2e_sandbox.sh
@@ -446,6 +446,50 @@ else
     fi
 fi
 
+# ── Test 7: CLI app.main writing to a real TTY under the sandbox ──────
+#
+# glibc stdio runs isatty() -> ioctl(TCGETS) on first write to a
+# character device (a real tty). The sandbox grants the `tty` pledge
+# promise (which covers that ioctl) only when a terminal is present or
+# the app is a TUI; a plain app.main printing to a terminal must still
+# work. The bug is invisible under a pipe (glibc skips the isatty probe
+# for non-char-device fds), which is why it escaped CI - so this test
+# drives hull under a PTY. Native-Linux-only: that is the platform whose
+# seccomp filter SIGKILLs the ioctl (macOS seatbelt returns EPERM from
+# isatty - graceful "not a tty", no crash; cosmo/OpenBSD pledge differ).
+
+echo ""
+echo "=== Test 7: CLI app.main writes to a TTY under the sandbox ==="
+
+if [ "$UNAME_S" != "Linux" ] || [ "${IS_COSMO:-0}" = "1" ]; then
+    skip "TTY-write regression — native Linux only"
+elif ! command -v python3 >/dev/null 2>&1; then
+    skip "TTY-write regression — python3 (pty) unavailable"
+else
+    cat > "$WORKDIR/cli.lua" << 'EOF'
+app.manifest({ modules = {} })
+app.main(function(ctx)
+    ctx.stdout:write("cli-tty-ok\n")
+    return 0
+end)
+EOF
+    # Allocate a PTY so isatty(stdout) is true, exercising the char-device
+    # path. pty.spawn copies the child's tty output onto our stdout and
+    # returns its wait status; a seccomp SIGKILL surfaces as !WIFEXITED.
+    TTY_OUT=$(python3 - "$HULL" "$WORKDIR/cli.lua" <<'PY' 2>&1
+import os, pty, sys
+status = pty.spawn([sys.argv[1], sys.argv[2]])
+sys.exit(os.WEXITSTATUS(status) if os.WIFEXITED(status) else 1)
+PY
+)
+    RC=$?
+    if [ "$RC" = "0" ] && printf '%s' "$TTY_OUT" | grep -q "cli-tty-ok"; then
+        pass "app.main stdout under a PTY not killed by the sandbox"
+    else
+        fail "app.main under a PTY failed (exit $RC): $TTY_OUT"
+    fi
+fi
+
 # ── Summary ──────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
Corrected re-do of #169 (reverted in #171). **This time: wait for CI green before merging.**

## What went wrong in #169
#169 probed `isatty()` in sandbox **phase 2** to decide the `tty` promise. But phase-1 pledge (`stdio`, no `tty`) is already active there, and pledge filters `ioctl` by **request number regardless of fd**, so the `isatty()`→`ioctl(TCGETS)` probe *itself* was killed. It aborted **every** app on Linux (servers included, in CI and out), because the ioctl is filtered whether or not the fd is a tty. macOS phase 1 is a no-op, so local validation missed it — it reached main and broke `e2e_build` ("Aborted (core dumped)").

## Correct approach
- **Probe `isatty(0/1/2)` once at the top of phase 1, before any pledge**, into a cached `g_stdio_is_tty`. Phase 2 reads the cache and **never calls `isatty()`** itself — so the #169 abort cannot recur.
- **Grant `tty` in both phases** when a terminal is present. seccomp only restricts (not widens), so phase 1 must be a superset for phase 2's grant to take effect. This also makes the pre-existing TUI phase-2 `tty` genuinely effective on Linux.
- Piped/redirected fds are not terminals → `g_stdio_is_tty` is 0 → promise set **unchanged** for servers/CI.

## Why it's safe vs #169
The regression was the phase-2 `isatty()` syscall under a restrictive pledge. That call is **gone**. For any non-tty process (all of CI, all servers) the phase-2 code is byte-identical to pre-#169. The only behavior change is: when a terminal *is* present, both phases additionally allow `tty`.

## Regression test
`e2e_sandbox.sh` Test 7 drives hull under a **PTY** (so `isatty(stdout)` is true) and asserts an `app.main` writing to stdout exits 0 with its output — native-Linux-only. A pipe can't trigger the bug, so the PTY is load-bearing.

## Validation
- Darwin build + PTY sanity green.
- Linux validated via Docker (build + PTY test) — see PR thread.
- CI (Linux x86_64 runner) is the gate; **not** merging until green.