### PR TITLE
docs: Tier-4 consistency — taxonomy, image dual-role, seam guide, doc-rot (T4a/b/c/f)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,16 +396,17 @@ composed `compute.call`, both runtimes).
 
 ### Extension taxonomy: feature vs flavor vs tool vs stdlib
 
-A new capability reaches an app through exactly one of four shipping units.
+A new capability reaches an app through exactly one of five shipping units.
 Classifying it correctly is the difference between a signed static archive and
-twenty lines of Lua. The four, and the single question that separates each:
+twenty lines of Lua. The five, and the single question that separates each:
 
 | Unit | What it is | Ships as | Reached via | Axis |
 |------|-----------|----------|-------------|------|
 | **stdlib** | pure Lua/JS built on capabilities the base already has (no new C, no new authority) | always in the base VFS | `require("hull.X")` / `import "hull:X"` + `manifest.modules` | orchestration |
+| **base cap module** | a SMALL always-in-base C capability (a codec / sniffer / store) built on stdio + the caps already shipped, with no vendored engine and no off switch | compiled into the base (`CAP_OBJS`; NO `HL_ENABLE_*` gate + NO `--with` archive) | `require`/`import` + `manifest.modules` (like stdlib, but C-backed) | in-base |
 | **feature** | a large optional C subsystem, off by default, adding a new vendored engine, wire backend, or authority | signed `libhull_feature-<name>-<arch>.a` | `hull build --with=<name>` (auto-inferred or forced) | **additive** |
 | **flavor** | a build.lua **preset** validating the app against a slimmer cap set (since Phase 4.3 - the base already composes; pre-built per-flavor libs are gone) | (none - a preset on the default base) | `hull build --flavor=<name>` | **subtractive** |
-| **tool** | a separate companion **program** Hull spawns (never linked in) | `hull-<tool>-<platform>` binary | `hl_tool_spawn` at build time; `hull tools install` | is-it-Hull-or-a-program-Hull-runs |
+| **tool** | a separate companion **program** Hull spawns (never linked in) | `hull-<tool>-<platform>` binary, OR a `.tar` **bundle** for a multi-file tool (`hull-<name>.tar` / `hull-<name>-<platform>.tar` extracting to a dir) | `hl_tool_spawn` at build time; `hull tools install` | is-it-Hull-or-a-program-Hull-runs |
 
 **Decision procedure** (ask in order; first yes wins):
 
@@ -419,24 +420,39 @@ twenty lines of Lua. The four, and the single question that separates each:
    caps we already ship," it does NOT get a C archive. Example: an S3 /
    object-storage client is `http.fetch` + SigV4 (`crypto`) → stdlib, never a
    feature. Same for most webhook/integration clients.
-3. **Does it add a large optional C subsystem or a new authority, off by
+3. **Does it need a LITTLE new C (a codec, a sniffer, a store) but no vendored
+   engine, no new OS/hardware authority, and no reason to be optional** (it's
+   small and every app might want it)? → **base cap module**. Add
+   `src/hull/cap/<name>.c` (it rides `CAP_OBJS` in the base automatically - the
+   Makefile globs `cap/*.c` and only *subtracts* the reducible ones) + the two
+   runtime bindings + one `HlModuleSpec` row. No `HL_ENABLE_*` gate, no `--with`
+   archive, no weak seam. Examples: `mime` (content sniffer), `blob` (cache
+   store), `tar` (archive codec). `image` is the boundary case: it is a base cap
+   module by nature but is ALSO auto-composed for size (see T4b / "Composable
+   runtime + HTTP base"), so it carries both an `HL_ENABLE_IMAGE` knob and a weak
+   seam - do NOT copy that dual role for a plain codec.
+4. **Does it add a large optional C subsystem or a new authority, off by
    default?** (a vendored engine, a pure-C wire protocol, a new hardware/OS
    surface) → **feature**. It fills a base-resident **weak hook** with a
    **strong override** from the composed archive; register one row in
    `FEATURES[]` (`src/hull/commands/feature.c`) + one `FEATURE_SPECS` entry
    (`stdlib/cli/lua/hull/build.lua`). Examples: `duckdb`, `postgres`, `mysql`,
    `gpu`, `tui`.
-4. **Are you turning a default subsystem OFF to produce a smaller base?** →
+5. **Are you turning a default subsystem OFF to produce a smaller base?** →
    **flavor** (preset). Example: `pure-compute`.
 
-**The sharp rules.** New vendored C or new authority → **feature** (additive).
-Turning a default off → **flavor** (subtractive). A separate program → **tool**.
-Pure orchestration over existing caps → **stdlib** (and this is the most common
-misclassification: reach for stdlib before a feature). "On by default and you
-subtract" is a flavor; "off by default and you add" is a feature. HTTP itself is
-just a feature that happens to be on by default, which is why the flavor/feature
-line is a distribution fact (enumerable pre-published base vs. combinatorial
-bolt-on), not an architectural one. Full rationale in
+**The sharp rules.** SMALL new C, always wanted, no new authority → **base cap
+module** (in-base, rides `CAP_OBJS`). LARGE new vendored C or a new authority,
+off by default → **feature** (additive). Turning a default off → **flavor**
+(subtractive). A separate program → **tool**. Pure orchestration over existing
+caps → **stdlib** (and this is the most common misclassification: reach for
+stdlib before a feature). The base-cap-module ↔ feature line is SIZE + optionality:
+a self-contained codec everyone might use rides the base; a vendored engine or a
+new authority that most apps never touch is a composed feature. "On by default
+and you subtract" is a flavor; "off by default and you add" is a feature. HTTP
+itself is just a feature that happens to be on by default, which is why the
+flavor/feature line is a distribution fact (enumerable pre-published base vs.
+combinatorial bolt-on), not an architectural one. Full rationale in
 [docs/features_and_flavors.md](docs/features_and_flavors.md); near-term
 candidates classified against this table live in
 [docs/roadmap.md](docs/roadmap.md) ("Extension taxonomy and near-term targets").

--- a/Makefile
+++ b/Makefile
@@ -797,10 +797,15 @@ PLEDGE_OBJS ?=
 
 # ── Hull source files ───────────────────────────────────────────────
 
-# Capability sources (always compiled, except cap/tool.c and cap/test.c
-# which need runtimes / linker visibility from runtime bindings).
-# Runtime-layer test bindings live in runtime/{lua,js}/mod_test.c (picked
-# up via the JS_RT_SRCS / LUA_RT_SRCS globs below).
+# Capability sources. The convention: `cap/*.c` is glob-included by DEFAULT and
+# reducible subsystems are SUBTRACTED below (the ifeq/ifneq `filter-out` blocks).
+# So a "base cap module" - a small always-in-base C capability with no HL_ENABLE_*
+# gate and no --with archive (mime, blob, tar; see CLAUDE.md "Extension taxonomy")
+# - needs NO Makefile edit: dropping cap/<name>.c into the glob rides CAP_OBJS
+# automatically. Only tool.c / test.c (they need runtime/linker visibility from
+# the runtime bindings) and the OPTIONAL subsystems (image, the DB backends, GPU,
+# HTTP halves) are filtered out. Runtime-layer test bindings live in
+# runtime/{lua,js}/mod_test.c (picked up via the JS_RT_SRCS / LUA_RT_SRCS globs).
 CAP_SRCS := $(filter-out $(SRCDIR)/hull/cap/tool.c $(SRCDIR)/hull/cap/test.c,$(wildcard $(SRCDIR)/hull/cap/*.c))
 ifeq ($(HL_ENABLE_IMAGE),0)
   # Image codecs off: drop the codec vtable + stb backend (stb obj already

--- a/docs/build_arc_audit.md
+++ b/docs/build_arc_audit.md
@@ -114,26 +114,37 @@ Execution order (agreed): **#6+#1 → #7 → #4 → #5 → #2 → #3 → #8**, t
 
 ## Tier 4 — architectural consistency & docs (lower urgency)
 
-- [ ] **T4a "base cap module" taxonomy category.** image/mime/blob/**tar** are all-C in-base cap
-  modules, but the CLAUDE.md taxonomy says stdlib = "no new C" and has no home for them; mime
-  `.pure=1` vs tar `.pure=0` exposes the inconsistency. Document a 5th row + the small+in-base
-  vs large+off-by-default rule vs a feature. Also add an explicit "tar rides CAP_OBJS,
-  always-in-base" note (today it's implicit via `wildcard` + denylist omission).
-- [ ] **T4b image half-migrated** — `#ifdef HL_ENABLE_IMAGE` in `modules.c` coexists with the
-  composed-feature weak-stub seam; document the dual role or unify on the seam.
-- [ ] **T4c Weak-hook seam divergence** — two shapes (header hook + `_present()` vs
-  weak-stub-as-sentinel, forcing WASM's bespoke `HL_CAP_WASM_ABSENT`); no `HL_WEAK` macro,
-  no single "how to add a seam" doc. Add a canonical section to features_and_flavors.md;
-  optionally an `HL_WEAK` macro over the ~21 raw `__attribute__((weak))` sites.
+- [x] **T4a "base cap module" taxonomy category.** DONE (docs). Added a 5th "base cap module" row
+  to the CLAUDE.md extension-taxonomy table (small always-in-base C cap: mime/blob/tar; no
+  `HL_ENABLE_*` gate, no `--with` archive), a decision-procedure step 3 + a size-vs-optionality
+  sharp rule separating it from a feature, and a Makefile comment on the `CAP_SRCS` glob-minus-
+  denylist "always-in-base" convention (a new base cap module needs no Makefile edit).
+- [x] **T4b image half-migrated** — DONE (docs). Documented the image DUAL role at both
+  `runtime/{lua,js}/modules.c` `#ifdef HL_ENABLE_IMAGE` sites: the `#ifdef` is the SUBTRACTIVE gate
+  (`HL_ENABLE_IMAGE=0` drops image wholesale), the weak `luaopen_hull_image` /
+  `hl_js_init_image_module` (image_stub.c) is the independent COMPOSABLE gate on the default base.
+  Kept both (they gate different axes); the taxonomy note flags image as the boundary case not to
+  copy for a plain codec.
+- [x] **T4c Weak-hook seam divergence** — DONE (docs). Added §3.4 "Weak-hook seams" to
+  features_and_flavors.md documenting the two shapes (header-hook + accessor vs
+  weak-stub-as-sentinel, incl. `HL_CAP_WASM_ABSENT`), when to use each, and the add-a-seam steps.
+  `HL_WEAK` macro DELIBERATELY NOT added: `__attribute__((weak))` is load-bearing (it decides link
+  resolution + what the base falls back to under security review), so it should stay visible at
+  each site, not named away - documented as an explicit decision.
 - [ ] **T4d tools "bundle" facts duplicated** across `release.yml` (3×) + `tools.c`; registry
   isn't the single source the comment claims. Consider `hull tools list --json --assets`.
   Extend `release_smoke.sh` to install one bundle shape (zig/floor), not just wamrc.
+  *(release_smoke half already DONE in #4d: floor + platform-musl + zig bundle sections. Remaining:
+  the release.yml ↔ registry drift - a CI guard + the misleading "single source" comment.)*
 - [ ] **T4e FEATURE_SPECS not cross-checked** against `feature.c` FEATURES[] / Makefile —
   extend `scripts/check_feature_registry.sh` to assert `feature_specs.lua` keys ⊇ installable
   stems.
-- [ ] **T4f doc-rot** — build.lua tcc hints (retired), "planned" COFF/Mach-O comments (done),
-  mold "near-term" (deferred/not-started), CLAUDE.md tool row missing `.tar` bundle shape,
-  `obj_emit.h`/`linker.h` "planned" comments.
+- [x] **T4f doc-rot** — DONE. Fixed: the build.lua `--compiler` docstring (was "default: embedded
+  tcc"; now "default: NONE - compiler-free emitter"); the `obj_emit.h` `HL_OBJ_MACHO`/`HL_OBJ_COFF`
+  `/* planned */` comments + header intro (all three formats are IMPLEMENTED - emit_elf/emit_macho/
+  emit_coff); the CLAUDE.md `tool` taxonomy row (now notes the `.tar` bundle shape). Verified
+  ACCURATE (no change needed): `mold` is honestly "deferred/unregistered", and `linker.h`'s
+  `hull_exe … reserved for future` is a live placeholder.
 
 ## Already resolved (do not re-chase)
 

--- a/docs/features_and_flavors.md
+++ b/docs/features_and_flavors.md
@@ -151,6 +151,51 @@ exactly like the missing-flavor-lib path today. A cache-sourced feature lib is
 re-verified against its signed manifest before linking (the same
 `hl_release_io_verify_local_asset` TOCTOU close as flavored builds).
 
+### 3.4 Weak-hook seams: how a base-resident symbol gets overridden
+
+§3.2's generated registry is one seam. The other - used by the AUTO-composed
+subsystems (runtime, http, wasm, image, tls, keel) and the gpu/tui features - is
+a **weak default + strong override**: the base defines a symbol
+`__attribute__((weak))` so it links on its own; a composed archive defines the
+same symbol *strong* and wins at link. No `dlopen`, no linker sets, portable
+across ELF / Mach-O / cosmo. There are **two shapes**; pick by whether callers
+need to distinguish "feature absent" from "feature present but failed":
+
+1. **Header hook + accessor** (the richer shape). A header
+   (`include/hull/<x>_feature.h`) declares an accessor
+   `const HlFooBackend *hl_foo_active_backend(void)`; the base provides a WEAK
+   default returning a fail-closed / portable backend, the composed archive a
+   STRONG override returning the real one. Callers get a vtable and never branch
+   on presence. Examples: `hl_crypto_hmac_active_backend` /
+   `hl_crypto_asym_active_backend` (tls_feature.h), the gpu/db feature hooks.
+   Use this when the subsystem is a **vtable/backend** and "absent" should behave
+   as a working fail-closed default (verify returns -2, HMAC uses the portable
+   backend).
+
+2. **Weak-stub-as-sentinel** (the leaner shape). No header hook: a base TU
+   (`src/hull/<x>_weakstub.c`) defines each entry point WEAK, returning a
+   distinguished **absent sentinel** so callers can tell "not composed" from a
+   real error. WASM uses `HL_CAP_WASM_ABSENT` (a positive code, distinct from
+   0-ok / -1-error) so `db.udf` can fail closed with a specific message when the
+   wasm feature wasn't composed. The per-runtime module openers use the simplest
+   form: a weak `luaopen_hull_image` / `hl_js_init_image_module` returning 0
+   (module absent → `require` yields nil). Use this when there is **no vtable** -
+   just entry points whose absence must be detectable, or a module opener whose
+   absence is a soft nil.
+
+**Convention.** Prefer shape 1 when a vtable exists (callers stay branch-free);
+use shape 2 for entry-point sets or module openers. Keep `__attribute__((weak))`
+**written out at each site** rather than behind an `HL_WEAK` macro - the weakness
+of a symbol is load-bearing (it decides link resolution + the security review of
+what the base falls back to), so it should be visible, not named away. A
+composed archive's override MUST be strong (plain, non-weak) and the whole
+archive is `--whole-archive`/`-force_load`'d so the linker can't drop the
+overriding TU. Adding a seam = (a) declare/define the weak default in the base,
+(b) `extern` the same signature in the feature TU and define it strong, (c) if
+callers must detect absence, return a documented sentinel (shape 2) or a
+fail-closed backend (shape 1). The base must link + run correctly with EVERY
+seam left at its weak default (that is the "SLIM base" contract).
+
 ## 4. The dev loop: `hull dev` self-links a cached feature runtime
 
 A pre-built lean `hull` **cannot statically compose a feature at runtime** — no

--- a/include/hull/obj_emit.h
+++ b/include/hull/obj_emit.h
@@ -2,9 +2,10 @@
  * obj_emit.h — compiler-free app_registry object emitter
  *
  * Serializes hl_app_entries[] (the app's embedded-file registry) directly
- * as a relocatable object in the target's native format (ELF today; Mach-O
- * and COFF are planned), so `hull build` never needs a C compiler for the
- * data object — only a linker. See docs/compiler_free_build.md.
+ * as a relocatable object in the target's native format (ELF, Mach-O, and
+ * COFF/PE are all implemented — see emit_elf / emit_macho / emit_coff), so
+ * `hull build` never needs a C compiler for the data object — only a linker.
+ * See docs/compiler_free_build.md.
  *
  * The emitter is HOST-INDEPENDENT: a macOS host emits ELF for a Linux
  * target and vice versa. All fields are written little-endian explicitly;
@@ -29,8 +30,8 @@ typedef struct {
 
 typedef enum {
     HL_OBJ_ELF = 0,
-    HL_OBJ_MACHO,   /* planned */
-    HL_OBJ_COFF     /* planned */
+    HL_OBJ_MACHO,   /* macOS/Darwin */
+    HL_OBJ_COFF     /* Windows PE */
 } HlObjFormat;
 
 typedef enum {

--- a/src/hull/runtime/js/modules.c
+++ b/src/hull/runtime/js/modules.c
@@ -88,8 +88,14 @@ int hl_js_register_modules(HlJS *js)
     if (hl_js_init_tar_module(js->ctx, js) != 0)
         return -1;
 
+    /* image has a DUAL role (audit T4b), unlike the always-in-base blob/mime/tar
+     * above. Two independent gates: the #ifdef HL_ENABLE_IMAGE is the SUBTRACTIVE
+     * gate (HL_ENABLE_IMAGE=0 drops image wholesale), while
+     * hl_js_init_image_module itself is a WEAK no-op stub (runtime/js/image_stub.c)
+     * on the default composable base - a no-op until the composed
+     * libhull_feature-image-js.a provides the STRONG real initializer for an app
+     * that declares hull/image. See the Lua modules.c for the full note. */
 #ifdef HL_ENABLE_IMAGE
-    /* Register hull:image module (dropped on a HL_ENABLE_IMAGE=0 build). */
     if (hl_js_init_image_module(js->ctx, js) != 0)
         return -1;
 #endif

--- a/src/hull/runtime/lua/modules.c
+++ b/src/hull/runtime/lua/modules.c
@@ -81,6 +81,20 @@ int hl_lua_register_modules(HlLua *lua)
     register_native_module(L, "hull.blob",   luaopen_hull_blob);
     register_native_module(L, "hull.mime",   luaopen_hull_mime);
     register_native_module(L, "hull.archive.tar", luaopen_hull_tar);
+    /* image has a DUAL role (audit T4b), unlike blob/mime/tar above which are
+     * plain always-in-base cap modules. Two independent gates:
+     *   - #ifdef HL_ENABLE_IMAGE: the SUBTRACTIVE gate. `make HL_ENABLE_IMAGE=0`
+     *     drops image entirely (no cap, no bindings) - registration compiles out
+     *     and `hull/image` fails module resolution. This is why image alone here
+     *     is #ifdef-wrapped.
+     *   - luaopen_hull_image itself: the COMPOSABLE gate. On the default
+     *     HL_ENABLE_IMAGE=1 base, image is DROPPED from the base and composed
+     *     back only for apps that declare hull/image (docs/image_feature.md). The
+     *     symbol is a WEAK no-op stub (runtime/lua/image_stub.c) that returns 0
+     *     (module absent -> require returns nil) until the composed
+     *     libhull_feature-image-lua.a provides the STRONG real opener.
+     * So the registration CALL is always emitted on an HL_ENABLE_IMAGE=1 build;
+     * whether it yields a real module is decided at LINK by the seam, not here. */
 #ifdef HL_ENABLE_IMAGE
     register_native_module(L, "hull.image",  luaopen_hull_image);
 #endif

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -4,7 +4,8 @@
 -- Usage: hull build [options] [app_dir]
 --   --runtime lua|js|both  Runtime to include (default: lua)
 --   --sign <key_file>      Sign with Ed25519 private key
---   --compiler tcc|system|<path>  C compiler backend (default: embedded tcc → cc/gcc/clang)
+--   --compiler system|<path>  Opt into a system C compiler (default: NONE - the
+--                             compiler-free object emitter + linker; docs/compiler_free_build.md)
 --   --output <path>        Output binary path (default: app_dir/app)
 --
 -- SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
Tier-4 audit items **T4a, T4b, T4c, T4f** — documentation + code comments only, no logic change (`make` green).

- **T4a** — a 5th **base cap module** row in the CLAUDE.md extension taxonomy (small always-in-base C cap: `mime`/`blob`/`tar`; no `HL_ENABLE_*` gate, no `--with` archive), a decision-procedure step + size/optionality sharp rule vs a feature, and a Makefile comment on the `CAP_SRCS` glob-minus-denylist "always-in-base" convention.
- **T4b** — document the `image` **dual role** at both `runtime/{lua,js}/modules.c` `#ifdef` sites: the `#ifdef` is the subtractive gate (`HL_ENABLE_IMAGE=0`), the weak `luaopen_hull_image`/`hl_js_init_image_module` is the independent composable gate.
- **T4c** — new `features_and_flavors.md` §3.4 "Weak-hook seams": the two shapes (header-hook+accessor vs weak-stub-as-sentinel incl. `HL_CAP_WASM_ABSENT`), when to use each, add-a-seam steps. **No `HL_WEAK` macro** — deliberately: a symbol's weakness is load-bearing (link resolution + security review of the base fallback) and should stay visible at each site.
- **T4f** — doc-rot fixes: the `build.lua --compiler` docstring (was "embedded tcc"; now the compiler-free default), the `obj_emit.h` `HL_OBJ_MACHO`/`HL_OBJ_COFF` `/* planned */` comments (all three formats are implemented — `emit_elf`/`emit_macho`/`emit_coff`), and the CLAUDE.md `tool` row (notes the `.tar` bundle shape). `mold` + `linker.h` verified accurate.

**T4d/T4e** (registry cross-check guards) follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)