### PR TITLE
docs: reconcile build-arc roadmap; #8 (hex_decode) assessed + deferred

### DIFF
--- a/docs/build_arc_audit.md
+++ b/docs/build_arc_audit.md
@@ -17,20 +17,20 @@ Execution order (agreed): **#6+#1 → #7 → #4 → #5 → #2 → #3 → #8**, t
   Ejecting a db/compute/image/HTTPS app yields a project that won't link/run. Drift
   the modularization arc introduced. **Fix converges with #6.** DONE (PR #203): shared fcompose.plan_mandatory; eject now composes the full ordered set (validated: ejected compute app links + runs with WAMR).
 
-- [ ] **#2 Cross-compile silently mis-links.** ✓ `--target=<foreign>` emits a correct cross
+- [x] **#2 Cross-compile silently mis-links.** DONE (PR #206): early cross-target guard + target_spec arch/os validation + --target= parsing. ✓ `--target=<foreign>` emits a correct cross
   `app_registry.o`, but only the `zig` backend consumes the triple (system/lld `(void)tgt`),
   and the bundled `app_main.o` + platform `.a` are host-only, so end-to-end cross can't
   succeed regardless. No guard. Minimum fix: reject a host-mismatched `--target` that can't
   be satisfied (needs zig + a target platform lib). `target_spec` (build.lua:339) is also
   lenient — validate arch/os.
 
-- [ ] **#3a `FEATURE_ARCHIVES` / `RUNTIME_FEATURE_LIBS` drifted from the registry** — `tls`,
+- [x] **#3a `FEATURE_ARCHIVES` / `RUNTIME_FEATURE_LIBS` drifted from the registry** — `tls`,
   `keel`, `sqlite` archives miss the `: Makefile` rebuild guard (latent stale-`ar`
-  duplicate-symbol class bug, uncaught by CI). Fix: derive from `$(FEATURE_EMBEDDED_LIBS)`.
-- [ ] **#3b `HL_ENABLE_MYSQL` missing from the config-sentinel fingerprint** (asymmetric with
-  POSTGRES, Makefile:~1823). Add `MYSQL=$(HL_ENABLE_MYSQL)|`.
-- [ ] **#3c Tier B (`lld-static`) omits `--gc-sections`** (linker_lld.c direct branch) — dead
-  sections / latent dangling-symbol risk that the zig backend explicitly guards against.
+  duplicate-symbol class bug, uncaught by CI). Fix: derive from `$(FEATURE_EMBEDDED_LIBS)`. DONE (PR #207).
+- [x] **#3b `HL_ENABLE_MYSQL` missing from the config-sentinel fingerprint** (asymmetric with
+  POSTGRES, Makefile:~1823). Add `MYSQL=$(HL_ENABLE_MYSQL)|`. DONE (PR #207).
+- [x] **#3c Tier B (`lld-static`) omits `--gc-sections`** (linker_lld.c direct branch) — dead
+  sections / latent dangling-symbol risk that the zig backend explicitly guards against. DONE (PR #207).
 
 ## Tier 2 — make the toolchain-free story real for install-only users
 
@@ -38,23 +38,34 @@ Execution order (agreed): **#6+#1 → #7 → #4 → #5 → #2 → #3 → #8**, t
   so `--linker=lld-static` and `--linker=zig --target=…-musl` work ONLY from a source build.
   Publish a signed `libhull_platform-musl-<arch>.a` (+ runtime/feature archives) and teach
   `prepare_platform` to select it for a musl target. Highest-value "make it real" gap.
-- [ ] **#5 `--linker=zig` has zero e2e** ✓ **and no `test_linker` unit test** ✓. Add
-  `tests/hull/test_linker.c` (mock vtable capturing argv: `-Wl,` stripping + group flatten,
-  zig format→GC flag, `hl_linker_select` dispatch) + `tests/e2e_linker_zig.sh` (Docker run of
-  a cross/native zig-linked app) wired into Linux CI.
+- [x] **#5 `--linker=zig` has zero e2e** ✓. DONE (PR #205): `tests/e2e_linker_zig.sh` builds +
+  runs a real app through the zig backend on Linux x86_64 (skips elsewhere - cross needs a
+  target platform lib, #2/#4); wired into Linux CI. A `test_linker.c` unit test was deferred
+  (backends spawn via `hl_tool_spawn`; low regression risk now that the backend is e2e-covered).
 
 ## Tier 3 — simplifications (two prevent Tier-1 bugs)
 
-- [x] **#6 Table-drive `compose_features()`** — 690-line fn, same 12-line block ×8. Collapse to a
-  data table + one loop; **fixes #1 for free** (eject calls the same helper). DONE (PR #203): build.lua 2365->1995 lines; compose blocks -> one data-driven plan + loop; extract_manifest also centralized. e2e composed_sig/build/feature_runtime/feature_wasm green.
-- [ ] **#7 One `HULL_CORE_OBJS` variable** — the ~60-token object list is duplicated across 8
-  sites (hull link prereqs+recipe, `PLATFORM_OBJS`, 5 test lists); drift already exists
-  (`fs_util.o` missing from the sentinel purge). Collapse to one var + `$^` recipe; derive
-  `PLATFORM_OBJS` via `filter-out`. Also: derive the sentinel purge list from the same set.
-- [ ] **#8 Consolidate trust-critical duplicate helpers** — `hex_decode` ×4 byte-identical on
-  Ed25519 signature-verify paths (`signature.c`, `release.c`, `verify_release.c`,
-  `verify_self.c`) while canonical `hl_cap_crypto_hex_decode` exists. Same as `mkdir_p`
-  consolidation, higher stakes. (`hex_encode` ×9, `secure_zero` ×5 follow.)
+- [x] **#6 Table-drive `compose_features()`** — DONE (PR #203, converged with #1): build.lua
+  2365->1995 lines; compose blocks -> one data-driven plan + loop; extract_manifest centralized.
+- [x] **#7 `HULL_CORE_OBJS`** — DONE (PR #204): shipped `HULL_LINK_OBJS` (the hull-target
+  prereq+recipe double-listing, byte-identical 74-token diff) + the sentinel purge drift fix
+  (fs_util.o + ~20 others). Full cross-target `HULL_CORE_OBJS`-with-`PLATFORM_OBJS` DEFERRED:
+  the shared vars are interleaved with each list's distinct ones, so a shared-core extraction
+  would REORDER the link line and risk weak/strong seam resolution.
+- [~] **#8 Consolidate trust-critical duplicate helpers** — ASSESSED + DEFERRED (needs focused,
+  security-reviewed work). The `hex_decode` ×4 copies (`signature.c`, `release.c`,
+  `verify_release.c`, `verify_self.c`) are byte-identical to EACH OTHER, but the canonical
+  `hl_cap_crypto_hex_decode` has a DIFFERENT contract: it returns the BYTE COUNT (not 0) on
+  success and does NOT enforce exact length (out_size is a capacity, not the expected size),
+  whereas the local copies return 0/-1 and require `hex_len == out_len*2` exactly. So a naive
+  swap breaks every caller's `!= 0` check AND drops the exact-length enforcement — a SECURITY
+  regression risk on Ed25519 signature-verify paths (a short/malformed sig could decode
+  partially instead of failing closed). Two safe paths, either a focused PR: (a) a shared
+  `hl_hex_decode_exact` helper preserving the local 0/-1 exact-length contract (no canonical
+  change; needs its own object + link-list wiring); or (b) adapt each of the ~10 call sites to
+  the canonical's byte-count/`< 0` contract AND add an explicit `hex_len == N*2` check. NOT a
+  mechanical mkdir_p-style consolidation. (`hex_encode` ×9, `secure_zero` ×5 have the same
+  "identical-to-each-other but a different-contract canonical exists" shape.)
 
 ## Tier 4 — architectural consistency & docs (lower urgency)
 


### PR DESCRIPTION
Reconciles `docs/build_arc_audit.md` after the roadmap sweep and records the **#8** analysis.

## Landed this sweep
- **#1 + #6** (PR #203) — eject-compose parity + table-drive `plan_mandatory`.
- **#7** (PR #204) — `HULL_LINK_OBJS` + purge-drift fix.
- **#5** (PR #205) — zig-backend e2e.
- **#2** (PR #206) — cross-`--target` guard + `--target=` parsing.
- **#3** (PR #207) — FEATURE_ARCHIVES derivation + mysql fingerprint + Tier-B `--gc-sections`.

## #8 — assessed and **deferred** (not mechanical; security-sensitive)
The `hex_decode` ×4 copies are byte-identical **to each other**, but the canonical `hl_cap_crypto_hex_decode` has a **different contract**: it returns the **byte count** (not 0) on success and does **not** enforce exact length (`out_size` is a *capacity*), whereas the local copies return 0/-1 and require `hex_len == out_len*2` exactly. A naive swap would break every caller's `!= 0` check **and drop the exact-length enforcement** — a **security-regression risk on the Ed25519 signature-verify paths** (a short/malformed signature could decode partially instead of failing closed). So it's not the mechanical `mkdir_p`-style consolidation the audit assumed; deferred to a focused, security-reviewed PR (two safe paths documented in the doc).

## Remaining
**#4** (publish a signed musl `libhull_platform.a`) — a release-pipeline change needing a pre-release dry-run (like the musl-floor/lld-zig arcs). Plus the Tier-4 consistency/doc items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)