### PR TITLE
build: make the compiler-free (emit) path the default (Phase 3a)

### DIFF
--- a/docs/compiler_free_build.md
+++ b/docs/compiler_free_build.md
@@ -302,13 +302,19 @@ The whole reason to keep the linked form over an appended overlay:
 
 ## Rollout
 
-1. Land `obj_emit.c` + `HlLinkerVtable` + bundled `app_main.o` assets +
-   `tool.emit_app_registry` binding, behind `hull build --no-compiler`
-   (opt-in), keeping the current compile path as fallback.
-2. Flip `--no-compiler` to default once the per-format e2e is green
-   across the CI matrix.
-3. Remove `compiler_tcc.c`, the `vendor/tcc` submodule, `e2e_tcc.sh`,
-   and the tcc embedding pipeline (this design is its replacement).
+1. **Done (#182).** Land `obj_emit.c` + `HlLinkerVtable` +
+   `tool.emit_app_registry`/`tool.linker` bindings + `test_obj_emit`.
+   **Done (#185).** Bundled `app_main.o` / `app_feature_registry-<rt>.o`
+   assets + the `hull build --no-compiler` opt-in path + `e2e_compiler_free.sh`.
+2. **Done (Phase 3a).** The emit path is now the **default**. `--compiler[=X]`
+   opts back into the C compiler; a `--with` feature (needs a generated
+   feature registry), a cosmo/APE target (dual-arch), or a missing linker
+   **auto-fall back** to the compiler rather than erroring. The whole e2e
+   suite now builds through the emit path on the CI matrix.
+3. **Next.** Remove `compiler_tcc.c`, `mk/vendor/tcc.mk`, the `vendor/tcc`
+   submodule, `e2e_tcc.sh`, the `test_compiler` tcc cases, the tcc embedding
+   pipeline, and the `build-tcc` release job (this design is its replacement).
+   The system compiler stays as the `--with`/cosmo fallback.
 4. `linker_lld`/`linker_mold` embedding is a follow-up that upgrades
    "compiler-free" to "toolchain-free" on the user's box.
 

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -39,11 +39,14 @@ local function parse_args()
                                 -- --no-verify-platform skips it; use for
                                 -- dev hulls (no embedded manifest) or
                                 -- forks signing with their own platform key.
-        no_compiler = false,    -- Compiler-free build: emit app_registry.o
-                                -- directly (obj_emit) + extract the bundled
-                                -- app_main.o / app_feature_registry-<rt>.o and
-                                -- link, with no C compiler. Opt-in; the common
-                                -- (no --with) case. docs/compiler_free_build.md
+        no_compiler = true,     -- Compiler-free build (DEFAULT since Phase 3):
+                                -- emit app_registry.o (obj_emit) + extract the
+                                -- bundled app_main.o / app_feature_registry-<rt>.o
+                                -- and link, with no C compiler. Auto-falls back
+                                -- to the compiler for --with features / cosmo /
+                                -- when no linker is resolvable (see the guard in
+                                -- main()). `--compiler[=X]` forces the compiler
+                                -- path. docs/compiler_free_build.md
     }
 
     local i = 1
@@ -65,6 +68,12 @@ local function parse_args()
             else
                 opts.cc = comp
             end
+            -- Asking for a specific compiler opts back into the compiler path
+            -- (the emit path is now the default).
+            opts.no_compiler = false
+        elseif a:sub(1, 11) == "--compiler=" then
+            opts.cc = a:sub(12)
+            opts.no_compiler = false
         elseif a == "--output" or a == "-o" then
             i = i + 1
             opts.output = arg[i]
@@ -2064,24 +2073,24 @@ local function main()
         end
     end
 
-    -- --no-compiler scope guard (docs/compiler_free_build.md "Rollout"). A
-    -- --with feature additionally codegens feature_registry.c (real code that
-    -- varies by feature combo), and cosmo/APE is a dual-arch link the emitter
-    -- v1 doesn't drive - both still need the compiler. Fail early + clearly.
+    -- The compiler-free (emit) path is the default (docs/compiler_free_build.md
+    -- "Rollout"). It can't cover every case yet, so auto-fall back to the C
+    -- compiler when needed rather than erroring: a --with feature additionally
+    -- codegens feature_registry.c (real code, varies by feature combo); cosmo/APE
+    -- is a dual-arch link the emitter v1 doesn't drive; and it needs a resolvable
+    -- linker. `--compiler[=X]` already forced the compiler path in parse_args.
     if opts.no_compiler then
+        local fallback
         if opts.with and next(opts.with) then
-            tool.stderr("hull build --no-compiler does not support --with features yet "
-                        .. "(feature_registry.c needs a compiler); drop --with or --no-compiler\n")
-            tool.rmdir(tmpdir); tool.exit(1)
+            fallback = "a --with feature (needs a generated feature registry)"
+        elseif is_cosmo then
+            fallback = "a cosmo/APE target (dual-arch)"
+        elseif not tool.linker or not tool.linker.is_available() then
+            fallback = "no resolvable linker"
         end
-        if is_cosmo then
-            tool.stderr("hull build --no-compiler does not support cosmo/APE targets yet "
-                        .. "(dual-arch); use a native target\n")
-            tool.rmdir(tmpdir); tool.exit(1)
-        end
-        if not tool.linker or not tool.linker.is_available() then
-            tool.stderr("hull build --no-compiler: no linker available (need cc/ld on PATH)\n")
-            tool.rmdir(tmpdir); tool.exit(1)
+        if fallback then
+            print("hull build: using the C compiler (" .. fallback .. ")")
+            opts.no_compiler = false
         end
     end
 

--- a/tests/e2e_compiler_free.sh
+++ b/tests/e2e_compiler_free.sh
@@ -102,9 +102,16 @@ else
     echo "  (skip JS: entry not built)"
 fi
 
-echo "== scope guard: --no-compiler rejects --with features =="
-out="$($HULL build "$APP" --no-compiler --with=gpu --no-verify-platform -o "$WORKDIR/nope" 2>&1 || true)"
-assert "--with=gpu is rejected under --no-compiler" sh -c "printf '%s' \"$out\" | grep -qi 'does not support --with'"
+echo "== default is now the emit path; --with auto-falls back to the compiler =="
+# The emit path is the default (Phase 3): a plain build emits, and a --with
+# feature transparently falls back to the C compiler (it needs a generated
+# feature registry) rather than erroring.
+out_default="$($HULL build "$APP" --no-verify-platform -o "$WORKDIR/def" 2>&1 || true)"
+assert "default build uses the emit path" sh -c "printf '%s' \"$out_default\" | grep -qi 'emitting app_registry'"
+out_with="$($HULL build "$APP" --with=gpu --no-verify-platform -o "$WORKDIR/nope" 2>&1 || true)"
+assert "--with falls back to the C compiler" sh -c "printf '%s' \"$out_with\" | grep -qi 'using the C compiler'"
+out_cc="$($HULL build "$APP" --compiler=system --no-verify-platform -o "$WORKDIR/ccbin" 2>&1 || true)"
+assert "--compiler=system forces the compiler path" sh -c "printf '%s' \"$out_cc\" | grep -qi 'compiling with'"
 
 echo ""
 echo "compiler-free e2e: $PASS passed, $FAIL failed"

--- a/tests/e2e_tcc.sh
+++ b/tests/e2e_tcc.sh
@@ -127,14 +127,16 @@ if [ "$TCC_VIABLE" = "1" ]; then
     wait "$SERVER_PID" 2>/dev/null || true
     SERVER_PID=""
 
-    # ── Auto-select prefers a resolvable tcc ──
+    # ── Bare `hull build` uses the emit path (Phase 3 default), even with a
+    #    resolvable tcc installed. tcc is used only when explicitly asked
+    #    (`--compiler=tcc`, tested above). ──
     echo ""
-    echo "Test: hull build (no --compiler) prefers a resolvable tcc"
+    echo "Test: hull build (no --compiler) uses the emit path, not tcc"
     HOME="$FAKEHOME" "$HULL" build --no-verify-platform -o "$WORKDIR/hello.auto" . \
         > "$WORKDIR/auto.log" 2>&1
     assert "hull build exits 0" [ $? -eq 0 ]
-    grep -qi "compiling with tcc" "$WORKDIR/auto.log"
-    assert "auto-select prefers tcc when installed" [ $? -eq 0 ]
+    grep -qi "emitting app_registry" "$WORKDIR/auto.log"
+    assert "bare build emits by default (does not auto-pick tcc)" [ $? -eq 0 ]
 
 else
     # ── macOS/cosmo: --compiler=tcc must fail; system cc still works. ──


### PR DESCRIPTION
`hull build` now **emits `app_registry.o` and links with no C compiler by default** (Phase 1/2 landed the machinery in #182/#185). Per [docs/compiler_free_build.md](docs/compiler_free_build.md) "Rollout" step 2.

## Changes
- `parse_args`: `no_compiler` defaults **true**. `--compiler[=X]` (both `--compiler X` and `--compiler=X`) opts back into the compiler path.
- The former hard `--with`/cosmo/no-linker **guard becomes an automatic fallback** to the C compiler (a `--with` feature needs a generated feature registry; cosmo is a dual-arch link the emitter v1 doesn't drive), printing which case triggered it — never an error.
- `e2e_compiler_free.sh`: asserts the new default routings instead of the old rejection.

## Routing
| Invocation | Path |
|---|---|
| `hull build` | **emit** (default) |
| `hull build --compiler=system` | compiler (forced) |
| `hull build --with=gpu` | compiler (auto-fallback) |
| cosmo / no linker | compiler (auto-fallback) |

## Validation
- `e2e-build` **118/118** — default emit path **through `--sign`** → `inspect` VALID (both runtimes).
- `e2e_compiler_free` **17/17**.
- All three routings confirmed by hand.
- The **whole e2e suite now builds through the emit path on the CI matrix** — the per-format validation the rollout requires.

## Next
tcc retirement (`compiler_tcc.c` / `vendor/tcc` / `e2e_tcc.sh` / the `build-tcc` release job) is the separate final step; the system compiler stays as the `--with`/cosmo fallback.