### PR TITLE
build: musl cross-build loop — fetch + select + smoke/e2e (audit #4c + #4d)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,18 @@ jobs:
           fi
           make e2e-linker-zig
 
+      - name: musl cross-build E2E (hull build --target=…-linux-musl --linker=zig)
+        # Linux x86_64 + Docker only (self-skips elsewhere). Builds the musl
+        # archive set (scripts/build_musl_platform.sh, Alpine), stages it + the
+        # zig installed above, cross-builds a compute app, and RUNS the static
+        # musl result in Alpine. Audit #4c. The musl archive build is the slow
+        # part, hence the wider timeout.
+        if: runner.os == 'Linux' && runner.arch == 'X64'
+        timeout-minutes: 25
+        run: |
+          command -v zig >/dev/null 2>&1 || export PATH="/opt/zig:$PATH"
+          make e2e-musl-cross
+
       - name: Attachment E2E tests
         timeout-minutes: 2
         run: make e2e-attachment

--- a/Makefile
+++ b/Makefile
@@ -1891,7 +1891,7 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
 
 # ── Targets ─────────────────────────────────────────────────────────
 
-.PHONY: all clean test debug msan tsan fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-linker-zig e2e-cross-build e2e-musl floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint platform platform-cosmo hardening check-hardening
+.PHONY: all clean test debug msan tsan fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-linker-zig e2e-cross-build e2e-musl e2e-musl-cross floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint platform platform-cosmo hardening check-hardening
 
 all: $(BUILDDIR)/hull
 

--- a/docs/build_arc_audit.md
+++ b/docs/build_arc_audit.md
@@ -54,28 +54,24 @@ Execution order (agreed): **#6+#1 → #7 → #4 → #5 → #2 → #3 → #8**, t
     full signed release published, `hull-platform-musl-x86_64.tar` SHA `4d731724…` matched its
     `hull.sha256` entry byte-for-byte, tar held all 20 archives, prerelease flag set (v0.9.0 stayed
     Latest), then torn down (`gh release delete --cleanup-tag`).
-  - [ ] **#4c Fetch + select (+ maybe §5c).** A `hull ... install musl-<arch>` fetch (release-key
-    verify, a `tools install` bundle like `libc-musl-<arch>`, or a `flavor install` to
-    `~/.hull/platform/`) + teach `prepare_platform` (and the `feature_compose` resolve ladder) to
-    select the musl base AND musl feature archives for a `-musl`/cross target; relax the `#206`
-    cross guard once a musl lib is resolvable. A partial consumer that redirects only the base (not
-    the feature archives) would re-link a glibc feature lib against a musl base - the exact bug -
-    so this lands atomically. **PIVOTAL §5c-for-cross question** (determines whether #4c needs a
-    2nd release dry-run): §5c is present-gated on the app's `package.sig.gethull.composed.
-    platform_domain` block (signature.c ~748). The musl platform lib is built by #4a's
-    `make platform` with **`HL_EMBED_PLATFORM_SIG=0`** (no signed manifest present at build), so it
-    carries NO embedded manifest. So the open question is whether the glibc RELEASE hull (which
-    DOES have an embedded platform-sig) *writes* the composed block when cross-building a musl app,
-    and if so whether the musl app's §5c then tries to verify musl hashes it has no manifest for.
-    - If cross builds **skip** writing the composed block (mirrors the build-time cross-check skip
-      at prepare_platform ~1291) OR the musl app has no manifest and §5c is absent → **#4c is just
-      fetch + select + guard**, no platform-manifest change, no 2nd dry-run.
-    - If cross builds **do** write it AND the musl app runs §5c → the musl archive hashes must be
-      signed into the platform manifest (`sign-platform-manifest` gains `musl-<arch>` /
-      `libhull_feature-<stem>.musl-<arch>.a` rows), #4a's producer must embed the signed manifest
-      into the musl lib, and `platform_sig.c`'s entry cap bumps 64→128 (~97 rows) → a **2nd release
-      dry-run**. Answer it with a real glibc-hull cross-build of a musl app + inspect its
-      `package.sig`, once the fetch/select scaffolding exists to run the experiment.
+  - [x] **#4c Fetch + select.** DONE. `hull tools install platform-musl-<arch>` (a data-only bundle
+    in `tools_install.c`'s REGISTRY, mirror of `libc-musl-<arch>`, release-key-verified to
+    `~/.hull/tools/platform-musl-<arch>/`; all three native hosts publish it since it is a
+    cross-target asset). `feature_compose` gained a `ctx.musl_dir` that takes precedence over the
+    embedded glibc copies for EVERY resolver (base + all feature archives, atomically);
+    `prepare_platform` sources the musl base from it and sets `platform_sig_blob = nil`; the `#206`
+    guard now resolves the bundle for a `-musl` target (fails closed with a `hull tools install`
+    hint if absent). The two link objects `obj_emit` can't produce (`app_main.o` +
+    `app_feature_registry.o`, compiled C) are cross-compiled for the target with
+    `zig cc --target`; the `is_darwin`/`--start-group` link-flag gates were fixed to key on the
+    TARGET format, not the host. **§5c question RESOLVED (the simple branch): no 2nd dry-run
+    needed.** A cross target sets `platform_sig_blob = nil`, so build.lua writes NO gethull/composed
+    block, so §5c is present-gated off in the produced app (and the musl base is
+    `HL_EMBED_PLATFORM_SIG=0` anyway); trust is the release-signed install + the developer app sig.
+    Also allowlisted the zig backend's benign `-Wl,--gc-sections` / `-Wl,-dead_strip` in
+    `hl_tool_validate_args`. **Validated end-to-end**: `hull build --target=x86_64-linux-musl
+    --linker=zig` on macOS/arm64 → a static x86_64 musl ELF that RUNS on Alpine (`app.main` →
+    `exit 0`); native macOS build unregressed (`make test` green).
   - [ ] **#4d Smoke.** `release_smoke.sh` section: `hull … install musl-x86_64` + a
     `--target=x86_64-linux-musl --linker=zig` build that runs in Alpine.
 - [x] **#5 `--linker=zig` has zero e2e** ✓. DONE (PR #205): `tests/e2e_linker_zig.sh` builds +

--- a/docs/build_arc_audit.md
+++ b/docs/build_arc_audit.md
@@ -72,8 +72,14 @@ Execution order (agreed): **#6+#1 → #7 → #4 → #5 → #2 → #3 → #8**, t
     `hl_tool_validate_args`. **Validated end-to-end**: `hull build --target=x86_64-linux-musl
     --linker=zig` on macOS/arm64 → a static x86_64 musl ELF that RUNS on Alpine (`app.main` →
     `exit 0`); native macOS build unregressed (`make test` green).
-  - [ ] **#4d Smoke.** `release_smoke.sh` section: `hull … install musl-x86_64` + a
-    `--target=x86_64-linux-musl --linker=zig` build that runs in Alpine.
+  - [x] **#4d Smoke + e2e.** DONE. `release_smoke.sh` gained a `platform-musl-x86_64` install
+    section (LIVE fetch → SHA-256 verify → bundle extract → assert the base + slim + a feature
+    archive → uninstall), mirroring the floor. New `tests/e2e_musl_cross.sh` (+ `make
+    e2e-musl-cross`, wired into the Linux-x86_64 CI job) does the FULL loop per-push: builds the
+    musl archive set (`build_musl_platform.sh`, Alpine), stages it + zig, cross-builds a compute
+    app with `--target=x86_64-linux-musl --linker=zig`, and RUNS the static musl result in Alpine
+    (asserts ELF/x86-64 + statically-linked + the app's stdout). Skips cleanly off Linux-x86_64 /
+    without Docker or zig.
 - [x] **#5 `--linker=zig` has zero e2e** ✓. DONE (PR #205): `tests/e2e_linker_zig.sh` builds +
   runs a real app through the zig backend on Linux x86_64 (skips elsewhere - cross needs a
   target platform lib, #2/#4); wired into Linux CI. A `test_linker.c` unit test was deferred

--- a/docs/musl_build.md
+++ b/docs/musl_build.md
@@ -143,13 +143,27 @@ is never clobbered by the in-container musl objects.
   default seccomp/landlock restrictions make pledge/unveil enforcement fail
   inside an unprivileged container. That is a container-capability limitation,
   not a musl issue; a musl binary on a real host sandboxes normally.
-- **Consuming the musl archives.** The release now BUILDS + PUBLISHES the musl
-  archive set: the `build-platform-musl` job runs `build_musl_platform.sh` per
-  arch and the resulting `hull-platform-musl-<arch>.tar` is hashed into the signed
-  `hull.sha256` (release-key trust chain, same as the floor / wamrc / zig tars) -
-  so it can be fetched + verified. What is NOT wired yet: `hull build` does not
-  select a musl platform lib for a `-musl` target (the `#206` guard still rejects
-  the cross with a clear message), and the runtime §5c composed-archive
-  attestation is not musl-aware. Teaching `hull ... install musl-<arch>` +
-  `prepare_platform`/`feature_compose` to fetch + select the musl base AND feature
-  archives (atomically) is audit item #4c (docs/build_arc_audit.md).
+
+## Cross-building to musl from any host
+
+The full loop is wired (audit #4). Install the musl platform archive set + the
+zig cross-linker, then build with a `-musl` target - from macOS or Linux:
+
+```sh
+hull tools install platform-musl-$(uname -m)   # release-signed archive set
+hull tools install zig                          # cross-linker (bundles musl libc)
+hull build --target=x86_64-linux-musl --linker=zig ./app -o app-musl
+# -> a fully static x86_64 musl ELF; runs on Alpine / any musl box.
+```
+
+`hull build` selects the installed musl base + every composed feature archive
+(`~/.hull/tools/platform-musl-<arch>/`) instead of the glibc copies embedded in
+hull, cross-compiles the two entry objects (`app_main.o` +
+`app_feature_registry.o`) for the target with `zig cc --target`, and links with
+the target-format archive flags. The musl archive set is release-signed +
+SHA-256-verified at install (`hull.sha256`); the runtime platform-sig §5c
+composed-archive attestation is skipped for a cross target (the running glibc
+hull can't attest musl archives it doesn't embed, and the musl base is built
+`HL_EMBED_PLATFORM_SIG=0`), so trust comes from the signed install + the
+developer app signature. Without `platform-musl-<arch>` installed, a `-musl`
+target fails closed with a `hull tools install` hint (the `#206` guard).

--- a/include/hull/cap/tool.h
+++ b/include/hull/cap/tool.h
@@ -70,6 +70,14 @@ int hl_tool_unveil_check(const HlToolUnveilCtx *ctx, const char *path, char need
 int hl_tool_spawn(const char *const argv[]);
 
 /*
+ * Like hl_tool_spawn, but apply extra environment entries (an array of
+ * "KEY=VALUE" strings, NULL-terminated; NULL = none) in the child before exec.
+ * Used to redirect a spawned toolchain's cache into a sandbox-writable dir
+ * (e.g. ZIG_GLOBAL_CACHE_DIR under the build tmpdir for zig cross-compiles).
+ */
+int hl_tool_spawn_env(const char *const argv[], const char *const envadd[]);
+
+/*
  * Spawn a process and capture its stdout.
  * Returns a malloc'd string (caller frees), or NULL on error.
  * If out_len is non-NULL, the output length is stored there.

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -729,6 +729,14 @@ e2e-cross-build:
 e2e-musl:
 	sh tests/e2e_musl.sh
 
+# The musl CROSS-build loop (audit #4c): a glibc host builds the musl archive set
+# (scripts/build_musl_platform.sh, Alpine), stages it + zig, then
+# `hull build --target=x86_64-linux-musl --linker=zig` a compute app and RUNS the
+# static musl result in Alpine. Linux x86_64 + Docker + zig; skips elsewhere. An
+# EMBED_PLATFORM hull is needed to compose, so it depends on the platform lib.
+e2e-musl-cross: $(BUILDDIR)/hull $(BUILDDIR)/libhull_platform.a
+	sh tests/e2e_musl_cross.sh
+
 # Assemble a self-contained musl static-link floor (crt*.o + libc.a + libgcc.a)
 # for Tier B (`hull build --linker=lld-static`) - the contents of a
 # `hull tools install libc-musl-<arch>` bundle. Run on a musl host (Alpine).

--- a/src/hull/cap/tool.c
+++ b/src/hull/cap/tool.c
@@ -203,6 +203,11 @@ int hl_tool_validate_args(const char *const argv[])
                  * references base symbols (tls_client) in the platform lib. Only
                  * affects archive resolution order -- no code execution. */
                 "--start-group", "--end-group",
+                /* Dead-code section stripping, emitted by the zig linker backend
+                 * (linker_zig.c) per target format: --gc-sections on ELF,
+                 * -dead_strip on Mach-O. Pure size optimization (drops unreferenced
+                 * sections) -- no plugin, no codegen, no code execution. */
+                "--gc-sections", "-dead_strip",
                 NULL
             };
             const char *wl_arg = a + 4;

--- a/src/hull/cap/tool.c
+++ b/src/hull/cap/tool.c
@@ -227,6 +227,11 @@ int hl_tool_validate_args(const char *const argv[])
 
 int hl_tool_spawn(const char *const argv[])
 {
+    return hl_tool_spawn_env(argv, NULL);
+}
+
+int hl_tool_spawn_env(const char *const argv[], const char *const envadd[])
+{
     if (!argv || !argv[0]) return -1;
     if (hl_tool_check_allowlist(argv[0]) != 0 ||
         hl_tool_validate_args(argv) != 0) {
@@ -245,7 +250,12 @@ int hl_tool_spawn(const char *const argv[])
     if (pid < 0) return -1;
 
     if (pid == 0) {
-        /* Child: exec */
+        /* Child: apply extra env (KEY=VALUE strings), then exec. putenv points
+         * into envadd, which lives in the parent's memory the child shares
+         * post-fork until execvp - fine for this immediate exec. */
+        if (envadd)
+            for (int i = 0; envadd[i]; i++)
+                putenv((char *)(uintptr_t)envadd[i]);
         execvp(argv[0], (char *const *)(uintptr_t)argv);  /* POSIX execvp takes char*const[] but does not modify argv */
         _exit(127);
     }

--- a/src/hull/linker_zig.c
+++ b/src/hull/linker_zig.c
@@ -73,7 +73,27 @@ static int zig_link(HlLinker *l, const char *output,
     for (int i = 0; libs && libs[i] && n < HL_LINKER_MAX_ARGS - 2; i++)
         argv[n++] = libs[i];
     argv[n] = NULL;
-    return hl_tool_spawn(argv) == 0 ? 0 : -1;
+
+    /* Point zig's cache at the build tmpdir (under /tmp, which the tool-mode
+     * sandbox unveils rwcx) so a SANDBOXED link doesn't fail AccessDenied
+     * writing zig's default ~/.cache/zig / ./.zig-cache. A cross-musl link
+     * compiles zig's bundled crt/libc glue, so it DOES write a cache (unlike a
+     * native-glibc link, which is why --linker=zig worked before this). The
+     * build's objects live in that tmpdir, so derive it from objs[0]
+     * (<tmpdir>/app_main.o); fall back to /tmp. Mirrors the compile-side
+     * redirect in build.lua. (#4c) */
+    char dbuf[PATH_MAX];
+    const char *base = "/tmp";
+    if (objs && objs[0]) {
+        snprintf(dbuf, sizeof dbuf, "%s", objs[0]);
+        char *slash = strrchr(dbuf, '/');
+        if (slash) { *slash = '\0'; base = dbuf; }
+    }
+    char gcache[PATH_MAX + 64], lcache[PATH_MAX + 64];
+    snprintf(gcache, sizeof gcache, "ZIG_GLOBAL_CACHE_DIR=%s/zig-cache", base);
+    snprintf(lcache, sizeof lcache, "ZIG_LOCAL_CACHE_DIR=%s/zig-cache", base);
+    const char *envadd[] = { gcache, lcache, NULL };
+    return hl_tool_spawn_env(argv, envadd) == 0 ? 0 : -1;
 }
 
 static void zig_destroy(HlLinker *l)

--- a/src/hull/runtime/lua/mod_tool.c
+++ b/src/hull/runtime/lua/mod_tool.c
@@ -103,8 +103,38 @@ static int l_tool_spawn(lua_State *L)
     }
     argv[n] = NULL;
 
-    int rc = hl_tool_spawn(argv);
+    /* Optional arg 2: an env table { KEY = VALUE, ... } applied in the child
+     * before exec (e.g. ZIG_GLOBAL_CACHE_DIR for a sandbox-writable zig cache).
+     * Built into a NULL-terminated array of malloc'd "KEY=VALUE" strings. */
+    const char **envadd = NULL;
+    int envn = 0;
+    if (!lua_isnoneornil(L, 2)) {
+        luaL_checktype(L, 2, LUA_TTABLE);
+        int cap = 0;
+        lua_pushnil(L);
+        while (lua_next(L, 2) != 0) { cap++; lua_pop(L, 1); }
+        envadd = malloc(((size_t)cap + 1) * sizeof(const char *));
+        if (!envadd) { free(argv); return luaL_error(L, "tool.spawn: oom"); }
+        lua_pushnil(L);
+        while (lua_next(L, 2) != 0) {
+            const char *k = lua_tostring(L, -2);
+            const char *v = lua_tostring(L, -1);
+            if (k && v) {
+                size_t len = strlen(k) + 1 + strlen(v) + 1;
+                char *kv = malloc(len);
+                if (kv) { snprintf(kv, len, "%s=%s", k, v); envadd[envn++] = kv; }
+            }
+            lua_pop(L, 1);
+        }
+        envadd[envn] = NULL;
+    }
+
+    int rc = envadd ? hl_tool_spawn_env(argv, envadd) : hl_tool_spawn(argv);
     free(argv);
+    if (envadd) {
+        for (int i = 0; i < envn; i++) free((void *)(uintptr_t)envadd[i]);
+        free(envadd);
+    }
 
     if (rc == 0) {
         lua_pushboolean(L, 1);

--- a/src/hull/tools_install.c
+++ b/src/hull/tools_install.c
@@ -73,6 +73,38 @@ static const HlToolSpec REGISTRY[] = {
         .is_bundle         = 1,
         .bundle_entry      = "crt1.o",
     },
+    /* The musl-built Hull platform archive SET (libhull_platform.a + slim +
+     * every libhull_feature-*.a) for `hull build --target=<arch>-linux-musl`
+     * (cross via zig) or `--linker=lld-static` (Tier B). The counterpart of the
+     * libc-musl floor above: the floor is the musl libc, this is Hull's own
+     * archives, musl-built. A data-only bundle extracting to $HOME/.hull/tools/
+     * platform-musl-<arch>/; build.lua resolves the dir via the sentinel
+     * bundle_entry libhull_platform.a. Unlike the floor (on-musl-host only),
+     * this is a CROSS-target asset: you install it on ANY native host to
+     * cross-build TO musl, so all three native platforms can fetch it (the tar
+     * bytes are host-independent). No cosmo (a fat APE can't drive a native
+     * cross tree). Asset: hull-platform-musl-<arch>.tar. See docs/musl_build.md
+     * + audit #4c. */
+    {
+        .name              = "platform-musl-x86_64",
+        .description       = "musl-built Hull platform archive set for "
+                             "`hull build --target=x86_64-linux-musl`.",
+        .has_linux_x86_64  = 1,
+        .has_linux_aarch64 = 1,
+        .has_darwin_arm64  = 1,
+        .is_bundle         = 1,
+        .bundle_entry      = "libhull_platform.a", /* data-only; dir sentinel */
+    },
+    {
+        .name              = "platform-musl-aarch64",
+        .description       = "musl-built Hull platform archive set for "
+                             "`hull build --target=aarch64-linux-musl`.",
+        .has_linux_x86_64  = 1,
+        .has_linux_aarch64 = 1,
+        .has_darwin_arm64  = 1,
+        .is_bundle         = 1,
+        .bundle_entry      = "libhull_platform.a",
+    },
     /* The toolchain-free LINKER for `hull build --linker=zig --target=<triple>`.
      * A multi-file tree shipped as a per-platform bundle (arch-free name, one
      * artifact per native platform -> hull-zig-<platform>.tar). The bundle

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -874,7 +874,7 @@ local function compose_features(opts, tmpdir, platform_lib, is_cosmo, compute_fi
             else
                 record_composed(asset or libname, dest, "release")
             end
-            local is_darwin = plat and plat:sub(1, 6) == "darwin"
+            local is_darwin = target_spec(opts).fmt == "macho"  -- target, not host (#4c)
 
             if spec.whole_archive then
                 -- Force-load the whole archive: its strong overrides of the
@@ -1002,7 +1002,29 @@ local function compose_features(opts, tmpdir, platform_lib, is_cosmo, compute_fi
             -- disk either way for provenance / debugging.
             write_file(tmpdir .. "/app_feature_registry.c",
                        fcompose.gen_app_registry_c(app_rt))
-            if opts.no_compiler then
+            if opts.musl_dir then
+                -- Cross-target (audit #4c): the bundled app_feature_registry.o is
+                -- host-arch; compile the (self-contained, no-libc-headers)
+                -- generated registry FOR the target with zig, exactly like
+                -- app_main.o. These are the only two link objects obj_emit can't
+                -- produce (compiled C, not an emitted data table).
+                local zig = tool.find_tool and tool.find_tool("zig")
+                if not zig or zig == "" then
+                    tool.stderr("hull build: --target=" .. opts.target
+                        .. " needs zig to compile app_feature_registry.o.\n"
+                        .. "hint: `hull tools install zig`\n")
+                    tool.rmdir(tmpdir); tool.exit(1)
+                end
+                local triple = target_spec(opts).triple
+                local ok_fr = tool.spawn({ zig, "cc", "--target=" .. triple, "-O2",
+                    "-c", tmpdir .. "/app_feature_registry.c",
+                    "-o", tmpdir .. "/app_feature_registry.o" })
+                if not ok_fr then
+                    tool.stderr("hull build: failed to cross-compile "
+                        .. "app_feature_registry.o for " .. triple .. " with zig\n")
+                    tool.rmdir(tmpdir); tool.exit(1)
+                end
+            elseif opts.no_compiler then
                 local afr = tool.bundled_object("app_feature_registry_" .. app_rt)
                 if not afr then
                     tool.stderr("hull build --no-compiler: no bundled app_feature_registry for runtime '"
@@ -1028,11 +1050,14 @@ local function compose_features(opts, tmpdir, platform_lib, is_cosmo, compute_fi
             local rt_plat = tool.platform_name and tool.platform_name() or nil
             local rt_hull_dir = ""
             if __hull_exe then rt_hull_dir = __hull_exe:match("(.*/)") or "" end
-            local is_darwin = rt_plat and rt_plat:sub(1, 6) == "darwin"
+            -- Target format, not host: a musl cross FROM macOS whole-archives
+            -- ELF (--whole-archive), not Mach-O (-force_load). Audit #4c.
+            local is_darwin = target_spec(opts).fmt == "macho"
 
             local plan = fcompose.plan_mandatory({
                 app_dir = opts.app_dir, app_rt = app_rt, tmpdir = tmpdir,
                 hull_dir = rt_hull_dir, plat = rt_plat, platform_lib = platform_lib,
+                musl_dir = opts.musl_dir,
                 compute_count = #compute_files, with = opts.with, flavor = opts.flavor,
                 with_list = with_feature_list(opts),
                 on_fail = function(msg)
@@ -1072,6 +1097,28 @@ end
 local function prepare_platform(opts, tmpdir, cc, is_cosmo, flavor_asset)
     local platform_extracted = false
     local platform_lib = tmpdir .. "/libhull_platform.a"
+
+    -- Musl cross-target (audit #4c): the base comes from the installed musl
+    -- archive set (opts.musl_dir, from `hull tools install platform-musl-<arch>`),
+    -- NOT the glibc lib embedded in this hull. platform_sig_blob is left nil so
+    -- no gethull/composed block is written: the running (glibc) hull's manifest
+    -- can't attest a musl archive it doesn't embed, and the musl base is itself
+    -- HL_EMBED_PLATFORM_SIG=0, so §5c is present-gated off in the produced app
+    -- (trust comes from the release-signed install + the developer app
+    -- signature). The feature archives resolve from the same dir via
+    -- feature_compose's ctx.musl_dir.
+    if opts.musl_dir then
+        local src = opts.musl_dir .. "/libhull_platform.a"
+        if not file_exists(src) then
+            tool.stderr("hull build: musl platform lib not found at " .. src
+                .. "\nhint: re-run `hull tools install platform-musl-"
+                .. target_spec(opts).arch .. "`\n")
+            tool.rmdir(tmpdir)
+            tool.exit(1)
+        end
+        tool.copy(src, platform_lib)
+        return platform_lib, nil, nil, nil
+    end
 
     -- --flavor: link a locally-built non-default platform lib instead of the
     -- embedded (full) one. The flavor lib isn't covered by the signed
@@ -1623,7 +1670,34 @@ local function main()
         local pn = tool.platform_name() or ""
         local nat_fmt = (pn:sub(1, 6) == "darwin") and "macho" or "elf"
         local nat_arch = (pn:find("aarch64") or pn:find("arm64")) and "aarch64" or "x86_64"
-        if ts.arch ~= nat_arch or ts.fmt ~= nat_fmt then
+        local is_musl = ts.os == "linux" and opts.target:match("%-musl$") ~= nil
+        if is_musl then
+            -- Cross-build to musl (audit #4c). Select the installed musl platform
+            -- archive set (`hull tools install platform-musl-<arch>` ->
+            -- ~/.hull/tools/platform-musl-<arch>/, resolved via the sentinel
+            -- bundle_entry). A cross-capable linker does the link: `--linker=zig`
+            -- bundles musl libc; `--linker=lld-static` uses the libc-musl floor.
+            -- The archive set was release-signed + SHA-256-verified at install
+            -- (hull.sha256), so it is trusted; the runtime platform-sig
+            -- cross-attest (§5c) is skipped for cross in prepare_platform.
+            -- hl_tools_lookup_path returns the bundle DIR for this data-only
+            -- bundle: the sentinel (libhull_platform.a) isn't executable, so the
+            -- bundle_entry X_OK probe misses and it falls through to the
+            -- $HOME/.hull/tools/<name> dir (searchable → X_OK on the dir). So the
+            -- returned path IS ~/.hull/tools/platform-musl-<arch>, used as-is.
+            local bundle = "platform-musl-" .. ts.arch
+            local dir = tool.find_tool and tool.find_tool(bundle)
+            if dir and dir ~= "" and file_exists(dir .. "/libhull_platform.a") then
+                opts.musl_dir = dir
+            end
+            if not opts.musl_dir then
+                tool.stderr("hull build: --target=" .. opts.target
+                    .. " needs the musl platform archives, which are not installed.\n"
+                    .. "hint: `hull tools install " .. bundle
+                    .. "`  then build with `--linker=zig`.\n")
+                tool.exit(1)
+            end
+        elseif ts.arch ~= nat_arch or ts.fmt ~= nat_fmt then
             tool.stderr("hull build: cross-compilation to '" .. (ts.triple or ts.arch)
                 .. "' is not yet supported - the platform library is built for the "
                 .. "host (" .. nat_arch .. "/"
@@ -1862,12 +1936,38 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
         end
         write_file(tmpdir .. "/app_registry.o", obj)
 
-        local am = tool.bundled_object("app_main")
-        if not am then
-            tool.stderr("hull build --no-compiler: this hull has no bundled app_main.o\n")
-            tool.rmdir(tmpdir); tool.exit(1)
+        if opts.musl_dir then
+            -- Cross-target (audit #4c): the bundled app_main.o is host-arch
+            -- (Mach-O/arm64 or the host ELF), incompatible with the ELF/musl
+            -- target - so compile the tiny entry trampoline FOR the target with
+            -- the zig linker's zig (`zig cc --target=<triple> -c`). zig bundles
+            -- clang + the target crt/libc headers, so no host toolchain and no
+            -- second linker is involved. This is the one object obj_emit can't
+            -- produce (it's compiled C, not an emitted data table).
+            local zig = tool.find_tool and tool.find_tool("zig")
+            if not zig or zig == "" then
+                tool.stderr("hull build: --target=" .. opts.target
+                    .. " compiles the entry trampoline for the target with zig,\n"
+                    .. "which was not found. hint: `hull tools install zig`\n")
+                tool.rmdir(tmpdir); tool.exit(1)
+            end
+            write_file(tmpdir .. "/app_main.c", app_main)
+            local triple = target_spec(opts).triple
+            local ok_am = tool.spawn({ zig, "cc", "--target=" .. triple, "-O2",
+                "-c", tmpdir .. "/app_main.c", "-o", tmpdir .. "/app_main.o" })
+            if not ok_am then
+                tool.stderr("hull build: failed to cross-compile app_main.o for "
+                    .. triple .. " with zig\n")
+                tool.rmdir(tmpdir); tool.exit(1)
+            end
+        else
+            local am = tool.bundled_object("app_main")
+            if not am then
+                tool.stderr("hull build --no-compiler: this hull has no bundled app_main.o\n")
+                tool.rmdir(tmpdir); tool.exit(1)
+            end
+            write_file(tmpdir .. "/app_main.o", am)
         end
-        write_file(tmpdir .. "/app_main.o", am)
     else
         -- Generate unified app_registry.c
         local registry_c = generate_app_registry(opts.app_dir, app_files)
@@ -1919,7 +2019,9 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
     -- archives in --start-group/--end-group (ld iterates to a fixed point).
     -- GNU ld / lld only: macOS ld64 rescans archives natively AND rejects
     -- --start-group ("unknown option"), so it's gated off for a darwin target.
-    local target_is_darwin = (tool.platform_name() or ""):sub(1, 6) == "darwin"
+    -- Keyed on the TARGET format, not the host: a musl cross-build FROM macOS
+    -- links an ELF target that DOES need --start-group (audit #4c).
+    local target_is_darwin = target_spec(opts).fmt == "macho"
     local group = needs_base_group and not target_is_darwin
     local link_libs = {}
     if group then link_libs[#link_libs + 1] = "-Wl,--start-group" end

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1016,9 +1016,11 @@ local function compose_features(opts, tmpdir, platform_lib, is_cosmo, compute_fi
                     tool.rmdir(tmpdir); tool.exit(1)
                 end
                 local triple = target_spec(opts).triple
+                local zcache = { ZIG_GLOBAL_CACHE_DIR = tmpdir .. "/zig-cache",
+                                 ZIG_LOCAL_CACHE_DIR = tmpdir .. "/zig-cache" }
                 local ok_fr = tool.spawn({ zig, "cc", "--target=" .. triple, "-O2",
                     "-c", tmpdir .. "/app_feature_registry.c",
-                    "-o", tmpdir .. "/app_feature_registry.o" })
+                    "-o", tmpdir .. "/app_feature_registry.o" }, zcache)
                 if not ok_fr then
                     tool.stderr("hull build: failed to cross-compile "
                         .. "app_feature_registry.o for " .. triple .. " with zig\n")
@@ -1953,8 +1955,14 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
             end
             write_file(tmpdir .. "/app_main.c", app_main)
             local triple = target_spec(opts).triple
+            -- Redirect zig's cache into the build tmpdir (under /tmp, which the
+            -- tool-mode sandbox unveils rwcx); zig's default ~/.cache/zig /
+            -- ./.zig-cache are NOT sandbox-writable, so a `zig cc -c` under the
+            -- build sandbox fails AccessDenied without this. (#4c)
+            local zcache = { ZIG_GLOBAL_CACHE_DIR = tmpdir .. "/zig-cache",
+                             ZIG_LOCAL_CACHE_DIR = tmpdir .. "/zig-cache" }
             local ok_am = tool.spawn({ zig, "cc", "--target=" .. triple, "-O2",
-                "-c", tmpdir .. "/app_main.c", "-o", tmpdir .. "/app_main.o" })
+                "-c", tmpdir .. "/app_main.c", "-o", tmpdir .. "/app_main.o" }, zcache)
             if not ok_am then
                 tool.stderr("hull build: failed to cross-compile app_main.o for "
                     .. triple .. " with zig\n")

--- a/stdlib/cli/lua/hull/feature_compose.lua
+++ b/stdlib/cli/lua/hull/feature_compose.lua
@@ -129,6 +129,15 @@ end
 -- @return string, string    (path, "local"|"cache") on success.
 -- @return nil, string       (nil, "cache-verify-failed"|"not-found") on failure.
 function M.resolve_lib(libname, asset_name, ctx)
+    -- Musl cross-target: the archives come from an installed musl bundle
+    -- (`hull tools install platform-musl-<arch>` -> ctx.musl_dir), not the
+    -- glibc copy embedded in this hull. Takes precedence over every other
+    -- source; the embedded extract above is gated off (and not ctx.musl_dir).
+    -- Trust: the whole bundle tar was release-signed + SHA-256-verified at
+    -- install (hull.sha256), same as the libc-musl floor. See docs/musl_build.md.
+    if ctx.musl_dir and file_exists(ctx.musl_dir .. "/" .. libname) then
+        return ctx.musl_dir .. "/" .. libname, "musl"
+    end
     for _, d in ipairs({ ctx.hull_dir or "", "build/", "../build/" }) do
         if file_exists(d .. libname) then return d .. libname, "local" end
     end
@@ -203,7 +212,7 @@ function M.resolve_runtime_lib(rt, tmpdir, ctx)
     local libname = "libhull_feature-" .. rt .. ".a"
     -- 1. Embedded in this hull (the distributed native path): extract it.
     if tool.extract_feature_runtime and tool.extract_feature_runtime(tmpdir, rt)
-       and file_exists(tmpdir .. "/" .. libname) then
+       and file_exists(tmpdir .. "/" .. libname) and not ctx.musl_dir then
         return tmpdir .. "/" .. libname, "embedded"
     end
     -- 2/3. Local build dirs, then the signed feature cache.
@@ -226,7 +235,7 @@ function M.resolve_http_lib(tmpdir, ctx)
     local libname = "libhull_feature-http.a"
     -- 1. Embedded in this hull (the distributed native path): extract it.
     if tool.extract_feature_http and tool.extract_feature_http(tmpdir)
-       and file_exists(tmpdir .. "/" .. libname) then
+       and file_exists(tmpdir .. "/" .. libname) and not ctx.musl_dir then
         return tmpdir .. "/" .. libname, "embedded"
     end
     -- 2/3. Local build dirs, then the signed feature cache.
@@ -240,7 +249,7 @@ end
 function M.resolve_keel_lib(tmpdir, ctx)
     local libname = "libhull_feature-keel.a"
     if tool.extract_feature_keel and tool.extract_feature_keel(tmpdir)
-       and file_exists(tmpdir .. "/" .. libname) then
+       and file_exists(tmpdir .. "/" .. libname) and not ctx.musl_dir then
         return tmpdir .. "/" .. libname, "embedded"
     end
     local asset = ctx.plat and ("libhull_feature-keel-" .. ctx.plat .. ".a") or nil
@@ -264,7 +273,7 @@ function M.resolve_http_rt_lib(rt, tmpdir, ctx)
     local libname = "libhull_feature-http-" .. rt .. ".a"
     -- 1. Embedded in this hull (the distributed native path): extract it.
     if tool.extract_feature_http_rt and tool.extract_feature_http_rt(tmpdir, rt)
-       and file_exists(tmpdir .. "/" .. libname) then
+       and file_exists(tmpdir .. "/" .. libname) and not ctx.musl_dir then
         return tmpdir .. "/" .. libname, "embedded"
     end
     -- 2/3. Local build dirs, then the signed feature cache.
@@ -287,7 +296,7 @@ end
 function M.resolve_tui_rt_lib(rt, tmpdir, ctx)
     local libname = "libhull_feature-tui-" .. rt .. ".a"
     if tool.extract_feature_tui_rt and tool.extract_feature_tui_rt(tmpdir, rt)
-       and file_exists(tmpdir .. "/" .. libname) then
+       and file_exists(tmpdir .. "/" .. libname) and not ctx.musl_dir then
         return tmpdir .. "/" .. libname, "embedded"
     end
     local asset = ctx.plat and ("libhull_feature-tui-" .. rt .. "-" .. ctx.plat .. ".a") or nil
@@ -301,7 +310,7 @@ end
 function M.resolve_wasm_lib(tmpdir, ctx)
     local libname = "libhull_feature-wasm.a"
     if tool.extract_feature_wasm and tool.extract_feature_wasm(tmpdir)
-       and file_exists(tmpdir .. "/" .. libname) then
+       and file_exists(tmpdir .. "/" .. libname) and not ctx.musl_dir then
         return tmpdir .. "/" .. libname, "embedded"
     end
     local asset = ctx.plat and ("libhull_feature-wasm-" .. ctx.plat .. ".a") or nil
@@ -314,7 +323,7 @@ end
 function M.resolve_wasm_rt_lib(rt, tmpdir, ctx)
     local libname = "libhull_feature-wasm-" .. rt .. ".a"
     if tool.extract_feature_wasm_rt and tool.extract_feature_wasm_rt(tmpdir, rt)
-       and file_exists(tmpdir .. "/" .. libname) then
+       and file_exists(tmpdir .. "/" .. libname) and not ctx.musl_dir then
         return tmpdir .. "/" .. libname, "embedded"
     end
     local asset = ctx.plat and ("libhull_feature-wasm-" .. rt .. "-" .. ctx.plat .. ".a") or nil
@@ -330,7 +339,7 @@ end
 function M.resolve_sqlite_lib(tmpdir, ctx)
     local libname = "libhull_feature-sqlite.a"
     if tool.extract_feature_sqlite and tool.extract_feature_sqlite(tmpdir)
-       and file_exists(tmpdir .. "/" .. libname) then
+       and file_exists(tmpdir .. "/" .. libname) and not ctx.musl_dir then
         return tmpdir .. "/" .. libname, "embedded"
     end
     local asset = ctx.plat and ("libhull_feature-sqlite-" .. ctx.plat .. ".a") or nil
@@ -345,7 +354,7 @@ end
 function M.resolve_tls_lib(tmpdir, ctx)
     local libname = "libhull_feature-tls.a"
     if tool.extract_feature_tls and tool.extract_feature_tls(tmpdir)
-       and file_exists(tmpdir .. "/" .. libname) then
+       and file_exists(tmpdir .. "/" .. libname) and not ctx.musl_dir then
         return tmpdir .. "/" .. libname, "embedded"
     end
     local asset = ctx.plat and ("libhull_feature-tls-" .. ctx.plat .. ".a") or nil
@@ -359,7 +368,7 @@ end
 function M.resolve_sqlite_rt_lib(rt, tmpdir, ctx)
     local libname = "libhull_feature-sqlite-" .. rt .. ".a"
     if tool.extract_feature_sqlite_rt and tool.extract_feature_sqlite_rt(tmpdir, rt)
-       and file_exists(tmpdir .. "/" .. libname) then
+       and file_exists(tmpdir .. "/" .. libname) and not ctx.musl_dir then
         return tmpdir .. "/" .. libname, "embedded"
     end
     local asset = ctx.plat and ("libhull_feature-sqlite-" .. rt .. "-" .. ctx.plat .. ".a") or nil
@@ -374,7 +383,7 @@ end
 function M.resolve_image_lib(tmpdir, ctx)
     local libname = "libhull_feature-image.a"
     if tool.extract_feature_image and tool.extract_feature_image(tmpdir)
-       and file_exists(tmpdir .. "/" .. libname) then
+       and file_exists(tmpdir .. "/" .. libname) and not ctx.musl_dir then
         return tmpdir .. "/" .. libname, "embedded"
     end
     local asset = ctx.plat and ("libhull_feature-image-" .. ctx.plat .. ".a") or nil
@@ -387,7 +396,7 @@ end
 function M.resolve_image_rt_lib(rt, tmpdir, ctx)
     local libname = "libhull_feature-image-" .. rt .. ".a"
     if tool.extract_feature_image_rt and tool.extract_feature_image_rt(tmpdir, rt)
-       and file_exists(tmpdir .. "/" .. libname) then
+       and file_exists(tmpdir .. "/" .. libname) and not ctx.musl_dir then
         return tmpdir .. "/" .. libname, "embedded"
     end
     local asset = ctx.plat and ("libhull_feature-image-" .. rt .. "-" .. ctx.plat .. ".a") or nil
@@ -422,7 +431,8 @@ end
 --                   --start-group). runtime, tls, keel set it.
 function M.plan_mandatory(ctx)
     local rt = ctx.app_rt
-    local rctx = { hull_dir = ctx.hull_dir or "", plat = ctx.plat }
+    local rctx = { hull_dir = ctx.hull_dir or "", plat = ctx.plat,
+                   musl_dir = ctx.musl_dir }
     local plat_infix = ctx.plat or ""
 
     -- ── Compute the needs-gates (resolver + build-time signals) ──
@@ -454,6 +464,12 @@ function M.plan_mandatory(ctx)
     -- dropped them (HL_TLS_FEATURE=1 / HL_KEEL_FEATURE=1). Default to "present"
     -- (skip) on an unreadable/absent nm, so a stock full base is byte-identical.
     local function base_lacks(sym)
+        -- The musl base is always the SLIM base (build_musl_platform.sh runs
+        -- `make platform`, which is TLS-less + Keel-less), so it lacks every
+        -- dropped symbol - compose tls/keel whenever needed. Special-cased
+        -- because a cross-libc `nm` probe (macOS host reading a Linux/musl ELF
+        -- archive) is unreliable; assuming "present" there would under-compose.
+        if ctx.musl_dir then return true end
         local out = tool.spawn_read({ "nm", ctx.platform_lib })
         return out and not out:find(sym, 1, true)
     end

--- a/tests/e2e_musl_cross.sh
+++ b/tests/e2e_musl_cross.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+# e2e_musl_cross.sh - the musl cross-build loop (audit #4c).
+#
+# End-to-end proof that a glibc host can `hull build --target=<arch>-linux-musl
+# --linker=zig` and produce a STATIC musl ELF that runs on Alpine, using the
+# musl platform archive set (#4a producer + #4c fetch/select). Steps:
+#   1. build the musl archive set with scripts/build_musl_platform.sh (Docker
+#      Alpine) and stage it at ~/.hull/tools/platform-musl-x86_64/ (where
+#      `hull tools install platform-musl-x86_64` would place it),
+#   2. stage a system zig into ~/.hull/tools/zig/ (the turnkey cross-linker),
+#   3. cross-build a pure compute app.main for x86_64-linux-musl,
+#   4. RUN the result inside alpine:3.20 (musl) and assert its output.
+#
+# Runs on a Linux x86_64 host with Docker (needs Docker to build the musl set +
+# run the musl result). SKIPS cleanly elsewhere / when zig or Docker is absent.
+# The full musl archive-set build is ~minutes; cached across runs (skips the
+# rebuild when the staged set already exists).
+#
+# Requires: an EMBED_PLATFORM=1 hull, Docker, a system zig (0.13.x).
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+SRCDIR="$(cd "$(dirname "$0")/.." && pwd)"
+HULL="${HULL:-$SRCDIR/build/hull}"
+PASS=0; FAIL=0
+assert() { msg="$1"; shift; if "$@"; then echo "  ok  $msg"; PASS=$((PASS+1)); \
+    else echo "  FAIL $msg"; FAIL=$((FAIL+1)); fi; }
+
+[ -x "$HULL" ] || { echo "FAIL: $HULL not found - run 'make' first"; exit 1; }
+
+HOST_OS=$(uname -s); HOST_ARCH=$(uname -m)
+if [ "$HOST_OS" != "Linux" ] || { [ "$HOST_ARCH" != "x86_64" ] && [ "$HOST_ARCH" != "amd64" ]; }; then
+    echo "SKIP: musl cross e2e runs on a Linux x86_64 host (needs Docker Alpine +"
+    echo "      the musl archive set). Host: $HOST_OS/$HOST_ARCH"
+    exit 0
+fi
+command -v docker >/dev/null 2>&1 || { echo "SKIP: docker not available"; exit 0; }
+docker info >/dev/null 2>&1 || { echo "SKIP: docker daemon not running"; exit 0; }
+
+find_zig() {
+    p=$(command -v zig 2>/dev/null) && { echo "$p"; return 0; }
+    for d in /opt/zig /opt/homebrew/bin /usr/local/bin; do
+        [ -x "$d/zig" ] && { echo "$d/zig"; return 0; }
+    done
+    return 1
+}
+ZIG_BIN=$(find_zig) || { echo "SKIP: no system zig found (install from ziglang.org)"; exit 0; }
+echo "── using zig: $ZIG_BIN ($("$ZIG_BIN" version 2>/dev/null)) ──"
+
+ARCH=x86_64
+PM_DIR="$HOME/.hull/tools/platform-musl-$ARCH"
+ZIG_DIR="$HOME/.hull/tools/zig"
+STAGED_ZIG=""; STAGED_PM=""
+cleanup() {
+    [ -n "$STAGED_ZIG" ] && rm -f "$STAGED_ZIG" 2>/dev/null || true
+    [ -n "$STAGED_PM" ] && rm -rf "$PM_DIR" 2>/dev/null || true
+    rm -rf "${WORKDIR:-}" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# 1. Build + stage the musl archive set (cached: skip if already present).
+if [ -f "$PM_DIR/libhull_platform.a" ]; then
+    echo "── musl archive set already staged at $PM_DIR ──"
+else
+    echo "── building the musl archive set (scripts/build_musl_platform.sh, Alpine) ──"
+    OUT_TAR="$(mktemp -d)/hull-platform-musl-$ARCH.tar"
+    docker run --rm -v "$SRCDIR":/work:ro -v "$(dirname "$OUT_TAR")":/out alpine:3.20 sh -c '
+        set -e
+        apk add --no-cache build-base clang lld make xxd bash git perl linux-headers >/dev/null 2>&1
+        sh /work/scripts/build_musl_platform.sh /work /out/'"$(basename "$OUT_TAR")"'
+    '
+    mkdir -p "$PM_DIR"; tar xf "$OUT_TAR" -C "$PM_DIR"; STAGED_PM="$PM_DIR"
+    rm -rf "$(dirname "$OUT_TAR")"
+fi
+assert "musl base staged"          [ -f "$PM_DIR/libhull_platform.a" ]
+assert "musl lua runtime staged"   [ -f "$PM_DIR/libhull_feature-lua.a" ]
+
+# 2. Stage zig (symlink; zig finds its lib/ via the real exe path).
+mkdir -p "$ZIG_DIR"
+if [ ! -e "$ZIG_DIR/zig" ]; then ln -sf "$ZIG_BIN" "$ZIG_DIR/zig"; STAGED_ZIG="$ZIG_DIR/zig"; fi
+
+# 3. Cross-build a pure compute app.main for x86_64-linux-musl.
+WORKDIR="$(mktemp -d)"
+APP="$WORKDIR/app"; mkdir -p "$APP"
+cat > "$APP/app.lua" <<'LUA'
+app.manifest({ modules = {} })
+app.main(function() print("musl-cross-ok"); return 0 end)
+LUA
+
+# Skip cleanly if this hull can't compose (no embedded platform lib).
+probe="$("$HULL" build "$APP" --target=x86_64-linux-musl --linker=zig -o "$WORKDIR/probe" 2>&1 || true)"
+case "$probe" in
+    *"platform library not embedded"*|*"cannot find libhull_platform.a"*)
+        echo "SKIP: hull not built with EMBED_PLATFORM=1"; exit 0 ;;
+esac
+
+echo "== hull build --target=x86_64-linux-musl --linker=zig =="
+BIN="$WORKDIR/app-musl"
+OUT="$("$HULL" build "$APP" --target=x86_64-linux-musl --linker=zig -o "$BIN" 2>&1 || true)"
+echo "$OUT" | sed 's/^/    /'
+assert "build wrote the binary"        [ -f "$BIN" ]
+if [ -f "$BIN" ]; then
+    # Must be a static x86_64 ELF (cross-produced from the glibc host).
+    assert "is an ELF x86-64 binary"   sh -c "file '$BIN' | grep -q 'ELF 64-bit.*x86-64'"
+    assert "is statically linked"      sh -c "file '$BIN' | grep -q 'statically linked'"
+
+    # 4. RUN it inside Alpine (musl). --no-sandbox: an unprivileged container
+    #    has no landlock, so pledge/unveil sealing fails (a container limit, not
+    #    a musl issue - same convention as e2e_musl.sh).
+    echo "== run the musl binary in alpine:3.20 =="
+    RUN="$(docker run --rm -v "$WORKDIR":/app:ro alpine:3.20 /app/app-musl --no-sandbox 2>&1 || true)"
+    echo "$RUN" | sed 's/^/    /'
+    assert "app.main ran on musl"      sh -c "printf '%s' '$RUN' | grep -q 'musl-cross-ok'"
+fi
+
+echo ""
+echo "e2e_musl_cross: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/release_smoke.sh
+++ b/tests/release_smoke.sh
@@ -230,6 +230,34 @@ if [ "$(uname -s)" = "Linux" ]; then
     assert "floor dir removed"             [ ! -d "$FLOOR_DIR" ]
 fi
 
+# musl platform archive SET (audit #4c) — the counterpart of the floor: Hull's
+# own archives (libhull_platform.a + slim + every libhull_feature-*.a) built
+# against musl, for `hull build --target=<arch>-linux-musl`. A data-only .tar
+# bundle like the floor, but a CROSS-target asset published for ALL native
+# hosts (install on any host to build TO musl), so this runs unconditionally.
+# fetch -> SHA-256 verify -> ustar extract into a dir -> dir uninstall.
+PM_ARCH=x86_64
+PM_TOOL="platform-musl-$PM_ARCH"
+PM_DIR="$HOME/.hull/tools/$PM_TOOL"
+"$HULL" tools uninstall "$PM_TOOL" >/dev/null 2>&1 || true
+echo ""
+echo "── hull tools install $PM_TOOL (musl platform archive set, LIVE download) ──"
+OUT=$("$HULL" tools install "$PM_TOOL" 2>&1); RC=$?
+echo "$OUT" | sed 's/^/    /'
+assert "exits 0"                       [ "$RC" -eq 0 ]
+assert_contains "SHA-256 verified"     "$OUT" "SHA-256 verified"
+assert_contains "installed as bundle"  "$OUT" "(bundle)"
+assert "bundle dir created"            [ -d "$PM_DIR" ]
+assert "musl base extracted"           [ -f "$PM_DIR/libhull_platform.a" ]
+assert "musl slim base extracted"      [ -f "$PM_DIR/libhull_platform-slim.a" ]
+assert "musl lua runtime archive"      [ -f "$PM_DIR/libhull_feature-lua.a" ]
+OUT=$("$HULL" tools list 2>&1)
+assert_contains "list shows $PM_TOOL installed" "$OUT" "$PM_TOOL"
+echo "── hull tools uninstall $PM_TOOL ──"
+OUT=$("$HULL" tools uninstall "$PM_TOOL" 2>&1)
+assert_contains "musl set uninstalled" "$OUT" "uninstalled $PM_TOOL"
+assert "musl set dir removed"          [ ! -d "$PM_DIR" ]
+
 # Toolchain-free linker bundle: zig. A per-platform multi-file .tar bundle
 # published for all three native platforms (hull-zig-<platform>.tar) - the
 # largest tool asset (~330 MB), so it also exercises the raised download cap.


### PR DESCRIPTION
Completes the musl "make it real" story (audit **#4c + #4d**) on top of #4a (producer) + #4b (publish). A glibc/macOS host can now `hull build --target=<arch>-linux-musl --linker=zig` → a **static musl ELF that runs on Alpine**.

## #4c — fetch + select
- **Fetch**: `hull tools install platform-musl-<arch>` — a data-only bundle (`tools_install.c` REGISTRY, mirror of `libc-musl-<arch>`), release-key-verified to `~/.hull/tools/platform-musl-<arch>/`. Published for all native hosts (cross-target asset).
- **Select**: `feature_compose` gained `ctx.musl_dir`, taking precedence over hull's embedded glibc copies for **every** resolver (base **and** all feature archives, atomically). `prepare_platform` sources the musl base + sets `platform_sig_blob = nil`. The `#206` guard resolves the bundle for a `-musl` target (fails closed with a `hull tools install` hint).
- **Cross-compile**: the two objects `obj_emit` can't produce (`app_main.o` + `app_feature_registry.o`) are built for the target with `zig cc --target`. Fixed the `is_darwin`/`--start-group` link-flag gates to key on the **target** format, not the host. Allowlisted the zig backend's benign `-Wl,--gc-sections` / `-Wl,-dead_strip`.
- **§5c**: a cross target writes no `gethull/composed` block → §5c present-gated off. **No 2nd dry-run needed.** Trust = release-signed install + developer app sig.

## #4d — smoke + e2e
- `release_smoke.sh`: a `platform-musl-x86_64` install section (LIVE fetch → verify → extract → uninstall).
- `tests/e2e_musl_cross.sh` (+ `make e2e-musl-cross`, wired into the Linux-x86_64 CI job): the **full loop per-push** — build the musl set (Alpine), stage it + zig, cross-build, and **run the static musl binary in Alpine** (asserts ELF/x86-64 + static + app stdout). Skips cleanly without Linux-x86_64 / Docker / zig.

## Validation
End-to-end on macOS/arm64: `--target=x86_64-linux-musl --linker=zig` → static x86_64 musl ELF → **runs on Alpine** (`app.main` → exit 0). Native macOS build unregressed; `make test` green; `test_tool` 51 pass; cppcheck clean. The new e2e exercises the same loop on Linux in CI.

Docs: `musl_build.md` "Cross-building to musl from any host"; audit #4c/#4d marked done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)