### PR TITLE
feat(jobs): queue pause/resume + purge

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -192,7 +192,13 @@ jobs.dead({ limit = 50 })     -- list dead-lettered jobs (newest first) for insp
 jobs.retry(id)                -- requeue a dead job with a fresh attempt budget; false if not dead
 jobs.cancel(id)               -- delete a still-pending (e.g. delayed) job; false if not pending
 jobs.cleanup({ older_than = 7 * 86400 })   -- purge terminal (done + dead) rows past a retention age
+jobs.pause("emails") / jobs.resume("emails")   -- stop / resume dispatching a queue (durable, fleet-wide)
+jobs.purge("emails")          -- delete pending jobs in a queue ("clear the backlog"); returns count
 ```
+`jobs.pause(queue)` stops workers claiming from that queue (in-flight jobs
+finish, and `enqueue` still works) - durable and fleet-wide, taking effect within
+~1s on other workers. `jobs.purge(queue)` deletes `pending` jobs by default; pass
+`{ statuses = { "pending", "running", "done", "dead" } }` to widen.
 `jobs.get(id)` is the "did my job run?" primitive: after `local id =
 jobs.enqueue(...)`, poll `jobs.get(id).status` (`pending` → `running` → `done` /
 `dead`). It's the only way to inspect an individual job from app code -

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -15,7 +15,7 @@
  * Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
  * catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
  * visibility-timeout reaper), the dedicated worker (jobs.runWorker +
- * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, and fleet-wide rate limiting (jobs.limit).
+ * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), and queue pause/resume/purge.
  *
  * @license AGPL-3.0-or-later
  */
@@ -62,6 +62,10 @@ const _limits = Object.create(null);
 // Row-lock clause for the rate counter: blocking FOR UPDATE on PG/MySQL, empty
 // on SQLite (its write txn already serializes). Set in init().
 let _rlLock = "";
+// Paused-queue cache: set of paused queue names + when it was last loaded.
+// Refreshed at most every 1s so pausing never adds a DB read to every claim.
+let _paused = Object.create(null);
+let _pausedAt = 0;
 
 /**
  * Create the `_hull_jobs` table and its indexes. Idempotent - safe on every
@@ -142,6 +146,15 @@ function init(opts) {
         "window_start INTEGER      NOT NULL," +
         "n            INTEGER      NOT NULL)");
     _rlLock = db.backendName === "sqlite" ? "" : " FOR UPDATE";
+
+    // Durable per-queue pause state (jobs.pause / resume). A paused queue is not
+    // claimed (workers skip it); fleet-wide (in the DB) and restart-durable.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_queue (" +
+        "name   VARCHAR(255) NOT NULL PRIMARY KEY," +
+        "paused INTEGER      NOT NULL DEFAULT 0)");
+    _paused = Object.create(null);
+    _pausedAt = 0;
 
     // Verify the server actually parses SKIP LOCKED (the compile-time dialect
     // flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
@@ -259,6 +272,58 @@ function rlApply(queue, out) {
     return out.slice(0, granted);   // keep the top `granted`
 }
 
+// Is `queue` paused? Reads the durable state at most once/second (cached), so
+// pausing never adds a DB read to the steady claim path.
+function isPaused(queue) {
+    const now = time.now();
+    if (now - _pausedAt >= 1) {
+        _paused = Object.create(null);
+        for (const r of db.query("SELECT name FROM _hull_queue WHERE paused=1")) _paused[r.name] = true;
+        _pausedAt = now;
+    }
+    return _paused[queue] === true;
+}
+
+function setPaused(queue, v) {
+    const n = db.exec("UPDATE _hull_queue SET paused=? WHERE name=?", [v, queue]);
+    if ((n || 0) === 0) db.exec("INSERT INTO _hull_queue (name, paused) VALUES (?, ?)", [queue, v]);
+    _pausedAt = 0;   // invalidate this process's cache so the change is seen now
+    return jobs;
+}
+
+/**
+ * Pause a queue: workers stop claiming from it (in-flight jobs finish; enqueue
+ * still works). Durable + fleet-wide. Takes effect within ~1s on other workers.
+ * @param {string} queue
+ * @returns {object} the jobs module (for chaining)
+ */
+function pause(queue) { return setPaused(queue, 1); }
+
+/**
+ * Resume a paused queue.
+ * @param {string} queue
+ * @returns {object} the jobs module (for chaining)
+ */
+function resume(queue) { return setPaused(queue, 0); }
+
+/**
+ * Delete jobs from a queue (the "clear the backlog" op). Defaults to `pending`
+ * only, leaving in-flight and terminal rows; pass opts.statuses to widen.
+ * Returns the number deleted.
+ * @param {string} queue
+ * @param {object} [opts]  { statuses = ["pending"] }
+ * @returns {number}
+ */
+function purge(queue, opts) {
+    const o = opts || {};
+    const statuses = o.statuses || ["pending"];
+    const params = [queue].concat(statuses);
+    const ph = statuses.map(() => "?");
+    return db.exec(
+        "DELETE FROM _hull_jobs WHERE queue=? AND status IN (" + ph.join(",") + ")",
+        params) || 0;
+}
+
 /**
  * Atomically claim up to `batch` ready jobs from a queue, marking them
  * `running`. Concurrency-safe across workers and processes (SKIP LOCKED on
@@ -272,6 +337,7 @@ function claim(opts) {
     const o = opts || {};
     const queue = o.queue || "default";
     const batch = o.batch || 10;
+    if (isPaused(queue)) return [];   // paused: don't dispatch
     const now = time.now();
     const token = crypto.base64urlEncode(crypto.random(16));
     const d = db.dialect;
@@ -796,9 +862,11 @@ function _tick(now) { processCron(now !== undefined ? now : time.now()); }
 
 export const jobs = {
     init, enqueue, claim, handler, default: setDefault, work, reap, stats,
-    runWorker, stop, get, heartbeat, limit, dead, retry, cancel, cleanup, cron, uncron,
+    runWorker, stop, get, heartbeat, limit, pause, resume, purge,
+    dead, retry, cancel, cleanup, cron, uncron,
     RETRY, DEAD, DISCARD, _config: _cfg, _cronNext, _tick,
 };
 export { init, enqueue, claim, handler, work, reap, stats, runWorker, stop,
-         get, heartbeat, limit, dead, retry, cancel, cleanup, cron, uncron };
+         get, heartbeat, limit, pause, resume, purge,
+         dead, retry, cancel, cleanup, cron, uncron };
 export default jobs;

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -11,7 +11,7 @@
 -- Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
 -- catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
 -- visibility-timeout reaper), the dedicated worker (jobs.run_worker +
--- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, and fleet-wide rate limiting (jobs.limit).
+-- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), and queue pause/resume/purge.
 --
 -- Usage (target shape):
 --   local jobs = require("hull.jobs")
@@ -69,6 +69,10 @@ local _limits = {}
 -- Row-lock clause for the rate counter: blocking FOR UPDATE on PG/MySQL (serialize
 -- reservers), empty on SQLite (its write txn already serializes). Set in init.
 local _rl_lock = ""
+-- Paused-queue cache: a set of paused queue names + when it was last loaded.
+-- Refreshed at most every 1s so a paused queue isn't a DB read on every claim.
+local _paused = {}
+local _paused_at = 0
 
 --- Create the `_hull_jobs` table and its indexes. Idempotent - safe to call on
 -- every boot. Uses the connection's portable identity DDL + IF-NOT-EXISTS index
@@ -156,6 +160,14 @@ function jobs.init(opts)
     -- Blocking FOR UPDATE serializes reservers on PG/MySQL; SQLite's write txn
     -- already serializes (and rejects FOR UPDATE syntactically).
     _rl_lock = (db.backend_name == "sqlite") and "" or " FOR UPDATE"
+
+    -- Durable per-queue pause state (jobs.pause / resume). A paused queue is not
+    -- claimed (workers skip it); fleet-wide (in the DB) and restart-durable.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_queue ("
+        .. "name   VARCHAR(255) NOT NULL PRIMARY KEY,"
+        .. "paused INTEGER      NOT NULL DEFAULT 0)")
+    _paused, _paused_at = {}, 0   -- force a reload after (re)init
 
     -- Verify the server actually parses SKIP LOCKED (the compile-time dialect
     -- flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
@@ -290,6 +302,55 @@ local function rl_apply(queue, out)
     return out
 end
 
+-- Is `queue` currently paused? Reads the durable state at most once/second
+-- (cached), so pausing never adds a DB read to the steady claim path.
+local function is_paused(queue)
+    local now = time.now()
+    if now - _paused_at >= 1 then
+        _paused = {}
+        local rows = db.query("SELECT name FROM _hull_queue WHERE paused=1")
+        for _, r in ipairs(rows) do _paused[r.name] = true end
+        _paused_at = now
+    end
+    return _paused[queue] == true
+end
+
+local function set_paused(queue, v)
+    local n = db.exec("UPDATE _hull_queue SET paused=? WHERE name=?", { v, queue })
+    if (n or 0) == 0 then
+        db.exec("INSERT INTO _hull_queue (name, paused) VALUES (?, ?)", { queue, v })
+    end
+    _paused_at = 0   -- invalidate this process's cache so the change is seen now
+    return jobs
+end
+
+--- Pause a queue: workers stop claiming from it (in-flight jobs finish; enqueue
+-- still works). Durable + fleet-wide. Takes effect within ~1s on other workers.
+-- @tparam string queue
+-- @treturn table the jobs module (for chaining)
+function jobs.pause(queue) return set_paused(queue, 1) end
+
+--- Resume a paused queue.
+-- @tparam string queue
+-- @treturn table the jobs module (for chaining)
+function jobs.resume(queue) return set_paused(queue, 0) end
+
+--- Delete jobs from a queue (the "clear the backlog" op). Defaults to `pending`
+-- only, leaving in-flight and terminal rows; pass opts.statuses to widen (e.g.
+-- { "pending", "running", "done", "dead" }). Returns the number deleted.
+-- @tparam string queue
+-- @tparam[opt] table opts  { statuses = { "pending" } }
+-- @treturn number
+function jobs.purge(queue, opts)
+    opts = opts or {}
+    local statuses = opts.statuses or { "pending" }
+    local ph, params = {}, { queue }
+    for _, s in ipairs(statuses) do ph[#ph + 1] = "?"; params[#params + 1] = s end
+    return db.exec(
+        "DELETE FROM _hull_jobs WHERE queue=? AND status IN (" .. table.concat(ph, ",") .. ")",
+        params) or 0
+end
+
 --- Atomically claim up to `batch` ready jobs from a queue, marking them
 -- `running`. Concurrency-safe across workers and processes: SKIP LOCKED on
 -- Postgres/MySQL, serialized on SQLite (single-writer + WAL busy-wait). A
@@ -303,6 +364,7 @@ function jobs.claim(opts)
     opts = opts or {}
     local queue = opts.queue or "default"
     local batch = opts.batch or 10
+    if is_paused(queue) then return {} end   -- paused: don't dispatch
     local now   = time.now()
     local token = crypto.base64url_encode(crypto.random(16))
     local d = db.dialect

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -594,6 +594,49 @@ app.main(async (ctx) => {
 echo "== v1.2 rate limit: Lua =="; check_rl "lua" "lua" "$LUA_RL"
 echo "== v1.2 rate limit: JS =="; check_rl "js" "js" "$JS_RL"
 
+# ── v1.3: queue pause / resume / purge ──────────────────────────────────────
+# A paused queue is not claimed; resume restores it; purge deletes pending.
+check_pq() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"PQ paused=0 resumed=5 purged=3 after_purge=0"*)
+            pass "$label: queue pause / resume / purge" ;;
+        *) fail "$label: v1.3 pause/resume/purge" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_PQ='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init()
+  for i=1,5 do jobs.enqueue("t", {}) end
+  jobs.pause("default"); local c1 = jobs.claim({ batch = 10 })
+  jobs.resume("default"); local c2 = jobs.claim({ batch = 10 })
+  for i=1,3 do jobs.enqueue("t", {}) end
+  local purged = jobs.purge("default"); local c3 = jobs.claim({ batch = 10 })
+  ctx.stdout:write(("PQ paused=%d resumed=%d purged=%d after_purge=%d\n"):format(#c1, #c2, purged, #c3))
+  return 0
+end)'
+
+JS_PQ='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init();
+  for (let i=0;i<5;i++) jobs.enqueue("t", {});
+  jobs.pause("default"); const c1 = jobs.claim({ batch: 10 });
+  jobs.resume("default"); const c2 = jobs.claim({ batch: 10 });
+  for (let i=0;i<3;i++) jobs.enqueue("t", {});
+  const purged = jobs.purge("default"); const c3 = jobs.claim({ batch: 10 });
+  ctx.stdout.write(`PQ paused=${c1.length} resumed=${c2.length} purged=${purged} after_purge=${c3.length}\n`);
+  return 0;
+});'
+
+echo "== v1.3 pause/resume/purge: Lua =="; check_pq "lua" "lua" "$LUA_PQ"
+echo "== v1.3 pause/resume/purge: JS =="; check_pq "js" "js" "$JS_PQ"
+
 # Fleet gate: K processes share one rate counter -> total dispatched == rate.
 echo "== v1.2 rate limit fleet ($CONC processes, one shared counter) =="
 W="$(mktemp -d)"; DB="$W/rl.db"


### PR DESCRIPTION
Closes #237. Stacked on #234 (v1.2); retargets to main after that merges.

## `jobs.pause(queue)` / `jobs.resume(queue)`
Stop / resume **dispatching** a queue. Durable + fleet-wide (a `_hull_queue` table), so it survives restarts and applies across all workers, taking effect within ~1s (a per-process paused-set cache refreshed at most once/second, so pausing adds **no DB read to the steady claim path**). A paused queue's claim short-circuits to empty; **in-flight jobs finish and `enqueue` still works** — pause gates dispatch, not production.

## `jobs.purge(queue, opts?)`
Delete jobs from a queue (the "clear the backlog" op). Defaults to `pending` only (leaves in-flight + terminal); `{ statuses: ["pending","running","done","dead"] }` widens. Returns the count.

## Tests
Both runtimes. `e2e_jobs.sh` +pause/resume/purge (paused→0 claimed, resumed→5, purged→3, nothing left). **25/25** green; `lint-js`/`lint-lua` clean.

Refs #232. Next: #236 (workflows).