### PR TITLE
release.yml: derive embedded-feature lists from the registry (Phase 4b)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,47 +71,25 @@ jobs:
         if: runner.os == 'Linux'
         uses: ./.github/actions/hull-build-container
         with:
-          run: >
-            make feature-lua feature-js feature-http feature-http-lua
-            feature-http-js feature-tui-lua feature-tui-js
-            feature-wasm feature-wasm-lua feature-wasm-js
-            feature-sqlite feature-sqlite-lua feature-sqlite-js
-            feature-image feature-image-lua feature-image-js
-            feature-tls
-            feature-keel
+          # The embedded-archive set is the FEATURE_EMBEDDED_STEMS registry in
+          # mk/feature.mk (Phase 4). feature-embedded builds all of them, so
+          # adding an embedded feature is one edit there, not four here.
+          run: make feature-embedded
       - name: Build embedded feature archives (macOS)
         if: runner.os == 'macOS'
-        run: >
-          make feature-lua feature-js feature-http feature-http-lua
-          feature-http-js feature-tui-lua feature-tui-js
-          feature-wasm feature-wasm-lua feature-wasm-js
-          feature-sqlite feature-sqlite-lua feature-sqlite-js
-          feature-image feature-image-lua feature-image-js
-          feature-tls
-          feature-keel
+        run: make feature-embedded
+      - name: Stage embedded feature archives (registry-explicit)
+        # Copy exactly the FEATURE_EMBEDDED_STEMS archives (via the registry
+        # print target) into a clean dir, so the uploaded artifact is precisely
+        # those regardless of anything else that may sit in build/.
+        run: |
+          mkdir -p features-out
+          cp $(make -s print-feature-embedded-libs) features-out/
       - name: Upload embedded feature archives
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: platform-features-${{ matrix.name }}
-          path: |
-            build/libhull_feature-lua.a
-            build/libhull_feature-js.a
-            build/libhull_feature-http.a
-            build/libhull_feature-http-lua.a
-            build/libhull_feature-http-js.a
-            build/libhull_feature-tui-lua.a
-            build/libhull_feature-tui-js.a
-            build/libhull_feature-wasm.a
-            build/libhull_feature-wasm-lua.a
-            build/libhull_feature-wasm-js.a
-            build/libhull_feature-sqlite.a
-            build/libhull_feature-sqlite-lua.a
-            build/libhull_feature-sqlite-js.a
-            build/libhull_feature-image.a
-            build/libhull_feature-image-lua.a
-            build/libhull_feature-image-js.a
-            build/libhull_feature-tls.a
-            build/libhull_feature-keel.a
+          path: features-out/libhull_feature-*.a
 
       # Per-flavor platform libs for `hull build --flavor` + `hull platform
       # install`. Each native platform-<flavor> target builds into its own obj
@@ -270,9 +248,12 @@ jobs:
             # `sqlite` = the engine (Phase D), `sqlite-lua`/`sqlite-js` = the udf
             # bridges (Phase C.2b). `tls` = the mbedTLS + crypto/transport backends
             # (docs/tls_feature.md, a2; one archive, no per-runtime bridge).
+            # Glob the downloaded embedded archives (the FEATURE_EMBEDDED_STEMS
+            # set that feature-embedded produced + uploaded) rather than a
+            # hardcoded stem list; the stem is recovered from each filename.
             for arch in linux-x86_64 linux-aarch64 darwin-arm64; do
-              for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js sqlite sqlite-lua sqlite-js image image-lua image-js tls keel; do
-                f="platforms/platform-features-$arch/libhull_feature-$stem.a"
+              for f in platforms/platform-features-$arch/libhull_feature-*.a; do
+                stem=$(basename "$f" .a); stem=${stem#libhull_feature-}
                 sha256sum "$f" \
                   | awk -v n="libhull_feature-$stem.$arch.a" '{print $1"  "n}'
               done
@@ -566,7 +547,7 @@ jobs:
           # name (libhull_feature-<stem>.<arch>.a), or the runtime §5c check on
           # every app this hull builds would fail. Includes the SQLite engine
           # (sqlite) + udf bridges (sqlite-lua/sqlite-js) + the TLS backends (tls).
-          for stem in lua js http http-lua http-js tui-lua tui-js wasm wasm-lua wasm-js sqlite sqlite-lua sqlite-js image image-lua image-js tls keel; do
+          for stem in $(make -s print-feature-embedded-stems); do
             fa="build/libhull_feature-$stem.a"
             name="libhull_feature-$stem.${{ matrix.name }}.a"
             fact=$(sha256sum "$fa" | awk '{print $1}')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -586,21 +586,30 @@ jobs:
           user: host
           run: |
             make EMBED_PLATFORM=1 HL_APP_BASE_SQLITELESS=1 HL_APP_BASE_TLSLESS=1 TRUST_PLATFORM_LIB=1 TRUST_FEATURE_LIBS=1
-            make hardening
-            make check-hardening
+            # hardening/check-hardening MUST carry the same EMBED flags. check-hardening
+            # depends on $(BUILDDIR)/hull; run plain, it rebuilds the shared build_assets.o
+            # in the non-EMBED (stub) config and relinks hull WITHOUT the embedded platform
+            # (EMBED_PLATFORM isn't in the config-sentinel fingerprint), which then breaks
+            # the Platform-sig E2E + the released binary. Same flags = no non-EMBED rebuild.
+            make hardening EMBED_PLATFORM=1 HL_APP_BASE_SQLITELESS=1 HL_APP_BASE_TLSLESS=1 TRUST_PLATFORM_LIB=1 TRUST_FEATURE_LIBS=1
+            make check-hardening EMBED_PLATFORM=1 HL_APP_BASE_SQLITELESS=1 HL_APP_BASE_TLSLESS=1 TRUST_PLATFORM_LIB=1 TRUST_FEATURE_LIBS=1
       - name: Build hull with embedded platform (macOS)
         if: runner.os == 'macOS'
         run: make EMBED_PLATFORM=1 HL_APP_BASE_SQLITELESS=1 HL_APP_BASE_TLSLESS=1 TRUST_PLATFORM_LIB=1 TRUST_FEATURE_LIBS=1
       - name: Hardening summary (macOS)
         if: runner.os == 'macOS'
-        run: make hardening
+        # Same EMBED flags as the build (see the Linux step) so this does not
+        # rebuild build_assets.o / hull in the non-EMBED config.
+        run: make hardening EMBED_PLATFORM=1 HL_APP_BASE_SQLITELESS=1 HL_APP_BASE_TLSLESS=1 TRUST_PLATFORM_LIB=1 TRUST_FEATURE_LIBS=1
       - name: Hardening verification (macOS)
         # Verifies the just-built binary carries the expected compiler/linker
         # hardening properties (PIE, RELRO+BIND_NOW, NX, canaries, CET/BTI).
         # Required protections missing for this platform cause a non-zero exit
         # and the release fails.
         if: runner.os == 'macOS'
-        run: make check-hardening
+        # Same EMBED flags (see the Linux step): plain check-hardening rebuilds
+        # build_assets.o + relinks hull WITHOUT the embedded platform.
+        run: make check-hardening EMBED_PLATFORM=1 HL_APP_BASE_SQLITELESS=1 HL_APP_BASE_TLSLESS=1 TRUST_PLATFORM_LIB=1 TRUST_FEATURE_LIBS=1
 
       - name: Smoke-test version + platform
         run: |


### PR DESCRIPTION
Phase 4b — wire `release.yml` to the Phase 4a registry (`FEATURE_EMBEDDED_STEMS`), collapsing the embedded 18-archive list that was hardcoded **~4×** (Linux build, macOS build, upload paths, sign loop, embed loop) into **one edit** in `mk/feature.mk`.

## Changes
- **Build** (Linux + macOS): `make feature-lua feature-js …` (18 targets) → `make feature-embedded` (the registry aggregate).
- **Upload**: a registry-explicit staging step (`cp $(make -s print-feature-embedded-libs) features-out/`) then upload `features-out/`, so the artifact is **exactly the 18** regardless of anything else in `build/` — deliberately *not* a `build/*.a` glob (a polluted `build/` could over-match; I hit exactly that locally).
- **sign-platform-manifest** (no checkout → no `make`): glob the **downloaded** `platform-features` artifact (guaranteed to be the 18 the staging upload produced) and recover each stem from the filename.
- **build-native embed cross-check** (has checkout): `for stem in $(make -s print-feature-embedded-stems)` — registry-explicit, `build/`-independent.

Design: the registry drives the one build; the checkout-less sign job follows the uploaded artifact. Net **-19 lines**.

## Validation
- Locally: `make feature-embedded` builds 18; `print-feature-embedded-{libs,stems}` emit 18; the staging `cp` and the basename stem-recovery were exercised. YAML parses.
- **End-to-end: a pre-release-tag dry-run** of the full release workflow (the only faithful test for a release.yml change) — running next; this is why I picked option (a).

## Note
Normal PR CI validates the Makefile registry + YAML but **cannot** run `release.yml` (tag-triggered). The dry-run is the real gate; I'll link its run here.