### PR TITLE
ci: registry cross-check guards — FEATURE_SPECS + tools registry (T4d, T4e)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,14 @@ jobs:
 
       # Phase 4c: fail fast if feature.c FEATURES[] drifts from the mk/feature.mk
       # feature registry (the single source of truth). Cheap (grep + make vars).
-      - name: Feature registry consistency (feature.c vs mk/feature.mk)
+      # Also asserts every installable feature has a FEATURE_SPECS codegen entry (T4e).
+      - name: Feature registry consistency (feature.c vs mk/feature.mk vs FEATURE_SPECS)
         run: make check-feature-registry
+
+      # T4d: the side-load tool REGISTRY (tools_install.c) vs the release workflow
+      # that must publish each tool's asset.
+      - name: Tool registry consistency (tools_install.c vs release.yml)
+        run: make check-tools-registry
 
       - name: Build
         run: make

--- a/docs/build_arc_audit.md
+++ b/docs/build_arc_audit.md
@@ -125,12 +125,19 @@ Execution order (agreed): **#6+#1 → #7 → #4 → #5 → #2 → #3 → #8**, t
   weak-stub-as-sentinel, forcing WASM's bespoke `HL_CAP_WASM_ABSENT`); no `HL_WEAK` macro,
   no single "how to add a seam" doc. Add a canonical section to features_and_flavors.md;
   optionally an `HL_WEAK` macro over the ~21 raw `__attribute__((weak))` sites.
-- [ ] **T4d tools "bundle" facts duplicated** across `release.yml` (3×) + `tools.c`; registry
-  isn't the single source the comment claims. Consider `hull tools list --json --assets`.
-  Extend `release_smoke.sh` to install one bundle shape (zig/floor), not just wamrc.
-- [ ] **T4e FEATURE_SPECS not cross-checked** against `feature.c` FEATURES[] / Makefile —
-  extend `scripts/check_feature_registry.sh` to assert `feature_specs.lua` keys ⊇ installable
-  stems.
+- [x] **T4d tools "bundle" facts duplicated** — DONE. Fixed the misleading `tools_install.c`
+  registry comment (it claimed the registry was the single source; it is the CONSUMER side -
+  release.yml is a second, coordinated edit site) and added `scripts/check_tools_registry.sh`
+  (+ `make check-tools-registry`, wired into the Linux CI `build` job) that asserts every REGISTRY
+  `.name` has a matching `hull-<name>` asset in release.yml - catching drift per push instead of
+  only at `release_smoke.sh` time. The `release_smoke.sh` bundle-install half was already done in
+  #4d (floor + platform-musl + zig). `hull tools list --json --assets` deliberately NOT added (the
+  drift guard covers the need; a machine-readable asset dump is a speculative feature).
+- [x] **T4e FEATURE_SPECS not cross-checked** — DONE. Extended `scripts/check_feature_registry.sh`
+  (already run in CI) to assert every INSTALLABLE `--with` stem has a top-level `FEATURE_SPECS`
+  entry in `feature_specs.lua` (the codegen source `hull build --with=<name>` reads). Directional
+  (installable ⊆ FEATURE_SPECS keys, since FEATURE_SPECS also carries the mandatory `sqlite`
+  default). Negative-tested: removing a spec key fails the check with a fix-it hint.
 - [ ] **T4f doc-rot** — build.lua tcc hints (retired), "planned" COFF/Mach-O comments (done),
   mold "near-term" (deferred/not-started), CLAUDE.md tool row missing `.tar` bundle shape,
   `obj_emit.h`/`linker.h` "planned" comments.

--- a/mk/feature.mk
+++ b/mk/feature.mk
@@ -84,3 +84,9 @@ print-feature-installable-stems: ; @echo $(FEATURE_INSTALLABLE_STEMS)
 # last of the four-place feature-list duplication; run in CI.
 .PHONY: check-feature-registry
 check-feature-registry: ; @sh scripts/check_feature_registry.sh "$(FEATURE_INSTALLABLE_STEMS)" "$(FEATURE_EMBEDDED_STEMS)"
+
+# T4d: the side-load tool REGISTRY (src/hull/tools_install.c) vs the release
+# workflow that must publish each tool's asset. Catches a new tool row with no
+# matching release.yml artifact per push (before release_smoke.sh would).
+.PHONY: check-tools-registry
+check-tools-registry: ; @sh scripts/check_tools_registry.sh

--- a/scripts/check_feature_registry.sh
+++ b/scripts/check_feature_registry.sh
@@ -31,4 +31,27 @@ for f in $(grep -E '\{ *"[a-z]+".*HL_FEATURE_EMBEDDED,' "$FC" \
   esac
 done
 
-echo "check-feature-registry: OK (installable: $c_inst)"
+# T4e: every INSTALLABLE `--with` feature must have a FEATURE_SPECS entry - the
+# codegen source of truth `hull build --with=<name>` reads to compose it (backend
+# symbol, vtable type, hook name, extra link libs). Without it, `--with=<name>`
+# would resolve the archive but emit no feature_registry.c to wire it into the
+# base. FEATURE_SPECS is a SUPERSET (it also carries the mandatory `sqlite`
+# default backend, which is not a `--with` feature), so the check is directional:
+# installable stems must be a SUBSET of FEATURE_SPECS keys.
+FS=stdlib/cli/lua/hull/feature_specs.lua
+# Top-level keys only: exactly 4 leading spaces (direct children of `return {`).
+# A looser `[[:space:]]+` would also match nested sub-tables like the 8-space
+# `libs = {` inside the gpu/tui specs.
+fs_keys=$(grep -E '^    [a-z][a-z_-]* = \{' "$FS" \
+          | sed -E 's/^    ([a-z][a-z_-]*) =.*/\1/' | sort | tr '\n' ' ')
+for f in $1; do
+  case " $fs_keys " in
+    *" $f "*) ;;
+    *) echo "ERROR: installable feature '$f' has no FEATURE_SPECS entry in $FS" >&2
+       echo "  FEATURE_SPECS keys: [$fs_keys]" >&2
+       echo "  -> add a '$f = { ... }' block so 'hull build --with=$f' can compose it" >&2
+       exit 1 ;;
+  esac
+done
+
+echo "check-feature-registry: OK (installable: $c_inst; FEATURE_SPECS: $fs_keys)"

--- a/scripts/check_tools_registry.sh
+++ b/scripts/check_tools_registry.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# T4d (docs/build_arc_audit.md): fail if the side-load tool REGISTRY in
+# src/hull/tools_install.c drifts from the release workflow that must publish each
+# tool's asset. The registry is the CONSUMER-side truth (install / lookup / list);
+# .github/workflows/release.yml is the PRODUCER. A new registry row with no
+# matching release asset would `hull tools install`-fail at runtime, and the
+# post-release tests/release_smoke.sh would be the first to notice - this catches
+# it per push instead.
+#
+# For each REGISTRY `.name`, assert `hull-<name>` appears in release.yml (as a
+# binary `hull-<name>-<platform>` or a bundle `hull-<name>[-<platform>].tar`).
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+TI=src/hull/tools_install.c
+RY=.github/workflows/release.yml
+
+names=$(grep -E '^[[:space:]]*\.name[[:space:]]*=[[:space:]]*"[a-z0-9._-]+"' "$TI" \
+        | sed -E 's/.*"([a-z0-9._-]+)".*/\1/' | sort -u)
+[ -n "$names" ] || { echo "ERROR: no tool names parsed from $TI" >&2; exit 1; }
+
+miss=0
+for n in $names; do
+  if ! grep -q "hull-$n" "$RY"; then
+    echo "ERROR: tool '$n' (tools_install.c REGISTRY) has no 'hull-$n' asset in $RY" >&2
+    echo "  -> publish hull-$n[-<platform>][.tar] in the release workflow (build job" >&2
+    echo "     + the flatten / sha256 / attest / publish lists)" >&2
+    miss=1
+  fi
+done
+[ "$miss" -eq 0 ] || exit 1
+
+echo "check-tools-registry: OK ($(echo $names | tr '\n' ' '))"

--- a/src/hull/tools_install.c
+++ b/src/hull/tools_install.c
@@ -33,10 +33,15 @@
 
 /* ── Registry ────────────────────────────────────────────────────────
  *
- * Static table; entries are NUL-terminated by an all-zeros sentinel.
- * Adding a tool here is half of the install-path wiring; the other
- * half is publishing matching `hull-<name>-<platform>` artifacts in
- * the release workflow and listing them in `hull.sha256`.
+ * Static table; entries are NUL-terminated by an all-zeros sentinel. This
+ * registry is the CONSUMER-side source of truth (install / lookup / list); it is
+ * NOT the only edit site. Adding a tool is TWO coordinated edits: (1) a row here,
+ * and (2) publishing matching `hull-<name>[-<platform>]` (binary) or
+ * `hull-<name>[-<platform>].tar` (bundle) artifacts in .github/workflows/
+ * release.yml (the build job + the flatten/sha256/attest/publish lists). The two
+ * are kept from drifting by scripts/check_tools_registry.sh (a CI guard asserting
+ * every registry name has a matching release.yml asset) + the post-release
+ * tests/release_smoke.sh (which actually fetches + verifies each). See T4d.
  */
 static const HlToolSpec REGISTRY[] = {
     {


### PR DESCRIPTION
Tier-4 audit items **T4d** + **T4e** — per-push CI guards against registry drift.

- **T4e** — extend `scripts/check_feature_registry.sh` (already CI-run) to assert every INSTALLABLE `--with` feature has a top-level `FEATURE_SPECS` entry in `feature_specs.lua` (the codegen source `hull build --with=<name>` reads to wire the feature into the base). Directional: installable ⊆ FEATURE_SPECS keys (FEATURE_SPECS also carries the mandatory `sqlite` default). Matches only 4-space top-level keys so nested `libs = {` sub-tables don't leak in.
- **T4d** — the tool `REGISTRY` (`tools_install.c`) is the *consumer* side; `release.yml` is a second, coordinated edit site that must publish each tool's asset. Fixed the misleading "single source" registry comment, and added `scripts/check_tools_registry.sh` (+ `make check-tools-registry`, wired into the CI `build` job) asserting every `REGISTRY .name` has a matching `hull-<name>` asset in `release.yml` — catching drift per push instead of only at `release_smoke.sh` time. (The `release_smoke.sh` bundle-install half was already done in #4d.)

Both checks **negative-tested** (removing a `FEATURE_SPECS` key / renaming a `REGISTRY` name each fail with a fix-it hint). `make` green; both checks pass.

With this + #214 (T4a/b/c/f), **all Tier-4 items are complete** — closing out the entire `build_arc_audit.md` roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)