### PR TITLE
archive: hull/archive/tar stdlib module (Lua + JS)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1515,6 +1515,7 @@ Register with `app.use(method, pattern, mw)`:
 | `form` | `hull.web.form` | `hull:web:form` | URL-encoded form body parsing |
 | `i18n` | `hull.i18n` | `hull:i18n` | Internationalization: locale detection, translations, formatting |
 | `csv` | `hull.csv` | `hull:csv` | CSV parse/encode (RFC 4180) |
+| `tar` | `hull.archive.tar` | `hull:archive:tar` | ustar archive parse/create/extract/pack (extract/pack compose the fs capability) |
 | `qrcode` | `hull.qrcode` | `hull:qrcode` | QR Code generator (ISO/IEC 18004), pure Lua/JS |
 | `search` | `hull.search` | `hull:search` | Full-text search (SQLite FTS5) |
 | `rbac` | `hull.web.middleware.rbac` | `hull:web:middleware:rbac` | Role-based access control |
@@ -1941,6 +1942,30 @@ template.clearCache();                           // clear compiled function cach
 - `opts.headers`. Rows are objects; emit header row (default: `false`)
 - `opts.separator`. Field delimiter (default: `","`)
 - Returns CSV string.
+
+**tar** (`hull.archive.tar` / `hull:archive:tar`). ustar (`.tar`) archive
+handling backed by the shared C core (`cap/tar.c`) - the SAME core `hull tools
+install` uses for signed bundles. Namespaced under `hull/archive/` as the
+container-format family (a future `zip` would be a sibling; stream codecs like
+gzip belong under a separate `hull/compress/`). `parse`/`create` are pure
+byte<->table transforms (no authority); `extract`/`pack` COMPOSE the fs
+capability, so they enforce `manifest.fs.write` / `fs.read` exactly like
+`fs.write`/`fs.read` (path validation + allowlist), NOT the trusted install-path
+extractor. `parse`/`create`/`extract` accept any buffer type (string /
+`MappedBuffer` / `WasmBuffer` / `ArrayBuffer`) for the archive bytes.
+- `tar.parse(bytes)` -> array of `{ name, data, size, mode, is_dir }` (JS:
+  `isDir`; `data` is a Lua string / JS `ArrayBuffer`). Malformed / truncated /
+  traversal-bearing archives return `nil, err` (Lua) / throw (JS).
+- `tar.create(entries)` -> archive bytes (Lua string / JS `ArrayBuffer`). Each
+  entry is `{ name, data?, mode?, is_dir? }` (JS: `isDir`; `mode` defaults 0644).
+  An absolute or `..`-bearing member name is refused.
+- `tar.extract(bytes, dest_dir)` -> `true` | `nil, err` (JS: throws on error).
+  Writes each member under `dest_dir` via the fs capability (needs
+  `manifest.fs.write`). Directory entries are skipped (file writes create their
+  parents; empty dirs are dropped).
+- `tar.pack(files)` -> archive bytes. `files` is an array of path strings or
+  `{ path, name? }` tables; each is read via the fs capability (needs
+  `manifest.fs.read`) and added as a member (name defaults to the path).
 
 **qrcode**. QR Code generator (ISO/IEC 18004). Pure Lua / JS, byte
 mode, all four EC levels, versions 1-40, all 8 mask patterns scored

--- a/src/hull/module_registry.c
+++ b/src/hull/module_registry.c
@@ -46,6 +46,18 @@ static const HlModuleSpec REGISTRY[] = {
 
     /* ── C-native side-effect modules + cross-cutting utilities ───── */
     {
+        /* ustar archive parse/create/extract/pack. Namespaced under
+         * hull/archive/ as the container-format family (zip/etc. would
+         * be siblings; stream codecs live under a separate hull/compress/).
+         * parse/create are pure byte<->table transforms (no authority);
+         * extract/pack compose the fs capability, so they need
+         * manifest.fs.write / fs.read at call time (gated independently,
+         * not a module dep). */
+        .name = "hull/archive/tar",
+        .api_major = 1, .intrinsic = 0, .pure = 0,
+        .required_caps = 0, .deps = {0},
+    },
+    {
         /* Attachment storage: content-addressed disk via hull/blob,
          * metadata + dedup-by-refcount via hull/db. Flat top-level
          * (not under hull/web/) — the core API (store/read/metadata/

--- a/src/hull/runtime/js/mod_buffer.h
+++ b/src/hull/runtime/js/mod_buffer.h
@@ -84,6 +84,7 @@ int hl_js_init_fs_module(JSContext *ctx, HlJS *js);
 int hl_js_init_blob_module(JSContext *ctx, HlJS *js);
 int hl_js_init_mime_module(JSContext *ctx, HlJS *js);
 int hl_js_init_image_module(JSContext *ctx, HlJS *js);
+int hl_js_init_tar_module(JSContext *ctx, HlJS *js);
 
 #ifdef HL_ENABLE_WASM
 int hl_js_init_compute_module(JSContext *ctx, HlJS *js);

--- a/src/hull/runtime/js/mod_tar.c
+++ b/src/hull/runtime/js/mod_tar.c
@@ -1,0 +1,325 @@
+/* mod_tar.c — hull:tar module (QuickJS bindings)
+ *
+ * Parallel to the Lua binding (src/hull/runtime/lua/mod_tar.c). Thin wrappers
+ * over the shared ustar core (cap/tar.h). parse/create are pure byte<->object
+ * transforms accepting any buffer type; extract/pack compose the fs capability
+ * (hl_cap_fs_*) so app archive I/O stays inside the manifest fs sandbox.
+ *
+ *   tar.parse(bytes)          -> [ {name,data,size,mode,isDir}, ... ]
+ *   tar.create(entries)       -> ArrayBuffer
+ *   tar.extract(bytes, dir)   -> true               (writes via fs.write)
+ *   tar.pack(files [, opts])  -> ArrayBuffer          (reads via fs.read)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "mod_buffer.h"
+#include "hull/cap/tar.h"
+#include "hull/cap/fs.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* ── tar.parse ─────────────────────────────────────────────────────── */
+
+struct js_parse_ctx {
+    JSContext *ctx;
+    JSValue    arr;
+    uint32_t   n;
+    int        oom;
+};
+
+static int js_parse_collect(const HlTarEntry *e, void *vctx)
+{
+    struct js_parse_ctx *c = (struct js_parse_ctx *)vctx;
+    JSContext *ctx = c->ctx;
+
+    JSValue o = JS_NewObject(ctx);
+    if (JS_IsException(o)) { c->oom = 1; return -1; }
+    JS_SetPropertyStr(ctx, o, "name", JS_NewString(ctx, e->name));
+    JS_SetPropertyStr(ctx, o, "data",
+                      JS_NewArrayBufferCopy(ctx, e->data ? e->data : (const uint8_t *)"",
+                                            e->size));
+    JS_SetPropertyStr(ctx, o, "size", JS_NewInt64(ctx, (int64_t)e->size));
+    JS_SetPropertyStr(ctx, o, "mode", JS_NewInt32(ctx, (int32_t)e->mode));
+    JS_SetPropertyStr(ctx, o, "isDir", JS_NewBool(ctx, e->is_dir));
+    JS_SetPropertyUint32(ctx, c->arr, c->n++, o);
+    return 0;
+}
+
+static JSValue js_tar_parse(JSContext *ctx, JSValueConst this_val,
+                            int argc, JSValueConst *argv)
+{
+    (void)this_val;
+    HlBufferView view;
+    const char *str = NULL;
+    int needs_free = 0;
+    if (argc < 1 || !js_get_buffer(ctx, argv[0], &view, &str, &needs_free))
+        return JS_ThrowTypeError(ctx, "tar.parse: arg 1 must be a buffer");
+
+    JSValue arr = JS_NewArray(ctx);
+    struct js_parse_ctx c = { ctx, arr, 0, 0 };
+    int rc = hl_tar_parse((const unsigned char *)view.data, view.len,
+                          js_parse_collect, &c);
+    if (needs_free) JS_FreeCString(ctx, str);
+
+    if (rc != 0) {
+        JS_FreeValue(ctx, arr);
+        if (c.oom) return JS_EXCEPTION;
+        return JS_ThrowTypeError(ctx, "tar.parse: malformed or unsafe archive");
+    }
+    return arr;
+}
+
+/* ── tar.create ────────────────────────────────────────────────────── */
+
+static JSValue js_tar_create(JSContext *ctx, JSValueConst this_val,
+                             int argc, JSValueConst *argv)
+{
+    (void)this_val;
+    if (argc < 1 || !JS_IsArray(ctx, argv[0]))
+        return JS_ThrowTypeError(ctx, "tar.create: arg 1 must be an array of entries");
+
+    int64_t n = 0;
+    JSValue lenv = JS_GetPropertyStr(ctx, argv[0], "length");
+    JS_ToInt64(ctx, &n, lenv);
+    JS_FreeValue(ctx, lenv);
+    if (n < 0) return JS_ThrowTypeError(ctx, "tar.create: bad length");
+
+    HlTarEntry *ents = n ? (HlTarEntry *)calloc((size_t)n, sizeof(HlTarEntry)) : NULL;
+    /* Keep each entry's name CString + data buffer alive until create returns. */
+    const char **names = n ? (const char **)calloc((size_t)n, sizeof(char *)) : NULL;
+    HlBufferView *views = n ? (HlBufferView *)calloc((size_t)n, sizeof(HlBufferView)) : NULL;
+    const char **dstrs = n ? (const char **)calloc((size_t)n, sizeof(char *)) : NULL;
+    int *dfree = n ? (int *)calloc((size_t)n, sizeof(int)) : NULL;
+    if (n && (!ents || !names || !views || !dstrs || !dfree)) {
+        free(ents); free(names); free(views); free(dstrs); free(dfree);
+        return JS_ThrowOutOfMemory(ctx);
+    }
+
+    const char *err = NULL;
+    int64_t i;
+    for (i = 0; i < n; i++) {
+        JSValue ent = JS_GetPropertyUint32(ctx, argv[0], (uint32_t)i);
+        if (!JS_IsObject(ent)) { JS_FreeValue(ctx, ent); err = "each entry must be an object"; break; }
+
+        JSValue nv = JS_GetPropertyStr(ctx, ent, "name");
+        names[i] = JS_ToCString(ctx, nv);
+        JS_FreeValue(ctx, nv);
+        if (!names[i]) { JS_FreeValue(ctx, ent); err = "entry missing 'name'"; break; }
+        ents[i].name = names[i];
+
+        JSValue dv = JS_GetPropertyStr(ctx, ent, "isDir");
+        ents[i].is_dir = JS_ToBool(ctx, dv);
+        JS_FreeValue(ctx, dv);
+
+        JSValue mv = JS_GetPropertyStr(ctx, ent, "mode");
+        int32_t mode = 0;
+        if (!JS_IsUndefined(mv)) JS_ToInt32(ctx, &mode, mv);
+        JS_FreeValue(ctx, mv);
+        ents[i].mode = (unsigned)mode;
+
+        if (!ents[i].is_dir) {
+            JSValue data = JS_GetPropertyStr(ctx, ent, "data");
+            if (!JS_IsUndefined(data) && !JS_IsNull(data)) {
+                if (!js_get_buffer(ctx, data, &views[i], &dstrs[i], &dfree[i])) {
+                    JS_FreeValue(ctx, data); JS_FreeValue(ctx, ent);
+                    err = "entry 'data' must be a buffer"; break;
+                }
+                ents[i].data = (const unsigned char *)views[i].data;
+                ents[i].size = views[i].len;
+            }
+            JS_FreeValue(ctx, data);
+        }
+        JS_FreeValue(ctx, ent);
+    }
+
+    unsigned char *out = NULL;
+    size_t out_len = 0;
+    int rc = -1;
+    if (!err && i == n)
+        rc = hl_tar_create(ents, (size_t)n, &out, &out_len);
+
+    for (int64_t j = 0; j < n; j++) {
+        if (names && names[j]) JS_FreeCString(ctx, names[j]);
+        if (dfree && dfree[j] && dstrs[j]) JS_FreeCString(ctx, dstrs[j]);
+    }
+    free(ents); free(names); free(views); free(dstrs); free(dfree);
+
+    if (rc != 0) {
+        return err ? JS_ThrowTypeError(ctx, "tar.create: %s", err)
+                   : JS_ThrowTypeError(ctx, "tar.create: unsafe name or out of memory");
+    }
+    JSValue ab = JS_NewArrayBufferCopy(ctx, out, out_len);
+    free(out);
+    return ab;
+}
+
+/* ── tar.extract (fs-composed, sandboxed) ──────────────────────────── */
+
+struct js_extract_ctx {
+    const HlFsConfig *fs;
+    const char       *dir;
+    const char       *err;
+};
+
+static int js_extract_write(const HlTarEntry *e, void *vctx)
+{
+    struct js_extract_ctx *c = (struct js_extract_ctx *)vctx;
+    if (e->is_dir) return 0;
+
+    char path[4096];
+    int pn;
+    if (c->dir && c->dir[0])
+        pn = snprintf(path, sizeof(path), "%s/%s", c->dir, e->name);
+    else
+        pn = snprintf(path, sizeof(path), "%s", e->name);
+    if (pn < 0 || (size_t)pn >= sizeof(path)) { c->err = "path too long"; return -1; }
+
+    int rc = hl_cap_fs_write(c->fs, path,
+                             (const char *)(e->data ? e->data : (const unsigned char *)""),
+                             e->size, &c->err);
+    return rc == 0 ? 0 : -1;
+}
+
+static JSValue js_tar_extract(JSContext *ctx, JSValueConst this_val,
+                              int argc, JSValueConst *argv)
+{
+    (void)this_val;
+    HlJS *js = (HlJS *)JS_GetContextOpaque(ctx);
+    if (!js || !js->base.fs_cfg)
+        return JS_ThrowTypeError(ctx, "tar.extract: not available (declare fs.write in manifest)");
+
+    HlBufferView view;
+    const char *str = NULL;
+    int needs_free = 0;
+    if (argc < 1 || !js_get_buffer(ctx, argv[0], &view, &str, &needs_free))
+        return JS_ThrowTypeError(ctx, "tar.extract: arg 1 must be a buffer");
+
+    const char *dir = argc >= 2 ? JS_ToCString(ctx, argv[1]) : NULL;
+
+    struct js_extract_ctx c = { js->base.fs_cfg, dir ? dir : "", NULL };
+    int rc = hl_tar_parse((const unsigned char *)view.data, view.len,
+                          js_extract_write, &c);
+
+    if (dir) JS_FreeCString(ctx, dir);
+    if (needs_free) JS_FreeCString(ctx, str);
+
+    if (rc != 0)
+        return JS_ThrowTypeError(ctx, "tar.extract: %s",
+                                 c.err ? c.err : "malformed or unsafe archive");
+    return JS_TRUE;
+}
+
+/* ── tar.pack (fs-composed, sandboxed) ─────────────────────────────── */
+
+static JSValue js_tar_pack(JSContext *ctx, JSValueConst this_val,
+                           int argc, JSValueConst *argv)
+{
+    (void)this_val;
+    HlJS *js = (HlJS *)JS_GetContextOpaque(ctx);
+    if (!js || !js->base.fs_cfg)
+        return JS_ThrowTypeError(ctx, "tar.pack: not available (declare fs.read in manifest)");
+    if (argc < 1 || !JS_IsArray(ctx, argv[0]))
+        return JS_ThrowTypeError(ctx, "tar.pack: arg 1 must be an array of files");
+
+    int64_t n = 0;
+    JSValue lenv = JS_GetPropertyStr(ctx, argv[0], "length");
+    JS_ToInt64(ctx, &n, lenv);
+    JS_FreeValue(ctx, lenv);
+    if (n <= 0) return JS_ThrowTypeError(ctx, "tar.pack: no files");
+
+    HlTarEntry *ents = (HlTarEntry *)calloc((size_t)n, sizeof(HlTarEntry));
+    char **bufs = (char **)calloc((size_t)n, sizeof(char *));
+    /* Own the CStrings the whole loop: `paths` feeds fs.read, `names` feeds the
+     * archive member name (NULL means "use paths[i]"). Both freed after create,
+     * so ents[i].name stays valid through hl_tar_create. */
+    const char **paths = (const char **)calloc((size_t)n, sizeof(char *));
+    const char **names = (const char **)calloc((size_t)n, sizeof(char *));
+    if (!ents || !bufs || !paths || !names) {
+        free(ents); free(bufs); free(paths); free(names);
+        return JS_ThrowOutOfMemory(ctx);
+    }
+
+    const char *err = NULL;
+    int64_t i;
+    for (i = 0; i < n; i++) {
+        JSValue el = JS_GetPropertyUint32(ctx, argv[0], (uint32_t)i);
+        if (JS_IsString(el)) {
+            paths[i] = JS_ToCString(ctx, el);       /* member name = path */
+        } else if (JS_IsObject(el)) {
+            JSValue pv = JS_GetPropertyStr(ctx, el, "path");
+            paths[i] = JS_ToCString(ctx, pv);
+            JS_FreeValue(ctx, pv);
+            JSValue nv = JS_GetPropertyStr(ctx, el, "name");
+            names[i] = JS_IsUndefined(nv) ? NULL : JS_ToCString(ctx, nv);
+            JS_FreeValue(ctx, nv);
+        }
+        JS_FreeValue(ctx, el);
+        if (!paths[i]) { err = "tar.pack: entry needs a path"; break; }
+
+        int64_t size = hl_cap_fs_read(js->base.fs_cfg, paths[i], NULL, 0, &err);
+        if (size < 0) break;
+        char *buf = (char *)malloc(size ? (size_t)size : 1);
+        if (!buf) { err = "out_of_memory"; break; }
+        if (size > 0) {
+            int64_t got = hl_cap_fs_read(js->base.fs_cfg, paths[i], buf, (size_t)size, &err);
+            if (got < 0) { free(buf); break; }
+        }
+        bufs[i] = buf;
+        ents[i].name = names[i] ? names[i] : paths[i];
+        ents[i].data = (const unsigned char *)buf;
+        ents[i].size = (size_t)size;
+        ents[i].mode = 0644;
+        ents[i].is_dir = 0;
+    }
+
+    unsigned char *out = NULL;
+    size_t out_len = 0;
+    int rc = -1;
+    if (!err && i == n)
+        rc = hl_tar_create(ents, (size_t)n, &out, &out_len);
+
+    for (int64_t j = 0; j < n; j++) {
+        free(bufs[j]);
+        if (paths[j]) JS_FreeCString(ctx, paths[j]);
+        if (names[j]) JS_FreeCString(ctx, names[j]);
+    }
+    free(ents); free(bufs); free(paths); free(names);
+
+    if (rc != 0)
+        return JS_ThrowTypeError(ctx, "tar.pack: %s", err ? err : "failed");
+    JSValue ab = JS_NewArrayBufferCopy(ctx, out, out_len);
+    free(out);
+    return ab;
+}
+
+/* ── Registration ──────────────────────────────────────────────────── */
+
+static int js_tar_module_init(JSContext *ctx, JSModuleDef *m)
+{
+    if (hl_js_check_module_declared(ctx, "hull/archive/tar", "hull:archive:tar") != 0)
+        return -1;
+
+    JSValue tar_obj = JS_NewObject(ctx);
+    JS_SetPropertyStr(ctx, tar_obj, "parse",
+                      JS_NewCFunction(ctx, js_tar_parse, "parse", 1));
+    JS_SetPropertyStr(ctx, tar_obj, "create",
+                      JS_NewCFunction(ctx, js_tar_create, "create", 1));
+    JS_SetPropertyStr(ctx, tar_obj, "extract",
+                      JS_NewCFunction(ctx, js_tar_extract, "extract", 2));
+    JS_SetPropertyStr(ctx, tar_obj, "pack",
+                      JS_NewCFunction(ctx, js_tar_pack, "pack", 2));
+
+    JS_SetModuleExport(ctx, m, "tar", tar_obj);
+    return 0;
+}
+
+int hl_js_init_tar_module(JSContext *ctx, HlJS *js)
+{
+    (void)js;
+    JSModuleDef *m = JS_NewCModule(ctx, "hull:archive:tar", js_tar_module_init);
+    if (!m) return -1;
+    JS_AddModuleExport(ctx, m, "tar");
+    return 0;
+}

--- a/src/hull/runtime/js/modules.c
+++ b/src/hull/runtime/js/modules.c
@@ -84,6 +84,10 @@ int hl_js_register_modules(HlJS *js)
     if (hl_js_init_mime_module(js->ctx, js) != 0)
         return -1;
 
+    /* Register hull:tar module — pure format core; extract/pack use fs cap */
+    if (hl_js_init_tar_module(js->ctx, js) != 0)
+        return -1;
+
 #ifdef HL_ENABLE_IMAGE
     /* Register hull:image module (dropped on a HL_ENABLE_IMAGE=0 build). */
     if (hl_js_init_image_module(js->ctx, js) != 0)

--- a/src/hull/runtime/lua/mod_buffer.h
+++ b/src/hull/runtime/lua/mod_buffer.h
@@ -67,6 +67,7 @@ int luaopen_hull_fs(lua_State *L);
 int luaopen_hull_image(lua_State *L);
 int luaopen_hull_blob(lua_State *L);
 int luaopen_hull_mime(lua_State *L);
+int luaopen_hull_tar(lua_State *L);
 
 #ifdef HL_ENABLE_WASM
 int luaopen_hull_compute(lua_State *L);

--- a/src/hull/runtime/lua/mod_tar.c
+++ b/src/hull/runtime/lua/mod_tar.c
@@ -286,7 +286,7 @@ static int l_tar_pack(lua_State *L)
         HlTarEntry *e = &ents[i - 1];
         e->name = name;                 /* borrowed from arg-1 nested string */
         e->data = (const unsigned char *)buf;
-        e->size = (size_t)(size < 0 ? 0 : size);
+        e->size = (size_t)size;   /* size >= 0 here (guarded above) */
         e->mode = 0644;
         e->is_dir = 0;
         built++;

--- a/src/hull/runtime/lua/mod_tar.c
+++ b/src/hull/runtime/lua/mod_tar.c
@@ -1,0 +1,330 @@
+/* mod_tar.c — hull.tar module: ustar archive parse / create / extract / pack
+ *
+ * Thin bindings over the shared C core (cap/tar.h). The format primitives
+ * (parse/create) are pure byte<->table transforms and accept any buffer type
+ * (string / MappedBuffer / WasmBuffer) via the unified buffer protocol. The
+ * ergonomic helpers (extract/pack) COMPOSE the fs capability (hl_cap_fs_*) so
+ * app-side archive I/O goes through the manifest fs allowlist + path validation
+ * exactly like fs.read/fs.write - NOT the trusted hl_tar_extract install path.
+ *
+ *   tar.parse(bytes)          -> { {name,data,size,mode,is_dir}, ... } | nil,err
+ *   tar.create(entries)       -> bytes | nil,err
+ *   tar.extract(bytes, dir)   -> true | nil,err   (writes via fs.write)
+ *   tar.pack(files [, opts])  -> bytes | nil,err   (reads via fs.read)
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "mod_buffer.h"
+#include "hull/cap/tar.h"
+#include "hull/cap/fs.h"
+#include "hull/utils/alloc.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* ── tar.parse ─────────────────────────────────────────────────────── */
+
+/* Collect each member into a Lua array-of-tables at a fixed stack slot. */
+struct parse_ctx {
+    lua_State *L;
+    int        tbl;   /* stack index of the result table */
+    int        n;     /* count so far */
+};
+
+static int parse_collect(const HlTarEntry *e, void *vctx)
+{
+    struct parse_ctx *c = (struct parse_ctx *)vctx;
+    lua_State *L = c->L;
+
+    lua_newtable(L);
+    lua_pushstring(L, e->name);
+    lua_setfield(L, -2, "name");
+    /* data is a copy (parse borrows into the input; the Lua string owns bytes) */
+    lua_pushlstring(L, e->data ? (const char *)e->data : "", e->size);
+    lua_setfield(L, -2, "data");
+    lua_pushinteger(L, (lua_Integer)e->size);
+    lua_setfield(L, -2, "size");
+    lua_pushinteger(L, (lua_Integer)e->mode);
+    lua_setfield(L, -2, "mode");
+    lua_pushboolean(L, e->is_dir);
+    lua_setfield(L, -2, "is_dir");
+
+    lua_rawseti(L, c->tbl, ++c->n);
+    return 0;
+}
+
+/* tar.parse(bytes) -> array of entries | nil, err */
+static int l_tar_parse(lua_State *L)
+{
+    HlBufferView view;
+    if (!lua_get_buffer(L, 1, &view)) {
+        lua_pushnil(L);
+        lua_pushstring(L, "tar.parse: arg 1 must be a buffer (string/mmap/wasm)");
+        return 2;
+    }
+
+    lua_newtable(L);                 /* result table at the top */
+    struct parse_ctx c = { L, lua_gettop(L), 0 };
+    int rc = hl_tar_parse((const unsigned char *)view.data, view.len,
+                          parse_collect, &c);
+    if (rc != 0) {
+        lua_pushnil(L);
+        lua_pushstring(L, "tar.parse: malformed or unsafe archive");
+        return 2;
+    }
+    /* result table already on top */
+    return 1;
+}
+
+/* ── tar.create ────────────────────────────────────────────────────── */
+
+/* Read the entries array at stack index 1 into a C HlTarEntry array. The
+ * borrowed name/data pointers stay valid while arg 1 (and its nested strings)
+ * remain on the stack. Returns a malloc'd array (caller frees) + count, or
+ * NULL on a shape error (msg set). */
+static HlTarEntry *read_entries(lua_State *L, int idx, size_t *out_n,
+                                const char **msg)
+{
+    if (lua_type(L, idx) != LUA_TTABLE) {
+        *msg = "tar.create: arg 1 must be a table of entries";
+        return NULL;
+    }
+    lua_Integer n = luaL_len(L, idx);
+    if (n < 0) { *msg = "tar.create: bad entry count"; return NULL; }
+    if (n == 0) { *out_n = 0; return NULL; }   /* empty -> caller handles */
+
+    HlTarEntry *ents = (HlTarEntry *)calloc((size_t)n, sizeof(HlTarEntry));
+    if (!ents) { *msg = "out_of_memory"; return NULL; }
+
+    for (lua_Integer i = 1; i <= n; i++) {
+        lua_geti(L, idx, i);                    /* entry table */
+        if (lua_type(L, -1) != LUA_TTABLE) {
+            lua_pop(L, 1);
+            free(ents);
+            *msg = "tar.create: each entry must be a table";
+            return NULL;
+        }
+        HlTarEntry *e = &ents[i - 1];
+
+        lua_getfield(L, -1, "name");
+        e->name = lua_tostring(L, -1);          /* borrowed (kept by entry tbl) */
+        lua_pop(L, 1);
+        if (!e->name) {
+            lua_pop(L, 1);
+            free(ents);
+            *msg = "tar.create: entry missing 'name'";
+            return NULL;
+        }
+
+        lua_getfield(L, -1, "is_dir");
+        e->is_dir = lua_toboolean(L, -1);
+        lua_pop(L, 1);
+
+        lua_getfield(L, -1, "mode");
+        e->mode = (unsigned)luaL_optinteger(L, -1, 0);
+        lua_pop(L, 1);
+
+        if (!e->is_dir) {
+            lua_getfield(L, -1, "data");
+            size_t len = 0;
+            const char *d = lua_tolstring(L, -1, &len);  /* borrowed */
+            lua_pop(L, 1);
+            e->data = (const unsigned char *)(d ? d : "");
+            e->size = d ? len : 0;
+        }
+        lua_pop(L, 1);                           /* entry table */
+    }
+    *out_n = (size_t)n;
+    return ents;
+}
+
+/* tar.create(entries) -> bytes | nil, err */
+static int l_tar_create(lua_State *L)
+{
+    size_t n = 0;
+    const char *msg = NULL;
+    HlTarEntry *ents = read_entries(L, 1, &n, &msg);
+    if (!ents && n != 0) {          /* real error (n==0 is the empty-array case) */
+        lua_pushnil(L);
+        lua_pushstring(L, msg ? msg : "tar.create: bad entries");
+        return 2;
+    }
+
+    unsigned char *out = NULL;
+    size_t out_len = 0;
+    int rc = hl_tar_create(ents, n, &out, &out_len);
+    free(ents);
+    if (rc != 0) {
+        lua_pushnil(L);
+        lua_pushstring(L, "tar.create: unsafe name or out of memory");
+        return 2;
+    }
+    lua_pushlstring(L, (const char *)out, out_len);
+    free(out);
+    return 1;
+}
+
+/* ── tar.extract (fs-composed, sandboxed) ──────────────────────────── */
+
+struct extract_ctx {
+    const HlFsConfig *fs;
+    const char       *dir;     /* destination prefix (relative, fs-validated) */
+    const char       *err;     /* set on first failure */
+};
+
+static int extract_write(const HlTarEntry *e, void *vctx)
+{
+    struct extract_ctx *c = (struct extract_ctx *)vctx;
+    if (e->is_dir) return 0;   /* fs.write creates parents; empty dirs dropped */
+
+    /* Build "<dir>/<name>". Both halves are already traversal-checked (dir by
+     * the fs cap on write, name by hl_tar_parse), but keep it bounded. */
+    char path[4096];
+    int pn;
+    if (c->dir && c->dir[0])
+        pn = snprintf(path, sizeof(path), "%s/%s", c->dir, e->name);
+    else
+        pn = snprintf(path, sizeof(path), "%s", e->name);
+    if (pn < 0 || (size_t)pn >= sizeof(path)) { c->err = "path too long"; return -1; }
+
+    int rc = hl_cap_fs_write(c->fs, path, (const char *)(e->data ? e->data : (const unsigned char *)""),
+                             e->size, &c->err);
+    return rc == 0 ? 0 : -1;
+}
+
+/* tar.extract(bytes, dest_dir) -> true | nil, err */
+static int l_tar_extract(lua_State *L)
+{
+    HlLua *lua = get_hl_lua(L);
+    if (!lua || !lua->base.fs_cfg) {
+        lua_pushnil(L);
+        lua_pushstring(L, "tar.extract: not available (declare fs.write in manifest)");
+        return 2;
+    }
+    HlBufferView view;
+    if (!lua_get_buffer(L, 1, &view)) {
+        lua_pushnil(L);
+        lua_pushstring(L, "tar.extract: arg 1 must be a buffer");
+        return 2;
+    }
+    const char *dir = luaL_optstring(L, 2, "");
+
+    struct extract_ctx c = { lua->base.fs_cfg, dir, NULL };
+    int rc = hl_tar_parse((const unsigned char *)view.data, view.len,
+                          extract_write, &c);
+    if (rc != 0) {
+        lua_pushnil(L);
+        lua_pushstring(L, c.err ? c.err : "tar.extract: malformed or unsafe archive");
+        return 2;
+    }
+    lua_pushboolean(L, 1);
+    return 1;
+}
+
+/* ── tar.pack (fs-composed, sandboxed) ─────────────────────────────── */
+
+/* tar.pack(files) -> bytes | nil, err
+ *
+ * `files` is an array; each element is either a path string (the archive
+ * member name is the path) or a table { path=, name?= }. Each file is read
+ * through hl_cap_fs_read (manifest fs.read allowlist). */
+static int l_tar_pack(lua_State *L)
+{
+    HlLua *lua = get_hl_lua(L);
+    if (!lua || !lua->base.fs_cfg) {
+        lua_pushnil(L);
+        lua_pushstring(L, "tar.pack: not available (declare fs.read in manifest)");
+        return 2;
+    }
+    if (lua_type(L, 1) != LUA_TTABLE) {
+        lua_pushnil(L);
+        lua_pushstring(L, "tar.pack: arg 1 must be an array of files");
+        return 2;
+    }
+    lua_Integer n = luaL_len(L, 1);
+    if (n <= 0) {
+        lua_pushnil(L);
+        lua_pushstring(L, "tar.pack: no files");
+        return 2;
+    }
+
+    HlTarEntry *ents = (HlTarEntry *)calloc((size_t)n, sizeof(HlTarEntry));
+    /* Parallel array of read buffers to free after create. */
+    char **bufs = (char **)calloc((size_t)n, sizeof(char *));
+    if (!ents || !bufs) {
+        free(ents); free(bufs);
+        lua_pushnil(L);
+        lua_pushstring(L, "out_of_memory");
+        return 2;
+    }
+
+    const char *err = NULL;
+    lua_Integer built = 0;
+    for (lua_Integer i = 1; i <= n; i++) {
+        lua_geti(L, 1, i);
+        const char *path = NULL, *name = NULL;
+        if (lua_type(L, -1) == LUA_TSTRING) {
+            path = lua_tostring(L, -1);
+            name = path;
+        } else if (lua_type(L, -1) == LUA_TTABLE) {
+            lua_getfield(L, -1, "path"); path = lua_tostring(L, -1); lua_pop(L, 1);
+            lua_getfield(L, -1, "name"); name = lua_tostring(L, -1); lua_pop(L, 1);
+            if (!name) name = path;
+        }
+        if (!path) { lua_pop(L, 1); err = "tar.pack: entry needs a path"; break; }
+
+        int64_t size = hl_cap_fs_read(lua->base.fs_cfg, path, NULL, 0, &err);
+        if (size < 0) { lua_pop(L, 1); break; }
+        char *buf = (char *)malloc(size ? (size_t)size : 1);
+        if (!buf) { lua_pop(L, 1); err = "out_of_memory"; break; }
+        if (size > 0) {
+            int64_t got = hl_cap_fs_read(lua->base.fs_cfg, path, buf, (size_t)size, &err);
+            if (got < 0) { free(buf); lua_pop(L, 1); break; }
+        }
+        bufs[i - 1] = buf;
+        HlTarEntry *e = &ents[i - 1];
+        e->name = name;                 /* borrowed from arg-1 nested string */
+        e->data = (const unsigned char *)buf;
+        e->size = (size_t)(size < 0 ? 0 : size);
+        e->mode = 0644;
+        e->is_dir = 0;
+        built++;
+        lua_pop(L, 1);
+    }
+
+    unsigned char *out = NULL;
+    size_t out_len = 0;
+    int rc = -1;
+    if (!err && built == n)
+        rc = hl_tar_create(ents, (size_t)n, &out, &out_len);
+
+    for (lua_Integer i = 0; i < n; i++) free(bufs[i]);
+    free(bufs);
+    free(ents);
+
+    if (rc != 0) {
+        lua_pushnil(L);
+        lua_pushstring(L, err ? err : "tar.pack: failed");
+        return 2;
+    }
+    lua_pushlstring(L, (const char *)out, out_len);
+    free(out);
+    return 1;
+}
+
+/* ── Registration ──────────────────────────────────────────────────── */
+
+static const luaL_Reg tar_funcs[] = {
+    { "parse",   l_tar_parse   },
+    { "create",  l_tar_create  },
+    { "extract", l_tar_extract },
+    { "pack",    l_tar_pack    },
+    { NULL, NULL }
+};
+
+int luaopen_hull_tar(lua_State *L)
+{
+    luaL_newlib(L, tar_funcs);
+    return 1;
+}

--- a/src/hull/runtime/lua/modules.c
+++ b/src/hull/runtime/lua/modules.c
@@ -80,6 +80,7 @@ int hl_lua_register_modules(HlLua *lua)
     register_native_module(L, "hull.fs",     luaopen_hull_fs);
     register_native_module(L, "hull.blob",   luaopen_hull_blob);
     register_native_module(L, "hull.mime",   luaopen_hull_mime);
+    register_native_module(L, "hull.archive.tar", luaopen_hull_tar);
 #ifdef HL_ENABLE_IMAGE
     register_native_module(L, "hull.image",  luaopen_hull_image);
 #endif

--- a/tests/hull/runtime/js/test_js.c
+++ b/tests/hull/runtime/js/test_js.c
@@ -1995,6 +1995,80 @@ UTEST(js_cap, crypto_base64url_encode_arraybuffer)
 
 /* ── hull:qrcode tests ─────────────────────────────────────────────────── */
 
+/* ── hull:archive:tar tests (parse/create marshalling) ──────────────── */
+
+UTEST(js_stdlib, tar_create_parse_roundtrip)
+{
+    init_js_with_caps();
+    ASSERT_TRUE(js_initialized);
+
+    const char *code =
+        "import { tar } from 'hull:archive:tar';\n"
+        "const ascii = (ab) => String.fromCharCode.apply(null, new Uint8Array(ab));\n"
+        "const b = tar.create([\n"
+        "  { name: 'greet.txt', data: 'hello', mode: 0o644 },\n"
+        "  { name: 'sub', isDir: true, mode: 0o755 },\n"
+        "  { name: 'sub/x.bin', data: 'abc' },\n"
+        "]);\n"
+        "const e = tar.parse(b);\n"
+        "globalThis.__tar_ok = (e.length === 3 && e[0].name === 'greet.txt' &&\n"
+        "  ascii(e[0].data) === 'hello' && e[0].mode === 0o644 &&\n"
+        "  e[1].isDir === true && e[2].name === 'sub/x.bin' &&\n"
+        "  e[2].data.byteLength === 3) ? 1 : 0;\n";
+    JSValue val = JS_Eval(js.ctx, code, strlen(code), "<test>",
+                          JS_EVAL_TYPE_MODULE);
+    if (JS_IsException(val)) hl_js_dump_error(&js);
+    JS_FreeValue(js.ctx, val);
+    hl_js_run_jobs(&js);
+
+    ASSERT_EQ(eval_int("globalThis.__tar_ok"), 1);
+    cleanup_js_caps();
+}
+
+UTEST(js_stdlib, tar_parse_rejects_truncated)
+{
+    init_js_with_caps();
+    ASSERT_TRUE(js_initialized);
+
+    /* A valid archive truncated mid-data throws rather than over-reading. */
+    const char *code =
+        "import { tar } from 'hull:archive:tar';\n"
+        "let threw = 0;\n"
+        "const b = tar.create([{ name: 'f', data: 'x'.repeat(1000) }]);\n"
+        "try { tar.parse(b.slice(0, 600)); }\n"
+        "catch (e) { threw = 1; }\n"
+        "globalThis.__tar_threw = threw;\n";
+    JSValue val = JS_Eval(js.ctx, code, strlen(code), "<test>",
+                          JS_EVAL_TYPE_MODULE);
+    if (JS_IsException(val)) hl_js_dump_error(&js);
+    JS_FreeValue(js.ctx, val);
+    hl_js_run_jobs(&js);
+
+    ASSERT_EQ(eval_int("globalThis.__tar_threw"), 1);
+    cleanup_js_caps();
+}
+
+UTEST(js_stdlib, tar_create_rejects_unsafe_name)
+{
+    init_js_with_caps();
+    ASSERT_TRUE(js_initialized);
+
+    const char *code =
+        "import { tar } from 'hull:archive:tar';\n"
+        "let threw = 0;\n"
+        "try { tar.create([{ name: '../escape', data: 'x' }]); }\n"
+        "catch (e) { threw = 1; }\n"
+        "globalThis.__tar_unsafe = threw;\n";
+    JSValue val = JS_Eval(js.ctx, code, strlen(code), "<test>",
+                          JS_EVAL_TYPE_MODULE);
+    if (JS_IsException(val)) hl_js_dump_error(&js);
+    JS_FreeValue(js.ctx, val);
+    hl_js_run_jobs(&js);
+
+    ASSERT_EQ(eval_int("globalThis.__tar_unsafe"), 1);
+    cleanup_js_caps();
+}
+
 UTEST(js_stdlib, qrcode_hello_v1)
 {
     init_js_with_caps();

--- a/tests/hull/runtime/lua/test_lua.c
+++ b/tests/hull/runtime/lua/test_lua.c
@@ -3767,6 +3767,68 @@ UTEST(lua_stdlib, csv_encode_sanitize_formulas)
     cleanup_lua();
 }
 
+/* ── hull.archive.tar tests (parse/create marshalling) ──────────────── */
+
+UTEST(lua_stdlib, tar_create_parse_roundtrip)
+{
+    init_lua();
+    ASSERT_TRUE(lua_initialized);
+
+    /* create -> parse must recover names, data, dir flag, and mode. */
+    int ok = eval_int(
+        "(function() "
+        "  local tar = require('hull.archive.tar') "
+        "  local b = tar.create({ "
+        "     { name='greet.txt', data='hello', mode=420 }, "     /* 0644 */
+        "     { name='sub', is_dir=true, mode=493 }, "            /* 0755 */
+        "     { name='sub/x.bin', data='\\0\\1\\2' } }) "
+        "  local e = tar.parse(b) "
+        "  return (#e==3 and e[1].name=='greet.txt' and e[1].data=='hello' "
+        "          and e[1].mode==420 and e[2].is_dir==true "
+        "          and e[3].name=='sub/x.bin' and #e[3].data==3) and 1 or 0 "
+        "end)()");
+    ASSERT_EQ(ok, 1);
+
+    cleanup_lua();
+}
+
+UTEST(lua_stdlib, tar_parse_rejects_truncated)
+{
+    init_lua();
+    ASSERT_TRUE(lua_initialized);
+
+    /* A valid archive truncated mid-data: the 512-byte header declares a
+     * 1000-byte member but the buffer is cut short, so parse returns
+     * (nil, err) rather than reading past the end. */
+    int ok = eval_int(
+        "(function() "
+        "  local tar = require('hull.archive.tar') "
+        "  local b = tar.create({ { name='f', data=string.rep('x', 1000) } }) "
+        "  local r, err = tar.parse(b:sub(1, 600)) "
+        "  return (r == nil and type(err) == 'string') and 1 or 0 "
+        "end)()");
+    ASSERT_EQ(ok, 1);
+
+    cleanup_lua();
+}
+
+UTEST(lua_stdlib, tar_create_rejects_unsafe_name)
+{
+    init_lua();
+    ASSERT_TRUE(lua_initialized);
+
+    /* An absolute / ".." member name is refused by the writer. */
+    int ok = eval_int(
+        "(function() "
+        "  local tar = require('hull.archive.tar') "
+        "  local r = tar.create({ { name='../escape', data='x' } }) "
+        "  return (r == nil) and 1 or 0 "
+        "end)()");
+    ASSERT_EQ(ok, 1);
+
+    cleanup_lua();
+}
+
 /* ── hull.search tests ───────────────────────────────────────────────── */
 
 UTEST(lua_stdlib, search_create_and_query)


### PR DESCRIPTION
## Summary

Exposes the shared ustar core (`cap/tar.c`, landed in #199) to app code as a first-party module: `require("hull.archive.tar")` / `import { tar } from "hull:archive:tar"`. This is PR 2 of the tar arc — the **same C backend** serves both `hull tools install` (signed bundles) and now app code.

**Namespaced under `hull/archive/`** as the container-format family: a future `zip` would be a sibling, and stream codecs (gzip/zstd) belong under a separate `hull/compress/`. Archiving (bundling) and compression are distinct concerns; tar is uncompressed, so it's an archive, not a compressor.

## Module surface (both runtimes, identical semantics)

| Fn | Shape | Notes |
|----|-------|-------|
| `tar.parse(bytes)` | → `[{name,data,size,mode,is_dir}]` | pure; accepts any buffer (string / mmap / wasm / ArrayBuffer) |
| `tar.create(entries)` | → bytes | pure; refuses absolute / `..` member names |
| `tar.extract(bytes, dir)` | → `true` \| err | composes **fs.write** |
| `tar.pack(files)` | → bytes | composes **fs.read** |

(JS uses camelCase `isDir`; `data` is a Lua string / JS `ArrayBuffer`.)

## Security model

`parse`/`create` are pure byte↔table transforms with **no new authority**. `extract`/`pack` compose the **fs capability** (`hl_cap_fs_write` / `hl_cap_fs_read`) — so they enforce `manifest.fs.write` / `fs.read` exactly like `fs.*` (path validation + allowlist), **not** the trusted install-path `hl_tar_extract`. The module therefore needs no `required_caps` and no fs module dep; the fs gate applies independently at call time (declare `hull/fs` + `fs.write`/`fs.read` to use extract/pack).

## Notes

- New bindings `runtime/{lua,js}/mod_tar.c` auto-glob into the base runtime objects (no Makefile change); registered as `hull.archive.tar` / `hull:archive:tar`.
- `module_registry.c` entry kept strcmp-sorted (between `hull/app` and `hull/attachment`); registry self-check passes.
- Fixed a use-after-free/double-free in the JS `pack` string-path branch found during smoke (SIGSEGV) — now clean.

## Testing

- 6 runtime unit tests (create/parse round-trip incl. mode + dir flag; truncated archive → error; unsafe name → refused), both runtimes.
- End-to-end smoke: create/parse round-trip + `pack`→`extract` through the fs sandbox, both runtimes, content-verified.
- `make test` green (Lua 172, JS 154); **ASan/UBSan build clean** (core `test_tar` 11/11 + all tar runtime tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)