### PR TITLE
fix(obj_emit): emit app-registry into .data.rel.ro, not .rodata (musl loader crash)

### DIFF
--- a/src/hull/obj_emit.c
+++ b/src/hull/obj_emit.c
@@ -7,13 +7,22 @@
  * is built from self-defined constants (no elf.h or mach-o headers - a macOS
  * host must emit ELF for a Linux target and vice versa).
  *
- * A single planner lays out one read-only section:
+ * A single planner lays out one section:
  *   [ name strings | file blobs | pad-to-8 | (N+1)-entry array ]
  * Each real entry's name/data pointer slots become ABS64 relocation sites
  * (target offset = where the string/blob lives); `len` is inline. The
  * trailing sentinel entry is 24 zero bytes with no relocations. Three
  * format backends serialize that plan (ELF, Mach-O, COFF/PE); cosmo reuses
  * the ELF backend, parameterized by (osabi, flags).
+ *
+ * The section holds relocated pointers, so it must be RELRO-eligible, NOT
+ * plain read-only: at load time the dynamic linker writes the relocated
+ * name/data addresses into the entry array, then (with -z relro) remaps it
+ * read-only. ELF expresses this as `.data.rel.ro` (SHF_ALLOC|SHF_WRITE);
+ * Mach-O as `__DATA,__const`. Placing it in `.rodata` (SHF_ALLOC only) puts
+ * the relocation targets in a truly read-only page - glibc tolerates the
+ * resulting text relocations, but musl's stricter loader SIGSEGVs applying
+ * them. This is what `cc` does for a `const T[]` with pointer initializers.
  *
  * See docs/compiler_free_build.md.
  *
@@ -132,7 +141,7 @@ static int emit_elf(const HlObjTarget *tgt, const Plan *pl,
     uint16_t machine = (tgt->arch == HL_OBJ_AARCH64) ? EM_AARCH64 : EM_X86_64;
     uint32_t rtype   = (tgt->arch == HL_OBJ_AARCH64) ? R_AARCH64_ABS64 : R_X86_64_64;
 
-    /* .rela.rodata: explicit addend, targeting the .rodata section symbol (1). */
+    /* .rela.data.rel.ro: explicit addend, targeting the section symbol (1). */
     Buf rela = {0};
     for (size_t i = 0; i < pl->nreloc; i++) {
         buf_u64(&rela, pl->relocs[i].site);
@@ -151,8 +160,8 @@ static int emit_elf(const HlObjTarget *tgt, const Plan *pl,
     buf_u64(&symtab, pl->array_off); buf_u64(&symtab, pl->sym_size);
 
     Buf shstr = {0}; buf_u8(&shstr, 0);
-    uint32_t nm_rodata = strtab_add(&shstr, ".rodata");
-    uint32_t nm_rela   = strtab_add(&shstr, ".rela.rodata");
+    uint32_t nm_sec    = strtab_add(&shstr, ".data.rel.ro");
+    uint32_t nm_rela   = strtab_add(&shstr, ".rela.data.rel.ro");
     uint32_t nm_symtab = strtab_add(&shstr, ".symtab");
     uint32_t nm_strtab = strtab_add(&shstr, ".strtab");
     uint32_t nm_shstr  = strtab_add(&shstr, ".shstrtab");
@@ -173,8 +182,8 @@ static int emit_elf(const HlObjTarget *tgt, const Plan *pl,
     buf_u16(&o, 64); buf_u16(&o, 0); buf_u16(&o, 0);
     buf_u16(&o, 64); buf_u16(&o, 6); buf_u16(&o, 5);
 
-    uint64_t off_rodata, off_rela, off_symtab, off_strtab, off_shstr, off_shdrs;
-    buf_pad(&o, 8); off_rodata = o.len; buf_put(&o, pl->sec.p, pl->sec.len);
+    uint64_t off_sec, off_rela, off_symtab, off_strtab, off_shstr, off_shdrs;
+    buf_pad(&o, 8); off_sec = o.len; buf_put(&o, pl->sec.p, pl->sec.len);
     buf_pad(&o, 8); off_rela   = o.len; buf_put(&o, rela.p, rela.len);
     buf_pad(&o, 8); off_symtab = o.len; buf_put(&o, symtab.p, symtab.len);
     off_strtab = o.len; buf_put(&o, strtab.p, strtab.len);
@@ -187,7 +196,7 @@ static int emit_elf(const HlObjTarget *tgt, const Plan *pl,
         buf_u64(&o,(of)); buf_u64(&o,(sz)); buf_u32(&o,(lk)); buf_u32(&o,(inf)); \
         buf_u64(&o,(al)); buf_u64(&o,(es)); } while (0)
     SHDR(0,0,0,0,0,0,0,0,0);
-    SHDR(nm_rodata, 1 /*PROGBITS*/, 0x2 /*ALLOC*/, off_rodata, pl->sec.len, 0,0, 8, 0);
+    SHDR(nm_sec, 1 /*PROGBITS*/, 0x3 /*ALLOC|WRITE → RELRO*/, off_sec, pl->sec.len, 0,0, 8, 0);
     SHDR(nm_rela, 4 /*RELA*/, 0x40 /*INFO_LINK*/, off_rela, rela.len, 3,1, 8, 24);
     SHDR(nm_symtab, 2 /*SYMTAB*/, 0, off_symtab, symtab.len, 4, 2, 8, 24);
     SHDR(nm_strtab, 3 /*STRTAB*/, 0, off_strtab, strtab.len, 0,0, 1, 0);

--- a/tests/hull/test_obj_emit.c
+++ b/tests/hull/test_obj_emit.c
@@ -5,7 +5,7 @@
  * the bytes back: header, sections, the exported hl_app_entries symbol, the
  * ABS64 relocations, and that each entry's len is inline while its name/data
  * pointer slots are zeroed and their reloc addends point at the right bytes
- * in .rodata. Host-independent (no linking), so it runs on every CI arch;
+ * in .data.rel.ro. Host-independent (no linking), so it runs on every CI arch;
  * the link+run round-trip lives in the e2e.
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -83,16 +83,19 @@ static void check_emit(int *utest_result,
     ASSERT_EQ(want_machine, rd16(o + 18)); /* e_machine */
 
     Elf e; parse(&e, o);
-    int i_rodata = find_sec(&e, ".rodata");
-    int i_rela   = find_sec(&e, ".rela.rodata");
+    int i_sec = find_sec(&e, ".data.rel.ro");
+    int i_rela   = find_sec(&e, ".rela.data.rel.ro");
     int i_sym    = find_sec(&e, ".symtab");
     int i_str    = find_sec(&e, ".strtab");
-    ASSERT_TRUE(i_rodata > 0 && i_rela > 0 && i_sym > 0 && i_str > 0);
+    ASSERT_TRUE(i_sec > 0 && i_rela > 0 && i_sym > 0 && i_str > 0);
 
-    /* .rodata must be read-only (SHF_ALLOC, no SHF_WRITE = 0x1). */
-    ASSERT_EQ((uint64_t)0x2, SH_FLAGS(shdr(&e, i_rodata)) & 0x3);
+    /* The entry array holds relocated pointers, so the section must be
+     * RELRO-eligible: SHF_ALLOC|SHF_WRITE (0x3), NOT read-only .rodata. A
+     * plain-.rodata placement (0x2) puts the RELATIVE reloc targets in a
+     * truly RO page and musl's loader SIGSEGVs applying them. */
+    ASSERT_EQ((uint64_t)0x3, SH_FLAGS(shdr(&e, i_sec)) & 0x3);
 
-    const unsigned char *rodata = o + SH_OFFSET(shdr(&e, i_rodata));
+    const unsigned char *sec = o + SH_OFFSET(shdr(&e, i_sec));
     const unsigned char *strtab = o + SH_OFFSET(shdr(&e, i_str));
 
     /* Find the hl_app_entries global in .symtab. */
@@ -111,27 +114,27 @@ static void check_emit(int *utest_result,
         }
     }
     ASSERT_EQ(1, found);
-    ASSERT_EQ(i_rodata, sym_shndx);
+    ASSERT_EQ(i_sec, sym_shndx);
     ASSERT_EQ((uint64_t)(n + 1) * 24, sym_size);  /* N real + sentinel */
 
     /* Array: each real entry's len inline; name/data slots zeroed; sentinel zero. */
     for (size_t k = 0; k < n; k++) {
-        const unsigned char *ent = rodata + array_off + k*24;
+        const unsigned char *ent = sec + array_off + k*24;
         ASSERT_EQ((uint64_t)0, rd64(ent + 0));   /* name slot (reloc-filled) */
         ASSERT_EQ((uint64_t)0, rd64(ent + 8));   /* data slot */
         ASSERT_EQ(ents[k].len, rd32(ent + 16));  /* len inline */
     }
-    const unsigned char *sentinel = rodata + array_off + n*24;
+    const unsigned char *sentinel = sec + array_off + n*24;
     for (int b = 0; b < 24; b++) ASSERT_EQ(0, sentinel[b]);
 
     /* Relocs: exactly 2N ABS64, targeting the array slots, addends pointing
-     * at the entry's name / data bytes in .rodata. */
+     * at the entry's name / data bytes in .data.rel.ro. */
     const unsigned char *rela = o + SH_OFFSET(shdr(&e, i_rela));
     uint64_t nrel = SH_SIZE(shdr(&e, i_rela)) / 24;
     ASSERT_EQ((uint64_t)2 * n, nrel);
     ASSERT_EQ((uint64_t)24, SH_ENTSIZE(shdr(&e, i_rela)));
     ASSERT_EQ((uint32_t)i_sym, SH_LINK(shdr(&e, i_rela)));    /* → .symtab */
-    ASSERT_EQ((uint32_t)i_rodata, SH_INFO(shdr(&e, i_rela))); /* applies to .rodata */
+    ASSERT_EQ((uint32_t)i_sec, SH_INFO(shdr(&e, i_rela))); /* applies to .data.rel.ro */
 
     for (size_t k = 0; k < n; k++) {
         const unsigned char *rn = rela + (2*k)   * 24;  /* name reloc */
@@ -139,12 +142,12 @@ static void check_emit(int *utest_result,
         ASSERT_EQ(array_off + k*24 + 0, rd64(rn + 0));
         ASSERT_EQ(array_off + k*24 + 8, rd64(rd + 0));
         ASSERT_EQ(want_rtype, (uint32_t)(rd64(rn + 8) & 0xffffffff));
-        ASSERT_EQ((uint64_t)1, rd64(rn + 8) >> 32);     /* sym idx 1 = .rodata */
+        ASSERT_EQ((uint64_t)1, rd64(rn + 8) >> 32);     /* sym idx 1 = .data.rel.ro */
         uint64_t name_add = rd64(rn + 16);
         uint64_t data_add = rd64(rd + 16);
-        ASSERT_STREQ(ents[k].name, (const char *)rodata + name_add);
+        ASSERT_STREQ(ents[k].name, (const char *)sec + name_add);
         if (ents[k].len)
-            ASSERT_EQ(0, memcmp(rodata + data_add, ents[k].data, ents[k].len));
+            ASSERT_EQ(0, memcmp(sec + data_add, ents[k].data, ents[k].len));
     }
 
     free(o);
@@ -165,7 +168,7 @@ UTEST(obj_emit, empty_is_just_sentinel) {
     ASSERT_EQ(0, hl_obj_emit_app_registry(&tgt, NULL, 0, &o, &olen));
     ASSERT_TRUE(o != NULL);
     Elf e; parse(&e, o);
-    int i_sym = find_sec(&e, ".symtab"), i_rela = find_sec(&e, ".rela.rodata");
+    int i_sym = find_sec(&e, ".symtab"), i_rela = find_sec(&e, ".rela.data.rel.ro");
     /* one hl_app_entries sym of size 24 (sentinel only), zero relocs */
     ASSERT_EQ((uint64_t)0, SH_SIZE(shdr(&e, i_rela)));
     const unsigned char *strtab = o + SH_OFFSET(shdr(&e, find_sec(&e, ".strtab")));


### PR DESCRIPTION
## The bug

The compiler-free ELF emitter (`obj_emit.c`) placed `hl_app_entries[]` in **`.rodata`** with `SHF_ALLOC` only (`0x2`). But that array holds **pointers** (each entry's `name`/`data`), which need load-time **RELATIVE relocations** — so the section must be **RELRO-eligible**: the dynamic linker writes the relocated addresses into the array at load, then (`-z relro`) remaps it read-only. A `const T[]` with pointer initializers is exactly what `cc` puts in **`.data.rel.ro`** (`SHF_ALLOC|SHF_WRITE`, `0x3`).

Plain `.rodata` leaves the reloc targets in a **truly read-only page**:
- **glibc / macOS**: tolerated (glibc handles the resulting text relocations; the Mach-O backend already used `__DATA,__const`). So it shipped unnoticed — all CI is glibc/macOS.
- **musl**: its stricter loader **SIGSEGVs in `do_relocs`** applying them. Every emit-path (`hull build`, the default path) binary crashed at startup on Alpine/musl, before `main`.

## The fix

Name the section `.data.rel.ro` (+ `.rela.data.rel.ro`) and set `SHF_ALLOC|SHF_WRITE`. Three mechanical changes in the ELF backend; Mach-O/COFF untouched. Also the correct **hardening** posture — the entry array ends up RELRO-protected instead of relying on always-RO `.rodata` via text relocations.

## Verification
- **musl (Alpine aarch64, Docker):** the emit-path binary that SIGSEGV'd now **runs (exit 0)**; `readelf` confirms `hl_app_entries` is in `.data.rel.ro`, inside `GNU_RELRO`.
- **macOS:** emit-path build+run unaffected (exit 0).
- **`test_obj_emit`** updated for the new section/flags; **`make test` 61/61**.

Found by a musl build spike (Docker Alpine), not yet in CI. A **musl emit+run e2e** is the natural follow-up to lock this down (and would have caught it).