### PR TITLE
feat(musl): build + run on musl (Alpine), locked by a CI e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1161,3 +1161,18 @@ jobs:
           out=$(make embed-zig-smoke 2>&1); echo "$out"
           echo "$out" | grep -q "embed-zig-smoke: OK" \
             || { echo "::error::embed_zig did not run to completion"; exit 1; }
+
+  musl:
+    name: musl (Alpine)
+    runs-on: ubuntu-24.04
+    # A plain ubuntu runner (not container: alpine) so actions/checkout keeps
+    # working - GitHub's node runs on the glibc host. tests/e2e_musl.sh detects
+    # the non-musl host and re-execs itself inside an alpine:3.20 container,
+    # building hull under musl and running emit-path compute + HTTP apps.
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: recursive
+
+      - name: Build + emit/run E2E under musl (Docker Alpine)
+        run: sh tests/e2e_musl.sh

--- a/Makefile
+++ b/Makefile
@@ -1875,7 +1875,7 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
 
 # ── Targets ─────────────────────────────────────────────────────────
 
-.PHONY: all clean test debug msan tsan fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-cross-build e2e-tierb-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint platform platform-cosmo hardening check-hardening
+.PHONY: all clean test debug msan tsan fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-cross-build e2e-tierb-musl e2e-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint platform platform-cosmo hardening check-hardening
 
 all: $(BUILDDIR)/hull
 

--- a/docs/musl_build.md
+++ b/docs/musl_build.md
@@ -1,0 +1,85 @@
+# Building Hull on musl (Alpine)
+
+Hull builds and runs on musl libc (Alpine Linux), producing binaries for
+minimal `scratch`/Alpine containers. Hull's own CI and dev happen on glibc +
+macOS, so musl's stricter runtime is a useful second correctness check - it has
+already caught a latent bug the glibc loader silently tolerated.
+
+## What it takes: essentially nothing
+
+The vendored stack (mbedTLS, SQLite, WAMR, QuickJS, Lua, Keel, TweetNaCl,
+stb, sh_arena, sh_json) compiles clean under musl with **zero** source changes.
+Hull needs exactly **one** build shim plus **one** correctness fix that already
+landed:
+
+1. **`__O_TMPFILE` (build shim).** `vendor/pledge/libc/calls/pledge-linux.c`
+   references the glibc-only macro `__O_TMPFILE` - purely as the numeric
+   seccomp-mask constant `020000000` (the Linux ABI flag value, identical on
+   x86_64 and aarch64; the file's own comments spell it out). glibc defines it
+   via `<bits/fcntl-linux.h>`; musl does not. `mk/platform/linux.mk` detects a
+   musl target (`cc -dumpmachine` contains `musl`) and adds
+   `-D__O_TMPFILE=020000000` to `PLEDGE_CFLAGS` only - scoped to the one file
+   that uses it, and only on musl (a glibc `-D` would just warn on redefine).
+
+2. **`.data.rel.ro` emitter placement (landed in the ELF object emitter).**
+   The compiler-free emitter (`src/hull/obj_emit.c`) put the relocated
+   `hl_app_entries[]` array in `.rodata` (read-only). musl's loader SIGSEGVs
+   applying the RELATIVE relocations into a read-only page; glibc tolerates the
+   resulting text relocations. The fix emits it into `.data.rel.ro`
+   (RELRO-eligible), which is what `cc` does for a `const T[]` of pointers - and
+   the correct hardening posture. See the commit for
+   `fix(obj_emit): emit the app-registry into .data.rel.ro, not .rodata`.
+
+That is the whole port. No musl-specific `#ifdef` in Hull source, no forked
+platform code.
+
+## Building
+
+On an Alpine host (or `docker run alpine`):
+
+```sh
+apk add --no-cache build-base clang lld make xxd bash git perl linux-headers
+make -j"$(nproc)"          # the hull binary
+make platform -j"$(nproc)" # libhull_platform.a for `hull build`
+```
+
+`cc` on Alpine is a musl-targeting gcc, so `-dumpmachine` reports
+`<arch>-alpine-linux-musl` and the `__O_TMPFILE` shim engages automatically. No
+`CC=` override or manual `-D` is needed.
+
+Apps then build through the normal (compiler-free emit) path and produce
+musl-linked binaries:
+
+```sh
+hull build ./myapp -o ./myapp/bin
+```
+
+## What is verified
+
+`tests/e2e_musl.sh` (`make e2e-musl`, and the `musl (Alpine)` CI job) builds hull
+under musl and then, through the default emit path, builds and runs:
+
+- a **compute `app.main`** app - the regression lock for the `.data.rel.ro` fix
+  (this binary used to SIGSEGV in `ld-musl`'s `do_relocs` before `main`);
+- an **HTTP server** app - proves the full server runtime serves a request.
+
+The script is dual-mode: on a musl host it builds directly; on a non-musl host
+(dev macOS/glibc, CI ubuntu) it re-execs itself inside an `alpine:3.20` Docker
+container. That is why the CI job runs on a plain ubuntu runner rather than
+`container: alpine` - it sidesteps `actions/checkout`'s glibc-node breakage on an
+Alpine container while still exercising a real musl build.
+
+## Caveats / not-yet
+
+- **Static musl (`--linker=lld-static`, Tier B).** A musl platform library now
+  exists, which is the precondition Tier B was blocked on. End-to-end validation
+  of the direct `ld.lld -static` link on musl is the remaining follow-up before
+  Tier B is a supported, tested path. See
+  [docs/toolchain_free_build.md](toolchain_free_build.md).
+- **Sandbox in a container.** The e2e runs apps with `--no-sandbox`: Docker's
+  default seccomp/landlock restrictions make pledge/unveil enforcement fail
+  inside an unprivileged container. That is a container-capability limitation,
+  not a musl issue; a musl binary on a real host sandboxes normally.
+- **Published artifacts.** The signed release matrix ships glibc + cosmo
+  binaries. A published, signed musl platform library / binary would be a
+  separate release-pipeline decision (new matrix entry + manifest line).

--- a/mk/platform/linux.mk
+++ b/mk/platform/linux.mk
@@ -8,6 +8,18 @@
 PLEDGE_DIR := $(VENDDIR)/pledge
 PLEDGE_CFLAGS := -std=c11 -O2 -w -D_GNU_SOURCE -I$(PLEDGE_DIR) $(DEPFLAGS)
 
+# musl (Alpine) omits the glibc-only __O_TMPFILE macro that pledge-linux.c
+# references - purely as the numeric seccomp-mask constant 020000000 (the
+# vendored polyfill's own comments spell out that value; it is the Linux ABI
+# flag, identical on x86_64/aarch64). glibc defines it via <bits/fcntl-linux.h>,
+# so scope the define to a musl target (a glibc -D would just warn on redefine)
+# and to PLEDGE_CFLAGS (pledge-linux.c is its sole user tree-wide). Detected from
+# the compiler's target triple. This is the one shim a musl build needs; the
+# rest of the vendored stack is musl-clean. See docs/musl_build.md.
+ifneq ($(findstring musl,$(shell $(CC) -dumpmachine 2>/dev/null)),)
+PLEDGE_CFLAGS += -D__O_TMPFILE=020000000
+endif
+
 PLEDGE_SRCS := \
 	$(PLEDGE_DIR)/libc/calls/pledge.c \
 	$(PLEDGE_DIR)/libc/calls/pledge-linux.c \

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -719,6 +719,12 @@ e2e-cross-build:
 e2e-tierb-musl:
 	sh tests/e2e_tierb_musl.sh
 
+# Full musl support: builds hull under musl (Alpine) and runs emit-path compute
+# + HTTP apps. Self-re-execs into Docker on a non-musl host. No prereqs (it does
+# its own musl build). See tests/e2e_musl.sh + docs/musl_build.md.
+e2e-musl:
+	sh tests/e2e_musl.sh
+
 # `hull build --flavor` MVP. Builds the pure-compute platform lib itself.
 e2e-build-flavor: $(BUILDDIR)/hull
 	sh tests/e2e_build_flavor.sh

--- a/tests/e2e_musl.sh
+++ b/tests/e2e_musl.sh
@@ -1,0 +1,121 @@
+#!/bin/sh
+# E2E test: Hull builds and runs on musl (Alpine).
+#
+# Hull is developed on glibc + macOS; musl's stricter dynamic loader exposes
+# bugs those never hit (e.g. the .rodata-vs-.data.rel.ro relocation crash fixed
+# in the compiler-free emitter). This test locks musl support in CI.
+#
+# It builds hull under musl, then builds two apps through the DEFAULT (emit)
+# path and runs them:
+#   1. a compute app.main   - proves emit-path binaries load on musl (the
+#      relocation-in-.data.rel.ro regression: was SIGSEGV in ld-musl do_relocs).
+#   2. an HTTP server app    - proves the full server runtime serves a request.
+#
+# Dual mode: on a musl host it builds directly; elsewhere (dev macOS/glibc, CI
+# ubuntu) it re-execs itself inside an alpine:3.20 Docker container. So the CI
+# job is a plain ubuntu runner (avoids actions/checkout's glibc-node breakage on
+# an alpine container), and `make e2e-musl` just works on a dev box with Docker.
+#
+# Usage: sh tests/e2e_musl.sh   /   make e2e-musl
+# See docs/musl_build.md.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -u
+
+SRCDIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# On a musl Linux? Definitive: macOS is Darwin and glibc Linux has no
+# /lib/ld-musl-*, so both correctly resolve to 0. HULL_MUSL_INNER is a recursion
+# sentinel: the Docker re-exec sets it so the inner run never loops even if this
+# probe were ever wrong.
+ON_MUSL=0
+if [ "$(uname -s)" = "Linux" ] && ls /lib/ld-musl-* >/dev/null 2>&1; then
+    ON_MUSL=1
+fi
+
+# ── Not on musl: re-exec inside Alpine via Docker ──────────────────────────
+if [ "${HULL_MUSL_INNER:-0}" != "1" ] && [ "$ON_MUSL" != "1" ]; then
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "SKIP: host is not musl and docker is unavailable"
+        exit 0
+    fi
+    echo "== e2e_musl: host is not musl - re-exec inside alpine:3.20 =="
+    exec docker run --rm -e HULL_MUSL_INNER=1 -v "$SRCDIR":/src:ro alpine:3.20 sh -c '
+        set -u
+        apk add --no-cache build-base clang lld make xxd bash git perl linux-headers \
+            >/dev/null 2>&1 || { echo "SKIP: apk add failed (network?)"; exit 0; }
+        # Copy the read-only mount to a writable layer and strip any host-built
+        # (macOS/glibc) objects so everything recompiles native under musl.
+        cp -a /src/. /work/ 2>/dev/null || true
+        cd /work
+        find . -name "*.o" -delete 2>/dev/null || true
+        find . -name "*.a" -delete 2>/dev/null || true
+        rm -rf build
+        exec sh tests/e2e_musl.sh
+    '
+fi
+
+# ── On musl from here ──────────────────────────────────────────────────────
+PASS=0; FAIL=0; WORKDIR=""; SRV=""
+cleanup() {
+    [ -n "$SRV" ] && { kill "$SRV" 2>/dev/null || true; wait "$SRV" 2>/dev/null || true; }
+    [ -n "$WORKDIR" ] && [ -d "$WORKDIR" ] && rm -rf "$WORKDIR"
+}
+trap cleanup EXIT INT TERM
+ok()  { PASS=$((PASS + 1)); echo "  ok   $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "  FAIL $1"; }
+
+JOBS="$(nproc 2>/dev/null || echo 2)"
+echo "== building hull on musl ($(cc -dumpmachine 2>/dev/null)) =="
+if ! make -j"$JOBS" >/tmp/musl_mk.log 2>&1; then
+    echo "FAIL: make (musl build)"; tail -25 /tmp/musl_mk.log; exit 1
+fi
+if ! make platform -j"$JOBS" >/tmp/musl_mp.log 2>&1; then
+    echo "FAIL: make platform (musl)"; tail -25 /tmp/musl_mp.log; exit 1
+fi
+HULL="$SRCDIR/build/hull"
+"$HULL" version || { echo "FAIL: hull does not run on musl"; exit 1; }
+echo
+
+WORKDIR="$(mktemp -d)"
+
+# [1] compute app.main via the emit path - the #192 regression lock.
+mkdir -p "$WORKDIR/compute"
+printf 'app.manifest({ modules = {} })\napp.main(function(ctx) ctx.stdout:write("musl compute ok\\n"); return 0 end)\n' \
+    > "$WORKDIR/compute/app.lua"
+if "$HULL" build "$WORKDIR/compute" --no-verify-platform -o "$WORKDIR/compute/bin" \
+        >/tmp/musl_c.log 2>&1; then
+    out="$("$WORKDIR/compute/bin" --no-sandbox 2>/dev/null || true)"
+    if [ "$out" = "musl compute ok" ]; then
+        ok "compute emit-path app builds + runs on musl (no ld-musl reloc crash)"
+    else
+        bad "compute emit-path app ran but output was '$out'"
+    fi
+else
+    bad "compute emit-path app build"; tail -10 /tmp/musl_c.log
+fi
+
+# [2] HTTP server via the emit path - full server runtime on musl.
+mkdir -p "$WORKDIR/http"
+printf 'app.manifest({ modules = { "hull/http-server@1" } })\napp.get("/", function(req, res) res:text("hi from musl") end)\n' \
+    > "$WORKDIR/http/app.lua"
+if "$HULL" build "$WORKDIR/http" --no-verify-platform -o "$WORKDIR/http/srv" \
+        >/tmp/musl_h.log 2>&1; then
+    "$WORKDIR/http/srv" -p 8137 --no-sandbox >/tmp/musl_srv.log 2>&1 &
+    SRV=$!
+    sleep 1
+    body="$(wget -qO- http://127.0.0.1:8137/ 2>/dev/null || true)"
+    kill "$SRV" 2>/dev/null || true; wait "$SRV" 2>/dev/null || true; SRV=""
+    if [ "$body" = "hi from musl" ]; then
+        ok "HTTP server emit-path app serves a request on musl"
+    else
+        bad "HTTP server responded '$body' (expected 'hi from musl')"; tail -6 /tmp/musl_srv.log
+    fi
+else
+    bad "HTTP server app build"; tail -10 /tmp/musl_h.log
+fi
+
+echo
+echo "== e2e_musl: $PASS passed, $FAIL failed =="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Second step of the musl work (after **#192**, the `.data.rel.ro` emitter fix that unblocked the loader). This makes Hull build and run on musl and locks it in CI.

## The whole shim is one define

With #192 in, musl support needs exactly one build shim: `vendor/pledge/pledge-linux.c` references the glibc-only `__O_TMPFILE` macro — purely as the numeric seccomp-mask constant `020000000` (the Linux ABI flag value, identical on x86_64/aarch64; the vendored file's own comments spell it out). `mk/platform/linux.mk` defines it **only for a musl target** (auto-detected via `cc -dumpmachine`) and **only on `PLEDGE_CFLAGS`** (its sole user tree-wide). glibc defines it via `<bits/fcntl-linux.h>`, so glibc builds are untouched. The rest of the vendored stack (mbedTLS/SQLite/WAMR/QuickJS/Lua/Keel/…) is musl-clean with **zero** source changes.

## What's here
- **`mk/platform/linux.mk`**: the musl-scoped `__O_TMPFILE` define.
- **`tests/e2e_musl.sh`** (+ `make e2e-musl`): builds hull under musl, then through the default **emit path** builds+runs:
  - a **compute `app.main`** — the #192 regression lock (this binary used to SIGSEGV in `ld-musl`'s `do_relocs` before `main`);
  - an **HTTP server** — proves the full server runtime serves a request.
  Dual-mode: direct on a musl host, else self-re-execs into an `alpine:3.20` Docker container (bulletproof `uname`-based detection + a recursion sentinel).
- **CI**: a `musl (Alpine)` job on a plain **ubuntu** runner (the script re-execs into Docker) — sidesteps `actions/checkout`'s glibc-node breakage on an Alpine container while still exercising a real musl build.
- **`docs/musl_build.md`**.

## Verified
Locally via `make e2e-musl`: builds hull for **`aarch64-alpine-linux-musl`** and passes both assertions with genuine musl binaries (confirmed the triple, not a macOS false-pass).

## Not yet
- **Static-musl via `--linker=lld-static` (Tier B)** — a musl platform lib now exists (its precondition), so end-to-end Tier B validation on musl is the natural follow-up.
- The container e2e runs apps with `--no-sandbox` (Docker's default seccomp/landlock blocks pledge enforcement — a container limitation, not a musl issue).