### PR TITLE
feat(tools): hull tools install libc-musl-<arch> (signed static-link floor)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -771,6 +771,44 @@ jobs:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
 
+  build-floor-musl:
+    # The libc-musl-<arch> static-link floor bundles pulled by
+    # `hull tools install libc-musl-<arch>` for `hull build --linker=lld-static`
+    # (Tier B). Assembled INSIDE Alpine (musl) - crt*.o + libc.a + stub
+    # libm/libpthread + libgcc.a packed as a flat ustar - so a box with only
+    # hull + ld.lld links a fully static musl binary. Each tar's SHA-256 lands in
+    # the signed hull.sha256 below (same trust chain as wamrc). Native-only (musl
+    # is Linux); the name bakes in the arch, one artifact per arch. Uses the same
+    # scripts/build_musl_floor.sh the tests do. See docs/musl_build.md.
+    name: Build libc-musl floor (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: x86_64
+            os: ubuntu-24.04
+          - name: aarch64
+            os: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Assemble + pack the floor in Alpine (musl)
+        run: |
+          docker run --rm -v "$PWD":/work alpine:3.20 sh -c '
+            set -eu
+            apk add --no-cache build-base >/dev/null 2>&1
+            sh /work/scripts/build_musl_floor.sh /tmp/floor \
+               /work/hull-libc-musl-${{ matrix.name }}.tar
+          '
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: hull-libc-musl-${{ matrix.name }}.tar
+          path: hull-libc-musl-${{ matrix.name }}.tar
+
   build-feature-native:
     # Composable DuckDB feature archive (libhull_feature-duckdb-<arch>.a),
     # shipped as a release asset and pulled by `hull feature install duckdb`
@@ -1069,7 +1107,7 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-24.04
-    needs: [build-cosmo, build-native, build-wamrc, build-feature-native, build-feature-gpu, build-feature-tui, build-feature-postgres, build-feature-mysql, build-feature-lua, build-feature-js]
+    needs: [build-cosmo, build-native, build-wamrc, build-floor-musl, build-feature-native, build-feature-gpu, build-feature-tui, build-feature-postgres, build-feature-mysql, build-feature-lua, build-feature-js]
     permissions:
       contents: write       # publish GitHub release + assets
       id-token: write       # SLSA: OIDC for Sigstore signing
@@ -1090,6 +1128,10 @@ jobs:
           mv artifacts/hull-wamrc-linux-x86_64/hull-wamrc-linux-x86_64    dist/hull-wamrc-linux-x86_64
           mv artifacts/hull-wamrc-linux-aarch64/hull-wamrc-linux-aarch64  dist/hull-wamrc-linux-aarch64
           mv artifacts/hull-wamrc-darwin-arm64/hull-wamrc-darwin-arm64    dist/hull-wamrc-darwin-arm64
+          # libc-musl-<arch> static-link floor bundles (`hull tools install
+          # libc-musl-<arch>`); hashed into hull.sha256 below.
+          mv artifacts/hull-libc-musl-x86_64.tar/hull-libc-musl-x86_64.tar   dist/hull-libc-musl-x86_64.tar
+          mv artifacts/hull-libc-musl-aarch64.tar/hull-libc-musl-aarch64.tar dist/hull-libc-musl-aarch64.tar
           # Per-flavor platform libs. Consumed by `hull platform install
           # <flavor>` -> `hull build --flavor`. Native files:
           # libhull_platform-<flavor>-<arch>.a; cosmo files (dual-arch):
@@ -1215,6 +1257,7 @@ jobs:
         run: |
           sha256sum hull-cosmo hull-linux-x86_64 hull-linux-aarch64 hull-darwin-arm64 \
                     hull-wamrc-linux-x86_64 hull-wamrc-linux-aarch64 hull-wamrc-darwin-arm64 \
+                    hull-libc-musl-x86_64.tar hull-libc-musl-aarch64.tar \
                     hull.sbom.json hull.sbom.cdx.json hull.sbom.spdx.json \
                     libhull.sbom.json libhull.sbom.cdx.json libhull.sbom.spdx.json \
                     hull.build-env.json \
@@ -1290,6 +1333,8 @@ jobs:
             dist/hull-wamrc-linux-x86_64
             dist/hull-wamrc-linux-aarch64
             dist/hull-wamrc-darwin-arm64
+            dist/hull-libc-musl-x86_64.tar
+            dist/hull-libc-musl-aarch64.tar
             dist/hull.sha256
             dist/hull.sbom.json
             dist/hull.sbom.cdx.json
@@ -1309,6 +1354,8 @@ jobs:
             dist/hull-wamrc-linux-x86_64
             dist/hull-wamrc-linux-aarch64
             dist/hull-wamrc-darwin-arm64
+            dist/hull-libc-musl-x86_64.tar
+            dist/hull-libc-musl-aarch64.tar
             dist/hull.sha256
             dist/hull.sbom.json
             dist/hull.sbom.cdx.json

--- a/docs/musl_build.md
+++ b/docs/musl_build.md
@@ -88,19 +88,25 @@ archives reference, e.g. `__multf3`). Both the floor and `libgcc.a` are resolved
 
 So Tier B is **fully self-contained** on any Alpine with `build-base` (the glob
 finds the system `libgcc`; cc is never spawned), and on a box with **nothing**
-but hull + `ld.lld` once the bundle is present:
+but hull + `ld.lld` once the bundle is present. Two ways to get the bundle:
 
 ```sh
-make floor-musl                       # assemble ~/.hull/tools/libc-musl-<arch>
-hull build --linker=lld-static ./app  # no musl-dev, no gcc, no cc needed
+# 1. Fetch a prebuilt, Ed25519-signed bundle from Hull's release (no musl host):
+hull tools install libc-musl-$(uname -m)   # -> ~/.hull/tools/libc-musl-<arch>/
+# 2. Or assemble it yourself on a musl host:
+make floor-musl                            # (wrapper over scripts/build_musl_floor.sh)
+
+hull build --linker=lld-static ./app       # no musl-dev, no gcc, no cc needed
 ```
 
-`make floor-musl` (a wrapper over `scripts/build_musl_floor.sh`) collects
-`crt*.o` + `libc.a` + `libgcc.a` from a musl host into
-`~/.hull/tools/libc-musl-<arch>/`, and the linker resolves that dir automatically
-(above). A `hull tools install libc-musl-<arch>` that fetches a prebuilt,
-Ed25519-signed bundle from Hull's release - so end users need no musl host to
-assemble one - is the next step (the release producer + verified-fetch installer).
+The bundle holds `crt*.o` + `libc.a` + the stub `libm`/`libpthread` + `libgcc.a`,
+packed as a flat ustar. `hull tools install libc-musl-<arch>` fetches
+`hull-libc-musl-<arch>.tar` and verifies its SHA-256 against the signed
+`hull.sha256` manifest (the same trust chain as `hull tools install wamrc` /
+`hull update`) before extracting to `~/.hull/tools/libc-musl-<arch>/`, which the
+linker resolves automatically. Published for `linux-x86_64` and `linux-aarch64`
+(musl is Linux; macOS/cosmo have no floor). Like `wamrc`, the live install is
+exercised post-release via `tests/release_smoke.sh`, not in CI.
 
 `zig cc` (`--linker=zig`) remains the turnkey cross-target alternative (bundles
 crt+libc+compiler-rt for ~40 targets); Tier B is the purist `ld.lld` + floor

--- a/include/hull/tools_install.h
+++ b/include/hull/tools_install.h
@@ -47,6 +47,12 @@ typedef struct {
     int         has_linux_aarch64;
     int         has_darwin_arm64;
     int         has_cosmo;
+    /* A "bundle" tool ships as a `hull-<name>.tar` archive of several files
+     * (not a single executable) and installs by EXTRACTING to a DIRECTORY
+     * $HOME/.hull/tools/<name>/ rather than writing one blob + a symlink.
+     * Used by the libc-musl-<arch> static-link floor (crt*.o/libc.a/libgcc.a
+     * for `hull build --linker=lld-static`). 0 = a normal single-binary tool. */
+    int         is_bundle;
 } HlToolSpec;
 
 /**
@@ -132,5 +138,19 @@ int hl_tools_install_path(const char *name, char *out, size_t out_sz);
  */
 int hl_tools_lookup_path(const char *name, const char *hull_exe,
                          char *out, size_t out_sz);
+
+/**
+ * @brief Extract a ustar (.tar) bundle's flat files into @p dest_dir.
+ *
+ * For `is_bundle` tools. The archive is already SHA-256-verified by the caller
+ * (commands/tools.c) against the signed manifest, so this is trusted content;
+ * it still validates each member is a bare regular-file name (no '/', no "..",
+ * not absolute) as defense in depth and refuses anything else. @p dest_dir is
+ * created 0755; existing same-named files are overwritten.
+ *
+ * @returns 0 on success, -1 on a malformed archive / path / write error.
+ */
+int hl_tools_extract_tar(const unsigned char *tar, size_t tar_len,
+                         const char *dest_dir);
 
 #endif /* HL_TOOLS_INSTALL_H */

--- a/scripts/build_musl_floor.sh
+++ b/scripts/build_musl_floor.sh
@@ -1,12 +1,15 @@
 #!/bin/sh
-# build_musl_floor.sh <dest-dir>
+# build_musl_floor.sh <dest-dir> [<tar-out>]
 #
 # Assemble a self-contained musl static-link floor into <dest-dir>: the crt
 # startup objects + static libc + the compiler runtime, so `hull build
 # --linker=lld-static` (Tier B) can link a fully static musl binary with NOTHING
 # else installed (no musl-dev, no gcc, no cc). This is what a
 # `hull tools install libc-musl-<arch>` bundle contains; it is used by
-# tests/e2e_musl.sh and (in a later step) by the release producer.
+# tests/e2e_musl.sh and by the release producer.
+#
+# With a 2nd arg, also pack the floor as a flat ustar archive at <tar-out> -
+# the exact `hull-libc-musl-<arch>.tar` asset the installer fetches + extracts.
 #
 # Must run on a musl system (Alpine) with musl-dev + gcc present. Sources:
 #   crt1.o / crti.o / crtn.o / libc.a  <- $HULL_LIBC_DIR (default /usr/lib)
@@ -50,3 +53,13 @@ cp "$LIBGCC" "$DEST/libgcc.a"
 
 echo "build_musl_floor: assembled a self-contained floor in $DEST:"
 ls -1 "$DEST"
+
+# Optional: pack a flat ustar archive (the release asset). `-C "$DEST" .` makes
+# every member a bare "./<file>" - no absolute paths, no leading dirs - which is
+# exactly what hl_tools_extract_tar expects (it strips the "./" and refuses any
+# other path component).
+TAR_OUT="${2:-}"
+if [ -n "$TAR_OUT" ]; then
+    tar cf "$TAR_OUT" -C "$DEST" .
+    echo "build_musl_floor: packed $TAR_OUT ($(wc -c < "$TAR_OUT") bytes)"
+fi

--- a/src/hull/commands/tools.c
+++ b/src/hull/commands/tools.c
@@ -41,6 +41,7 @@
 #include <keel/allocator.h>
 #include <keel/tls_mbedtls.h>
 
+#include <dirent.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdbool.h>
@@ -104,6 +105,23 @@ static int tool_installed(const char *name, char *out_path, size_t out_path_sz,
     if (hl_tools_install_path(name, path, sizeof(path)) != 0) return 0;
     struct stat st;
     if (stat(path, &st) != 0) return 0;
+
+    const HlToolSpec *spec = hl_tools_find(name);
+    if (spec && spec->is_bundle) {
+        /* A bundle installs as a DIRECTORY; consider it present when the dir
+         * exists and holds the crt1.o sentinel (a complete floor). */
+        if (!S_ISDIR(st.st_mode)) return 0;
+        char crt[PATH_MAX];
+        int n = snprintf(crt, sizeof(crt), "%s/crt1.o", path);
+        struct stat cs;
+        if (n < 0 || (size_t)n >= sizeof(crt) ||
+            stat(crt, &cs) != 0 || !S_ISREG(cs.st_mode))
+            return 0;
+        if (out_path && out_path_sz > 0) snprintf(out_path, out_path_sz, "%s", path);
+        if (out_size) *out_size = 0;
+        return 1;
+    }
+
     if (!S_ISREG(st.st_mode)) return 0;
     if (out_path && out_path_sz > 0)
         snprintf(out_path, out_path_sz, "%s", path);
@@ -311,6 +329,26 @@ static int install_one(const HlToolSpec *spec, const char *platform,
     }
     fprintf(stdout, "hull tools: SHA-256 verified, blob stored (%s)\n",
             blob_id);
+
+    /* A bundle (libc-musl-<arch>) is a .tar of several files, not one
+     * executable: extract the just-verified archive into ~/.hull/tools/<name>/
+     * and we're done - no blob chmod / symlink dance. */
+    if (spec->is_bundle) {
+        char dest[PATH_MAX];
+        int rc = hl_tools_install_path(spec->name, dest, sizeof(dest));
+        if (rc == 0)
+            rc = hl_tools_extract_tar((const unsigned char *)body, body_len, dest);
+        hl_blob_store_close(store);
+        kl_free(alloc, body, body_len);
+        if (rc != 0) {
+            fprintf(stderr, "hull tools: failed to extract %s bundle\n", spec->name);
+            return -1;
+        }
+        fprintf(stdout, "hull tools: installed %s → %s/ (bundle)\n",
+                spec->name, dest);
+        return 0;
+    }
+
     kl_free(alloc, body, body_len);
 
     /* Compose the on-disk blob path so we can chmod it executable and
@@ -475,7 +513,8 @@ static int cmd_uninstall(int argc, char **argv)
         return 2;
     }
     const char *name = argv[1];
-    if (!hl_tools_find(name)) {
+    const HlToolSpec *spec = hl_tools_find(name);
+    if (!spec) {
         fprintf(stderr, "hull tools: unknown tool '%s'\n", name);
         return 1;
     }
@@ -484,6 +523,39 @@ static int cmd_uninstall(int argc, char **argv)
         fprintf(stderr, "hull tools: cannot compose install path\n");
         return 1;
     }
+
+    /* A bundle installs as a flat directory (crt*.o/libc.a/...); unlink its
+     * files then rmdir. The floor has no subdirectories, so a shallow sweep is
+     * enough. */
+    if (spec->is_bundle) {
+        DIR *d = opendir(path);
+        if (!d) {
+            if (errno == ENOENT) {
+                fprintf(stdout, "hull tools: %s is not installed\n", name);
+                return 0;
+            }
+            fprintf(stderr, "hull tools: cannot open %s: %s\n",
+                    path, strerror(errno));
+            return 1;
+        }
+        struct dirent *e;
+        while ((e = readdir(d)) != NULL) {
+            if (strcmp(e->d_name, ".") == 0 || strcmp(e->d_name, "..") == 0)
+                continue;
+            char fp[PATH_MAX];
+            int fn = snprintf(fp, sizeof(fp), "%s/%s", path, e->d_name);
+            if (fn > 0 && (size_t)fn < sizeof(fp)) (void)unlink(fp);
+        }
+        closedir(d);
+        if (rmdir(path) != 0 && errno != ENOENT) {
+            fprintf(stderr, "hull tools: cannot remove %s: %s\n",
+                    path, strerror(errno));
+            return 1;
+        }
+        fprintf(stdout, "hull tools: uninstalled %s (%s)\n", name, path);
+        return 0;
+    }
+
     if (unlink(path) != 0) {
         if (errno == ENOENT) {
             fprintf(stdout, "hull tools: %s is not installed\n", name);

--- a/src/hull/tools_install.c
+++ b/src/hull/tools_install.c
@@ -50,6 +50,26 @@ static const HlToolSpec REGISTRY[] = {
          * users build from source with `make wamrc`. See docs/tools_install.md. */
         .has_cosmo         = 0,
     },
+    /* The static-link floor bundles for `hull build --linker=lld-static` (Tier B):
+     * crt*.o + libc.a + the stub libm/libpthread + libgcc.a, so a box with only
+     * hull + ld.lld can link a fully static musl binary - no musl-dev, no gcc.
+     * Arch-baked into the name (one row per arch, each published only for its
+     * platform) so the install dir matches the linker's ~/.hull/tools/
+     * libc-musl-<arch>/ lookup. Native-only; musl is Linux. See docs/musl_build.md. */
+    {
+        .name              = "libc-musl-x86_64",
+        .description       = "musl static-link floor (crt/libc/libgcc) for "
+                             "`hull build --linker=lld-static` on x86_64.",
+        .has_linux_x86_64  = 1,
+        .is_bundle         = 1,
+    },
+    {
+        .name              = "libc-musl-aarch64",
+        .description       = "musl static-link floor (crt/libc/libgcc) for "
+                             "`hull build --linker=lld-static` on aarch64.",
+        .has_linux_aarch64 = 1,
+        .is_bundle         = 1,
+    },
     { 0 }  /* sentinel */
 };
 
@@ -107,8 +127,97 @@ int hl_tools_asset_name(const HlToolSpec *spec, const char *platform,
 {
     if (!spec || !platform || !out || out_sz == 0) return -1;
     if (!hl_tools_published_for(spec, platform))   return -1;
-    int n = snprintf(out, out_sz, "hull-%s-%s", spec->name, platform);
+    /* A bundle's arch is already baked into its name (libc-musl-<arch>) and it
+     * is published for exactly that one platform, so the asset is
+     * `hull-<name>.tar` - no redundant platform suffix. A binary tool keeps the
+     * per-platform `hull-<name>-<platform>` form. */
+    int n = spec->is_bundle
+        ? snprintf(out, out_sz, "hull-%s.tar", spec->name)
+        : snprintf(out, out_sz, "hull-%s-%s", spec->name, platform);
     if (n < 0 || (size_t)n >= out_sz) return -1;
+    return 0;
+}
+
+/* ── ustar (.tar) bundle extraction ──────────────────────────────────
+ *
+ * A minimal, flat, read-only ustar reader for `is_bundle` tools. We control
+ * both the producer (build_musl_floor.sh -> `tar cf`) and consumer, and the
+ * archive is SHA-256-verified before we get here, so we only need the regular-
+ * file path and reject everything unusual. FLAT only: every member must be a
+ * bare filename (after stripping a leading "./") with no other '/', no "..",
+ * not absolute - a floor bundle has no subdirectories.
+ */
+static int ensure_dir(const char *path, mode_t mode);   /* defined below */
+
+static unsigned long tar_octal(const unsigned char *p, size_t n)
+{
+    unsigned long v = 0;
+    size_t i = 0;
+    while (i < n && (p[i] == ' ' || p[i] == '\0')) i++;   /* leading pad */
+    for (; i < n && p[i] >= '0' && p[i] <= '7'; i++)
+        v = (v << 3) + (unsigned long)(p[i] - '0');
+    return v;
+}
+
+/* Validate + normalize a ustar member name to a bare filename. Returns the
+ * pointer to the flat name on success, NULL to reject. */
+static const char *tar_flat_name(const char *name)
+{
+    if (name[0] == '/') return NULL;                 /* absolute */
+    if (name[0] == '.' && name[1] == '/') name += 2; /* strip leading "./" */
+    if (name[0] == '\0') return NULL;                /* the "./" dir entry */
+    if (strstr(name, "..")) return NULL;             /* traversal */
+    if (strchr(name, '/'))  return NULL;             /* not flat */
+    return name;
+}
+
+int hl_tools_extract_tar(const unsigned char *tar, size_t tar_len,
+                         const char *dest_dir)
+{
+    if (!tar || !dest_dir) return -1;
+    if (ensure_dir(dest_dir, 0755) != 0) return -1;
+
+    size_t off = 0;
+    while (off + 512 <= tar_len) {
+        const unsigned char *hdr = tar + off;
+
+        /* An all-zero header block marks end of archive. */
+        int zero = 1;
+        for (int i = 0; i < 512; i++) if (hdr[i]) { zero = 0; break; }
+        if (zero) break;
+
+        /* name is NUL-padded within [0,100); ensure it terminates. */
+        char name[101];
+        memcpy(name, hdr, 100);
+        name[100] = '\0';
+
+        char typeflag = (char)hdr[156];
+        unsigned long size = tar_octal(hdr + 124, 12);
+
+        off += 512;
+        if (off + size > tar_len) return -1;          /* truncated data */
+
+        /* Only extract regular files ('0' or legacy '\0'); skip dir/link/etc. */
+        if (typeflag == '0' || typeflag == '\0') {
+            const char *flat = tar_flat_name(name);
+            if (!flat) return -1;
+
+            char path[PATH_MAX];
+            int pn = snprintf(path, sizeof(path), "%s/%s", dest_dir, flat);
+            if (pn < 0 || (size_t)pn >= sizeof(path)) return -1;
+
+            FILE *f = fopen(path, "wb");
+            if (!f) return -1;
+            if (size && fwrite(tar + off, 1, size, f) != size) {
+                fclose(f);
+                return -1;
+            }
+            if (fclose(f) != 0) return -1;
+        }
+
+        /* Advance past the data, rounded up to the 512-byte block. */
+        off += (size + 511) & ~(size_t)511;
+    }
     return 0;
 }
 

--- a/tests/hull/test_tools_install.c
+++ b/tests/hull/test_tools_install.c
@@ -420,4 +420,132 @@ UTEST_F(tools_fixture, lookup_rejects_invalid_name) {
     ASSERT_EQ(hl_tools_lookup_path("foo/bar", NULL, out, sizeof(out)), -1);
 }
 
+/* ── libc-musl bundle (.tar) tests ─────────────────────────────────── */
+
+/* Minimal ustar header (name, size, regular-file typeflag). Our reader ignores
+ * the checksum field, so we leave it blank. */
+static void tar_put_header(unsigned char *b, const char *name, size_t size) {
+    memset(b, 0, 512);
+    strncpy((char *)b, name, 99);
+    snprintf((char *)(b + 124), 12, "%011o", (unsigned)size);  /* size, octal */
+    memset(b + 148, ' ', 8);                                   /* chksum: blank */
+    b[156] = '0';                                              /* regular file */
+}
+
+static void tar_add_file(unsigned char *buf, size_t *off,
+                         const char *name, const char *data, size_t len) {
+    tar_put_header(buf + *off, name, len);
+    *off += 512;
+    memcpy(buf + *off, data, len);
+    *off += (len + 511) & ~(size_t)511;
+}
+
+UTEST(tools_bundle, registry_has_musl_floors) {
+    const HlToolSpec *x = hl_tools_find("libc-musl-x86_64");
+    const HlToolSpec *a = hl_tools_find("libc-musl-aarch64");
+    ASSERT_NE(x, NULL);
+    ASSERT_NE(a, NULL);
+    ASSERT_TRUE(x->is_bundle);
+    ASSERT_TRUE(a->is_bundle);
+    ASSERT_TRUE(hl_tools_published_for(x, "linux-x86_64"));
+    ASSERT_EQ(hl_tools_published_for(x, "linux-aarch64"), 0);  /* wrong arch */
+    ASSERT_TRUE(hl_tools_published_for(a, "linux-aarch64"));
+    ASSERT_EQ(hl_tools_published_for(a, "darwin-arm64"), 0);
+}
+
+UTEST(tools_bundle, asset_name_is_dot_tar) {
+    char asset[128];
+    ASSERT_EQ(hl_tools_asset_name(hl_tools_find("libc-musl-x86_64"),
+                                  "linux-x86_64", asset, sizeof(asset)), 0);
+    ASSERT_STREQ(asset, "hull-libc-musl-x86_64.tar");
+    /* a binary tool keeps the per-platform form */
+    ASSERT_EQ(hl_tools_asset_name(hl_tools_find("wamrc"),
+                                  "linux-x86_64", asset, sizeof(asset)), 0);
+    ASSERT_STREQ(asset, "hull-wamrc-linux-x86_64");
+}
+
+UTEST_F(tools_fixture, extract_tar_bundle) {
+    unsigned char *buf = calloc(1, 8192);
+    ASSERT_NE(buf, NULL);
+    size_t off = 0;
+    tar_add_file(buf, &off, "./crt1.o", "OBJ1", 4);        /* leading ./ stripped */
+    tar_add_file(buf, &off, "libgcc.a", "ARCHIVE-BYTES", 13);
+    off += 512;                                            /* zero terminator block */
+
+    char dest[PATH_MAX];
+    snprintf(dest, sizeof(dest), "%s/floor", utest_fixture->tmpdir);
+    ASSERT_EQ(hl_tools_extract_tar(buf, off, dest), 0);
+
+    char p[PATH_MAX], rd[64];
+    FILE *f;
+    snprintf(p, sizeof(p), "%s/crt1.o", dest);
+    f = fopen(p, "rb"); ASSERT_NE(f, NULL);
+    size_t n = fread(rd, 1, sizeof(rd), f); fclose(f);
+    ASSERT_EQ(n, (size_t)4);
+    ASSERT_EQ(memcmp(rd, "OBJ1", 4), 0);
+
+    snprintf(p, sizeof(p), "%s/libgcc.a", dest);
+    f = fopen(p, "rb"); ASSERT_NE(f, NULL);
+    n = fread(rd, 1, sizeof(rd), f); fclose(f);
+    ASSERT_EQ(n, (size_t)13);
+    ASSERT_EQ(memcmp(rd, "ARCHIVE-BYTES", 13), 0);
+    free(buf);
+}
+
+/* Extract an archive produced by the SYSTEM `tar` (busybox / bsdtar / GNU),
+ * the way scripts/build_musl_floor.sh does it - proves the producer/consumer
+ * format contract, not just our hand-rolled headers. Skips if tar is absent. */
+UTEST_F(tools_fixture, extract_real_tar) {
+    char srcdir[PATH_MAX], f1[PATH_MAX], tarpath[PATH_MAX], cmd[PATH_MAX * 3];
+    snprintf(srcdir, sizeof(srcdir), "%s/src", utest_fixture->tmpdir);
+    ASSERT_EQ(mkdir(srcdir, 0755), 0);
+    snprintf(f1, sizeof(f1), "%s/crt1.o", srcdir);
+    FILE *w = fopen(f1, "wb");
+    ASSERT_NE(w, NULL);
+    fwrite("REALTARBYTES", 1, 12, w);
+    fclose(w);
+
+    snprintf(tarpath, sizeof(tarpath), "%s/floor.tar", utest_fixture->tmpdir);
+    /* The fixture blanks PATH for hermetic lookup tests; give system() a PATH. */
+    setenv("PATH", "/usr/bin:/bin", 1);
+    snprintf(cmd, sizeof(cmd), "tar cf '%s' -C '%s' . 2>/dev/null", tarpath, srcdir);
+    if (system(cmd) != 0) { setenv("PATH", "", 1); return; }  /* no tar → skip */
+    setenv("PATH", "", 1);
+
+    FILE *tf = fopen(tarpath, "rb");
+    ASSERT_NE(tf, NULL);
+    fseek(tf, 0, SEEK_END);
+    long tlen = ftell(tf);
+    fseek(tf, 0, SEEK_SET);
+    ASSERT_GT(tlen, 512);
+    unsigned char *tbuf = malloc((size_t)tlen);
+    ASSERT_NE(tbuf, NULL);
+    ASSERT_EQ(fread(tbuf, 1, (size_t)tlen, tf), (size_t)tlen);
+    fclose(tf);
+
+    char dest[PATH_MAX], out[PATH_MAX], rd[32];
+    snprintf(dest, sizeof(dest), "%s/floor", utest_fixture->tmpdir);
+    ASSERT_EQ(hl_tools_extract_tar(tbuf, (size_t)tlen, dest), 0);
+    snprintf(out, sizeof(out), "%s/crt1.o", dest);
+    FILE *rf = fopen(out, "rb");
+    ASSERT_NE(rf, NULL);
+    size_t n = fread(rd, 1, sizeof(rd), rf);
+    fclose(rf);
+    ASSERT_EQ(n, (size_t)12);
+    ASSERT_EQ(memcmp(rd, "REALTARBYTES", 12), 0);
+    free(tbuf);
+}
+
+UTEST_F(tools_fixture, extract_tar_rejects_traversal) {
+    unsigned char *buf = calloc(1, 4096);
+    ASSERT_NE(buf, NULL);
+    size_t off = 0;
+    tar_add_file(buf, &off, "../escape.o", "X", 1);
+    off += 512;
+    char dest[PATH_MAX];
+    snprintf(dest, sizeof(dest), "%s/floor2", utest_fixture->tmpdir);
+    ASSERT_EQ(hl_tools_extract_tar(buf, off, dest), -1);   /* traversal refused */
+    free(buf);
+}
+
 UTEST_MAIN()

--- a/tests/release_smoke.sh
+++ b/tests/release_smoke.sh
@@ -216,6 +216,34 @@ if [ "$(uname -s)" = "Linux" ]; then
     assert "tcc file removed"              [ ! -e "$TCC_PATH" ]
 fi
 
+# libc-musl static-link floor bundle (Tier B). Published for linux-x86_64 /
+# linux-aarch64 only. This is the ONLY multi-file .tar bundle asset, so it
+# exercises the new install path end to end: fetch -> SHA-256 verify -> ustar
+# extract into a directory -> directory uninstall. Linux-only (musl is Linux).
+if [ "$(uname -s)" = "Linux" ]; then
+    A=$(uname -m); [ "$A" = "arm64" ] && A=aarch64
+    FLOOR_TOOL="libc-musl-$A"
+    FLOOR_DIR="$HOME/.hull/tools/$FLOOR_TOOL"
+    "$HULL" tools uninstall "$FLOOR_TOOL" >/dev/null 2>&1 || true
+    echo ""
+    echo "── hull tools install $FLOOR_TOOL (Tier B floor bundle, LIVE download) ──"
+    OUT=$("$HULL" tools install "$FLOOR_TOOL" 2>&1); RC=$?
+    echo "$OUT" | sed 's/^/    /'
+    assert "exits 0"                       [ "$RC" -eq 0 ]
+    assert_contains "SHA-256 verified"     "$OUT" "SHA-256 verified"
+    assert_contains "installed as bundle"  "$OUT" "(bundle)"
+    assert "floor dir created"             [ -d "$FLOOR_DIR" ]
+    assert "crt1.o extracted"              [ -f "$FLOOR_DIR/crt1.o" ]
+    assert "libc.a extracted"              [ -f "$FLOOR_DIR/libc.a" ]
+    assert "libgcc.a extracted"            [ -f "$FLOOR_DIR/libgcc.a" ]
+    OUT=$("$HULL" tools list 2>&1)
+    assert_contains "list shows floor installed"  "$OUT" "$FLOOR_TOOL"
+    echo "── hull tools uninstall $FLOOR_TOOL ──"
+    OUT=$("$HULL" tools uninstall "$FLOOR_TOOL" 2>&1)
+    assert_contains "floor uninstalled"    "$OUT" "uninstalled $FLOOR_TOOL"
+    assert "floor dir removed"             [ ! -d "$FLOOR_DIR" ]
+fi
+
 # Per-flavor platform lib install (native single-arch lib).
 smoke_platform_install
 


### PR DESCRIPTION
PR 2 of "Both": the release-published half of a self-contained Tier B. Fetch a prebuilt, **Ed25519-signed** musl floor bundle so a box with only `hull` + `ld.lld` links a fully static musl binary — no musl host needed to assemble one. (PR 1 (#195) made the linker *consume* such a bundle + cc-free discovery; this ships and installs it.)

## New: a "bundle" tool kind
A bundle is a `hull-<name>.tar` (flat ustar) of several files that installs by **extracting to a directory** `~/.hull/tools/<name>/`, not writing one executable. Two registry rows — `libc-musl-x86_64` / `libc-musl-aarch64` — each published only for its platform, arch baked into the name so the install dir matches PR 1's linker lookup.

- **`HlToolSpec.is_bundle`** + the two rows; asset name is `hull-<name>.tar` for a bundle (binaries keep `hull-<name>-<platform>`).
- **`hl_tools_extract_tar`** — a minimal, flat, read-only ustar reader. The archive is **SHA-256-verified against the signed manifest before extraction** (same trust chain as `wamrc`); it still rejects any member that isn't a bare regular-file name (no `/`, no `..`, not absolute) as defense in depth.
- **`commands/tools.c`** — install extracts the verified tar; `tool_installed` treats a bundle as a directory (crt1.o sentinel); `uninstall` removes the directory.
- **`release.yml`** — a `build-floor-musl` job assembles + packs the floor **inside Alpine (musl)** per arch via `scripts/build_musl_floor.sh`, and the release job hashes it into the signed `hull.sha256` + attaches it (the `wamrc` pattern).
- **`build_musl_floor.sh`** grows an optional `<tar-out>` arg (the exact asset); **`release_smoke.sh`** installs/uninstalls the floor post-release.

## Testing
`make test` **61/61**, covering: the ustar extractor (**hand-built + real `tar` output + traversal rejection**), the bundle registry/asset-name, dir-based `tool_installed`, and directory uninstall.

**Honest boundary:** the live GitHub fetch can't be CI-tested until a release publishes the asset (the `wamrc` constraint) — it's exercised post-release by `release_smoke.sh`, and `release.yml` is validated by the pre-release dry-run. `actionlint` is clean on the new job + wiring.