### PR TITLE
feat(test): fs sandbox + streaming multipart in the in-process hull test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,10 @@ jobs:
         timeout-minutes: 2
         run: make e2e-blob
 
+      - name: Test-harness fs + multipart E2E tests
+        timeout-minutes: 2
+        run: make e2e-test-harness
+
       - name: Multipart upload E2E tests
         timeout-minutes: 3
         run: make e2e-multipart

--- a/Makefile
+++ b/Makefile
@@ -1904,7 +1904,7 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
 
 # ── Targets ─────────────────────────────────────────────────────────
 
-.PHONY: all clean test debug msan tsan fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-linker-zig e2e-cross-build e2e-musl e2e-musl-cross floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint platform platform-cosmo hardening check-hardening
+.PHONY: all clean test debug msan tsan fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-linker-zig e2e-cross-build e2e-musl e2e-musl-cross floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-test-harness e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint platform platform-cosmo hardening check-hardening
 
 all: $(BUILDDIR)/hull
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -590,6 +590,9 @@ e2e-attachment: $(BUILDDIR)/hull
 e2e-blob: $(BUILDDIR)/hull
 	sh tests/e2e_blob.sh
 
+e2e-test-harness: $(BUILDDIR)/hull
+	sh tests/e2e_test_harness.sh
+
 e2e-named-connections: $(BUILDDIR)/hull
 	sh tests/e2e_named_connections.sh
 

--- a/src/hull/app_context.c
+++ b/src/hull/app_context.c
@@ -20,6 +20,7 @@
 #include "hull/cap/db_backend.h"
 #include "hull/cap/db_sqlite.h"   /* hl_db_sqlite_raw (agent handle) */
 #include "hull/cap/db_registry.h"
+#include "hull/cap/fs.h"          /* HlFsConfig — test/agent fs sandbox wiring */
 #include "hull/migrate.h"
 #include "hull/worker_db.h"
 #include <sqlite3.h>
@@ -54,6 +55,17 @@ struct HlAppContext {
     HlVfs          platform_vfs;
     void          *platform_vfs_owned;  /* opaque sealed-arena handle to free, or NULL */
     HlRuntime     *rt;
+
+    /* Owned app_dir copy backing fs_cfg_storage.base_dir (rt->fs_cfg borrows it,
+     * so it must outlive the runtime — opts->app_dir may be a caller stack). */
+    char          *app_dir_copy;
+    /* fs capability config wired onto rt->fs_cfg when the app declares
+     * fs.read/fs.write, so blob.* / fs.* / fs.mmap work under `hull test` /
+     * `hull agent` the same way they do under `hull dev` (serve.c does the
+     * equivalent wiring in hl_serve_wire_caps). Only base_dir/base_len — the
+     * cap layer sandboxes to base_dir + rejects traversal; the per-path
+     * allowlist is the kernel sandbox, which the test harness runs without. */
+    HlFsConfig     fs_cfg_storage;
 
     /* Resolved module set (opt-in via opts.gate_modules). Lives here so
      * its lifetime matches the runtime — rt->module_set borrows. */
@@ -166,11 +178,15 @@ int hl_app_context_init(HlAppContext **out, const HlAppContextOpts *opts)
     HlAppContext *ctx = calloc(1, sizeof(*ctx));
     if (!ctx) return -1;
 
+    /* Own a stable copy of app_dir for fs_cfg.base_dir (see struct comment). */
+    ctx->app_dir_copy = strdup(opts->app_dir);
+    if (!ctx->app_dir_copy) { free(ctx); return -1; }
+
     /* Detect entry point and runtime type */
     char entry_buf[4096];
     const char *entry = NULL;
     if (resolve_entry_and_runtime(ctx, opts, &entry, entry_buf, sizeof(entry_buf)) != 0) {
-        free(ctx);
+        hl_app_context_free(ctx);
         return -1;
     }
 
@@ -307,6 +323,19 @@ int hl_app_context_init(HlAppContext **out, const HlAppContextOpts *opts)
                 char err[HL_MODULE_RESOLVER_ERR_MAX] = {0};
                 int rc = hl_module_resolver_resolve(&m, &ctx->module_set,
                                                      err, sizeof(err));
+                /* Wire the fs capability from the manifest, mirroring the serve
+                 * path (serve.c::hl_serve_wire_caps). Without this rt->fs_cfg
+                 * stays NULL and blob.init / fs.read/write / fs.mmap fail with
+                 * "fs config unavailable" under `hull test` / `hull agent`. Only
+                 * base_dir is needed (the cap layer sandboxes to base_dir +
+                 * rejects traversal; the per-path allowlist is the kernel
+                 * sandbox). Keyed on the app declaring fs.read OR fs.write, same
+                 * condition as serve. Safe to read m before the free below. */
+                if (m.fs_read_count > 0 || m.fs_write_count > 0) {
+                    ctx->fs_cfg_storage.base_dir = ctx->app_dir_copy;
+                    ctx->fs_cfg_storage.base_len = strlen(ctx->app_dir_copy);
+                    ctx->rt->fs_cfg = &ctx->fs_cfg_storage;
+                }
                 hl_manifest_free(&m);
                 if (rc != 0) {
                     fprintf(stderr, "[app-context] module resolver: %s\n", err);
@@ -393,6 +422,10 @@ void hl_app_context_free(HlAppContext *ctx)
     ctx->app_loaded = 0;
     hl_platform_vfs_dispose(ctx->platform_vfs_owned);
     ctx->platform_vfs_owned = NULL;
+    /* rt->fs_cfg borrowed &ctx->fs_cfg_storage, whose base_dir borrowed this;
+     * the runtime is already destroyed above, so no live borrow remains. */
+    free(ctx->app_dir_copy);
+    ctx->app_dir_copy = NULL;
     free(ctx);
 }
 

--- a/src/hull/app_context.c
+++ b/src/hull/app_context.c
@@ -15,12 +15,14 @@
 #include "hull/stdlib_feature.h"
 #include "hull/vfs.h"
 
+#include "hull/cap/fs.h"          /* HlFsConfig — test/agent fs sandbox wiring
+                                   * (unconditional: fs_cfg is not DB-gated) */
+
 #ifdef HL_ENABLE_DB
 #include "hull/cap/db.h"
 #include "hull/cap/db_backend.h"
 #include "hull/cap/db_sqlite.h"   /* hl_db_sqlite_raw (agent handle) */
 #include "hull/cap/db_registry.h"
-#include "hull/cap/fs.h"          /* HlFsConfig — test/agent fs sandbox wiring */
 #include "hull/migrate.h"
 #include "hull/worker_db.h"
 #include <sqlite3.h>

--- a/src/hull/cap/test.c
+++ b/src/hull/cap/test.c
@@ -86,16 +86,60 @@ int hl_cap_test_dispatch(KlRouter *router, const char *method,
     }
     req.num_headers = num_headers;
 
-    /* Fake body reader if body provided — must be KlBufReader so that
-     * hl_cap_body_data() can cast and read .data/.len fields. */
+    KlAllocator alloc = kl_allocator_default();
+
+    /* Body reader. Two shapes:
+     *
+     *  - A streaming-multipart route (registered via kl_server_route_streaming*)
+     *    needs the parkable multipart wrapper (hl_cap_multipart_factory) as
+     *    req.body_reader so req:multipart() / req.multipart() resolve. Unlike a
+     *    live socket, the synthetic harness has the WHOLE body up front, so we
+     *    reconstruct the wrapper via the matched route's own factory and pre-feed
+     *    the entire body + on_complete BEFORE dispatch. A well-formed body then
+     *    drives the iterator straight to DONE (Keel's body_reader_multipart.c
+     *    returns DONE, not NEED_DATA, once the stream has ended), so the handler
+     *    never parks / yields and no live connection is required. Previously
+     *    req:multipart() raised "no active connection" in-process.
+     *
+     *  - Any other route uses the plain KlBufReader (hl_cap_body_data reads it).
+     *
+     * mp_wrapper is destroyed after dispatch (the handler consumed the parts
+     * synchronously during dispatch, so the parsed state is no longer needed).
+     */
     KlBufReader fake_buf;
     memset(&fake_buf, 0, sizeof(fake_buf));
+    KlBodyReader *mp_wrapper = NULL;
     if (body_data && body_len > 0) {
-        fake_buf.data = (char *)(uintptr_t)body_data;  /* KlBody.data is char* but not modified here */
-        fake_buf.len = body_len;
-        fake_buf.cap = body_len;
-        req.body_reader = &fake_buf.base;
-        req.content_length = body_len;
+        KlRoute *matched = NULL;
+        int nparams = 0;
+        (void)kl_router_match(router, method, req.method_len,
+                              req.path, req.path_len,
+                              &matched, req.params, &nparams);
+        if (matched && matched->streaming_handler && matched->body_reader) {
+            KlBodyReader *w = matched->body_reader(&alloc, &req,
+                                                   matched->user_data);
+            if (w) {
+                /* Feed the whole body in one on_data, then complete the stream.
+                 * A cap-exceeding body makes on_data return < 0, which the
+                 * wrapper records as errored (mp_wrap_on_data); we then skip
+                 * on_complete and still hand the wrapper to the handler so
+                 * req:multipart() surfaces the parser error the same way a live
+                 * server would. */
+                int rc = w->on_data ? w->on_data(w, body_data, body_len) : 0;
+                if (rc >= 0 && w->on_complete)
+                    w->on_complete(w);
+                req.body_reader = w;
+                req.content_length = body_len;
+                mp_wrapper = w;
+            }
+        }
+        if (!mp_wrapper) {
+            fake_buf.data = (char *)(uintptr_t)body_data;  /* KlBody.data is char* but not modified here */
+            fake_buf.len = body_len;
+            fake_buf.cap = body_len;
+            req.body_reader = &fake_buf.base;
+            req.content_length = body_len;
+        }
     }
 
     /* Inject context if provided (parsed as JSON by Lua/JS bindings).
@@ -121,7 +165,6 @@ int hl_cap_test_dispatch(KlRouter *router, const char *method,
      * pipeline. dispatch_synthetic encapsulates the match → pre-body
      * mw → post-body mw → handler sequence so this file no longer
      * needs to mirror Keel internals. */
-    KlAllocator alloc = kl_allocator_default();
     KlResponse res;
     if (kl_response_init(&res, &alloc) != 0) return -1;
     res.conn_fd = -1; /* no actual connection */
@@ -136,6 +179,11 @@ int hl_cap_test_dispatch(KlRouter *router, const char *method,
      * value because the caller inspects res->status / res->body
      * directly, not the dispatch verdict. */
     (void)kl_router_dispatch_synthetic(router, &req, &res, run_middleware);
+
+    /* The handler consumed the multipart parts synchronously during dispatch;
+     * tear the wrapper (and its inner reader + buffered parts) down now. */
+    if (mp_wrapper && mp_wrapper->destroy)
+        mp_wrapper->destroy(mp_wrapper);
 
     /* Extract results — copy body and headers into hl_alloc-owned
      * storage before freeing the response (kl_response_free releases

--- a/src/hull/runtime/js/routes.c
+++ b/src/hull/runtime/js/routes.c
@@ -72,6 +72,13 @@ int hl_js_track_alloc(HlJS *js, void ***arr, size_t *count,
 
 /* ── Route wiring ──────────────────────────────────────────────────── */
 
+/* Defined below; forward-declared so the router (test-harness) wiring can
+ * register streaming-multipart routes the same way the server wiring does. */
+static KlMultipartConfig *js_build_multipart_config(HlJS *js, JSValueConst mp);
+static KlBodyReader *hl_js_multipart_factory(KlAllocator *alloc,
+                                             const KlRequest *req,
+                                             void *user_data);
+
 int hl_js_wire_routes(HlJS *js, KlRouter *router)
 {
     JSContext *ctx = js->ctx;
@@ -98,6 +105,7 @@ int hl_js_wire_routes(HlJS *js, KlRouter *router)
         JSValue method_val = JS_GetPropertyStr(ctx, def, "method");
         JSValue pattern_val = JS_GetPropertyStr(ctx, def, "pattern");
         JSValue id_val = JS_GetPropertyStr(ctx, def, "handler_id");
+        JSValue mp_val = JS_GetPropertyStr(ctx, def, "multipart");
 
         const char *method_str = JS_ToCString(ctx, method_val);
         const char *pattern = JS_ToCString(ctx, pattern_val);
@@ -111,14 +119,35 @@ int hl_js_wire_routes(HlJS *js, KlRouter *router)
                 route->js = js;
                 route->handler_id = handler_id;
                 route->multipart_config = NULL;
+
+                /* Peek def.multipart — present → streaming route. Mirror the
+                 * server path (hl_js_wire_routes_server) so req.multipart()
+                 * resolves under `hull test`; the in-process harness pre-feeds
+                 * the whole body to this factory's wrapper (hl_cap_test_dispatch). */
+                int is_streaming = JS_IsObject(mp_val) &&
+                                   !JS_IsFunction(ctx, mp_val) &&
+                                   !JS_IsArray(ctx, mp_val);
+                if (is_streaming) {
+                    route->multipart_config =
+                        js_build_multipart_config(js, mp_val);
+                    if (!route->multipart_config) is_streaming = 0;
+                }
+
                 hl_js_track_route(js, route);
-                kl_router_add(router, method_str, pattern,
-                              hl_js_keel_handler, route, NULL);
+                if (is_streaming) {
+                    kl_router_add_streaming_async(router, method_str, pattern,
+                                                  hl_js_keel_handler, route,
+                                                  hl_js_multipart_factory);
+                } else {
+                    kl_router_add(router, method_str, pattern,
+                                  hl_js_keel_handler, route, NULL);
+                }
             }
         }
 
         if (pattern) JS_FreeCString(ctx, pattern);
         if (method_str) JS_FreeCString(ctx, method_str);
+        JS_FreeValue(ctx, mp_val);
         JS_FreeValue(ctx, id_val);
         JS_FreeValue(ctx, pattern_val);
         JS_FreeValue(ctx, method_val);

--- a/src/hull/runtime/lua/routes.c
+++ b/src/hull/runtime/lua/routes.c
@@ -76,6 +76,13 @@ int hl_lua_track_alloc(HlLua *lua, void ***arr, size_t *count,
 
 /* ── Route wiring ──────────────────────────────────────────────────── */
 
+/* Defined below; forward-declared so the router (test-harness) wiring can
+ * register streaming-multipart routes the same way the server wiring does. */
+static KlMultipartConfig *lua_build_multipart_config(HlLua *lua);
+static KlBodyReader *hl_lua_multipart_factory(KlAllocator *alloc,
+                                              const KlRequest *req,
+                                              void *user_data);
+
 int hl_lua_wire_routes(HlLua *lua, KlRouter *router)
 {
     lua_State *L = lua->L;
@@ -116,8 +123,29 @@ int hl_lua_wire_routes(HlLua *lua, KlRouter *router)
                 route->lua = lua;
                 route->handler_id = handler_id;
                 route->multipart_config = NULL;
+
+                /* Peek def.multipart — present → streaming route. Mirror the
+                 * server path (hl_lua_wire_routes_server) so req:multipart()
+                 * resolves under `hull test`. The in-process harness pre-feeds
+                 * the whole body to this factory's wrapper (hl_cap_test_dispatch),
+                 * so the handler iterates synchronously without a live socket. */
+                lua_getfield(L, -4, "multipart");
+                int is_streaming = lua_istable(L, -1);
+                if (is_streaming) {
+                    route->multipart_config = lua_build_multipart_config(lua);
+                    if (!route->multipart_config) is_streaming = 0;
+                }
+                lua_pop(L, 1); /* multipart subtable */
+
                 if (hl_lua_track_route(lua, route) != 0) {
+                    if (route->multipart_config)
+                        hl_alloc_free(lua->base.alloc, route->multipart_config,
+                                      sizeof(KlMultipartConfig));
                     hl_alloc_free(lua->base.alloc, route, sizeof(HlLuaRoute));
+                } else if (is_streaming) {
+                    kl_router_add_streaming_async(router, method_str, pattern,
+                                                  hl_lua_keel_handler, route,
+                                                  hl_lua_multipart_factory);
                 } else {
                     kl_router_add(router, method_str, pattern,
                                   hl_lua_keel_handler, route, NULL);

--- a/tests/e2e_test_harness.sh
+++ b/tests/e2e_test_harness.sh
@@ -1,0 +1,179 @@
+#!/bin/sh
+# e2e_test_harness.sh — the in-process `hull test` harness exposes the same
+# fs sandbox as `hull dev`, and supports streaming multipart bodies.
+#
+# Regression guard for the nexogen asset-tracker PLATFORM_GAPS 2026-07-13
+# ("Blob storage unavailable in hull test" + "no multipart in test.post"):
+#
+#   - blob.init / fs.* work under `hull test` (rt->fs_cfg is now wired from
+#     the manifest by the shared HlAppContext, mirroring the serve path).
+#   - req:multipart() / req.multipart() work in the in-process dispatch: the
+#     harness pre-feeds the whole synthetic body to the route's multipart
+#     wrapper, so a well-formed body drives the iterator to DONE without a
+#     live socket. Previously it raised "no active connection".
+#
+# Both are checked in Lua AND JS.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -e
+
+HULL="${HULL:-build/hull}"
+case "$HULL" in
+    /*) ;;
+    *)  HULL="$(pwd)/$HULL" ;;
+esac
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1${2:+ — $2}"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ── Lua fixture ──────────────────────────────────────────────────────
+mkdir -p "$TMP/lua/tests"
+cat > "$TMP/lua/app.lua" <<'LUA'
+local crypto = require("hull.crypto")
+app.manifest({
+    modules = { "hull/http-server@1", "hull/blob@1", "hull/crypto@1" },
+    fs = { write = { "data/blobs" } },
+})
+app.post("/upload", function(req, res)
+    local fields, files = {}, {}
+    for part in req:multipart() do
+        if part.filename then
+            local buf = {}
+            for chunk in part:chunks() do buf[#buf + 1] = chunk end
+            files[part.name] = { filename = part.filename,
+                                 sha = crypto.sha256(table.concat(buf)) }
+        else
+            fields[part.name] = part:read()
+        end
+    end
+    res:json({ fields = fields, files = files })
+end, { multipart = { max_part_size = 1024 * 1024, max_parts = 8 } })
+LUA
+cat > "$TMP/lua/tests/test_harness.lua" <<'LUA'
+local blob = require("hull.blob")
+local crypto = require("hull.crypto")
+
+test("blob round-trip under hull test (fs_cfg wired)", function()
+    blob.init({ dir = "data/blobs" })
+    local id = blob.put("hello nexogen")
+    test.ok(id ~= nil, "put returns id")
+    test.eq(blob.get(id), "hello nexogen")
+    test.ok(blob.exists(id), "exists after put")
+end)
+
+test("multipart upload in the in-process dispatch", function()
+    local B = "X7HULLBOUNDARY"
+    local body = table.concat({
+        "--" .. B, 'Content-Disposition: form-data; name="title"', "",
+        "Nexogen Asset", "--" .. B,
+        'Content-Disposition: form-data; name="doc"; filename="a.txt"',
+        "Content-Type: text/plain", "", "hello file", "--" .. B .. "--", "",
+    }, "\r\n")
+    local r = test.post("/upload", {
+        body = body,
+        headers = { ["content-type"] = "multipart/form-data; boundary=" .. B },
+    })
+    test.eq(r.status, 200)
+    test.eq(r.json.fields.title, "Nexogen Asset")
+    test.eq(r.json.files.doc.filename, "a.txt")
+    test.eq(r.json.files.doc.sha, crypto.sha256("hello file"))
+end)
+LUA
+
+# ── JS fixture ───────────────────────────────────────────────────────
+mkdir -p "$TMP/js/tests"
+cat > "$TMP/js/app.js" <<'JS'
+import { app } from "hull:app";
+import { crypto } from "hull:crypto";
+app.manifest({
+    modules: ["hull/http-server@1", "hull/blob@1", "hull/crypto@1"],
+    fs: { write: ["data/blobs"] },
+});
+app.post("/upload", async (req, res) => {
+    const fields = {}, files = {};
+    for await (const part of req.multipart()) {
+        if (part.filename) {
+            const chunks = [];
+            for await (const c of part.chunks()) chunks.push(new Uint8Array(c));
+            let total = 0; for (const c of chunks) total += c.length;
+            const all = new Uint8Array(total); let o = 0;
+            for (const c of chunks) { all.set(c, o); o += c.length; }
+            files[part.name] = { filename: part.filename, sha: crypto.sha256(all.buffer) };
+        } else {
+            const buf = await part.read();
+            const u = new Uint8Array(buf); let s = "";
+            for (let i = 0; i < u.length; i++) s += String.fromCharCode(u[i]);
+            fields[part.name] = s;
+        }
+    }
+    res.json({ fields, files });
+}, { multipart: { maxPartSize: 1024 * 1024, maxParts: 8 } });
+JS
+cat > "$TMP/js/tests/test_harness.js" <<'JS'
+import { blob } from "hull:blob";
+import { crypto } from "hull:crypto";
+
+test("blob round-trip under hull test (fs_cfg wired)", () => {
+    blob.init({ dir: "data/blobs" });
+    const { id } = blob.put("hello nexogen");   // JS put → { id, size }
+    test.ok(id, "put returns id");
+    test.ok(blob.exists(id), "exists after put");
+    const bytes = new Uint8Array(blob.get(id));
+    test.eq(bytes.length, 13, "13 bytes round-tripped");
+});
+
+test("multipart upload in the in-process dispatch", () => {
+    const B = "X7HULLBOUNDARY";
+    const body = [
+        "--" + B, 'Content-Disposition: form-data; name="title"', "",
+        "Nexogen Asset", "--" + B,
+        'Content-Disposition: form-data; name="doc"; filename="a.txt"',
+        "Content-Type: text/plain", "", "hello file", "--" + B + "--", "",
+    ].join("\r\n");
+    const r = test.post("/upload", {
+        body,
+        headers: { "content-type": "multipart/form-data; boundary=" + B },
+    });
+    test.eq(r.status, 200);
+    test.eq(r.json.fields.title, "Nexogen Asset");
+    test.eq(r.json.files.doc.filename, "a.txt");
+    test.eq(r.json.files.doc.sha, crypto.sha256("hello file"));
+});
+JS
+
+check_runtime() {
+    label="$1"; dir="$2"
+    out="$("$HULL" test "$dir" 2>&1)" || true
+    # Every test must pass; a "no active connection" / "fs config unavailable"
+    # regression shows up as a FAIL line.
+    case "$out" in
+        *"no active connection"*) fail "$label: multipart in test" "raised 'no active connection'"; echo "$out"; return ;;
+        *"fs config unavailable"*) fail "$label: blob in test" "raised 'fs config unavailable'"; echo "$out"; return ;;
+    esac
+    # 2 tests in the fixture; require both green and none failed.
+    case "$out" in
+        *"2/2 tests passed"*)
+            case "$out" in
+                *"FAIL"*) fail "$label" "a test FAILed"; echo "$out" ;;
+                *)        pass "$label: blob + multipart under hull test" ;;
+            esac ;;
+        *) fail "$label" "did not see 2/2 tests passed"; echo "$out" ;;
+    esac
+}
+
+echo "== Lua =="
+check_runtime "lua" "$TMP/lua"
+echo "== JS =="
+check_runtime "js" "$TMP/js"
+
+echo ""
+echo "=== Summary ==="
+echo "PASSED: $PASS"
+echo "FAILED: $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes two of the nexogen asset-tracker `PLATFORM_GAPS.md` items (2026-07-13, "Blob storage unavailable in `hull test`" + "no multipart in `test.post`"). The in-process test harness now exposes the same fs sandbox as `hull dev` **and** supports streaming multipart bodies — in **both** runtimes.

### 2a — fs capability under `hull test` / `hull agent`
The shared `HlAppContext` extracted the manifest but wired only the module set; `rt->fs_cfg` stayed `NULL`, so `blob.init` / `fs.read/write` / `fs.mmap` failed with `fs config unavailable`. It now wires `rt->fs_cfg` from the manifest (`base_dir = app_dir`) whenever the app declares `fs.read`/`fs.write`, mirroring `serve.c::hl_serve_wire_caps`. The cap layer sandboxes to `base_dir` + rejects traversal; the per-path allowlist is the kernel sandbox (which the harness runs without). `app_dir` is copied onto the context so the borrow outlives the runtime.

### 2b — streaming multipart in the synthetic dispatch
Two halves:
- **Route wiring:** the test-harness path (`hl_{lua,js}_wire_routes`, a bare `KlRouter`) registered every route with plain `kl_router_add`, so a `{ multipart }` route was never flagged streaming and `req:multipart()` was nil. It now peeks `def.multipart` and registers via `kl_router_add_streaming_async` with the same factory the server path uses.
- **Body feed:** `hl_cap_test_dispatch` matches the route and, for a streaming one, reconstructs the multipart wrapper via the route's own factory, pre-feeds the **whole** synthetic body + `on_complete` before dispatch, and hands it to the handler as `req.body_reader`. Because Keel's `body_reader_multipart` returns `DONE` (not `NEED_DATA`) once the stream has ended, a well-formed body drives the iterator straight to completion — **no park / yield, no live socket** (previously it raised `no active connection`). Zero changes to the runtime multipart bindings; the live-server park path is untouched.

### Regression guard
`tests/e2e_test_harness.sh` drives a `blob.init` round-trip + a multipart upload (fields + file chunks + byte-fidelity SHA) through `hull test` in Lua **and** JS. Wired as `make e2e-test-harness` + a CI step.

### Validation
`make test` 62/62; `e2e-test-harness` 2/2 both runtimes; live `e2e-multipart` 94/94 (server park path intact); `hull test` on `rest_api`/`hello` (both runtimes) + `todo` (Lua) unchanged.

Remaining nexogen gap after this: server-side PDF generation (`hull/pdf@1`) — a separate scope/product decision (pure-Lua minimal writer as stdlib vs a vendored HTML→PDF engine as a feature).
