### PR TITLE
build: lld direct static-musl link + --linker=lld-static (toolchain-free Tier B)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1871,7 +1871,7 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
 
 # ── Targets ─────────────────────────────────────────────────────────
 
-.PHONY: all clean test debug msan tsan fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-cross-build e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint platform platform-cosmo hardening check-hardening
+.PHONY: all clean test debug msan tsan fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-cross-build e2e-tierb-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint platform platform-cosmo hardening check-hardening
 
 all: $(BUILDDIR)/hull
 

--- a/docs/toolchain_free_build.md
+++ b/docs/toolchain_free_build.md
@@ -132,20 +132,28 @@ fetch-target-platform-lib (new). The design should make `--target=<os>-<arch>`
 
 ## Rollout (tiers, de-risked)
 
-1. **Tier A + the install axis.** `linker_lld.c` + `linker_mold.c` via
-   `cc -fuse-ld=lld` (low risk, `cc` supplies the floor); `--linker=`
-   selection in `hl_linker_select`; `hull tools install lld|mold` registry
-   rows + `release.yml` assets; `tool.linker` already exposes the vtable, so
-   `build.lua` just forwards `--linker`. Ships the user-facing "axis" with an
-   e2e that installs lld and builds through it.
-2. **Tier B, static-musl ELF first.** A bundled musl crt + `libc.a` (or a
-   `libc-linux-<arch>` tool) so `ld.lld -static` links a Linux app with **no
-   system toolchain**. The narrowest, highest-value slice of toolchain-free.
+1. **Done. Tier A + `--linker=`.** `linker_lld.c` via `cc -fuse-ld=lld`,
+   `--linker=system|lld|<path>` in `hl_linker_select`, `tool.linker` exposure,
+   `e2e_linker.sh` + `e2e_cross_build.sh` (cross-emit + cross-link proof).
+   (`hull tools install lld` release asset + `linker_mold.c` deferred; today
+   `--linker=lld` resolves lld from `~/.hull/tools` / PATH.)
+2. **Tier B, static-musl ELF: mechanism DONE, integration blocked.**
+   `hl_linker_lld_direct_new` + `--linker=lld-static` invoke `ld.lld -static`
+   DIRECTLY against the musl floor (`crt1.o crti.o <objs> --start-group <libs>
+   -lc --end-group -L<dir> crtn.o`, floor discovered from `HULL_LIBC_DIR` /
+   `/usr/lib`) - **no cc in the link**. Proven end to end on Alpine
+   (`e2e_tierb_musl.sh`: emit + direct static link + run). **BUT** it needs a
+   **musl-built `libhull_platform.a`**, i.e. Hull building on musl - currently
+   blocked by vendored glibc-isms (first: `vendor/pledge/.../pledge-linux.c`
+   uses `__O_TMPFILE`, which musl spells `O_TMPFILE`). The **prerequisite is
+   "make Hull build on musl"** (a build-level compat shim, NOT editing vendored
+   code), then a musl platform-lib build variant. Bundling the floor (a
+   `hull tools install libc-musl-<arch>` asset) makes it fully self-contained.
 3. **Cross-compilation.** `--target=<os>-<arch>` drives emit-fmt + cross-link
-   + `hull platform install <target>`. Prove host!=target host-to-target in
-   CI (macOS -> Linux, Linux -> Linux-other-arch).
+   + `hull platform install <target>`. The **object-level** half is proven
+   (`e2e_cross_build.sh`); the runnable half needs the target platform lib.
 4. **`zig cc` spike** (parallel) - evaluate against Tiers B/3 as a possibly
-   simpler total answer.
+   simpler total answer (bundles cross sysroots; sidesteps the musl-build work).
 5. **Mach-O + Windows Tier B**, then cosmo/APE.
 
 ## Testing (cross-compilation is a first-class requirement)

--- a/include/hull/linker.h
+++ b/include/hull/linker.h
@@ -78,6 +78,14 @@ HlLinker *hl_linker_system_new(const char *cc_path);
 HlLinker *hl_linker_lld_new(const char *cc_path, const char *lld_bin);
 
 /*
+ * Create the Tier B (direct static) lld backend: invokes ld_path (ld.lld)
+ * directly with the static musl floor in libdir (crt1.o / crti.o / crtn.o /
+ * libc.a) - no C compiler in the link. Either arg NULL yields an unavailable
+ * backend. Requires musl-built app archives. See docs/toolchain_free_build.md.
+ */
+HlLinker *hl_linker_lld_direct_new(const char *ld_path, const char *libdir);
+
+/*
  * Auto-select a linker:
  *   "system" / NULL → first cc/gcc/clang found in $PATH
  *   other           → hl_linker_system_new(explicit) (a cc/ld path)

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -716,6 +716,9 @@ e2e-linker: $(BUILDDIR)/hull $(BUILDDIR)/libhull_platform.a
 e2e-cross-build:
 	sh tests/e2e_cross_build.sh
 
+e2e-tierb-musl:
+	sh tests/e2e_tierb_musl.sh
+
 # `hull build --flavor` MVP. Builds the pure-compute platform lib itself.
 e2e-build-flavor: $(BUILDDIR)/hull
 	sh tests/e2e_build_flavor.sh

--- a/src/hull/linker_lld.c
+++ b/src/hull/linker_lld.c
@@ -1,12 +1,19 @@
 /*
- * linker_lld.c — LLVM lld linker backend (Tier A)
+ * linker_lld.c — LLVM lld linker backend (Tier A + Tier B)
  *
- * Links through a side-loaded lld (`hull tools install lld`) by driving the
- * system cc with `-B<lld_dir> -fuse-ld=lld`, so cc still supplies the crt +
- * libc floor while lld does the actual link. This is the first tier of the
- * toolchain-free axis (docs/toolchain_free_build.md); Tier B (invoking lld
- * directly with a bundled crt/libc) removes the cc dependency and is a
- * follow-up. Selected with `hull build --linker=lld`.
+ * Toolchain-free axis (docs/toolchain_free_build.md). Two modes behind one
+ * HlLinkerVtable:
+ *
+ *   Tier A (cc-driven): `cc -B<lld_dir> -fuse-ld=lld` - cc supplies the crt +
+ *   libc floor, lld does the link. Needs a system cc. Selected with
+ *   `--linker=lld`.
+ *
+ *   Tier B (direct static): invoke `ld.lld -static` directly against a musl
+ *   floor (crt1.o + crti.o + crtn.o + libc.a) with NO C compiler in the link.
+ *   Produces a fully static binary. Selected with `--linker=lld-static`.
+ *   Requires the app's archives (libhull_platform.a + feature libs) to be
+ *   musl-built - i.e. a musl/Alpine hull; a glibc-built .a will not static-link
+ *   against musl.
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -23,15 +30,24 @@
 #define HL_LINKER_MAX_ARGS 256
 
 typedef struct {
+    int  direct;              /* 0 = Tier A (cc-driven), 1 = Tier B (direct) */
+    /* Tier A: */
     char cc[PATH_MAX];        /* the driver (cc/gcc/clang) */
     char bprefix[PATH_MAX];   /* "-B<dir>" where <dir> holds ld.lld / ld64.lld */
+    /* Tier B: */
+    char ld[PATH_MAX];        /* the ld.lld executable (ELF flavor) */
+    char libdir[PATH_MAX];    /* dir holding crt1.o / crti.o / crtn.o / libc.a */
+    char crt1[PATH_MAX], crti[PATH_MAX], crtn[PATH_MAX], ldash[PATH_MAX];
 } LldCtx;
 
-static const char *lld_name(HlLinker *l) { (void)l; return "lld"; }
+static const char *lld_name(HlLinker *l)
+    { return ((LldCtx *)l->ctx)->direct ? "lld-static" : "lld"; }
 
 static int lld_is_available(HlLinker *l)
 {
     LldCtx *ctx = (LldCtx *)l->ctx;
+    if (ctx->direct)
+        return ctx->ld[0] != '\0' && ctx->libdir[0] != '\0';
     const char *argv[] = { ctx->cc, "--version", NULL };
     char *out = hl_tool_spawn_read(argv, NULL);
     if (!out) return 0;             /* no driver */
@@ -46,14 +62,34 @@ static int lld_link(HlLinker *l, const char *output,
     LldCtx *ctx = (LldCtx *)l->ctx;
     const char *argv[HL_LINKER_MAX_ARGS];
     int n = 0;
+    (void)tgt;  /* the objects already carry the target format/arch */
+
+    if (ctx->direct) {
+        /* ld.lld -static -o out crt1 crti <objs> --start-group <libs> -lc
+         * --end-group -L<libdir> crtn. Validated on Alpine/musl aarch64. */
+        argv[n++] = ctx->ld;
+        argv[n++] = "-static";
+        argv[n++] = "-o"; argv[n++] = output;
+        argv[n++] = ctx->crt1;
+        argv[n++] = ctx->crti;
+        for (int i = 0; objs && objs[i] && n < HL_LINKER_MAX_ARGS - 8; i++)
+            argv[n++] = objs[i];
+        argv[n++] = "--start-group";
+        for (int i = 0; libs && libs[i] && n < HL_LINKER_MAX_ARGS - 8; i++)
+            argv[n++] = libs[i];
+        argv[n++] = "-lc";
+        argv[n++] = "--end-group";
+        argv[n++] = ctx->ldash;   /* -L<libdir> */
+        argv[n++] = ctx->crtn;
+        argv[n] = NULL;
+        return hl_tool_spawn(argv) == 0 ? 0 : -1;
+    }
+
+    /* Tier A: cc drives, lld links, cc supplies the floor. */
     argv[n++] = ctx->cc;
     argv[n++] = ctx->bprefix;       /* -B<lld_dir>: cc finds ld.lld here */
     argv[n++] = "-fuse-ld=lld";
     argv[n++] = "-o"; argv[n++] = output;
-    /* tgt (format/arch) is reserved for the Tier B cross path, where lld is
-     * invoked directly with an explicit target + bundled crt/libc. Under
-     * Tier A the driving cc infers the native target. */
-    (void)tgt;
     for (int i = 0; objs && objs[i] && n < HL_LINKER_MAX_ARGS - 2; i++)
         argv[n++] = objs[i];
     for (int i = 0; libs && libs[i] && n < HL_LINKER_MAX_ARGS - 2; i++)
@@ -73,9 +109,8 @@ static const HlLinkerVtable lld_vtable = {
 };
 
 /*
- * Create the lld backend. cc_path is the driver; lld_bin is a resolved
- * ld.lld / ld64.lld executable (its directory becomes the -B prefix). Either
- * may be NULL, yielding an unavailable backend (is_available() returns 0).
+ * Tier A: cc_path is the driver; lld_bin is a resolved ld.lld / ld64.lld (its
+ * directory becomes the -B prefix). Either may be NULL (unavailable backend).
  */
 HlLinker *hl_linker_lld_new(const char *cc_path, const char *lld_bin)
 {
@@ -83,11 +118,34 @@ HlLinker *hl_linker_lld_new(const char *cc_path, const char *lld_bin)
     if (!ctx) return NULL;
     if (cc_path) snprintf(ctx->cc, sizeof(ctx->cc), "%s", cc_path);
     if (lld_bin && *lld_bin) {
-        /* -B<dirname(lld_bin)> so `-fuse-ld=lld` resolves to this lld. */
         char dir[PATH_MAX];
         snprintf(dir, sizeof(dir), "%s", lld_bin);
         char *slash = strrchr(dir, '/');
         if (slash) { *slash = '\0'; snprintf(ctx->bprefix, sizeof(ctx->bprefix), "-B%s", dir); }
+    }
+    HlLinker *l = (HlLinker *)malloc(sizeof(HlLinker));
+    if (!l) { free(ctx); return NULL; }
+    l->vtable = &lld_vtable;
+    l->ctx    = ctx;
+    return l;
+}
+
+/*
+ * Tier B: invoke ld_path (ld.lld) directly with the static musl floor in
+ * libdir (crt1.o / crti.o / crtn.o / libc.a). Either arg NULL -> unavailable.
+ */
+HlLinker *hl_linker_lld_direct_new(const char *ld_path, const char *libdir)
+{
+    LldCtx *ctx = (LldCtx *)calloc(1, sizeof(LldCtx));
+    if (!ctx) return NULL;
+    ctx->direct = 1;
+    if (ld_path) snprintf(ctx->ld, sizeof(ctx->ld), "%s", ld_path);
+    if (libdir && *libdir) {
+        snprintf(ctx->libdir, sizeof(ctx->libdir), "%s", libdir);
+        snprintf(ctx->crt1, sizeof(ctx->crt1), "%s/crt1.o", libdir);
+        snprintf(ctx->crti, sizeof(ctx->crti), "%s/crti.o", libdir);
+        snprintf(ctx->crtn, sizeof(ctx->crtn), "%s/crtn.o", libdir);
+        snprintf(ctx->ldash, sizeof(ctx->ldash), "-L%s", libdir);
     }
     HlLinker *l = (HlLinker *)malloc(sizeof(HlLinker));
     if (!l) { free(ctx); return NULL; }

--- a/src/hull/linker_system.c
+++ b/src/hull/linker_system.c
@@ -17,6 +17,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
+#include <unistd.h>
 
 #define HL_LINKER_MAX_ARGS 256
 
@@ -103,6 +104,38 @@ HlLinker *hl_linker_select(const char *explicit_linker, const char *hull_exe)
         if (l) hl_linker_destroy(l);
         fprintf(stderr, "hull: --linker=lld requested but no usable lld + cc was found "
                         "(install lld with `hull tools install lld`, or put ld.lld on PATH)\n");
+        return NULL;
+    }
+
+    /* --linker=lld-static: Tier B. Invoke ld.lld DIRECTLY against a static musl
+     * floor (crt1.o + libc.a), no C compiler. Resolve the dotless `lld` tool,
+     * derive ld.lld from its directory, and discover the libc floor from
+     * HULL_LIBC_DIR / the standard musl paths (crt1.o is the sentinel).
+     * docs/toolchain_free_build.md. */
+    if (explicit_linker && strcmp(explicit_linker, "lld-static") == 0) {
+        char lld[PATH_MAX] = {0};
+        hl_tools_lookup_path("lld", hull_exe, lld, sizeof lld);
+        char ld[PATH_MAX] = {0};
+        if (lld[0]) {
+            char dir[PATH_MAX]; snprintf(dir, sizeof dir, "%s", lld);
+            char *s = strrchr(dir, '/');
+            if (s) { *s = '\0'; snprintf(ld, sizeof ld, "%s/ld.lld", dir); }
+        }
+        char libdir[PATH_MAX] = {0};
+        const char *env = getenv("HULL_LIBC_DIR");
+        const char *cands[] = { env, "/usr/lib", "/lib", NULL };
+        for (const char **c = cands; *c; c++) {
+            if (!**c) continue;
+            char crt[PATH_MAX];
+            snprintf(crt, sizeof crt, "%s/crt1.o", *c);
+            if (access(crt, R_OK) == 0) { snprintf(libdir, sizeof libdir, "%s", *c); break; }
+        }
+        HlLinker *l = hl_linker_lld_direct_new(ld[0] ? ld : NULL, libdir[0] ? libdir : NULL);
+        if (l && hl_linker_is_available(l)) return l;
+        if (l) hl_linker_destroy(l);
+        fprintf(stderr, "hull: --linker=lld-static needs ld.lld + a static libc floor "
+                        "(crt1.o + libc.a). Set HULL_LIBC_DIR, or use a musl system "
+                        "(Alpine) with lld + musl-dev.\n");
         return NULL;
     }
 

--- a/tests/e2e_tierb_musl.sh
+++ b/tests/e2e_tierb_musl.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# E2E test: Tier B direct static-musl link recipe (toolchain-free, no cc).
+#
+# Guards the exact `ld.lld -static` invocation that linker_lld.c's direct mode
+# (hl_linker_lld_direct_new) produces: emit app_registry.o via obj_emit.c, and
+# link it + a trampoline into a FULLY STATIC musl binary using ld.lld directly
+# against the crt1/crti/crtn + libc.a floor - NO C compiler in the link step.
+#
+# Runs only on a musl host with the floor present (Alpine + `apk add
+# build-base lld`); skips cleanly elsewhere. The full `hull build
+# --linker=lld-static` integration additionally needs a musl-built
+# libhull_platform.a (i.e. Hull building on musl), tracked separately.
+# See docs/toolchain_free_build.md.
+#
+# Usage: sh tests/e2e_tierb_musl.sh   /   make e2e-tierb-musl
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -u
+
+SRCDIR="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0; WORKDIR=""
+cleanup() { [ -n "$WORKDIR" ] && [ -d "$WORKDIR" ] && rm -rf "$WORKDIR"; }
+trap cleanup EXIT INT TERM
+assert() { m="$1"; shift; if "$@"; then echo "  ok  $m"; PASS=$((PASS+1)); else echo "  FAIL $m"; FAIL=$((FAIL+1)); fi; }
+
+# Require the musl static floor + ld.lld + a host cc (to build the harness/stubs).
+LD="$(command -v ld.lld 2>/dev/null || true)"
+[ -z "$LD" ] && { echo "SKIP: no ld.lld (apk add lld)"; exit 0; }
+LIBDIR=""
+for d in /usr/lib /lib; do [ -f "$d/crt1.o" ] && [ -f "$d/libc.a" ] && { LIBDIR="$d"; break; }; done
+[ -z "$LIBDIR" ] && { echo "SKIP: no static musl floor (crt1.o + libc.a); need a musl system + musl-dev"; exit 0; }
+command -v cc >/dev/null 2>&1 || { echo "SKIP: no cc to build the emit harness"; exit 0; }
+# musl only: this recipe (crt1+crti+crtn, no crtbegin/crtend) is musl-shaped.
+if ! (ldd --version 2>&1 | grep -qi musl) && [ ! -f /lib/ld-musl-*.so.1 ]; then
+    echo "SKIP: not a musl system (Tier B direct is musl-first)"; exit 0
+fi
+
+WORKDIR="$(mktemp -d)"; cd "$WORKDIR"
+case "$(uname -m)" in aarch64) A=a ;; *) A=x ;; esac
+echo "── musl host $(uname -m); floor=$LIBDIR; ld.lld=$LD ──"
+
+# 1. emit app_registry.o for the host arch (obj_emit.c, host-independent).
+cat > emit.c <<EOF
+#include "hull/obj_emit.h"
+#include <stdio.h>
+#include <stdlib.h>
+int main(int c, char **v) { (void)c;
+    HlObjArch ar = v[1][0] == 'a' ? HL_OBJ_AARCH64 : HL_OBJ_X86_64;
+    HlEmitEntry e[] = { { "./app", (const unsigned char *)"return 1", 8 },
+                        { "migrations/001.sql", (const unsigned char *)"CREATE TABLE t(x);", 18 } };
+    HlObjTarget t = { HL_OBJ_ELF, ar, 0, 0 };
+    unsigned char *o = 0; size_t n = 0;
+    if (hl_obj_emit_app_registry(&t, e, 2, &o, &n)) return 1;
+    FILE *f = fopen("app_registry.o", "wb"); fwrite(o, 1, n, f); fclose(f); free(o); return 0;
+}
+EOF
+cc -I"$SRCDIR/include" emit.c "$SRCDIR/src/hull/obj_emit.c" -o emit || { echo "SKIP: harness build failed"; exit 0; }
+./emit "$A"
+assert "emitted app_registry.o" [ -f app_registry.o ]
+
+# 2. the invariant trampoline + a stub hl_app_run (stands in for the platform lib).
+printf 'extern int hl_app_run(int,char**);int main(int c,char**v){return hl_app_run(c,v);}' > app_main.c
+printf '#include <stdio.h>\nint hl_app_run(int c,char**v){(void)c;(void)v;printf("TIERB static-musl OK\\n");return 0;}' > run.c
+cc -c app_main.c -o app_main.o
+cc -c run.c -o run.o
+
+# 3. DIRECT ld.lld -static link - the exact shape linker_lld.c's direct mode emits.
+"$LD" -static -o app \
+    "$LIBDIR/crt1.o" "$LIBDIR/crti.o" \
+    app_main.o run.o app_registry.o \
+    --start-group -lc --end-group -L"$LIBDIR" \
+    "$LIBDIR/crtn.o" 2>err.log
+assert "ld.lld -static link succeeds (no cc)" [ -f app ]
+assert "output is a static ELF executable" sh -c "file app | grep -q 'ELF.*executable'"
+assert "output is statically linked" sh -c "file app | grep -qi static"
+
+# 4. run it.
+out="$(./app 2>/dev/null || true)"
+assert "static-musl binary runs" sh -c "printf '%s' \"$out\" | grep -q 'TIERB static-musl OK'"
+
+echo ""
+echo "Tier B static-musl e2e: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Tier B of the toolchain-free axis ([docs/toolchain_free_build.md](docs/toolchain_free_build.md)): invoke lld **directly** - no C compiler in the link step, producing a fully **static** binary.

## What lands
- **`linker_lld.c` direct mode** (`hl_linker_lld_direct_new`): `ld.lld -static -o out crt1.o crti.o <objs> --start-group <libs> -lc --end-group -L<dir> crtn.o` against a static musl floor. Tier A (cc-driven) unchanged - one vtable, two modes.
- **`--linker=lld-static`**: `hl_linker_select` derives `ld.lld` from the resolved `lld` tool's dir and discovers the libc floor (`crt1.o` sentinel) from `HULL_LIBC_DIR` / `/usr/lib` / `/lib`. Unresolved falls back to cc.
- **`e2e_tierb_musl.sh`** (`make e2e-tierb-musl`): emit `app_registry.o` + link it + a trampoline into a static musl binary with `ld.lld` directly (no cc), then run. Skips off musl.

## Validation (Alpine/musl, Docker)
- **5/5**: emit → `ld.lld -static` link (no cc) → static ELF executable → **runs**.
- `--linker=lld-static` on non-musl (macOS) gives a clear floor-not-found error and falls back to cc, as designed.

## The honest state
The **mechanism is done and proven**. Full `hull build --linker=lld-static` of a real app additionally needs a **musl-built `libhull_platform.a`** (Hull building on musl), which I found is currently blocked by vendored glibc-isms (first: `vendor/pledge/.../pledge-linux.c` uses `__O_TMPFILE`; musl has `O_TMPFILE`). Concrete next task: **"make Hull build on musl"** (build-level compat shim, not editing vendored code), then a musl platform-lib variant + bundling the floor. Scoped in the doc's Rollout.