### PR TITLE
jobs(v1.5): result backend, multi-queue, bulk enqueue, lifecycle hooks, polish

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -87,6 +87,32 @@ processes scale those better).
 app.main(function() jobs.init(); jobs.run_worker({ concurrency = 8 }) end)
 ```
 
+**Multiple queues.** A worker can drain several named queues via `opts.queues`
+(on `claim`, `work`, or `run_worker`). A **list** is strict priority - each queue
+tried in order, claiming from the first with ready work (higher queues drain
+first). A **map** is weighted fairness - a weighted-random draw with every queue
+still a fallback, so none starves and a homogeneous fleet is fair fleet-wide.
+
+```lua
+jobs.run_worker({ queues = { "critical", "default", "low" } })  -- strict priority
+jobs.run_worker({ queues = { critical = 3, default = 2, low = 1 } })  -- weighted
+```
+
+## Lifecycle hooks
+
+`jobs.on(event, fn)` registers an **in-process** listener fired synchronously by
+`jobs.work`, in the worker that processed the job - for observability, metrics,
+and side-effects. Events: `completed` (`info.result`), `retried`
+(`info = { error, attempt }`, a failed attempt that will retry), `dead`
+(`info.error`; exhausted / `jobs.DEAD` / no handler). Listeners are isolated (a
+throwing hook can't derail the loop); keep them fast and synchronous. These are
+per-worker (not fleet-wide - durable cross-process eventing is a separate epic).
+
+```lua
+jobs.on("completed", function(job, info) metrics.inc("jobs.done", { type = job.type }) end)
+jobs.on("dead",      function(job, info) log.error("job died: " .. info.error) end)
+```
+
 ## Recurring jobs (cron)
 
 `jobs.cron(name, spec, data?, opts?)` registers a **durable** recurring
@@ -117,6 +143,10 @@ jobs.uncron("heartbeat");
   comma lists; `day-of-week` is `0`/`7` = Sunday. When both day-of-month and
   day-of-week are restricted, a match on **either** fires (standard cron).
 - **`opts`**: `type`, `queue`, `priority`, `max_attempts` for the enqueued jobs.
+- **`opts.tz`**: evaluate the spec in a **fixed offset** east of UTC -
+  `"+02:00"`, `"-0530"`, or minutes as a number (`120`). IANA zone names
+  (`"Europe/Budapest"`) are rejected: a DST-correct named zone needs a tz
+  database Hull can't read inside the sandbox. Default is UTC.
 - **Missed ticks** (all workers were down) advance to the next future occurrence
   - fire-once, no backfill storm.
 
@@ -211,18 +241,38 @@ jobs.enqueue(type, data, {
     queue        = "emails",   -- named queue (default "default")
     priority     = 10,         -- higher runs first (default 0)
     delay        = 60,         -- seconds until claimable (run_at = now + delay)
+    at           = 1735689600, -- absolute unix ts to run at (wins over run_at/delay)
     run_at       = 1735689600, -- absolute unix ts (overrides delay)
     max_attempts = 5,          -- override the module default (25)
     dedup_key    = "order-42", -- idempotent enqueue: a duplicate un-run key is a no-op
+    throttle     = 60,         -- windowed: skip if a (queue,type) job was made in the last N s
 })
 ```
-Returns the new job id, or `nil` when a `dedup_key` collapsed it. JS keys are
-camelCase (`runAt`, `maxAttempts`, `dedupKey`).
+Returns the new job id, or `nil` when a `dedup_key` collapsed it (or a
+`throttle` window suppressed it). JS keys are camelCase (`runAt`, `maxAttempts`,
+`dedupKey`). `throttle` is best-effort (keyed by `(queue, type)`, no unique
+constraint - use `dedup_key` for exact-once).
+
+**Bulk enqueue.** `jobs.enqueue_many(items)` (`enqueueMany` in JS) inserts a list
+of `{ type, data, opts }` in **one transaction** - a single commit/fsync instead
+of one per job. Returns ids in input order (`nil` for a deduped item). Every
+`opts` field works except `depends_on` (bulk is for independent jobs; build
+graphs with `enqueue`).
+
+```lua
+local ids = jobs.enqueue_many({
+    { type = "email", data = { to = "a@b.c" } },
+    { type = "email", data = { to = "d@e.f" }, opts = { priority = 5 } },
+})
+```
 
 ## Ops surface
 
 ```lua
 jobs.get(id)                  -- one job's full status view, or nil if it doesn't exist
+jobs.result(id)               -- terminal result: { status, result?, error? }, or nil if unknown
+jobs.await(id, { timeout = 5000 })   -- yield until the job is terminal, then return jobs.result
+jobs.progress(id, 42)         -- set a running job's progress 0-100 (surfaced by get(id).progress)
 jobs.stats()                  -- { pending, running, done, dead } (opts.queue to scope)
 jobs.dead({ limit = 50 })     -- list dead-lettered jobs (newest first) for inspection
 jobs.retry(id)                -- requeue a dead job with a fresh attempt budget; false if not dead
@@ -238,9 +288,17 @@ finish, and `enqueue` still works) - durable and fleet-wide, taking effect withi
 `jobs.get(id)` is the "did my job run?" primitive: after `local id =
 jobs.enqueue(...)`, poll `jobs.get(id).status` (`pending` → `running` → `done` /
 `dead`). It's the only way to inspect an individual job from app code -
-`_hull_jobs` is namespace-protected, so a direct query is blocked. Jobs are
-fire-and-forget (no result backend), so a job that produces output must persist
-it itself; poll `get(id)` only for the terminal *status*.
+`_hull_jobs` is namespace-protected, so a direct query is blocked.
+
+**Result backend.** A handler's non-nil return value is persisted, so
+`jobs.result(id)` returns `{ status, result?, error? }` for any job (a `done`
+job carries its return value, a `dead` job its error) - `nil` if the id is
+unknown or already purged. `jobs.await(id, { timeout, interval })` yields to the
+event loop and polls until the job is terminal (or the timeout elapses), then
+returns the same shape - the "enqueue then wait for the value" pattern. Results
+live as long as the job row (governed by `jobs.cleanup`), so read before purge.
+`jobs.progress(id, pct)` lets a long handler publish 0-100 progress, surfaced on
+`jobs.get(id).progress`.
 
 `jobs.cancel` only removes a `pending` job (a delayed/scheduled one that hasn't
 started); a `running` job is mid-flight and is left to finish or dead-letter.

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -443,10 +443,41 @@ function purge(queue, opts) {
  * @param {object} [opts]  { queue = "default", batch = 10 }
  * @returns {Array}  claimed jobs { id, type, data, attempts, maxAttempts }
  */
-function claim(opts) {
-    const o = opts || {};
-    const queue = o.queue || "default";
-    const batch = o.batch || 10;
+// Resolve opts.queue / opts.queues to an ordered list of queues to try. A single
+// `queue` (or the default) is a one-element order. `queues` may be a LIST
+// ["critical","default","low"] (strict priority - try each in order, claim from
+// the first with ready work) or a MAP {critical:3, default:2, low:1} (weighted
+// fairness: a weighted-random shuffle with every queue still present as a
+// fallback, so no claim cycle is wasted and no queue starves; a homogeneous
+// fleet gives fleet-wide fairness). Zero/negative/non-number weights are dropped.
+function resolveQueueOrder(opts) {
+    const qs = opts.queues;
+    if (qs == null) return [opts.queue || "default"];
+    if (Array.isArray(qs)) return qs.slice();                 // list (strict priority)
+    const names = [], weights = {};                           // map (weighted)
+    let total = 0;
+    for (const name of Object.keys(qs)) {
+        const w = qs[name];
+        if (typeof w === "number" && w > 0) { names.push(name); weights[name] = w; total += w; }
+    }
+    const order = [];
+    while (names.length) {
+        const pick = Math.random() * total;
+        let acc = 0, idx = names.length - 1;
+        for (let i = 0; i < names.length; i++) {
+            acc += weights[names[i]];
+            if (pick <= acc) { idx = i; break; }
+        }
+        const chosen = names[idx];
+        order.push(chosen);
+        total -= weights[chosen];
+        names.splice(idx, 1);
+    }
+    return order;
+}
+
+// Claim up to `batch` ready jobs from ONE queue (the per-backend atomic claim).
+function claimOne(queue, batch) {
     if (isPaused(queue)) return [];   // paused: don't dispatch
     const now = time.now();
     const token = crypto.base64urlEncode(crypto.random(16));
@@ -504,6 +535,26 @@ function claim(opts) {
         });
     // Enforce a fleet-wide rate limit (claim-then-reconcile; requeues the excess).
     return rlApply(queue, out);
+}
+
+/**
+ * Atomically claim up to `batch` ready jobs, marking them `running`.
+ * Concurrency-safe (SKIP LOCKED on Postgres/MySQL, serialized on SQLite). Draws
+ * from a single queue (`opts.queue`, default "default") or across several via
+ * `opts.queues` - a LIST for strict priority or a MAP for weighted fairness (see
+ * resolveQueueOrder). Multi-queue claims from the first queue in the resolved
+ * order with ready work; a worker loop drains the rest on later calls.
+ * @param {object} [opts]  { queue | queues, batch }
+ * @returns {object[]}
+ */
+function claim(opts) {
+    const o = opts || {};
+    const batch = o.batch || 10;
+    for (const q of resolveQueueOrder(o)) {
+        const got = claimOne(q, batch);
+        if (got.length) return got;
+    }
+    return [];
 }
 
 // ── Handlers + the work loop ────────────────────────────────────────────

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -881,14 +881,68 @@ function shapeOps(r) {
  * Fetch a single job by id (its full status view), or null if it doesn't exist.
  * The only way to inspect an individual job from app code: `_hull_jobs` is in the
  * protected namespace, so a direct query is blocked. Poll this for a terminal
- * status (jobs are fire-and-forget; there is no result backend - a handler that
- * produces output must persist it itself).
+ * status, or use `jobs.result` / `jobs.await` to fetch a finished job's return
+ * value (a handler's non-null return is persisted as the job's result).
  * @param {number} id
  * @returns {object|null}
  */
 function get(id) {
     const rows = db.query("SELECT * FROM _hull_jobs WHERE id=?", [id]);
     return rows.length ? shapeOps(rows[0]) : null;
+}
+
+/**
+ * Fetch a job's terminal result without the full status view. Returns null when
+ * the job is unknown (never enqueued, or already purged by `jobs.cleanup`);
+ * otherwise `{ status, result?, error? }`:
+ *   - a `done` job carries `result` = the handler's decoded return value (absent
+ *     when the handler returned null/undefined/true/jobs.DISCARD),
+ *   - a `dead` job carries `error` = its last error string,
+ *   - a still-running (`pending`/`running`/`blocked`) job carries neither.
+ * The standalone counterpart to a workflow dependent's injected
+ * `job.deps[i].result`: any job's return value is readable here, not only a
+ * dependency's. The result lives as long as the job row (governed by
+ * `jobs.cleanup`), so read it before the terminal row is purged.
+ * @param {number} id
+ * @returns {object|null}
+ */
+function result(id) {
+    const rows = db.query("SELECT status, last_error FROM _hull_jobs WHERE id=?", [id]);
+    if (!rows.length) return null;
+    const status = rows[0].status;
+    const out = { status };
+    if (status === "done") {
+        const rr = db.query("SELECT result FROM _hull_job_results WHERE job_id=?", [id]);
+        if (rr.length && rr[0].result != null) out.result = JSON.parse(rr[0].result);
+    } else if (status === "dead") {
+        out.error = rows[0].last_error;
+    }
+    return out;
+}
+
+/**
+ * Block (yielding to the event loop) until a job reaches a terminal status, then
+ * return its `result`. For the "enqueue then await the value" pattern; it polls
+ * `result` every `opts.interval` ms (default 100), `await hull.sleep`-ing between
+ * polls so other work keeps running. With `opts.timeout` (ms) it gives up after
+ * that budget and returns the last (non-terminal) result view instead of the
+ * terminal one; without a timeout it waits indefinitely. Returns null immediately
+ * if the job is unknown. Async: `await jobs.await(id)`.
+ * @param {number} id
+ * @param {object} [opts]  { timeout: <ms>, interval: <ms> }
+ * @returns {Promise<object|null>}
+ */
+async function await_(id, opts) {
+    opts = opts || {};
+    const interval = opts.interval || 100;
+    const deadline = opts.timeout != null ? time.clock() + opts.timeout : null;
+    for (;;) {
+        const r = result(id);
+        if (r === null) return null;                            // unknown / purged
+        if (r.status === "done" || r.status === "dead") return r;
+        if (deadline !== null && time.clock() >= deadline) return r;
+        await hull.sleep(interval);
+    }
 }
 
 /**
@@ -991,11 +1045,12 @@ function _tick(now) { processCron(now !== undefined ? now : time.now()); }
 
 export const jobs = {
     init, enqueue, claim, handler, default: setDefault, work, reap, stats,
-    runWorker, stop, get, heartbeat, limit, pause, resume, purge,
+    runWorker, stop, get, result, await: await_, heartbeat, limit,
+    pause, resume, purge,
     dead, retry, cancel, cleanup, cron, uncron,
     RETRY, DEAD, DISCARD, _config: _cfg, _cronNext, _tick,
 };
 export { init, enqueue, claim, handler, work, reap, stats, runWorker, stop,
-         get, heartbeat, limit, pause, resume, purge,
+         get, result, heartbeat, limit, pause, resume, purge,
          dead, retry, cancel, cleanup, cron, uncron };
 export default jobs;

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -54,6 +54,11 @@ function defaultBackoff(attempt) {
 const _handlers = Object.create(null);
 let _default = null;
 
+// In-process lifecycle listeners (jobs.on). Fired synchronously by work() in the
+// worker that processed the job, for jobs THAT worker ran. Not fleet-wide - a
+// durable cross-process event stream is the LISTEN/NOTIFY epic (#235).
+const _listeners = { completed: [], retried: [], dead: [] };
+
 // Whether the server parses SKIP LOCKED (probed in init(); null = not probed).
 let _skipLocked = null;
 // Per-queue rate limits { [queue]: { rate, per } }, in-memory (re-registered on
@@ -615,6 +620,33 @@ function setDefault(fn) {
     return jobs;
 }
 
+/**
+ * Register an in-process lifecycle listener. `event` is one of "completed",
+ * "retried" (a failed attempt that will be retried with backoff), or "dead"
+ * (dead-lettered: retries exhausted, handler returned jobs.DEAD, or no handler).
+ * The listener is called `fn(job, info)` synchronously by work(), in the worker
+ * that processed the job, right after the outcome is applied:
+ *   - completed -> info = { result }   (the handler's return value, or undefined)
+ *   - retried   -> info = { error, attempt }   (attempt = the one that just failed)
+ *   - dead      -> info = { error }
+ * Multiple listeners per event fire in registration order; each is isolated (a
+ * throwing listener can't derail the loop or the others). Keep hooks fast and
+ * synchronous - they run inline on the event-loop thread and their return
+ * (incl. a promise) is not awaited. Per-worker, for observability/metrics/side-
+ * effects; a durable fleet-wide event stream is the LISTEN/NOTIFY epic (#235).
+ * Workflow cascade-failures don't emit here (the dependency's own `dead` fires).
+ * @param {string} event  "completed" | "retried" | "dead"
+ * @param {Function} fn
+ * @returns {object} the jobs module (for chaining)
+ */
+function on(event, fn) {
+    if (!_listeners[event])
+        throw new Error(`jobs.on: unknown event '${event}' (completed|retried|dead)`);
+    if (typeof fn !== "function") throw new Error("jobs.on: listener must be a function");
+    _listeners[event].push(fn);
+    return jobs;
+}
+
 function markDone(id, result) {
     db.exec("UPDATE _hull_jobs SET status='done', claim_token=NULL, updated_at=? WHERE id=?",
         [time.now(), id]);
@@ -636,16 +668,29 @@ function markDead(id, err) {
 
 // Reschedule with backoff, or dead-letter once attempts are exhausted. attempts
 // was already incremented by the claim (the attempt that just ran).
+// Returns the disposition it applied: "dead" (retries exhausted -> dead-letter)
+// or "retried" (rescheduled with backoff), so work() can emit the right event.
 function markRetry(job, err) {
     const attempts = job.attempts || 0;
     const max = job.maxAttempts !== undefined && job.maxAttempts !== null
         ? job.maxAttempts : _cfg.maxAttempts;
-    if (attempts >= max) { markDead(job.id, err); return; }
+    if (attempts >= max) { markDead(job.id, err); return "dead"; }
     const now = time.now();
     db.exec(
         "UPDATE _hull_jobs SET status='pending', run_at=?, last_error=?, claim_token=NULL, " +
         "updated_at=? WHERE id=?",
         [now + _cfg.backoff(attempts), err, now, job.id]);
+    return "retried";
+}
+
+// Fire in-process listeners for a lifecycle event. Each listener is isolated: a
+// throwing hook can't derail the work loop or the other listeners. Listener
+// return values (incl. promises) are ignored - hooks are fire-and-forget.
+function emit(event, job, info) {
+    const L = _listeners[event];
+    for (let i = 0; i < L.length; i++) {
+        try { L[i](job, info); } catch (e) { /* isolated: hooks must not break work */ }
+    }
 }
 
 /**
@@ -839,20 +884,31 @@ async function work(opts) {
     for (const job of batch) {
         job.deps = loadDeps(job.id);   // workflow: dependency results, in order
         const h = _handlers[job.type] || _default;
-        if (!h) { markDead(job.id, `no handler for job type '${job.type}'`); continue; }
+        if (!h) {
+            const err = `no handler for job type '${job.type}'`;
+            markDead(job.id, err);
+            emit("dead", job, { error: err });
+            continue;
+        }
         try {
             const result = await h(job);
-            if (result === DEAD) markDead(job.id, "handler returned jobs.DEAD");
-            else if (result === RETRY) markRetry(job, "handler requested retry");
-            else {
+            if (result === DEAD) {
+                markDead(job.id, "handler returned jobs.DEAD");
+                emit("dead", job, { error: "handler returned jobs.DEAD" });
+            } else if (result === RETRY) {
+                emit(markRetry(job, "handler requested retry"), job,
+                     { error: "handler requested retry", attempt: job.attempts });
+            } else {
                 // undefined / true / DISCARD -> done, no result; any other return
                 // value is stored as the job's result (for dependents).
                 const res = (result !== undefined && result !== true && result !== DISCARD)
                     ? result : undefined;
                 markDone(job.id, res);
+                emit("completed", job, { result: res });
             }
         } catch (e) {
-            markRetry(job, String((e && e.message) || e));
+            const err = String((e && e.message) || e);
+            emit(markRetry(job, err), job, { error: err, attempt: job.attempts });
         }
     }
     return batch.length;
@@ -1124,13 +1180,13 @@ function _cronNext(spec, from) {
 function _tick(now) { processCron(now !== undefined ? now : time.now()); }
 
 export const jobs = {
-    init, enqueue, enqueueMany, claim, handler, default: setDefault, work, reap,
+    init, enqueue, enqueueMany, claim, handler, default: setDefault, on, work, reap,
     stats, runWorker, stop, get, result, await: await_, heartbeat, limit,
     pause, resume, purge,
     dead, retry, cancel, cleanup, cron, uncron,
     RETRY, DEAD, DISCARD, _config: _cfg, _cronNext, _tick,
 };
-export { init, enqueue, enqueueMany, claim, handler, work, reap, stats, runWorker,
-         stop, get, result, heartbeat, limit, pause, resume, purge,
+export { init, enqueue, enqueueMany, claim, handler, on, work, reap, stats,
+         runWorker, stop, get, result, heartbeat, limit, pause, resume, purge,
          dead, retry, cancel, cleanup, cron, uncron };
 export default jobs;

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -108,7 +108,8 @@ function init(opts) {
         "dedup_key    VARCHAR(255)," +
         "last_error   TEXT," +
         "created_at   INTEGER      NOT NULL," +
-        "updated_at   INTEGER      NOT NULL)");
+        "updated_at   INTEGER      NOT NULL," +
+        "progress     INTEGER      NOT NULL DEFAULT 0)");
 
     // Claim scan path: ready-to-run pending jobs in a queue, by priority then id.
     db.exec(
@@ -140,8 +141,14 @@ function init(opts) {
         "max_attempts INTEGER," +
         "next_run_at  INTEGER      NOT NULL," +
         "last_run_at  INTEGER," +
-        "updated_at   INTEGER      NOT NULL)");
+        "updated_at   INTEGER      NOT NULL," +
+        "tz_offset    INTEGER      NOT NULL DEFAULT 0)");
     db.exec("CREATE INDEX IF NOT EXISTS idx_hull_cron_due ON _hull_cron(next_run_at)");
+
+    // Additive migrations for DBs created before v1.5 (idempotent: a duplicate-
+    // column error on an already-migrated DB is expected and swallowed).
+    try { db.exec("ALTER TABLE _hull_jobs ADD COLUMN progress INTEGER NOT NULL DEFAULT 0"); } catch (e) { /* exists */ }
+    try { db.exec("ALTER TABLE _hull_cron ADD COLUMN tz_offset INTEGER NOT NULL DEFAULT 0"); } catch (e) { /* exists */ }
 
     // Fleet-wide rate-limit counters (jobs.limit). One row per limited queue;
     // `name` (not the reserved word `key`), a window start, and the count.
@@ -279,7 +286,18 @@ function enqueue(jobType, data, opts) {
         throw new Error("jobs.enqueue: type must be a non-empty string");
     const o = opts || {};
     const now = time.now();
-    const runAt = o.runAt !== undefined ? o.runAt : now + (o.delay || 0);
+    // Schedule: absolute `at` (unix ts) wins, else `runAt`, else now + `delay`.
+    const runAt = o.at !== undefined ? o.at
+        : (o.runAt !== undefined ? o.runAt : now + (o.delay || 0));
+    // Windowed throttle: skip (return null) if a job of this (queue, type) was
+    // created within the last `throttle` seconds. Best-effort - keyed by
+    // (queue, type), no unique constraint (use dedupKey for exact-once).
+    if (o.throttle && o.throttle > 0) {
+        const hit = db.query(
+            "SELECT 1 AS x FROM _hull_jobs WHERE queue=? AND type=? AND created_at > ? LIMIT 1",
+            [o.queue || "default", jobType, now - o.throttle]);
+        if (hit.length) return null;
+    }
     const deps = o.dependsOn;
     const hasDeps = Array.isArray(deps) && deps.length > 0;
     const vals = [
@@ -770,10 +788,34 @@ function parseCron(spec) {
 }
 
 // Smallest unix ts strictly after `fromTs` whose UTC time matches `c`.
-function cronNext(c, fromTs) {
+// Resolve a cron `tz` option to a FIXED offset in seconds east of UTC. Accepts a
+// number (minutes east of UTC) or a string "+HH:MM" / "-HH:MM" / "+HHMM" / "Z".
+// IANA names ("Europe/Budapest") are rejected: a DST-correct named zone needs a
+// tz database Hull can't read inside the sandbox. Fixed-offset only - no DST.
+function parseTzOffset(tz) {
+    if (tz == null) return 0;
+    if (typeof tz === "number") return Math.floor(tz * 60);
+    if (typeof tz === "string") {
+        if (tz === "Z" || tz === "UTC" || tz === "utc") return 0;
+        const m = tz.match(/^([+-])(\d\d):?(\d\d)$/);
+        if (m) {
+            const off = Number(m[2]) * 3600 + Number(m[3]) * 60;
+            return m[1] === "-" ? -off : off;
+        }
+        throw new Error(`jobs.cron: tz must be a fixed offset ("+02:00", "-0530", or minutes ` +
+            `east of UTC); IANA zone names like '${tz}' need a tz database unavailable in the sandbox`);
+    }
+    throw new Error("jobs.cron: tz must be a string offset or a number of minutes");
+}
+
+// Next matching instant at or after fromTs, as a UTC unix timestamp. `offset`
+// (seconds east of UTC, default 0) shifts only the calendar decode, so the spec
+// matches wall-clock fields in that fixed-offset zone while the result stays UTC.
+function cronNext(c, fromTs, offset) {
+    const off = offset || 0;
     let t = Math.floor(fromTs / 60) * 60 + 60;
     for (let i = 0; i < 200000; i++) {
-        const { month, day, hour, minute, dow } = decodeTs(t);
+        const { month, day, hour, minute, dow } = decodeTs(t + off);
         if (!c.month.has(month)) { t = (Math.floor(t / 86400) + 1) * 86400; continue; }
         let dayOk;
         if (c.domStar && c.dowStar) dayOk = true;
@@ -793,11 +835,11 @@ function cronNext(c, fromTs) {
 // (fire-once, no backfill). Called (throttled) from work().
 function processCron(now) {
     const due = db.query(
-        "SELECT name, spec, type, payload, queue, priority, max_attempts, next_run_at " +
+        "SELECT name, spec, type, payload, queue, priority, max_attempts, next_run_at, tz_offset " +
         "FROM _hull_cron WHERE next_run_at <= ?", [now]);
     for (const c of due) {
         const parsed = parseCron(c.spec);
-        const nxt = parsed ? cronNext(parsed, now) : (now + 60);
+        const nxt = parsed ? cronNext(parsed, now, c.tz_offset) : (now + 60);
         const won = db.exec(
             "UPDATE _hull_cron SET next_run_at=?, last_run_at=?, updated_at=? " +
             "WHERE name=? AND next_run_at=?",
@@ -833,7 +875,8 @@ function cron(name, spec, data, opts) {
     if (!parsed) throw new Error("jobs.cron: invalid cron spec");
     const o = opts || {};
     const now = time.now();
-    const nxt = cronNext(parsed, now);
+    const tzOffset = parseTzOffset(o.tz);
+    const nxt = cronNext(parsed, now, tzOffset);
     if (nxt === null) throw new Error("jobs.cron: spec has no upcoming occurrence");
     const jobType = o.type || name;
     const payload = data !== undefined && data !== null ? json.encode(data) : null;
@@ -842,13 +885,13 @@ function cron(name, spec, data, opts) {
     const ma = o.maxAttempts !== undefined ? o.maxAttempts : null;
     const n = db.exec(
         "UPDATE _hull_cron SET spec=?, type=?, payload=?, queue=?, priority=?, " +
-        "max_attempts=?, next_run_at=?, updated_at=? WHERE name=?",
-        [spec, jobType, payload, queue, priority, ma, nxt, now, name]);
+        "max_attempts=?, next_run_at=?, tz_offset=?, updated_at=? WHERE name=?",
+        [spec, jobType, payload, queue, priority, ma, nxt, tzOffset, now, name]);
     if ((n || 0) === 0) {
         db.exec(
             "INSERT INTO _hull_cron (name, spec, type, payload, queue, priority, " +
-            "max_attempts, next_run_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            [name, spec, jobType, payload, queue, priority, ma, nxt, now]);
+            "max_attempts, next_run_at, tz_offset, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [name, spec, jobType, payload, queue, priority, ma, nxt, tzOffset, now]);
     }
     return jobs;
 }
@@ -1010,7 +1053,25 @@ function shapeOps(r) {
     j.lastError = r.last_error;
     j.createdAt = r.created_at;
     j.updatedAt = r.updated_at;
+    j.progress = r.progress;
     return j;
+}
+
+/**
+ * Set a running job's progress percent (0-100), surfaced by
+ * `jobs.get(id).progress`. Advisory - a UI/ops hint for long jobs, orthogonal to
+ * the claim/heartbeat. Clamped to [0,100] and rounded. Call from a handler with
+ * `job.id`. Returns the clamped value stored.
+ * @param {number} id
+ * @param {number} pct  0..100
+ * @returns {number}  the clamped value written
+ */
+function progress(id, pct) {
+    let p = Number(pct) || 0;
+    if (p < 0) p = 0; else if (p > 100) p = 100;
+    p = Math.round(p);
+    db.exec("UPDATE _hull_jobs SET progress=?, updated_at=? WHERE id=?", [p, time.now(), id]);
+    return p;
 }
 
 /**
@@ -1173,20 +1234,20 @@ function cleanup(opts) {
 }
 
 // Internal seams for tests / introspection; not part of the app-facing contract.
-function _cronNext(spec, from) {
+function _cronNext(spec, from, offset) {
     const p = parseCron(spec);
-    return p ? cronNext(p, from !== undefined ? from : time.now()) : null;
+    return p ? cronNext(p, from !== undefined ? from : time.now(), offset) : null;
 }
 function _tick(now) { processCron(now !== undefined ? now : time.now()); }
 
 export const jobs = {
     init, enqueue, enqueueMany, claim, handler, default: setDefault, on, work, reap,
-    stats, runWorker, stop, get, result, await: await_, heartbeat, limit,
+    stats, runWorker, stop, get, result, await: await_, progress, heartbeat, limit,
     pause, resume, purge,
     dead, retry, cancel, cleanup, cron, uncron,
     RETRY, DEAD, DISCARD, _config: _cfg, _cronNext, _tick,
 };
 export { init, enqueue, enqueueMany, claim, handler, on, work, reap, stats,
-         runWorker, stop, get, result, heartbeat, limit, pause, resume, purge,
-         dead, retry, cancel, cleanup, cron, uncron };
+         runWorker, stop, get, result, progress, heartbeat, limit, pause, resume,
+         purge, dead, retry, cancel, cleanup, cron, uncron };
 export default jobs;

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -318,6 +318,35 @@ function enqueue(jobType, data, opts) {
     return id;
 }
 
+/**
+ * Enqueue many jobs in one transaction. `items` is an array of
+ * `{ type, data?, opts? }`, each accepting the same `opts` as `jobs.enqueue`
+ * EXCEPT `dependsOn` (bulk is for independent jobs - build graphs with
+ * `jobs.enqueue`, which throws here if seen). All rows commit together (one
+ * `db.batch`), so the batch is atomic AND cheap: a single commit/fsync instead
+ * of one per job. Returns an array of ids in input order, with `null` for any
+ * item whose `dedupKey` collided with an existing un-run job.
+ * @param {Array<{type:string,data?:*,opts?:object}>} items
+ * @returns {Array<number|null>}  ids in input order (null per deduped item)
+ */
+function enqueueMany(items) {
+    if (!Array.isArray(items)) throw new Error("jobs.enqueueMany: items must be an array");
+    if (items.length === 0) return [];
+    items.forEach((it, i) => {
+        if (!it || typeof it.type !== "string" || it.type === "")
+            throw new Error(`jobs.enqueueMany: item ${i} needs a non-empty string type`);
+        if (it.opts && it.opts.dependsOn)
+            throw new Error("jobs.enqueueMany: dependsOn is not supported in bulk; use jobs.enqueue for graph nodes");
+    });
+    const ids = [];
+    db.batch(() => {
+        for (let i = 0; i < items.length; i++) {
+            ids[i] = enqueue(items[i].type, items[i].data, items[i].opts);
+        }
+    });
+    return ids;
+}
+
 // Decode a claimed DB row into a handler-facing job (payload -> data).
 function shape(row) {
     let data = null;
@@ -1095,13 +1124,13 @@ function _cronNext(spec, from) {
 function _tick(now) { processCron(now !== undefined ? now : time.now()); }
 
 export const jobs = {
-    init, enqueue, claim, handler, default: setDefault, work, reap, stats,
-    runWorker, stop, get, result, await: await_, heartbeat, limit,
+    init, enqueue, enqueueMany, claim, handler, default: setDefault, work, reap,
+    stats, runWorker, stop, get, result, await: await_, heartbeat, limit,
     pause, resume, purge,
     dead, retry, cancel, cleanup, cron, uncron,
     RETRY, DEAD, DISCARD, _config: _cfg, _cronNext, _tick,
 };
-export { init, enqueue, claim, handler, work, reap, stats, runWorker, stop,
-         get, result, heartbeat, limit, pause, resume, purge,
+export { init, enqueue, enqueueMany, claim, handler, work, reap, stats, runWorker,
+         stop, get, result, heartbeat, limit, pause, resume, purge,
          dead, retry, cancel, cleanup, cron, uncron };
 export default jobs;

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -15,7 +15,7 @@
  * Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
  * catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
  * visibility-timeout reaper), the dedicated worker (jobs.runWorker +
- * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing).
+ * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueueMany), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron).
  *
  * @license AGPL-3.0-or-later
  */

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -351,6 +351,38 @@ function jobs.enqueue(job_type, data, opts)
     return id
 end
 
+--- Enqueue many jobs in one transaction. `items` is a list of
+-- `{ type, data?, opts? }` tables, each accepting the same `opts` as
+-- `jobs.enqueue` EXCEPT `depends_on` (bulk is for independent jobs - build graphs
+-- with `jobs.enqueue`, which errors here if seen). All rows commit together (one
+-- `db.batch`), so the whole batch is atomic AND cheap: a single commit/fsync
+-- instead of one per job - the reason to prefer this over a loop of `enqueue`.
+-- Returns an array of ids in input order, with `nil` for any item whose
+-- `dedup_key` collided with an existing un-run job (same as `jobs.enqueue`).
+-- @tparam table items  list of { type, data, opts }
+-- @treturn table  array of ids (nil per deduped item), in input order
+function jobs.enqueue_many(items)
+    if type(items) ~= "table" then error("jobs.enqueue_many: items must be a list") end
+    local n = #items
+    local ids = {}
+    if n == 0 then return ids end
+    for i = 1, n do
+        local it = items[i]
+        if type(it) ~= "table" or type(it.type) ~= "string" or it.type == "" then
+            error("jobs.enqueue_many: item " .. i .. " needs a non-empty string type")
+        end
+        if it.opts and it.opts.depends_on then
+            error("jobs.enqueue_many: depends_on is not supported in bulk; use jobs.enqueue for graph nodes")
+        end
+    end
+    db.batch(function()
+        for i = 1, n do
+            ids[i] = jobs.enqueue(items[i].type, items[i].data, items[i].opts)
+        end
+    end)
+    return ids
+end
+
 -- Decode a claimed DB row into a handler-facing job (payload -> data).
 local function shape(row)
     local data

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -963,8 +963,8 @@ end
 --- Fetch a single job by id (its full status view), or nil if it doesn't exist.
 -- The only way to inspect an individual job from app code: `_hull_jobs` is in the
 -- protected namespace, so a direct query is blocked. Poll this for a terminal
--- status (jobs are fire-and-forget; there is no result backend - a handler that
--- produces output must persist it itself).
+-- status, or use `jobs.result` / `jobs.await` to fetch a finished job's return
+-- value (a handler's non-nil return is persisted as the job's result).
 -- @tparam number id
 -- @treturn table|nil  { id, type, data, status, queue, priority, attempts,
 --                       max_attempts, run_at, last_error, created_at, updated_at }
@@ -972,6 +972,60 @@ function jobs.get(id)
     local rows = db.query("SELECT * FROM _hull_jobs WHERE id=?", { id })
     if not rows or #rows == 0 then return nil end
     return shape_ops(rows[1])
+end
+
+--- Fetch a job's terminal result without the full status view. Returns nil when
+-- the job is unknown (never enqueued, or already purged by `jobs.cleanup`);
+-- otherwise `{ status, result?, error? }`:
+--   * a `done` job carries `result` = the handler's decoded return value (absent
+--     when the handler returned nil / true / jobs.DISCARD),
+--   * a `dead` job carries `error` = its last error string,
+--   * a still-running (`pending`/`running`/`blocked`) job carries neither.
+-- This is the standalone counterpart to a workflow dependent's injected
+-- `job.deps[i].result`: any job's return value is readable here, not only a
+-- dependency's. The result lives as long as the job row (governed by
+-- `jobs.cleanup`), so read it before the terminal row is purged.
+-- @tparam number id
+-- @treturn table|nil
+function jobs.result(id)
+    local rows = db.query("SELECT status, last_error FROM _hull_jobs WHERE id=?", { id })
+    if not rows or #rows == 0 then return nil end
+    local status = rows[1].status
+    local out = { status = status }
+    if status == "done" then
+        local rr = db.query("SELECT result FROM _hull_job_results WHERE job_id=?", { id })
+        if rr and #rr > 0 and rr[1].result ~= nil then
+            out.result = json.decode(rr[1].result)
+        end
+    elseif status == "dead" then
+        out.error = rows[1].last_error
+    end
+    return out
+end
+
+--- Block (yielding to the event loop) until a job reaches a terminal status,
+-- then return its `jobs.result`. For the "enqueue then wait for the value"
+-- pattern; it polls `jobs.result` every `opts.interval` ms (default 100),
+-- sleeping via `hull.sleep` between polls so other work keeps running. With
+-- `opts.timeout` (ms) it gives up after that budget and returns the last
+-- (non-terminal) result view instead of the terminal one; without a timeout it
+-- waits indefinitely. Returns nil immediately if the job is unknown. Requires a
+-- yielding context (`app.main`, a handler, a timer) - a worker still processes
+-- jobs while another coroutine awaits.
+-- @tparam number id
+-- @tparam[opt] table opts  { timeout = <ms>, interval = <ms> }
+-- @treturn table|nil  the terminal `jobs.result`, a timed-out view, or nil
+function jobs.await(id, opts)
+    opts = opts or {}
+    local interval = opts.interval or 100
+    local deadline = opts.timeout and (time.clock() + opts.timeout) or nil
+    while true do
+        local r = jobs.result(id)
+        if r == nil then return nil end                     -- unknown / purged
+        if r.status == "done" or r.status == "dead" then return r end
+        if deadline and time.clock() >= deadline then return r end
+        hull.sleep(interval)
+    end
 end
 
 --- Extend the claim on a job the current handler is processing (heartbeat). A

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -11,7 +11,7 @@
 -- Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
 -- catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
 -- visibility-timeout reaper), the dedicated worker (jobs.run_worker +
--- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing).
+-- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueue_many), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron).
 --
 -- Usage (target shape):
 --   local jobs = require("hull.jobs")

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -115,7 +115,8 @@ function jobs.init(opts)
         .. "dedup_key    VARCHAR(255),"
         .. "last_error   TEXT,"
         .. "created_at   INTEGER      NOT NULL,"
-        .. "updated_at   INTEGER      NOT NULL)")
+        .. "updated_at   INTEGER      NOT NULL,"
+        .. "progress     INTEGER      NOT NULL DEFAULT 0)")
 
     -- Claim scan path: ready-to-run pending jobs in a queue, by priority then id.
     db.exec([[
@@ -150,10 +151,16 @@ function jobs.init(opts)
         .. "max_attempts INTEGER,"
         .. "next_run_at  INTEGER      NOT NULL,"
         .. "last_run_at  INTEGER,"
-        .. "updated_at   INTEGER      NOT NULL)")
+        .. "updated_at   INTEGER      NOT NULL,"
+        .. "tz_offset    INTEGER      NOT NULL DEFAULT 0)")
     db.exec([[
         CREATE INDEX IF NOT EXISTS idx_hull_cron_due ON _hull_cron(next_run_at)
     ]])
+
+    -- Additive migrations for DBs created before v1.5 (idempotent: a duplicate-
+    -- column error on an already-migrated DB is expected and swallowed).
+    pcall(db.exec, "ALTER TABLE _hull_jobs ADD COLUMN progress INTEGER NOT NULL DEFAULT 0")
+    pcall(db.exec, "ALTER TABLE _hull_cron ADD COLUMN tz_offset INTEGER NOT NULL DEFAULT 0")
 
     -- Fleet-wide rate-limit counters (jobs.limit). One row per limited queue;
     -- `name` (not the reserved word `key`), a window start, and the count.
@@ -302,7 +309,17 @@ function jobs.enqueue(job_type, data, opts)
     end
     opts = opts or {}
     local now    = time.now()
-    local run_at = opts.run_at or (now + (opts.delay or 0))
+    -- Schedule: absolute `at` (unix ts) wins, else `run_at`, else now + `delay`.
+    local run_at = opts.at or opts.run_at or (now + (opts.delay or 0))
+    -- Windowed throttle: skip (return nil) if a job of this (queue, type) was
+    -- created within the last `throttle` seconds. Best-effort - keyed by
+    -- (queue, type), no unique constraint (use dedup_key for exact-once).
+    if opts.throttle and opts.throttle > 0 then
+        local hit = db.query(
+            "SELECT 1 AS x FROM _hull_jobs WHERE queue=? AND type=? AND created_at > ? LIMIT 1",
+            { opts.queue or "default", job_type, now - opts.throttle })
+        if hit and #hit > 0 then return nil end
+    end
     local deps = opts.depends_on
     local has_deps = type(deps) == "table" and #deps > 0
     local vals = {
@@ -827,10 +844,37 @@ end
 -- Smallest unix ts strictly after `from_ts` whose UTC time matches `c`.
 -- Coarse-to-fine skips (whole day / hour / minute) keep it fast even for rare
 -- specs like "0 0 29 2 *". Returns nil if none within the search bound.
-local function cron_next(c, from_ts)
+-- Resolve a cron `tz` option to a FIXED offset in seconds east of UTC. Accepts a
+-- number (minutes east of UTC) or a string "+HH:MM" / "-HH:MM" / "+HHMM" / "Z".
+-- IANA names ("Europe/Budapest") are rejected: a DST-correct named zone needs a
+-- tz database Hull can't read inside the sandbox. So this is fixed-offset only -
+-- no daylight-saving transitions.
+local function parse_tz_offset(tz)
+    if tz == nil then return 0 end
+    if type(tz) == "number" then return math.floor(tz * 60) end
+    if type(tz) == "string" then
+        if tz == "Z" or tz == "UTC" or tz == "utc" then return 0 end
+        local sign, hh, mm = tz:match("^([+-])(%d%d):?(%d%d)$")
+        if sign then
+            local off = tonumber(hh) * 3600 + tonumber(mm) * 60
+            return sign == "-" and -off or off
+        end
+        error("jobs.cron: tz must be a fixed offset (\"+02:00\", \"-0530\", or minutes "
+            .. "east of UTC); IANA zone names like '" .. tz .. "' need a tz database "
+            .. "unavailable in the sandbox")
+    end
+    error("jobs.cron: tz must be a string offset or a number of minutes")
+end
+
+-- Next matching instant AT OR AFTER from_ts, as a UTC unix timestamp. `offset`
+-- (seconds east of UTC, default 0) shifts only the calendar decode, so the spec
+-- matches wall-clock fields in that fixed-offset zone while the returned value
+-- stays UTC.
+local function cron_next(c, from_ts, offset)
+    offset = offset or 0
     local t = math.floor(from_ts / 60) * 60 + 60
     for _ = 1, 200000 do
-        local month, day, hour, minute, dow = decode_ts(t)
+        local month, day, hour, minute, dow = decode_ts(t + offset)
         if not c.month[month] then
             t = (math.floor(t / 86400) + 1) * 86400
         else
@@ -858,11 +902,11 @@ end
 -- occurrence - fire-once, no backfill storm. Called (throttled) from jobs.work.
 local function process_cron(now)
     local due = db.query(
-        "SELECT name, spec, type, payload, queue, priority, max_attempts, next_run_at "
+        "SELECT name, spec, type, payload, queue, priority, max_attempts, next_run_at, tz_offset "
         .. "FROM _hull_cron WHERE next_run_at <= ?", { now })
     for _, c in ipairs(due) do
         local parsed = parse_cron(c.spec)
-        local nxt = parsed and cron_next(parsed, now) or (now + 60)
+        local nxt = parsed and cron_next(parsed, now, c.tz_offset) or (now + 60)
         local won = db.exec(
             "UPDATE _hull_cron SET next_run_at=?, last_run_at=?, updated_at=? "
             .. "WHERE name=? AND next_run_at=?",
@@ -896,7 +940,8 @@ function jobs.cron(name, spec, data, opts)
     if not parsed then error("jobs.cron: " .. (err or "invalid cron spec")) end
     opts = opts or {}
     local now = time.now()
-    local nxt = cron_next(parsed, now)
+    local tz_offset = parse_tz_offset(opts.tz)
+    local nxt = cron_next(parsed, now, tz_offset)
     if not nxt then error("jobs.cron: spec has no upcoming occurrence") end
     local job_type = opts.type or name
     local payload  = data ~= nil and json.encode(data) or nil
@@ -904,13 +949,13 @@ function jobs.cron(name, spec, data, opts)
     local priority = opts.priority or 0
     local n = db.exec(
         "UPDATE _hull_cron SET spec=?, type=?, payload=?, queue=?, priority=?, "
-        .. "max_attempts=?, next_run_at=?, updated_at=? WHERE name=?",
-        { spec, job_type, payload, queue, priority, opts.max_attempts, nxt, now, name })
+        .. "max_attempts=?, next_run_at=?, tz_offset=?, updated_at=? WHERE name=?",
+        { spec, job_type, payload, queue, priority, opts.max_attempts, nxt, tz_offset, now, name })
     if (n or 0) == 0 then
         db.exec(
             "INSERT INTO _hull_cron (name, spec, type, payload, queue, priority, "
-            .. "max_attempts, next_run_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            { name, spec, job_type, payload, queue, priority, opts.max_attempts, nxt, now })
+            .. "max_attempts, next_run_at, tz_offset, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            { name, spec, job_type, payload, queue, priority, opts.max_attempts, nxt, tz_offset, now })
     end
     return jobs
 end
@@ -923,9 +968,9 @@ function jobs.uncron(name)
 end
 
 -- Internal seams for tests / introspection; not part of the app-facing contract.
-jobs._cron_next = function(spec, from)
+jobs._cron_next = function(spec, from, offset)
     local p = parse_cron(spec)
-    return p and cron_next(p, from or time.now()) or nil
+    return p and cron_next(p, from or time.now(), offset) or nil
 end
 jobs._tick = function(now) process_cron(now or time.now()) end
 
@@ -1087,7 +1132,23 @@ local function shape_ops(r)
     j.last_error = r.last_error
     j.created_at = r.created_at
     j.updated_at = r.updated_at
+    j.progress   = r.progress
     return j
+end
+
+--- Set a running job's progress percent (0-100), surfaced by
+-- `jobs.get(id).progress`. Advisory - a UI/ops hint for long jobs, orthogonal
+-- to the claim/heartbeat. The value is clamped to [0,100] and rounded. Call it
+-- from a handler with `job.id`. Returns the clamped value stored.
+-- @tparam number id
+-- @tparam number pct  0..100
+-- @treturn number  the clamped value written
+function jobs.progress(id, pct)
+    local p = tonumber(pct) or 0
+    if p < 0 then p = 0 elseif p > 100 then p = 100 end
+    p = math.floor(p + 0.5)
+    db.exec("UPDATE _hull_jobs SET progress=?, updated_at=? WHERE id=?", { p, time.now(), id })
+    return p
 end
 
 --- Fetch a single job by id (its full status view), or nil if it doesn't exist.

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -472,19 +472,46 @@ function jobs.purge(queue, opts)
         params) or 0
 end
 
---- Atomically claim up to `batch` ready jobs from a queue, marking them
--- `running`. Concurrency-safe across workers and processes: SKIP LOCKED on
--- Postgres/MySQL, serialized on SQLite (single-writer + WAL busy-wait). A
--- `claim_token` nonce disambiguates the claimant on backends without RETURNING.
--- Each ready job is claimed by exactly one caller. Low-level: `jobs.work`
--- wraps this; a custom worker can call it directly.
---
--- @tparam[opt] table opts  { queue = "default", batch = 10 }
--- @treturn table  array of claimed jobs { id, type, data, attempts, max_attempts }
-function jobs.claim(opts)
-    opts = opts or {}
-    local queue = opts.queue or "default"
-    local batch = opts.batch or 10
+-- Resolve opts.queue / opts.queues to an ordered list of queues to try. A single
+-- `queue` (or the default) is a one-element order. `queues` may be:
+--   * a LIST { "critical", "default", "low" } - strict priority: try each in
+--     order, claim from the first with ready work (higher queues drain first).
+--   * a MAP { critical=3, default=2, low=1 } - weighted fairness: the order is a
+--     weighted-random shuffle (first-choice ~ weight over many calls), with every
+--     queue still present as a fallback so no claim cycle is wasted and no queue
+--     starves. A homogeneous fleet gives fleet-wide fairness (each worker draws
+--     independently). Zero/negative weights and non-number values are dropped.
+local function resolve_queue_order(opts)
+    local qs = opts.queues
+    if qs == nil then return { opts.queue or "default" } end
+    if qs[1] ~= nil then                          -- list form (strict priority)
+        local order = {}
+        for i = 1, #qs do order[i] = qs[i] end
+        return order
+    end
+    local names, weights, total = {}, {}, 0       -- map form (weighted)
+    for name, w in pairs(qs) do
+        if type(w) == "number" and w > 0 then
+            names[#names + 1] = name; weights[name] = w; total = total + w
+        end
+    end
+    local order = {}
+    while #names > 0 do
+        local pick, acc, idx = math.random() * total, 0, #names
+        for i = 1, #names do
+            acc = acc + weights[names[i]]
+            if pick <= acc then idx = i; break end
+        end
+        local chosen = names[idx]
+        order[#order + 1] = chosen
+        total = total - weights[chosen]
+        table.remove(names, idx)
+    end
+    return order
+end
+
+-- Claim up to `batch` ready jobs from ONE queue (the per-backend atomic claim).
+local function claim_one(queue, batch)
     if is_paused(queue) then return {} end   -- paused: don't dispatch
     local now   = time.now()
     local token = crypto.base64url_encode(crypto.random(16))
@@ -553,6 +580,30 @@ function jobs.claim(opts)
     end
     -- Enforce a fleet-wide rate limit (claim-then-reconcile; requeues the excess).
     return rl_apply(queue, out)
+end
+
+--- Atomically claim up to `batch` ready jobs, marking them `running`.
+-- Concurrency-safe across workers and processes: SKIP LOCKED on Postgres/MySQL,
+-- serialized on SQLite (single-writer + WAL busy-wait). A `claim_token` nonce
+-- disambiguates the claimant on backends without RETURNING. Each ready job is
+-- claimed by exactly one caller. Low-level: `jobs.work` wraps this.
+--
+-- Draws from a single queue (`opts.queue`, default "default") or across several
+-- via `opts.queues` - a LIST for strict priority or a MAP for weighted fairness
+-- (see `resolve_queue_order`). Multi-queue claims from the first queue in the
+-- resolved order that has ready work, so a single call returns jobs from one
+-- queue; a worker loop drains the rest on subsequent calls.
+--
+-- @tparam[opt] table opts  { queue = "default" | queues = {...}, batch = 10 }
+-- @treturn table  array of claimed jobs { id, type, data, attempts, max_attempts }
+function jobs.claim(opts)
+    opts = opts or {}
+    local batch = opts.batch or 10
+    for _, q in ipairs(resolve_queue_order(opts)) do
+        local got = claim_one(q, batch)
+        if #got > 0 then return got end
+    end
+    return {}
 end
 
 -- ── Handlers + the work loop ────────────────────────────────────────────

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -57,6 +57,11 @@ jobs._config = _cfg
 local _handlers = {}
 local _default = nil
 
+-- In-process lifecycle listeners (jobs.on). Fired synchronously by jobs.work in
+-- the worker that processed the job, for jobs THAT worker ran. Not fleet-wide -
+-- a durable cross-process event stream is the LISTEN/NOTIFY epic (#235).
+local _listeners = { completed = {}, retried = {}, dead = {} }
+
 -- Unix ts of the last reaper sweep (throttled in jobs.work via _cfg.reap_interval).
 local _last_reap = 0
 -- Unix ts of the last cron due-check (throttled to >=1s; cron is minute-grained).
@@ -665,6 +670,32 @@ function jobs.default(fn)
     return jobs
 end
 
+--- Register an in-process lifecycle listener. `event` is one of "completed",
+-- "retried" (a failed attempt that will be retried with backoff), or "dead"
+-- (dead-lettered: retries exhausted, handler returned jobs.DEAD, or no handler).
+-- The listener is called `fn(job, info)` synchronously by `jobs.work`, in the
+-- worker that processed the job, right after the outcome is applied:
+--   * completed -> info = { result = <handler return value or nil> }
+--   * retried   -> info = { error, attempt }   (attempt = the one that just failed)
+--   * dead      -> info = { error }
+-- Multiple listeners per event fire in registration order; each is isolated (a
+-- throwing listener can't derail the loop or the others). Keep hooks fast and
+-- synchronous - they run inline on the event-loop thread. These are per-worker,
+-- for observability/metrics/side-effects; a durable fleet-wide event stream is
+-- the LISTEN/NOTIFY epic (#235). Workflow cascade-failures don't emit here (the
+-- failing dependency's own `dead` event is the signal).
+-- @tparam string event  "completed" | "retried" | "dead"
+-- @tparam function fn
+function jobs.on(event, fn)
+    if not _listeners[event] then
+        error("jobs.on: unknown event '" .. tostring(event) .. "' (completed|retried|dead)")
+    end
+    if type(fn) ~= "function" then error("jobs.on: listener must be a function") end
+    local L = _listeners[event]
+    L[#L + 1] = fn
+    return jobs
+end
+
 local function mark_done(id, result)
     db.exec("UPDATE _hull_jobs SET status='done', claim_token=NULL, updated_at=? WHERE id=?",
         { time.now(), id })
@@ -689,18 +720,28 @@ end
 -- Reschedule with backoff, or dead-letter once attempts are exhausted. `attempts`
 -- was already incremented by the claim, so it is the count of the attempt that
 -- just ran.
+-- Returns the disposition it applied: "dead" (retries exhausted -> dead-letter)
+-- or "retried" (rescheduled with backoff), so jobs.work can emit the right event.
 local function mark_retry(job, err)
     local attempts = job.attempts or 0
     local max = job.max_attempts or _cfg.max_attempts
     if attempts >= max then
         mark_dead(job.id, err)
-        return
+        return "dead"
     end
     local now = time.now()
     db.exec(
         "UPDATE _hull_jobs SET status='pending', run_at=?, last_error=?, claim_token=NULL, "
         .. "updated_at=? WHERE id=?",
         { now + _cfg.backoff(attempts), err, now, job.id })
+    return "retried"
+end
+
+-- Fire in-process listeners for a lifecycle event. Each listener is isolated:
+-- a throwing hook can't derail the work loop or the other listeners.
+local function emit(event, job, info)
+    local L = _listeners[event]
+    for i = 1, #L do pcall(L[i], job, info) end
 end
 
 --- Reclaim jobs stuck in `running` past the visibility timeout - a worker that
@@ -915,15 +956,20 @@ function jobs.work(opts)
         job.deps = load_deps(job.id)   -- workflow: dependency results, in order
         local h = _handlers[job.type] or _default
         if not h then
-            mark_dead(job.id, "no handler for job type '" .. tostring(job.type) .. "'")
+            local err = "no handler for job type '" .. tostring(job.type) .. "'"
+            mark_dead(job.id, err)
+            emit("dead", job, { error = err })
         else
             local ok, result = pcall(h, job)
             if not ok then
-                mark_retry(job, tostring(result))
+                local err = tostring(result)
+                emit(mark_retry(job, err), job, { error = err, attempt = job.attempts })
             elseif result == jobs.DEAD then
                 mark_dead(job.id, "handler returned jobs.DEAD")
+                emit("dead", job, { error = "handler returned jobs.DEAD" })
             elseif result == jobs.RETRY then
-                mark_retry(job, "handler requested retry")
+                emit(mark_retry(job, "handler requested retry"), job,
+                     { error = "handler requested retry", attempt = job.attempts })
             else
                 -- nil / true / jobs.DISCARD -> done, no result; any other return
                 -- value is stored as the job's result (for dependents).
@@ -932,6 +978,7 @@ function jobs.work(opts)
                     res = result
                 end
                 mark_done(job.id, res)
+                emit("completed", job, { result = res })
             end
         end
     end

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -701,6 +701,59 @@ app.main(async (ctx) => {
 echo "== v1.4 workflows: Lua =="; check_wf "lua" "lua" "$LUA_WF"
 echo "== v1.4 workflows: JS =="; check_wf "js" "js" "$JS_WF"
 
+# ── v1.5: jobs.result(id) + jobs.await(id) - the standalone result backend ──
+# A handler's non-nil return is readable via jobs.result (done->value,
+# dead->error, pending->neither, unknown->nil); jobs.await yields until terminal.
+check_result() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"RES pre=pending done=7 dead=boom void=nil unknown=nil await=7"*)
+            pass "$label: result/await (done-value / dead-error / void / unknown / yielding await)" ;;
+        *) fail "$label: v1.5 result/await" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_RES='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init()
+  jobs.handler("sum",  function(j) return { total = j.data.a + j.data.b } end)
+  jobs.handler("boom", function(j) error("boom") end)
+  jobs.handler("void", function(j) return end)
+  local ok=jobs.enqueue("sum",{a=2,b=5}); local bad=jobs.enqueue("boom",{},{max_attempts=1}); local vd=jobs.enqueue("void",{})
+  local pre=jobs.result(ok).status
+  jobs.work({ batch = 10 })
+  local r1=jobs.result(ok); local r2=jobs.result(bad); local r3=jobs.result(vd); local r4=jobs.result(999999)
+  local aw=jobs.await(ok, { timeout = 2000 })
+  local derr = tostring(r2.error):match("boom") and "boom" or "?"
+  ctx.stdout:write(("RES pre=%s done=%s dead=%s void=%s unknown=%s await=%s\n"):format(
+    pre, tostring(r1.result.total), derr, tostring(r3.result), tostring(r4), tostring(aw.result.total)))
+  return 0
+end)'
+
+JS_RES='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init();
+  jobs.handler("sum",  (j) => ({ total: j.data.a + j.data.b }));
+  jobs.handler("boom", (j) => { throw new Error("boom"); });
+  jobs.handler("void", (j) => {});
+  const ok=jobs.enqueue("sum",{a:2,b:5}); const bad=jobs.enqueue("boom",{},{maxAttempts:1}); const vd=jobs.enqueue("void",{});
+  const pre=jobs.result(ok).status;
+  await jobs.work({ batch: 10 });
+  const r1=jobs.result(ok), r2=jobs.result(bad), r3=jobs.result(vd), r4=jobs.result(999999);
+  const aw=await jobs.await(ok, { timeout: 2000 });
+  const derr = /boom/.test(String(r2.error)) ? "boom" : "?";
+  ctx.stdout.write(`RES pre=${pre} done=${r1.result.total} dead=${derr} void=${r3.result === undefined ? "nil" : r3.result} unknown=${r4 === null ? "nil" : r4} await=${aw.result.total}\n`);
+  return 0;
+});'
+
+echo "== v1.5 result/await: Lua =="; check_result "lua" "lua" "$LUA_RES"
+echo "== v1.5 result/await: JS =="; check_result "js" "js" "$JS_RES"
+
 # Fleet gate: K processes share one rate counter -> total dispatched == rate.
 echo "== v1.2 rate limit fleet ($CONC processes, one shared counter) =="
 W="$(mktemp -d)"; DB="$W/rl.db"

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -859,6 +859,65 @@ app.main((ctx) => {
 echo "== v1.5 bulk enqueue: Lua =="; check_bulk "lua" "lua" "$LUA_BULK"
 echo "== v1.5 bulk enqueue: JS =="; check_bulk "js" "js" "$JS_BULK"
 
+# ── v1.5: in-process lifecycle hooks (jobs.on completed/retried/dead) ───────
+# A throwing hook is isolated (completed still counts). ok->completed, a
+# max_attempts=1 throw + a no-handler type ->2 dead, a max_attempts=2 throw
+# ->1 retried (backoff defers its death past the drain, so dead stays 2).
+check_events() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"EV completed=1 retried=1 dead=2 res=42 deaderr=nohandler"*)
+            pass "$label: jobs.on (completed/retried/dead, isolated throwing hook)" ;;
+        *) fail "$label: v1.5 job events" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_EVENTS='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init()
+  local ev = { completed=0, retried=0, dead=0 }; local last_result, last_err
+  jobs.on("completed", function(job, info) ev.completed = ev.completed + 1; last_result = info.result and info.result.v end)
+  jobs.on("completed", function(job, info) error("hook boom") end)
+  jobs.on("retried",   function(job, info) ev.retried = ev.retried + 1 end)
+  jobs.on("dead",      function(job, info) ev.dead = ev.dead + 1; last_err = info.error end)
+  jobs.handler("ok",    function(j) return { v = 42 } end)
+  jobs.handler("die",   function(j) error("fatal") end)
+  jobs.handler("flaky", function(j) error("transient") end)
+  jobs.enqueue("ok", {}); jobs.enqueue("die", {}, { max_attempts = 1 })
+  jobs.enqueue("mystery", {}); jobs.enqueue("flaky", {}, { max_attempts = 2 })
+  jobs.run_worker({ drain = true, poll_ms = 1 })
+  ctx.stdout:write(("EV completed=%d retried=%d dead=%d res=%s deaderr=%s\n"):format(
+    ev.completed, ev.retried, ev.dead, tostring(last_result),
+    tostring(last_err):match("no handler") and "nohandler" or "other"))
+  return 0
+end)'
+
+JS_EVENTS='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init();
+  const ev = { completed:0, retried:0, dead:0 }; let lastResult, lastErr;
+  jobs.on("completed", (job, info) => { ev.completed++; lastResult = info.result && info.result.v; });
+  jobs.on("completed", (job, info) => { throw new Error("hook boom"); });
+  jobs.on("retried",   (job, info) => { ev.retried++; });
+  jobs.on("dead",      (job, info) => { ev.dead++; lastErr = info.error; });
+  jobs.handler("ok",    (j) => ({ v: 42 }));
+  jobs.handler("die",   (j) => { throw new Error("fatal"); });
+  jobs.handler("flaky", (j) => { throw new Error("transient"); });
+  jobs.enqueue("ok", {}); jobs.enqueue("die", {}, { maxAttempts: 1 });
+  jobs.enqueue("mystery", {}); jobs.enqueue("flaky", {}, { maxAttempts: 2 });
+  await jobs.runWorker({ drain: true, pollMs: 1 });
+  ctx.stdout.write(`EV completed=${ev.completed} retried=${ev.retried} dead=${ev.dead} res=${lastResult} deaderr=${/no handler/.test(String(lastErr))?"nohandler":"other"}\n`);
+  return 0;
+});'
+
+echo "== v1.5 job events: Lua =="; check_events "lua" "lua" "$LUA_EVENTS"
+echo "== v1.5 job events: JS =="; check_events "js" "js" "$JS_EVENTS"
+
 # Fleet gate: K processes share one rate counter -> total dispatched == rate.
 echo "== v1.2 rate limit fleet ($CONC processes, one shared counter) =="
 W="$(mktemp -d)"; DB="$W/rl.db"

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -810,6 +810,55 @@ app.main((ctx) => {
 echo "== v1.5 multi-queue: Lua =="; check_queues "lua" "lua" "$LUA_QUEUES"
 echo "== v1.5 multi-queue: JS =="; check_queues "js" "js" "$JS_QUEUES"
 
+# ── v1.5: bulk enqueue - one transaction, chunked, dedup holes, no depends_on ──
+check_bulk() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"BULK ids=251 dupnil=nil total=251 reject=true"*)
+            pass "$label: enqueue_many (250+ in one txn, dedup->nil, depends_on rejected)" ;;
+        *) fail "$label: v1.5 bulk enqueue" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_BULK='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init()
+  local items = {}
+  for i=1,250 do items[i] = { type="t", data={n=i}, opts={priority=(i%3)} } end
+  items[251] = { type="dup", data={}, opts={dedup_key="k"} }
+  items[252] = { type="dup", data={}, opts={dedup_key="k"} }
+  local ids = jobs.enqueue_many(items)
+  local nn=0; for i=1,252 do if ids[i]~=nil then nn=nn+1 end end
+  local total=0
+  while true do local b=jobs.claim({batch=50}); if #b==0 then break end; total=total+#b end
+  local ok = pcall(function() jobs.enqueue_many({{type="x", opts={depends_on={1}}}}) end)
+  ctx.stdout:write(("BULK ids=%d dupnil=%s total=%d reject=%s\n"):format(nn, tostring(ids[252]), total, tostring(not ok)))
+  return 0
+end)'
+
+JS_BULK='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main((ctx) => {
+  jobs.init();
+  const items = [];
+  for (let i=1;i<=250;i++) items.push({ type:"t", data:{n:i}, opts:{priority:(i%3)} });
+  items.push({ type:"dup", data:{}, opts:{dedupKey:"k"} });
+  items.push({ type:"dup", data:{}, opts:{dedupKey:"k"} });
+  const ids = jobs.enqueueMany(items);
+  let nn=0; for (const x of ids) if (x!=null) nn++;
+  let total=0; for(;;){ const b=jobs.claim({batch:50}); if(!b.length) break; total+=b.length; }
+  let reject=false; try { jobs.enqueueMany([{type:"x", opts:{dependsOn:[1]}}]); } catch(e){ reject=true; }
+  ctx.stdout.write(`BULK ids=${nn} dupnil=${ids[251]===null?"nil":ids[251]} total=${total} reject=${reject}\n`);
+  return 0;
+});'
+
+echo "== v1.5 bulk enqueue: Lua =="; check_bulk "lua" "lua" "$LUA_BULK"
+echo "== v1.5 bulk enqueue: JS =="; check_bulk "js" "js" "$JS_BULK"
+
 # Fleet gate: K processes share one rate counter -> total dispatched == rate.
 echo "== v1.2 rate limit fleet ($CONC processes, one shared counter) =="
 W="$(mktemp -d)"; DB="$W/rl.db"

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -33,7 +33,7 @@ FAIL=0
 pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
 fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1${2:+ - $2}"; }
 
-EXPECT_COLS="id,queue,type,payload,status,priority,attempts,max_attempts,run_at,claim_token,claimed_at,dedup_key,last_error,created_at,updated_at"
+EXPECT_COLS="id,queue,type,payload,status,priority,attempts,max_attempts,run_at,claim_token,claimed_at,dedup_key,last_error,created_at,updated_at,progress"
 
 # ── Phase 1: init + schema; Phase 2: correctness round-trip (both runtimes) ──
 check_runtime() {
@@ -917,6 +917,59 @@ app.main(async (ctx) => {
 
 echo "== v1.5 job events: Lua =="; check_events "lua" "lua" "$LUA_EVENTS"
 echo "== v1.5 job events: JS =="; check_events "js" "js" "$JS_EVENTS"
+
+# ── v1.5: polish - absolute at, progress, windowed throttle, fixed-offset tz ──
+check_polish() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"POLISH claimed=1 prog=43 throttle=ok tzhh=7 iana_reject=true"*)
+            pass "$label: polish (absolute at / progress / throttle window / tz-offset cron + IANA reject)" ;;
+        *) fail "$label: v1.5 polish" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_POLISH='local jobs = require("hull.jobs"); local time = require("hull.time")
+app.manifest({ modules = { "hull/jobs@1", "hull/time@1" } })
+app.main(function(ctx)
+  jobs.init()
+  jobs.enqueue("t", {}, { at = time.now() + 3600 })
+  local now_id = jobs.enqueue("t", {})
+  local claimed = jobs.claim({ batch = 10 })
+  jobs.progress(now_id, 42.6)
+  local prog = jobs.get(now_id).progress
+  local a = jobs.enqueue("th", {}, { throttle = 60 })
+  local b = jobs.enqueue("th", {}, { throttle = 60 })
+  local nx = jobs._cron_next("0 9 * * *", 1735689600, 2*3600)
+  local hh = math.floor((nx % 86400) / 3600)
+  local ok_iana = pcall(function() jobs.cron("x", "0 9 * * *", nil, { tz = "Europe/Budapest" }) end)
+  ctx.stdout:write(("POLISH claimed=%d prog=%s throttle=%s tzhh=%d iana_reject=%s\n"):format(
+    #claimed, tostring(prog), (a~=nil and b==nil) and "ok" or "bad", hh, tostring(not ok_iana)))
+  return 0
+end)'
+
+JS_POLISH='import { app } from "hull:app"; import { jobs } from "hull:jobs"; import { time } from "hull:time";
+app.manifest({ modules: ["hull/jobs@1","hull/time@1"] });
+app.main((ctx) => {
+  jobs.init();
+  jobs.enqueue("t", {}, { at: time.now() + 3600 });
+  const nowId = jobs.enqueue("t", {});
+  const claimed = jobs.claim({ batch: 10 });
+  jobs.progress(nowId, 42.6);
+  const prog = jobs.get(nowId).progress;
+  const a = jobs.enqueue("th", {}, { throttle: 60 });
+  const b = jobs.enqueue("th", {}, { throttle: 60 });
+  const nx = jobs._cronNext("0 9 * * *", 1735689600, 2*3600);
+  const hh = Math.floor((nx % 86400) / 3600);
+  let okIana = true; try { jobs.cron("x", "0 9 * * *", null, { tz: "Europe/Budapest" }); } catch(e){ okIana = false; }
+  ctx.stdout.write(`POLISH claimed=${claimed.length} prog=${prog} throttle=${a!==null&&b===null?"ok":"bad"} tzhh=${hh} iana_reject=${!okIana}\n`);
+  return 0;
+});'
+
+echo "== v1.5 polish: Lua =="; check_polish "lua" "lua" "$LUA_POLISH"
+echo "== v1.5 polish: JS =="; check_polish "js" "js" "$JS_POLISH"
 
 # Fleet gate: K processes share one rate counter -> total dispatched == rate.
 echo "== v1.2 rate limit fleet ($CONC processes, one shared counter) =="

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -754,6 +754,62 @@ app.main(async (ctx) => {
 echo "== v1.5 result/await: Lua =="; check_result "lua" "lua" "$LUA_RES"
 echo "== v1.5 result/await: JS =="; check_result "js" "js" "$JS_RES"
 
+# ── v1.5: multi-queue draining - strict-priority list + weighted map ────────
+# A list = strict priority (critical drained before default before low); a map =
+# weighted fairness (every queue drains, no starvation).
+check_queues() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"STRICT order=c1,c2,d1,l1 WEIGHTED drained=20"*)
+            pass "$label: multi-queue (strict-priority list + weighted-map no-starvation)" ;;
+        *) fail "$label: v1.5 multi-queue draining" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_QUEUES='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init()
+  jobs.enqueue("t",{n="c1"},{queue="critical"}); jobs.enqueue("t",{n="c2"},{queue="critical"})
+  jobs.enqueue("t",{n="d1"},{queue="default"});  jobs.enqueue("t",{n="l1"},{queue="low"})
+  local order = {}
+  while true do
+    local b = jobs.claim({ queues = {"critical","default","low"}, batch = 1 })
+    if #b == 0 then break end
+    order[#order+1] = b[1].data.n
+  end
+  for i=1,10 do jobs.enqueue("t",{},{queue="A"}); jobs.enqueue("t",{},{queue="B"}) end
+  local drained, safety = 0, 0
+  while safety < 200 do
+    local b = jobs.claim({ queues = {A=3, B=1}, batch = 3 })
+    if #b == 0 then break end
+    drained = drained + #b; safety = safety + 1
+  end
+  ctx.stdout:write(("STRICT order=%s WEIGHTED drained=%d\n"):format(table.concat(order,","), drained))
+  return 0
+end)'
+
+JS_QUEUES='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main((ctx) => {
+  jobs.init();
+  jobs.enqueue("t",{n:"c1"},{queue:"critical"}); jobs.enqueue("t",{n:"c2"},{queue:"critical"});
+  jobs.enqueue("t",{n:"d1"},{queue:"default"});  jobs.enqueue("t",{n:"l1"},{queue:"low"});
+  const order = [];
+  for (;;) { const b = jobs.claim({ queues: ["critical","default","low"], batch: 1 }); if (!b.length) break; order.push(b[0].data.n); }
+  for (let i=0;i<10;i++){ jobs.enqueue("t",{},{queue:"A"}); jobs.enqueue("t",{},{queue:"B"}); }
+  let drained=0, safety=0;
+  while (safety<200){ const b=jobs.claim({ queues:{A:3,B:1}, batch:3 }); if(!b.length) break; drained+=b.length; safety++; }
+  ctx.stdout.write(`STRICT order=${order.join(",")} WEIGHTED drained=${drained}\n`);
+  return 0;
+});'
+
+echo "== v1.5 multi-queue: Lua =="; check_queues "lua" "lua" "$LUA_QUEUES"
+echo "== v1.5 multi-queue: JS =="; check_queues "js" "js" "$JS_QUEUES"
+
 # Fleet gate: K processes share one rate counter -> total dispatched == rate.
 echo "== v1.2 rate limit fleet ($CONC processes, one shared counter) =="
 W="$(mktemp -d)"; DB="$W/rl.db"


### PR DESCRIPTION
Closes the competitive gap in `hull/jobs` - the surface is now at/beyond pg-boss / SolidQueue and near BullMQ / Sidekiq. Six commits, one per feature, both runtimes with full parity, each with an e2e phase. **37/37 e2e green, unit tests green.**

## What's new

1. **Result backend** - `jobs.result(id)` → `{ status, result?, error? }` for any job (a handler's non-nil return is already persisted); `jobs.await(id, { timeout, interval })` yields until terminal. The last "expected primitive" that was missing (Celery `AsyncResult` / RQ `job.result` / BullMQ `returnvalue`).
2. **Multi-queue draining** - `opts.queues` on claim/work/run_worker: a **list** = strict priority, a **map** = weighted fairness (no starvation, fleet-wide fair). Reuses the per-backend atomic claim untouched.
3. **Bulk enqueue** - `jobs.enqueue_many(items)` in one `db.batch` (one commit/fsync instead of N). Returns ids in order, `nil` per deduped item; `depends_on` rejected.
4. **Lifecycle hooks** - `jobs.on("completed"|"retried"|"dead", fn)`, fired synchronously in the worker that ran the job; listeners isolated. `mark_retry` now returns its true disposition so the right event fires. Per-worker; durable fleet-wide eventing stays the LISTEN/NOTIFY epic (#235).
5. **Polish** - absolute `at`; `jobs.progress(id, pct)` (+ `progress` column); `throttle` window; fixed-offset `tz` cron (`"+02:00"`; IANA names rejected honestly - a DST-correct zone needs a tz database the sandbox can't read).

## Notes
- New columns `_hull_jobs.progress` and `_hull_cron.tz_offset` are **appended** with idempotent `ALTER`s, so pre-v1.5 DBs migrate transparently and the column order stays stable (`EXPECT_COLS` updated).
- No C changes - pure stdlib Lua/JS. `docs/jobs.md` + the module header updated.
- Design context: this wraps the jobs story; remaining items are tracked perf (#235 LISTEN/NOTIFY latency, #238 already covered here as bulk enqueue).

Design/DAG note surfaced during review: workflow cycles are impossible by construction (deps reference only already-existing job ids, immutable at enqueue), and scheduling is deliberately decentralized (the atomic claim query + reactive dep-resolution + cron CAS) - no central scheduler, matching the peer set.