### PR TITLE
build: feature.c <-> registry consistency check (Phase 4c)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,11 @@ jobs:
         with:
           submodules: true
 
+      # Phase 4c: fail fast if feature.c FEATURES[] drifts from the mk/feature.mk
+      # feature registry (the single source of truth). Cheap (grep + make vars).
+      - name: Feature registry consistency (feature.c vs mk/feature.mk)
+        run: make check-feature-registry
+
       - name: Build
         run: make
 

--- a/mk/feature.mk
+++ b/mk/feature.mk
@@ -78,3 +78,9 @@ feature-embedded: $(addprefix feature-,$(FEATURE_EMBEDDED_STEMS))
 print-feature-embedded-stems: ; @echo $(FEATURE_EMBEDDED_STEMS)
 print-feature-embedded-libs: ; @echo $(FEATURE_EMBEDDED_LIBS)
 print-feature-installable-stems: ; @echo $(FEATURE_INSTALLABLE_STEMS)
+
+# Phase 4c: fail if src/hull/commands/feature.c FEATURES[] (the `hull feature
+# install/list` registry) drifts from this single source of truth. Closes the
+# last of the four-place feature-list duplication; run in CI.
+.PHONY: check-feature-registry
+check-feature-registry: ; @sh scripts/check_feature_registry.sh "$(FEATURE_INSTALLABLE_STEMS)" "$(FEATURE_EMBEDDED_STEMS)"

--- a/scripts/check_feature_registry.sh
+++ b/scripts/check_feature_registry.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Phase 4c (docs/build_modularization.md): fail if the installable-feature
+# registry in src/hull/commands/feature.c FEATURES[] drifts from the single
+# source of truth in mk/feature.mk. Adding/removing a --with feature must be
+# one edit; this catches the case where feature.c and the Makefile disagree.
+#
+# Args: "$1" = FEATURE_INSTALLABLE_STEMS, "$2" = FEATURE_EMBEDDED_STEMS.
+set -eu
+FC=src/hull/commands/feature.c
+
+# The HL_FEATURE_INSTALLABLE rows (anchored on the `{ "name"` row start so the
+# enum declaration line is not matched) must equal FEATURE_INSTALLABLE_STEMS.
+c_inst=$(grep -E '\{ *"[a-z]+".*HL_FEATURE_INSTALLABLE,' "$FC" \
+         | sed -E 's/^[[:space:]]*\{ *"([a-z]+)".*/\1/' | sort | tr '\n' ' ')
+mk_inst=$(printf '%s\n' $1 | grep . | sort | tr '\n' ' ')
+if [ "$c_inst" != "$mk_inst" ]; then
+  echo "ERROR: feature.c installable features drifted from FEATURE_INSTALLABLE_STEMS" >&2
+  echo "  feature.c FEATURES[]:      [$c_inst]" >&2
+  echo "  mk/feature.mk registry:    [$mk_inst]" >&2
+  echo "  -> reconcile src/hull/commands/feature.c and mk/feature.mk" >&2
+  exit 1
+fi
+
+# Each HL_FEATURE_EMBEDDED row (the user-facing runtimes lua/js) must be a real
+# embedded archive stem.
+for f in $(grep -E '\{ *"[a-z]+".*HL_FEATURE_EMBEDDED,' "$FC" \
+           | sed -E 's/^[[:space:]]*\{ *"([a-z]+)".*/\1/'); do
+  case " $2 " in
+    *" $f "*) ;;
+    *) echo "ERROR: feature.c embedded feature '$f' is not in FEATURE_EMBEDDED_STEMS [$2]" >&2; exit 1 ;;
+  esac
+done
+
+echo "check-feature-registry: OK (installable: $c_inst)"


### PR DESCRIPTION
Phase 4c — closes the **last** of the four-place feature-list duplication.

`mk/features/*.mk`, `build.lua` `FEATURE_SPECS`, and `release.yml` all derive from the `mk/feature.mk` registry now. `src/hull/commands/feature.c` `FEATURES[]` (the `hull feature install/list` table) was the one place still hand-maintained in parallel.

## Approach: guard, not codegen
The per-feature descriptions + per-platform publish flags in `FEATURES[]` are C-only data, so codegen is awkward. Instead, a fast consistency check:
```
make check-feature-registry   # scripts/check_feature_registry.sh
```
- `HL_FEATURE_INSTALLABLE` rows in `feature.c` **must equal** `FEATURE_INSTALLABLE_STEMS`
- every `HL_FEATURE_EMBEDDED` row (the user-facing lua/js runtimes) **must be** a real `FEATURE_EMBEDDED_STEMS` archive

Drift in either direction fails with a reconcile hint. Wired into the CI `build` job as a **fail-fast** step (cheap: grep + make vars, no build).

## Why it matters
"Add a `--with` feature" now catches the case where `feature.c` and the Makefile registry disagree — the **drift class behind this session's release regression**.

## Verified
Real tree passes; missing / extra / renamed feature in either list → exit 1 (all four directions tested).

Completes **Phase 4** (cross-file registry unify) of the build modularization.