### PR TITLE
feat(jobs): v1.2 - SKIP LOCKED fallback + fleet-wide rate limiting

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -262,3 +262,9 @@ handlers; bounded / batch-drain runs) and `jobs.stop()` for graceful shutdown.
 - **PostgreSQL / MySQL**: `SKIP LOCKED` gives lock-free, contention-free claims
   across many worker processes. Selected by DSN scheme on the connection; the
   same jobs code runs unchanged.
+- **`SKIP LOCKED` version floor.** It needs PostgreSQL 9.5+, MySQL 8+, or
+  MariaDB 10.6+. `jobs.init` probes the server once; on an older one it
+  transparently falls back to plain `FOR UPDATE` - still exactly-once (one job,
+  one worker), but concurrent claimants **block** on locked rows instead of
+  skipping them (lower throughput under heavy contention). No configuration
+  needed; upgrade the server to regain skip-based claims.

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -120,6 +120,36 @@ jobs.uncron("heartbeat");
 - **Missed ticks** (all workers were down) advance to the next future occurrence
   - fire-once, no backfill storm.
 
+## Rate limiting
+
+`jobs.limit(queue, { rate, per })` caps how fast a queue is dispatched:
+**at most `rate` jobs per `per`-second window across the whole fleet** (default
+`per = 1`). The window counter lives in the DB (`_hull_ratelimit`), so K worker
+processes share one budget - unlike a per-process limiter that would let K
+workers each run `rate`. Use it to respect a downstream's limit (an email
+provider, a third-party API quota).
+
+```lua
+jobs.limit("emails", { rate = 10 })            -- <=10 jobs/sec, fleet-wide
+jobs.limit("reports", { rate = 100, per = 60 })-- <=100/min
+jobs.limit("emails", nil)                       -- remove the limit
+```
+```javascript
+jobs.limit("emails", { rate: 10 });
+jobs.limit("reports", { rate: 100, per: 60 });
+```
+
+- The limit is **per queue** (the `queue` arg). Enqueue rate-limited work onto
+  that queue: `jobs.enqueue("send", data, { queue = "emails" })`.
+- Register the limit at startup **on every worker** (the limit config lives in
+  code; only the counter is shared). A homogeneous fleet is assumed.
+- Enforcement is **claim-then-reconcile**: a claim keeps the highest-priority
+  jobs the window budget allows and requeues the excess (undoing the claim, so a
+  rate-deferred job keeps its full retry budget). Deferred jobs run in the next
+  window - throughput is shaped, nothing is dropped.
+- Costs one extra small DB write per claim **only on limited queues**; unlimited
+  queues are unaffected.
+
 ## Handler contract
 
 `jobs.work` dispatches each claimed job to its registered handler, else the

--- a/examples/jobs/app.js
+++ b/examples/jobs/app.js
@@ -32,7 +32,7 @@ jobs.init();
 
 // A normal handler: return nothing -> the job is done.
 jobs.handler("send_email", (job) => {
-    log.info("send_email -> " + (job.data && job.data.to));
+    log.info(`send_email -> ${job.data?.to}`);
 });
 
 // A flaky handler: fails the first two attempts, succeeds on the third. Throwing
@@ -40,14 +40,14 @@ jobs.handler("send_email", (job) => {
 // dead-letters. `job.attempts` is the count of the attempt now running.
 jobs.handler("flaky", (job) => {
     if ((job.attempts || 0) < 3) {
-        throw new Error("transient failure (attempt " + job.attempts + ")");
+        throw new Error(`transient failure (attempt ${job.attempts})`);
     }
-    log.info("flaky succeeded on attempt " + job.attempts);
+    log.info(`flaky succeeded on attempt ${job.attempts}`);
 });
 
 // Catch-all for unregistered types.
 jobs.default((job) => {
-    log.warn("no handler for job type '" + job.type + "'");
+    log.warn(`no handler for job type '${job.type}'`);
     return jobs.DISCARD;
 });
 
@@ -55,7 +55,7 @@ jobs.default((job) => {
 // Fire-and-forget (the timer re-arms immediately); jobs.work catches per-job
 // errors internally, and the .catch guards a claim/reap DB error so it can't
 // surface as an unhandled rejection.
-app.every(500, () => { jobs.work({ batch: 20 }).catch((e) => log.error("jobs.work: " + e)); });
+app.every(500, () => { jobs.work({ batch: 20 }).catch((e) => log.error(`jobs.work: ${e}`)); });
 
 // Nightly retention sweep so done/dead rows don't accumulate forever.
 app.daily("03:00", () => { jobs.cleanup({ olderThan: 7 * 86400 }); });
@@ -71,12 +71,12 @@ app.post("/jobs", (req, res) => {
 });
 
 // Status counts (pending / running / done / dead).
-app.get("/jobs/stats", (req, res) => { res.json(jobs.stats()); });
+app.get("/jobs/stats", (_req, res) => { res.json(jobs.stats()); });
 
 // Inspect the dead-letter queue.
-app.get("/jobs/dead", (req, res) => { res.json({ dead: jobs.dead({ limit: 50 }) }); });
+app.get("/jobs/dead", (_req, res) => { res.json({ dead: jobs.dead({ limit: 50 }) }); });
 
 // Requeue a dead job for another run (fresh attempt budget).
 app.post("/jobs/retry/:id", (req, res) => {
-    res.json({ requeued: jobs.retry(parseInt(req.params.id, 10)) });
+    res.json({ requeued: jobs.retry(Number.parseInt(req.params.id, 10)) });
 });

--- a/examples/jobs/worker.js
+++ b/examples/jobs/worker.js
@@ -22,11 +22,11 @@ app.main(async () => {
     jobs.init();
 
     jobs.handler("send_email", (job) => {
-        log.info("send_email -> " + (job.data && job.data.to));
+        log.info(`send_email -> ${job.data?.to}`);
     });
     jobs.handler("flaky", (job) => {
         if ((job.attempts || 0) < 3) {
-            throw new Error("transient failure (attempt " + job.attempts + ")");
+            throw new Error(`transient failure (attempt ${job.attempts})`);
         }
     });
 

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -15,7 +15,7 @@
  * Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
  * catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
  * visibility-timeout reaper), the dedicated worker (jobs.runWorker +
- * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), and jobs.heartbeat for long jobs.
+ * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, and fleet-wide rate limiting (jobs.limit).
  *
  * @license AGPL-3.0-or-later
  */
@@ -56,6 +56,12 @@ let _default = null;
 
 // Whether the server parses SKIP LOCKED (probed in init(); null = not probed).
 let _skipLocked = null;
+// Per-queue rate limits { [queue]: { rate, per } }, in-memory (re-registered on
+// boot); the shared window COUNTER lives in _hull_ratelimit (fleet-wide).
+const _limits = Object.create(null);
+// Row-lock clause for the rate counter: blocking FOR UPDATE on PG/MySQL, empty
+// on SQLite (its write txn already serializes). Set in init().
+let _rlLock = "";
 
 /**
  * Create the `_hull_jobs` table and its indexes. Idempotent - safe on every
@@ -128,6 +134,15 @@ function init(opts) {
         "updated_at   INTEGER      NOT NULL)");
     db.exec("CREATE INDEX IF NOT EXISTS idx_hull_cron_due ON _hull_cron(next_run_at)");
 
+    // Fleet-wide rate-limit counters (jobs.limit). One row per limited queue;
+    // `name` (not the reserved word `key`), a window start, and the count.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_ratelimit (" +
+        "name         VARCHAR(255) NOT NULL PRIMARY KEY," +
+        "window_start INTEGER      NOT NULL," +
+        "n            INTEGER      NOT NULL)");
+    _rlLock = db.backendName === "sqlite" ? "" : " FOR UPDATE";
+
     // Verify the server actually parses SKIP LOCKED (the compile-time dialect
     // flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
     // does not). A 0-row probe against the real table detects it once; the claim
@@ -191,6 +206,60 @@ function shape(row) {
 }
 
 /**
+ * Set (or clear) a fleet-wide rate limit for a queue: at most `rate` jobs are
+ * dispatched per `per`-second window across ALL workers (a shared DB counter, so
+ * K processes still total `rate`). Register at startup on every worker (the
+ * limit lives in code; only the counter is shared).
+ * @param {string} queue  the queue to limit
+ * @param {object} [opts] { rate, per = 1 } - null/false removes it
+ * @returns {object} the jobs module (for chaining)
+ */
+function limit(queue, opts) {
+    if (opts === null || opts === undefined || opts === false) { delete _limits[queue]; return jobs; }
+    if (typeof opts.rate !== "number" || opts.rate < 1)
+        throw new Error("jobs.limit: opts.rate must be a positive number");
+    _limits[queue] = { rate: opts.rate, per: opts.per || 1 };
+    return jobs;
+}
+
+// Atomically reserve up to `want` slots in the current window for `key`, rolling
+// the window if stale. Returns how many were granted (0..want).
+function rlReserve(key, want, rate, per) {
+    const now = time.now();
+    let granted = 0;
+    db.insertIfAbsent("_hull_ratelimit", ["name"],
+        ["name", "window_start", "n"], [key, now, 0]);
+    db.batch(() => {
+        const sel = db.query(
+            "SELECT window_start, n FROM _hull_ratelimit WHERE name=?" + _rlLock, [key]);
+        let ws = sel[0].window_start, cnt = sel[0].n;
+        if (now - ws >= per) { ws = now; cnt = 0; }
+        granted = Math.min(want, rate - cnt);
+        if (granted < 0) granted = 0;
+        db.exec("UPDATE _hull_ratelimit SET window_start=?, n=? WHERE name=?",
+            [ws, cnt + granted, key]);
+    });
+    return granted;
+}
+
+// Enforce a queue's rate limit on a just-claimed batch: keep the highest-priority
+// `granted`, requeue the excess (undoing the claim's attempts+1). Returns kept.
+function rlApply(queue, out) {
+    const lim = _limits[queue];
+    if (!lim || out.length === 0) return out;
+    const granted = rlReserve(queue, out.length, lim.rate, lim.per);
+    if (granted >= out.length) return out;
+    const excess = out.slice(granted);
+    const params = [time.now()];
+    const ph = excess.map((j) => { params.push(j.id); return "?"; });
+    db.exec(
+        "UPDATE _hull_jobs SET status='pending', claim_token=NULL, claimed_at=NULL, " +
+        "attempts=attempts-1, updated_at=? WHERE id IN (" + ph.join(",") + ")",
+        params);
+    return out.slice(0, granted);   // keep the top `granted`
+}
+
+/**
  * Atomically claim up to `batch` ready jobs from a queue, marking them
  * `running`. Concurrency-safe across workers and processes (SKIP LOCKED on
  * Postgres/MySQL, serialized on SQLite). Each ready job is claimed by exactly
@@ -250,13 +319,15 @@ function claim(opts) {
 
     // Priority-correct order within the batch: RETURNING / the token read-back
     // don't preserve the subquery's ORDER BY, so sort by priority DESC, id ASC.
-    return (rows || [])
+    const out = (rows || [])
         .sort((x, y) => (y.priority || 0) - (x.priority || 0) || (x.id - y.id))
         .map((r) => {
             const j = shape(r);
             j.claimToken = token;   // handle for jobs.heartbeat on long-running work
             return j;
         });
+    // Enforce a fleet-wide rate limit (claim-then-reconcile; requeues the excess).
+    return rlApply(queue, out);
 }
 
 // ── Handlers + the work loop ────────────────────────────────────────────
@@ -725,9 +796,9 @@ function _tick(now) { processCron(now !== undefined ? now : time.now()); }
 
 export const jobs = {
     init, enqueue, claim, handler, default: setDefault, work, reap, stats,
-    runWorker, stop, get, heartbeat, dead, retry, cancel, cleanup, cron, uncron,
+    runWorker, stop, get, heartbeat, limit, dead, retry, cancel, cleanup, cron, uncron,
     RETRY, DEAD, DISCARD, _config: _cfg, _cronNext, _tick,
 };
 export { init, enqueue, claim, handler, work, reap, stats, runWorker, stop,
-         get, heartbeat, dead, retry, cancel, cleanup, cron, uncron };
+         get, heartbeat, limit, dead, retry, cancel, cleanup, cron, uncron };
 export default jobs;

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -54,6 +54,9 @@ function defaultBackoff(attempt) {
 const _handlers = Object.create(null);
 let _default = null;
 
+// Whether the server parses SKIP LOCKED (probed in init(); null = not probed).
+let _skipLocked = null;
+
 /**
  * Create the `_hull_jobs` table and its indexes. Idempotent - safe on every
  * boot. Uses the connection's portable identity DDL + IF-NOT-EXISTS index
@@ -125,6 +128,16 @@ function init(opts) {
         "updated_at   INTEGER      NOT NULL)");
     db.exec("CREATE INDEX IF NOT EXISTS idx_hull_cron_due ON _hull_cron(next_run_at)");
 
+    // Verify the server actually parses SKIP LOCKED (the compile-time dialect
+    // flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
+    // does not). A 0-row probe against the real table detects it once; the claim
+    // falls back to plain FOR UPDATE otherwise.
+    _skipLocked = db.dialect.supportsSkipLocked;
+    if (_skipLocked) {
+        try { db.query("SELECT id FROM _hull_jobs WHERE 1=0 FOR UPDATE SKIP LOCKED"); }
+        catch (_e) { _skipLocked = false; }
+    }
+
     return jobs;
 }
 
@@ -193,6 +206,11 @@ function claim(opts) {
     const now = time.now();
     const token = crypto.base64urlEncode(crypto.random(16));
     const d = db.dialect;
+    // SKIP LOCKED needs PG 9.5+ / MySQL 8+ / MariaDB 10.6+. init() probes the
+    // server and clears _skipLocked on older ones, where we fall back to plain
+    // FOR UPDATE (correct - one job, one worker - but claimants block instead of
+    // skipping). null = not probed yet -> assume supported.
+    const lock = _skipLocked === false ? "FOR UPDATE" : "FOR UPDATE SKIP LOCKED";
 
     let rows;
     if (d.supportsSkipLocked && d.supportsReturning) {
@@ -200,14 +218,14 @@ function claim(opts) {
             "UPDATE _hull_jobs SET status='running', claim_token=?, claimed_at=?, " +
             "attempts=attempts+1, updated_at=? WHERE id IN (" +
             "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? " +
-            "ORDER BY priority DESC, id LIMIT ? FOR UPDATE SKIP LOCKED) " +
+            "ORDER BY priority DESC, id LIMIT ? " + lock + ") " +
             "RETURNING id, type, payload, priority, attempts, max_attempts",
             [token, now, now, queue, now, batch]);
     } else if (d.supportsSkipLocked) {
         db.batch(() => {
             const sel = db.query(
                 "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? " +
-                "ORDER BY priority DESC, id LIMIT ? FOR UPDATE SKIP LOCKED",
+                "ORDER BY priority DESC, id LIMIT ? " + lock,
                 [queue, now, batch]);
             if (sel.length === 0) return;
             const ph = [], params = [token, now, now];

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -61,6 +61,8 @@ local _default = nil
 local _last_reap = 0
 -- Unix ts of the last cron due-check (throttled to >=1s; cron is minute-grained).
 local _last_cron = 0
+-- Whether the server parses SKIP LOCKED (probed in jobs.init; nil = not probed).
+local _skip_locked = nil
 
 --- Create the `_hull_jobs` table and its indexes. Idempotent - safe to call on
 -- every boot. Uses the connection's portable identity DDL + IF-NOT-EXISTS index
@@ -137,6 +139,18 @@ function jobs.init(opts)
     db.exec([[
         CREATE INDEX IF NOT EXISTS idx_hull_cron_due ON _hull_cron(next_run_at)
     ]])
+
+    -- Verify the server actually parses SKIP LOCKED (the compile-time dialect
+    -- flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
+    -- does not). A 0-row probe against the real table detects it once; the claim
+    -- falls back to plain FOR UPDATE otherwise.
+    _skip_locked = db.dialect.supports_skip_locked
+    if _skip_locked then
+        local ok = pcall(function()
+            db.query("SELECT id FROM _hull_jobs WHERE 1=0 FOR UPDATE SKIP LOCKED")
+        end)
+        if not ok then _skip_locked = false end
+    end
 
     return jobs
 end
@@ -216,6 +230,11 @@ function jobs.claim(opts)
     local now   = time.now()
     local token = crypto.base64url_encode(crypto.random(16))
     local d = db.dialect
+    -- SKIP LOCKED needs PG 9.5+ / MySQL 8+ / MariaDB 10.6+. jobs.init probes the
+    -- server and clears _skip_locked on older ones, where we fall back to plain
+    -- FOR UPDATE (correct - one job, one worker - but claimants block instead of
+    -- skipping). nil = not probed yet -> assume supported.
+    local lock = (_skip_locked ~= false) and "FOR UPDATE SKIP LOCKED" or "FOR UPDATE"
 
     local rows
     if d.supports_skip_locked and d.supports_returning then
@@ -224,7 +243,7 @@ function jobs.claim(opts)
             "UPDATE _hull_jobs SET status='running', claim_token=?, claimed_at=?, "
             .. "attempts=attempts+1, updated_at=? WHERE id IN ("
             .. "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? "
-            .. "ORDER BY priority DESC, id LIMIT ? FOR UPDATE SKIP LOCKED) "
+            .. "ORDER BY priority DESC, id LIMIT ? " .. lock .. ") "
             .. "RETURNING id, type, payload, priority, attempts, max_attempts",
             { token, now, now, queue, now, batch })
     elseif d.supports_skip_locked then
@@ -232,7 +251,7 @@ function jobs.claim(opts)
         db.batch(function()
             local sel = db.query(
                 "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? "
-                .. "ORDER BY priority DESC, id LIMIT ? FOR UPDATE SKIP LOCKED",
+                .. "ORDER BY priority DESC, id LIMIT ? " .. lock,
                 { queue, now, batch })
             if #sel == 0 then return end
             local ph, params = {}, { token, now, now }

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -11,7 +11,7 @@
 -- Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
 -- catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
 -- visibility-timeout reaper), the dedicated worker (jobs.run_worker +
--- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), and jobs.heartbeat for long jobs.
+-- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, and fleet-wide rate limiting (jobs.limit).
 --
 -- Usage (target shape):
 --   local jobs = require("hull.jobs")
@@ -63,6 +63,12 @@ local _last_reap = 0
 local _last_cron = 0
 -- Whether the server parses SKIP LOCKED (probed in jobs.init; nil = not probed).
 local _skip_locked = nil
+-- Per-queue rate limits { [queue] = { rate, per } }, in-memory (re-registered on
+-- boot); the shared window COUNTER lives in _hull_ratelimit (fleet-wide).
+local _limits = {}
+-- Row-lock clause for the rate counter: blocking FOR UPDATE on PG/MySQL (serialize
+-- reservers), empty on SQLite (its write txn already serializes). Set in init.
+local _rl_lock = ""
 
 --- Create the `_hull_jobs` table and its indexes. Idempotent - safe to call on
 -- every boot. Uses the connection's portable identity DDL + IF-NOT-EXISTS index
@@ -140,6 +146,17 @@ function jobs.init(opts)
         CREATE INDEX IF NOT EXISTS idx_hull_cron_due ON _hull_cron(next_run_at)
     ]])
 
+    -- Fleet-wide rate-limit counters (jobs.limit). One row per limited queue;
+    -- `name` (not the reserved word `key`), a window start, and the count.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_ratelimit ("
+        .. "name         VARCHAR(255) NOT NULL PRIMARY KEY,"
+        .. "window_start INTEGER      NOT NULL,"
+        .. "n            INTEGER      NOT NULL)")
+    -- Blocking FOR UPDATE serializes reservers on PG/MySQL; SQLite's write txn
+    -- already serializes (and rejects FOR UPDATE syntactically).
+    _rl_lock = (db.backend_name == "sqlite") and "" or " FOR UPDATE"
+
     -- Verify the server actually parses SKIP LOCKED (the compile-time dialect
     -- flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
     -- does not). A 0-row probe against the real table detects it once; the claim
@@ -212,6 +229,65 @@ local function shape(row)
         id = row.id, type = row.type, data = data,
         attempts = row.attempts, max_attempts = row.max_attempts,
     }
+end
+
+--- Set (or clear) a fleet-wide rate limit for a queue: at most `rate` jobs are
+-- dispatched per `per`-second window across ALL workers (a shared DB counter, so
+-- K processes still total `rate`, unlike a per-process limiter). Use it to
+-- respect a downstream's limit (an email/API quota). Register at startup on
+-- every worker (the limit lives in code; only the counter is shared).
+-- @tparam string queue  the queue to limit
+-- @tparam[opt] table opts  { rate = <max jobs>, per = 1 } - nil/false removes it
+-- @treturn table the jobs module (for chaining)
+function jobs.limit(queue, opts)
+    if opts == nil or opts == false then _limits[queue] = nil; return jobs end
+    if type(opts.rate) ~= "number" or opts.rate < 1 then
+        error("jobs.limit: opts.rate must be a positive number")
+    end
+    _limits[queue] = { rate = opts.rate, per = opts.per or 1 }
+    return jobs
+end
+
+-- Atomically reserve up to `want` slots in the current window for `key`, rolling
+-- the window if stale. Returns how many were granted (0..want). The row is
+-- pre-created (idempotent), then read-modify-written under a row lock so K
+-- workers share one counter.
+local function rl_reserve(key, want, rate, per)
+    local now = time.now()
+    local granted = 0
+    db.insert_if_absent("_hull_ratelimit", { "name" },
+        { "name", "window_start", "n" }, { key, now, 0 })
+    db.batch(function()
+        local sel = db.query(
+            "SELECT window_start, n FROM _hull_ratelimit WHERE name=?" .. _rl_lock, { key })
+        local ws, cnt = sel[1].window_start, sel[1].n
+        if now - ws >= per then ws, cnt = now, 0 end
+        granted = math.min(want, rate - cnt)
+        if granted < 0 then granted = 0 end
+        db.exec("UPDATE _hull_ratelimit SET window_start=?, n=? WHERE name=?",
+            { ws, cnt + granted, key })
+    end)
+    return granted
+end
+
+-- Enforce a queue's rate limit on a just-claimed batch: keep the highest-priority
+-- `granted` jobs, requeue the excess (undoing the claim's attempts+1 so a
+-- rate-deferred job keeps its retry budget). Claim-then-reconcile avoids burning
+-- window budget on empty polls. Mutates + returns `out`.
+local function rl_apply(queue, out)
+    local lim = _limits[queue]
+    if not lim or #out == 0 then return out end
+    local granted = rl_reserve(queue, #out, lim.rate, lim.per)
+    if granted >= #out then return out end
+    local params = { time.now() }
+    local ph = {}
+    for i = granted + 1, #out do ph[#ph + 1] = "?"; params[#params + 1] = out[i].id end
+    db.exec(
+        "UPDATE _hull_jobs SET status='pending', claim_token=NULL, claimed_at=NULL, "
+        .. "attempts=attempts-1, updated_at=? WHERE id IN (" .. table.concat(ph, ",") .. ")",
+        params)
+    for i = #out, granted + 1, -1 do out[i] = nil end   -- keep the top `granted`
+    return out
 end
 
 --- Atomically claim up to `batch` ready jobs from a queue, marking them
@@ -292,7 +368,8 @@ function jobs.claim(opts)
         j.claim_token = token   -- handle for jobs.heartbeat on long-running work
         out[#out + 1] = j
     end
-    return out
+    -- Enforce a fleet-wide rate limit (claim-then-reconcile; requeues the excess).
+    return rl_apply(queue, out)
 end
 
 -- ── Handlers + the work loop ────────────────────────────────────────────

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -548,6 +548,85 @@ app.main(async (ctx) => {
 echo "== v1.1 get/heartbeat: Lua =="; check_gethb "lua" "lua" "$LUA_GH"
 echo "== v1.1 get/heartbeat: JS =="; check_gethb "js" "js" "$JS_GH"
 
+# ── v1.2: fleet-wide rate limiting (jobs.limit) ─────────────────────────────
+# rate=3 per long window: first claim yields 3, second yields 0 (budget spent),
+# and a rate-deferred (requeued) job keeps attempts=0 (the claim was undone).
+check_rl() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"RL first=3 second=0 attempts=0"*)
+            pass "$label: rate limit (window budget + requeue keeps attempts)" ;;
+        *) fail "$label: v1.2 rate limit" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_RL='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init()
+  jobs.limit("default", { rate = 3, per = 100 })
+  for i=1,10 do jobs.enqueue("t", {}) end
+  local c1 = jobs.claim({ batch = 10 })
+  local c2 = jobs.claim({ batch = 10 })
+  local at = -1
+  for id=1,10 do local g=jobs.get(id); if g and g.status=="pending" then at=g.attempts; break end end
+  ctx.stdout:write(("RL first=%d second=%d attempts=%d\n"):format(#c1, #c2, at))
+  return 0
+end)'
+
+JS_RL='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init();
+  jobs.limit("default", { rate: 3, per: 100 });
+  for (let i=0;i<10;i++) jobs.enqueue("t", {});
+  const c1 = jobs.claim({ batch: 10 });
+  const c2 = jobs.claim({ batch: 10 });
+  let at = -1;
+  for (let id=1; id<=10; id++) { const g=jobs.get(id); if (g && g.status==="pending") { at=g.attempts; break; } }
+  ctx.stdout.write(`RL first=${c1.length} second=${c2.length} attempts=${at}\n`);
+  return 0;
+});'
+
+echo "== v1.2 rate limit: Lua =="; check_rl "lua" "lua" "$LUA_RL"
+echo "== v1.2 rate limit: JS =="; check_rl "js" "js" "$JS_RL"
+
+# Fleet gate: K processes share one rate counter -> total dispatched == rate.
+echo "== v1.2 rate limit fleet ($CONC processes, one shared counter) =="
+W="$(mktemp -d)"; DB="$W/rl.db"
+cat > "$W/seed.lua" <<LUA
+local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function() jobs.init(); jobs.limit("default",{rate=5,per=100}); for i=1,50 do jobs.enqueue("t",{}) end; return 0 end)
+LUA
+cat > "$W/claim.lua" <<'LUA'
+local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init(); jobs.limit("default",{rate=5,per=100})
+  while true do
+    local b = jobs.claim({ batch = 2 })
+    if #b == 0 then break end
+    for _,j in ipairs(b) do ctx.stdout:write(j.id .. "\n") end
+  end
+  return 0
+end)
+LUA
+"$HULL" "$W/seed.lua" -d "$DB" >/dev/null 2>&1
+i=1; while [ "$i" -le "$CONC" ]; do "$HULL" "$W/claim.lua" -d "$DB" > "$W/out.$i" 2>/dev/null & i=$((i+1)); done
+wait
+total="$(cat "$W"/out.* | grep -c . || true)"
+uniq="$(cat "$W"/out.* | sort -n | uniq | grep -c . || true)"
+if [ "$total" -eq 5 ] && [ "$uniq" -eq 5 ]; then
+    pass "rate limit fleet: $CONC processes dispatched exactly 5 (the shared budget)"
+else
+    fail "rate limit fleet: expected 5 total" "total=$total uniq=$uniq"
+fi
+rm -rf "$W"
+
 echo ""
 echo "=== Summary ==="
 echo "PASSED: $PASS"


### PR DESCRIPTION
Two more #232 follow-ups (in the order requested), on top of v1.1 (#233, merged).

## 1. SKIP LOCKED version caveat → graceful fallback
The claim used `SKIP LOCKED` on any backend whose compile-time dialect flag advertises it, but it needs **PostgreSQL 9.5+ / MySQL 8+ / MariaDB 10.6+** — an older server would error on the claim SQL. `jobs.init` now **probes the connected server once** (a 0-row `FOR UPDATE SKIP LOCKED` against the real table) and, on failure, transparently falls back to plain `FOR UPDATE`: still exactly-once (row locks serialize claimants), just blocking instead of skipping under contention. SQLite is untouched. Both runtimes; documented.

## 2. Fleet-wide rate limiting (`jobs.limit`)
`jobs.limit(queue, { rate, per })` caps a queue to **≤ `rate` jobs per `per`-second window across the whole fleet** (default `per = 1`). The window counter lives in the DB (`_hull_ratelimit`), so K worker processes share one budget — unlike a per-process limiter that would let K workers each run `rate`.

> **Re the stdlib ratelimit middleware:** not reused — it's HTTP-shaped (`req`/`res` → 429) and **in-memory/per-process**, which would give K× the limit. A shared DB counter is what "respect a downstream's global quota" actually needs (chosen per the design question).

Enforcement is **claim-then-reconcile**: keep the highest-priority jobs the budget allows, requeue the excess (undoing the claim's `attempts+1`, so a rate-deferred job keeps its full retry budget). Avoids burning budget on empty polls; drops nothing. The reservation is atomic (idempotent row create + read-modify-write under a blocking `FOR UPDATE` on PG/MySQL; SQLite's write txn serializes). One extra small write per claim **only on limited queues**.

```lua
jobs.limit("emails", { rate = 10 })             -- <=10/sec fleet-wide
jobs.limit("reports", { rate = 100, per = 60 }) -- <=100/min
```

## Also
- Fixed the (non-required) Lint job that #233 tripped: biome nits in `examples/jobs` (template literals, optional chain, `Number.parseInt`, unused params).

## Tests
`e2e_jobs.sh` **23/23**: +rate-limit (window budget + attempts-preserving requeue, both runtimes) + a **fleet gate** (4 processes share one counter → dispatch exactly the budget). `make lint-js` / `lint-lua` clean.

Refs #232. Remaining there: LISTEN/NOTIFY low-latency (next), workflows/result-backend (likely non-goals).