### PR TITLE
refactor: dedup the compiler/linker arc (compile-only compiler, shared cc resolver)

### DIFF
--- a/include/hull/compiler.h
+++ b/include/hull/compiler.h
@@ -28,13 +28,11 @@ typedef struct {
     int (*compile)(HlCompiler *c, const char *src, const char *obj,
                    const char *include_dir);
     /*
-     * Link objects + libraries → output binary. Returns 0 on success.
-     * objs: NULL-terminated array of .o paths.
-     * libs: NULL-terminated array of -lfoo flags or /path/to/lib.a paths.
+     * Free compiler resources. (Linking is NOT a compiler responsibility -
+     * it goes through HlLinkerVtable / hl_linker_link, so a single code path
+     * drives the `cc -o out objs libs` invocation for both the compile and the
+     * emit build paths. See linker.h.)
      */
-    int (*link)(HlCompiler *c, const char *output,
-                const char **objs, const char **libs);
-    /* Free compiler resources. */
     void (*destroy)(HlCompiler *c);
 } HlCompilerVtable;
 
@@ -53,9 +51,6 @@ static inline char *hl_compiler_version(HlCompiler *c)
 static inline int hl_compiler_compile(HlCompiler *c,
     const char *src, const char *obj, const char *inc)
     { return c->vtable->compile(c, src, obj, inc); }
-static inline int hl_compiler_link(HlCompiler *c,
-    const char *out, const char **objs, const char **libs)
-    { return c->vtable->link(c, out, objs, libs); }
 static inline void hl_compiler_destroy(HlCompiler *c)
     { if (c) { c->vtable->destroy(c); free(c); } }
 
@@ -71,10 +66,19 @@ HlCompiler *hl_compiler_system_new(const char *cc_path);
  *   "system" → find the first system compiler in PATH
  *   other    → hl_compiler_system_new(explicit_cc) (a path or PATH name)
  *   NULL     → cc/gcc/clang from PATH (cosmocc on a cosmo hull)
- * hull_exe (may be NULL) is currently unused (was the retired tcc tool's
- * resolution seed); kept for call-site stability.
  * Returns NULL if nothing is found.
  */
-HlCompiler *hl_compiler_select(const char *explicit_cc, const char *hull_exe);
+HlCompiler *hl_compiler_select(const char *explicit_cc);
+
+/*
+ * Resolve a native toolchain driver (the cc/gcc/clang - or cosmocc on a cosmo
+ * hull - that acts as the compile AND default-link driver). Writes the resolved
+ * invocation (a PATH name or absolute path) into out and returns 0; returns -1
+ * if none is available. Availability is probed via `<cand> --version`.
+ *
+ * Shared by hl_compiler_select and the linker's hl_linker_select so the
+ * candidate list + cosmo resolution live in exactly one place.
+ */
+int hl_driver_resolve_native(char *out, size_t outsz);
 
 #endif /* HL_COMPILER_H */

--- a/include/hull/linker.h
+++ b/include/hull/linker.h
@@ -19,16 +19,16 @@
 
 #include <stdlib.h>
 
-#include "hull/obj_emit.h"   /* HlObjFormat, HlObjArch */
+#include "hull/obj_emit.h"   /* HlObjFormat */
 
 typedef struct HlLinker HlLinker;
 
 /* What we are linking, so a cross/embedded linker knows how to invoke.
- * The system-cc backend infers format/arch from the objects and mostly
- * ignores this; it exists for cosmo dual-arch + lld/zig. */
+ * The system-cc + lld backends infer format/arch from the objects and ignore
+ * this entirely; only zig reads it (format → the GC flag, triple → --target=).
+ * The emitted objects already carry the arch, so no `arch` field is needed. */
 typedef struct {
     HlObjFormat format;
-    HlObjArch   arch;
     /* Full cross triple <arch>-<os>-<abi> (e.g. x86_64-linux-gnu). NULL/empty
      * = native host. Consumed by the zig backend's `--target=`; other backends
      * ignore it. Not owned. */

--- a/src/hull/compiler.c
+++ b/src/hull/compiler.c
@@ -92,30 +92,6 @@ static int sys_compile(HlCompiler *c, const char *src, const char *obj,
     return hl_tool_spawn(argv) == 0 ? 0 : -1;
 }
 
-static int sys_link(HlCompiler *c, const char *output,
-                    const char **objs, const char **libs)
-{
-    SysCtx *ctx = (SysCtx *)c->ctx;
-    const char *argv[HL_COMPILER_MAX_ARGS];
-    int n = 0;
-    argv[n++] = ctx->cc;
-    argv[n++] = "-o"; argv[n++] = output;
-    /* Reproducibility note: GNU ld's default `--build-id=sha1` already
-     * produces content-addressed Build-IDs (deterministic for identical
-     * inputs) so apps `hull build` produces on Linux are reproducible
-     * without an explicit flag. An earlier attempt to inject
-     * `-Wl,--build-id=none` here broke test_compiler's link tests; the
-     * default behavior is already correct, so no flag is needed. macOS
-     * LC_UUID is a
-     * separate (unfixable-here) story tracked in roadmap_next.md §0.2. */
-    for (int i = 0; objs && objs[i] && n < HL_COMPILER_MAX_ARGS - 2; i++)
-        argv[n++] = objs[i];
-    for (int i = 0; libs && libs[i] && n < HL_COMPILER_MAX_ARGS - 2; i++)
-        argv[n++] = libs[i];
-    argv[n] = NULL;
-    return hl_tool_spawn(argv) == 0 ? 0 : -1;
-}
-
 static void sys_destroy(HlCompiler *c)
 {
     free(c->ctx);
@@ -124,7 +100,7 @@ static void sys_destroy(HlCompiler *c)
 
 static const HlCompilerVtable sys_vtable = {
     sys_name, sys_is_available, sys_version,
-    sys_compile, sys_link, sys_destroy
+    sys_compile, sys_destroy
 };
 
 HlCompiler *hl_compiler_system_new(const char *cc_path)
@@ -140,18 +116,68 @@ HlCompiler *hl_compiler_system_new(const char *cc_path)
     return c;
 }
 
+/* ── Native driver resolution (shared with the linker) ──────────── */
+
+/* Is `path` a runnable toolchain driver? Probe `<path> --version`. */
+static int driver_ok(const char *path)
+{
+    const char *argv[] = { path, "--version", NULL };
+    char *out = hl_tool_spawn_read(argv, NULL);
+    if (!out) return 0;
+    free(out);
+    return 1;
+}
+
+int hl_driver_resolve_native(char *out, size_t outsz)
+{
+    if (!out || outsz == 0) return -1;
+
+#ifdef __COSMOPOLITAN__
+    /* Cosmo hull: prefer cosmocc since the embedded platform .a's are
+     * cosmo-format archives. Native cc/gcc/clang would link them to ELF/Mach-O
+     * (not APE), so the output wouldn't be a portable cosmo binary anyway.
+     * Check known install locations before $PATH because the cosmocc.zip
+     * installer typically doesn't put cosmocc on PATH by default. §3.1 of
+     * roadmap_next.md. */
+    {
+        const char *home = getenv("HOME");
+        char path[512];
+        if (home && *home) {
+            int n = snprintf(path, sizeof(path), "%s/.cosmocc/bin/cosmocc", home);
+            if (n > 0 && (size_t)n < sizeof(path) && driver_ok(path)) {
+                snprintf(out, outsz, "%s", path); return 0;
+            }
+            n = snprintf(path, sizeof(path), "%s/cosmocc/bin/cosmocc", home);
+            if (n > 0 && (size_t)n < sizeof(path) && driver_ok(path)) {
+                snprintf(out, outsz, "%s", path); return 0;
+            }
+        }
+        if (driver_ok("/opt/cosmo/bin/cosmocc")) {
+            snprintf(out, outsz, "/opt/cosmo/bin/cosmocc"); return 0;
+        }
+        if (driver_ok("cosmocc")) { snprintf(out, outsz, "cosmocc"); return 0; }
+        /* Fall through to cc/gcc/clang. They won't produce a working APE
+         * against cosmo .a's, but letting them resolve gives a clearer
+         * link-time error than a silent "no compiler found." */
+    }
+#endif
+
+    static const char *candidates[] = { "cc", "gcc", "clang", NULL };
+    for (const char **p = candidates; *p; p++)
+        if (driver_ok(*p)) { snprintf(out, outsz, "%s", *p); return 0; }
+
+    return -1;
+}
+
 /* ── Selection ──────────────────────────────────────────────────── */
 
-HlCompiler *hl_compiler_select(const char *explicit_cc, const char *hull_exe)
+HlCompiler *hl_compiler_select(const char *explicit_cc)
 {
-    (void)hull_exe;   /* was used to resolve the retired tcc tool */
-
-    /* "system" sentinel → force system auto-detect below (kept for symmetry
-     * with `hull build --compiler=system`; the emit path is the default now). */
+    /* "system" sentinel → force auto-detect below (kept for symmetry with
+     * `hull build --compiler=system`; the emit path is the default now). */
     int is_system = (explicit_cc && strcmp(explicit_cc, "system") == 0);
 
-    /* Explicit named compiler (a path or a PATH name; a user's own `tcc`
-     * still works here as a plain system compiler). */
+    /* Explicit named compiler (a path or a PATH name). */
     if (explicit_cc && !is_system) {
         HlCompiler *c = hl_compiler_system_new(explicit_cc);
         if (c && hl_compiler_is_available(c)) return c;
@@ -160,57 +186,10 @@ HlCompiler *hl_compiler_select(const char *explicit_cc, const char *hull_exe)
         return NULL;
     }
 
-#ifdef __COSMOPOLITAN__
-    /* Cosmo hull: prefer cosmocc since the embedded platform .a's are
-     * cosmo-format archives. Native cc/gcc/clang link them to ELF/Mach-O
-     * (not APE), so the output wouldn't be a portable cosmo binary
-     * anyway. Check known install locations before $PATH because the
-     * cosmocc.zip installer typically doesn't put cosmocc on PATH by
-     * default. §3.1 of roadmap_next.md. */
-    {
-        const char *home = getenv("HOME");
-        char path[512];
-
-        /* User-install paths first (cosmocc.zip default layouts) */
-        if (home && *home) {
-            int n = snprintf(path, sizeof(path),
-                             "%s/.cosmocc/bin/cosmocc", home);
-            if (n > 0 && (size_t)n < sizeof(path)) {
-                HlCompiler *c = hl_compiler_system_new(path);
-                if (c && hl_compiler_is_available(c)) return c;
-                if (c) hl_compiler_destroy(c);
-            }
-            n = snprintf(path, sizeof(path),
-                         "%s/cosmocc/bin/cosmocc", home);
-            if (n > 0 && (size_t)n < sizeof(path)) {
-                HlCompiler *c = hl_compiler_system_new(path);
-                if (c && hl_compiler_is_available(c)) return c;
-                if (c) hl_compiler_destroy(c);
-            }
-        }
-        /* System-wide install (`make fetch-cosmocc COSMOCC_DIR=/opt/cosmo`,
-         * package managers) */
-        HlCompiler *c = hl_compiler_system_new("/opt/cosmo/bin/cosmocc");
-        if (c && hl_compiler_is_available(c)) return c;
-        if (c) hl_compiler_destroy(c);
-        /* $PATH fallback */
-        c = hl_compiler_system_new("cosmocc");
-        if (c && hl_compiler_is_available(c)) return c;
-        if (c) hl_compiler_destroy(c);
-        /* Fall through to cc/gcc/clang below. Those won't actually
-         * produce a working APE against cosmo .a's, but letting them
-         * try gives a clearer link-time error than a silent
-         * "no compiler found." */
-    }
-#endif
-
-    /* Auto: try system compilers in PATH */
-    static const char *candidates[] = { "cc", "gcc", "clang", NULL };
-    for (const char **p = candidates; *p; p++) {
-        HlCompiler *c = hl_compiler_system_new(*p);
-        if (c && hl_compiler_is_available(c)) return c;
-        if (c) hl_compiler_destroy(c);
-    }
-
+    /* Auto: the shared native-driver resolver (cc/gcc/clang; cosmocc on a
+     * cosmo hull). */
+    char cc[PATH_MAX];
+    if (hl_driver_resolve_native(cc, sizeof cc) == 0)
+        return hl_compiler_system_new(cc);
     return NULL;
 }

--- a/src/hull/linker_system.c
+++ b/src/hull/linker_system.c
@@ -10,6 +10,7 @@
  */
 
 #include "hull/linker.h"
+#include "hull/compiler.h"   /* hl_driver_resolve_native (shared cc resolution) */
 #include "hull/cap/tool.h"
 #include "hull/tools_install.h"
 
@@ -162,40 +163,11 @@ HlLinker *hl_linker_select(const char *explicit_linker, const char *hull_exe)
         return NULL;
     }
 
-#ifdef __COSMOPOLITAN__
-    /* Cosmo hull links cosmo-format archives → prefer cosmocc as the driver
-     * (mirrors compiler.c's cosmo resolution). */
-    {
-        const char *home = getenv("HOME");
-        char path[512];
-        if (home && *home) {
-            int m = snprintf(path, sizeof(path), "%s/.cosmocc/bin/cosmocc", home);
-            if (m > 0 && (size_t)m < sizeof(path)) {
-                HlLinker *l = hl_linker_system_new(path);
-                if (l && hl_linker_is_available(l)) return l;
-                if (l) hl_linker_destroy(l);
-            }
-            m = snprintf(path, sizeof(path), "%s/cosmocc/bin/cosmocc", home);
-            if (m > 0 && (size_t)m < sizeof(path)) {
-                HlLinker *l = hl_linker_system_new(path);
-                if (l && hl_linker_is_available(l)) return l;
-                if (l) hl_linker_destroy(l);
-            }
-        }
-        HlLinker *l = hl_linker_system_new("/opt/cosmo/bin/cosmocc");
-        if (l && hl_linker_is_available(l)) return l;
-        if (l) hl_linker_destroy(l);
-        l = hl_linker_system_new("cosmocc");
-        if (l && hl_linker_is_available(l)) return l;
-        if (l) hl_linker_destroy(l);
-    }
-#endif
-
-    static const char *candidates[] = { "cc", "gcc", "clang", NULL };
-    for (const char **p = candidates; *p; p++) {
-        HlLinker *l = hl_linker_system_new(*p);
-        if (l && hl_linker_is_available(l)) return l;
-        if (l) hl_linker_destroy(l);
-    }
+    /* Auto: the shared native-driver resolver (cc/gcc/clang; cosmocc on a cosmo
+     * hull) - the same cc the compiler backend resolves, so one link driver
+     * serves both build paths. See compiler.c::hl_driver_resolve_native. */
+    char cc[PATH_MAX];
+    if (hl_driver_resolve_native(cc, sizeof cc) == 0)
+        return hl_linker_system_new(cc);
     return NULL;
 }

--- a/src/hull/runtime/lua/mod_tool.c
+++ b/src/hull/runtime/lua/mod_tool.c
@@ -713,42 +713,6 @@ static int l_compiler_compile(lua_State *L) {
     return 1;
 }
 
-static int l_compiler_link(lua_State *L) {
-    const char *output = luaL_checkstring(L, 1);
-    luaL_checktype(L, 2, LUA_TTABLE);
-    luaL_checktype(L, 3, LUA_TTABLE);
-    lua_getfield(L, LUA_REGISTRYINDEX, TOOL_COMPILER_KEY);
-    HlCompiler *c = (HlCompiler *)lua_touserdata(L, -1);
-    lua_pop(L, 1);
-    if (!c) { lua_pushboolean(L, 0); return 1; }
-
-    int nobj = (int)luaL_len(L, 2);
-    int nlib = (int)luaL_len(L, 3);
-    const char **objs = (const char **)malloc(((size_t)nobj + 1) * sizeof(char *));
-    const char **libs = (const char **)malloc(((size_t)nlib + 1) * sizeof(char *));
-    if (!objs || !libs) {
-        free(objs); free(libs);
-        lua_pushboolean(L, 0); return 1;
-    }
-    for (int i = 1; i <= nobj; i++) {
-        lua_rawgeti(L, 2, i);
-        objs[i - 1] = lua_tostring(L, -1);
-        lua_pop(L, 1);
-    }
-    for (int i = 1; i <= nlib; i++) {
-        lua_rawgeti(L, 3, i);
-        libs[i - 1] = lua_tostring(L, -1);
-        lua_pop(L, 1);
-    }
-    objs[nobj] = NULL;
-    libs[nlib] = NULL;
-
-    int rc = hl_compiler_link(c, output, objs, libs);
-    free(objs); free(libs);
-    lua_pushboolean(L, rc == 0);
-    return 1;
-}
-
 /*
  * tool.emit_app_registry(entries, format, arch [, elf_osabi, elf_flags]) → string|nil
  *
@@ -877,7 +841,7 @@ static int l_linker_link(lua_State *L) {
         if      (strcmp(fmts, "macho") == 0) fmt = HL_OBJ_MACHO;
         else if (strcmp(fmts, "coff")  == 0) fmt = HL_OBJ_COFF;
     }
-    HlLinkTarget tgt = { fmt, 0, triple };
+    HlLinkTarget tgt = { fmt, triple };
     int rc = hl_linker_link(l, output, objs, libs,
                             ((triple && *triple) || fmts) ? &tgt : NULL);
     free(objs); free(libs);
@@ -918,7 +882,6 @@ void hl_lua_tool_expose_compiler(lua_State *L, HlCompiler *compiler)
     lua_pushcfunction(L, l_compiler_is_available);  lua_setfield(L, -2, "is_available");
     lua_pushcfunction(L, l_compiler_version);       lua_setfield(L, -2, "version");
     lua_pushcfunction(L, l_compiler_compile);       lua_setfield(L, -2, "compile");
-    lua_pushcfunction(L, l_compiler_link);          lua_setfield(L, -2, "link");
     lua_setfield(L, -2, "compiler");
     lua_pop(L, 1);
 }

--- a/src/hull/tool.c
+++ b/src/hull/tool.c
@@ -351,7 +351,7 @@ int hull_tool(const char *module, int argc, char **argv, const char *hull_exe)
     /* Select compiler backend and expose as tool.compiler.
      * If no explicit cc was given, use auto-detection (NULL) rather than
      * requiring the default (cosmocc) to be installed. */
-    HlCompiler *compiler = hl_compiler_select(cc_explicit, hull_exe);
+    HlCompiler *compiler = hl_compiler_select(cc_explicit);
     if (compiler)
         hl_lua_tool_expose_compiler(L, compiler);
 

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -2114,13 +2114,16 @@ local function main()
     -- is a dual-arch link the emitter v1 doesn't drive; and it needs a resolvable
     -- linker. `--compiler[=X]` already forced the compiler path in parse_args.
     if opts.no_compiler then
+        -- An unresolvable linker is NOT a fallback reason: both the emit path
+        -- and the compiler path link through tool.linker now, so switching to
+        -- the compiler can't rescue a missing linker. It's a hard error at the
+        -- link step below, which also correctly surfaces an explicit
+        -- --linker=<x> that failed to resolve instead of silently using cc.
         local fallback
         if opts.with and next(opts.with) then
             fallback = "a --with feature (needs a generated feature registry)"
         elseif is_cosmo then
             fallback = "a cosmo/APE target (dual-arch)"
-        elseif not tool.linker or not tool.linker.is_available() then
-            fallback = "no resolvable linker"
         end
         if fallback then
             print("hull build: using the C compiler (" .. fallback .. ")")
@@ -2232,17 +2235,26 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
     if group then link_libs[#link_libs + 1] = "-Wl,--end-group" end
     link_libs[#link_libs + 1] = "-lm"
     link_libs[#link_libs + 1] = "-lpthread"
-    -- The compiler-free path links through the standalone linker vtable
-    -- (tool.linker, cc/ld driver); the default path uses the compiler's own
-    -- link. Both consume the same objects + libs.
+    -- BOTH build paths link through the standalone linker vtable (tool.linker,
+    -- a cc/ld driver) - the compiler vtable is compile-only now, so there is one
+    -- code path for the `cc -o out objs libs` invocation. Both consume the same
+    -- objects + libs.
+    if not tool.linker or not tool.linker.is_available() then
+        tool.stderr("hull build: no usable linker (need cc/gcc/clang on PATH, "
+                    .. "or an installed --linker=<lld|zig|...>)\n")
+        tool.rmdir(tmpdir)
+        tool.exit(1)
+    end
     if opts.no_compiler then
-        -- Pass the cross triple (nil for native) + the target format; only the
-        -- zig backend consumes them (--target= + the format-correct link GC
-        -- flag). docs/toolchain_free_build.md.
+        -- Emit path may cross-target: pass the triple (nil for native) + the
+        -- target format; only the zig backend consumes them (--target= + the
+        -- format-correct link GC flag). docs/toolchain_free_build.md.
         local ts = target_spec(opts)
         ok = tool.linker.link(opts.output, link_objs, link_libs, ts.triple, ts.fmt)
     else
-        ok = tool.compiler.link(opts.output, link_objs, link_libs)
+        -- Compiler path is native-only (--with features + cosmo are native), so
+        -- it passes no triple/format.
+        ok = tool.linker.link(opts.output, link_objs, link_libs)
     end
     if not ok then
         tool.stderr("hull build: linking failed\n")

--- a/tests/hull/compiler/test_compiler.c
+++ b/tests/hull/compiler/test_compiler.c
@@ -112,42 +112,37 @@ UTEST(compiler, system_version_cc)
     hl_compiler_destroy(c);
 }
 
-/* ── Tests: compile + link round-trip ───────────────────────────── */
+/* ── Tests: compile ─────────────────────────────────────────────── */
 
-UTEST(compiler, compile_and_link_hello)
+/* The compiler vtable is compile-only now; linking goes through the linker
+ * vtable (hl_linker_link), exercised by the linker e2es (e2e_linker.sh,
+ * e2e_compiler_free.sh) and every `hull build` e2e. This asserts only the
+ * .c → .o step. */
+UTEST(compiler, compile_hello)
 {
     char *tmpdir = make_tmpdir();
     ASSERT_NE(tmpdir, NULL);
 
     /* Write a trivial C program */
-    char src[512], obj[512], out[512];
+    char src[512], obj[512];
     snprintf(src, sizeof(src), "%s/hello.c", tmpdir);
     snprintf(obj, sizeof(obj), "%s/hello.o", tmpdir);
-    snprintf(out, sizeof(out), "%s/hello", tmpdir);
 
     int w = write_file(src,
         "extern int puts(const char *);\n"
         "int main(void) { puts(\"hello\"); return 0; }\n");
     ASSERT_EQ(w, 0);
 
-    HlCompiler *c = hl_compiler_select(NULL, NULL);
+    HlCompiler *c = hl_compiler_select(NULL);
     if (!c) {
         /* No compiler available — skip */
         rm_rf(tmpdir); free(tmpdir);
         return;
     }
 
-    /* Compile */
     int rc = hl_compiler_compile(c, src, obj, NULL);
     ASSERT_EQ(rc, 0);
     ASSERT_EQ(access(obj, F_OK), 0);
-
-    /* Link */
-    const char *objs[] = { obj, NULL };
-    const char *libs[] = { NULL };
-    rc = hl_compiler_link(c, out, objs, libs);
-    ASSERT_EQ(rc, 0);
-    ASSERT_EQ(access(out, X_OK), 0);
 
     hl_compiler_destroy(c);
     rm_rf(tmpdir);
@@ -174,7 +169,7 @@ UTEST(compiler, compile_with_include_dir)
         "#include \"entry.h\"\n"
         "const HlEntry entries[] = { { 0, 0, 0 } };\n");
 
-    HlCompiler *c = hl_compiler_select(NULL, NULL);
+    HlCompiler *c = hl_compiler_select(NULL);
     if (!c) { rm_rf(tmpdir); free(tmpdir); return; }
 
     int rc = hl_compiler_compile(c, src, obj, tmpdir);
@@ -190,7 +185,7 @@ UTEST(compiler, compile_with_include_dir)
 
 UTEST(compiler, select_null_returns_compiler)
 {
-    HlCompiler *c = hl_compiler_select(NULL, NULL);
+    HlCompiler *c = hl_compiler_select(NULL);
     /* At least one compiler should be available in CI */
     ASSERT_NE(c, NULL);
     ASSERT_EQ(hl_compiler_is_available(c), 1);
@@ -199,7 +194,7 @@ UTEST(compiler, select_null_returns_compiler)
 
 UTEST(compiler, select_explicit_cc)
 {
-    HlCompiler *c = hl_compiler_select("cc", NULL);
+    HlCompiler *c = hl_compiler_select("cc");
     ASSERT_NE(c, NULL);
     ASSERT_STREQ(hl_compiler_name(c), "cc");
     hl_compiler_destroy(c);
@@ -207,13 +202,13 @@ UTEST(compiler, select_explicit_cc)
 
 UTEST(compiler, select_fake_returns_null)
 {
-    HlCompiler *c = hl_compiler_select("__nonexistent_xyz__", NULL);
+    HlCompiler *c = hl_compiler_select("__nonexistent_xyz__");
     ASSERT_EQ(c, NULL);
 }
 
 UTEST(compiler, select_system_forces_system)
 {
-    HlCompiler *c = hl_compiler_select("system", NULL);
+    HlCompiler *c = hl_compiler_select("system");
     /* system compilers should always be available in CI */
     ASSERT_NE(c, NULL);
     hl_compiler_destroy(c);
@@ -254,7 +249,7 @@ UTEST(compiler, compile_app_registry_pattern)
         "    { 0, 0, 0 }\n"
         "};\n");
 
-    HlCompiler *c = hl_compiler_select(NULL, NULL);
+    HlCompiler *c = hl_compiler_select(NULL);
     if (!c) { rm_rf(tmpdir); free(tmpdir); return; }
 
     int rc = hl_compiler_compile(c, src, obj, tmpdir);
@@ -271,7 +266,7 @@ UTEST(compiler, compile_app_registry_pattern)
 UTEST(compiler, default_compiler_resolves)
 {
     /* Auto-select must resolve an available compiler (the system cc). */
-    HlCompiler *c = hl_compiler_select(NULL, NULL);
+    HlCompiler *c = hl_compiler_select(NULL);
     ASSERT_NE(c, NULL);
     ASSERT_EQ(hl_compiler_is_available(c), 1);
     hl_compiler_destroy(c);


### PR DESCRIPTION
Post-#190 cleanup of the compiler-free / toolchain-free build arc. Removes four redundant/superfluous pieces surfaced in the arc review, **no user-visible behavior change on the happy paths** (net **-75 lines**).

## What changed

**1. Drop the dead `HlLinkTarget.arch` field.** No linker backend read it (lld/system ignore the target; zig reads only `.format` + `.triple`), and its one construction site hardcoded it to `0`. Emitted objects already carry the arch.

**2. Make the compiler vtable compile-only.** `HlCompilerVtable.link`, `compiler.c::sys_link`, the `l_compiler_link` Lua binding, and `tool.compiler.link` were a second way to do the exact `cc -o out objs libs` the linker vtable already does. Both build paths now link through `tool.linker`:
- emit path: unchanged (already used `tool.linker`).
- compiler path (`--compiler=system` / `--with` / cosmo): compiles with the compiler, links with the linker, which auto-resolves the same `cc` - so C++ (`--with=duckdb`, `-lstdc++`) and cosmo (`cosmocc`) links are unchanged.

  *Improvement side effect:* an explicit `--linker=<x>` that fails to resolve is now a **hard error** at link time instead of silently falling back to `cc`. The old "no resolvable linker -> use the compiler path" fallback couldn't rescue a missing linker anymore (both paths need it), so it was removed.

**3. Factor the duplicated native-driver resolution** into one shared `hl_driver_resolve_native` (in `compiler.c`), used by both `hl_compiler_select` and `hl_linker_select`. The ~40-line cosmocc block + the cc/gcc/clang candidate scan were verbatim in both selectors.

**4. Drop the dead `hull_exe` param from `hl_compiler_select`** (the retired tcc tool's resolution seed; the comment already said "currently unused"). The linker's `hull_exe` stays - it's live (resolves lld/zig).

`lld` is **kept**: Tier A (`--linker=lld`) is the cheapest rung and the e2es exercise it; Tier B (`--linker=lld-static`) stays as a dormant-but-correct mechanism. Not touched here.

## Verification
- `make test` **61/61**
- a compute app builds + runs via **both** the emit path and `--compiler=system`
- `--linker=__nope__` hard-fails with a clear message (no binary produced)

CI additionally exercises the `--with` compiler-path link (e2e_feature_duckdb) and the linker/cross e2es.