### PR TITLE
feat(tools): generalize bundle install for nested toolchain trees (lld/zig prep)

### DIFF
--- a/include/hull/tools_install.h
+++ b/include/hull/tools_install.h
@@ -49,10 +49,18 @@ typedef struct {
     int         has_cosmo;
     /* A "bundle" tool ships as a `hull-<name>.tar` archive of several files
      * (not a single executable) and installs by EXTRACTING to a DIRECTORY
-     * $HOME/.hull/tools/<name>/ rather than writing one blob + a symlink.
-     * Used by the libc-musl-<arch> static-link floor (crt*.o/libc.a/libgcc.a
-     * for `hull build --linker=lld-static`). 0 = a normal single-binary tool. */
+     * $HOME/.hull/tools/<name>/ rather than writing one blob + a symlink. The
+     * archive may be nested (subdirs), e.g. zig's lib/ tree. Used by the
+     * libc-musl-<arch> static-link floor and the lld/zig toolchains.
+     * 0 = a normal single-binary tool. */
     int         is_bundle;
+    /* For a bundle: the primary file inside the extracted dir. It proves the
+     * bundle is installed (tool_installed checks $dir/<bundle_entry>) and, when
+     * it is the toolchain executable (zig, lld), is what hl_tools_lookup_path
+     * resolves to ($HOME/.hull/tools/<name>/<bundle_entry>). Data-only bundles
+     * (the floor) point it at a sentinel file (crt1.o) that is never exec-looked
+     * up. NULL for a single-binary tool. */
+    const char *bundle_entry;
 } HlToolSpec;
 
 /**

--- a/src/hull/commands/tools.c
+++ b/src/hull/commands/tools.c
@@ -109,13 +109,15 @@ static int tool_installed(const char *name, char *out_path, size_t out_path_sz,
     const HlToolSpec *spec = hl_tools_find(name);
     if (spec && spec->is_bundle) {
         /* A bundle installs as a DIRECTORY; consider it present when the dir
-         * exists and holds the crt1.o sentinel (a complete floor). */
-        if (!S_ISDIR(st.st_mode)) return 0;
-        char crt[PATH_MAX];
-        int n = snprintf(crt, sizeof(crt), "%s/crt1.o", path);
+         * exists and holds its bundle_entry sentinel (crt1.o for the floor, the
+         * zig/lld executable for a toolchain - a complete extraction). */
+        if (!S_ISDIR(st.st_mode) || !spec->bundle_entry) return 0;
+        char sentinel[PATH_MAX];
+        int n = snprintf(sentinel, sizeof(sentinel), "%s/%s", path,
+                         spec->bundle_entry);
         struct stat cs;
-        if (n < 0 || (size_t)n >= sizeof(crt) ||
-            stat(crt, &cs) != 0 || !S_ISREG(cs.st_mode))
+        if (n < 0 || (size_t)n >= sizeof(sentinel) ||
+            stat(sentinel, &cs) != 0 || !S_ISREG(cs.st_mode))
             return 0;
         if (out_path && out_path_sz > 0) snprintf(out_path, out_path_sz, "%s", path);
         if (out_size) *out_size = 0;
@@ -506,6 +508,31 @@ static int cmd_install(int argc, char **argv, const char *repo)
 
 /* ── `hull tools uninstall` ──────────────────────────────────────── */
 
+/* Recursively remove a file or directory tree (an extracted bundle, which may
+ * be nested - zig's lib/). Depth is bounded by the bundle's real nesting.
+ * Returns 0 on success, -1 on any failure (errno set). */
+static int rm_rf(const char *path)
+{
+    struct stat st;
+    if (lstat(path, &st) != 0) return errno == ENOENT ? 0 : -1;
+    if (!S_ISDIR(st.st_mode)) return unlink(path) == 0 ? 0 : -1;
+
+    DIR *d = opendir(path);
+    if (!d) return -1;
+    int rc = 0;
+    struct dirent *e;
+    while ((e = readdir(d)) != NULL) {
+        if (strcmp(e->d_name, ".") == 0 || strcmp(e->d_name, "..") == 0) continue;
+        char child[PATH_MAX];
+        int n = snprintf(child, sizeof(child), "%s/%s", path, e->d_name);
+        if (n < 0 || (size_t)n >= sizeof(child)) { rc = -1; continue; }
+        if (rm_rf(child) != 0) rc = -1;
+    }
+    closedir(d);
+    if (rmdir(path) != 0) rc = -1;
+    return rc;
+}
+
 static int cmd_uninstall(int argc, char **argv)
 {
     if (argc < 2) {
@@ -524,30 +551,20 @@ static int cmd_uninstall(int argc, char **argv)
         return 1;
     }
 
-    /* A bundle installs as a flat directory (crt*.o/libc.a/...); unlink its
-     * files then rmdir. The floor has no subdirectories, so a shallow sweep is
-     * enough. */
+    /* A bundle installs as a DIRECTORY, possibly nested (zig's lib/ tree).
+     * Remove it recursively - nftw(FTW_DEPTH) visits children before parents. */
     if (spec->is_bundle) {
-        DIR *d = opendir(path);
-        if (!d) {
+        struct stat bst;
+        if (stat(path, &bst) != 0) {
             if (errno == ENOENT) {
                 fprintf(stdout, "hull tools: %s is not installed\n", name);
                 return 0;
             }
-            fprintf(stderr, "hull tools: cannot open %s: %s\n",
+            fprintf(stderr, "hull tools: cannot stat %s: %s\n",
                     path, strerror(errno));
             return 1;
         }
-        struct dirent *e;
-        while ((e = readdir(d)) != NULL) {
-            if (strcmp(e->d_name, ".") == 0 || strcmp(e->d_name, "..") == 0)
-                continue;
-            char fp[PATH_MAX];
-            int fn = snprintf(fp, sizeof(fp), "%s/%s", path, e->d_name);
-            if (fn > 0 && (size_t)fn < sizeof(fp)) (void)unlink(fp);
-        }
-        closedir(d);
-        if (rmdir(path) != 0 && errno != ENOENT) {
+        if (rm_rf(path) != 0) {
             fprintf(stderr, "hull tools: cannot remove %s: %s\n",
                     path, strerror(errno));
             return 1;

--- a/src/hull/tools_install.c
+++ b/src/hull/tools_install.c
@@ -62,6 +62,7 @@ static const HlToolSpec REGISTRY[] = {
                              "`hull build --linker=lld-static` on x86_64.",
         .has_linux_x86_64  = 1,
         .is_bundle         = 1,
+        .bundle_entry      = "crt1.o",   /* data-only floor; not exec-resolved */
     },
     {
         .name              = "libc-musl-aarch64",
@@ -69,6 +70,7 @@ static const HlToolSpec REGISTRY[] = {
                              "`hull build --linker=lld-static` on aarch64.",
         .has_linux_aarch64 = 1,
         .is_bundle         = 1,
+        .bundle_entry      = "crt1.o",
     },
     { 0 }  /* sentinel */
 };
@@ -140,12 +142,12 @@ int hl_tools_asset_name(const HlToolSpec *spec, const char *platform,
 
 /* ── ustar (.tar) bundle extraction ──────────────────────────────────
  *
- * A minimal, flat, read-only ustar reader for `is_bundle` tools. We control
- * both the producer (build_musl_floor.sh -> `tar cf`) and consumer, and the
- * archive is SHA-256-verified before we get here, so we only need the regular-
- * file path and reject everything unusual. FLAT only: every member must be a
- * bare filename (after stripping a leading "./") with no other '/', no "..",
- * not absolute - a floor bundle has no subdirectories.
+ * A minimal read-only ustar reader for `is_bundle` tools. We control both the
+ * producer (`tar cf`) and consumer, and the archive is SHA-256-verified before
+ * we get here, so we ship files + directories only (producers dereference any
+ * symlink to a copy). NESTED relative paths are allowed (zig's lib/ tree); every
+ * member is still validated - not absolute, no ".." component - as defense in
+ * depth. The exec bit is preserved (zig / ld.lld need +x).
  */
 static int ensure_dir(const char *path, mode_t mode);   /* defined below */
 
@@ -159,16 +161,48 @@ static unsigned long tar_octal(const unsigned char *p, size_t n)
     return v;
 }
 
-/* Validate + normalize a ustar member name to a bare filename. Returns the
- * pointer to the flat name on success, NULL to reject. */
-static const char *tar_flat_name(const char *name)
+/* Validate + normalize a ustar member path for safe NESTED extraction. Strips a
+ * leading "./" and any trailing "/", then requires every segment to be non-empty
+ * and not "..", and the whole path to be relative (not absolute). Nested
+ * relative paths (a/b/c) are allowed - zig's lib/ tree needs them. Mutates
+ * `name` (trailing-slash strip). Returns the cleaned path or NULL to reject. */
+static const char *tar_safe_path(char *name)
 {
-    if (name[0] == '/') return NULL;                 /* absolute */
-    if (name[0] == '.' && name[1] == '/') name += 2; /* strip leading "./" */
-    if (name[0] == '\0') return NULL;                /* the "./" dir entry */
-    if (strstr(name, "..")) return NULL;             /* traversal */
-    if (strchr(name, '/'))  return NULL;             /* not flat */
+    if (name[0] == '/') return NULL;                     /* absolute → reject */
+    while (name[0] == '.' && name[1] == '/') name += 2;  /* strip leading "./" */
+    size_t len = strlen(name);
+    while (len > 0 && name[len - 1] == '/') name[--len] = '\0';  /* trailing "/" */
+    /* "" (from "./") or "." is the archive root - benign; return an EMPTY
+     * string so the caller skips it rather than treating it as a reject. */
+    if (len == 0)                    return name;          /* -> "" */
+    if (len == 1 && name[0] == '.')  return name + 1;      /* -> "" */
+    for (const char *p = name; *p; ) {
+        const char *slash = strchr(p, '/');
+        size_t seg = slash ? (size_t)(slash - p) : strlen(p);
+        if (seg == 0) return NULL;                        /* "//" */
+        if (seg == 2 && p[0] == '.' && p[1] == '.') return NULL;  /* ".." */
+        p += seg;
+        if (*p == '/') p++;
+    }
     return name;
+}
+
+/* mkdir every component of `path` (parents included). EEXIST is success. */
+static int mkdir_p(const char *path, mode_t mode)
+{
+    char tmp[PATH_MAX];
+    size_t n = strlen(path);
+    if (n == 0 || n >= sizeof(tmp)) return -1;
+    memcpy(tmp, path, n + 1);
+    for (char *p = tmp + 1; *p; p++) {
+        if (*p == '/') {
+            *p = '\0';
+            if (mkdir(tmp, mode) != 0 && errno != EEXIST) return -1;
+            *p = '/';
+        }
+    }
+    if (mkdir(tmp, mode) != 0 && errno != EEXIST) return -1;
+    return 0;
 }
 
 int hl_tools_extract_tar(const unsigned char *tar, size_t tar_len,
@@ -197,22 +231,42 @@ int hl_tools_extract_tar(const unsigned char *tar, size_t tar_len,
         off += 512;
         if (off + size > tar_len) return -1;          /* truncated data */
 
-        /* Only extract regular files ('0' or legacy '\0'); skip dir/link/etc. */
-        if (typeflag == '0' || typeflag == '\0') {
-            const char *flat = tar_flat_name(name);
-            if (!flat) return -1;
-
+        /* Directory ('5'): create it + parents. Regular file ('0'/legacy '\0'):
+         * create parent dirs, write, preserve the exec bit (zig / ld.lld need
+         * +x). Skip everything else (symlinks '2', hardlinks '1', ...) - our
+         * producers ship files + dirs only, dereferencing any symlink to a copy. */
+        const char *rel = (typeflag == '5' || typeflag == '0' || typeflag == '\0')
+            ? tar_safe_path(name) : NULL;
+        /* rel: NULL means either "not a file/dir entry we handle" (skip) or a
+         * MALICIOUS path. Distinguish: only the file/dir typeflags call
+         * tar_safe_path, and it returns NULL just for absolute/".." - reject
+         * those. An empty string is the archive root - skip. */
+        if ((typeflag == '5' || typeflag == '0' || typeflag == '\0') && !rel)
+            return -1;
+        if (rel && rel[0] != '\0') {
             char path[PATH_MAX];
-            int pn = snprintf(path, sizeof(path), "%s/%s", dest_dir, flat);
+            int pn = snprintf(path, sizeof(path), "%s/%s", dest_dir, rel);
             if (pn < 0 || (size_t)pn >= sizeof(path)) return -1;
 
-            FILE *f = fopen(path, "wb");
-            if (!f) return -1;
-            if (size && fwrite(tar + off, 1, size, f) != size) {
-                fclose(f);
-                return -1;
+            if (typeflag == '5') {
+                if (mkdir_p(path, 0755) != 0) return -1;
+            } else {
+                char *last = strrchr(path, '/');
+                if (last && last != path) {
+                    *last = '\0';
+                    if (mkdir_p(path, 0755) != 0) { *last = '/'; return -1; }
+                    *last = '/';
+                }
+                FILE *f = fopen(path, "wb");
+                if (!f) return -1;
+                if (size && fwrite(tar + off, 1, size, f) != size) {
+                    fclose(f);
+                    return -1;
+                }
+                if (fclose(f) != 0) return -1;
+                mode_t m = (mode_t)(tar_octal(hdr + 100, 8) & 0777);
+                if (m) (void)chmod(path, m);
             }
-            if (fclose(f) != 0) return -1;
         }
 
         /* Advance past the data, rounded up to the 512-byte block. */
@@ -371,6 +425,25 @@ int hl_tools_lookup_path(const char *name, const char *hull_exe,
     if (!hl_tools_name_valid(name)) {
         errno = EINVAL;
         return -1;
+    }
+
+    /* 0) An installed bundle: the toolchain executable lives INSIDE the
+     *    extracted dir at $HOME/.hull/tools/<name>/<bundle_entry> (e.g. zig,
+     *    lld). A data-only bundle (the floor) has a non-exec bundle_entry and
+     *    won't match X_OK here, so it falls through harmlessly. */
+    const HlToolSpec *bspec = hl_tools_find(name);
+    if (bspec && bspec->is_bundle && bspec->bundle_entry) {
+        char bdir[PATH_MAX];
+        if (hl_tools_install_path(name, bdir, sizeof(bdir)) == 0) {
+            char be[PATH_MAX];
+            int n = snprintf(be, sizeof(be), "%s/%s", bdir, bspec->bundle_entry);
+            if (n > 0 && (size_t)n < sizeof(be) && access(be, X_OK) == 0) {
+                int m = snprintf(out, out_sz, "%s", be);
+                if (m < 0 || (size_t)m >= out_sz) return -1;
+                return 0;
+            }
+        }
+        /* not installed as a bundle → fall through to PATH (a system zig/lld). */
     }
 
     /* 1) $HOME/.hull/tools/<name>  ── canonical install location.

--- a/tests/hull/test_tools_install.c
+++ b/tests/hull/test_tools_install.c
@@ -427,9 +427,17 @@ UTEST_F(tools_fixture, lookup_rejects_invalid_name) {
 static void tar_put_header(unsigned char *b, const char *name, size_t size) {
     memset(b, 0, 512);
     strncpy((char *)b, name, 99);
+    snprintf((char *)(b + 100), 8, "%07o", 0755);              /* mode 0755 */
     snprintf((char *)(b + 124), 12, "%011o", (unsigned)size);  /* size, octal */
     memset(b + 148, ' ', 8);                                   /* chksum: blank */
     b[156] = '0';                                              /* regular file */
+}
+
+/* A ustar directory entry (typeflag '5', no data). */
+static void tar_add_dir(unsigned char *buf, size_t *off, const char *name) {
+    tar_put_header(buf + *off, name, 0);
+    buf[*off + 156] = '5';   /* directory */
+    *off += 512;
 }
 
 static void tar_add_file(unsigned char *buf, size_t *off,
@@ -545,6 +553,43 @@ UTEST_F(tools_fixture, extract_tar_rejects_traversal) {
     char dest[PATH_MAX];
     snprintf(dest, sizeof(dest), "%s/floor2", utest_fixture->tmpdir);
     ASSERT_EQ(hl_tools_extract_tar(buf, off, dest), -1);   /* traversal refused */
+    free(buf);
+}
+
+UTEST_F(tools_fixture, extract_nested_tree) {
+    /* A zig-like nested tree: root dir entry (skipped), a top-level executable,
+     * and a file two directories deep with an explicit dir entry. */
+    unsigned char *buf = calloc(1, 16384);
+    ASSERT_NE(buf, NULL);
+    size_t off = 0;
+    tar_add_dir(buf, &off, "./");
+    tar_add_file(buf, &off, "./zig", "BINARY", 6);
+    tar_add_dir(buf, &off, "lib/std");
+    tar_add_file(buf, &off, "lib/std/foo.zig", "SRC", 3);
+    off += 512;
+
+    char dest[PATH_MAX], p[PATH_MAX];
+    struct stat st;
+    snprintf(dest, sizeof(dest), "%s/tree", utest_fixture->tmpdir);
+    ASSERT_EQ(hl_tools_extract_tar(buf, off, dest), 0);
+
+    snprintf(p, sizeof(p), "%s/zig", dest);
+    ASSERT_EQ(stat(p, &st), 0);
+    ASSERT_TRUE(st.st_mode & S_IXUSR);            /* exec bit preserved */
+    snprintf(p, sizeof(p), "%s/lib/std/foo.zig", dest);
+    ASSERT_EQ(stat(p, &st), 0);                   /* deep nested file created */
+    free(buf);
+}
+
+UTEST_F(tools_fixture, extract_rejects_nested_traversal) {
+    unsigned char *buf = calloc(1, 4096);
+    ASSERT_NE(buf, NULL);
+    size_t off = 0;
+    tar_add_file(buf, &off, "lib/../../escape", "X", 1);
+    off += 512;
+    char dest[PATH_MAX];
+    snprintf(dest, sizeof(dest), "%s/tree2", utest_fixture->tmpdir);
+    ASSERT_EQ(hl_tools_extract_tar(buf, off, dest), -1);   /* nested ".." refused */
     free(buf);
 }
 


### PR DESCRIPTION
**Stage A** of the lld + zig install capstone. Extends the #196 bundle machinery from **flat** (the libc-musl floor) to **nested trees**, so a toolchain bundle — `lld` (binary + `ld.lld`/`ld64.lld`) or `zig` (`zig` + its `lib/` tree) — can be fetched, verified, extracted, resolved, and removed. **No behavior change for the floor.** The tools themselves + their release producers are **Stage B**.

- **`hl_tools_extract_tar`** now handles **nested** relative paths + ustar directory entries, creates parent dirs, and **preserves the exec bit** (zig/ld.lld need `+x`). Still files+dirs only (producers dereference symlinks to copies); `tar_safe_path` rejects absolute + any `..` component and skips the benign archive-root entry — defense in depth over the already-SHA-256-verified archive.
- **`HlToolSpec.bundle_entry`** — the primary file inside the extracted dir: the install sentinel *and*, when it's the toolchain executable, what `hl_tools_lookup_path` resolves to (`~/.hull/tools/<name>/<bundle_entry>`, `X_OK`). The floor points it at `crt1.o` (never exec-resolved). Replaces the hardcoded `crt1.o` sentinel.
- **`hl_tools_lookup_path`** step 0 resolves an installed toolchain bundle's inner executable, falling through to the existing file/PATH lookup (a system zig/lld still works).
- **uninstall** removes a bundle **recursively** (zig's `lib/` is nested).

## Tested
`make test` **61/61**, incl. new unit tests for **nested extraction (subdirs + exec-bit)** and **nested-`..` rejection**, plus a local recursive-uninstall check on a nested dir. The libc-musl floor still passes unchanged (flat archives extract fine through the nested path).