### PR TITLE
fix(windows): blob.init drive-root mkdir (mis-filed as spaces-in-path)

### DIFF
--- a/.github/workflows/cosmocc-windows-e2e.yml
+++ b/.github/workflows/cosmocc-windows-e2e.yml
@@ -28,6 +28,8 @@ on:
       - 'src/hull/sandbox_tool.c'
       - 'src/hull/compiler.c'
       - 'src/hull/cap/tar.c'
+      - 'src/hull/cap/fs.c'
+      - 'src/hull/sandbox.c'
       - 'stdlib/cli/lua/hull/build.lua'
 
 permissions:
@@ -121,6 +123,41 @@ jobs:
           Write-Host "cosmocc : $(Test-Path "$dest\bin\cosmocc")"
           Write-Host "busybox : $(Test-Path "$dest\bin\busybox.exe")"
           .\hull-cosmo.exe version
+
+      # Reproduce + verify the spaces-in-path fs-sandbox gap (nexogen asset-tracker
+      # PLATFORM_GAPS 2026-07-14): `hull dev` on a path WITH A SPACE failed
+      # blob.init ("check fs.write declares data/blobs") because realpath()
+      # canonicalizes a spaced Windows path inconsistently, breaking the cap-layer
+      # prefix match. HULL_FS_DEBUG traces the exact realpath in/out so we can see
+      # (and, after the fix, confirm) it. Plain local NTFS path with a space -
+      # isolates the space from the Google-Drive virtual FS in the original report.
+      - name: Spaces-in-path fs sandbox (blob.init on a spaced dir)
+        id: spaces
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $sp = "$env:TEMP\has space\reproapp"
+          New-Item -ItemType Directory -Force -Path $sp | Out-Null
+          $lua = @'
+          local blob = require("hull.blob")
+          app.manifest({ modules = { "hull/blob@1" }, fs = { write = { "data/blobs" } } })
+          app.main(function(ctx)
+            local ok, err = pcall(function() blob.init({ dir = "data/blobs" }) end)
+            ctx.stdout:write("REPRO blob.init ok=" .. tostring(ok) .. " err=" .. tostring(err) .. "\n")
+            return ok and 0 or 3
+          end)
+          '@
+          Set-Content -NoNewline "$sp\app.lua" -Value $lua -Encoding ascii
+          $env:HULL_FS_DEBUG = "1"
+          Write-Host "=== cosmo hull on SPACED path: $sp ==="
+          $out = & .\hull-cosmo.exe "$sp\app.lua" 2>&1 | Out-String
+          Write-Host $out
+          Write-Host "--- spaced-path run exit: $LASTEXITCODE ---"
+          if ($out -match "REPRO blob.init ok=true") {
+            Write-Host "SPACES-OK: blob.init succeeded on a spaced path"
+          } else {
+            Write-Host "SPACES-FAIL: blob.init failed on a spaced path (the gap)"
+          }
 
       - name: hull build a trivial app -> APE
         id: build

--- a/.github/workflows/cosmocc-windows-e2e.yml
+++ b/.github/workflows/cosmocc-windows-e2e.yml
@@ -125,16 +125,16 @@ jobs:
           Write-Host "busybox : $(Test-Path "$dest\bin\busybox.exe")"
           .\hull-cosmo.exe version
 
-      # Reproduce + verify the spaces-in-path fs-sandbox gap (nexogen asset-tracker
-      # PLATFORM_GAPS 2026-07-14): `hull dev` on a path WITH A SPACE failed
-      # blob.init ("check fs.write declares data/blobs") because realpath()
-      # canonicalizes a spaced Windows path inconsistently, breaking the cap-layer
-      # prefix match. HULL_FS_DEBUG traces the exact realpath in/out so we can see
-      # (and, after the fix, confirm) it. Plain local NTFS path with a space -
-      # isolates the space from the Google-Drive virtual FS in the original report.
-      - name: Spaces-in-path fs sandbox (isolate space vs 8.3 short-name)
-        id: spaces
-        continue-on-error: true
+      # Regression guard for the Windows blob.init drive-root mkdir bug (nexogen
+      # asset-tracker PLATFORM_GAPS 2026-07-14, mis-filed as "spaces in path"):
+      # hl_mkdir_p walks an absolute path from the root and mkdir()s the drive-root
+      # component ("/C", "/D"), which Cosmo-on-Windows rejects with EIO (not
+      # EEXIST) - so blob.init failed for ANY path (case B has no space, and still
+      # failed before the fix). The fix makes hl_ensure_dir stat-check for an
+      # existing directory on any mkdir errno. All three path shapes must boot
+      # blob.init cleanly; a regression fails the job. HULL_FS_DEBUG keeps the
+      # mkdir-fail trace on if it ever breaks again.
+      - name: blob.init on Windows (drive-root mkdir + spaces regression guard)
         shell: pwsh
         run: |
           $lua = @'
@@ -147,6 +147,7 @@ jobs:
           end)
           '@
           $env:HULL_FS_DEBUG = "1"
+          $script:fails = @()
           function Try-Path($label, $dir) {
             New-Item -ItemType Directory -Force -Path $dir | Out-Null
             Set-Content -NoNewline "$dir\app.lua" -Value $lua -Encoding ascii
@@ -154,15 +155,20 @@ jobs:
             $out = & .\hull-cosmo.exe "$dir\app.lua" 2>&1 | Out-String
             Write-Host $out
             if ($out -match "REPRO blob.init ok=true") { Write-Host "[$label] OK" }
-            else { Write-Host "[$label] FAIL" }
+            else { Write-Host "[$label] FAIL"; $script:fails += $label }
             Write-Host "------------------------------------------------------------"
           }
-          # A: RUNNER_TEMP (clean prefix, no 8.3) + a SPACE  -> isolates the SPACE.
+          # A: RUNNER_TEMP (clean prefix, no 8.3) + a SPACE.
           Try-Path "A space-clean-prefix" "$env:RUNNER_TEMP\sp ace\reproapp"
-          # B: RUNNER_TEMP, NO space (control - should pass).
+          # B: RUNNER_TEMP, NO space (control - drive-root mkdir path).
           Try-Path "B nospace-clean-prefix" "$env:RUNNER_TEMP\nospace\reproapp"
           # C: TEMP (8.3 'RUNNER~1' short-name) + a space (the original report).
           Try-Path "C space-and-83" "$env:TEMP\has space\reproapp"
+          if ($script:fails.Count -gt 0) {
+            Write-Host "BLOB-WINDOWS-FAIL: $($script:fails -join ', ')"
+            exit 1
+          }
+          Write-Host "BLOB-WINDOWS-OK: blob.init works on Windows for all path shapes"
 
       - name: hull build a trivial app -> APE
         id: build

--- a/.github/workflows/cosmocc-windows-e2e.yml
+++ b/.github/workflows/cosmocc-windows-e2e.yml
@@ -30,6 +30,7 @@ on:
       - 'src/hull/cap/tar.c'
       - 'src/hull/cap/fs.c'
       - 'src/hull/sandbox.c'
+      - 'src/hull/shared/fs_util.c'
       - 'stdlib/cli/lua/hull/build.lua'
 
 permissions:
@@ -131,13 +132,11 @@ jobs:
       # prefix match. HULL_FS_DEBUG traces the exact realpath in/out so we can see
       # (and, after the fix, confirm) it. Plain local NTFS path with a space -
       # isolates the space from the Google-Drive virtual FS in the original report.
-      - name: Spaces-in-path fs sandbox (blob.init on a spaced dir)
+      - name: Spaces-in-path fs sandbox (isolate space vs 8.3 short-name)
         id: spaces
         continue-on-error: true
         shell: pwsh
         run: |
-          $sp = "$env:TEMP\has space\reproapp"
-          New-Item -ItemType Directory -Force -Path $sp | Out-Null
           $lua = @'
           local blob = require("hull.blob")
           app.manifest({ modules = { "hull/blob@1" }, fs = { write = { "data/blobs" } } })
@@ -147,17 +146,23 @@ jobs:
             return ok and 0 or 3
           end)
           '@
-          Set-Content -NoNewline "$sp\app.lua" -Value $lua -Encoding ascii
           $env:HULL_FS_DEBUG = "1"
-          Write-Host "=== cosmo hull on SPACED path: $sp ==="
-          $out = & .\hull-cosmo.exe "$sp\app.lua" 2>&1 | Out-String
-          Write-Host $out
-          Write-Host "--- spaced-path run exit: $LASTEXITCODE ---"
-          if ($out -match "REPRO blob.init ok=true") {
-            Write-Host "SPACES-OK: blob.init succeeded on a spaced path"
-          } else {
-            Write-Host "SPACES-FAIL: blob.init failed on a spaced path (the gap)"
+          function Try-Path($label, $dir) {
+            New-Item -ItemType Directory -Force -Path $dir | Out-Null
+            Set-Content -NoNewline "$dir\app.lua" -Value $lua -Encoding ascii
+            Write-Host "=== [$label] cosmo hull on: $dir ==="
+            $out = & .\hull-cosmo.exe "$dir\app.lua" 2>&1 | Out-String
+            Write-Host $out
+            if ($out -match "REPRO blob.init ok=true") { Write-Host "[$label] OK" }
+            else { Write-Host "[$label] FAIL" }
+            Write-Host "------------------------------------------------------------"
           }
+          # A: RUNNER_TEMP (clean prefix, no 8.3) + a SPACE  -> isolates the SPACE.
+          Try-Path "A space-clean-prefix" "$env:RUNNER_TEMP\sp ace\reproapp"
+          # B: RUNNER_TEMP, NO space (control - should pass).
+          Try-Path "B nospace-clean-prefix" "$env:RUNNER_TEMP\nospace\reproapp"
+          # C: TEMP (8.3 'RUNNER~1' short-name) + a space (the original report).
+          Try-Path "C space-and-83" "$env:TEMP\has space\reproapp"
 
       - name: hull build a trivial app -> APE
         id: build

--- a/src/hull/cap/fs.c
+++ b/src/hull/cap/fs.c
@@ -60,12 +60,20 @@ int hl_cap_fs_validate(const HlFsConfig *cfg, const char *path,
         p = slash + 1;
     }
 
+    /* TEMP DIAG (HULL_FS_DEBUG): trace realpath canonicalization for the Windows
+     * spaces-in-path gap (nexogen PLATFORM_GAPS 2026-07-14). Remove after fix. */
+    int fsdbg = getenv("HULL_FS_DEBUG") != NULL;
+    if (fsdbg) fprintf(stderr, "[FSDBG] validate path='%s' base_dir='%s'\n",
+                       path, cfg->base_dir);
+
     /* Resolve the base directory (must exist) */
     char resolved_base[PATH_MAX];
     if (realpath(cfg->base_dir, resolved_base) == NULL) {
+        if (fsdbg) fprintf(stderr, "[FSDBG] realpath(base_dir) FAILED errno=%d\n", errno);
         if (err_msg) *err_msg = "validate_failed";
         return -1; /* base dir must exist */
     }
+    if (fsdbg) fprintf(stderr, "[FSDBG] resolved_base='%s'\n", resolved_base);
 
     /* Build full path */
     char full[PATH_MAX];
@@ -85,18 +93,24 @@ int hl_cap_fs_validate(const HlFsConfig *cfg, const char *path,
     while (realpath(probe, resolved) == NULL) {
         char *slash = strrchr(probe, '/');
         if (!slash || slash == probe) {
+            if (fsdbg) fprintf(stderr, "[FSDBG] walk-up exhausted, full='%s'\n", full);
             if (err_msg) *err_msg = "validate_failed";
             return -1; /* exhausted all ancestors */
         }
         *slash = '\0';
     }
+    if (fsdbg) fprintf(stderr, "[FSDBG] full='%s' resolved_ancestor='%s'\n", full, resolved);
 
     /* Verify the resolved ancestor starts with resolved base */
     size_t base_len = strlen(resolved_base);
     if (strncmp(resolved, resolved_base, base_len) != 0) {
+        if (fsdbg) fprintf(stderr, "[FSDBG] PREFIX MISMATCH: resolved='%s' !startswith resolved_base='%s' (base_len=%zu)\n",
+                           resolved, resolved_base, base_len);
         if (err_msg) *err_msg = "symlink_escape";
         return -1;
     }
+    if (fsdbg) fprintf(stderr, "[FSDBG] prefix OK; boundary char='%c'\n",
+                       resolved[base_len] ? resolved[base_len] : '0');
 
     /* Must be followed by '/' or be exactly the base dir */
     if (resolved[base_len] != '/' && resolved[base_len] != '\0') {

--- a/src/hull/cap/fs.c
+++ b/src/hull/cap/fs.c
@@ -60,20 +60,12 @@ int hl_cap_fs_validate(const HlFsConfig *cfg, const char *path,
         p = slash + 1;
     }
 
-    /* TEMP DIAG (HULL_FS_DEBUG): trace realpath canonicalization for the Windows
-     * spaces-in-path gap (nexogen PLATFORM_GAPS 2026-07-14). Remove after fix. */
-    int fsdbg = getenv("HULL_FS_DEBUG") != NULL;
-    if (fsdbg) fprintf(stderr, "[FSDBG] validate path='%s' base_dir='%s'\n",
-                       path, cfg->base_dir);
-
     /* Resolve the base directory (must exist) */
     char resolved_base[PATH_MAX];
     if (realpath(cfg->base_dir, resolved_base) == NULL) {
-        if (fsdbg) fprintf(stderr, "[FSDBG] realpath(base_dir) FAILED errno=%d\n", errno);
         if (err_msg) *err_msg = "validate_failed";
         return -1; /* base dir must exist */
     }
-    if (fsdbg) fprintf(stderr, "[FSDBG] resolved_base='%s'\n", resolved_base);
 
     /* Build full path */
     char full[PATH_MAX];
@@ -93,24 +85,18 @@ int hl_cap_fs_validate(const HlFsConfig *cfg, const char *path,
     while (realpath(probe, resolved) == NULL) {
         char *slash = strrchr(probe, '/');
         if (!slash || slash == probe) {
-            if (fsdbg) fprintf(stderr, "[FSDBG] walk-up exhausted, full='%s'\n", full);
             if (err_msg) *err_msg = "validate_failed";
             return -1; /* exhausted all ancestors */
         }
         *slash = '\0';
     }
-    if (fsdbg) fprintf(stderr, "[FSDBG] full='%s' resolved_ancestor='%s'\n", full, resolved);
 
     /* Verify the resolved ancestor starts with resolved base */
     size_t base_len = strlen(resolved_base);
     if (strncmp(resolved, resolved_base, base_len) != 0) {
-        if (fsdbg) fprintf(stderr, "[FSDBG] PREFIX MISMATCH: resolved='%s' !startswith resolved_base='%s' (base_len=%zu)\n",
-                           resolved, resolved_base, base_len);
         if (err_msg) *err_msg = "symlink_escape";
         return -1;
     }
-    if (fsdbg) fprintf(stderr, "[FSDBG] prefix OK; boundary char='%c'\n",
-                       resolved[base_len] ? resolved[base_len] : '0');
 
     /* Must be followed by '/' or be exactly the base dir */
     if (resolved[base_len] != '/' && resolved[base_len] != '\0') {

--- a/src/hull/shared/fs_util.c
+++ b/src/hull/shared/fs_util.c
@@ -10,25 +10,25 @@
 #include <limits.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <stdio.h>    /* TEMP DIAG */
-#include <stdlib.h>   /* TEMP DIAG (getenv) */
 
 int hl_ensure_dir(const char *path, mode_t mode)
 {
     if (mkdir(path, mode) == 0) return 0;
-    int mkerr = errno;
-    if (mkerr == EEXIST) {
-        struct stat st;
-        if (stat(path, &st) == 0 && S_ISDIR(st.st_mode)) return 0;
-        /* TEMP DIAG: EEXIST but stat failed / not a dir (Windows spaces gap). */
-        if (getenv("HULL_FS_DEBUG"))
-            fprintf(stderr, "[FSDBG] ensure_dir '%s': EEXIST but stat-fail/not-dir (errno=%d)\n",
-                    path, errno);
-        if (errno == 0) errno = ENOTDIR;
-    } else if (getenv("HULL_FS_DEBUG")) {
-        /* TEMP DIAG: mkdir failed with something other than EEXIST. */
-        fprintf(stderr, "[FSDBG] ensure_dir '%s': mkdir FAILED errno=%d\n", path, mkerr);
-    }
+
+    /* mkdir failed. On POSIX an already-existing directory yields EEXIST, but
+     * some platforms report a pre-existing path with a DIFFERENT errno: notably
+     * Cosmopolitan on Windows returns EIO (errno 5) for a drive root ("/C",
+     * "/D") - which every absolute Windows path starts with - and can return
+     * EACCES for some existing system directories. So do NOT special-case
+     * EEXIST: if the path already IS a directory, treat it as created regardless
+     * of the mkdir errno. Without this, hl_mkdir_p fails on the very first
+     * (drive-root) component of any absolute path on Windows, which broke
+     * hull/blob@1 there for ALL paths (nexogen PLATFORM_GAPS 2026-07-14, which
+     * mis-attributed it to spaces in the path). A real failure - the path exists
+     * but is not a directory, or is unreadable - still returns -1 below. */
+    struct stat st;
+    if (stat(path, &st) == 0 && S_ISDIR(st.st_mode)) return 0;
+    if (errno == 0) errno = ENOTDIR;
     return -1;
 }
 

--- a/src/hull/shared/fs_util.c
+++ b/src/hull/shared/fs_util.c
@@ -10,14 +10,24 @@
 #include <limits.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <stdio.h>    /* TEMP DIAG */
+#include <stdlib.h>   /* TEMP DIAG (getenv) */
 
 int hl_ensure_dir(const char *path, mode_t mode)
 {
     if (mkdir(path, mode) == 0) return 0;
-    if (errno == EEXIST) {
+    int mkerr = errno;
+    if (mkerr == EEXIST) {
         struct stat st;
         if (stat(path, &st) == 0 && S_ISDIR(st.st_mode)) return 0;
+        /* TEMP DIAG: EEXIST but stat failed / not a dir (Windows spaces gap). */
+        if (getenv("HULL_FS_DEBUG"))
+            fprintf(stderr, "[FSDBG] ensure_dir '%s': EEXIST but stat-fail/not-dir (errno=%d)\n",
+                    path, errno);
         if (errno == 0) errno = ENOTDIR;
+    } else if (getenv("HULL_FS_DEBUG")) {
+        /* TEMP DIAG: mkdir failed with something other than EEXIST. */
+        fprintf(stderr, "[FSDBG] ensure_dir '%s': mkdir FAILED errno=%d\n", path, mkerr);
     }
     return -1;
 }


### PR DESCRIPTION
## Windows `blob.init` (and all `hl_mkdir_p` callers) broken by drive-root mkdir

Filed in the asset-tracker `PLATFORM_GAPS.md` (2026-07-14) as "spaces in the
project path break the blob sandbox on Windows" - but the Windows-CI repro in
this PR proved that framing wrong.

**Actual root cause.** `hl_cap_fs_validate` PASSES (it uses `realpath`, which is
consistent). `blob.init` fails downstream in `hl_blob_store_open` -> `hl_mkdir_p`
-> `hl_ensure_dir`. `hl_mkdir_p` walks an absolute path from the root and
`mkdir()`s each prefix, including the **drive-root** component (`/C`, `/D`).
Cosmo-on-Windows rejects `mkdir` of a drive root with **EIO (errno 5)**, not
`EEXIST` - and `hl_ensure_dir` only stat-checked on `EEXIST`, so it failed on the
very first component. This broke `blob.init` for **every** absolute Windows path,
not just spaced ones (the isolating trace's no-space control case B failed too).
`subst X:` happened to sidestep it.

**Fix.** `hl_ensure_dir` now stat-checks for an existing directory on **any**
mkdir errno (not just `EEXIST`), succeeding if the path already is a directory.
Real failures (exists-but-not-a-dir / unreadable) still return -1.

**Repro -> guard.** The Windows-CI step is now a regression guard: it boots
`blob.init` on three path shapes (clean+space, clean+no-space, `%TEMP%`/8.3+space)
and fails the job unless all three succeed.
