### PR TITLE
build: HULL_LINK_OBJS var (dedup hull link) + fix config-sentinel purge drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1872,6 +1872,17 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
           $(BUILDDIR)/hull_alloc.o $(BUILDDIR)/hull_async.o $(BUILDDIR)/hull_compress.o \
           $(BUILDDIR)/worker_db.o $(BUILDDIR)/worker_wasm.o $(BUILDDIR)/worker_gpu.o \
           $(BUILDDIR)/stdlib_registry.o $(BUILDDIR)/app_entries_default.o \
+          $(BUILDDIR)/stdlib_lua_registry.o $(BUILDDIR)/stdlib_js_registry.o \
+          $(BUILDDIR)/stdlib_toolchain_registry.o $(BUILDDIR)/runtime_toolchain_registry.o \
+          $(BUILDDIR)/stdlib_feature.o $(BUILDDIR)/runtime_cache_common.o \
+          $(BUILDDIR)/app_context_runtime.o $(BUILDDIR)/embedded_platform_sig.o \
+          $(BUILDDIR)/fs_util.o $(BUILDDIR)/blob_store.o $(BUILDDIR)/cache_dir.o \
+          $(BUILDDIR)/cache_registry.o $(BUILDDIR)/host_match.o $(BUILDDIR)/path_normalize.o \
+          $(BUILDDIR)/thread_affinity.o $(BUILDDIR)/tls_client.o $(BUILDDIR)/tls_transport.o \
+          $(BUILDDIR)/tls_transport_stub.o $(BUILDDIR)/csp.o $(BUILDDIR)/sbom.o \
+          $(BUILDDIR)/sh_seal_arena.o \
+          $(BUILDDIR)/http_weakstub.o $(BUILDDIR)/wasm_weakstub.o $(BUILDDIR)/image_weakstub.o \
+          $(BUILDDIR)/app_runner.o $(BUILDDIR)/build_assets_stub.o \
           $(BUILDDIR)/hull $(PLATFORM_LIB_PURGE) \
           $(BUILDDIR)/test_* 2>/dev/null; \
     printf '%s\n' '$(BUILD_FINGERPRINT)' > $(BUILD_CONFIG_FILE); \
@@ -2434,9 +2445,20 @@ $(BUILD_ASSET_OBJ): $(EMBEDDED_PLATFORM_H) $(EMBEDDED_TEMPLATES_H) $(EMBEDDED_RU
 endif
 
 # Hull binary
-$(BUILDDIR)/hull: $(CAP_OBJS) $(CAP_TOOL_OBJ) $(CAP_TEST_OBJ) $(CMD_OBJS) $(RT_OBJS) $(ALLOC_OBJ) $(ASYNC_OBJ) $(COMPRESS_OBJ) $(MINIZ_OBJ) $(WORKER_DB_OBJ) $(WORKER_WASM_OBJ) $(WORKER_GPU_OBJ) $(MANIFEST_OBJ) $(MODULE_OBJ) $(ASYNC_BACKEND_OBJS) $(NET_BACKEND_OBJS) $(SANDBOX_OBJ) $(SANDBOX_TOOL_OBJ) $(SIG_OBJ) $(RELEASE_OBJ) $(RELEASE_IO_OBJ) $(TOOLS_INSTALL_OBJ) $(PLATFORM_SIG_OBJ) $(EMBEDDED_PLATFORM_SIG_OBJ) $(TEST_RUNNER_OBJ) $(RUNTIME_FACTORY_OBJ) $(STATIC_OBJ) $(MIGRATE_OBJ) $(VFS_OBJ) $(PATH_NORM_OBJ) $(THREAD_AFFINITY_OBJ) $(CACHE_DIR_OBJ) $(FS_UTIL_OBJ) $(BLOB_STORE_OBJ) $(CACHE_REGISTRY_OBJ) $(CACERT_OBJ) $(TLS_CLIENT_OBJ) $(TLS_TRANSPORT_OBJ) $(TLS_TRANSPORT_STUB_OBJ) $(CSP_OBJ) $(SH_SEAL_ARENA_OBJ) $(SBOM_OBJ) $(STDLIB_FEATURE_OBJ) $(APP_CONTEXT_OBJ) $(APP_CONTEXT_RT_OBJ) $(AGENT_LIB_OBJ) $(AGENT_API_OBJ) $(TOOL_OBJ) $(BUILD_ASSET_OBJ) $(COMPILER_OBJ) $(OBJ_EMIT_OBJ) $(LINKER_SYSTEM_OBJ) $(LINKER_LLD_OBJ) $(LINKER_ZIG_OBJ) $(BUNDLED_OBJS_OBJ) $(MAIN_OBJ) $(SERVE_OBJ) $(ENTRY_OBJ) $(APP_EXTRA_OBJS) $(STDLIB_REGISTRY_O) $(STDLIB_RT_REGISTRY_OBJS) $(STDLIB_TOOLCHAIN_REGISTRY_O) $(RUNTIME_TOOLCHAIN_REGISTRY_O) $(WAMR_OBJS) $(VEND_OBJS) $(MBEDTLS_OBJS) $(SQLITE_OBJ) $(LOG_OBJ) $(LOG_LOCK_OBJ) $(SH_ARENA_OBJ) $(SH_JSON_OBJ) $(TWEETNACL_OBJ) $(STB_OBJ) $(PLEDGE_OBJS) $(KEEL_LIB) $(TUI_TOOLCHAIN_ARCHIVE) | $(RUNTIME_FEATURE_LIBS)
-	$(CC) $(LDFLAGS) -o $@ $(CAP_OBJS) $(CAP_TOOL_OBJ) $(CAP_TEST_OBJ) $(CMD_OBJS) $(RT_OBJS) $(ALLOC_OBJ) $(ASYNC_OBJ) $(COMPRESS_OBJ) $(MINIZ_OBJ) $(WORKER_DB_OBJ) $(WORKER_WASM_OBJ) $(WORKER_GPU_OBJ) $(MANIFEST_OBJ) $(MODULE_OBJ) $(ASYNC_BACKEND_OBJS) $(NET_BACKEND_OBJS) $(SANDBOX_OBJ) $(SANDBOX_TOOL_OBJ) $(SIG_OBJ) $(RELEASE_OBJ) $(RELEASE_IO_OBJ) $(TOOLS_INSTALL_OBJ) $(PLATFORM_SIG_OBJ) $(EMBEDDED_PLATFORM_SIG_OBJ) $(TEST_RUNNER_OBJ) $(RUNTIME_FACTORY_OBJ) $(STATIC_OBJ) $(MIGRATE_OBJ) $(VFS_OBJ) $(PATH_NORM_OBJ) $(THREAD_AFFINITY_OBJ) $(CACHE_DIR_OBJ) $(FS_UTIL_OBJ) $(BLOB_STORE_OBJ) $(CACHE_REGISTRY_OBJ) $(CACERT_OBJ) $(TLS_CLIENT_OBJ) $(TLS_TRANSPORT_OBJ) $(TLS_TRANSPORT_STUB_OBJ) $(CSP_OBJ) $(SH_SEAL_ARENA_OBJ) $(SBOM_OBJ) $(STDLIB_FEATURE_OBJ) $(APP_CONTEXT_OBJ) $(APP_CONTEXT_RT_OBJ) $(AGENT_LIB_OBJ) $(AGENT_API_OBJ) $(TOOL_OBJ) $(BUILD_ASSET_OBJ) $(COMPILER_OBJ) $(OBJ_EMIT_OBJ) $(LINKER_SYSTEM_OBJ) $(LINKER_LLD_OBJ) $(LINKER_ZIG_OBJ) $(BUNDLED_OBJS_OBJ) $(MAIN_OBJ) $(SERVE_OBJ) $(ENTRY_OBJ) $(APP_EXTRA_OBJS) $(STDLIB_REGISTRY_O) $(STDLIB_RT_REGISTRY_OBJS) $(STDLIB_TOOLCHAIN_REGISTRY_O) $(RUNTIME_TOOLCHAIN_REGISTRY_O) $(WAMR_OBJS) $(VEND_OBJS) $(MBEDTLS_OBJS) \
-		$(SQLITE_OBJ) $(LOG_OBJ) $(LOG_LOCK_OBJ) $(SH_ARENA_OBJ) $(SH_JSON_OBJ) $(TWEETNACL_OBJ) $(STB_OBJ) $(PLEDGE_OBJS) $(KEEL_LIB) $(TUI_TOOLCHAIN_LDFLAGS) $(WGPU_LIB) $(WGPU_FRAMEWORKS) $(DUCKDB_LIBS) -lm -lpthread
+#
+# The object list is defined once as HULL_LINK_OBJS and referenced by BOTH the
+# prerequisite line and the link recipe (it was previously written out verbatim
+# in both — the same ~70-token list twice for one target, an easy drift point).
+# Order is preserved exactly, so the produced binary is byte-identical. The
+# prereq / recipe TAILS legitimately differ (order-only feature-lib prereqs vs
+# the -l link flags), so they stay inline. (The larger cross-target sharing with
+# PLATFORM_OBJS is deliberately NOT collapsed: the shared vars are interleaved
+# with each list's distinct ones, so a shared-core extraction would REORDER the
+# link line and risk weak/strong seam resolution — see docs/build_arc_audit.md.)
+HULL_LINK_OBJS := $(CAP_OBJS) $(CAP_TOOL_OBJ) $(CAP_TEST_OBJ) $(CMD_OBJS) $(RT_OBJS) $(ALLOC_OBJ) $(ASYNC_OBJ) $(COMPRESS_OBJ) $(MINIZ_OBJ) $(WORKER_DB_OBJ) $(WORKER_WASM_OBJ) $(WORKER_GPU_OBJ) $(MANIFEST_OBJ) $(MODULE_OBJ) $(ASYNC_BACKEND_OBJS) $(NET_BACKEND_OBJS) $(SANDBOX_OBJ) $(SANDBOX_TOOL_OBJ) $(SIG_OBJ) $(RELEASE_OBJ) $(RELEASE_IO_OBJ) $(TOOLS_INSTALL_OBJ) $(PLATFORM_SIG_OBJ) $(EMBEDDED_PLATFORM_SIG_OBJ) $(TEST_RUNNER_OBJ) $(RUNTIME_FACTORY_OBJ) $(STATIC_OBJ) $(MIGRATE_OBJ) $(VFS_OBJ) $(PATH_NORM_OBJ) $(THREAD_AFFINITY_OBJ) $(CACHE_DIR_OBJ) $(FS_UTIL_OBJ) $(BLOB_STORE_OBJ) $(CACHE_REGISTRY_OBJ) $(CACERT_OBJ) $(TLS_CLIENT_OBJ) $(TLS_TRANSPORT_OBJ) $(TLS_TRANSPORT_STUB_OBJ) $(CSP_OBJ) $(SH_SEAL_ARENA_OBJ) $(SBOM_OBJ) $(STDLIB_FEATURE_OBJ) $(APP_CONTEXT_OBJ) $(APP_CONTEXT_RT_OBJ) $(AGENT_LIB_OBJ) $(AGENT_API_OBJ) $(TOOL_OBJ) $(BUILD_ASSET_OBJ) $(COMPILER_OBJ) $(OBJ_EMIT_OBJ) $(LINKER_SYSTEM_OBJ) $(LINKER_LLD_OBJ) $(LINKER_ZIG_OBJ) $(BUNDLED_OBJS_OBJ) $(MAIN_OBJ) $(SERVE_OBJ) $(ENTRY_OBJ) $(APP_EXTRA_OBJS) $(STDLIB_REGISTRY_O) $(STDLIB_RT_REGISTRY_OBJS) $(STDLIB_TOOLCHAIN_REGISTRY_O) $(RUNTIME_TOOLCHAIN_REGISTRY_O) $(WAMR_OBJS) $(VEND_OBJS) $(MBEDTLS_OBJS) $(SQLITE_OBJ) $(LOG_OBJ) $(LOG_LOCK_OBJ) $(SH_ARENA_OBJ) $(SH_JSON_OBJ) $(TWEETNACL_OBJ) $(STB_OBJ) $(PLEDGE_OBJS)
+
+$(BUILDDIR)/hull: $(HULL_LINK_OBJS) $(KEEL_LIB) $(TUI_TOOLCHAIN_ARCHIVE) | $(RUNTIME_FEATURE_LIBS)
+	$(CC) $(LDFLAGS) -o $@ $(HULL_LINK_OBJS) $(KEEL_LIB) $(TUI_TOOLCHAIN_LDFLAGS) $(WGPU_LIB) $(WGPU_FRAMEWORKS) $(DUCKDB_LIBS) -lm -lpthread
 
 # libhull no-runtime embedding library lives in mk/libhull.mk.
 include mk/libhull.mk
@@ -3126,3 +3148,4 @@ clean:
 # is the simplest portable way to gather all of them.
 DEPS_ALL := $(shell find $(BUILDDIR) -name '*.d' 2>/dev/null)
 -include $(DEPS_ALL)
+


### PR DESCRIPTION
Item **#7** from `docs/build_arc_audit.md` (audit doc lands with #203).

## HULL_LINK_OBJS — kill the hull-target double-listing

The `$(BUILDDIR)/hull` target wrote its ~74-token object list **verbatim in both** the prerequisite line and the link recipe — the same list twice for one target, an easy drift point (adding one object meant editing both). Hoisted to a single `HULL_LINK_OBJS := …` referenced by both. The prereq/recipe **tails** legitimately differ (order-only feature-lib prereqs vs the `-l` link flags), so they stay inline.

**Byte-identical:** the extracted list is **74 tokens in the same order** (diff-verified against `main`), so the produced binary is unchanged.

### Why not the full `HULL_CORE_OBJS`-shared-with-`PLATFORM_OBJS`?
Assessed and **deferred** — with evidence. The 60 vars shared between the hull link and `PLATFORM_OBJS` are **interleaved** with each list's distinct ones (not a contiguous run), so a shared-core extraction would **reorder** the link line. Hull composes via weak-default / strong-override seams, which are **link-order sensitive**, so a reorder risks a weak default winning over a strong override. Not worth that hazard for a maintainability-only change.

## Fix the config-sentinel purge drift

The audit flagged that the hand-listed purge (run when the build fingerprint changes, to drop objects compiled with stale flags) had lost `fs_util.o` + ~20 other recently-added Hull objects (`blob_store`, `cache_dir`, `host_match`, `tls_*`, `csp`, `sbom`, the stdlib registries, the weak stubs, `app_runner`, …). Added them.

A **fully-derived** purge is blocked by parse-order: the `$(shell …)` purge runs at Makefile-read time, *before* `HULL_LINK_OBJS` and its component object vars are defined, so it must use literal filenames.

## Validation
- hull builds **byte-identically** (74-token ordered diff empty) + runs.
- A config flag flip now **purges `fs_util.o`** (was the drift).
- `test_vfs` / `test_dispatch` / `test_tools_install` link + pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)