### PR TITLE
chore(smoke): drop the retired tcc-as-a-tool section from release_smoke.sh

### DIFF
--- a/tests/release_smoke.sh
+++ b/tests/release_smoke.sh
@@ -199,22 +199,8 @@ OUT=$("$HULL" tools uninstall wamrc 2>&1)
 assert_contains "uninstalled"          "$OUT" "uninstalled wamrc"
 assert "file removed"                  [ ! -e "$WAMRC_PATH" ]
 
-# tcc is a Linux-only tool (ELF); skip the live install on macOS/cosmo where
-# it isn't published.
-if [ "$(uname -s)" = "Linux" ]; then
-    echo ""
-    echo "── hull tools install tcc (LIVE GitHub HTTPS download) ──"
-    OUT=$("$HULL" tools install tcc 2>&1)
-    assert_contains "tcc installed"        "$OUT" "tcc"
-    TCC_PATH="$HOME/.hull/tools/tcc"
-    assert "tcc file present"              [ -x "$TCC_PATH" ]
-    OUT=$("$TCC_PATH" -v 2>&1 || true)
-    assert_contains "tcc -v runs"          "$OUT" "tcc"
-    echo "── hull tools uninstall tcc ──"
-    OUT=$("$HULL" tools uninstall tcc 2>&1)
-    assert_contains "tcc uninstalled"      "$OUT" "uninstalled tcc"
-    assert "tcc file removed"              [ ! -e "$TCC_PATH" ]
-fi
+# (tcc-as-a-tool was retired in the compiler-free work - it is no longer in the
+# registry nor published, so there is no `hull tools install tcc` to smoke-test.)
 
 # libc-musl static-link floor bundle (Tier B). Published for linux-x86_64 /
 # linux-aarch64 only. This is the ONLY multi-file .tar bundle asset, so it


### PR DESCRIPTION
`tcc`-as-a-tool was retired in the compiler-free work — it's no longer in the tool registry (`src/hull/tools_install.c`) nor published by `release.yml`, so `hull tools install tcc` returns "unknown tool" and the smoke section's asserts always fail. Surfaced during the libc-musl floor dry-run smoke (4 failures, of which 2 were this dead section). Pure dead-test removal; replaced with a one-line comment noting why there's no tcc smoke. `release_smoke.sh` is a manual post-release script (not run in CI); `sh -n` clean.