### PR TITLE
build: canonical feature registry + feature-embedded aggregate (Phase 4a)

### DIFF
--- a/mk/feature.mk
+++ b/mk/feature.mk
@@ -54,3 +54,27 @@ $$(BUILDDIR)/libhull_feature-$(1).a: $(2) $$($(3)) | $$(BUILDDIR)
 	done; rm -rf $$$$tmproot
 	@echo "built $$@ ($$$$(du -h $$@ | cut -f1))"
 endef
+
+# ── Canonical feature registry (single source of truth, Phase 4) ─────
+# The one place the feature set is enumerated. release.yml derives its
+# embedded-archive build / upload / sign lists from these (via the
+# feature-embedded aggregate + the print-* targets) so adding a feature is one
+# edit here, not four across Makefile / build.lua / feature.c / release.yml.
+#
+#   FEATURE_EMBEDDED_STEMS     archives that ship INSIDE the distributed hull
+#                              (platform-domain, attested by signature.c 5c:
+#                              runtime + http + wasm + sqlite + image + tls +
+#                              keel + per-runtime bridges). Native-only; cosmo
+#                              (fat APE) has none.
+#   FEATURE_INSTALLABLE_STEMS  the --with features published as signed archives
+#                              for `hull feature install` (release-domain).
+FEATURE_EMBEDDED_STEMS := lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js sqlite sqlite-lua sqlite-js image image-lua image-js tls keel
+FEATURE_INSTALLABLE_STEMS := duckdb postgres mysql gpu tui
+FEATURE_EMBEDDED_LIBS := $(addprefix $(BUILDDIR)/libhull_feature-,$(addsuffix .a,$(FEATURE_EMBEDDED_STEMS)))
+
+.PHONY: feature-embedded print-feature-embedded-stems print-feature-embedded-libs print-feature-installable-stems
+# Build every embedded feature archive (what release.yml's embedded build step runs).
+feature-embedded: $(addprefix feature-,$(FEATURE_EMBEDDED_STEMS))
+print-feature-embedded-stems: ; @echo $(FEATURE_EMBEDDED_STEMS)
+print-feature-embedded-libs: ; @echo $(FEATURE_EMBEDDED_LIBS)
+print-feature-installable-stems: ; @echo $(FEATURE_INSTALLABLE_STEMS)


### PR DESCRIPTION
Phase 4 of the build modularization — the cross-file registry unify. **4a: the foundation** (source of truth + interface), no consumers rewired yet.

## The problem
The feature set is hardcoded in **four** places — `mk/features/*.mk`, `build.lua` `FEATURE_SPECS`, `feature.c` `FEATURES[]`, and `release.yml`'s `make feature-*` lists (the embedded-archive list alone appears ~4×: Linux build, macOS build, upload paths, sign). Adding a feature means four synchronized edits.

## This PR — the single source of truth (`mk/feature.mk`)
- `FEATURE_EMBEDDED_STEMS` — the **18** archives that ship inside the distributed hull (platform-domain, attested by signature.c §5c: runtime + http + wasm + sqlite + image + tls + keel + per-runtime bridges).
- `FEATURE_INSTALLABLE_STEMS` — the **5** `--with` features published for `hull feature install` (duckdb/postgres/mysql/gpu/tui).

Plus the interface release.yml will derive from:
- `feature-embedded` — aggregate that builds all 18 archives
- `print-feature-embedded-stems` / `print-feature-embedded-libs` / `print-feature-installable-stems`

## Safety
**Pure additions** — no existing target or variable changed, so the base build is untouched. Validated locally: the print targets emit **exactly** the list release.yml hardcodes today, and `make feature-embedded` builds all 18 archives.

## Next
- **4b** (separate — touches the release pipeline, needs a pre-release-tag **dry-run**): wire release.yml's build / upload / sign lists to these.
- **4c** (later): `feature.c` `FEATURES[]` codegen.