### PR TITLE
feat(jobs): workflows - depends_on + result passing + cascade

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -150,6 +150,42 @@ jobs.limit("reports", { rate: 100, per: 60 });
 - Costs one extra small DB write per claim **only on limited queues**; unlimited
   queues are unaffected.
 
+## Workflows (job dependencies)
+
+`jobs.enqueue(type, data, { depends_on = { id1, id2 } })` makes a job **wait
+until those jobs complete**. It starts `blocked` (not claimed) and becomes
+`pending` only once every dependency is `done`. Each dependency's result is
+passed to the handler as **`job.deps`** — an array in declaration order.
+
+```lua
+-- chain: extract -> transform -> load, passing results forward
+local a = jobs.enqueue("extract", { src = "..." })
+local b = jobs.enqueue("transform", {}, { depends_on = { a } })
+           jobs.enqueue("load", {}, { depends_on = { b } })
+
+jobs.handler("extract",   function(job) return fetch(job.data.src) end)     -- return = result
+jobs.handler("transform", function(job) return massage(job.deps[1]) end)    -- deps[1] = extract's result
+jobs.handler("load",      function(job) save(job.deps[1]) end)              -- deps[1] = transform's result
+
+-- fan-in: run after BOTH parts, with both results
+local p1 = jobs.enqueue("part1", d); local p2 = jobs.enqueue("part2", d)
+jobs.enqueue("merge", {}, { depends_on = { p1, p2 } })   -- job.deps = { r1, r2 }
+```
+`depends_on` with N parents expresses **chains** (depend on 1), **fan-in**
+(depend on N), and **fan-out** (enqueue N children). JS uses `dependsOn` and
+`job.deps[0]`, `[1]`, …
+
+- **Results.** A handler's **return value** is stored as the job's result (JSON)
+  and injected into dependents as `job.deps`. Returning nothing / `true` /
+  `jobs.DISCARD` stores no result. (Results live in `_hull_job_results` and are
+  swept by `jobs.cleanup`.)
+- **Failure cascades.** If a dependency **dead-letters**, the dependent
+  cascade-fails too (dead-lettered, transitively down the graph) - you don't run
+  `load` if `transform` died. Opt a job out with `on_dep_failure = "run"`
+  (`onDepFailure` in JS) to run it regardless (e.g. a cleanup / notify step).
+- Depend on job **ids** returned from `enqueue`; enqueue parents first. Unknown /
+  already-cleaned-up dependency ids are treated as satisfied.
+
 ## Handler contract
 
 `jobs.work` dispatches each claimed job to its registered handler, else the

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -15,7 +15,7 @@
  * Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
  * catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
  * visibility-timeout reaper), the dedicated worker (jobs.runWorker +
- * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), and queue pause/resume/purge.
+ * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing).
  *
  * @license AGPL-3.0-or-later
  */
@@ -156,6 +156,27 @@ function init(opts) {
     _paused = Object.create(null);
     _pausedAt = 0;
 
+    // Workflow dependency edges (jobs.enqueue dependsOn). A dependent starts
+    // 'blocked'; each edge is marked satisfied when its dependency completes, and
+    // the dependent unblocks once its last edge is satisfied. The edge survives
+    // until the dependent runs, so its deps' results can be injected. failMode
+    // 'run' = "run even if this dep failed" (else cascade).
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_job_deps (" +
+        "dependent_id INTEGER NOT NULL," +
+        "dep_id       INTEGER NOT NULL," +
+        "ord          INTEGER NOT NULL," +
+        "fail_mode    VARCHAR(8)," +
+        "satisfied    INTEGER NOT NULL DEFAULT 0," +
+        "PRIMARY KEY (dependent_id, dep_id))");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_hull_job_deps_dep ON _hull_job_deps(dep_id)");
+
+    // A job's result (its handler's return value), for a dependent to consume.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_job_results (" +
+        "job_id INTEGER NOT NULL PRIMARY KEY," +
+        "result TEXT)");
+
     // Verify the server actually parses SKIP LOCKED (the compile-time dialect
     // flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
     // does not). A 0-row probe against the real table detects it once; the claim
@@ -169,13 +190,83 @@ function init(opts) {
     return jobs;
 }
 
+// ── Workflow dependencies (jobs.enqueue dependsOn) ──────────────────────────
+
+// Apply one dependency's terminal outcome to one edge. Idempotent. Returns
+// "failed" when it cascade-fails the dependent (so callers recurse).
+function resolveEdge(dependentId, depId, depOk, failMode) {
+    if (depOk || failMode === "run") {
+        const n = db.exec(
+            "UPDATE _hull_job_deps SET satisfied=1 WHERE dependent_id=? AND dep_id=? AND satisfied=0",
+            [dependentId, depId]);
+        if ((n || 0) === 0) return null;   // already satisfied / gone
+        const rows = db.query(
+            "SELECT COUNT(*) AS c FROM _hull_job_deps WHERE dependent_id=? AND satisfied=0",
+            [dependentId]);
+        if ((rows[0] ? rows[0].c : 0) === 0) {
+            db.exec("UPDATE _hull_jobs SET status='pending', updated_at=? WHERE id=? AND status='blocked'",
+                [time.now(), dependentId]);
+        }
+        return null;
+    }
+    // cascade-fail: this dependency died and the dependent didn't opt to run.
+    const n = db.exec(
+        "UPDATE _hull_jobs SET status='dead', last_error=?, updated_at=? WHERE id=? AND status='blocked'",
+        [`dependency ${depId} failed`, time.now(), dependentId]);
+    if ((n || 0) > 0) {
+        db.exec("DELETE FROM _hull_job_deps WHERE dependent_id=?", [dependentId]);
+        return "failed";
+    }
+    return null;
+}
+
+// A job reached a terminal state; propagate to its dependents transitively.
+function resolveDeps(id, ok) {
+    const work = [{ id, ok }];
+    let guard = 0;
+    while (work.length > 0 && guard < 100000) {
+        guard++;
+        const cur = work.pop();
+        const edges = db.query(
+            "SELECT dependent_id, fail_mode FROM _hull_job_deps WHERE dep_id=?", [cur.id]);
+        for (const e of edges) {
+            if (resolveEdge(e.dependent_id, cur.id, cur.ok, e.fail_mode) === "failed") {
+                work.push({ id: e.dependent_id, ok: false });
+            }
+        }
+    }
+}
+
+// Gather a dependent's dependency results (declaration order) for job.deps.
+// Returns null when the job has no dependencies (a PK-indexed 0-row probe).
+function loadDeps(dependentId) {
+    const edges = db.query(
+        "SELECT dep_id FROM _hull_job_deps WHERE dependent_id=? ORDER BY ord", [dependentId]);
+    if (edges.length === 0) return null;
+    const out = [];
+    edges.forEach((e, i) => {
+        const r = db.query("SELECT result FROM _hull_job_results WHERE job_id=?", [e.dep_id]);
+        if (r[0] && r[0].result !== undefined && r[0].result !== null) {
+            try { out[i] = json.decode(r[0].result); } catch (_e) { out[i] = undefined; }
+        } else {
+            out[i] = undefined;
+        }
+    });
+    return out;
+}
+
 /**
  * Enqueue a job. A plain INSERT, so calling it inside a `db.batch()` commits
  * the job atomically with the business row (transactional coupling).
  *
+ * With `opts.dependsOn` (a list of job ids) the job starts `blocked` and only
+ * becomes claimable once all those jobs complete; each dependency's result is
+ * injected into the handler as `job.deps` (in order). If a dependency
+ * dead-letters, the dependent cascade-fails too, unless `opts.onDepFailure === "run"`.
+ *
  * @param {string} jobType  handler dispatch key (non-empty)
  * @param {*} [data]        JSON-encodable payload (reaches the handler as job.data)
- * @param {object} [opts]   { queue, priority, delay, runAt, maxAttempts, dedupKey }
+ * @param {object} [opts]   { queue, priority, delay, runAt, maxAttempts, dedupKey, dependsOn, onDepFailure }
  * @returns {number|null}   the new job id, or null when a dedupKey collapsed it
  */
 function enqueue(jobType, data, opts) {
@@ -184,6 +275,8 @@ function enqueue(jobType, data, opts) {
     const o = opts || {};
     const now = time.now();
     const runAt = o.runAt !== undefined ? o.runAt : now + (o.delay || 0);
+    const deps = o.dependsOn;
+    const hasDeps = Array.isArray(deps) && deps.length > 0;
     const vals = [
         o.queue || "default",
         jobType,
@@ -196,16 +289,33 @@ function enqueue(jobType, data, opts) {
     ];
     const cols = ["queue", "type", "payload", "priority", "max_attempts",
                   "run_at", "dedup_key", "created_at", "updated_at"];
+    if (hasDeps) { cols.push("status"); vals.push("blocked"); }
+    let id;
     if (o.dedupKey !== undefined && o.dedupKey !== null) {
         const n = db.insertIfAbsent("_hull_jobs", ["queue", "dedup_key"], cols, vals);
-        if (n && n > 0) return db.lastId();
-        return null;   // an un-run job with this (queue, dedupKey) already exists
+        if (!(n && n > 0)) return null;   // an un-run job with this (queue, dedupKey) exists
+        id = db.lastId();
+    } else {
+        const ph = cols.map(() => "?");
+        db.exec("INSERT INTO _hull_jobs (" + cols.join(", ") +
+            ") VALUES (" + ph.join(", ") + ")", vals);
+        id = db.lastId();
     }
-    db.exec(
-        "INSERT INTO _hull_jobs (queue, type, payload, priority, max_attempts, " +
-        "run_at, dedup_key, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        vals);
-    return db.lastId();
+    if (hasDeps) {
+        // Record edges, then re-check each dep: closes the enqueue/complete race
+        // (whichever side runs second is a no-op - both idempotent).
+        const failMode = o.onDepFailure === "run" ? "run" : null;
+        deps.forEach((dep, i) => {
+            db.exec("INSERT INTO _hull_job_deps (dependent_id, dep_id, ord, fail_mode) " +
+                "VALUES (?, ?, ?, ?)", [id, dep, i + 1, failMode]);
+        });
+        for (const dep of deps) {
+            const g = get(dep);
+            if (g === null || g.status === "done") resolveEdge(id, dep, true, failMode);
+            else if (g.status === "dead") resolveEdge(id, dep, false, failMode);
+        }
+    }
+    return id;
 }
 
 // Decode a claimed DB row into a handler-facing job (payload -> data).
@@ -425,14 +535,23 @@ function setDefault(fn) {
     return jobs;
 }
 
-function markDone(id) {
+function markDone(id, result) {
     db.exec("UPDATE _hull_jobs SET status='done', claim_token=NULL, updated_at=? WHERE id=?",
         [time.now(), id]);
+    if (result !== undefined) {   // persist the handler's return value for dependents
+        const enc = json.encode(result);
+        const n = db.exec("UPDATE _hull_job_results SET result=? WHERE job_id=?", [enc, id]);
+        if ((n || 0) === 0) db.exec("INSERT INTO _hull_job_results (job_id, result) VALUES (?, ?)", [id, enc]);
+    }
+    resolveDeps(id, true);                                   // unblock dependents
+    db.exec("DELETE FROM _hull_job_deps WHERE dependent_id=?", [id]);   // consumed its own deps
 }
 
 function markDead(id, err) {
     db.exec("UPDATE _hull_jobs SET status='dead', last_error=?, claim_token=NULL, updated_at=? WHERE id=?",
         [err, time.now(), id]);
+    resolveDeps(id, false);                                  // cascade to dependents
+    db.exec("DELETE FROM _hull_job_deps WHERE dependent_id=?", [id]);
 }
 
 // Reschedule with backoff, or dead-letter once attempts are exhausted. attempts
@@ -638,13 +757,20 @@ async function work(opts) {
     if (now - _lastCron >= 1) { processCron(now); _lastCron = now; }
     const batch = claim(o);
     for (const job of batch) {
+        job.deps = loadDeps(job.id);   // workflow: dependency results, in order
         const h = _handlers[job.type] || _default;
         if (!h) { markDead(job.id, `no handler for job type '${job.type}'`); continue; }
         try {
             const result = await h(job);
             if (result === DEAD) markDead(job.id, "handler returned jobs.DEAD");
             else if (result === RETRY) markRetry(job, "handler requested retry");
-            else markDone(job.id);   // undefined / true / DISCARD / any value -> done
+            else {
+                // undefined / true / DISCARD -> done, no result; any other return
+                // value is stored as the job's result (for dependents).
+                const res = (result !== undefined && result !== true && result !== DISCARD)
+                    ? result : undefined;
+                markDone(job.id, res);
+            }
         } catch (e) {
             markRetry(job, String((e && e.message) || e));
         }
@@ -731,7 +857,7 @@ function stats(opts) {
     const rows = o.queue
         ? db.query("SELECT status, COUNT(*) AS c FROM _hull_jobs WHERE queue=? GROUP BY status", [o.queue])
         : db.query("SELECT status, COUNT(*) AS c FROM _hull_jobs GROUP BY status");
-    const s = { pending: 0, running: 0, done: 0, dead: 0 };
+    const s = { pending: 0, running: 0, done: 0, dead: 0, blocked: 0 };
     for (const r of rows) s[r.status] = r.c;
     return s;
 }
@@ -850,7 +976,10 @@ function cleanup(opts) {
     let sql = "DELETE FROM _hull_jobs WHERE status IN (" +
         placeholders.join(",") + ") AND updated_at < ?";
     if (o.queue) { sql += " AND queue=?"; params.push(o.queue); }
-    return db.exec(sql, params) || 0;
+    const deleted = db.exec(sql, params) || 0;
+    // Drop results whose producing job is gone (workflow result store hygiene).
+    db.exec("DELETE FROM _hull_job_results WHERE job_id NOT IN (SELECT id FROM _hull_jobs)");
+    return deleted;
 }
 
 // Internal seams for tests / introspection; not part of the app-facing contract.

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -11,7 +11,7 @@
 -- Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
 -- catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
 -- visibility-timeout reaper), the dedicated worker (jobs.run_worker +
--- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), and queue pause/resume/purge.
+-- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing).
 --
 -- Usage (target shape):
 --   local jobs = require("hull.jobs")
@@ -169,6 +169,27 @@ function jobs.init(opts)
         .. "paused INTEGER      NOT NULL DEFAULT 0)")
     _paused, _paused_at = {}, 0   -- force a reload after (re)init
 
+    -- Workflow dependency edges (jobs.enqueue depends_on). A dependent starts
+    -- 'blocked'; each edge is marked satisfied when its dependency completes, and
+    -- the dependent unblocks (-> pending) once its last edge is satisfied. The
+    -- edge survives until the dependent runs, so its deps' results can be
+    -- injected. fail_mode 'run' = "run even if this dep failed" (else cascade).
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_job_deps ("
+        .. "dependent_id INTEGER NOT NULL,"
+        .. "dep_id       INTEGER NOT NULL,"
+        .. "ord          INTEGER NOT NULL,"
+        .. "fail_mode    VARCHAR(8),"
+        .. "satisfied    INTEGER NOT NULL DEFAULT 0,"
+        .. "PRIMARY KEY (dependent_id, dep_id))")
+    db.exec([[ CREATE INDEX IF NOT EXISTS idx_hull_job_deps_dep ON _hull_job_deps(dep_id) ]])
+
+    -- A job's result (its handler's return value), for a dependent to consume.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_job_results ("
+        .. "job_id INTEGER NOT NULL PRIMARY KEY,"
+        .. "result TEXT)")
+
     -- Verify the server actually parses SKIP LOCKED (the compile-time dialect
     -- flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
     -- does not). A 0-row probe against the real table detects it once; the claim
@@ -184,9 +205,81 @@ function jobs.init(opts)
     return jobs
 end
 
+-- ── Workflow dependencies (jobs.enqueue depends_on) ─────────────────────────
+
+-- Apply one dependency's terminal outcome to one edge. Idempotent (safe if the
+-- edge was already resolved by a concurrent completion or the enqueue recheck).
+-- Returns "failed" when it cascade-fails the dependent (so callers recurse).
+local function resolve_edge(dependent_id, dep_id, dep_ok, fail_mode)
+    if dep_ok or fail_mode == "run" then
+        local n = db.exec(
+            "UPDATE _hull_job_deps SET satisfied=1 WHERE dependent_id=? AND dep_id=? AND satisfied=0",
+            { dependent_id, dep_id })
+        if (n or 0) == 0 then return nil end   -- already satisfied / gone
+        local rows = db.query(
+            "SELECT COUNT(*) AS c FROM _hull_job_deps WHERE dependent_id=? AND satisfied=0",
+            { dependent_id })
+        if (rows[1] and rows[1].c or 0) == 0 then
+            db.exec("UPDATE _hull_jobs SET status='pending', updated_at=? WHERE id=? AND status='blocked'",
+                { time.now(), dependent_id })
+        end
+        return nil
+    end
+    -- cascade-fail: this dependency died and the dependent didn't opt to run.
+    local n = db.exec(
+        "UPDATE _hull_jobs SET status='dead', last_error=?, updated_at=? WHERE id=? AND status='blocked'",
+        { "dependency " .. tostring(dep_id) .. " failed", time.now(), dependent_id })
+    if (n or 0) > 0 then
+        db.exec("DELETE FROM _hull_job_deps WHERE dependent_id=?", { dependent_id })
+        return "failed"
+    end
+    return nil
+end
+
+-- A job reached a terminal state; propagate to its dependents - unblock on
+-- success, cascade-fail on failure, transitively.
+local function resolve_deps(id, ok)
+    local work, guard = { { id = id, ok = ok } }, 0
+    while #work > 0 and guard < 100000 do
+        guard = guard + 1
+        local cur = table.remove(work)
+        local edges = db.query(
+            "SELECT dependent_id, fail_mode FROM _hull_job_deps WHERE dep_id=?", { cur.id })
+        for _, e in ipairs(edges) do
+            if resolve_edge(e.dependent_id, cur.id, cur.ok, e.fail_mode) == "failed" then
+                work[#work + 1] = { id = e.dependent_id, ok = false }
+            end
+        end
+    end
+end
+
+-- Gather a dependent's dependency results (in declaration order) for injection
+-- as job.deps. Returns nil when the job has no dependencies (the common case;
+-- a PK-indexed 0-row probe). A slot is nil when that dependency had no result.
+local function load_deps(dependent_id)
+    local edges = db.query(
+        "SELECT dep_id FROM _hull_job_deps WHERE dependent_id=? ORDER BY ord", { dependent_id })
+    if #edges == 0 then return nil end
+    local out = {}
+    for i, e in ipairs(edges) do
+        local r = db.query("SELECT result FROM _hull_job_results WHERE job_id=?", { e.dep_id })
+        if r[1] and r[1].result ~= nil then
+            local ok, decoded = pcall(json.decode, r[1].result)
+            if ok then out[i] = decoded end
+        end
+    end
+    return out
+end
+
 --- Enqueue a job. A plain INSERT, so calling it inside a `db.batch()` commits
 -- the job atomically with the business row (transactional coupling - the reason
 -- jobs is DB-backed, not an external broker).
+--
+-- With `opts.depends_on` (a list of job ids) the job starts `blocked` and only
+-- becomes claimable once all those jobs complete; each dependency's result is
+-- injected into the handler as `job.deps` (in declaration order). If a
+-- dependency dead-letters, the dependent cascade-fails too, unless
+-- `opts.on_dep_failure == "run"`.
 --
 -- @tparam string job_type  handler dispatch key (non-empty)
 -- @tparam[opt] any data     JSON-encodable payload (reaches the handler as job.data)
@@ -205,6 +298,8 @@ function jobs.enqueue(job_type, data, opts)
     opts = opts or {}
     local now    = time.now()
     local run_at = opts.run_at or (now + (opts.delay or 0))
+    local deps = opts.depends_on
+    local has_deps = type(deps) == "table" and #deps > 0
     local vals = {
         opts.queue or "default",
         job_type,
@@ -217,17 +312,43 @@ function jobs.enqueue(job_type, data, opts)
     }
     local cols = { "queue", "type", "payload", "priority", "max_attempts",
                    "run_at", "dedup_key", "created_at", "updated_at" }
+    if has_deps then
+        cols[#cols + 1] = "status"; vals[#vals + 1] = "blocked"
+    end
+    local id
     if opts.dedup_key ~= nil then
         -- INSERT ... ON CONFLICT(queue,dedup_key) DO NOTHING / INSERT OR IGNORE.
         local n = db.insert_if_absent("_hull_jobs", { "queue", "dedup_key" }, cols, vals)
-        if n and n > 0 then return db.last_id() end
-        return nil   -- an un-run job with this (queue, dedup_key) already exists
+        if not (n and n > 0) then
+            return nil   -- an un-run job with this (queue, dedup_key) already exists
+        end
+        id = db.last_id()
+    else
+        local ph = {}
+        for i = 1, #cols do ph[i] = "?" end
+        db.exec("INSERT INTO _hull_jobs (" .. table.concat(cols, ", ")
+            .. ") VALUES (" .. table.concat(ph, ", ") .. ")", vals)
+        id = db.last_id()
     end
-    db.exec(
-        "INSERT INTO _hull_jobs (queue, type, payload, priority, max_attempts, "
-        .. "run_at, dedup_key, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        vals)
-    return db.last_id()
+    if has_deps then
+        -- Record edges first, then re-check each dependency's current state: this
+        -- closes the enqueue/complete race (a dep that finished between the check
+        -- and the insert is caught by whichever side runs second - both idempotent).
+        local fail_mode = (opts.on_dep_failure == "run") and "run" or nil
+        for i, dep in ipairs(deps) do
+            db.exec("INSERT INTO _hull_job_deps (dependent_id, dep_id, ord, fail_mode) "
+                .. "VALUES (?, ?, ?, ?)", { id, dep, i, fail_mode })
+        end
+        for _, dep in ipairs(deps) do
+            local g = jobs.get(dep)
+            if g == nil or g.status == "done" then
+                resolve_edge(id, dep, true, fail_mode)   -- already satisfied
+            elseif g.status == "dead" then
+                resolve_edge(id, dep, false, fail_mode)  -- already failed
+            end
+        end
+    end
+    return id
 end
 
 -- Decode a claimed DB row into a handler-facing job (payload -> data).
@@ -461,14 +582,25 @@ function jobs.default(fn)
     return jobs
 end
 
-local function mark_done(id)
+local function mark_done(id, result)
     db.exec("UPDATE _hull_jobs SET status='done', claim_token=NULL, updated_at=? WHERE id=?",
         { time.now(), id })
+    if result ~= nil then   -- persist the handler's return value for dependents
+        local enc = json.encode(result)
+        local n = db.exec("UPDATE _hull_job_results SET result=? WHERE job_id=?", { enc, id })
+        if (n or 0) == 0 then
+            db.exec("INSERT INTO _hull_job_results (job_id, result) VALUES (?, ?)", { id, enc })
+        end
+    end
+    resolve_deps(id, true)                                   -- unblock dependents
+    db.exec("DELETE FROM _hull_job_deps WHERE dependent_id=?", { id })   -- consumed its own deps
 end
 
 local function mark_dead(id, err)
     db.exec("UPDATE _hull_jobs SET status='dead', last_error=?, claim_token=NULL, updated_at=? WHERE id=?",
         { err, time.now(), id })
+    resolve_deps(id, false)                                  -- cascade to dependents
+    db.exec("DELETE FROM _hull_job_deps WHERE dependent_id=?", { id })
 end
 
 -- Reschedule with backoff, or dead-letter once attempts are exhausted. `attempts`
@@ -697,6 +829,7 @@ function jobs.work(opts)
     end
     local batch = jobs.claim(opts)
     for _, job in ipairs(batch) do
+        job.deps = load_deps(job.id)   -- workflow: dependency results, in order
         local h = _handlers[job.type] or _default
         if not h then
             mark_dead(job.id, "no handler for job type '" .. tostring(job.type) .. "'")
@@ -709,8 +842,13 @@ function jobs.work(opts)
             elseif result == jobs.RETRY then
                 mark_retry(job, "handler requested retry")
             else
-                -- nil / true / jobs.DISCARD / any other value -> done.
-                mark_done(job.id)
+                -- nil / true / jobs.DISCARD -> done, no result; any other return
+                -- value is stored as the job's result (for dependents).
+                local res
+                if result ~= nil and result ~= true and result ~= jobs.DISCARD then
+                    res = result
+                end
+                mark_done(job.id, res)
             end
         end
     end
@@ -802,7 +940,7 @@ function jobs.stats(opts)
     else
         rows = db.query("SELECT status, COUNT(*) AS c FROM _hull_jobs GROUP BY status")
     end
-    local s = { pending = 0, running = 0, done = 0, dead = 0 }
+    local s = { pending = 0, running = 0, done = 0, dead = 0, blocked = 0 }
     for _, r in ipairs(rows) do s[r.status] = r.c end
     return s
 end
@@ -933,7 +1071,10 @@ function jobs.cleanup(opts)
         sql = sql .. " AND queue=?"
         params[#params + 1] = opts.queue
     end
-    return db.exec(sql, params) or 0
+    local deleted = db.exec(sql, params) or 0
+    -- Drop results whose producing job is gone (workflow result store hygiene).
+    db.exec("DELETE FROM _hull_job_results WHERE job_id NOT IN (SELECT id FROM _hull_jobs)")
+    return deleted
 end
 
 return jobs

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -637,6 +637,70 @@ app.main(async (ctx) => {
 echo "== v1.3 pause/resume/purge: Lua =="; check_pq "lua" "lua" "$LUA_PQ"
 echo "== v1.3 pause/resume/purge: JS =="; check_pq "js" "js" "$JS_PQ"
 
+# ── v1.4: workflows (depends_on) - chain, result-passing, cascade, fan-in ───
+# extract->transform->load chain passes results via job.deps; a failed dep
+# cascade-fails its dependent (on_dep_failure="run" opts out); fan-in gets both.
+check_wf() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"WF blocked=1 t=10 l=20 cascade=dead runaway=done ran=1 fanin=done m1=10 m2=10"*)
+            pass "$label: workflows (chain/result/cascade/run-anyway/fan-in)" ;;
+        *) fail "$label: v1.4 workflows" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_WF='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init()
+  local L = {}
+  jobs.handler("extract",   function(j) return { v = 10 } end)
+  jobs.handler("transform", function(j) L.t = j.deps[1].v; return { v = j.deps[1].v * 2 } end)
+  jobs.handler("load",      function(j) L.l = j.deps[1].v end)
+  jobs.handler("boom",      function(j) error("fail") end)
+  jobs.handler("child",     function(j) end)
+  jobs.handler("run_anyway",function(j) L.ran = true end)
+  jobs.handler("merge",     function(j) L.m1 = j.deps[1].v; L.m2 = j.deps[2].v end)
+  local a=jobs.enqueue("extract",{}); local b=jobs.enqueue("transform",{},{depends_on={a}})
+  local c=jobs.enqueue("load",{},{depends_on={b}}); local b0=jobs.get(b).status
+  local x=jobs.enqueue("boom",{},{max_attempts=1}); local y=jobs.enqueue("child",{},{depends_on={x}})
+  local p=jobs.enqueue("boom",{},{max_attempts=1}); local q=jobs.enqueue("run_anyway",{},{depends_on={p},on_dep_failure="run"})
+  local e1=jobs.enqueue("extract",{}); local e2=jobs.enqueue("extract",{}); local m=jobs.enqueue("merge",{},{depends_on={e1,e2}})
+  jobs.run_worker({ drain = true, poll_ms = 5 })
+  ctx.stdout:write(("WF blocked=%d t=%s l=%s cascade=%s runaway=%s ran=%d fanin=%s m1=%s m2=%s\n"):format(
+    b0=="blocked" and 1 or 0, tostring(L.t), tostring(L.l), jobs.get(y).status, jobs.get(q).status,
+    L.ran and 1 or 0, jobs.get(m).status, tostring(L.m1), tostring(L.m2)))
+  return 0
+end)'
+
+JS_WF='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init();
+  const L = {};
+  jobs.handler("extract",   (j) => ({ v: 10 }));
+  jobs.handler("transform", (j) => { L.t = j.deps[0].v; return { v: j.deps[0].v * 2 }; });
+  jobs.handler("load",      (j) => { L.l = j.deps[0].v; });
+  jobs.handler("boom",      (j) => { throw new Error("fail"); });
+  jobs.handler("child",     (j) => {});
+  jobs.handler("run_anyway",(j) => { L.ran = true; });
+  jobs.handler("merge",     (j) => { L.m1 = j.deps[0].v; L.m2 = j.deps[1].v; });
+  const a=jobs.enqueue("extract",{}); const b=jobs.enqueue("transform",{},{dependsOn:[a]});
+  const c=jobs.enqueue("load",{},{dependsOn:[b]}); const b0=jobs.get(b).status;
+  const x=jobs.enqueue("boom",{},{maxAttempts:1}); const y=jobs.enqueue("child",{},{dependsOn:[x]});
+  const p=jobs.enqueue("boom",{},{maxAttempts:1}); const q=jobs.enqueue("run_anyway",{},{dependsOn:[p],onDepFailure:"run"});
+  const e1=jobs.enqueue("extract",{}); const e2=jobs.enqueue("extract",{}); const m=jobs.enqueue("merge",{},{dependsOn:[e1,e2]});
+  await jobs.runWorker({ drain: true, pollMs: 5 });
+  ctx.stdout.write(`WF blocked=${b0==="blocked"?1:0} t=${L.t} l=${L.l} cascade=${jobs.get(y).status} runaway=${jobs.get(q).status} ran=${L.ran?1:0} fanin=${jobs.get(m).status} m1=${L.m1} m2=${L.m2}\n`);
+  return 0;
+});'
+
+echo "== v1.4 workflows: Lua =="; check_wf "lua" "lua" "$LUA_WF"
+echo "== v1.4 workflows: JS =="; check_wf "js" "js" "$JS_WF"
+
 # Fleet gate: K processes share one rate counter -> total dispatched == rate.
 echo "== v1.2 rate limit fleet ($CONC processes, one shared counter) =="
 W="$(mktemp -d)"; DB="$W/rl.db"


### PR DESCRIPTION
Closes #236. Stacked on #239 (pause/resume); retargets to main after that merges.

The one headline feature the big Redis frameworks have that the DB-backed peers don't — and, per your steer, **it passes results between depending jobs**.

## API
```lua
-- chain: extract -> transform -> load, results flow forward
local a = jobs.enqueue("extract", { src })
local b = jobs.enqueue("transform", {}, { depends_on = { a } })
           jobs.enqueue("load", {}, { depends_on = { b } })

jobs.handler("extract",   function(job) return fetch(job.data.src) end)   -- return = result
jobs.handler("transform", function(job) return massage(job.deps[1]) end)  -- deps[1] = extract's result
jobs.handler("load",      function(job) save(job.deps[1]) end)

-- fan-in: run after both, with both results
jobs.enqueue("merge", {}, { depends_on = { p1, p2 } })   -- job.deps = { r1, r2 }
```
`depends_on` with N parents expresses **chains** (1), **fan-in** (N), and **fan-out** (enqueue N). JS: `dependsOn`, `job.deps[0]`.

- **Results** — a handler's **return value** is stored (JSON, `_hull_job_results`) and injected into dependents as `job.deps` in declaration order. nothing / `true` / `DISCARD` → no result. `jobs.cleanup` sweeps orphans.
- **Cascade** — a dead-lettered dependency cascade-fails its dependents (transitively). Opt out per job: `on_dep_failure = "run"` (`onDepFailure` in JS).

## Mechanics
A `_hull_job_deps` edge table `(dependent_id, dep_id, ord, fail_mode, satisfied)`. On a dep's completion the edge is marked satisfied; the dependent unblocks (`blocked` → `pending`) once its last edge clears. The edge survives until the dependent runs (so results inject), then is deleted. Enqueue records edges **then re-checks** each dep's current state — closing the enqueue/complete race (both sides idempotent). `stats()` gains a `blocked` count.

## Tests
Both runtimes. `e2e_jobs.sh` +workflows: extract→transform→load chain with result-passing, cascade-on-dep-fail, `on_dep_failure=run`, and fan-in with both results. **27/27** green; existing 25 unaffected; `lint-js`/`lint-lua` clean.

Refs #232.