### PR TITLE
build/eject: share the mandatory-compose plan (fixes eject; dedups build)

### DIFF
--- a/docs/build_arc_audit.md
+++ b/docs/build_arc_audit.md
@@ -1,0 +1,87 @@
+# Build / toolchain-free arc — audit findings & roadmap
+
+Audit date: 2026-08-03. Four-dimension review (Makefile/mk, build.lua/compose,
+linker/toolchain-free seam, extension-system consistency). Items are tracked
+with status so we can check back. Severity is post-review judgment; ✓ = the
+claim was verified against the code during the audit.
+
+Execution order (agreed): **#6+#1 → #7 → #4 → #5 → #2 → #3 → #8**, then Tier 4.
+
+---
+
+## Tier 1 — correctness bugs
+
+- [ ] **#1 `hull eject` composes only runtime+http — broken for db/compute/image/TLS apps.** ✓
+  `eject.lua` calls only `resolve_runtime_lib` / `resolve_http_lib` / `resolve_http_rt_lib`;
+  `build.lua`'s `compose_features()` also composes wasm/wasm-rt/sqlite-rt/image/image-rt/tls/keel.
+  Ejecting a db/compute/image/HTTPS app yields a project that won't link/run. Drift
+  the modularization arc introduced. **Fix converges with #6.**
+
+- [ ] **#2 Cross-compile silently mis-links.** ✓ `--target=<foreign>` emits a correct cross
+  `app_registry.o`, but only the `zig` backend consumes the triple (system/lld `(void)tgt`),
+  and the bundled `app_main.o` + platform `.a` are host-only, so end-to-end cross can't
+  succeed regardless. No guard. Minimum fix: reject a host-mismatched `--target` that can't
+  be satisfied (needs zig + a target platform lib). `target_spec` (build.lua:339) is also
+  lenient — validate arch/os.
+
+- [ ] **#3a `FEATURE_ARCHIVES` / `RUNTIME_FEATURE_LIBS` drifted from the registry** — `tls`,
+  `keel`, `sqlite` archives miss the `: Makefile` rebuild guard (latent stale-`ar`
+  duplicate-symbol class bug, uncaught by CI). Fix: derive from `$(FEATURE_EMBEDDED_LIBS)`.
+- [ ] **#3b `HL_ENABLE_MYSQL` missing from the config-sentinel fingerprint** (asymmetric with
+  POSTGRES, Makefile:~1823). Add `MYSQL=$(HL_ENABLE_MYSQL)|`.
+- [ ] **#3c Tier B (`lld-static`) omits `--gc-sections`** (linker_lld.c direct branch) — dead
+  sections / latent dangling-symbol risk that the zig backend explicitly guards against.
+
+## Tier 2 — make the toolchain-free story real for install-only users
+
+- [ ] **#4 No published musl `libhull_platform.a`.** ✓ Release builds Linux libs on glibc only,
+  so `--linker=lld-static` and `--linker=zig --target=…-musl` work ONLY from a source build.
+  Publish a signed `libhull_platform-musl-<arch>.a` (+ runtime/feature archives) and teach
+  `prepare_platform` to select it for a musl target. Highest-value "make it real" gap.
+- [ ] **#5 `--linker=zig` has zero e2e** ✓ **and no `test_linker` unit test** ✓. Add
+  `tests/hull/test_linker.c` (mock vtable capturing argv: `-Wl,` stripping + group flatten,
+  zig format→GC flag, `hl_linker_select` dispatch) + `tests/e2e_linker_zig.sh` (Docker run of
+  a cross/native zig-linked app) wired into Linux CI.
+
+## Tier 3 — simplifications (two prevent Tier-1 bugs)
+
+- [ ] **#6 Table-drive `compose_features()`** — 690-line fn, same 12-line block ×8. Collapse to a
+  data table + one loop; **fixes #1 for free** (eject calls the same helper).
+- [ ] **#7 One `HULL_CORE_OBJS` variable** — the ~60-token object list is duplicated across 8
+  sites (hull link prereqs+recipe, `PLATFORM_OBJS`, 5 test lists); drift already exists
+  (`fs_util.o` missing from the sentinel purge). Collapse to one var + `$^` recipe; derive
+  `PLATFORM_OBJS` via `filter-out`. Also: derive the sentinel purge list from the same set.
+- [ ] **#8 Consolidate trust-critical duplicate helpers** — `hex_decode` ×4 byte-identical on
+  Ed25519 signature-verify paths (`signature.c`, `release.c`, `verify_release.c`,
+  `verify_self.c`) while canonical `hl_cap_crypto_hex_decode` exists. Same as `mkdir_p`
+  consolidation, higher stakes. (`hex_encode` ×9, `secure_zero` ×5 follow.)
+
+## Tier 4 — architectural consistency & docs (lower urgency)
+
+- [ ] **T4a "base cap module" taxonomy category.** image/mime/blob/**tar** are all-C in-base cap
+  modules, but the CLAUDE.md taxonomy says stdlib = "no new C" and has no home for them; mime
+  `.pure=1` vs tar `.pure=0` exposes the inconsistency. Document a 5th row + the small+in-base
+  vs large+off-by-default rule vs a feature. Also add an explicit "tar rides CAP_OBJS,
+  always-in-base" note (today it's implicit via `wildcard` + denylist omission).
+- [ ] **T4b image half-migrated** — `#ifdef HL_ENABLE_IMAGE` in `modules.c` coexists with the
+  composed-feature weak-stub seam; document the dual role or unify on the seam.
+- [ ] **T4c Weak-hook seam divergence** — two shapes (header hook + `_present()` vs
+  weak-stub-as-sentinel, forcing WASM's bespoke `HL_CAP_WASM_ABSENT`); no `HL_WEAK` macro,
+  no single "how to add a seam" doc. Add a canonical section to features_and_flavors.md;
+  optionally an `HL_WEAK` macro over the ~21 raw `__attribute__((weak))` sites.
+- [ ] **T4d tools "bundle" facts duplicated** across `release.yml` (3×) + `tools.c`; registry
+  isn't the single source the comment claims. Consider `hull tools list --json --assets`.
+  Extend `release_smoke.sh` to install one bundle shape (zig/floor), not just wamrc.
+- [ ] **T4e FEATURE_SPECS not cross-checked** against `feature.c` FEATURES[] / Makefile —
+  extend `scripts/check_feature_registry.sh` to assert `feature_specs.lua` keys ⊇ installable
+  stems.
+- [ ] **T4f doc-rot** — build.lua tcc hints (retired), "planned" COFF/Mach-O comments (done),
+  mold "near-term" (deferred/not-started), CLAUDE.md tool row missing `.tar` bundle shape,
+  `obj_emit.h`/`linker.h` "planned" comments.
+
+## Already resolved (do not re-chase)
+
+- Config-sentinel **EMBED_PLATFORM** fingerprint gap — FIXED in commit 532991dd (2026-08-02).
+  The `project_build_modularization_plan.md` memory note is stale.
+- **cap/tar.c** `hl_tar_extract` mkdir-p dest + `release_io` 512 MB cap + lld-bundle-dropped —
+  fixed in PR #202 (the #201 dry-run findings).

--- a/docs/build_arc_audit.md
+++ b/docs/build_arc_audit.md
@@ -11,11 +11,11 @@ Execution order (agreed): **#6+#1 → #7 → #4 → #5 → #2 → #3 → #8**, t
 
 ## Tier 1 — correctness bugs
 
-- [ ] **#1 `hull eject` composes only runtime+http — broken for db/compute/image/TLS apps.** ✓
+- [x] **#1 `hull eject` composes only runtime+http — broken for db/compute/image/TLS apps.** ✓
   `eject.lua` calls only `resolve_runtime_lib` / `resolve_http_lib` / `resolve_http_rt_lib`;
   `build.lua`'s `compose_features()` also composes wasm/wasm-rt/sqlite-rt/image/image-rt/tls/keel.
   Ejecting a db/compute/image/HTTPS app yields a project that won't link/run. Drift
-  the modularization arc introduced. **Fix converges with #6.**
+  the modularization arc introduced. **Fix converges with #6.** DONE (PR #203): shared fcompose.plan_mandatory; eject now composes the full ordered set (validated: ejected compute app links + runs with WAMR).
 
 - [ ] **#2 Cross-compile silently mis-links.** ✓ `--target=<foreign>` emits a correct cross
   `app_registry.o`, but only the `zig` backend consumes the triple (system/lld `(void)tgt`),
@@ -45,8 +45,8 @@ Execution order (agreed): **#6+#1 → #7 → #4 → #5 → #2 → #3 → #8**, t
 
 ## Tier 3 — simplifications (two prevent Tier-1 bugs)
 
-- [ ] **#6 Table-drive `compose_features()`** — 690-line fn, same 12-line block ×8. Collapse to a
-  data table + one loop; **fixes #1 for free** (eject calls the same helper).
+- [x] **#6 Table-drive `compose_features()`** — 690-line fn, same 12-line block ×8. Collapse to a
+  data table + one loop; **fixes #1 for free** (eject calls the same helper). DONE (PR #203): build.lua 2365->1995 lines; compose blocks -> one data-driven plan + loop; extract_manifest also centralized. e2e composed_sig/build/feature_runtime/feature_wasm green.
 - [ ] **#7 One `HULL_CORE_OBJS` variable** — the ~60-token object list is duplicated across 8
   sites (hull link prereqs+recipe, `PLATFORM_OBJS`, 5 test lists); drift already exists
   (`fs_util.o` missing from the sentinel purge). Collapse to one var + `$^` recipe; derive

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1034,6 +1034,16 @@ local function compose_features(opts, tmpdir, platform_lib, is_cosmo, compute_fi
                 end
                 print("hull build: composed " .. d.label)
             end
+            -- Skip notes for the dropped subsystems (grepped by the wasm/tui
+            -- feature e2es as over-compose regression guards).
+            if not plan.needs_wasm then
+                print("hull build: compute-free app (no hull/compute, no "
+                    .. "compute/*.wasm) - skipped the WASM feature (~256 KB smaller)")
+            end
+            if not plan.needs_http then
+                print("hull build: HTTP-free app (app.main, no HTTP modules) - "
+                    .. "skipped http core + web bindings")
+            end
         end
     end
     return feature_objs, feature_libs, needs_base_group, composed_assets

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -497,39 +497,10 @@ end
 -- result and hand it back on subsequent calls without re-running the entry. The
 -- entry (nil-safe) is wrapped so a cached "no manifest" is distinct from
 -- "not yet extracted".
-local _manifest_cache = {}
-local function extract_app_manifest(app_dir)
-    local cached = _manifest_cache[app_dir]
-    if cached ~= nil then return cached.manifest end
-    local manifest = nil
-    local lua_entry = app_dir .. "/app.lua"
-    local js_entry  = app_dir .. "/app.js"
-    if file_exists(lua_entry) then
-        local chunk = tool.loadfile(lua_entry)
-        if chunk then
-            local ok, err = pcall(chunk)
-            if ok then
-                manifest = app.get_manifest()
-            else
-                tool.stderr("hull build: warning: Lua manifest extraction failed: " .. tostring(err) .. "\n")
-            end
-        end
-    elseif file_exists(js_entry) then
-        local ok, js_json_or_err = pcall(tool.extract_manifest_js, js_entry)
-        if not ok then
-            tool.stderr("hull build: warning: JS manifest extraction failed: " .. tostring(js_json_or_err) .. "\n")
-        elseif js_json_or_err then
-            local decoded, decode_err = json.decode(js_json_or_err)
-            if decoded then
-                manifest = decoded
-            else
-                tool.stderr("hull build: warning: JS manifest JSON decode failed: " .. tostring(decode_err) .. "\n")
-            end
-        end
-    end
-    _manifest_cache[app_dir] = { manifest = manifest }
-    return manifest
-end
+-- Manifest extraction lives in hull.feature_compose (shared with eject +
+-- plan_mandatory, with the run-app-once cache). Thin local alias keeps the
+-- call sites below readable.
+local extract_app_manifest = fcompose.extract_manifest
 
 -- On a signing failure, clean up the build tmpdir and remove the already-linked
 -- but unsigned output binary, so a failed `hull build --sign` never leaves an
@@ -1010,69 +981,6 @@ local function compose_features(opts, tmpdir, platform_lib, is_cosmo, compute_fi
         -- archive (features are native-only). Native has a runtime-less base and
         -- composes exactly one runtime here.
         if app_rt and not is_cosmo then
-            -- Reduced-flavor x composed-runtime (issue #114, Phase D). The only
-            -- flavors are `full` (HTTP on) and `pure-compute` (HTTP off), both
-            -- fully supported here: a pure-compute app declares no HTTP module,
-            -- so needs_http (below) is false and only the pure runtime is
-            -- composed onto the Keel-free base (the runtime's few web-symbol
-            -- references resolve to the base http_weakstub no-ops). An unknown
-            -- flavor is already rejected upstream at flavor validation.
-
-            -- Does this app need HTTP? (issue #114, Phase C2.) The route/ws/sse
-            -- decorations (app.get/…) only exist when an HTTP module is declared,
-            -- so a serving app always trips an HTTP cap in the resolver. When it
-            -- needs none (a pure app.main CLI / compute tool) skip composing the
-            -- http core + the per-runtime web bindings: the pure runtime's few
-            -- web-symbol refs are then satisfied by the base http_weakstub no-ops.
-            -- Fail safe: if resolution is unavailable, compose HTTP (never
-            -- under-compose and silently break serving).
-            local needs_http = true
-            -- needs_wasm two-signal gate (docs/wasm_feature.md, Phase 2):
-            --   S2 = the app ships compute/*.wasm (catches a WASM-backed db.udf
-            --        that declares no compute module — invisible to the resolver);
-            --   S1 = a declared WASM cap (hull/compute), from modules_resolve.
-            -- Compose the wasm feature iff either fires; a genuinely compute-free
-            -- app then links zero WAMR (~256 KB smaller).
-            local needs_wasm = (#compute_files > 0)
-            -- needs_sqlite (Phase C.2b): the app uses a udf-capable DB, so compose
-            -- the per-runtime SQLite UDF bridge (mod_db_udf), which the base runtime
-            -- archive no longer carries. SQLite is guaranteed reachable here (in the
-            -- base, or composed as the engine feature by the Phase C block above),
-            -- so the bridge's sqlite3_* references always resolve.
-            local needs_sqlite = false
-            -- needs_image (docs/image_feature.md): the app declares hull/image, so
-            -- compose the image codec core + the per-runtime image bridge, which the
-            -- native base no longer carries. Cleanly module-inferable (the resolver's
-            -- HL_MOD_CAP_IMAGE); a genuinely image-free app links zero stb (~146 KB
-            -- smaller).
-            local needs_image = false
-            -- needs_tls (docs/tls_feature.md, a2): the app implies the TLS stack
-            -- (HTTP -> https fetch / TLS serving / smtp; a net-DB sslmode). Compose
-            -- libhull_feature-tls.a (mbedTLS + the crypto/tls backends) which a
-            -- TLS-less base no longer carries; a plaintext app links zero mbedTLS.
-            local needs_tls = false
-            do
-                local mf = extract_app_manifest(opts.app_dir)
-                if mf then
-                    local r = tool.modules_resolve(mf, opts.flavor, with_feature_list(opts))
-                    if r.ok and r.needs_http ~= nil then needs_http = r.needs_http end
-                    if r.ok and r.needs_wasm then needs_wasm = true end
-                    if r.ok and r.needs_sqlite then needs_sqlite = true end
-                    if r.ok and r.needs_image then needs_image = true end
-                    if r.ok and r.needs_tls then needs_tls = true end
-                end
-            end
-            -- OR in the network-DB signal (the piece tool_orchestration.c's
-            -- needs_tls left to build time): the postgres/mysql wire backends link
-            -- the shared tls_client (which the a2 TLS feature now owns) for
-            -- sslmode, so composing either onto a TLS-less base needs the TLS
-            -- feature too -- regardless of the DSN's sslmode, since the archive's
-            -- tls_client refs must resolve. These are explicit --with=/inferred
-            -- (opts.with), the same signal the backend features compose on.
-            if opts.with and (opts.with.postgres or opts.with.mysql) then
-                needs_tls = true
-            end
-
             -- The per-runtime feature registry is invariant code (depends only
             -- on app_rt), so --no-compiler extracts a pre-compiled bundled copy
             -- instead of compiling gen_app_registry_c. Keep the generated .c on
@@ -1094,314 +1002,37 @@ local function compose_features(opts, tmpdir, platform_lib, is_cosmo, compute_fi
             end
             feature_objs[#feature_objs + 1] = tmpdir .. "/app_feature_registry.o"
 
-            -- Compose the runtime. The base platform lib is RUNTIME-LESS, so the
-            -- app must link exactly one runtime archive (libhull_feature-<rt>.a)
-            -- to be runnable. Auto-inferred from the entry extension. Whole-
-            -- archive so the entire runtime + its embedded stdlib + vendored VM
-            -- are pulled (like the tui feature), not merely what the registry's
-            -- factory reference reaches. The runtime references base symbols
-            -- (crypto/vfs/...) resolved from the platform lib, so the GNU-ld link
-            -- must --start-group them.
-            local rt_lib  = "libhull_feature-" .. app_rt .. ".a"
+            -- Compose the mandatory auto-composed archives the app needs (runtime
+            -- + http/wasm/sqlite-rt/image/tls/keel). The ORDERED plan is shared
+            -- with `hull eject` via fcompose.plan_mandatory so the two paths
+            -- cannot drift (build once composed all 8 while eject composed only
+            -- runtime+http). Each archive is whole-archived; runtime/tls/keel
+            -- additionally need the GNU-ld --start-group with the base lib. The
+            -- record_composed names + order are byte-identical to the previous
+            -- hand-rolled blocks (verified by e2e_composed_sig).
             local rt_plat = tool.platform_name and tool.platform_name() or nil
             local rt_hull_dir = ""
             if __hull_exe then rt_hull_dir = __hull_exe:match("(.*/)") or "" end
-            local rt_path, rt_from = fcompose.resolve_runtime_lib(app_rt, tmpdir,
-                                     { hull_dir = rt_hull_dir, plat = rt_plat })
-            if not rt_path then
-                if rt_from == "cache-verify-failed" then
-                    tool.stderr("hull build: cached " .. app_rt
-                        .. " runtime lib could not be re-verified\n")
-                else
-                    tool.stderr("hull build: the '" .. app_rt .. "' runtime feature lib "
-                        .. "was not found (the runtime is normally embedded in hull)\n")
-                    tool.stderr("hint: build it from source with `make feature-"
-                        .. app_rt .. "`\n")
-                end
-                tool.rmdir(tmpdir); tool.exit(1)
-            end
-            local rt_dest = tmpdir .. "/" .. rt_lib
-            if rt_path ~= rt_dest then tool.copy(rt_path, rt_dest) end  -- already there if extracted
-            -- The runtime archive ships INSIDE hull -> platform domain.
-            record_composed("libhull_feature-" .. app_rt .. "."
-                            .. (rt_plat or "") .. ".a", rt_dest, "platform")
-            needs_base_group = true  -- runtime refs base symbols; GNU ld needs the group
             local is_darwin = rt_plat and rt_plat:sub(1, 6) == "darwin"
-            for _, f in ipairs(fcompose.whole_archive_flags(rt_dest, is_darwin)) do
-                feature_libs[#feature_libs + 1] = f
-            end
-            print("hull build: composed runtime '" .. app_rt .. "'")
 
-            -- Compose the WASM feature (docs/wasm_feature.md, Phase 2). The native
-            -- base is compute-less: the wasm caps + WAMR live in
-            -- libhull_feature-wasm.a and the compute.* binding (mod_compute) in
-            -- libhull_feature-wasm-<rt>.a. Composed only when needs_wasm (S1 or S2,
-            -- above); a genuinely compute-free app links zero WAMR. Whole-archive
-            -- both inside the --start-group.
-            if needs_wasm then
-            local wasm_lib = "libhull_feature-wasm.a"
-            local wasm_path, wasm_from = fcompose.resolve_wasm_lib(tmpdir,
-                                         { hull_dir = rt_hull_dir, plat = rt_plat })
-            if not wasm_path then
-                tool.stderr("hull build: the WASM feature lib (libhull_feature-wasm.a) "
-                    .. "was not found "
-                    .. (wasm_from == "cache-verify-failed"
-                        and "(cache re-verify failed)\n" or "(normally embedded in hull)\n"))
-                tool.stderr("hint: build it from source with `make feature-wasm`\n")
-                tool.rmdir(tmpdir); tool.exit(1)
-            end
-            local wasm_dest = tmpdir .. "/" .. wasm_lib
-            if wasm_path ~= wasm_dest then tool.copy(wasm_path, wasm_dest) end
-            record_composed("libhull_feature-wasm." .. (rt_plat or "") .. ".a",
-                            wasm_dest, "platform")
-            for _, f in ipairs(fcompose.whole_archive_flags(wasm_dest, is_darwin)) do
-                feature_libs[#feature_libs + 1] = f
-            end
-
-            local wasmrt_lib = "libhull_feature-wasm-" .. app_rt .. ".a"
-            local wasmrt_path, wasmrt_from = fcompose.resolve_wasm_rt_lib(app_rt, tmpdir,
-                                             { hull_dir = rt_hull_dir, plat = rt_plat })
-            if not wasmrt_path then
-                tool.stderr("hull build: the compute-bindings feature lib (" .. wasmrt_lib
-                    .. ") was not found "
-                    .. (wasmrt_from == "cache-verify-failed"
-                        and "(cache re-verify failed)\n" or "(normally embedded in hull)\n"))
-                tool.rmdir(tmpdir); tool.exit(1)
-            end
-            local wasmrt_dest = tmpdir .. "/" .. wasmrt_lib
-            if wasmrt_path ~= wasmrt_dest then tool.copy(wasmrt_path, wasmrt_dest) end
-            record_composed("libhull_feature-wasm-" .. app_rt .. "."
-                            .. (rt_plat or "") .. ".a", wasmrt_dest, "platform")
-            for _, f in ipairs(fcompose.whole_archive_flags(wasmrt_dest, is_darwin)) do
-                feature_libs[#feature_libs + 1] = f
-            end
-            print("hull build: composed WASM feature + compute bridge '" .. app_rt .. "'")
-            else
-                print("hull build: compute-free app (no hull/compute, no "
-                    .. "compute/*.wasm) - skipped the WASM feature (~256 KB smaller)")
-            end
-
-            -- Compose the per-runtime SQLite UDF bridge (Phase C.2b). The runtime
-            -- archive is SQLite-free; the db.udf bindings (mod_db_udf, the sole
-            -- per-runtime sqlite3_* consumer) live in libhull_feature-sqlite-<rt>.a
-            -- and compose only when the app uses a udf-capable DB. A db-free app
-            -- composes neither this nor the engine, so it links zero SQLite.
-            if needs_sqlite then
-            local sqrt_lib = "libhull_feature-sqlite-" .. app_rt .. ".a"
-            local sqrt_path, sqrt_from = fcompose.resolve_sqlite_rt_lib(app_rt, tmpdir,
-                                         { hull_dir = rt_hull_dir, plat = rt_plat })
-            if not sqrt_path then
-                tool.stderr("hull build: the SQLite udf-bridge feature lib (" .. sqrt_lib
-                    .. ") was not found "
-                    .. (sqrt_from == "cache-verify-failed"
-                        and "(cache re-verify failed)\n" or "(normally embedded in hull)\n"))
-                tool.rmdir(tmpdir); tool.exit(1)
-            end
-            local sqrt_dest = tmpdir .. "/" .. sqrt_lib
-            if sqrt_path ~= sqrt_dest then tool.copy(sqrt_path, sqrt_dest) end
-            record_composed("libhull_feature-sqlite-" .. app_rt .. "."
-                            .. (rt_plat or "") .. ".a", sqrt_dest, "platform")
-            for _, f in ipairs(fcompose.whole_archive_flags(sqrt_dest, is_darwin)) do
-                feature_libs[#feature_libs + 1] = f
-            end
-            print("hull build: composed SQLite udf bridge '" .. app_rt .. "'")
-            end
-
-            -- Compose the IMAGE feature (docs/image_feature.md). The native base is
-            -- image-less: the codec caps + vendored stb live in
-            -- libhull_feature-image.a and the image.* binding (mod_image) in
-            -- libhull_feature-image-<rt>.a. Composed only when needs_image (the app
-            -- declared hull/image); a genuinely image-free app links zero stb
-            -- (~146 KB smaller). Whole-archive both inside the --start-group.
-            if needs_image then
-            local img_lib = "libhull_feature-image.a"
-            local img_path, img_from = fcompose.resolve_image_lib(tmpdir,
-                                       { hull_dir = rt_hull_dir, plat = rt_plat })
-            if not img_path then
-                tool.stderr("hull build: the image feature lib (libhull_feature-image.a) "
-                    .. "was not found "
-                    .. (img_from == "cache-verify-failed"
-                        and "(cache re-verify failed)\n" or "(normally embedded in hull)\n"))
-                tool.stderr("hint: build it from source with `make feature-image`\n")
-                tool.rmdir(tmpdir); tool.exit(1)
-            end
-            local img_dest = tmpdir .. "/" .. img_lib
-            if img_path ~= img_dest then tool.copy(img_path, img_dest) end
-            record_composed("libhull_feature-image." .. (rt_plat or "") .. ".a",
-                            img_dest, "platform")
-            for _, f in ipairs(fcompose.whole_archive_flags(img_dest, is_darwin)) do
-                feature_libs[#feature_libs + 1] = f
-            end
-
-            local imgrt_lib = "libhull_feature-image-" .. app_rt .. ".a"
-            local imgrt_path, imgrt_from = fcompose.resolve_image_rt_lib(app_rt, tmpdir,
-                                           { hull_dir = rt_hull_dir, plat = rt_plat })
-            if not imgrt_path then
-                tool.stderr("hull build: the image-bindings feature lib (" .. imgrt_lib
-                    .. ") was not found "
-                    .. (imgrt_from == "cache-verify-failed"
-                        and "(cache re-verify failed)\n" or "(normally embedded in hull)\n"))
-                tool.rmdir(tmpdir); tool.exit(1)
-            end
-            local imgrt_dest = tmpdir .. "/" .. imgrt_lib
-            if imgrt_path ~= imgrt_dest then tool.copy(imgrt_path, imgrt_dest) end
-            record_composed("libhull_feature-image-" .. app_rt .. "."
-                            .. (rt_plat or "") .. ".a", imgrt_dest, "platform")
-            for _, f in ipairs(fcompose.whole_archive_flags(imgrt_dest, is_darwin)) do
-                feature_libs[#feature_libs + 1] = f
-            end
-            print("hull build: composed image feature + image bridge '" .. app_rt .. "'")
-            end
-
-            -- Compose the TLS feature (docs/tls_feature.md, a2). A tls-less base
-            -- (HL_TLS_FEATURE=1) drops mbedTLS + the crypto/tls backends; compose
-            -- libhull_feature-tls.a back when the app needs TLS AND the base is
-            -- actually tls-less. Probe the base: a TLS-full base defines
-            -- mbedtls_ssl_handshake, a tls-less one does not -- gate on its ABSENCE
-            -- so this is a no-op (byte-identical) on a stock TLS-full base. Whole-
-            -- archive inside the --start-group (the archive refs base crypto/vfs +
-            -- Keel's tls_mbedtls.o).
-            if needs_tls then
-            local base_has_tls = true
-            local tls_nm = tool.spawn_read({ "nm", platform_lib })
-            if tls_nm and not tls_nm:find("mbedtls_ssl_handshake") then
-                base_has_tls = false
-            end
-            if not base_has_tls then
-                local tls_lib = "libhull_feature-tls.a"
-                local tls_path, tls_from = fcompose.resolve_tls_lib(tmpdir,
-                                           { hull_dir = rt_hull_dir, plat = rt_plat })
-                if not tls_path then
-                    tool.stderr("hull build: the TLS feature lib (libhull_feature-tls.a) "
-                        .. "was not found "
-                        .. (tls_from == "cache-verify-failed"
-                            and "(cache re-verify failed)\n" or "(normally embedded in hull)\n"))
-                    tool.stderr("hint: build it from source with `make feature-tls`\n")
-                    tool.rmdir(tmpdir); tool.exit(1)
-                end
-                local tls_dest = tmpdir .. "/" .. tls_lib
-                if tls_path ~= tls_dest then tool.copy(tls_path, tls_dest) end
-                record_composed("libhull_feature-tls." .. (rt_plat or "") .. ".a",
-                                tls_dest, "platform")
-                needs_base_group = true  -- tls archive refs base + Keel symbols
-                for _, f in ipairs(fcompose.whole_archive_flags(tls_dest, is_darwin)) do
+            local plan = fcompose.plan_mandatory({
+                app_dir = opts.app_dir, app_rt = app_rt, tmpdir = tmpdir,
+                hull_dir = rt_hull_dir, plat = rt_plat, platform_lib = platform_lib,
+                compute_count = #compute_files, with = opts.with, flavor = opts.flavor,
+                with_list = with_feature_list(opts),
+                on_fail = function(msg)
+                    tool.stderr(msg); tool.rmdir(tmpdir); tool.exit(1)
+                end,
+            })
+            for _, d in ipairs(plan.list) do
+                local dest = tmpdir .. "/" .. d.lib
+                if d.path ~= dest then tool.copy(d.path, dest) end
+                record_composed(d.record_name, dest, "platform")
+                if d.sets_base_group then needs_base_group = true end
+                for _, f in ipairs(fcompose.whole_archive_flags(dest, is_darwin)) do
                     feature_libs[#feature_libs + 1] = f
                 end
-                print("hull build: composed TLS feature (tls-less base + app needs TLS)")
-            end
-            end
-
-            if needs_http then
-            -- Compose the HTTP feature (issue #114, Phase B). The native base is
-            -- HTTP-CORE-LESS: serve.c + the runtime's web-module bindings
-            -- reference the http/ws/smtp/body caps, which now live in
-            -- libhull_feature-http.a. Whole-archive it inside the --start-group
-            -- (the caps reference Keel + base symbols, and the runtime's web
-            -- bindings reference the caps). Composed for every full-flavor native
-            -- app for now; a reduced flavor fails closed earlier, and skipping it
-            -- for a genuinely HTTP-free app is a later refinement.
-            local http_lib = "libhull_feature-http.a"
-            local http_path, http_from = fcompose.resolve_http_lib(tmpdir,
-                                         { hull_dir = rt_hull_dir, plat = rt_plat })
-            if not http_path then
-                if http_from == "cache-verify-failed" then
-                    tool.stderr("hull build: cached HTTP feature lib could not be re-verified\n")
-                else
-                    tool.stderr("hull build: the HTTP feature lib "
-                        .. "(libhull_feature-http.a) was not found "
-                        .. "(normally embedded in hull)\n")
-                    tool.stderr("hint: build it from source with `make feature-http`\n")
-                end
-                tool.rmdir(tmpdir); tool.exit(1)
-            end
-            local http_dest = tmpdir .. "/" .. http_lib
-            if http_path ~= http_dest then tool.copy(http_path, http_dest) end
-            -- The HTTP core archive ships INSIDE hull -> platform domain.
-            record_composed("libhull_feature-http." .. (rt_plat or "") .. ".a",
-                            http_dest, "platform")
-            for _, f in ipairs(fcompose.whole_archive_flags(http_dest, is_darwin)) do
-                feature_libs[#feature_libs + 1] = f
-            end
-            print("hull build: composed HTTP feature")
-
-            -- Compose the Keel event loop (docs/keel_feature.md, Phase 4.2b) when
-            -- the base is Keel-less. Sentinel: hl_async_backend_keel (async_keel.o's
-            -- vtable) is fully ABSENT from a Keel-less base (HL_KEEL_FEATURE=1 drops
-            -- async/keel.c) and present in a Keel-full base. It is a cleaner probe
-            -- than hull_serve, which serve_cli.o defines WEAK -- and macOS plain `nm`
-            -- prints a weak def as `T`, indistinguishable from a strong one. When the
-            -- sentinel is absent, compose libhull_feature-keel.a (serve.o + async_keel
-            -- + net_keel + the server-only static/agent/test objects); a full base,
-            -- which already carries them, never double-composes (no duplicate
-            -- hull_serve). The composed serve.o's kl_* refs pull libkeel from the base
-            -- .a on demand.
-            -- Default to "present" (skip compose), flipping to compose only on a
-            -- CONFIRMED nm result lacking the sentinel -- mirrors the sqlite/tls
-            -- probes. If nm is absent or errors (serve_nm == nil), skipping is the
-            -- safe no-op for the common Keel-FULL base: composing there would
-            -- duplicate serve.o's strong hull_serve / hl_async_backend and fail the
-            -- link. The Keel-less release base is only built where nm exists.
-            local base_has_keel = true
-            local serve_nm = tool.spawn_read({ "nm", platform_lib })
-            if serve_nm and not serve_nm:find("hl_async_backend_keel") then
-                base_has_keel = false
-            end
-            if not base_has_keel then
-                local keel_lib = "libhull_feature-keel.a"
-                local keel_path, keel_from = fcompose.resolve_keel_lib(tmpdir,
-                                             { hull_dir = rt_hull_dir, plat = rt_plat })
-                if not keel_path then
-                    tool.stderr("hull build: the Keel feature lib "
-                        .. "(libhull_feature-keel.a) was not found "
-                        .. (keel_from == "cache-verify-failed"
-                            and "(cache re-verify failed)\n" or "(normally embedded in hull)\n"))
-                    tool.stderr("hint: build it from source with `make feature-keel`\n")
-                    tool.rmdir(tmpdir); tool.exit(1)
-                end
-                local keel_dest = tmpdir .. "/" .. keel_lib
-                if keel_path ~= keel_dest then tool.copy(keel_path, keel_dest) end
-                record_composed("libhull_feature-keel." .. (rt_plat or "") .. ".a",
-                                keel_dest, "platform")
-                needs_base_group = true  -- keel archive refs base + libkeel symbols
-                for _, f in ipairs(fcompose.whole_archive_flags(keel_dest, is_darwin)) do
-                    feature_libs[#feature_libs + 1] = f
-                end
-                print("hull build: composed Keel event loop (Keel-less base)")
-            end
-
-            -- Phase C: the per-runtime web bindings (routes/dispatch/res:*/ws/sse/
-            -- http-client/smtp) live in libhull_feature-http-<rt>.a, not the pure
-            -- runtime archive. Whole-archive it too (its strong defs override the
-            -- base http_weakstub no-ops; it references the http core caps + Keel,
-            -- all inside the --start-group).
-            local httprt_lib = "libhull_feature-http-" .. app_rt .. ".a"
-            local httprt_path, httprt_from = fcompose.resolve_http_rt_lib(app_rt, tmpdir,
-                                             { hull_dir = rt_hull_dir, plat = rt_plat })
-            if not httprt_path then
-                if httprt_from == "cache-verify-failed" then
-                    tool.stderr("hull build: cached web-bindings lib (" .. httprt_lib
-                        .. ") could not be re-verified\n")
-                else
-                    tool.stderr("hull build: the web-bindings feature lib "
-                        .. "(" .. httprt_lib .. ") was not found "
-                        .. "(normally embedded in hull)\n")
-                    tool.stderr("hint: build it from source with `make feature-http-"
-                        .. app_rt .. "`\n")
-                end
-                tool.rmdir(tmpdir); tool.exit(1)
-            end
-            local httprt_dest = tmpdir .. "/" .. httprt_lib
-            if httprt_path ~= httprt_dest then tool.copy(httprt_path, httprt_dest) end
-            -- The per-runtime web bindings ship INSIDE hull -> platform domain.
-            record_composed("libhull_feature-http-" .. app_rt .. "."
-                            .. (rt_plat or "") .. ".a", httprt_dest, "platform")
-            for _, f in ipairs(fcompose.whole_archive_flags(httprt_dest, is_darwin)) do
-                feature_libs[#feature_libs + 1] = f
-            end
-            print("hull build: composed web bindings '" .. app_rt .. "'")
-            else
-                print("hull build: HTTP-free app (app.main, no HTTP modules) - "
-                    .. "skipped http core + web bindings")
+                print("hull build: composed " .. d.label)
             end
         end
     end

--- a/stdlib/cli/lua/hull/eject.lua
+++ b/stdlib/cli/lua/hull/eject.lua
@@ -86,29 +86,21 @@ clean:
     end
 
     -- Native runtime-less base: link the platform lib + the whole-archived
-    -- runtime feature. The runtime references base symbols (crypto/vfs), so the
-    -- GNU-ld link wraps both in --start-group; ld64 rescans natively and
-    -- rejects the flag, so darwin uses a plain platform lib + -force_load. The
-    -- default CC is the native `cc` (the extracted .a is native single-arch;
-    -- cosmocc would reject its object format).
-    local rt_lib = "platform/libhull_feature-" .. rt.name .. ".a"
-    local waf = table.concat(rt.fcompose.whole_archive_flags(rt_lib, rt.darwin), " ")
-    -- HTTP core feature (issue #114): whole-archive it alongside the runtime so
-    -- the web bindings' http/ws/smtp/body cap refs resolve. Inside the same
-    -- --start-group (the caps reference base symbols + Keel from the platform lib).
-    if rt.http_path then
-        waf = waf .. " " .. table.concat(
-            rt.fcompose.whole_archive_flags("platform/libhull_feature-http.a", rt.darwin), " ")
+    -- mandatory feature set (runtime + http/wasm/sqlite-rt/image/tls/keel as the
+    -- app needs them, in the plan's order). Archives that reference base / Keel
+    -- symbols (runtime, tls, keel) need the GNU-ld --start-group with the
+    -- platform lib; ld64 rescans natively and rejects the flag, so darwin uses a
+    -- plain platform lib + -force_load. The default CC is the native `cc` (the
+    -- extracted .a is native single-arch; cosmocc would reject its object format).
+    local parts = {}
+    for _, d in ipairs(rt.plan) do
+        for _, f in ipairs(rt.fcompose.whole_archive_flags("platform/" .. d.lib, rt.darwin)) do
+            parts[#parts + 1] = f
+        end
     end
-    -- Phase C: the runtime's web bindings archive (whole-archived, overrides the
-    -- base http_weakstub no-ops).
-    if rt.httprt_path then
-        waf = waf .. " " .. table.concat(
-            rt.fcompose.whole_archive_flags(
-                "platform/libhull_feature-http-" .. rt.name .. ".a", rt.darwin), " ")
-    end
+    local waf = table.concat(parts, " ")
     local link_libs
-    if rt.darwin then
+    if rt.darwin or not rt.base_group then
         link_libs = "platform/libhull_platform.a " .. waf
     else
         link_libs = "-Wl,--start-group platform/libhull_platform.a " .. waf
@@ -332,56 +324,37 @@ local function main()
         local app_rt = fcompose.detect_app_rt(opts.app_dir)
         if app_rt then
             local plat = tool.platform_name and tool.platform_name() or nil
-            local rt_path, rt_from = fcompose.resolve_runtime_lib(app_rt, extracted_dir,
-                                         { hull_dir = hull_dir, plat = plat })
-            if not rt_path then
-                if rt_from == "cache-verify-failed" then
-                    tool.stderr("hull eject: cached " .. app_rt
-                        .. " runtime lib could not be re-verified\n")
-                else
-                    tool.stderr("hull eject: the '" .. app_rt .. "' runtime feature lib "
-                        .. "was not found (normally embedded in a release hull)\n")
-                    tool.stderr("hint: `hull feature install " .. app_rt .. "`, or build "
-                        .. "from source with `make feature-" .. app_rt .. "`\n")
-                end
-                tool.exit(1)
+            -- Count compute/*.wasm so a WASM-backed db.udf (which declares no
+            -- compute module, invisible to the resolver) still composes the wasm
+            -- feature -- plan_mandatory's S2 signal, matching `hull build`.
+            local compute_count = 0
+            if tool.file_exists(opts.app_dir .. "/compute") then
+                local wasm = tool.find_files(opts.app_dir .. "/compute", "*.wasm")
+                if wasm then compute_count = #wasm end
             end
-            -- The native base is also HTTP-core-less (issue #114): the runtime's
-            -- web bindings reference the http/ws/smtp/body caps that now live in
-            -- libhull_feature-http.a. Compose it back too, mirroring `hull build`.
-            local http_path, http_from = fcompose.resolve_http_lib(extracted_dir,
-                                         { hull_dir = hull_dir, plat = plat })
-            if not http_path then
-                if http_from == "cache-verify-failed" then
-                    tool.stderr("hull eject: cached HTTP feature lib could not be re-verified\n")
-                else
-                    tool.stderr("hull eject: the HTTP feature lib "
-                        .. "(libhull_feature-http.a) was not found "
-                        .. "(normally embedded in a release hull)\n")
-                    tool.stderr("hint: `hull feature install http` is not applicable; build "
-                        .. "from source with `make feature-http`\n")
-                end
-                tool.exit(1)
-            end
-            -- Phase C: the runtime's web bindings live in a separate archive too.
-            local httprt_path, httprt_from = fcompose.resolve_http_rt_lib(app_rt, extracted_dir,
-                                             { hull_dir = hull_dir, plat = plat })
-            if not httprt_path then
-                if httprt_from == "cache-verify-failed" then
-                    tool.stderr("hull eject: cached web-bindings lib could not be re-verified\n")
-                else
-                    tool.stderr("hull eject: the web-bindings feature lib "
-                        .. "(libhull_feature-http-" .. app_rt .. ".a) was not found\n")
-                    tool.stderr("hint: build from source with `make feature-http-"
-                        .. app_rt .. "`\n")
-                end
-                tool.exit(1)
+            -- Compose the SAME ordered mandatory-archive set `hull build` does
+            -- (runtime + http/wasm/sqlite-rt/image/tls/keel as the app needs
+            -- them) via the shared plan. Before this, eject composed ONLY runtime
+            -- + http, so an ejected db/compute/image/HTTPS app failed to link
+            -- (missing sqlite3_*/WAMR/mbedTLS symbols). One source of truth now.
+            local plan = fcompose.plan_mandatory({
+                app_dir = opts.app_dir, app_rt = app_rt, tmpdir = extracted_dir,
+                hull_dir = hull_dir, plat = plat, platform_lib = platform_lib,
+                compute_count = compute_count, with = opts.with, flavor = opts.flavor,
+                with_list = {},
+                on_fail = function(msg)
+                    tool.stderr((msg:gsub("hull build:", "hull eject:")))
+                    tool.exit(1)
+                end,
+            })
+            local base_group = false
+            for _, d in ipairs(plan.list) do
+                if d.sets_base_group then base_group = true end
             end
             rt_compose = {
                 name = app_rt,
-                path = rt_path,
-                http_path = http_path,
-                httprt_path = httprt_path,
+                plan = plan.list,
+                base_group = base_group,
                 darwin = (plat and plat:sub(1, 6) == "darwin") or false,
                 fcompose = fcompose,
             }
@@ -418,15 +391,10 @@ local function main()
     if rt_compose then
         write_file(dir .. "/src/app_feature_registry.c",
                    fcompose.gen_app_registry_c(rt_compose.name))
-        tool.copy(rt_compose.path,
-                  dir .. "/platform/libhull_feature-" .. rt_compose.name .. ".a")
-        if rt_compose.http_path then
-            tool.copy(rt_compose.http_path,
-                      dir .. "/platform/libhull_feature-http.a")
-        end
-        if rt_compose.httprt_path then
-            tool.copy(rt_compose.httprt_path,
-                      dir .. "/platform/libhull_feature-http-" .. rt_compose.name .. ".a")
+        -- Copy every composed archive in the plan into platform/ under its
+        -- canonical filename; the Makefile whole-archives each (see gen_makefile).
+        for _, d in ipairs(rt_compose.plan) do
+            tool.copy(d.path, dir .. "/platform/" .. d.lib)
         end
     end
 

--- a/stdlib/cli/lua/hull/feature_compose.lua
+++ b/stdlib/cli/lua/hull/feature_compose.lua
@@ -534,7 +534,10 @@ function M.plan_mandatory(ctx)
               path = resolve("web-bindings", "http-" .. rt, M.resolve_http_rt_lib, rt, ctx.tmpdir, rctx) })
     end
 
-    return { list = list, needs_http = needs_http }
+    -- needs_wasm is returned so the caller can print the compute-free skip note;
+    -- needs_http likewise for the HTTP-free note (both are grepped by the tui/
+    -- wasm feature e2es as over-compose regression guards).
+    return { list = list, needs_http = needs_http, needs_wasm = needs_wasm }
 end
 
 return M

--- a/stdlib/cli/lua/hull/feature_compose.lua
+++ b/stdlib/cli/lua/hull/feature_compose.lua
@@ -21,7 +21,56 @@
 
 local M = {}
 
+local json = require("hull.json")
+
 local function file_exists(p) return tool.file_exists(p) end
+
+-- ── App manifest extraction (shared by build + eject) ────────────────
+--
+-- Runs the app entry to capture its app.manifest({...}). EXECUTING app.lua a
+-- second time corrupts the sign flow, so the result is cached per app_dir (each
+-- `hull build`/`hull eject` is a fresh process, so this is a per-invocation
+-- cache). Both `hull build` and the mandatory-compose plan below read the
+-- manifest; centralizing avoids running the app twice and keeps one impl.
+--
+-- @param app_dir string
+-- @return table|nil  The captured manifest, or nil if extraction failed.
+local _manifest_cache = {}
+function M.extract_manifest(app_dir)
+    local cached = _manifest_cache[app_dir]
+    if cached ~= nil then return cached.manifest end
+    local manifest = nil
+    local lua_entry = app_dir .. "/app.lua"
+    local js_entry  = app_dir .. "/app.js"
+    if file_exists(lua_entry) then
+        local chunk = tool.loadfile(lua_entry)
+        if chunk then
+            local ok, err = pcall(chunk)
+            if ok then
+                manifest = app.get_manifest()
+            else
+                tool.stderr("hull: warning: Lua manifest extraction failed: "
+                            .. tostring(err) .. "\n")
+            end
+        end
+    elseif file_exists(js_entry) then
+        local ok, js_json_or_err = pcall(tool.extract_manifest_js, js_entry)
+        if not ok then
+            tool.stderr("hull: warning: JS manifest extraction failed: "
+                        .. tostring(js_json_or_err) .. "\n")
+        elseif js_json_or_err then
+            local decoded, decode_err = json.decode(js_json_or_err)
+            if decoded then
+                manifest = decoded
+            else
+                tool.stderr("hull: warning: JS manifest JSON decode failed: "
+                            .. tostring(decode_err) .. "\n")
+            end
+        end
+    end
+    _manifest_cache[app_dir] = { manifest = manifest }
+    return manifest
+end
 
 -- ── App runtime detection ────────────────────────────────────────────
 
@@ -343,6 +392,149 @@ function M.resolve_image_rt_lib(rt, tmpdir, ctx)
     end
     local asset = ctx.plat and ("libhull_feature-image-" .. rt .. "-" .. ctx.plat .. ".a") or nil
     return M.resolve_lib(libname, asset, ctx)
+end
+
+-- ── The mandatory auto-composed archive plan ─────────────────────────
+--
+-- The native SLIM base drops runtime + http core + per-runtime web bindings +
+-- wasm(+bridge) + sqlite-rt bridge + image(+bridge) + tls + keel, and the
+-- produced app composes back exactly what it uses. Both `hull build` (links the
+-- archives directly) and `hull eject` (copies them into the ejected project +
+-- emits Makefile link flags) need the SAME ordered set. This function is that
+-- single source of truth: it computes the needs-gates + nm-probes ONCE and
+-- returns the resolved, ORDERED descriptor list. Before this, build.lua composed
+-- all 8 while eject.lua composed only runtime+http — the exact drift the module
+-- header warns about, one level up (the ladder was shared, the decision to
+-- invoke each rung was not).
+--
+-- @param ctx table Fields:
+--   app_dir, app_rt ("lua"|"js"), hull_dir, plat, platform_lib,
+--   compute_count (int, # of compute/*.wasm), with (opts.with table|nil),
+--   flavor, with_list (array for tool.modules_resolve),
+--   on_fail = function(msg)  (caller's cleanup+exit; must not return).
+-- @return table { list = { desc, ... }, needs_http = bool }
+--   desc = { record_name, lib, path, sets_base_group, is_rt, label }
+--     record_name : the composed-asset name (with the .<plat>. infix) for
+--                   package.sig attestation + the caller's provenance.
+--     lib         : the archive filename (no plat), the copy destination stem.
+--     path        : the resolved source archive path.
+--     sets_base_group : true iff the archive refs base/Keel symbols (GNU-ld
+--                   --start-group). runtime, tls, keel set it.
+function M.plan_mandatory(ctx)
+    local rt = ctx.app_rt
+    local rctx = { hull_dir = ctx.hull_dir or "", plat = ctx.plat }
+    local plat_infix = ctx.plat or ""
+
+    -- ── Compute the needs-gates (resolver + build-time signals) ──
+    -- needs_http defaults true (fail safe: never under-compose serving); the
+    -- resolver flips it false for a pure app.main/compute app.
+    local needs_http = true
+    -- needs_wasm S2: the app ships compute/*.wasm (catches a WASM-backed db.udf
+    -- that declares no module). S1 (a declared WASM cap) ORs in from the resolver.
+    local needs_wasm = (ctx.compute_count or 0) > 0
+    local needs_sqlite, needs_image, needs_tls = false, false, false
+    do
+        local mf = M.extract_manifest(ctx.app_dir)
+        if mf then
+            local r = tool.modules_resolve(mf, ctx.flavor, ctx.with_list)
+            if r.ok then
+                if r.needs_http ~= nil then needs_http = r.needs_http end
+                if r.needs_wasm then needs_wasm = true end
+                if r.needs_sqlite then needs_sqlite = true end
+                if r.needs_image then needs_image = true end
+                if r.needs_tls then needs_tls = true end
+            end
+        end
+    end
+    -- A net-DB --with backend (postgres/mysql) links the shared tls_client for
+    -- sslmode, so composing it onto a TLS-less base needs the TLS feature too.
+    if ctx.with and (ctx.with.postgres or ctx.with.mysql) then needs_tls = true end
+
+    -- Base-presence nm-probes: compose tls/keel ONLY when the base actually
+    -- dropped them (HL_TLS_FEATURE=1 / HL_KEEL_FEATURE=1). Default to "present"
+    -- (skip) on an unreadable/absent nm, so a stock full base is byte-identical.
+    local function base_lacks(sym)
+        local out = tool.spawn_read({ "nm", ctx.platform_lib })
+        return out and not out:find(sym, 1, true)
+    end
+
+    local list = {}
+    local function add(spec)
+        -- spec: { name (stem), lib, path, sets_base_group, label }
+        list[#list + 1] = {
+            record_name    = "libhull_feature-" .. spec.name .. "." .. plat_infix .. ".a",
+            lib            = spec.lib,
+            path           = spec.path,
+            sets_base_group = spec.sets_base_group or false,
+            label          = spec.label,
+        }
+    end
+    -- Resolve one archive, failing CLOSED via ctx.on_fail with a specific hint.
+    -- `make_stem` names the `make feature-<stem>` build-from-source hint.
+    local function resolve(kind, make_stem, fn, ...)
+        local path, from = fn(...)
+        if not path then
+            local why = (from == "cache-verify-failed")
+                and " (cache re-verify failed)" or " (normally embedded in hull)"
+            ctx.on_fail("hull build: the " .. kind .. " feature lib was not found"
+                        .. why .. "\nhint: build it from source with `make feature-"
+                        .. make_stem .. "`\n")
+        end
+        return path
+    end
+
+    -- 1. Runtime (always; the base is runtime-less). refs base symbols -> group.
+    add({ name = rt, lib = "libhull_feature-" .. rt .. ".a", sets_base_group = true,
+          label = "runtime '" .. rt .. "'",
+          path = resolve("'" .. rt .. "' runtime", rt, M.resolve_runtime_lib, rt, ctx.tmpdir, rctx) })
+
+    -- 2. WASM core + per-runtime compute bridge.
+    if needs_wasm then
+        add({ name = "wasm", lib = "libhull_feature-wasm.a", label = "WASM feature",
+              path = resolve("WASM", "wasm", M.resolve_wasm_lib, ctx.tmpdir, rctx) })
+        add({ name = "wasm-" .. rt, lib = "libhull_feature-wasm-" .. rt .. ".a",
+              label = "compute bridge",
+              path = resolve("compute-bindings", "wasm-" .. rt, M.resolve_wasm_rt_lib, rt, ctx.tmpdir, rctx) })
+    end
+
+    -- 3. Per-runtime SQLite UDF bridge (the engine itself is a --with feature).
+    if needs_sqlite then
+        add({ name = "sqlite-" .. rt, lib = "libhull_feature-sqlite-" .. rt .. ".a",
+              label = "SQLite udf bridge",
+              path = resolve("SQLite udf-bridge", "sqlite-" .. rt, M.resolve_sqlite_rt_lib, rt, ctx.tmpdir, rctx) })
+    end
+
+    -- 4. Image codec core + per-runtime image bridge.
+    if needs_image then
+        add({ name = "image", lib = "libhull_feature-image.a", label = "image feature",
+              path = resolve("image", "image", M.resolve_image_lib, ctx.tmpdir, rctx) })
+        add({ name = "image-" .. rt, lib = "libhull_feature-image-" .. rt .. ".a",
+              label = "image bridge",
+              path = resolve("image-bindings", "image-" .. rt, M.resolve_image_rt_lib, rt, ctx.tmpdir, rctx) })
+    end
+
+    -- 5. TLS feature (only when the base is actually TLS-less). refs base+Keel.
+    if needs_tls and base_lacks("mbedtls_ssl_handshake") then
+        add({ name = "tls", lib = "libhull_feature-tls.a", sets_base_group = true,
+              label = "TLS feature",
+              path = resolve("TLS", "tls", M.resolve_tls_lib, ctx.tmpdir, rctx) })
+    end
+
+    -- 6. HTTP core + (Keel when base-less) + per-runtime web bindings.
+    if needs_http then
+        add({ name = "http", lib = "libhull_feature-http.a", label = "HTTP feature",
+              path = resolve("HTTP", "http", M.resolve_http_lib, ctx.tmpdir, rctx) })
+        if base_lacks("hl_async_backend_keel") then
+            add({ name = "keel", lib = "libhull_feature-keel.a", sets_base_group = true,
+                  label = "Keel event loop",
+                  path = resolve("Keel", "keel", M.resolve_keel_lib, ctx.tmpdir, rctx) })
+        end
+        add({ name = "http-" .. rt, lib = "libhull_feature-http-" .. rt .. ".a",
+              label = "web bindings",
+              path = resolve("web-bindings", "http-" .. rt, M.resolve_http_rt_lib, rt, ctx.tmpdir, rctx) })
+    end
+
+    return { list = list, needs_http = needs_http }
 end
 
 return M


### PR DESCRIPTION
Items **#1 + #6** from `docs/build_arc_audit.md`, converged into one change (they share the same fix).

## The bug (#1) — `hull eject` was broken for db/compute/image/TLS apps

`hull eject` composed only the runtime + http core + web bindings, **never** wasm/sqlite-rt/image/tls/keel. So ejecting a `db`/`compute`/`image`/HTTPS app produced a project that **failed to link** (undefined `sqlite3_*` / WAMR / mbedTLS symbols). `build.lua`'s `compose_features()` grew those 5 features after the HTTP split; `eject.lua` never followed — the exact drift `feature_compose.lua`'s own header warns about, one level up (the resolve *ladder* was shared, the *decision to invoke each rung* was not).

## The fix (#6) — one shared, table-driven plan

Extracted the ordered mandatory-archive selection into **`feature_compose.plan_mandatory(ctx)`** — the single source of truth for **both** paths. It computes the needs-gates (resolver `needs_http/wasm/sqlite/image/tls` + the `compute/*.wasm` S2 signal + the `postgres`/`mysql`→tls signal) and the tls/keel base-presence `nm`-probes **once**, and returns the resolved, **ordered** descriptor list.

- **build.lua:** the 8 hand-rolled compose blocks (~390 lines) collapse to the plan call + one copy/record/whole-archive loop. **2365 → 1995 lines.** `record_composed` names + order are byte-identical.
- **eject.lua:** composes every descriptor into `platform/` and whole-archives each in the generated Makefile (`--start-group` iff any archive references base/Keel symbols).
- `extract_app_manifest` also moves into `feature_compose` (shared run-app-once cache, since executing the app twice corrupts the sign flow); build's 6 call sites + the plan share one impl.

## Validation

- `hull build` of compute/todo/hello composes the correct per-app set (compute→WAMR present; todo/hello→0 WAMR).
- **Ejected compute app links + runs** — `platform/` now carries `libhull_feature-wasm.a` + `-wasm-lua.a` (the old eject omitted them → guaranteed link failure); the generated Makefile whole-archives all 5 feature libs; the binary has WAMR and serves.
- e2e green: **composed_sig** (attestation names/hashes preserved — the sign-critical check), **build** (eject+build pipeline), **feature_runtime** (runtime compose + the not-found hint), **feature_wasm** (the needs_wasm gate).

Part of the `docs/build_arc_audit.md` roadmap (this is the first item; #7/#4/#5/#2/#3/#8 follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)