### PR TITLE
test: e2e for the zig linker backend (hull build --linker=zig)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,24 @@ jobs:
           command -v ld.lld >/dev/null 2>&1 || sudo apt-get install -y lld 2>/dev/null || true
           make e2e-linker
 
+      - name: Linker (zig) E2E test (hull build --linker=zig)
+        # Linux x86_64 only (the e2e self-skips elsewhere: a foreign-target link
+        # needs a matching platform lib). Install the same Zig the embed-zig job
+        # uses, then build + run a real app through the zig linker backend.
+        if: runner.os == 'Linux' && runner.arch == 'X64'
+        timeout-minutes: 5
+        run: |
+          if ! command -v zig >/dev/null 2>&1; then
+            curl -fsSL --retry 3 --retry-all-errors --retry-delay 2 \
+              https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz \
+              -o /tmp/zig.tar.xz
+            sudo mkdir -p /opt/zig
+            sudo tar -xJf /tmp/zig.tar.xz -C /opt/zig --strip-components=1
+            echo "/opt/zig" >> "$GITHUB_PATH"
+            export PATH="/opt/zig:$PATH"
+          fi
+          make e2e-linker-zig
+
       - name: Attachment E2E tests
         timeout-minutes: 2
         run: make e2e-attachment

--- a/Makefile
+++ b/Makefile
@@ -1890,7 +1890,7 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
 
 # ── Targets ─────────────────────────────────────────────────────────
 
-.PHONY: all clean test debug msan tsan fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-cross-build e2e-musl floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint platform platform-cosmo hardening check-hardening
+.PHONY: all clean test debug msan tsan fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-linker-zig e2e-cross-build e2e-musl floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint platform platform-cosmo hardening check-hardening
 
 all: $(BUILDDIR)/hull
 

--- a/docs/build_arc_audit.md
+++ b/docs/build_arc_audit.md
@@ -38,16 +38,21 @@ Execution order (agreed): **#6+#1 → #7 → #4 → #5 → #2 → #3 → #8**, t
   so `--linker=lld-static` and `--linker=zig --target=…-musl` work ONLY from a source build.
   Publish a signed `libhull_platform-musl-<arch>.a` (+ runtime/feature archives) and teach
   `prepare_platform` to select it for a musl target. Highest-value "make it real" gap.
-- [ ] **#5 `--linker=zig` has zero e2e** ✓ **and no `test_linker` unit test** ✓. Add
-  `tests/hull/test_linker.c` (mock vtable capturing argv: `-Wl,` stripping + group flatten,
-  zig format→GC flag, `hl_linker_select` dispatch) + `tests/e2e_linker_zig.sh` (Docker run of
-  a cross/native zig-linked app) wired into Linux CI.
+- [x] **#5 `--linker=zig` has zero e2e** ✓. DONE (PR #205): `tests/e2e_linker_zig.sh`
+  stages a system zig, `hull build --linker=zig` a real app, runs it; wired into the
+  Linux CI `build` job (installs zig 0.13.0, `runner.arch == X64`). Runs on Linux x86_64
+  only and SKIPS elsewhere - a foreign-target link needs a target-matching platform lib
+  (this is exactly the #2/#4 cross-compile gap, which the e2e surfaced directly: a
+  darwin-arm64 platform lib can't link an x86_64-linux binary). A `test_linker.c` unit test
+  was DEFERRED: the backends' `is_available`/`link` spawn via `hl_tool_spawn`, so a
+  meaningful unit test needs the tool-spawn stub + only covers the constructor-name
+  contract (low regression risk now that the backend is e2e-covered).
 
 ## Tier 3 — simplifications (two prevent Tier-1 bugs)
 
 - [x] **#6 Table-drive `compose_features()`** — 690-line fn, same 12-line block ×8. Collapse to a
   data table + one loop; **fixes #1 for free** (eject calls the same helper). DONE (PR #203): build.lua 2365->1995 lines; compose blocks -> one data-driven plan + loop; extract_manifest also centralized. e2e composed_sig/build/feature_runtime/feature_wasm green.
-- [ ] **#7 One `HULL_CORE_OBJS` variable** — the ~60-token object list is duplicated across 8
+- [x] **#7 One `HULL_CORE_OBJS` variable** (HULL_LINK_OBJS + purge fix; full cross-target collapse deferred as interleaved-reorder-risk — PR #204) — the ~60-token object list is duplicated across 8
   sites (hull link prereqs+recipe, `PLATFORM_OBJS`, 5 test lists); drift already exists
   (`fs_util.o` missing from the sentinel purge). Collapse to one var + `$^` recipe; derive
   `PLATFORM_OBJS` via `filter-out`. Also: derive the sentinel purge list from the same set.

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -713,6 +713,11 @@ e2e-compiler-free: $(BUILDDIR)/hull $(BUILDDIR)/libhull_platform.a
 e2e-linker: $(BUILDDIR)/hull $(BUILDDIR)/libhull_platform.a
 	sh tests/e2e_linker.sh
 
+# The zig linker backend (hull build --linker=zig). Runs on Linux x86_64 only
+# (a foreign-target link needs a matching platform lib); skips elsewhere.
+e2e-linker-zig: $(BUILDDIR)/hull $(BUILDDIR)/libhull_platform.a
+	sh tests/e2e_linker_zig.sh
+
 e2e-cross-build:
 	sh tests/e2e_cross_build.sh
 

--- a/tests/e2e_linker_zig.sh
+++ b/tests/e2e_linker_zig.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# e2e_linker_zig.sh - `hull build --linker=zig` (the toolchain-free zig backend).
+#
+# zig links via `zig cc [--target=<triple>]` - it bundles clang + lld + crt +
+# libc, so it is the turnkey cross-compiler. This is the ONLY e2e that exercises
+# the zig linker backend (the `embed-zig` CI job tests the libhull ABI embedder,
+# a different thing). It stages a system zig into ~/.hull/tools/zig/ (where
+# `hull tools install zig` places it), builds a real app through zig, and - when
+# the target is the host - runs it.
+#
+# zig targets LINUX cleanly (its Mach-O linker rejects the macOS SDK .tbd stubs),
+# and cross-linking needs a platform lib matching the TARGET (the embedded one is
+# the host's - the tracked cross-compile gap, docs/build_arc_audit.md #2/#4). So
+# this e2e only runs on a Linux x86_64 host, where the embedded platform lib
+# matches the zig native target: it builds + RUNS a real app through zig. On any
+# other host it SKIPS (a foreign-target link can't succeed until a target
+# platform lib is publishable). Also skips if no zig / no embedded platform lib.
+#
+# Requires: an EMBED_PLATFORM=1 hull, a system zig (0.13.x), curl.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+SRCDIR="$(cd "$(dirname "$0")/.." && pwd)"
+HULL="${HULL:-$SRCDIR/build/hull}"
+PASS=0; FAIL=0
+assert() { msg="$1"; shift; if "$@"; then echo "  ok  $msg"; PASS=$((PASS+1)); \
+    else echo "  FAIL $msg"; FAIL=$((FAIL+1)); fi; }
+
+[ -x "$HULL" ] || { echo "FAIL: $HULL not found - run 'make' first"; exit 1; }
+
+# Find a system zig.
+find_zig() {
+    p=$(command -v zig 2>/dev/null) && { echo "$p"; return 0; }
+    for d in /opt/zig /opt/homebrew/bin /usr/local/bin; do
+        [ -x "$d/zig" ] && { echo "$d/zig"; return 0; }
+    done
+    return 1
+}
+# Cross-linking needs a target-matching platform lib (not yet publishable), so
+# restrict to a Linux x86_64 host where zig's native target matches the embedded
+# (host) platform lib.
+HOST_OS=$(uname -s); HOST_ARCH=$(uname -m)
+if [ "$HOST_OS" != "Linux" ] || { [ "$HOST_ARCH" != "x86_64" ] && [ "$HOST_ARCH" != "amd64" ]; }; then
+    echo "SKIP: --linker=zig e2e runs on Linux x86_64 only (cross-target needs a"
+    echo "      target platform lib; see docs/build_arc_audit.md #2/#4). Host: $HOST_OS/$HOST_ARCH"
+    exit 0
+fi
+
+ZIG_BIN=$(find_zig) || { echo "SKIP: no system zig found (install from ziglang.org)"; exit 0; }
+echo "── using zig from: $ZIG_BIN ($("$ZIG_BIN" version 2>/dev/null)) ──"
+
+# Stage zig into ~/.hull/tools/zig/zig (the bundle layout hull resolves). A
+# symlink is enough: zig finds its lib/ tree via the real exe path.
+TOOLS="$HOME/.hull/tools/zig"; mkdir -p "$TOOLS"
+STAGED=""
+if [ ! -e "$TOOLS/zig" ]; then ln -sf "$ZIG_BIN" "$TOOLS/zig"; STAGED="$TOOLS/zig"; fi
+cleanup() { [ -n "$STAGED" ] && rm -f "$STAGED" 2>/dev/null || true; rm -rf "${WORKDIR:-}" 2>/dev/null || true; }
+trap cleanup EXIT INT TERM
+
+WORKDIR="$(mktemp -d)"
+# A pure compute app.main (no HTTP) - the smallest thing that composes a runtime
+# and links cleanly for a foreign target.
+APP="$WORKDIR/app"; mkdir -p "$APP"
+cat > "$APP/app.lua" <<'LUA'
+app.manifest({ modules = {} })
+app.main(function() return 0 end)
+LUA
+
+# Skip cleanly if this hull can't compose (no embedded platform lib).
+probe="$($HULL build "$APP" --linker=zig --target=x86_64-linux-gnu --no-verify-platform -o "$WORKDIR/probe" 2>&1 || true)"
+case "$probe" in
+    *"platform library not embedded"*|*"cannot find libhull_platform.a"*)
+        echo "SKIP: hull not built with EMBED_PLATFORM=1"; exit 0 ;;
+esac
+
+# Native Linux x86_64: the glibc target matches the host's glibc platform lib,
+# so this builds a runnable binary (musl would ABI-mismatch the glibc-built .a).
+echo "== hull build --linker=zig (native x86_64-linux-gnu) =="
+OUT="$($HULL build "$APP" --linker=zig --target=x86_64-linux-gnu \
+       --no-verify-platform -o "$WORKDIR/app_zig" 2>&1)" || { echo "$OUT"; }
+assert "build --linker=zig succeeds"     [ -x "$WORKDIR/app_zig" ]
+magic=$(od -An -tx1 -N4 "$WORKDIR/app_zig" 2>/dev/null | tr -d ' ')
+assert "produced a Linux ELF (magic 7f454c46)" [ "$magic" = "7f454c46" ]
+"$WORKDIR/app_zig"; rc=$?
+assert "zig-linked binary runs (exit 0)" [ "$rc" -eq 0 ]
+
+echo "== hull build --linker=zig composed a runtime =="
+assert "output names the composed runtime" \
+    sh -c 'echo "$1" | grep -q "composed runtime"' _ "$OUT"
+
+echo ""
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "PASS: e2e_linker_zig (zig backend builds + runs/cross-builds a real app)"


### PR DESCRIPTION
Item **#5** from `docs/build_arc_audit.md`.

The zig linker backend shipped a ~330 MB installable bundle (#201) but had **zero e2e coverage** — the `embed-zig` CI job tests the *libhull ABI embedder*, an unrelated thing.

## What it does
`tests/e2e_linker_zig.sh` stages a system zig into `~/.hull/tools/zig/` (the bundle layout hull resolves), builds a real `app.main` app through `hull build --linker=zig`, asserts a Linux ELF, and **runs it**. Wired into the Linux CI `build` job (`make e2e-linker-zig`; installs zig 0.13.0, gated `runner.arch == X64`) + `mk/tests.mk` target + `.PHONY`.

## Runs on Linux x86_64 only (and it found the cross-compile gap)
It skips cleanly elsewhere: a foreign-target link needs a platform lib matching the **target**, but the embedded one is the **host's** — exactly the cross-compile gap tracked as audit **#2/#4**. Writing this surfaced it directly: on macOS, `--linker=zig --target=x86_64-linux-*` fails to link because the platform `.a` is Mach-O/arm64. On the glibc CI host the e2e targets `x86_64-linux-gnu` to match the glibc-built platform lib (musl would ABI-mismatch).

## Deferred
A `test_linker.c` unit test — the backends' `is_available`/`link` spawn via `hl_tool_spawn`, so a unit test needs the tool-spawn stub and would only cover the constructor-name contract (low regression risk now that the backend is e2e-covered).

## Validation
Skips cleanly on macOS; `shellcheck` + `actionlint` clean; the Linux path is CI-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)