### PR TITLE
feat(linker): Tier B is cc-free + supports an installed floor bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1875,7 +1875,7 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
 
 # ── Targets ─────────────────────────────────────────────────────────
 
-.PHONY: all clean test debug msan tsan fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-cross-build e2e-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint platform platform-cosmo hardening check-hardening
+.PHONY: all clean test debug msan tsan fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-cross-build e2e-musl floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint platform platform-cosmo hardening check-hardening
 
 all: $(BUILDDIR)/hull
 

--- a/docs/musl_build.md
+++ b/docs/musl_build.md
@@ -74,20 +74,38 @@ Alpine container while still exercising a real musl build.
 
 On musl, `hull build --linker=lld-static ./app` produces a **fully static**
 executable (no interpreter, runs on bare `scratch`) by invoking `ld.lld`
-directly - no cc driving the link. It needs three things beyond the emitted
-object: the musl floor (`crt1.o`/`crti.o`/`crtn.o`/`libc.a`, from `musl-dev`,
-located via `HULL_LIBC_DIR`, default `/usr/lib`), `ld.lld` (from `lld`), and the
-**compiler runtime** `libgcc.a` (soft-float builtins the app archives
-reference). The linker discovers `libgcc.a` via `cc -print-libgcc-file-name`;
-`HULL_LIBGCC=/path/to/libgcc.a` overrides it for a hand-assembled, cc-free floor.
+directly - no cc driving the link. Beyond the emitted object it needs `ld.lld`
+(from `lld`), the musl floor (`crt1.o`/`crti.o`/`crtn.o`/`libc.a`, from
+`musl-dev`), and the **compiler runtime** `libgcc.a` (soft-float builtins the app
+archives reference, e.g. `__multf3`). Both the floor and `libgcc.a` are resolved
+**without a compiler**, in this order:
 
-Note the honest nuance: Tier B is **compiler-DRIVER-free** (no cc invokes the
-link), but locating `libgcc.a` still consults `cc` unless `HULL_LIBGCC` is set.
-`zig cc` (`--linker=zig`) remains the turnkey, self-contained alternative
-(bundles crt+libc+compiler-rt for ~40 targets); Tier B is the purist path when
-you want `ld.lld` + a system floor and nothing else. See
-[docs/toolchain_free_build.md](toolchain_free_build.md). Covered by
-`tests/e2e_musl.sh` (asserts the binary is static and runs).
+- **Floor** (`crt*.o` + `libc.a`): `HULL_LIBC_DIR` → an installed bundle
+  `~/.hull/tools/libc-musl-<arch>/` → `/usr/lib` (the musl-dev default).
+- **libgcc.a**: `HULL_LIBGCC` → the installed bundle → a glob of the system gcc
+  runtime (`/usr/lib/gcc/*/*/libgcc.a`, no cc spawn) → `cc
+  -print-libgcc-file-name` (last resort, the only cc-needing path).
+
+So Tier B is **fully self-contained** on any Alpine with `build-base` (the glob
+finds the system `libgcc`; cc is never spawned), and on a box with **nothing**
+but hull + `ld.lld` once the bundle is present:
+
+```sh
+make floor-musl                       # assemble ~/.hull/tools/libc-musl-<arch>
+hull build --linker=lld-static ./app  # no musl-dev, no gcc, no cc needed
+```
+
+`make floor-musl` (a wrapper over `scripts/build_musl_floor.sh`) collects
+`crt*.o` + `libc.a` + `libgcc.a` from a musl host into
+`~/.hull/tools/libc-musl-<arch>/`, and the linker resolves that dir automatically
+(above). A `hull tools install libc-musl-<arch>` that fetches a prebuilt,
+Ed25519-signed bundle from Hull's release - so end users need no musl host to
+assemble one - is the next step (the release producer + verified-fetch installer).
+
+`zig cc` (`--linker=zig`) remains the turnkey cross-target alternative (bundles
+crt+libc+compiler-rt for ~40 targets); Tier B is the purist `ld.lld` + floor
+path. See [docs/toolchain_free_build.md](toolchain_free_build.md). Covered by
+`tests/e2e_musl.sh` (asserts static + runs, cc-free, and via the bundle).
 
 ## Caveats / not-yet
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -724,6 +724,13 @@ e2e-cross-build:
 e2e-musl:
 	sh tests/e2e_musl.sh
 
+# Assemble a self-contained musl static-link floor (crt*.o + libc.a + libgcc.a)
+# for Tier B (`hull build --linker=lld-static`) - the contents of a
+# `hull tools install libc-musl-<arch>` bundle. Run on a musl host (Alpine).
+# DEST overrides the destination (default ~/.hull/tools/libc-musl-<arch>).
+floor-musl:
+	sh scripts/build_musl_floor.sh "$(if $(DEST),$(DEST),$(HOME)/.hull/tools/libc-musl-$(shell uname -m | sed -e s/arm64/aarch64/))"
+
 # `hull build --flavor` MVP. Builds the pure-compute platform lib itself.
 e2e-build-flavor: $(BUILDDIR)/hull
 	sh tests/e2e_build_flavor.sh

--- a/scripts/build_musl_floor.sh
+++ b/scripts/build_musl_floor.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# build_musl_floor.sh <dest-dir>
+#
+# Assemble a self-contained musl static-link floor into <dest-dir>: the crt
+# startup objects + static libc + the compiler runtime, so `hull build
+# --linker=lld-static` (Tier B) can link a fully static musl binary with NOTHING
+# else installed (no musl-dev, no gcc, no cc). This is what a
+# `hull tools install libc-musl-<arch>` bundle contains; it is used by
+# tests/e2e_musl.sh and (in a later step) by the release producer.
+#
+# Must run on a musl system (Alpine) with musl-dev + gcc present. Sources:
+#   crt1.o / crti.o / crtn.o / libc.a  <- $HULL_LIBC_DIR (default /usr/lib)
+#   libgcc.a                           <- system gcc runtime (glob; cc fallback)
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+DEST="${1:?usage: build_musl_floor.sh <dest-dir>}"
+LIBC_DIR="${HULL_LIBC_DIR:-/usr/lib}"
+
+mkdir -p "$DEST"
+
+for f in crt1.o crti.o crtn.o libc.a; do
+    if [ ! -r "$LIBC_DIR/$f" ]; then
+        echo "build_musl_floor: missing $LIBC_DIR/$f (install musl-dev, or set HULL_LIBC_DIR)" >&2
+        exit 1
+    fi
+    cp "$LIBC_DIR/$f" "$DEST/$f"
+done
+
+# musl folds libm/libpthread/rt/dl/... into libc.a and ships EMPTY stub archives
+# purely for `-l` compatibility. Bundle whichever exist so ld.lld resolves the
+# `-lm -lpthread` (etc.) that build.lua emits without reaching the system
+# /usr/lib - the whole point of a self-contained bundle.
+for f in libm.a libpthread.a librt.a libdl.a libutil.a libresolv.a libcrypt.a libxnet.a; do
+    [ -r "$LIBC_DIR/$f" ] && cp "$LIBC_DIR/$f" "$DEST/$f" || true
+done
+
+# libgcc.a: glob the system gcc runtime dir first (no compiler spawn); fall back
+# to `cc -print-libgcc-file-name`. Mirrors linker_lld.c's discovery order.
+LIBGCC="$(ls /usr/lib/gcc/*/*/libgcc.a 2>/dev/null | head -1 || true)"
+if [ -z "$LIBGCC" ]; then
+    LIBGCC="$(cc -print-libgcc-file-name 2>/dev/null || true)"
+fi
+if [ -z "$LIBGCC" ] || [ ! -r "$LIBGCC" ]; then
+    echo "build_musl_floor: no libgcc.a found (install gcc)" >&2
+    exit 1
+fi
+cp "$LIBGCC" "$DEST/libgcc.a"
+
+echo "build_musl_floor: assembled a self-contained floor in $DEST:"
+ls -1 "$DEST"

--- a/src/hull/linker_lld.c
+++ b/src/hull/linker_lld.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <limits.h>
 #include <unistd.h>
+#include <glob.h>
 
 #define HL_LINKER_MAX_ARGS 256
 
@@ -172,23 +173,42 @@ HlLinker *hl_linker_lld_direct_new(const char *ld_path, const char *libdir)
         snprintf(ctx->crtn, sizeof(ctx->crtn), "%s/crtn.o", libdir);
         snprintf(ctx->ldash, sizeof(ctx->ldash), "-L%s", libdir);
     }
-    /* Discover the compiler runtime (libgcc.a) the way a cc driver would: via
-     * `cc -print-libgcc-file-name`. It lives in a gcc-version-specific dir the
-     * raw linker can't guess, and supplies builtins (soft-float __multf3, etc.)
-     * the app archives reference. HULL_LIBGCC overrides (a hand-assembled floor
-     * with no cc, or a clang compiler-rt archive). Absent = link without it. */
+    /* Discover the compiler runtime (libgcc.a) - it supplies builtins (soft-
+     * float __multf3, etc.) the app archives reference, and a raw ld.lld does
+     * not auto-link it. Resolution order, cc-free where possible:
+     *   1. HULL_LIBGCC override (explicit, or a hand-assembled floor).
+     *   2. <libdir>/libgcc.a - an installed self-contained floor bundle
+     *      (`hull tools install libc-musl-<arch>`) drops it beside crt/libc, so
+     *      a bare box with no gcc still resolves it.
+     *   3. glob the system gcc runtime dir - no compiler spawn.
+     *   4. `cc -print-libgcc-file-name` - last resort, the only cc-needing path.
+     * So Tier B is fully self-contained on any box that has the bundle OR a
+     * system libgcc; cc is consulted only if neither is present. */
     {
         const char *env = getenv("HULL_LIBGCC");
+        char cand[PATH_MAX];
         if (env && *env) {
             snprintf(ctx->libgcc, sizeof(ctx->libgcc), "%s", env);
+        } else if (libdir && *libdir &&
+                   snprintf(cand, sizeof(cand), "%s/libgcc.a", libdir) > 0 &&
+                   access(cand, R_OK) == 0) {
+            snprintf(ctx->libgcc, sizeof(ctx->libgcc), "%s", cand);
         } else {
-            const char *q[] = { "cc", "-print-libgcc-file-name", NULL };
-            char *lg = hl_tool_spawn_read(q, NULL);
-            if (lg) {
-                char *nl = strchr(lg, '\n'); if (nl) *nl = '\0';
-                if (lg[0] && access(lg, R_OK) == 0)
-                    snprintf(ctx->libgcc, sizeof(ctx->libgcc), "%s", lg);
-                free(lg);
+            glob_t g;
+            if (glob("/usr/lib/gcc/*/*/libgcc.a", 0, NULL, &g) == 0 &&
+                g.gl_pathc > 0) {
+                snprintf(ctx->libgcc, sizeof(ctx->libgcc), "%s", g.gl_pathv[0]);
+            }
+            globfree(&g);
+            if (!ctx->libgcc[0]) {
+                const char *q[] = { "cc", "-print-libgcc-file-name", NULL };
+                char *lg = hl_tool_spawn_read(q, NULL);
+                if (lg) {
+                    char *nl = strchr(lg, '\n'); if (nl) *nl = '\0';
+                    if (lg[0] && access(lg, R_OK) == 0)
+                        snprintf(ctx->libgcc, sizeof(ctx->libgcc), "%s", lg);
+                    free(lg);
+                }
             }
         }
     }

--- a/src/hull/linker_system.c
+++ b/src/hull/linker_system.c
@@ -122,9 +122,29 @@ HlLinker *hl_linker_select(const char *explicit_linker, const char *hull_exe)
             char *s = strrchr(dir, '/');
             if (s) { *s = '\0'; snprintf(ld, sizeof ld, "%s/ld.lld", dir); }
         }
+        /* Floor discovery (crt1.o is the sentinel). An installed self-contained
+         * bundle - `hull tools install libc-musl-<arch>` extracts crt*.o +
+         * libc.a + libgcc.a to ~/.hull/tools/libc-musl-<arch>/ - takes
+         * precedence over the system musl-dev floor; HULL_LIBC_DIR overrides
+         * everything. */
+        char bundle[PATH_MAX] = {0};
+#if defined(__aarch64__)
+        const char *arch = "aarch64";
+#elif defined(__x86_64__)
+        const char *arch = "x86_64";
+#else
+        const char *arch = NULL;
+#endif
+        {
+            const char *home = getenv("HOME");
+            if (arch && home && *home)
+                snprintf(bundle, sizeof bundle, "%s/.hull/tools/libc-musl-%s",
+                         home, arch);
+        }
         char libdir[PATH_MAX] = {0};
         const char *env = getenv("HULL_LIBC_DIR");
-        const char *cands[] = { env, "/usr/lib", "/lib", NULL };
+        if (!env) env = "";   /* an empty entry is skipped, not a NULL terminator */
+        const char *cands[] = { env, bundle, "/usr/lib", "/lib", NULL };
         for (const char **c = cands; *c; c++) {
             if (!**c) continue;
             char crt[PATH_MAX];

--- a/src/hull/sandbox_tool.c
+++ b/src/hull/sandbox_tool.c
@@ -157,6 +157,20 @@ int hl_tool_sandbox_init(HlToolUnveilCtx *ctx,
     if (platform_dir)
         hl_tool_unveil_add(ctx, platform_dir, "rx");
 
+    /* Side-loaded tool assets: $HOME/.hull/tools holds tool binaries (wamrc,
+     * lld) that get executed AND the libc-musl-<arch> floor bundle
+     * (crt*.o / libc.a / libgcc.a) that Tier B's `ld.lld` reads at link time.
+     * Read + execute; narrow to the .hull/tools subtree, not all of $HOME. */
+    {
+        const char *home = getenv("HOME");
+        if (home && *home) {
+            char path[PATH_MAX];
+            int n = snprintf(path, sizeof(path), "%s/.hull/tools", home);
+            if (n > 0 && (size_t)n < sizeof(path))
+                hl_tool_unveil_add(ctx, path, "rx");
+        }
+    }
+
     hl_tool_unveil_seal(ctx);
 
     /* Also apply kernel-level unveil on supported platforms */
@@ -192,6 +206,15 @@ int hl_tool_sandbox_init(HlToolUnveilCtx *ctx,
             char cache_path[PATH_MAX];
             if (hl_hull_cache_dir(cache_path, sizeof(cache_path)) == 0)
                 unveil(cache_path, "rwc");
+        }
+        {
+            const char *home = getenv("HOME");
+            if (home && *home) {
+                char path[PATH_MAX];
+                int n = snprintf(path, sizeof(path), "%s/.hull/tools", home);
+                if (n > 0 && (size_t)n < sizeof(path))
+                    unveil(path, "rx");   /* installed tools + Tier B floor bundle */
+            }
         }
         unveil(NULL, NULL); /* seal */
 

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1866,7 +1866,11 @@ typedef struct {
     -- isn't available (very old hulls, mocked test harnesses):
     -- fall back to the compiler name. The cosmocc CC name is a
     -- reliable cosmo signal — a real cosmo build invokes cosmocc.
-    if not is_cosmo then
+    -- Only trust this when a real compiler resolved: with NO compiler
+    -- available, `cc` above defaults to tool.cc ("cosmocc"), which would
+    -- mis-flag a native, compiler-less emit build (e.g. --linker=lld-static
+    -- on a box with only ld.lld) as cosmo.
+    if not is_cosmo and tool.compiler then
         is_cosmo = cc:find("cosmocc") ~= nil
     end
 
@@ -1987,8 +1991,15 @@ local function main()
         end
     end
 
-    -- Guard: ensure compiler vtable is available
-    if not tool.compiler then
+    -- Guard: a C compiler is needed only when we will actually COMPILE - the
+    -- compiler build path, or a --with feature / cosmo target (both force the
+    -- compiler path via the fallback below). The default emit path links through
+    -- tool.linker and needs no compiler, so an explicit non-cc linker
+    -- (--linker=lld-static / lld / zig) can build on a box with no cc at all.
+    local will_compile = (not opts.no_compiler)
+        or (opts.with and next(opts.with) ~= nil)
+        or is_cosmo
+    if will_compile and not tool.compiler then
         tool.stderr("hull build: no C compiler available\n")
         tool.stderr("hint: install gcc or clang, or rebuild hull with HL_ENABLE_TCC=1\n")
         tool.rmdir(tmpdir)

--- a/tests/e2e_musl.sh
+++ b/tests/e2e_musl.sh
@@ -136,6 +136,40 @@ if command -v ld.lld >/dev/null 2>&1 && [ -r /usr/lib/crt1.o ]; then
     else
         bad "Tier B (--linker=lld-static) build"; tail -12 /tmp/musl_t.log
     fi
+
+    # A PATH with ONLY ld.lld/lld (no cc/gcc), to prove the link needs no cc.
+    ccfree="$(mktemp -d)"
+    ln -sf "$(command -v ld.lld)" "$ccfree/ld.lld"
+    [ -n "$(command -v lld || true)" ] && ln -sf "$(command -v lld)" "$ccfree/lld"
+
+    # [4] cc-free: with no cc on PATH, libgcc is found by glob (not `cc -print-...`).
+    if PATH="$ccfree" HULL_LIBC_DIR=/usr/lib "$HULL" build "$WORKDIR/static" \
+            --no-verify-platform --linker=lld-static -o "$WORKDIR/ccfree" \
+            >/tmp/musl_cf.log 2>&1 \
+       && "$WORKDIR/ccfree" --no-sandbox >/dev/null 2>&1; then
+        ok "Tier B links with NO cc on PATH (libgcc found by glob, not cc)"
+    else
+        bad "Tier B cc-free build"; tail -10 /tmp/musl_cf.log
+    fi
+
+    # [5] self-contained via an installed bundle: assemble
+    # ~/.hull/tools/libc-musl-<arch> (crt*.o + libc.a + libgcc.a), then build with
+    # NO cc AND no HULL_LIBC_DIR/HULL_LIBGCC - the bundle supplies everything.
+    arch="$(uname -m)"; [ "$arch" = arm64 ] && arch=aarch64
+    floor="${HOME:-/root}/.hull/tools/libc-musl-$arch"
+    if sh scripts/build_musl_floor.sh "$floor" >/tmp/musl_floor.log 2>&1; then
+        if PATH="$ccfree" "$HULL" build "$WORKDIR/static" --no-verify-platform \
+                --linker=lld-static -o "$WORKDIR/bundle" >/tmp/musl_bn.log 2>&1 \
+           && "$WORKDIR/bundle" --no-sandbox >/dev/null 2>&1; then
+            ok "Tier B self-contained via installed libc-musl-$arch bundle (no cc, no HULL_LIBC_DIR)"
+        else
+            bad "Tier B bundle build"; tail -10 /tmp/musl_bn.log
+        fi
+        rm -rf "$floor"
+    else
+        bad "assemble libc-musl bundle"; tail -6 /tmp/musl_floor.log
+    fi
+    rm -rf "$ccfree"
 else
     echo "  skip Tier B (no ld.lld or no musl floor at /usr/lib)"
 fi


### PR DESCRIPTION
The **tested half** of "make Tier B self-contained" (you chose *Both*). Makes `hull build --linker=lld-static` need no C compiler and able to source its whole floor from an installed bundle. **PR 2** (the signed-release producer + `hull tools install libc-musl-<arch>` fetch/extract, post-release-validated like `wamrc`) follows once this lands.

## Changes
- **`linker_lld.c`** — libgcc.a discovery is now **cc-free where possible**: `HULL_LIBGCC` → `<floor>/libgcc.a` (installed bundle) → glob `/usr/lib/gcc/*/*/libgcc.a` (no cc spawn) → `cc -print-libgcc-file-name` (last resort). On any Alpine with `build-base`, `cc` is never spawned.
- **`linker_system.c`** — the floor resolves from an installed bundle `~/.hull/tools/libc-musl-<arch>/` **before** the system musl-dev floor (`HULL_LIBC_DIR` still overrides). Also fixes a **latent bug**: an unset `HULL_LIBC_DIR` made `getenv()` return NULL as `cands[0]`, terminating the loop before `/usr/lib` (masked because the e2e always set it).
- **`build.lua`** — a compiler is required only when we'll actually **compile** (compiler path, or `--with`/cosmo); the default emit path links via `tool.linker` and needs no compiler, so a pure emit + `--linker=lld-static` build works with **no cc at all**. Also fixes **`is_cosmo` misfiring**: with no compiler, `cc` defaults to `tool.cc` (`"cosmocc"`), mis-flagging a native compiler-less build as cosmo — the cc-name heuristic now runs only when a real compiler resolved (matching the code's own "bare cosmocc fallback removed" comment).
- **`scripts/build_musl_floor.sh`** (+ `make floor-musl`) — assemble a self-contained floor bundle (`crt*.o` + `libc.a` + stub `libm`/`libpthread`/… + `libgcc.a`) from a musl host: the contents of a future `libc-musl-<arch>` asset.
- **`tests/e2e_musl.sh`** — two new assertions: Tier B links with **no cc on PATH**, and Tier B is **self-contained via an assembled bundle** (no cc, no `HULL_LIBC_DIR`).

## Verified
`make e2e-musl` **5/5** on `aarch64-alpine-linux-musl` (compute, HTTP, Tier B static, Tier B cc-free, Tier B via bundle); macOS `make test` **61/61**; the normal cc-present build path is unchanged.