### PR TITLE
harden: skip non-string keys in tool.spawn's env table (c-audit follow-up)

### DIFF
--- a/src/hull/runtime/lua/mod_tool.c
+++ b/src/hull/runtime/lua/mod_tool.c
@@ -117,7 +117,11 @@ static int l_tool_spawn(lua_State *L)
         if (!envadd) { free(argv); return luaL_error(L, "tool.spawn: oom"); }
         lua_pushnil(L);
         while (lua_next(L, 2) != 0) {
-            const char *k = lua_tostring(L, -2);
+            /* Only string KEYS: never call lua_tostring on the key during a
+             * lua_next walk (it converts a numeric key in place and can then
+             * corrupt the traversal - a documented Lua footgun). An env-var name
+             * is always a string anyway; a non-string key is skipped. */
+            const char *k = (lua_type(L, -2) == LUA_TSTRING) ? lua_tostring(L, -2) : NULL;
             const char *v = lua_tostring(L, -1);
             if (k && v) {
                 size_t len = strlen(k) + 1 + strlen(v) + 1;


### PR DESCRIPTION
c-audit follow-up on the `tool.spawn` env-table support added in #213.

The env-table loop called `lua_tostring` on the **key** during a `lua_next` walk. On a numeric key, `lua_tostring` converts it in place — a documented Lua footgun that can corrupt the traversal. Safe today (the only caller, build.lua's zig cross-compile, passes string keys `ZIG_GLOBAL_CACHE_DIR` / `ZIG_LOCAL_CACHE_DIR`), but guarded defensively: only use the key when `lua_type(L,-2) == LUA_TSTRING`.

Defensive only; no behavior change. `make` + `test_tool` (51) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)