### PR TITLE
build.lua: extract discover() -> ctx from main() (Phase 3.2 cont.)

### DIFF
--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1592,10 +1592,12 @@ local function prepare_platform(opts, tmpdir, cc, is_cosmo, flavor_asset)
     return platform_lib, platform_dir, platform_sig_blob, platform_arch_hashes
 end
 
-local function main()
-    local opts = parse_args()
-
-    -- Find app source files
+-- discover: find the app’s source/asset files, make the temp build dir, run the
+-- stale compute-AOT rebuild, and detect the compiler + cosmo flavor. Returns a
+-- ctx table of the discovered state main() threads into the later stages.
+-- Extracted from main() in Phase 3.2 (docs/build_modularization.md). The internal
+-- *_dir path locals stay private; only the 11 fields main uses downstream return.
+local function discover(opts)
     local lua_files = find_lua_files(opts.app_dir)
     local js_files = find_js_files(opts.app_dir)
     local json_files = find_json_files(opts.app_dir)
@@ -1828,6 +1830,25 @@ typedef struct {
         opts.flavor = picked
     end
 
+    return {
+        lua_files = lua_files, js_files = js_files, json_files = json_files,
+        tmpdir = tmpdir, html_files = html_files, static_files = static_files,
+        migration_files = migration_files, compute_files = compute_files,
+        shader_files = shader_files, cc = cc, is_cosmo = is_cosmo,
+    }
+end
+
+local function main()
+    local opts = parse_args()
+
+    -- Find app source files
+    -- Discover app files + toolchain (see discover() above); unpack into locals.
+    local ctx = discover(opts)
+    local lua_files, js_files, json_files, tmpdir, html_files, static_files,
+          migration_files, compute_files, shader_files, cc, is_cosmo =
+        ctx.lua_files, ctx.js_files, ctx.json_files, ctx.tmpdir, ctx.html_files,
+        ctx.static_files, ctx.migration_files, ctx.compute_files, ctx.shader_files,
+        ctx.cc, ctx.is_cosmo
     -- ── Build flavor (--flavor) ──
     -- Validate the requested flavor and (for non-default flavors) check the
     -- app's manifest against the TARGET flavor's caps, aborting if a declared


### PR DESCRIPTION
Phase 3.2 continued — the discovery stage, and the introduction of the **`ctx`-return pattern**.

## What
The ~232-line discovery stage at the top of `main()` — find the app's source/asset files, make the temp build dir, run the stale compute-AOT rebuild, detect the compiler + cosmo flavor — is lifted into `discover(opts)`, which returns a **`ctx` table** of the discovered state.

## The ctx pattern (low-churn form)
`main()` unpacks the **11 fields** it threads downstream (`lua_files`, `js_files`, `json_files`, `tmpdir`, `html_files`, `static_files`, `migration_files`, `compute_files`, `shader_files`, `cc`, `is_cosmo`) back into locals, so the rest of `main()` is **byte-identical** — no risky mass-rename of `tmpdir` (25 uses) etc. Which fields to return was derived by counting each discovered local's uses after the stage (`grep -w`): the 11 with downstream uses are returned; the 5 internal `*_dir` path locals (`templates_dir`, `static_dir`, `migrations_dir`, `compute_dir`, `shaders_dir`) are only used to find files, so they stay private to `discover()`. No bare returns.

## Result
`main()` ~626 → ~400 lines; `build.lua` 2148 → 2169. **Across Phase 3.2 (`compose_features` #174, `prepare_platform` #175, `discover`), `main()` is down from ~1,585 → ~400 lines.**

## Validated (Darwin) — all 7 feature-e2e suites individually
`runtime`, `sqlite`, `tui`, `wasm` (the `compute_files` discovery gate), `image`, `tls`, and `e2e_composed_sig` (full signed build through all four stages: discover → prepare_platform → compose_features → sign §5c). A batch TLS failure was test-ordering interference (conflicting sub-`make` builds when chained); tls + composed-sig pass in isolation.

CI is the gate; **not merging until green**.

## Phase 3 essentially complete after this
`main()` is now a readable pipeline: `parse_args → discover → flavor → prepare_platform → compile → compose_features → link → sign+emit`. The remaining `compile`/`link`/`sign+emit` tails are thin. Next up is **Phase 4** (cross-file registry unify) — the higher-value endgame that `FEATURE_SPECS` (#173) set up.