### PR TITLE
build: derive FEATURE_ARCHIVES from registry; +mysql fingerprint; +gc-sections (Tier B)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1821,6 +1821,7 @@ BUILD_FINGERPRINT := \
   DB=$(HL_ENABLE_DB)|\
   SQLITE=$(HL_ENABLE_SQLITE)|\
   POSTGRES=$(HL_ENABLE_POSTGRES)|\
+  MYSQL=$(HL_ENABLE_MYSQL)|\
   WASM=$(HL_ENABLE_WASM)|\
   GPU=$(HL_ENABLE_GPU)|\
   TUI=$(HL_ENABLE_TUI)|\
@@ -2266,15 +2267,14 @@ include mk/features/runtime.mk
 # stale member would then linger and surface as a `duplicate symbol` at compose.
 # The lists change only via a Makefile edit, so depending on the Makefile forces
 # the (cheap) rebuild exactly then. CI clean-builds are unaffected.
-FEATURE_ARCHIVES := $(BUILDDIR)/libhull_feature-lua.a $(BUILDDIR)/libhull_feature-js.a \
-                    $(BUILDDIR)/libhull_feature-http.a \
-                    $(BUILDDIR)/libhull_feature-http-lua.a $(BUILDDIR)/libhull_feature-http-js.a \
-                    $(BUILDDIR)/libhull_feature-tui.a \
-                    $(BUILDDIR)/libhull_feature-tui-lua.a $(BUILDDIR)/libhull_feature-tui-js.a \
-                    $(BUILDDIR)/libhull_feature-wasm.a \
-                    $(BUILDDIR)/libhull_feature-wasm-lua.a $(BUILDDIR)/libhull_feature-wasm-js.a \
-                    $(BUILDDIR)/libhull_feature-sqlite-lua.a $(BUILDDIR)/libhull_feature-sqlite-js.a \
-                    $(IMG_FEATURE_LIBS)
+# Derived from the registry (mk/feature.mk FEATURE_EMBEDDED_STEMS) rather than
+# hand-listed: the hand-list had drifted and OMITTED the tls, keel, and sqlite
+# (core) embedded archives, so those three missed this rebuild guard (the exact
+# stale-`ar` duplicate-symbol hazard the comment above warns about). Plus the
+# tui CORE archive (installable, but built here from an object list in this
+# Makefile, so it needs the guard too). FEATURE_EMBEDDED_LIBS already covers
+# lua/js/http(+rt)/wasm(+rt)/sqlite(+rt)/image(+rt)/tls/keel + the tui rt bridges.
+FEATURE_ARCHIVES := $(FEATURE_EMBEDDED_LIBS) $(BUILDDIR)/libhull_feature-tui.a
 $(FEATURE_ARCHIVES): Makefile
 # The base platform lib is built from an object LIST (PLATFORM_OBJS); a Phase-1
 # change to that list (wasm caps + WAMR removed) must retrigger the ar, which an
@@ -3148,4 +3148,5 @@ clean:
 # is the simplest portable way to gather all of them.
 DEPS_ALL := $(shell find $(BUILDDIR) -name '*.d' 2>/dev/null)
 -include $(DEPS_ALL)
+
 

--- a/src/hull/linker_lld.c
+++ b/src/hull/linker_lld.c
@@ -72,6 +72,12 @@ static int lld_link(HlLinker *l, const char *output,
          * --end-group -L<libdir> crtn. */
         argv[n++] = ctx->ld;
         argv[n++] = "-static";
+        /* Dead-strip unreferenced sections. A raw ld.lld does NOT --gc-sections
+         * by default (only a cc/ld64 driver defaults it on), so without this the
+         * static binary carries dead sections and any unresolved symbol reachable
+         * only from dead code would fail the link - the exact hazard the zig
+         * backend guards against for the same reason (linker_zig.c). */
+        argv[n++] = "--gc-sections";
         argv[n++] = "-o"; argv[n++] = output;
         argv[n++] = ctx->crt1;
         argv[n++] = ctx->crti;


### PR DESCRIPTION
Three small fixes from `docs/build_arc_audit.md` (#3a/#3b/#3c).

**#3a — `FEATURE_ARCHIVES` drifted from the registry.** The hand-listed set (the `$: Makefile` rebuild guard that forces an `ar` refresh when an archive's object *list* changes) had **omitted** the `tls`, `keel`, and `sqlite`-core embedded archives — so a member moved into one of those (without touching a `.o`) could linger stale and surface as a compose-time `duplicate symbol`, the exact hazard the guard's own comment warns about. Now derived from `$(FEATURE_EMBEDDED_LIBS)` (the single source of truth) + the tui core. **Verified a strict superset: 16 → 19 archives, adding exactly keel/sqlite/tls, dropping nothing.**

**#3b — `HL_ENABLE_MYSQL` missing from the config-sentinel `BUILD_FINGERPRINT`** (POSTGRES was present) — flipping it didn't purge stale objects. Added, symmetric with POSTGRES.

**#3c — Tier B (`--linker=lld-static`) omitted `--gc-sections`.** A raw `ld.lld` does **not** dead-strip by default (only a cc/ld64 driver defaults it on), so the static binary carried dead sections and any symbol reachable only from dead code would fail the link — the same reason the zig backend explicitly adds the GC flag. Added `--gc-sections` after `-static`.

## Validation
hull builds; the FEATURE_ARCHIVES superset diff is confirmed above; `make test` 0 failures; `linker_lld` cppcheck clean. (Tier B dead-strip is exercised by `e2e_musl` on CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)