### PR TITLE
release: build + publish the musl platform archive set (audit #4b)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -809,6 +809,59 @@ jobs:
           name: hull-libc-musl-${{ matrix.name }}.tar
           path: hull-libc-musl-${{ matrix.name }}.tar
 
+  build-platform-musl:
+    # The musl-built Hull archive SET (libhull_platform.a + libhull_platform-slim.a
+    # + every libhull_feature-*.a), the counterpart of build-floor-musl above: the
+    # floor is the musl libc; THIS is Hull's own archives, musl-built. Needed so
+    # `hull build --linker=lld-static` (Tier B) or `--linker=zig --target=<arch>-
+    # linux-musl` (cross) can link against a musl base - a glibc-built .a can't
+    # (audit item #4, docs/build_arc_audit.md). Assembled INSIDE Alpine (musl) via
+    # scripts/build_musl_platform.sh, packed as a flat ustar. Its SHA-256 lands in
+    # the signed hull.sha256 below (release-key trust chain, same as the floor /
+    # wamrc / zig tars), so `hull ... install` (the #4c fetch) can verify it.
+    # Native-only (musl is Linux); one artifact per arch.
+    #
+    # NOTE (#4b scope): this publishes the FETCHABLE tar into hull.sha256. Wiring
+    # the runtime §5c composed-archive attestation (platform-manifest.txt / the
+    # embedded platform-sig) for a musl cross-built app is #4c, where the composer
+    # that records the musl-tagged archive names is built + tested alongside it.
+    name: Build platform (musl, ${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: x86_64
+            os: ubuntu-24.04
+          - name: aarch64
+            os: ubuntu-24.04-arm
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true          # keel + wamr are needed to build the platform
+
+      - name: Write VERSION file
+        run: echo "${GITHUB_REF_NAME#v}" > VERSION
+
+      - name: Build the musl platform archive set in Alpine (musl)
+        # RW mount is fine on the ephemeral runner; the producer builds in a
+        # container-internal copy regardless, so nothing writes into the checkout
+        # except the output tar. Same toolchain set tests/e2e_musl.sh installs.
+        run: |
+          docker run --rm -v "$PWD":/work alpine:3.20 sh -c '
+            set -eu
+            apk add --no-cache build-base clang lld make xxd bash git perl linux-headers >/dev/null 2>&1
+            sh /work/scripts/build_musl_platform.sh /work \
+               /work/hull-platform-musl-${{ matrix.name }}.tar
+          '
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: hull-platform-musl-${{ matrix.name }}.tar
+          path: hull-platform-musl-${{ matrix.name }}.tar
+
   build-zig:
     # The turnkey cross-linker bundle pulled by `hull tools install zig` ->
     # `hull build --linker=zig --target=<triple>`. Zig's official release is a
@@ -1145,7 +1198,7 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-24.04
-    needs: [build-cosmo, build-native, build-wamrc, build-floor-musl, build-zig, build-feature-native, build-feature-gpu, build-feature-tui, build-feature-postgres, build-feature-mysql, build-feature-lua, build-feature-js]
+    needs: [build-cosmo, build-native, build-wamrc, build-floor-musl, build-platform-musl, build-zig, build-feature-native, build-feature-gpu, build-feature-tui, build-feature-postgres, build-feature-mysql, build-feature-lua, build-feature-js]
     permissions:
       contents: write       # publish GitHub release + assets
       id-token: write       # SLSA: OIDC for Sigstore signing
@@ -1170,6 +1223,11 @@ jobs:
           # libc-musl-<arch>`); hashed into hull.sha256 below.
           mv artifacts/hull-libc-musl-x86_64.tar/hull-libc-musl-x86_64.tar   dist/hull-libc-musl-x86_64.tar
           mv artifacts/hull-libc-musl-aarch64.tar/hull-libc-musl-aarch64.tar dist/hull-libc-musl-aarch64.tar
+          # musl-built Hull platform archive set (base + slim + feature archives),
+          # the #4c fetch target for a musl cross/static build; hashed into
+          # hull.sha256 below (release-key trust chain).
+          mv artifacts/hull-platform-musl-x86_64.tar/hull-platform-musl-x86_64.tar   dist/hull-platform-musl-x86_64.tar
+          mv artifacts/hull-platform-musl-aarch64.tar/hull-platform-musl-aarch64.tar dist/hull-platform-musl-aarch64.tar
           # Toolchain-free linker bundles (`hull tools install zig` / `install
           # lld`); per-platform flat ustar, hashed into hull.sha256 below.
           mv artifacts/hull-zig-linux-x86_64.tar/hull-zig-linux-x86_64.tar   dist/hull-zig-linux-x86_64.tar
@@ -1301,6 +1359,7 @@ jobs:
           sha256sum hull-cosmo hull-linux-x86_64 hull-linux-aarch64 hull-darwin-arm64 \
                     hull-wamrc-linux-x86_64 hull-wamrc-linux-aarch64 hull-wamrc-darwin-arm64 \
                     hull-libc-musl-x86_64.tar hull-libc-musl-aarch64.tar \
+                    hull-platform-musl-x86_64.tar hull-platform-musl-aarch64.tar \
                     hull-zig-linux-x86_64.tar hull-zig-linux-aarch64.tar hull-zig-darwin-arm64.tar \
                     hull.sbom.json hull.sbom.cdx.json hull.sbom.spdx.json \
                     libhull.sbom.json libhull.sbom.cdx.json libhull.sbom.spdx.json \
@@ -1379,6 +1438,8 @@ jobs:
             dist/hull-wamrc-darwin-arm64
             dist/hull-libc-musl-x86_64.tar
             dist/hull-libc-musl-aarch64.tar
+            dist/hull-platform-musl-x86_64.tar
+            dist/hull-platform-musl-aarch64.tar
             dist/hull-zig-linux-x86_64.tar
             dist/hull-zig-linux-aarch64.tar
             dist/hull-zig-darwin-arm64.tar
@@ -1403,6 +1464,8 @@ jobs:
             dist/hull-wamrc-darwin-arm64
             dist/hull-libc-musl-x86_64.tar
             dist/hull-libc-musl-aarch64.tar
+            dist/hull-platform-musl-x86_64.tar
+            dist/hull-platform-musl-aarch64.tar
             dist/hull-zig-linux-x86_64.tar
             dist/hull-zig-linux-aarch64.tar
             dist/hull-zig-darwin-arm64.tar

--- a/docs/build_arc_audit.md
+++ b/docs/build_arc_audit.md
@@ -43,17 +43,24 @@ Execution order (agreed): **#6+#1 → #7 → #4 → #5 → #2 → #3 → #8**, t
     checkout's `build/` is never clobbered). Validated end-to-end in `alpine:3.20`: all 20
     archives build under musl + pack to a ~15.8 MB flat ustar. Mirrors `build_musl_floor.sh`.
     Docs: musl_build.md "Producing the musl platform archive set".
-  - [ ] **#4b Release pipeline.** A `build-platform-musl` Alpine job (mirror `build-floor-musl`)
-    that runs #4a per arch, uploads the tar, and signs each `.a`'s SHA-256 into the platform
-    manifest (`sign-platform-manifest`, the same `embedded_platform_sig.h` §5c anchors, OR a
-    separate musl manifest). Touches the SIGNED release artifacts → needs a pre-release dry-run
-    (hyphenated tag) before it can land. `hull.sha256` gains the musl tars.
-  - [ ] **#4c Fetch + select.** A `hull flavor install musl-<arch>` (or tool-bundle) fetch to
-    `~/.hull/platform/`, + teach `prepare_platform` (and the `feature_compose` resolve ladder)
-    to select the musl base AND musl feature archives for a `-musl`/cross target, re-verifying
-    against the signed manifest; relax the `#206` cross guard once a musl lib is resolvable.
-    A partial consumer that redirects only the base (not the feature archives) would re-link a
-    glibc feature lib against a musl base - the exact bug - so this lands atomically.
+  - [~] **#4b Publish (release pipeline).** A `build-platform-musl` Alpine job (mirror
+    `build-floor-musl`) runs #4a per arch and packs `hull-platform-musl-<arch>.tar`; the final
+    `release` job hashes it into the signed `hull.sha256` (release-key trust chain, same as the
+    floor / wamrc / zig tars), attests it (SLSA), and publishes it. Scoped to the FETCHABLE tar
+    in `hull.sha256` - deliberately NOT the embedded platform-sig (`platform-manifest.txt`/§5c):
+    the runtime §5c coupling for a musl cross-built app is only testable with the composer that
+    records the musl-tagged composed names, so it moves to #4c. Artifact named
+    `hull-platform-musl-` (not `platform-`) so it does NOT leak into the untouched
+    `sign-platform-manifest` job. Touches signed release artifacts → validated by a pre-release
+    dry-run (hyphenated tag) before landing. IMPLEMENTED (release.yml); pending the dry-run.
+  - [ ] **#4c Fetch + select (+ §5c).** A `hull ... install musl-<arch>` fetch (release-key
+    verify, to `~/.hull/platform/`) + teach `prepare_platform` (and the `feature_compose` resolve
+    ladder) to select the musl base AND musl feature archives for a `-musl`/cross target;
+    determine + wire whatever runtime §5c / `platform-manifest.txt` change a musl cross-built app
+    needs (may need the musl-tagged rows in the embedded platform manifest + a `platform_sig.c`
+    entry-cap bump 64→128); relax the `#206` cross guard once a musl lib is resolvable. A partial
+    consumer that redirects only the base (not the feature archives) would re-link a glibc feature
+    lib against a musl base - the exact bug - so this lands atomically.
   - [ ] **#4d Smoke.** `release_smoke.sh` section: `hull … install musl-x86_64` + a
     `--target=x86_64-linux-musl --linker=zig` build that runs in Alpine.
 - [x] **#5 `--linker=zig` has zero e2e** ✓. DONE (PR #205): `tests/e2e_linker_zig.sh` builds +

--- a/docs/musl_build.md
+++ b/docs/musl_build.md
@@ -126,7 +126,7 @@ the musl counterpart of the floor script:
 # On a musl host (Alpine) with the C toolchain, or via Docker from anywhere:
 docker run --rm -v "$PWD":/work:ro -v /tmp/out:/out alpine:3.20 sh -c '
   apk add --no-cache build-base clang lld make xxd bash git perl linux-headers
-  sh /work/scripts/build_musl_platform.sh /work /out/hull-libhull-platform-musl-$(uname -m).tar
+  sh /work/scripts/build_musl_platform.sh /work /out/hull-platform-musl-$(uname -m).tar
 '
 ```
 
@@ -143,10 +143,13 @@ is never clobbered by the in-container musl objects.
   default seccomp/landlock restrictions make pledge/unveil enforcement fail
   inside an unprivileged container. That is a container-capability limitation,
   not a musl issue; a musl binary on a real host sandboxes normally.
-- **Publishing + consuming the musl archives.** `scripts/build_musl_platform.sh`
-  can now PRODUCE the musl archive set (above), but the signed release matrix
-  still ships only glibc + cosmo binaries, and `hull build` does not yet select a
-  musl platform lib for a `-musl` target (the `#206` guard rejects the cross with
-  a clear message). Publishing the set into the signed platform manifest (a new
-  `build-platform-musl` release job + a fetch/select path) is the remaining
-  half of audit item #4 (docs/build_arc_audit.md).
+- **Consuming the musl archives.** The release now BUILDS + PUBLISHES the musl
+  archive set: the `build-platform-musl` job runs `build_musl_platform.sh` per
+  arch and the resulting `hull-platform-musl-<arch>.tar` is hashed into the signed
+  `hull.sha256` (release-key trust chain, same as the floor / wamrc / zig tars) -
+  so it can be fetched + verified. What is NOT wired yet: `hull build` does not
+  select a musl platform lib for a `-musl` target (the `#206` guard still rejects
+  the cross with a clear message), and the runtime §5c composed-archive
+  attestation is not musl-aware. Teaching `hull ... install musl-<arch>` +
+  `prepare_platform`/`feature_compose` to fetch + select the musl base AND feature
+  archives (atomically) is audit item #4c (docs/build_arc_audit.md).


### PR DESCRIPTION
Audit item **#4b** (`docs/build_arc_audit.md`): build + publish the musl platform archive set so it can be fetched + verified. Builds on **#4a** (the `build_musl_platform.sh` producer, PR #210).

## What
A new `build-platform-musl` job (mirror of `build-floor-musl`) runs the producer per arch inside Alpine and packs `hull-platform-musl-<arch>.tar`. The final `release` job:
- hashes it into the signed **`hull.sha256`** (release-key trust chain — same as the floor / wamrc / zig tars),
- adds it to the **SLSA build-provenance** subject-path,
- publishes it as a release asset.

## Scope (deliberate)
This publishes the **fetchable tar** into `hull.sha256` — **not** the embedded platform-sig (`platform-manifest.txt` / runtime §5c). The §5c composed-archive attestation for a musl cross-built app is only testable alongside the composer that records the musl-tagged composed names, so it moves to **#4c** (fetch + select + §5c, lands atomically). The artifact is named `hull-platform-musl-` (not `platform-`) so it does **not** leak into the untouched `sign-platform-manifest` job.

Wired at five sites: the new job, the release job's `needs`, the flatten step, the `hull.sha256` list, the SLSA attestation subjects, and the publish assets list.

## Validation
- `actionlint` exit 0 (the two SC warnings it reports are pre-existing steps, not the new job); YAML valid.
- **release.yml is tag-triggered, so normal PR CI does not exercise it** — this is validated by a **pre-release dry-run** (a hyphenated tag → auto `--prerelease`, `latest` stays clean) that runs the real workflow and confirms the musl job builds + the tar lands in the published prerelease + `hull.sha256`, then is torn down. (#4a already proved the archive set builds under musl end-to-end.)

## Follow-ups (tracked in the audit doc)
- **#4c** — `hull … install musl-<arch>` fetch + `prepare_platform`/`feature_compose` select (base **and** feature archives, atomically) + whatever §5c/`platform-manifest.txt` change a cross-built app needs + relax the `#206` guard.
- **#4d** — `release_smoke.sh` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)