### PR TITLE
fix(e2e): stash base hull before `make feature-duckdb` (config-flip purge)

### DIFF
--- a/tests/e2e_feature_duckdb.sh
+++ b/tests/e2e_feature_duckdb.sh
@@ -17,14 +17,21 @@ cd "$(dirname "$0")/.."
 
 echo "=== build base hull (EMBED_PLATFORM=1; base is DuckDB-free) ==="
 make EMBED_PLATFORM=1 >/dev/null
+# Stash the base hull: `make feature-duckdb` re-invokes make with
+# HL_ENABLE_DUCKDB=1, and the build-config sentinel cleans build/ on the flag
+# flip (EMBED_PLATFORM is fingerprinted since #179), which would wipe build/hull.
+# Save the build-tool binary first so it survives the feature-archive build
+# (mirrors e2e_feature_gpu.sh).
+cp build/hull /tmp/hull_base_duckdb_e2e
+
 echo "=== build the DuckDB feature archive ==="
 make feature-duckdb >/dev/null
 ls -la build/libhull_feature-duckdb.a
 
-HULL=./build/hull
+HULL=/tmp/hull_base_duckdb_e2e
 APP=$(mktemp -d)
 PLAIN=$(mktemp -d)
-trap 'rm -rf "$APP" "$PLAIN"' EXIT
+trap 'rm -rf "$APP" "$PLAIN" /tmp/hull_base_duckdb_e2e' EXIT
 
 cat > "$APP/app.lua" <<'LUA'
 app.manifest({


### PR DESCRIPTION
**Fixes a pre-existing red check on `main`** (`DuckDB feature build (Linux)`).

`tests/e2e_feature_duckdb.sh` builds the base hull with `make EMBED_PLATFORM=1`, then `make feature-duckdb` - which re-invokes make with `HL_ENABLE_DUCKDB=1` and **no** `EMBED_PLATFORM`. Since **#179 fingerprinted `EMBED_PLATFORM`** into the build-config sentinel, that flag flip is now a fingerprint change, so the sentinel cleans `build/` and wipes `build/hull`. The script then ran `./build/hull` → **`not found`**.

## Fix
Mirror `e2e_feature_gpu.sh`, which already handles the identical flip: copy `build/hull` to `/tmp` **before** the feature-archive build and use that stashed binary. Feature archives (`libhull_feature-*.a`) aren't in the sentinel purge set (only `libhull_platform.a` is), so the archive survives.

```diff
 make EMBED_PLATFORM=1 >/dev/null
+cp build/hull /tmp/hull_base_duckdb_e2e
 make feature-duckdb >/dev/null
-HULL=./build/hull
+HULL=/tmp/hull_base_duckdb_e2e
```

## Validation
Reproduced + fixed; validating the real e2e on Linux (ubuntu-24.04, Docker) locally in addition to this PR's CI. Unblocks the `DuckDB feature build` check on main and on the stacked compiler-free PRs (#182/#183) that inherit it.