### PR TITLE
refactor: dedup trust-critical hex_decode onto the canonical helper

### DIFF
--- a/docs/build_arc_audit.md
+++ b/docs/build_arc_audit.md
@@ -52,20 +52,23 @@ Execution order (agreed): **#6+#1 → #7 → #4 → #5 → #2 → #3 → #8**, t
   (fs_util.o + ~20 others). Full cross-target `HULL_CORE_OBJS`-with-`PLATFORM_OBJS` DEFERRED:
   the shared vars are interleaved with each list's distinct ones, so a shared-core extraction
   would REORDER the link line and risk weak/strong seam resolution.
-- [~] **#8 Consolidate trust-critical duplicate helpers** — ASSESSED + DEFERRED (needs focused,
-  security-reviewed work). The `hex_decode` ×4 copies (`signature.c`, `release.c`,
-  `verify_release.c`, `verify_self.c`) are byte-identical to EACH OTHER, but the canonical
-  `hl_cap_crypto_hex_decode` has a DIFFERENT contract: it returns the BYTE COUNT (not 0) on
-  success and does NOT enforce exact length (out_size is a capacity, not the expected size),
-  whereas the local copies return 0/-1 and require `hex_len == out_len*2` exactly. So a naive
-  swap breaks every caller's `!= 0` check AND drops the exact-length enforcement — a SECURITY
-  regression risk on Ed25519 signature-verify paths (a short/malformed sig could decode
-  partially instead of failing closed). Two safe paths, either a focused PR: (a) a shared
-  `hl_hex_decode_exact` helper preserving the local 0/-1 exact-length contract (no canonical
-  change; needs its own object + link-list wiring); or (b) adapt each of the ~10 call sites to
-  the canonical's byte-count/`< 0` contract AND add an explicit `hex_len == N*2` check. NOT a
-  mechanical mkdir_p-style consolidation. (`hex_encode` ×9, `secure_zero` ×5 have the same
-  "identical-to-each-other but a different-contract canonical exists" shape.)
+- [x] **#8 Consolidate trust-critical duplicate `hex_decode`** — DONE. Deleted the 4 byte-identical
+  local copies (`hex_nibble` + `hex_decode`/`hex_decode_pk` in `signature.c`, `release.c`,
+  `commands/verify_release.c`, `commands/verify_self.c`) and routed all ~10 call sites through the
+  canonical `hl_cap_crypto_hex_decode`. Resolution of the contract mismatch (canonical returns the
+  BYTE COUNT with out_size as a capacity; the locals returned 0/-1 with an exact `hex_len==out_len*2`
+  check): the exact-length behavior is preserved by checking `rc == N` (not `rc != 0`), which is
+  provably equivalent — success requires `hex_len/2 == N` exactly, since a short input returns `<N`
+  and a long one returns `-1` (insufficient capacity). No security regression: fail-closed on
+  short/malformed input is retained, and the canonical adds NULL-guards + explicit bounds the
+  locals lacked. The `hex_decode_pk` sites pass `strlen(pubkey_hex)` so an over/under-length
+  `--pubkey` still rejects. No new object / link-list wiring (canonical's `cap_crypto.o` is a base
+  object already linked wherever `signature.o`/`release.o` are, all flavors). Validated:
+  `test_signature` (20), `test_release` (20), `test_crypto` (58), `test_dispatch` (4),
+  `test_verify_self` (5), full `make test` green, cppcheck clean. (`hex_encode` ×N, `secure_zero` ×N
+  have the same "identical-to-each-other but a different-contract canonical exists" shape — left as a
+  Tier-4 follow-on; `hex_encode` stays local in `signature.c`/`release.c` since it has no exact-length
+  hazard and a differing signature.)
 
 ## Tier 4 — architectural consistency & docs (lower urgency)
 

--- a/src/hull/commands/verify_release.c
+++ b/src/hull/commands/verify_release.c
@@ -15,6 +15,7 @@
 
 #include "hull/commands/verify_release.h"
 #include "hull/release.h"
+#include "hull/cap/crypto.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -30,26 +31,6 @@ static void usage(void)
         "  --pubkey <hex> override, 64 hex chars).\n"
         "\n"
         "  Exit code: 0 = valid, 1 = invalid / error.\n");
-}
-
-static int hex_nibble(unsigned char c)
-{
-    if (c >= '0' && c <= '9') return c - '0';
-    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
-    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
-    return -1;
-}
-
-static int hex_decode_pk(const char *hex, uint8_t out[32])
-{
-    if (strlen(hex) != 64) return -1;
-    for (size_t i = 0; i < 32; i++) {
-        int hi = hex_nibble((unsigned char)hex[i * 2]);
-        int lo = hex_nibble((unsigned char)hex[i * 2 + 1]);
-        if (hi < 0 || lo < 0) return -1;
-        out[i] = (uint8_t)((hi << 4) | lo);
-    }
-    return 0;
 }
 
 static int read_file(const char *path, char **out_buf, size_t *out_len)
@@ -116,7 +97,7 @@ int hl_cmd_verify_release(int argc, char **argv, const HlCommandEnv *env)
     uint8_t pubkey_buf[32];
     const uint8_t *pubkey = NULL;
     if (pubkey_hex) {
-        if (hex_decode_pk(pubkey_hex, pubkey_buf) != 0) {
+        if (hl_cap_crypto_hex_decode(pubkey_hex, strlen(pubkey_hex), pubkey_buf, 32) != 32) {
             fprintf(stderr, "hull verify-release: --pubkey must be 64 hex chars\n");
             return 1;
         }

--- a/src/hull/commands/verify_self.c
+++ b/src/hull/commands/verify_self.c
@@ -61,26 +61,6 @@ static void usage(FILE *fp)
         "Exit 1 = mismatch or any verification step failed.\n");
 }
 
-static int hex_nibble(unsigned char c)
-{
-    if (c >= '0' && c <= '9') return c - '0';
-    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
-    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
-    return -1;
-}
-
-static int hex_decode_pk(const char *hex, uint8_t out[32])
-{
-    if (strlen(hex) != 64) return -1;
-    for (size_t i = 0; i < 32; i++) {
-        int hi = hex_nibble((unsigned char)hex[i * 2]);
-        int lo = hex_nibble((unsigned char)hex[i * 2 + 1]);
-        if (hi < 0 || lo < 0) return -1;
-        out[i] = (uint8_t)((hi << 4) | lo);
-    }
-    return 0;
-}
-
 static int read_file(const char *path, char **out_buf, size_t *out_len)
 {
     FILE *f = fopen(path, "rb");
@@ -262,7 +242,7 @@ int hl_cmd_verify_self(int argc, char **argv, const HlCommandEnv *env)
     uint8_t pubkey_buf[32];
     const uint8_t *pubkey = NULL;
     if (pubkey_hex) {
-        if (hex_decode_pk(pubkey_hex, pubkey_buf) != 0) {
+        if (hl_cap_crypto_hex_decode(pubkey_hex, strlen(pubkey_hex), pubkey_buf, 32) != 32) {
             fprintf(stderr, "hull verify-self: --pubkey must be 64 hex chars\n");
             return 1;
         }

--- a/src/hull/release.c
+++ b/src/hull/release.c
@@ -18,26 +18,10 @@
 
 /* ── Local hex helpers ─────────────────────────────────────────────── */
 
-static int hex_nibble(unsigned char c)
-{
-    if (c >= '0' && c <= '9') return c - '0';
-    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
-    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
-    return -1;
-}
-
-static int hex_decode(const char *hex, size_t hex_len,
-                      uint8_t *out, size_t out_len)
-{
-    if (hex_len != out_len * 2) return -1;
-    for (size_t i = 0; i < out_len; i++) {
-        int hi = hex_nibble((unsigned char)hex[i * 2]);
-        int lo = hex_nibble((unsigned char)hex[i * 2 + 1]);
-        if (hi < 0 || lo < 0) return -1;
-        out[i] = (uint8_t)((hi << 4) | lo);
-    }
-    return 0;
-}
+/* hex decode goes through the canonical hl_cap_crypto_hex_decode (cap/crypto.h):
+ * it returns the byte count written (out_size is a capacity), so `rc == N`
+ * checks an exact N-byte decode - equivalent to the old local 0/-1 contract
+ * that required hex_len == N*2. See signature.c for the rationale. */
 
 static void hex_encode(const uint8_t *data, size_t len, char *out)
 {
@@ -84,7 +68,7 @@ int hl_release_pubkey_configured(void)
 int hl_release_pubkey_decode(uint8_t out_pk[32])
 {
     if (!out_pk) return -1;
-    return hex_decode(HL_RELEASE_PUBKEY_HEX, 64, out_pk, 32);
+    return hl_cap_crypto_hex_decode(HL_RELEASE_PUBKEY_HEX, 64, out_pk, 32) == 32 ? 0 : -1;
 }
 
 int hl_release_verify_manifest_sig(const void *manifest, size_t manifest_len,
@@ -99,7 +83,7 @@ int hl_release_verify_manifest_sig(const void *manifest, size_t manifest_len,
 
     /* Decode signature */
     uint8_t sig[64];
-    if (hex_decode(sig_hex, sig_hex_len, sig, sizeof(sig)) != 0)
+    if (hl_cap_crypto_hex_decode(sig_hex, sig_hex_len, sig, sizeof(sig)) != (int)sizeof(sig))
         return -1;
 
     /* Resolve public key */
@@ -164,7 +148,7 @@ int hl_release_load_secret_key(const char *path, uint8_t out_sk[64])
         return -1;
     }
 
-    int rc = hex_decode(buf, hex_len, out_sk, 64);
+    int rc = hl_cap_crypto_hex_decode(buf, hex_len, out_sk, 64) == 64 ? 0 : -1;
     secure_zero(buf, sizeof(buf));
     return rc;
 }

--- a/src/hull/signature.c
+++ b/src/hull/signature.c
@@ -27,26 +27,12 @@
 
 /* ── Hex utilities ────────────────────────────────────────────────── */
 
-static int hex_nibble(unsigned char c)
-{
-    if (c >= '0' && c <= '9') return c - '0';
-    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
-    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
-    return -1;
-}
-
-static int hex_decode(const char *hex, size_t hex_len,
-                      uint8_t *out, size_t out_len)
-{
-    if (hex_len != out_len * 2) return -1;
-    for (size_t i = 0; i < out_len; i++) {
-        int hi = hex_nibble((unsigned char)hex[i * 2]);
-        int lo = hex_nibble((unsigned char)hex[i * 2 + 1]);
-        if (hi < 0 || lo < 0) return -1;
-        out[i] = (uint8_t)((hi << 4) | lo);
-    }
-    return 0;
-}
+/* hex decode goes through the canonical hl_cap_crypto_hex_decode (cap/crypto.h).
+ * It returns the byte count written (out_size treated as a capacity), so a
+ * success check is `rc == N` where N is the expected byte count: that requires
+ * hex_len/2 == N exactly (a short input returns <N; a long one returns -1 for
+ * insufficient capacity), matching the exact-length fail-closed contract these
+ * Ed25519 verify paths need. */
 
 static void hex_encode(const uint8_t *data, size_t len, char *out)
 {
@@ -271,7 +257,7 @@ int hl_sig_verify(const HlSignature *sig, const uint8_t pubkey[32])
     if (sig_hex_len != 128) return -1;
 
     uint8_t sig_bytes[64];
-    if (hex_decode(sig->signature_hex, sig_hex_len, sig_bytes, 64) != 0)
+    if (hl_cap_crypto_hex_decode(sig->signature_hex, sig_hex_len, sig_bytes, 64) != 64)
         return -1;
 
     /*
@@ -385,7 +371,7 @@ int hl_sig_verify_platform(const HlSignature *sig, const uint8_t pubkey[32])
     if (sig_hex_len != 128) return -1;
 
     uint8_t sig_bytes[64];
-    if (hex_decode(sig->platform.signature_hex, sig_hex_len, sig_bytes, 64) != 0)
+    if (hl_cap_crypto_hex_decode(sig->platform.signature_hex, sig_hex_len, sig_bytes, 64) != 64)
         return -1;
 
     /* Serialize platforms value to canonical JSON */
@@ -608,7 +594,7 @@ int hl_verify_startup(const char *pubkey_path, const char *entry_point,
     }
 
     uint8_t pubkey[32];
-    if (hex_decode(pk_hex, 64, pubkey, 32) != 0) {
+    if (hl_cap_crypto_hex_decode(pk_hex, 64, pubkey, 32) != 32) {
         log_error("[sig] invalid pubkey hex");
         return -1;
     }
@@ -670,7 +656,7 @@ int hl_verify_startup(const char *pubkey_path, const char *entry_point,
     if (sig.platform.signature_hex && sig.platform.public_key_hex) {
         uint8_t platform_pk[32];
         if (strlen(sig.platform.public_key_hex) == 64 &&
-            hex_decode(sig.platform.public_key_hex, 64, platform_pk, 32) == 0) {
+            hl_cap_crypto_hex_decode(sig.platform.public_key_hex, 64, platform_pk, 32) == 32) {
             if (hl_sig_verify_platform(&sig, platform_pk) != 0) {
                 log_error("[sig] platform signature verification failed");
                 hl_sig_free(&sig);
@@ -726,7 +712,7 @@ int hl_verify_startup(const char *pubkey_path, const char *entry_point,
              * explicitly — avoids hl_platform_sig_verify decoding the
              * same macro a second time when its pubkey arg is NULL. */
             uint8_t embedded_pk[32];
-            if (hex_decode(HL_PLATFORM_PUBKEY_HEX, 64, embedded_pk, 32) != 0) {
+            if (hl_cap_crypto_hex_decode(HL_PLATFORM_PUBKEY_HEX, 64, embedded_pk, 32) != 32) {
                 log_error("[sig] HL_PLATFORM_PUBKEY_HEX is malformed "
                           "(compile-time misconfiguration)");
                 hl_sig_free(&sig);


### PR DESCRIPTION
Audit item **#8** (`docs/build_arc_audit.md`): consolidate the trust-critical duplicate `hex_decode` helpers.

## What
Delete the 4 byte-identical local copies (`hex_nibble` + `hex_decode`/`hex_decode_pk`) in `signature.c`, `release.c`, `commands/verify_release.c`, `commands/verify_self.c` and route all ~10 call sites through the canonical `hl_cap_crypto_hex_decode`.

## The contract mismatch (and why the swap is safe)
The canonical returns the **byte count** written (with `out_size` as a *capacity*); the locals returned **0/-1** with an exact `hex_len == out_len*2` check. A naive `!= 0` → canonical swap would drop the exact-length enforcement — a real fail-open risk on the Ed25519 signature-verify paths.

Resolution: check **`rc == N`** (not `rc != 0`), which is **provably equivalent** to the old exact-length contract:
- success requires `hex_len/2 == N` exactly,
- a **short** input returns `< N` → `!= N` → rejected,
- a **long** input returns `-1` (insufficient capacity, since `out_size = N < hex_len/2`) → rejected.

No security regression — fail-closed on short/malformed input is retained, and the canonical adds NULL-guards + explicit bounds the locals lacked. The two `hex_decode_pk` sites pass `strlen(pubkey_hex)` so an over/under-length `--pubkey` still rejects.

`return`/`rc`-propagating sites in `release.c` keep their 0/-1 function contract via `== N ? 0 : -1`. `hex_encode` stays local (no exact-length hazard, different signature).

No new object / link-list wiring: `cap_crypto.o` is a base object already linked wherever `signature.o`/`release.o` are, in every flavor.

## Validation
`test_signature` (20), `test_release` (20), `test_crypto` (58), `test_dispatch` (4), `test_verify_self` (5), full `make test` green, cppcheck clean. Net `5 files changed, 38 insertions(+), 104 deletions(-)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)