### PR TITLE
build: musl platform archive-set producer (audit #4a)

### DIFF
--- a/docs/build_arc_audit.md
+++ b/docs/build_arc_audit.md
@@ -34,10 +34,28 @@ Execution order (agreed): **#6+#1 → #7 → #4 → #5 → #2 → #3 → #8**, t
 
 ## Tier 2 — make the toolchain-free story real for install-only users
 
-- [ ] **#4 No published musl `libhull_platform.a`.** ✓ Release builds Linux libs on glibc only,
+- **#4 No published musl `libhull_platform.a`.** ✓ Release builds Linux libs on glibc only,
   so `--linker=lld-static` and `--linker=zig --target=…-musl` work ONLY from a source build.
-  Publish a signed `libhull_platform-musl-<arch>.a` (+ runtime/feature archives) and teach
-  `prepare_platform` to select it for a musl target. Highest-value "make it real" gap.
+  A coupled producer+pipeline+consumer epic; split into sub-steps:
+  - [x] **#4a Producer.** `scripts/build_musl_platform.sh` builds the FULL musl archive set
+    (`make platform` + `platform-slim` + `feature-embedded` = base + slim + all 18
+    `libhull_feature-*.a`), read-only-mount-safe (builds in a container-internal copy so a host
+    checkout's `build/` is never clobbered). Validated end-to-end in `alpine:3.20`: all 20
+    archives build under musl + pack to a ~15.8 MB flat ustar. Mirrors `build_musl_floor.sh`.
+    Docs: musl_build.md "Producing the musl platform archive set".
+  - [ ] **#4b Release pipeline.** A `build-platform-musl` Alpine job (mirror `build-floor-musl`)
+    that runs #4a per arch, uploads the tar, and signs each `.a`'s SHA-256 into the platform
+    manifest (`sign-platform-manifest`, the same `embedded_platform_sig.h` §5c anchors, OR a
+    separate musl manifest). Touches the SIGNED release artifacts → needs a pre-release dry-run
+    (hyphenated tag) before it can land. `hull.sha256` gains the musl tars.
+  - [ ] **#4c Fetch + select.** A `hull flavor install musl-<arch>` (or tool-bundle) fetch to
+    `~/.hull/platform/`, + teach `prepare_platform` (and the `feature_compose` resolve ladder)
+    to select the musl base AND musl feature archives for a `-musl`/cross target, re-verifying
+    against the signed manifest; relax the `#206` cross guard once a musl lib is resolvable.
+    A partial consumer that redirects only the base (not the feature archives) would re-link a
+    glibc feature lib against a musl base - the exact bug - so this lands atomically.
+  - [ ] **#4d Smoke.** `release_smoke.sh` section: `hull … install musl-x86_64` + a
+    `--target=x86_64-linux-musl --linker=zig` build that runs in Alpine.
 - [x] **#5 `--linker=zig` has zero e2e** ✓. DONE (PR #205): `tests/e2e_linker_zig.sh` builds +
   runs a real app through the zig backend on Linux x86_64 (skips elsewhere - cross needs a
   target platform lib, #2/#4); wired into Linux CI. A `test_linker.c` unit test was deferred

--- a/docs/musl_build.md
+++ b/docs/musl_build.md
@@ -113,12 +113,40 @@ crt+libc+compiler-rt for ~40 targets); Tier B is the purist `ld.lld` + floor
 path. See [docs/toolchain_free_build.md](toolchain_free_build.md). Covered by
 `tests/e2e_musl.sh` (asserts static + runs, cc-free, and via the bundle).
 
+## Producing the musl platform archive set
+
+The floor above is only half of a musl static link: `--linker=lld-static` (Tier
+B) and `--linker=zig --target=<arch>-linux-musl` (cross) also need Hull's OWN
+archives - `libhull_platform.a` + every composed feature archive - built against
+musl, because a glibc-built `.a` will not static-link against musl (see the
+`linker_lld.c` header). `scripts/build_musl_platform.sh` produces that full set,
+the musl counterpart of the floor script:
+
+```sh
+# On a musl host (Alpine) with the C toolchain, or via Docker from anywhere:
+docker run --rm -v "$PWD":/work:ro -v /tmp/out:/out alpine:3.20 sh -c '
+  apk add --no-cache build-base clang lld make xxd bash git perl linux-headers
+  sh /work/scripts/build_musl_platform.sh /work /out/hull-libhull-platform-musl-$(uname -m).tar
+'
+```
+
+It builds `make platform` + `platform-slim` + `feature-embedded` (the exact set
+the release's `build-platform-native` job produces, but musl-built) and packs a
+flat ustar of `libhull_platform.a`, `libhull_platform-slim.a`, and every
+`libhull_feature-*.a`. The build runs in a container-internal copy of the
+checkout, so the source may be mounted **read-only** - a host checkout's `build/`
+is never clobbered by the in-container musl objects.
+
 ## Caveats / not-yet
 
 - **Sandbox in a container.** The e2e runs apps with `--no-sandbox`: Docker's
   default seccomp/landlock restrictions make pledge/unveil enforcement fail
   inside an unprivileged container. That is a container-capability limitation,
   not a musl issue; a musl binary on a real host sandboxes normally.
-- **Published artifacts.** The signed release matrix ships glibc + cosmo
-  binaries. A published, signed musl platform library / binary would be a
-  separate release-pipeline decision (new matrix entry + manifest line).
+- **Publishing + consuming the musl archives.** `scripts/build_musl_platform.sh`
+  can now PRODUCE the musl archive set (above), but the signed release matrix
+  still ships only glibc + cosmo binaries, and `hull build` does not yet select a
+  musl platform lib for a `-musl` target (the `#206` guard rejects the cross with
+  a clear message). Publishing the set into the signed platform manifest (a new
+  `build-platform-musl` release job + a fetch/select path) is the remaining
+  half of audit item #4 (docs/build_arc_audit.md).

--- a/scripts/build_musl_platform.sh
+++ b/scripts/build_musl_platform.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# build_musl_platform.sh <src-dir> [<tar-out>]
+#
+# Build the FULL musl platform archive set from a Hull checkout: the composable
+# base + the SLIM app-build base + every embedded feature archive, all compiled
+# against musl libc. This is the producer for audit item #4 (docs/build_arc_audit.md)
+# - a musl `libhull_platform.a` + feature archives so an install-only user can
+# `hull build --target=<arch>-linux-musl` (or `--linker=lld-static`) WITHOUT
+# building hull from musl source. The companion `build_musl_floor.sh` produces the
+# musl libc floor (crt + libc.a); this produces Hull's own archives.
+#
+# Mirrors build_musl_floor.sh's contract: run inside a musl system (Alpine) with
+# the full C toolchain (build-base) present. With a 2nd arg, pack the produced
+# archives as a flat ustar at <tar-out> (every member a bare "./<file>", what
+# hl_tools_extract_tar expects).
+#
+# Produced archive set (matches the release producer's Linux native build -
+# release.yml `build-platform-native`, the `make platform` / `platform-slim` /
+# `feature-embedded` steps):
+#   libhull_platform.a              <- make platform      (composable base)
+#   libhull_platform-slim.a         <- make platform-slim (SQLite-less+TLS-less base)
+#   libhull_feature-*.a             <- make feature-embedded (FEATURE_EMBEDDED_STEMS)
+#
+# READ-ONLY-SAFE: the build runs in a container-internal copy of <src-dir>, so
+# <src-dir> may be mounted read-only. This keeps a host checkout's build/ from
+# being clobbered by the in-container musl .o/.a (a macOS host's build/ would
+# otherwise break - see the repo's Docker-repro convention). CI mounts $PWD and
+# passes it as <src-dir>; the copy costs a few seconds and buys the RO guarantee.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+SRC="${1:?usage: build_musl_platform.sh <src-dir> [<tar-out>]}"
+TAR_OUT="${2:-}"
+JOBS="${JOBS:-$(nproc 2>/dev/null || echo 4)}"
+
+if [ ! -f "$SRC/Makefile" ]; then
+    echo "build_musl_platform: '$SRC' is not a Hull checkout (no Makefile)" >&2
+    exit 1
+fi
+
+# Build in a writable copy so <src-dir> can be a read-only mount.
+BUILD_SRC="${HULL_MUSL_BUILD_DIR:-/tmp/hull-musl-build}"
+rm -rf "$BUILD_SRC"
+mkdir -p "$BUILD_SRC"
+# `cp -a .../.` copies the tree contents (incl. dotfiles + submodules) into the
+# fresh dir. Vendored submodules (keel, wamr) must already be checked out in SRC.
+cp -a "$SRC"/. "$BUILD_SRC"/
+cd "$BUILD_SRC"
+
+# A stray build/ carried in from the (possibly host) SRC would mix foreign-libc
+# objects with the musl ones. Start from clean so every object is musl-built.
+make -s clean >/dev/null 2>&1 || true
+
+echo "build_musl_platform: building the musl archive set (-j$JOBS) ..."
+make -j"$JOBS" platform
+make -j"$JOBS" platform-slim
+make -j"$JOBS" feature-embedded
+
+OUT="${HULL_MUSL_OUT_DIR:-/tmp/hull-musl-out}"
+rm -rf "$OUT"
+mkdir -p "$OUT"
+cp build/libhull_platform.a      "$OUT"/
+cp build/libhull_platform-slim.a "$OUT"/
+# The embedded feature archives, enumerated by the registry (mk/feature.mk's
+# FEATURE_EMBEDDED_STEMS) so this stays in lockstep with the release producer.
+# shellcheck disable=SC2046
+cp $(make -s print-feature-embedded-libs) "$OUT"/
+
+echo "build_musl_platform: assembled the musl archive set in $OUT:"
+ls -1 "$OUT"
+
+if [ -n "$TAR_OUT" ]; then
+    tar cf "$TAR_OUT" -C "$OUT" .
+    echo "build_musl_platform: packed $TAR_OUT ($(wc -c < "$TAR_OUT") bytes)"
+fi


### PR DESCRIPTION
First sub-step of audit item **#4** (`docs/build_arc_audit.md`): make the toolchain-free musl story real.

## Why
`--linker=lld-static` (Tier B) and `--linker=zig --target=<arch>-linux-musl` (cross) need Hull's OWN archives — `libhull_platform.a` + every composed `libhull_feature-*.a` — built against **musl**, because a glibc-built `.a` won't static-link against musl (see the `linker_lld.c` header). Today only the musl **libc floor** (`build_musl_floor.sh`) is produced, not the musl **platform archive set**. This adds the missing producer.

## What
`scripts/build_musl_platform.sh` — the musl counterpart of `build_musl_floor.sh`:
- Runs `make platform` + `platform-slim` + `feature-embedded` (the exact set the release's `build-platform-native` job produces) and packs a flat ustar of all 20 archives.
- **Read-only-mount-safe**: builds in a container-internal copy of the checkout, so the source may be mounted `:ro` — a host checkout's `build/` is never clobbered by the in-container musl objects (the repo's Docker-repro convention).

## Validation
Built end-to-end in `alpine:3.20`: all 20 archives (base + slim + 18 feature archives — lua/js runtimes, http, wasm, image, sqlite, tls, keel, tui bridges) compile under musl and pack to a ~15.8 MB tar. Confirmed the RO-mounted build left the macOS host `build/` untouched (still Mach-O/arm64). `sh -n` clean.

```
docker run --rm -v "\$PWD":/work:ro -v /tmp/out:/out alpine:3.20 sh -c '
  apk add --no-cache build-base clang lld make xxd bash git perl linux-headers
  sh /work/scripts/build_musl_platform.sh /work /out/hull-libhull-platform-musl-\$(uname -m).tar'
```

## Scope / follow-ups
This is producer-only. The remaining #4 halves (tracked in the audit doc as #4b/#4c/#4d):
- **#4b** a `build-platform-musl` Alpine release job that signs the archives into the platform manifest — touches signed release artifacts, **needs a pre-release dry-run**.
- **#4c** `hull … install musl-<arch>` fetch + teach `prepare_platform`/`feature_compose` to select the musl base **and** feature archives for a `-musl` target (lands atomically — a base-only redirect would re-link a glibc feature lib against a musl base), relaxing the `#206` cross guard.
- **#4d** a `release_smoke.sh` section.

Until then the `#206` guard still rejects a musl cross with a clear message (no silent mis-link).

Docs: `musl_build.md` "Producing the musl platform archive set".

🤖 Generated with [Claude Code](https://claude.com/claude-code)