### PR TITLE
harden(stdlib): c/js/lua audit follow-ups (parity + robustness)

### DIFF
--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -734,10 +734,23 @@ local function compose_features(opts, tmpdir, platform_lib, is_cosmo, compute_fi
             -- a SQLite-less (HL_SQLITE_FEATURE=1) base does not. nm may be absent
             -- (or the base unreadable); default to "has sqlite" so we never
             -- wrongly compose onto a SQLite-full base.
+            --
+            -- MUST mirror fcompose.plan_mandatory's base_lacks() musl short-circuit:
+            -- the musl base is always the SLIM base (build_musl_platform.sh runs
+            -- `make platform`, which is SQLite-less), and a cross-libc `nm` (a
+            -- macOS host reading a Linux/musl ELF archive) is unreliable - it can
+            -- return nil/empty and leave base_has_sqlite=true. Without this guard
+            -- the per-runtime udf BRIDGE (composed via base_lacks, which DOES
+            -- special-case musl) would compose while the ENGINE here would not,
+            -- and the app link fails on unresolved sqlite3_*/hl_db_backend_sqlite.
             local base_has_sqlite = true
-            local nm_out = tool.spawn_read({ "nm", platform_lib })
-            if nm_out and not nm_out:find("hl_db_backend_sqlite") then
+            if opts.musl_dir then
                 base_has_sqlite = false
+            else
+                local nm_out = tool.spawn_read({ "nm", platform_lib })
+                if nm_out and not nm_out:find("hl_db_backend_sqlite", 1, true) then
+                    base_has_sqlite = false
+                end
             end
             if not base_has_sqlite then
                 opts.with = opts.with or {}

--- a/stdlib/js/hull/i18n.js
+++ b/stdlib/js/hull/i18n.js
@@ -38,6 +38,12 @@ function deepGet(obj, key) {
 function interpolate(str, params) {
     if (!params) return str;
     return str.replace(/\$\{(\w+)\}/g, function(match, key) {
+        // Own-property lookup only: `${constructor}` / `${toString}` /
+        // `${__proto__}` must echo the literal placeholder, not resolve to an
+        // Object.prototype member. This matches the Lua sibling (a plain-table
+        // `params[k]` has no prototype chain, so a missing key returns nil ->
+        // the literal `${key}`).
+        if (!Object.prototype.hasOwnProperty.call(params, key)) return match;
         const v = params[key];
         if (v === undefined || v === null) return match;
         return String(v);

--- a/stdlib/js/hull/web/auth-flows.js
+++ b/stdlib/js/hull/web/auth-flows.js
@@ -746,6 +746,11 @@ function handleMagicLink(req, res) {
         if (!_state.magicLinkAutoSignup) return genericOk(res);
         const uid = _state.userCreate(body.email, null);
         user = _state.userGet(uid);
+        // Guard the create->get race / adapter inconsistency: a nil user here
+        // would mint a magic-link token with sub=null and then throw in
+        // sendEmail(user...). Stay enumeration-safe (same shape as the
+        // unknown-email path above) rather than 500.
+        if (!user) return genericOk(res);
     }
     const token = issueToken(userId(user), ACTIONS.magic_link,
         _state.magicLinkTtl);
@@ -924,8 +929,11 @@ function handleEmailChange(req, res) {
         user, link, token, new_email: body.new_email,
     });
     // Defense in depth: notify the OLD address with a revoke link
-    // if templates.email_change_notify is provided.
-    if (_state.templates.email_change_notify) {
+    // if templates.email_change_notify is provided. Guard `user` (nil only on
+    // a pathological row-deleted-mid-request race): the confirm email above
+    // passes it through a nil-safe template ctx, but user.email below is a
+    // hard deref.
+    if (user && _state.templates.email_change_notify) {
         const revokeTok = issueToken(uid, ACTIONS.email_change_revoke,
             _state.emailChangeTtl);
         const revokeUrl = origin + _state.prefix
@@ -1347,6 +1355,9 @@ function sendMagicLink(email, magicUrlPrefix) {
         if (!_state.magicLinkAutoSignup) return;
         const uid = _state.userCreate(email, null);
         user = _state.userGet(uid);
+        // create->get race guard (see handleMagicLink): a nil user would mint
+        // a sub=null token and throw in sendEmail.
+        if (!user) return;
     }
     const uid = userId(user);
     const token = issueToken(uid, ACTIONS.magic_link, _state.magicLinkTtl);

--- a/stdlib/js/hull/web/htmx/table.js
+++ b/stdlib/js/hull/web/htmx/table.js
@@ -87,7 +87,14 @@ function render(rows, schema, opts) {
                 const value = row[col.name];
                 let cellHtml;
                 if (col.render) {
+                    // CONTRACT: a custom render owns its own escaping; its
+                    // return is spliced into <td> RAW (see docs/htmx_widgets.md).
+                    // If a column shows user-controlled data, the render fn MUST
+                    // escape it. Defensive net: a non-string return (a bare
+                    // value from a naive `render:(v)=>v`) is routed through esc
+                    // so it can't inject.
                     cellHtml = col.render(value, row);
+                    if (typeof cellHtml !== "string") cellHtml = esc(cellHtml);
                 } else if (col.editable) {
                     if (!opts.editUrlFor) {
                         throw new Error("table.render: opts.editUrlFor is required "

--- a/stdlib/js/hull/web/middleware/csrf.js
+++ b/stdlib/js/hull/web/middleware/csrf.js
@@ -124,7 +124,7 @@ function parseCookieSessionId(req, cookieName) {
  * Build a CSRF middleware. Register with `app.usePost()`.
  *
  * Safe methods (GET/HEAD/OPTIONS): generates a token, attaches to
- * `req.ctx.csrfToken`. Unsafe methods: verifies token from
+ * `req.ctx.csrf_token`. Unsafe methods: verifies token from
  * `X-CSRF-Token` header or `_csrf` form field; sends 403 on failure.
  *
  * Body parsing capped at 1 MiB / 256 form pairs.
@@ -219,6 +219,12 @@ function middleware(opts) {
                 return 1;
             }
             for (let k = 0; k < pairs.length; k++) {
+                // Parity with Lua sibling (MAX_PAIR_BYTES): skip any single
+                // pair over 4 KiB before indexOf/decode. A CSRF token is short
+                // by construction; without this bound a single ~1 MiB `_csrf`
+                // pair (under the total-body cap) forces a full-body
+                // decodeURIComponent on every unsafe request.
+                if (pairs[k].length > 4096) continue;
                 const eqIdx = pairs[k].indexOf("=");
                 if (eqIdx >= 0) {
                     const key = pairs[k].substring(0, eqIdx);

--- a/stdlib/lua/hull/template.lua
+++ b/stdlib/lua/hull/template.lua
@@ -49,6 +49,15 @@ local function validate_ident(s, context)
     if not s:match("^[%a_][%w_]*$") then
         error("invalid identifier in template " .. (context or "expression") .. ": " .. s)
     end
+    -- Must NOT start with `__` (parity with the JS sibling): those names are
+    -- reserved for codegen helpers (`__p` output buffer, `__d` data, `__e`
+    -- escape, `__f` filters). A template var like `{% for __p in items %}`
+    -- would otherwise pass validation and shadow the output accumulator,
+    -- silently corrupting the render.
+    if s:sub(1, 2) == "__" then
+        error("identifier in template " .. (context or "expression")
+              .. " cannot start with '__' (reserved): " .. s)
+    end
 end
 
 -- ── HTML escape ──────────────────────────────────────────────────────

--- a/stdlib/lua/hull/web/auth-flows.lua
+++ b/stdlib/lua/hull/web/auth-flows.lua
@@ -1065,6 +1065,11 @@ local function handle_magic_link(req, res)
         -- password_hash; the app's user_create must accept that.
         local user_id = _state.user_create(body.email, nil)
         user = _state.user_get(user_id)
+        -- Guard the create->get race / adapter inconsistency: a nil user here
+        -- would issue a magic-link token with sub=nil and then error in
+        -- send_email(user...). Stay enumeration-safe (matches the guarded
+        -- sibling sites in handle_register / handle_magic_link_consume).
+        if not user then return generic_ok(res) end
     end
     local token = issue_token(user_uid(user),
         ACTIONS.magic_link, _state.magic_link_ttl)
@@ -1293,8 +1298,10 @@ local function handle_email_change(req, res)
     -- Defense in depth: notify the OLD address with a revoke link
     -- so a stolen session cookie can't quietly move the account.
     -- Opt-in by providing templates.email_change_notify; apps
-    -- without the template keep the v1 behavior.
-    if _state.templates.email_change_notify then
+    -- without the template keep the v1 behavior. Guard `user` (nil only on a
+    -- pathological row-deleted-mid-request race): the confirm email above uses
+    -- a nil-safe template ctx, but user.email below is a hard deref.
+    if user and _state.templates.email_change_notify then
         local revoke_tok = issue_token(user_id,
             ACTIONS.email_change_revoke, _state.email_change_ttl)
         local revoke_url = origin .. _state.prefix
@@ -1814,6 +1821,9 @@ function M.send_magic_link(email, magic_url_prefix)
         if not _state.magic_link_auto_signup then return end
         local user_id = _state.user_create(email, nil)
         user = _state.user_get(user_id)
+        -- create->get race guard (see handle_magic_link): a nil user would
+        -- issue a sub=nil token and error in send_email.
+        if not user then return end
     end
     local user_id = user_uid(user)
     local token = issue_token(user_id, ACTIONS.magic_link,

--- a/stdlib/lua/hull/web/htmx/table.lua
+++ b/stdlib/lua/hull/web/htmx/table.lua
@@ -177,7 +177,17 @@ function M.render(rows, schema, opts)
                 local value = row[col.name]
                 local cell_html
                 if col.render then
+                    -- CONTRACT: a custom render owns its own escaping; its
+                    -- return is spliced into <td> RAW (see docs/htmx_widgets.md).
+                    -- If a column shows user-controlled data, the render fn MUST
+                    -- escape it (the shipped example does). Defensive net: a
+                    -- non-string return (a bare number/bool from a naive
+                    -- `render=function(v) return v end`) is routed through esc
+                    -- so it can't inject and can't raise a concat error.
                     cell_html = col.render(value, row)
+                    if type(cell_html) ~= "string" then
+                        cell_html = esc(cell_html)
+                    end
                 elseif col.editable then
                     if not opts.edit_url_for then
                         error("table.render: opts.edit_url_for is required when "


### PR DESCRIPTION
Follow-ups from a **c-audit / js-audit / lua-audit** sweep of the recently-merged surface (the cosmocc-install epic #217 + the #218 Windows fix).

**No Critical/High.** The fresh C came back clean: the #218 `fs_util.c` fix was independently confirmed (masks nothing, non-dir path still rejected, TOCTOU benign), and the tar/verify trust chain plus the tool/spawn cosmocc->busybox reroute are well-guarded (shell-driver injection closed, allowlist enforced). The two C findings were Low and unreachable by current callers, so nothing to change there.

These are the actionable **JS/Lua parity + robustness** gaps — several are one-runtime-weaker-than-the-other:

| Sev | File | Fix |
|-----|------|-----|
| Med | `csrf.js` | Add the per-pair **4 KiB** body cap `csrf.lua` already enforces (a single ~1 MiB `_csrf` pair otherwise forces a full-body `decodeURIComponent` per unsafe request). |
| Med | `build.lua` | SQLite **engine** auto-compose probe now mirrors `plan_mandatory.base_lacks()`'s musl short-circuit. A macOS host cross-building for musl runs a cross-libc `nm` that can't read the Linux ELF archive → engine wasn't composed while the udf **bridge** was → link failure. Fails closed. |
| Low | `auth-flows.{js,lua}` | Guard a nil `user` in the magic-link auto-signup path (+ `send_magic_link` helper): a create->get race would mint a `sub=null` token then throw in `send_email`. Also guard the email-change notify branch's `user.email` hard-deref (confirm email still sends via its nil-safe ctx). |
| Low | `i18n.js` | `interpolate()` now does an own-property lookup, so `${constructor}` / `${__proto__}` echo the literal instead of leaking an `Object.prototype` member (parity with Lua's plain-table indexing). |
| Low | `template.lua` | `validate_ident` rejects `__`-prefixed names (parity with `template.js`), so a template var like `{% for __p in items %}` can't shadow the codegen accumulator. |
| Low | `csrf.js` | Docstring fix (`req.ctx.csrf_token`, was `csrfToken`). |
| Low | `htmx/table.{js,lua}` | `col.render` stays spliced raw (documented "app owns escaping" contract, kept), but a non-string return is now routed through `esc()` as a defensive net + a loud inline note. |

**PARITY-CONFIRMs (clean):** `csrf.lua` already enforces all three DoS caps; `i18n.lua` has no prototype-leak analogue; the totp/session atomic single-use / replay / session-rotation gates are correct in both runtimes.

**Validation:** `make test` 62/62; e2e templates 42/42, auth-flows 48/48, 2FA 30/30, hardening 42/42; i18n own-property guard smoke-confirmed on both runtimes.
