### PR TITLE
feat(jobs): v1.1 - durable cron + intra-process concurrency

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -164,6 +164,41 @@ jobs.cleanup({ older_than = 7 * 86400 })   -- purge terminal (done + dead) rows 
 ```
 `jobs.cancel` only removes a `pending` job (a delayed/scheduled one that hasn't
 started); a `running` job is mid-flight and is left to finish or dead-letter.
+
+## Compute-heavy jobs (WASM / GPU)
+
+A handler is ordinary app code, so it has full capability access - `compute.*`
+(WASM), `gpu.*`, `db.async.*`, `http.fetch`, everything the app's manifest
+grants. Offloading heavy work to a background job is a natural fit. Five things
+to get right (these are general compute-orchestration rules, not jobs-specific,
+but the visibility timeout makes the last one sharper):
+
+- **Use the async variants.** `compute.async.call` / `gpu.async.dispatch` yield
+  to the event loop; `compute.call` / `gpu.dispatch` **block** the single
+  event-loop thread for the whole computation, stalling every other concurrent
+  loop, timer, and (if the process also serves) HTTP request. With
+  `run_worker({ concurrency = N })` this matters more - one sync compute call
+  freezes the other N-1 loops.
+- **Parallelism is bounded by the thread pool, not by `concurrency`.**
+  `compute.async` / `gpu.async` / `db.async` all dispatch to one shared worker
+  pool; `concurrency = 32` firing async compute still only runs pool-size jobs on
+  hardware at once.
+- **Reference large inputs, don't inline them.** Payloads are JSON text, so a big
+  binary compute input would be base64-bloated. Store it (fs / blob / db) and put
+  a path/key in the payload; the handler loads it and feeds compute via the
+  zero-copy buffer protocol (`fs.mmap`, `WasmBuffer`).
+- **Jobs are fire-and-forget - persist the result.** There is no result backend;
+  a compute job that produces output must write it somewhere (db / blob) for the
+  enqueuer to read later. If you need the result inline, call `compute.async` in
+  the request handler instead of enqueuing a job.
+- **Mind the visibility timeout.** A compute job that runs longer than
+  `visibility_timeout` (default 300s) is presumed orphaned and re-run. For
+  multi-minute WASM/GPU work, raise `visibility_timeout` accordingly (a per-job
+  heartbeat is a tracked follow-up).
+
+Declare the modules (`hull/compute` + ship `compute/*.wasm`; `hull/gpu` +
+`manifest.gpu = true` for the sandbox grants), and `require`/`import` them -
+`compute` and `gpu` are modules, not globals.
 Run `jobs.cleanup` from `app.daily` to bound table growth; it only touches
 terminal rows, so it never races a live job. JS: `jobs.cleanup({ olderThan: ... })`.
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -156,12 +156,20 @@ camelCase (`runAt`, `maxAttempts`, `dedupKey`).
 ## Ops surface
 
 ```lua
+jobs.get(id)                  -- one job's full status view, or nil if it doesn't exist
 jobs.stats()                  -- { pending, running, done, dead } (opts.queue to scope)
 jobs.dead({ limit = 50 })     -- list dead-lettered jobs (newest first) for inspection
 jobs.retry(id)                -- requeue a dead job with a fresh attempt budget; false if not dead
 jobs.cancel(id)               -- delete a still-pending (e.g. delayed) job; false if not pending
 jobs.cleanup({ older_than = 7 * 86400 })   -- purge terminal (done + dead) rows past a retention age
 ```
+`jobs.get(id)` is the "did my job run?" primitive: after `local id =
+jobs.enqueue(...)`, poll `jobs.get(id).status` (`pending` → `running` → `done` /
+`dead`). It's the only way to inspect an individual job from app code -
+`_hull_jobs` is namespace-protected, so a direct query is blocked. Jobs are
+fire-and-forget (no result backend), so a job that produces output must persist
+it itself; poll `get(id)` only for the terminal *status*.
+
 `jobs.cancel` only removes a `pending` job (a delayed/scheduled one that hasn't
 started); a `running` job is mid-flight and is left to finish or dead-letter.
 
@@ -191,10 +199,25 @@ but the visibility timeout makes the last one sharper):
   a compute job that produces output must write it somewhere (db / blob) for the
   enqueuer to read later. If you need the result inline, call `compute.async` in
   the request handler instead of enqueuing a job.
-- **Mind the visibility timeout.** A compute job that runs longer than
-  `visibility_timeout` (default 300s) is presumed orphaned and re-run. For
-  multi-minute WASM/GPU work, raise `visibility_timeout` accordingly (a per-job
-  heartbeat is a tracked follow-up).
+- **Heartbeat long jobs.** A job that runs longer than `visibility_timeout`
+  (default 300s) is presumed orphaned and re-run. A long WASM/GPU handler should
+  call `jobs.heartbeat(job)` periodically (at least every `visibility_timeout/2`
+  s) to extend its claim. It returns `false` once the claim has been lost (the
+  reaper already reclaimed it, or another worker re-claimed it) - the handler's
+  signal to stop and let the other runner win, avoiding a double-run:
+
+  ```lua
+  jobs.handler("transcode", function(job)
+      for _, chunk in ipairs(chunks(job.data)) do
+          process(chunk)                       -- long, per-chunk work
+          if not jobs.heartbeat(job) then      -- lost the claim -> abort
+              return jobs.DEAD
+          end
+      end
+  end)
+  ```
+  (Or just raise `visibility_timeout` at `jobs.init` if the handler can't
+  checkpoint.)
 
 Declare the modules (`hull/compute` + ship `compute/*.wasm`; `hull/gpu` +
 `manifest.gpu = true` for the sandbox grants), and `require`/`import` them -

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -76,6 +76,50 @@ hull jobs worker worker.lua -d ./app.db  # resolves the entry, runs its app.main
 `hull jobs worker [entry|dir] [-d DSN] [args...]` resolves the entry (a file
 as-is; a directory -> `app.lua`|`app.js`) and forwards the rest to the app.
 
+**Intra-process concurrency.** `run_worker({ concurrency = N })` runs N
+independent claim-loops in one process, so up to N handlers are in flight at
+once - real parallelism for I/O-bound handlers (each loop claims disjoint jobs
+via the atomic claim). It's orthogonal to running K processes; the two multiply
+(K processes x N concurrency). Leave it at 1 for CPU-bound handlers (more
+processes scale those better).
+
+```lua
+app.main(function() jobs.init(); jobs.run_worker({ concurrency = 8 }) end)
+```
+
+## Recurring jobs (cron)
+
+`jobs.cron(name, spec, data?, opts?)` registers a **durable** recurring
+schedule: on each matching minute, exactly one worker enqueues a job. Schedules
+live in the DB (`_hull_cron`), so they survive restarts and coordinate across
+the fleet (a compare-and-set on the schedule row - no double-fire even with many
+workers). A worker (an `app.every` poller or `run_worker`) must be running to
+fire them.
+
+```lua
+jobs.init()
+jobs.handler("nightly_report", function(job) build_report(job.data) end)
+
+jobs.cron("nightly_report", "0 2 * * *", { region = "us" })   -- 02:00 UTC daily
+jobs.cron("heartbeat", "*/5 * * * *")                          -- every 5 minutes
+jobs.uncron("heartbeat")                                       -- remove a schedule
+```
+```javascript
+jobs.cron("nightly_report", "0 2 * * *", { region: "us" });
+jobs.cron("heartbeat", "*/5 * * * *");
+jobs.uncron("heartbeat");
+```
+
+- **`name`** is the schedule id and, by default, the enqueued **job type**
+  (override with `opts.type`). Re-registering the same `name` updates it.
+- **`spec`** is standard 5-field cron - `minute hour day-of-month month
+  day-of-week` - in **UTC**. Supports `*`, `n`, `a-b`, `*/step`, `a-b/step`, and
+  comma lists; `day-of-week` is `0`/`7` = Sunday. When both day-of-month and
+  day-of-week are restricted, a match on **either** fires (standard cron).
+- **`opts`**: `type`, `queue`, `priority`, `max_attempts` for the enqueued jobs.
+- **Missed ticks** (all workers were down) advance to the next future occurrence
+  - fire-once, no backfill storm.
+
 ## Handler contract
 
 `jobs.work` dispatches each claimed job to its registered handler, else the
@@ -149,8 +193,8 @@ terminal rows, so it never races a live job. JS: `jobs.cleanup({ olderThan: ... 
 | `backoff(attempt)` | `2^n·10s` cap 1h | retry-delay function |
 
 `jobs.work` / `jobs.run_worker` take `{ queue, batch, visibility_timeout, poll_ms }`;
-`jobs.run_worker` also accepts `{ drain, max_empty_polls }` for bounded / batch-drain
-runs and `jobs.stop()` for graceful shutdown.
+`jobs.run_worker` also accepts `{ concurrency, drain, max_empty_polls }` (N in-flight
+handlers; bounded / batch-drain runs) and `jobs.stop()` for graceful shutdown.
 
 ## Backend notes
 

--- a/src/hull/runtime/lua/async.c
+++ b/src/hull/runtime/lua/async.c
@@ -351,10 +351,67 @@ static int lua_hull_sleep(lua_State *L)
     return lua_yieldk(L, 0, 0, NULL);
 }
 
+/* hull.async(fn) — spawn fn in a detached coroutine running on the event loop.
+ * The body may call async-yielding primitives (hull.sleep, compute.async,
+ * http.fetch, db.async); those capture `lua->active_co` at suspension, so we
+ * set active_co (+ dispatch bookkeeping) to the bg coroutine for its first
+ * resume. Subsequent resumes go through hl_lua_async_resume, which sets it
+ * itself. A registry ref keeps the coroutine alive until it returns (here on a
+ * synchronous finish, or later in hl_lua_async_resume's OK/error branches).
+ *
+ * Detached = fire-and-forget (no join). Used by jobs.run_worker's concurrency
+ * (N in-flight claim-loops) and by hull.tui (tui.async aliases this). */
+int lua_hull_async(lua_State *L)
+{
+    luaL_checktype(L, 1, LUA_TFUNCTION);
+
+    lua_getfield(L, LUA_REGISTRYINDEX, "__hull_lua");
+    HlLua *lua = (HlLua *)lua_touserdata(L, -1);
+    lua_pop(L, 1);
+    if (!lua)
+        return luaL_error(L, "hull.async: no runtime context");
+
+    lua_State *co = lua_newthread(L);
+    int co_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+
+    lua_pushvalue(L, 1);
+    lua_xmove(L, co, 1);
+
+    lua_State *saved_co         = lua->active_co;
+    int        saved_thread_ref = lua->active_thread_ref;
+    KlConn    *saved_conn       = lua->active_conn;
+
+    lua->active_co         = co;
+    lua->active_thread_ref = co_ref;
+    lua->active_conn       = NULL;  /* bg is always detached */
+    lua->dispatch_depth++;
+
+    int nres = 0;
+    int sr   = lua_resume(co, L, 0, &nres);
+
+    if (sr == LUA_OK) {
+        luaL_unref(L, LUA_REGISTRYINDEX, co_ref);
+        lua->dispatch_depth--;
+    } else if (sr == LUA_YIELD) {
+        /* Bg yielded; hl_lua_async_resume owns cleanup when it returns. */
+    } else {
+        const char *msg = lua_tostring(co, -1);
+        log_error("[hull:async] coroutine error: %s", msg ? msg : "(unknown)");
+        luaL_unref(L, LUA_REGISTRYINDEX, co_ref);
+        lua->dispatch_depth--;
+    }
+
+    lua->active_co         = saved_co;
+    lua->active_thread_ref = saved_thread_ref;
+    lua->active_conn       = saved_conn;
+    return 0;
+}
+
 /* ── Module registration ──────────────────────────────────────────── */
 
 static const luaL_Reg hull_funcs[] = {
     {"sleep", lua_hull_sleep},
+    {"async", lua_hull_async},
     {NULL, NULL}
 };
 

--- a/src/hull/runtime/lua/internal.h
+++ b/src/hull/runtime/lua/internal.h
@@ -115,6 +115,10 @@ struct HlLuaSseRoute {
  * Lua instruction-count hook (gas metering). */
 void hl_lua_instruction_hook(lua_State *L, lua_Debug *ar);
 
+/* hull.async(fn): spawn a detached coroutine on the event loop (async.c).
+ * Shared by the `hull` global and hull.tui's `tui.async` alias. */
+int lua_hull_async(lua_State *L);
+
 /* ── Promoted: defined in timers.c, used in routes.c (initial schedule
  * during wire_routes_server) and from within timers.c itself. */
 int64_t hl_compute_daily_delay_ms(int hour, int minute, int use_local);

--- a/src/hull/runtime/lua/mod_tui.c
+++ b/src/hull/runtime/lua/mod_tui.c
@@ -467,82 +467,6 @@ static int lua_tui_enable_kitty_kbd(lua_State *L)
     return 0;
 }
 
-/* ── Async helper ──────────────────────────────────────────────── */
-
-/* tui.async(fn) — spawn fn in a detached coroutine running on the
- * event loop. Lives under hull.tui (not hull.*) because TUI is its
- * only caller today; promote to hull.async if another consumer
- * shows up.
- *
- * The body might call async-yielding primitives (hull.sleep,
- * compute.async, http.fetch). Those primitives capture
- * `lua->active_co` at suspension time as the coroutine they should
- * resume — so we MUST set active_co (and the matching dispatch
- * bookkeeping) to the bg coroutine for the duration of its first
- * resume. Subsequent resumes happen via hl_lua_async_resume which
- * sets active_co correctly itself.
- *
- * We hold a registry ref so the new coroutine survives GC until it
- * either returns synchronously here, or yields and is later
- * cleaned up by hl_lua_async_resume's LUA_OK / error branches
- * (which already unref + decrement dispatch_depth). */
-static int lua_tui_async(lua_State *L)
-{
-    luaL_checktype(L, 1, LUA_TFUNCTION);
-
-    lua_getfield(L, LUA_REGISTRYINDEX, "__hull_lua");
-    HlLua *lua = (HlLua *)lua_touserdata(L, -1);
-    lua_pop(L, 1);
-    if (!lua)
-        return luaL_error(L, "tui.async: no runtime context");
-
-    /* Create + ref the new coroutine. */
-    lua_State *co = lua_newthread(L);
-    int co_ref = luaL_ref(L, LUA_REGISTRYINDEX);
-
-    /* Move the user function onto the new coroutine's stack. */
-    lua_pushvalue(L, 1);
-    lua_xmove(L, co, 1);
-
-    /* Save caller's dispatch state so we can restore it after the
-     * first resume (whether the bg yields or completes). */
-    lua_State *saved_co         = lua->active_co;
-    int        saved_thread_ref = lua->active_thread_ref;
-    KlConn    *saved_conn       = lua->active_conn;
-
-    lua->active_co         = co;
-    lua->active_thread_ref = co_ref;
-    lua->active_conn       = NULL;  /* bg is always detached */
-    lua->dispatch_depth++;
-
-    int nres = 0;
-    int sr   = lua_resume(co, L, 0, &nres);
-
-    if (sr == LUA_OK) {
-        /* Completed synchronously — unref + balance dispatch. */
-        luaL_unref(L, LUA_REGISTRYINDEX, co_ref);
-        lua->dispatch_depth--;
-    } else if (sr == LUA_YIELD) {
-        /* Bg yielded. The async machinery captured (co_ref, co) on
-         * the suspension's cont; cleanup happens in
-         * hl_lua_async_resume when the bg finally returns. We just
-         * restore the caller's state below. */
-    } else {
-        /* Error on first dispatch. Log + unref + balance. */
-        const char *msg = lua_tostring(co, -1);
-        log_error("[hull:tui] tui.async coroutine error: %s",
-                  msg ? msg : "(unknown)");
-        luaL_unref(L, LUA_REGISTRYINDEX, co_ref);
-        lua->dispatch_depth--;
-    }
-
-    /* Restore caller's dispatch state. */
-    lua->active_co         = saved_co;
-    lua->active_thread_ref = saved_thread_ref;
-    lua->active_conn       = saved_conn;
-    return 0;
-}
-
 /* ── Module table ──────────────────────────────────────────────── */
 
 static const luaL_Reg tui_funcs[] = {
@@ -569,7 +493,7 @@ static const luaL_Reg tui_funcs[] = {
     {"enable_focus",     lua_tui_enable_focus},
     {"enable_kitty_kbd", lua_tui_enable_kitty_kbd},
 
-    {"async",            lua_tui_async},
+    {"async",            lua_hull_async},   /* shared primitive (async.c) */
 
     {NULL, NULL}
 };

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -15,7 +15,7 @@
  * Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
  * catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
  * visibility-timeout reaper), the dedicated worker (jobs.runWorker +
- * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup).
+ * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N).
  *
  * @license AGPL-3.0-or-later
  */
@@ -107,6 +107,23 @@ function init(opts) {
     db.exec(
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_hull_jobs_dedup " +
         "ON _hull_jobs(queue, dedup_key)");
+
+    // Durable cron schedules (jobs.cron). A worker atomically advances a due
+    // row's next_run_at (compare-and-set) and enqueues, so exactly one worker
+    // fires each tick across the fleet.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_cron (" +
+        "name         VARCHAR(255) NOT NULL PRIMARY KEY," +
+        "spec         VARCHAR(255) NOT NULL," +
+        "type         VARCHAR(255) NOT NULL," +
+        "payload      TEXT," +
+        "queue        VARCHAR(255) NOT NULL DEFAULT 'default'," +
+        "priority     INTEGER      NOT NULL DEFAULT 0," +
+        "max_attempts INTEGER," +
+        "next_run_at  INTEGER      NOT NULL," +
+        "last_run_at  INTEGER," +
+        "updated_at   INTEGER      NOT NULL)");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_hull_cron_due ON _hull_cron(next_run_at)");
 
     return jobs;
 }
@@ -289,6 +306,159 @@ function reap(opts) {
         [now, now - vt]) || 0;
 }
 
+// ── Cron (durable recurring schedules) ──────────────────────────────────────
+
+// Broken-down UTC calendar from a unix ts (civil algorithm; no Date/gmtime
+// dependency, so it's identical across backends and platforms).
+function civilFromDays(z) {
+    z += 719468;
+    const era = Math.floor((z >= 0 ? z : z - 146096) / 146097);
+    const doe = z - era * 146097;
+    const yoe = Math.floor((doe - Math.floor(doe / 1460) + Math.floor(doe / 36524)
+                - Math.floor(doe / 146096)) / 365);
+    const y = yoe + era * 400;
+    const doy = doe - (365 * yoe + Math.floor(yoe / 4) - Math.floor(yoe / 100));
+    const mp = Math.floor((5 * doy + 2) / 153);
+    const d = doy - Math.floor((153 * mp + 2) / 5) + 1;
+    const m = mp < 10 ? mp + 3 : mp - 9;
+    return { year: y + (m <= 2 ? 1 : 0), month: m, day: d };
+}
+
+function decodeTs(ts) {
+    const days = Math.floor(ts / 86400);
+    const secs = ts - days * 86400;
+    const c = civilFromDays(days);
+    return { month: c.month, day: c.day, hour: Math.floor(secs / 3600),
+             minute: Math.floor((secs % 3600) / 60), dow: ((days % 7) + 4) % 7 };
+}
+
+// Parse one cron field into a Set over [lo,hi]. Supports *, n, a-b, */s, a-b/s,
+// and comma lists. Returns null on any malformed / out-of-range part.
+function parseField(f, lo, hi) {
+    const set = new Set();
+    for (const part of f.split(",")) {
+        const m = part.match(/^([^/]+)\/(\d+)$/);
+        const step = m ? parseInt(m[2], 10) : 1;
+        const range = m ? m[1] : part;
+        let a, b;
+        if (range === "*") { a = lo; b = hi; }
+        else {
+            const r = range.match(/^(\d+)-(\d+)$/);
+            if (r) { a = parseInt(r[1], 10); b = parseInt(r[2], 10); }
+            else { a = parseInt(range, 10); b = a; }
+        }
+        if (!Number.isFinite(a) || !Number.isFinite(b) || step < 1 || a < lo || b > hi || a > b) return null;
+        for (let v = a; v <= b; v += step) set.add(v);
+    }
+    return set;
+}
+
+// Parse a 5-field cron spec (min hour dom month dow; dow 0/7=Sunday).
+function parseCron(spec) {
+    if (typeof spec !== "string") return null;
+    const f = spec.trim().split(/\s+/);
+    if (f.length !== 5) return null;
+    const min = parseField(f[0], 0, 59), hour = parseField(f[1], 0, 23);
+    const dom = parseField(f[2], 1, 31), month = parseField(f[3], 1, 12);
+    const dow = parseField(f[4], 0, 7);
+    if (!min || !hour || !dom || !month || !dow) return null;
+    if (dow.has(7)) { dow.add(0); dow.delete(7); }
+    return { min, hour, dom, month, dow, domStar: f[2] === "*", dowStar: f[4] === "*" };
+}
+
+// Smallest unix ts strictly after `fromTs` whose UTC time matches `c`.
+function cronNext(c, fromTs) {
+    let t = Math.floor(fromTs / 60) * 60 + 60;
+    for (let i = 0; i < 200000; i++) {
+        const { month, day, hour, minute, dow } = decodeTs(t);
+        if (!c.month.has(month)) { t = (Math.floor(t / 86400) + 1) * 86400; continue; }
+        let dayOk;
+        if (c.domStar && c.dowStar) dayOk = true;
+        else if (c.domStar) dayOk = c.dow.has(dow);
+        else if (c.dowStar) dayOk = c.dom.has(day);
+        else dayOk = c.dom.has(day) || c.dow.has(dow);
+        if (!dayOk) { t = (Math.floor(t / 86400) + 1) * 86400; continue; }
+        if (!c.hour.has(hour)) { t = (Math.floor(t / 3600) + 1) * 3600; continue; }
+        if (!c.min.has(minute)) { t += 60; continue; }
+        return t;
+    }
+    return null;
+}
+
+// Fire due schedules: compare-and-set next_run_at (multi-worker-safe on every
+// backend), then enqueue. Missed ticks advance to the next future occurrence
+// (fire-once, no backfill). Called (throttled) from work().
+function processCron(now) {
+    const due = db.query(
+        "SELECT name, spec, type, payload, queue, priority, max_attempts, next_run_at " +
+        "FROM _hull_cron WHERE next_run_at <= ?", [now]);
+    for (const c of due) {
+        const parsed = parseCron(c.spec);
+        const nxt = parsed ? cronNext(parsed, now) : (now + 60);
+        const won = db.exec(
+            "UPDATE _hull_cron SET next_run_at=?, last_run_at=?, updated_at=? " +
+            "WHERE name=? AND next_run_at=?",
+            [nxt, now, now, c.name, c.next_run_at]);
+        if ((won || 0) > 0) {
+            let data = null;
+            if (c.payload) { try { data = json.decode(c.payload); } catch (_e) { data = null; } }
+            enqueue(c.type, data, {
+                queue: c.queue, priority: c.priority,
+                // NULL (no override) -> undefined so enqueue applies its default,
+                // not a NULL bind into the NOT-NULL max_attempts column.
+                maxAttempts: c.max_attempts === null ? undefined : c.max_attempts,
+            });
+        }
+    }
+}
+
+/**
+ * Register (or update) a durable recurring schedule. On each matching minute,
+ * exactly one worker enqueues a job (compare-and-set on the schedule row).
+ * Schedules live in the DB, so they survive restarts and coordinate across the
+ * fleet; a worker (poller or runWorker) must be running to fire them.
+ * @param {string} name  unique schedule id; also the enqueued job type by default
+ * @param {string} spec  5-field cron: "min hour dom month dow" (UTC; dow 0/7=Sun)
+ * @param {*} [data]      payload for the enqueued job
+ * @param {object} [opts] { type, queue, priority, maxAttempts }
+ * @returns {object} the jobs module (for chaining)
+ */
+function cron(name, spec, data, opts) {
+    if (typeof name !== "string" || name === "")
+        throw new Error("jobs.cron: name must be a non-empty string");
+    const parsed = parseCron(spec);
+    if (!parsed) throw new Error("jobs.cron: invalid cron spec");
+    const o = opts || {};
+    const now = time.now();
+    const nxt = cronNext(parsed, now);
+    if (nxt === null) throw new Error("jobs.cron: spec has no upcoming occurrence");
+    const jobType = o.type || name;
+    const payload = data !== undefined && data !== null ? json.encode(data) : null;
+    const queue = o.queue || "default";
+    const priority = o.priority || 0;
+    const ma = o.maxAttempts !== undefined ? o.maxAttempts : null;
+    const n = db.exec(
+        "UPDATE _hull_cron SET spec=?, type=?, payload=?, queue=?, priority=?, " +
+        "max_attempts=?, next_run_at=?, updated_at=? WHERE name=?",
+        [spec, jobType, payload, queue, priority, ma, nxt, now, name]);
+    if ((n || 0) === 0) {
+        db.exec(
+            "INSERT INTO _hull_cron (name, spec, type, payload, queue, priority, " +
+            "max_attempts, next_run_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [name, spec, jobType, payload, queue, priority, ma, nxt, now]);
+    }
+    return jobs;
+}
+
+/**
+ * Remove a cron schedule by name. Returns whether a schedule was removed.
+ * @param {string} name
+ * @returns {boolean}
+ */
+function uncron(name) {
+    return (db.exec("DELETE FROM _hull_cron WHERE name=?", [name]) || 0) > 0;
+}
+
 /**
  * Claim a batch and run each job's handler (awaited, so sync and async handlers
  * both work), applying the outcome. Runs the reaper first. Drive from a timer
@@ -305,6 +475,8 @@ async function work(opts) {
     const interval = o.reapInterval !== undefined ? o.reapInterval : _cfg.reapInterval;
     const now = time.now();
     if (now - _lastReap >= interval) { reap(o); _lastReap = now; }
+    // Fire due cron schedules (throttled; cron is minute-grained).
+    if (now - _lastCron >= 1) { processCron(now); _lastCron = now; }
     const batch = claim(o);
     for (const job of batch) {
         const h = _handlers[job.type] || _default;
@@ -327,6 +499,8 @@ let _running = false;
 
 // Unix ts of the last reaper sweep (throttled in work() via _cfg.reapInterval).
 let _lastReap = 0;
+// Unix ts of the last cron due-check (throttled to >=1s; cron is minute-grained).
+let _lastCron = 0;
 
 /**
  * Request the running runWorker loop to stop after the current iteration.
@@ -345,32 +519,47 @@ function stop() {
  * back empty it sleeps `pollMs` (yielding to the event loop, so async handlers
  * and timers keep running). Returns the total jobs processed when the loop exits.
  *
+ * `concurrency` (default 1) runs N independent claim-loops in this one process,
+ * so up to N handlers are in flight at once - real intra-process parallelism for
+ * I/O-bound handlers (each loop's `work` claims disjoint jobs via the atomic
+ * claim). Orthogonal to running K processes; they multiply.
+ *
  * Exit conditions: `jobs.stop()` (graceful), or - for bounded / batch-drain
  * runs - `opts.drain` / `opts.maxEmptyPolls`. With neither, it runs until
  * stopped or the process is signalled (an in-flight job is then reclaimed by
  * the visibility-timeout reaper, since handlers are at-least-once).
- * @param {object} [opts]  { queue, batch, pollMs, visibilityTimeout, drain,
- *                           maxEmptyPolls }
+ * @param {object} [opts]  { queue, batch, concurrency, pollMs,
+ *                           visibilityTimeout, drain, maxEmptyPolls }
  * @returns {Promise<number>}  total jobs processed
  */
 async function runWorker(opts) {
     const o = opts || {};
     const pollMs = o.pollMs !== undefined ? o.pollMs : 1000;
     const maxEmpty = o.maxEmptyPolls !== undefined ? o.maxEmptyPolls : (o.drain ? 1 : 0);
+    const concurrency = (o.concurrency && o.concurrency > 1) ? o.concurrency : 1;
     _running = true;
-    let processed = 0, empty = 0;
-    while (_running) {
-        const n = await work(o);
-        processed += n;
-        if (n === 0) {
-            empty++;
-            if (maxEmpty > 0 && empty >= maxEmpty) break;
-            await hull.sleep(pollMs);
-        } else {
-            empty = 0;
+
+    // One independent claim-loop; returns its own processed count.
+    const loop = async () => {
+        let processed = 0, empty = 0;
+        while (_running) {
+            const n = await work(o);
+            processed += n;
+            if (n === 0) {
+                empty++;
+                if (maxEmpty > 0 && empty >= maxEmpty) break;
+                await hull.sleep(pollMs);
+            } else {
+                empty = 0;
+            }
         }
-    }
-    return processed;
+        return processed;
+    };
+
+    if (concurrency === 1) return loop();
+    // N loops in flight; Promise.all joins them (all exit on stop / drain).
+    const counts = await Promise.all(Array.from({ length: concurrency }, loop));
+    return counts.reduce((a, b) => a + b, 0);
 }
 
 /**
@@ -467,10 +656,18 @@ function cleanup(opts) {
     return db.exec(sql, params) || 0;
 }
 
+// Internal seams for tests / introspection; not part of the app-facing contract.
+function _cronNext(spec, from) {
+    const p = parseCron(spec);
+    return p ? cronNext(p, from !== undefined ? from : time.now()) : null;
+}
+function _tick(now) { processCron(now !== undefined ? now : time.now()); }
+
 export const jobs = {
     init, enqueue, claim, handler, default: setDefault, work, reap, stats,
-    runWorker, stop, dead, retry, cancel, cleanup, RETRY, DEAD, DISCARD, _config: _cfg,
+    runWorker, stop, dead, retry, cancel, cleanup, cron, uncron,
+    RETRY, DEAD, DISCARD, _config: _cfg, _cronNext, _tick,
 };
 export { init, enqueue, claim, handler, work, reap, stats, runWorker, stop,
-         dead, retry, cancel, cleanup };
+         dead, retry, cancel, cleanup, cron, uncron };
 export default jobs;

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -15,7 +15,7 @@
  * Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
  * catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
  * visibility-timeout reaper), the dedicated worker (jobs.runWorker +
- * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N).
+ * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), and jobs.heartbeat for long jobs.
  *
  * @license AGPL-3.0-or-later
  */
@@ -234,7 +234,11 @@ function claim(opts) {
     // don't preserve the subquery's ORDER BY, so sort by priority DESC, id ASC.
     return (rows || [])
         .sort((x, y) => (y.priority || 0) - (x.priority || 0) || (x.id - y.id))
-        .map(shape);
+        .map((r) => {
+            const j = shape(r);
+            j.claimToken = token;   // handle for jobs.heartbeat on long-running work
+            return j;
+        });
 }
 
 // ── Handlers + the work loop ────────────────────────────────────────────
@@ -578,15 +582,53 @@ function stats(opts) {
 }
 
 // Decode an ops row into an inspection view: the handler-facing shape plus the
-// bookkeeping columns an operator needs (queue, lastError, timestamps).
+// bookkeeping columns an operator needs (status, queue, lastError, timestamps).
 function shapeOps(r) {
     const j = shape(r);
+    j.status = r.status;
     j.queue = r.queue;
+    j.priority = r.priority;
     j.attempts = r.attempts;
+    j.runAt = r.run_at;
     j.lastError = r.last_error;
     j.createdAt = r.created_at;
     j.updatedAt = r.updated_at;
     return j;
+}
+
+/**
+ * Fetch a single job by id (its full status view), or null if it doesn't exist.
+ * The only way to inspect an individual job from app code: `_hull_jobs` is in the
+ * protected namespace, so a direct query is blocked. Poll this for a terminal
+ * status (jobs are fire-and-forget; there is no result backend - a handler that
+ * produces output must persist it itself).
+ * @param {number} id
+ * @returns {object|null}
+ */
+function get(id) {
+    const rows = db.query("SELECT * FROM _hull_jobs WHERE id=?", [id]);
+    return rows.length ? shapeOps(rows[0]) : null;
+}
+
+/**
+ * Extend the claim on a job the current handler is processing (heartbeat). A
+ * handler whose work may exceed `visibilityTimeout` should call this
+ * periodically (at least every visibilityTimeout/2 s) so the reaper doesn't
+ * presume it orphaned and re-run it elsewhere. Bumps `claimed_at` only while
+ * THIS worker still owns the claim (guarded by the job's claimToken): returns
+ * false once the claim has been lost (already reaped / re-claimed / finished),
+ * which is the handler's signal to stop and let the other runner win.
+ * @param {object} job  the job object passed to the handler
+ * @returns {boolean}  true if the claim was extended, false if no longer held
+ */
+function heartbeat(job) {
+    if (!job || job.id === undefined || job.claimToken === undefined) return false;
+    const now = time.now();
+    const n = db.exec(
+        "UPDATE _hull_jobs SET claimed_at=?, updated_at=? " +
+        "WHERE id=? AND claim_token=? AND status='running'",
+        [now, now, job.id, job.claimToken]);
+    return (n || 0) > 0;
 }
 
 /**
@@ -665,9 +707,9 @@ function _tick(now) { processCron(now !== undefined ? now : time.now()); }
 
 export const jobs = {
     init, enqueue, claim, handler, default: setDefault, work, reap, stats,
-    runWorker, stop, dead, retry, cancel, cleanup, cron, uncron,
+    runWorker, stop, get, heartbeat, dead, retry, cancel, cleanup, cron, uncron,
     RETRY, DEAD, DISCARD, _config: _cfg, _cronNext, _tick,
 };
 export { init, enqueue, claim, handler, work, reap, stats, runWorker, stop,
-         dead, retry, cancel, cleanup, cron, uncron };
+         get, heartbeat, dead, retry, cancel, cleanup, cron, uncron };
 export default jobs;

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -11,7 +11,7 @@
 -- Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
 -- catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
 -- visibility-timeout reaper), the dedicated worker (jobs.run_worker +
--- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N).
+-- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), and jobs.heartbeat for long jobs.
 --
 -- Usage (target shape):
 --   local jobs = require("hull.jobs")
@@ -268,7 +268,11 @@ function jobs.claim(opts)
     end)
 
     local out = {}
-    for _, r in ipairs(rows) do out[#out + 1] = shape(r) end
+    for _, r in ipairs(rows) do
+        local j = shape(r)
+        j.claim_token = token   -- handle for jobs.heartbeat on long-running work
+        out[#out + 1] = j
+    end
     return out
 end
 
@@ -646,15 +650,53 @@ function jobs.stats(opts)
 end
 
 -- Decode an ops row into an inspection view: the handler-facing shape plus the
--- bookkeeping columns an operator needs (queue, last_error, timestamps).
+-- bookkeeping columns an operator needs (status, queue, last_error, timestamps).
 local function shape_ops(r)
     local j = shape(r)
+    j.status     = r.status
     j.queue      = r.queue
+    j.priority   = r.priority
     j.attempts   = r.attempts
+    j.run_at     = r.run_at
     j.last_error = r.last_error
     j.created_at = r.created_at
     j.updated_at = r.updated_at
     return j
+end
+
+--- Fetch a single job by id (its full status view), or nil if it doesn't exist.
+-- The only way to inspect an individual job from app code: `_hull_jobs` is in the
+-- protected namespace, so a direct query is blocked. Poll this for a terminal
+-- status (jobs are fire-and-forget; there is no result backend - a handler that
+-- produces output must persist it itself).
+-- @tparam number id
+-- @treturn table|nil  { id, type, data, status, queue, priority, attempts,
+--                       max_attempts, run_at, last_error, created_at, updated_at }
+function jobs.get(id)
+    local rows = db.query("SELECT * FROM _hull_jobs WHERE id=?", { id })
+    if not rows or #rows == 0 then return nil end
+    return shape_ops(rows[1])
+end
+
+--- Extend the claim on a job the current handler is processing (heartbeat). A
+-- handler whose work may exceed `visibility_timeout` should call this
+-- periodically (at least every visibility_timeout/2 s) so the reaper doesn't
+-- presume it orphaned and re-run it elsewhere. Bumps `claimed_at` only while
+-- THIS worker still owns the claim (guarded by the job's claim_token): returns
+-- false once the claim has been lost (already reaped / re-claimed / finished),
+-- which is the handler's signal to stop and let the other runner win.
+-- @tparam table job  the job object passed to the handler
+-- @treturn boolean  true if the claim was extended, false if it is no longer held
+function jobs.heartbeat(job)
+    if type(job) ~= "table" or job.id == nil or job.claim_token == nil then
+        return false
+    end
+    local now = time.now()
+    local n = db.exec(
+        "UPDATE _hull_jobs SET claimed_at=?, updated_at=? "
+        .. "WHERE id=? AND claim_token=? AND status='running'",
+        { now, now, job.id, job.claim_token })
+    return (n or 0) > 0
 end
 
 --- List dead-lettered jobs (status='dead'), newest first. The ops entry point

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -11,7 +11,7 @@
 -- Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
 -- catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
 -- visibility-timeout reaper), the dedicated worker (jobs.run_worker +
--- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup).
+-- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N).
 --
 -- Usage (target shape):
 --   local jobs = require("hull.jobs")
@@ -59,6 +59,8 @@ local _default = nil
 
 -- Unix ts of the last reaper sweep (throttled in jobs.work via _cfg.reap_interval).
 local _last_reap = 0
+-- Unix ts of the last cron due-check (throttled to >=1s; cron is minute-grained).
+local _last_cron = 0
 
 --- Create the `_hull_jobs` table and its indexes. Idempotent - safe to call on
 -- every boot. Uses the connection's portable identity DDL + IF-NOT-EXISTS index
@@ -115,6 +117,25 @@ function jobs.init(opts)
     db.exec([[
         CREATE UNIQUE INDEX IF NOT EXISTS idx_hull_jobs_dedup
         ON _hull_jobs(queue, dedup_key)
+    ]])
+
+    -- Durable cron schedules (jobs.cron). A worker atomically advances a due
+    -- row's next_run_at (compare-and-set) and enqueues, so exactly one worker
+    -- fires each tick across the fleet.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_cron ("
+        .. "name         VARCHAR(255) NOT NULL PRIMARY KEY,"
+        .. "spec         VARCHAR(255) NOT NULL,"
+        .. "type         VARCHAR(255) NOT NULL,"
+        .. "payload      TEXT,"
+        .. "queue        VARCHAR(255) NOT NULL DEFAULT 'default',"
+        .. "priority     INTEGER      NOT NULL DEFAULT 0,"
+        .. "max_attempts INTEGER,"
+        .. "next_run_at  INTEGER      NOT NULL,"
+        .. "last_run_at  INTEGER,"
+        .. "updated_at   INTEGER      NOT NULL)")
+    db.exec([[
+        CREATE INDEX IF NOT EXISTS idx_hull_cron_due ON _hull_cron(next_run_at)
     ]])
 
     return jobs
@@ -320,6 +341,176 @@ function jobs.reap(opts)
         { now, now - vt }) or 0
 end
 
+-- ── Cron (durable recurring schedules) ─────────────────────────────────────
+
+-- Broken-down UTC calendar from a unix ts (civil algorithm; no os/time-fields
+-- dependency, so it's identical across backends and platforms).
+local function civil_from_days(z)
+    z = z + 719468
+    local era = math.floor((z >= 0 and z or z - 146096) / 146097)
+    local doe = z - era * 146097
+    local yoe = math.floor((doe - math.floor(doe / 1460) + math.floor(doe / 36524)
+                - math.floor(doe / 146096)) / 365)
+    local y = yoe + era * 400
+    local doy = doe - (365 * yoe + math.floor(yoe / 4) - math.floor(yoe / 100))
+    local mp = math.floor((5 * doy + 2) / 153)
+    local d = doy - math.floor((153 * mp + 2) / 5) + 1
+    local m = mp < 10 and mp + 3 or mp - 9
+    return y + (m <= 2 and 1 or 0), m, d
+end
+
+local function decode_ts(ts)
+    local days = math.floor(ts / 86400)
+    local secs = ts - days * 86400
+    local _, month, day = civil_from_days(days)
+    return month, day, math.floor(secs / 3600), math.floor((secs % 3600) / 60),
+           (days % 7 + 4) % 7   -- dow: 0=Sunday
+end
+
+-- Parse one cron field into a set over [lo,hi]. Supports *, n, a-b, */s, a-b/s,
+-- and comma lists of those. Returns nil on any malformed / out-of-range part.
+local function parse_field(f, lo, hi)
+    local set = {}
+    for part in f:gmatch("[^,]+") do
+        local range, step = part:match("^([^/]+)/(%d+)$")
+        step = step and tonumber(step) or 1
+        range = range or part
+        local a, b
+        if range == "*" then
+            a, b = lo, hi
+        else
+            local x, y = range:match("^(%d+)%-(%d+)$")
+            if x then a, b = tonumber(x), tonumber(y) else a = tonumber(range); b = a end
+        end
+        if not a or not b or step < 1 or a < lo or b > hi or a > b then return nil end
+        local v = a
+        while v <= b do set[v] = true; v = v + step end
+    end
+    return set
+end
+
+-- Parse a 5-field cron spec (min hour dom month dow; dow 0/7=Sunday).
+local function parse_cron(spec)
+    if type(spec) ~= "string" then return nil, "cron spec must be a string" end
+    local f = {}
+    for w in spec:gmatch("%S+") do f[#f + 1] = w end
+    if #f ~= 5 then return nil, "cron spec must have 5 fields" end
+    local min   = parse_field(f[1], 0, 59)
+    local hour  = parse_field(f[2], 0, 23)
+    local dom   = parse_field(f[3], 1, 31)
+    local month = parse_field(f[4], 1, 12)
+    local dow   = parse_field(f[5], 0, 7)
+    if not (min and hour and dom and month and dow) then return nil, "invalid cron field" end
+    if dow[7] then dow[0] = true; dow[7] = nil end
+    return { min = min, hour = hour, dom = dom, month = month, dow = dow,
+             dom_star = (f[3] == "*"), dow_star = (f[5] == "*") }
+end
+
+-- Smallest unix ts strictly after `from_ts` whose UTC time matches `c`.
+-- Coarse-to-fine skips (whole day / hour / minute) keep it fast even for rare
+-- specs like "0 0 29 2 *". Returns nil if none within the search bound.
+local function cron_next(c, from_ts)
+    local t = math.floor(from_ts / 60) * 60 + 60
+    for _ = 1, 200000 do
+        local month, day, hour, minute, dow = decode_ts(t)
+        if not c.month[month] then
+            t = (math.floor(t / 86400) + 1) * 86400
+        else
+            local day_ok
+            if c.dom_star and c.dow_star then day_ok = true
+            elseif c.dom_star then day_ok = c.dow[dow]
+            elseif c.dow_star then day_ok = c.dom[day]
+            else day_ok = c.dom[day] or c.dow[dow] end
+            if not day_ok then
+                t = (math.floor(t / 86400) + 1) * 86400
+            elseif not c.hour[hour] then
+                t = (math.floor(t / 3600) + 1) * 3600
+            elseif not c.min[minute] then
+                t = t + 60
+            else
+                return t
+            end
+        end
+    end
+    return nil
+end
+
+-- Fire due schedules: compare-and-set next_run_at (multi-worker-safe on every
+-- backend), then enqueue. Missed ticks (worker down) advance to the next future
+-- occurrence - fire-once, no backfill storm. Called (throttled) from jobs.work.
+local function process_cron(now)
+    local due = db.query(
+        "SELECT name, spec, type, payload, queue, priority, max_attempts, next_run_at "
+        .. "FROM _hull_cron WHERE next_run_at <= ?", { now })
+    for _, c in ipairs(due) do
+        local parsed = parse_cron(c.spec)
+        local nxt = parsed and cron_next(parsed, now) or (now + 60)
+        local won = db.exec(
+            "UPDATE _hull_cron SET next_run_at=?, last_run_at=?, updated_at=? "
+            .. "WHERE name=? AND next_run_at=?",
+            { nxt, now, now, c.name, c.next_run_at })
+        if (won or 0) > 0 then
+            local data
+            if c.payload and c.payload ~= "" then
+                local ok, d = pcall(json.decode, c.payload)
+                if ok then data = d end
+            end
+            jobs.enqueue(c.type, data,
+                { queue = c.queue, priority = c.priority, max_attempts = c.max_attempts })
+        end
+    end
+end
+
+--- Register (or update) a durable recurring schedule. On each matching minute,
+-- exactly one worker enqueues a job (compare-and-set on the schedule row).
+-- Schedules live in the DB, so they survive restarts and coordinate across the
+-- fleet; a worker (poller or `run_worker`) must be running to fire them.
+-- @tparam string name  unique schedule id; also the enqueued job type by default
+-- @tparam string spec  5-field cron: "min hour dom month dow" (UTC; dow 0/7=Sun)
+-- @tparam[opt] any data  payload for the enqueued job
+-- @tparam[opt] table opts  { type, queue, priority, max_attempts }
+-- @treturn table the jobs module (for chaining)
+function jobs.cron(name, spec, data, opts)
+    if type(name) ~= "string" or name == "" then
+        error("jobs.cron: name must be a non-empty string")
+    end
+    local parsed, err = parse_cron(spec)
+    if not parsed then error("jobs.cron: " .. (err or "invalid cron spec")) end
+    opts = opts or {}
+    local now = time.now()
+    local nxt = cron_next(parsed, now)
+    if not nxt then error("jobs.cron: spec has no upcoming occurrence") end
+    local job_type = opts.type or name
+    local payload  = data ~= nil and json.encode(data) or nil
+    local queue    = opts.queue or "default"
+    local priority = opts.priority or 0
+    local n = db.exec(
+        "UPDATE _hull_cron SET spec=?, type=?, payload=?, queue=?, priority=?, "
+        .. "max_attempts=?, next_run_at=?, updated_at=? WHERE name=?",
+        { spec, job_type, payload, queue, priority, opts.max_attempts, nxt, now, name })
+    if (n or 0) == 0 then
+        db.exec(
+            "INSERT INTO _hull_cron (name, spec, type, payload, queue, priority, "
+            .. "max_attempts, next_run_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            { name, spec, job_type, payload, queue, priority, opts.max_attempts, nxt, now })
+    end
+    return jobs
+end
+
+--- Remove a cron schedule by name. Returns whether a schedule was removed.
+-- @tparam string name
+-- @treturn boolean
+function jobs.uncron(name)
+    return (db.exec("DELETE FROM _hull_cron WHERE name=?", { name }) or 0) > 0
+end
+
+-- Internal seams for tests / introspection; not part of the app-facing contract.
+jobs._cron_next = function(spec, from)
+    local p = parse_cron(spec)
+    return p and cron_next(p, from or time.now()) or nil
+end
+jobs._tick = function(now) process_cron(now or time.now()) end
+
 --- Claim a batch and run each job's handler, applying the outcome (done /
 -- retry-with-backoff / dead-letter). Runs the reaper first. Drive it from a
 -- timer (`app.every(1000, function() jobs.work() end)`) or a dedicated worker
@@ -336,6 +527,11 @@ function jobs.work(opts)
     if now - _last_reap >= interval then
         jobs.reap(opts)
         _last_reap = now
+    end
+    -- Fire due cron schedules (throttled; cron is minute-grained).
+    if now - _last_cron >= 1 then
+        process_cron(now)
+        _last_cron = now
     end
     local batch = jobs.claim(opts)
     for _, job in ipairs(batch) do
@@ -379,32 +575,56 @@ end
 -- event loop, so async handlers and timers keep running). Returns the total
 -- number of jobs processed when the loop exits.
 --
+-- `concurrency` (default 1) runs N independent claim-loops in this one process
+-- (via hull.async), so up to N handlers are in flight at once - real
+-- intra-process parallelism for I/O-bound handlers (each loop's `jobs.work`
+-- claims disjoint jobs via the atomic claim). Orthogonal to running K processes;
+-- they multiply.
+--
 -- Exit conditions: `jobs.stop()` (graceful), or - for bounded / batch-drain
 -- runs - `opts.drain` / `opts.max_empty_polls`. With neither, it runs until
 -- stopped or the process is signalled (an in-flight job is then reclaimed by
 -- the visibility-timeout reaper, since handlers are at-least-once).
--- @tparam[opt] table opts  { queue, batch, poll_ms, visibility_timeout,
---                            drain, max_empty_polls }
+-- @tparam[opt] table opts  { queue, batch, concurrency, poll_ms,
+--                            visibility_timeout, drain, max_empty_polls }
 -- @treturn number  total jobs processed
 function jobs.run_worker(opts)
     opts = opts or {}
     local poll_ms = opts.poll_ms or 1000
     -- drain = "exit as soon as the queue is empty" (== max_empty_polls 1).
     local max_empty = opts.max_empty_polls or (opts.drain and 1 or 0)
+    local concurrency = (opts.concurrency and opts.concurrency > 1) and opts.concurrency or 1
     _running = true
-    local processed, empty = 0, 0
-    while _running do
-        local n = jobs.work(opts)
-        processed = processed + n
-        if n == 0 then
-            empty = empty + 1
-            if max_empty > 0 and empty >= max_empty then break end
-            hull.sleep(poll_ms)
-        else
-            empty = 0
+
+    -- Shared across loops (single event-loop thread, so no data race).
+    local total, active = 0, concurrency
+    local function loop()
+        local empty = 0
+        while _running do
+            local n = jobs.work(opts)
+            total = total + n
+            if n == 0 then
+                empty = empty + 1
+                if max_empty > 0 and empty >= max_empty then break end
+                hull.sleep(poll_ms)
+            else
+                empty = 0
+            end
         end
+        active = active - 1
     end
-    return processed
+
+    if concurrency == 1 then
+        loop()
+    else
+        -- N-1 detached loops (hull.async has no join) + 1 inline. Every loop
+        -- exits on the same _running flag / drain, and `active` counts down as
+        -- each finishes, so we can wait for all to settle before returning.
+        for _ = 1, concurrency - 1 do hull.async(loop) end
+        loop()
+        while active > 0 do hull.sleep(5) end
+    end
+    return total
 end
 
 --- Count jobs by status (optionally scoped to a queue). The ops overview.

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -383,6 +383,114 @@ check_phase5 "lua" "lua" "$LUA_P5"
 echo "== Phase 5: JS =="
 check_phase5 "js" "js" "$JS_P5"
 
+# ── v1.1: intra-process concurrency (run_worker concurrency=N) ───────────────
+# 12 jobs, concurrency=4, batch=1; handlers sleep so claims overlap. All 12 must
+# be processed exactly once AND max-in-flight must exceed 1 (real parallelism).
+check_conc() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"CONC ok=1"*) pass "$label: run_worker concurrency (N in-flight, exactly-once)" ;;
+        *) fail "$label: v1.1 concurrency" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_CONC='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init()
+  local inflight, maxf = 0, 0
+  jobs.handler("t", function(j)
+    inflight = inflight + 1; if inflight > maxf then maxf = inflight end
+    hull.sleep(30); inflight = inflight - 1
+  end)
+  for i=1,12 do jobs.enqueue("t", {}) end
+  local total = jobs.run_worker({ drain = true, concurrency = 4, batch = 1, poll_ms = 5 })
+  ctx.stdout:write(("CONC ok=%d total=%d max=%d\n"):format(
+    (total==12 and maxf>=2) and 1 or 0, total, maxf))
+  return 0
+end)'
+
+JS_CONC='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init();
+  let inflight = 0, maxf = 0;
+  jobs.handler("t", async (j) => {
+    inflight++; if (inflight > maxf) maxf = inflight;
+    await hull.sleep(30); inflight--;
+  });
+  for (let i=0;i<12;i++) jobs.enqueue("t", {});
+  const total = await jobs.runWorker({ drain: true, concurrency: 4, batch: 1, pollMs: 5 });
+  ctx.stdout.write(`CONC ok=${(total===12 && maxf>=2)?1:0} total=${total} max=${maxf}\n`);
+  return 0;
+});'
+
+echo "== v1.1 concurrency: Lua =="; check_conc "lua" "lua" "$LUA_CONC"
+echo "== v1.1 concurrency: JS =="; check_conc "js" "js" "$JS_CONC"
+
+# ── v1.1: durable cron (jobs.cron) ──────────────────────────────────────────
+# cron_next math on a fixed epoch; a due schedule fires exactly one job; a
+# second tick at the same time does NOT double-fire (CAS + missed-tick skip);
+# uncron removes it. Uses the _tick/_cronNext test seams for determinism.
+check_cron() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"CRON math=1 fired=1 nodup=1 uncron=1"*)
+            pass "$label: cron (math / fire / no-double-fire / uncron)" ;;
+        *) fail "$label: v1.1 cron" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_CRON='local jobs = require("hull.jobs")
+local time = require("hull.time")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init()
+  local b = 1609459200   -- 2021-01-01 00:00:00 UTC
+  local math_ok = (jobs._cron_next("*/15 * * * *",b)-b==900
+    and jobs._cron_next("0 0 * * *",b)-b==86400
+    and jobs._cron_next("30 2 * * *",b)-b==9000) and 1 or 0
+  local fired = 0
+  jobs.handler("beep", function(j) fired = fired + 1 end)
+  jobs.cron("beep", "* * * * *")
+  jobs._tick(time.now()+120); jobs.work({batch=10})
+  local f1 = fired
+  jobs._tick(time.now()+120); jobs.work({batch=10})   -- must not double-fire
+  local nodup = (fired == f1) and 1 or 0
+  local uncron = jobs.uncron("beep") and 1 or 0
+  ctx.stdout:write(("CRON math=%d fired=%d nodup=%d uncron=%d\n"):format(math_ok, f1, nodup, uncron))
+  return 0
+end)'
+
+JS_CRON='import { app } from "hull:app"; import { jobs } from "hull:jobs"; import { time } from "hull:time";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init();
+  const b = 1609459200;
+  const math_ok = (jobs._cronNext("*/15 * * * *",b)-b===900
+    && jobs._cronNext("0 0 * * *",b)-b===86400
+    && jobs._cronNext("30 2 * * *",b)-b===9000) ? 1 : 0;
+  let fired = 0;
+  jobs.handler("beep", (j) => { fired++; });
+  jobs.cron("beep", "* * * * *");
+  jobs._tick(time.now()+120); await jobs.work({batch:10});
+  const f1 = fired;
+  jobs._tick(time.now()+120); await jobs.work({batch:10});
+  const nodup = (fired === f1) ? 1 : 0;
+  const uncron = jobs.uncron("beep") ? 1 : 0;
+  ctx.stdout.write(`CRON math=${math_ok} fired=${f1} nodup=${nodup} uncron=${uncron}\n`);
+  return 0;
+});'
+
+echo "== v1.1 cron: Lua =="; check_cron "lua" "lua" "$LUA_CRON"
+echo "== v1.1 cron: JS =="; check_cron "js" "js" "$JS_CRON"
+
 echo ""
 echo "=== Summary ==="
 echo "PASSED: $PASS"

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -491,6 +491,63 @@ app.main(async (ctx) => {
 echo "== v1.1 cron: Lua =="; check_cron "lua" "lua" "$LUA_CRON"
 echo "== v1.1 cron: JS =="; check_cron "js" "js" "$JS_CRON"
 
+# ── v1.1: jobs.get(id) + jobs.heartbeat(job) ────────────────────────────────
+# get() returns a job's status view (pending -> done; nil for a missing id).
+# heartbeat() extends a held claim (true) and reports a lost claim (false) once
+# the reaper has reclaimed it - the handler's anti-double-run signal.
+check_gethb() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"GH get_ok=1 hb_held=1 hb_lost=1"*)
+            pass "$label: get(id) status view + heartbeat claim-guard" ;;
+        *) fail "$label: v1.1 get/heartbeat" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_GH='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init()
+  jobs.handler("t", function(j) return end)
+  local id = jobs.enqueue("t", { x = 7 })
+  local g0 = jobs.get(id)
+  jobs.work({ batch = 10 })
+  local g1 = jobs.get(id)
+  local get_ok = (g0.status=="pending" and g0.data.x==7 and g1.status=="done" and jobs.get(999999)==nil) and 1 or 0
+  jobs.enqueue("t", {})
+  local job = jobs.claim({ batch = 1 })[1]
+  local held = jobs.heartbeat(job) and 1 or 0
+  jobs.reap({ visibility_timeout = 0 })
+  local lost = (not jobs.heartbeat(job)) and 1 or 0
+  ctx.stdout:write(("GH get_ok=%d hb_held=%d hb_lost=%d\n"):format(get_ok, held, lost))
+  return 0
+end)'
+
+JS_GH='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init();
+  jobs.handler("t", (j) => {});
+  const id = jobs.enqueue("t", { x: 7 });
+  const g0 = jobs.get(id);
+  await jobs.work({ batch: 10 });
+  const g1 = jobs.get(id);
+  const get_ok = (g0.status==="pending" && g0.data.x===7 && g1.status==="done" && jobs.get(999999)===null) ? 1 : 0;
+  jobs.enqueue("t", {});
+  const job = jobs.claim({ batch: 1 })[0];
+  const held = jobs.heartbeat(job) ? 1 : 0;
+  jobs.reap({ visibilityTimeout: 0 });
+  const lost = (!jobs.heartbeat(job)) ? 1 : 0;
+  ctx.stdout.write(`GH get_ok=${get_ok} hb_held=${held} hb_lost=${lost}\n`);
+  return 0;
+});'
+
+echo "== v1.1 get/heartbeat: Lua =="; check_gethb "lua" "lua" "$LUA_GH"
+echo "== v1.1 get/heartbeat: JS =="; check_gethb "js" "js" "$JS_GH"
+
 echo ""
 echo "=== Summary ==="
 echo "PASSED: $PASS"


### PR DESCRIPTION
Closes the top two follow-ups from the post-merge API review (#232): **cron** (top usability gap) and **intra-process concurrency** (top performance gap). Design forks were confirmed: durable DB-backed cron + concurrency in both runtimes.

## Runtime primitive: `hull.async`
Promotes the detached-spawn `tui.async` to a general `hull.async(fn)` (`async.c`); `tui.async` now aliases it. Lua stdlib couldn't drive concurrent async coroutines without this — the async-resume machinery needs C-level `active_co` bookkeeping that plain `coroutine.create` doesn't set. Dedups ~50 lines of tricky coroutine code out of `mod_tui.c`.

## Intra-process concurrency (both runtimes)
`run_worker({ concurrency: N })` runs N independent claim-loops in one process → up to N handlers in flight at once (real parallelism for I/O-bound handlers; each loop claims disjoint jobs via the atomic claim). JS joins with `Promise.all`; Lua spawns N-1 detached `hull.async` loops + 1 inline and waits on a shared `active` counter. Orthogonal to K processes — they multiply.

## Durable cron (both runtimes)
`jobs.cron(name, spec, data?, opts?)` + `jobs.uncron(name)`. Schedules live in a new `_hull_cron` table (survive restarts, coordinate across the fleet) and fire via a **compare-and-set on `next_run_at`** — exactly one worker fires each tick on **every** backend (no SKIP LOCKED needed). Standard 5-field cron (UTC), parsed + next-occurrence computed in **pure Lua/JS** via the civil-calendar algorithm (no `gmtime` dependency; coarse-to-fine day/hour/minute skips keep it fast even for `0 0 29 2 *`). Fired from `work()` (throttled 1s). Missed ticks advance to the next future occurrence (fire-once, no backfill storm).

Also fixed: a NULL `max_attempts` override on the JS cron→enqueue path was binding NULL into the NOT-NULL column (Lua's `or` already handled it).

## Tests
`e2e_jobs.sh` +concurrency (N in-flight, exactly-once) and +cron (`cron_next` math on a fixed epoch, fire, no-double-fire via CAS, uncron) in both runtimes — **18/18 green**. Full unit **62/62**; `test_lua`/`test_js` + TUI e2e (validating the `tui.async` dedup) all green.

Refs #232. Remaining follow-ups there: long-job heartbeat (correctness), rate limiting, LISTEN/NOTIFY low-latency.