### PR TITLE
jobs(v1.5): audit hardening (L1-L4)

### DIFF
--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -127,6 +127,12 @@ function init(opts) {
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_hull_jobs_dedup " +
         "ON _hull_jobs(queue, dedup_key)");
 
+    // Throttle scan path: recent jobs of a (queue, type) within the window
+    // (enqueue opts.throttle). Without this the throttle probe scans the queue.
+    db.exec(
+        "CREATE INDEX IF NOT EXISTS idx_hull_jobs_throttle " +
+        "ON _hull_jobs(queue, type, created_at)");
+
     // Durable cron schedules (jobs.cron). A worker atomically advances a due
     // row's next_run_at (compare-and-set) and enqueues, so exactly one worker
     // fires each tick across the fleet.
@@ -145,10 +151,16 @@ function init(opts) {
         "tz_offset    INTEGER      NOT NULL DEFAULT 0)");
     db.exec("CREATE INDEX IF NOT EXISTS idx_hull_cron_due ON _hull_cron(next_run_at)");
 
-    // Additive migrations for DBs created before v1.5 (idempotent: a duplicate-
-    // column error on an already-migrated DB is expected and swallowed).
-    try { db.exec("ALTER TABLE _hull_jobs ADD COLUMN progress INTEGER NOT NULL DEFAULT 0"); } catch (e) { /* exists */ }
-    try { db.exec("ALTER TABLE _hull_cron ADD COLUMN tz_offset INTEGER NOT NULL DEFAULT 0"); } catch (e) { /* exists */ }
+    // Additive migrations for DBs created before v1.5: add the column only when
+    // absent (checked via the portable db.tableColumns, mirroring session.js),
+    // rather than catching a duplicate-column error - a caught ALTER would abort
+    // a surrounding transaction on Postgres if jobs.init ran inside a db.batch.
+    const ensureColumn = (tbl, col, coldef) => {
+        if (!(db.tableColumns(tbl) || []).includes(col))
+            db.exec(`ALTER TABLE ${tbl} ADD COLUMN ${coldef}`);
+    };
+    ensureColumn("_hull_jobs", "progress", "progress INTEGER NOT NULL DEFAULT 0");
+    ensureColumn("_hull_cron", "tz_offset", "tz_offset INTEGER NOT NULL DEFAULT 0");
 
     // Fleet-wide rate-limit counters (jobs.limit). One row per limited queue;
     // `name` (not the reserved word `key`), a window start, and the count.
@@ -1110,7 +1122,12 @@ function result(id) {
     const out = { status };
     if (status === "done") {
         const rr = db.query("SELECT result FROM _hull_job_results WHERE job_id=?", [id]);
-        if (rr.length && rr[0].result != null) out.result = JSON.parse(rr[0].result);
+        // Fail soft on a corrupted result row (we wrote valid JSON, but don't
+        // throw on external corruption): fall back to the raw string.
+        if (rr.length && rr[0].result != null) {
+            try { out.result = JSON.parse(rr[0].result); }
+            catch (e) { out.result = rr[0].result; }
+        }
     } else if (status === "dead") {
         out.error = rows[0].last_error;
     }
@@ -1131,7 +1148,7 @@ function result(id) {
  */
 async function await_(id, opts) {
     opts = opts || {};
-    const interval = opts.interval || 100;
+    const interval = Math.max(opts.interval || 100, 10);   // floor: never a tight loop
     const deadline = opts.timeout != null ? time.clock() + opts.timeout : null;
     for (;;) {
         const r = result(id);

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -137,6 +137,13 @@ function jobs.init(opts)
         ON _hull_jobs(queue, dedup_key)
     ]])
 
+    -- Throttle scan path: recent jobs of a (queue, type) within the window
+    -- (enqueue opts.throttle). Without this the throttle probe scans the queue.
+    db.exec([[
+        CREATE INDEX IF NOT EXISTS idx_hull_jobs_throttle
+        ON _hull_jobs(queue, type, created_at)
+    ]])
+
     -- Durable cron schedules (jobs.cron). A worker atomically advances a due
     -- row's next_run_at (compare-and-set) and enqueues, so exactly one worker
     -- fires each tick across the fleet.
@@ -157,10 +164,18 @@ function jobs.init(opts)
         CREATE INDEX IF NOT EXISTS idx_hull_cron_due ON _hull_cron(next_run_at)
     ]])
 
-    -- Additive migrations for DBs created before v1.5 (idempotent: a duplicate-
-    -- column error on an already-migrated DB is expected and swallowed).
-    pcall(db.exec, "ALTER TABLE _hull_jobs ADD COLUMN progress INTEGER NOT NULL DEFAULT 0")
-    pcall(db.exec, "ALTER TABLE _hull_cron ADD COLUMN tz_offset INTEGER NOT NULL DEFAULT 0")
+    -- Additive migrations for DBs created before v1.5: add the column only when
+    -- absent (checked via the portable db.table_columns, mirroring session.lua),
+    -- rather than catching a duplicate-column error - a caught ALTER would abort
+    -- a surrounding transaction on Postgres if jobs.init ran inside a db.batch.
+    local function ensure_column(tbl, col, coldef)
+        for _, name in ipairs(db.table_columns(tbl) or {}) do
+            if name == col then return end
+        end
+        db.exec("ALTER TABLE " .. tbl .. " ADD COLUMN " .. coldef)
+    end
+    ensure_column("_hull_jobs", "progress", "progress INTEGER NOT NULL DEFAULT 0")
+    ensure_column("_hull_cron", "tz_offset", "tz_offset INTEGER NOT NULL DEFAULT 0")
 
     -- Fleet-wide rate-limit counters (jobs.limit). One row per limited queue;
     -- `name` (not the reserved word `key`), a window start, and the count.
@@ -1186,7 +1201,11 @@ function jobs.result(id)
     if status == "done" then
         local rr = db.query("SELECT result FROM _hull_job_results WHERE job_id=?", { id })
         if rr and #rr > 0 and rr[1].result ~= nil then
-            out.result = json.decode(rr[1].result)
+            -- Fail soft on a corrupted result row (we wrote valid JSON, but don't
+            -- raise on external corruption). Explicit if: a decoded false/nil is
+            -- a valid result, so `ok and decoded or raw` would mis-map it.
+            local ok, decoded = pcall(json.decode, rr[1].result)
+            if ok then out.result = decoded else out.result = rr[1].result end
         end
     elseif status == "dead" then
         out.error = rows[1].last_error
@@ -1208,7 +1227,7 @@ end
 -- @treturn table|nil  the terminal `jobs.result`, a timed-out view, or nil
 function jobs.await(id, opts)
     opts = opts or {}
-    local interval = opts.interval or 100
+    local interval = math.max(opts.interval or 100, 10)   -- floor: never a tight yield-loop
     local deadline = opts.timeout and (time.clock() + opts.timeout) or nil
     while true do
         local r = jobs.result(id)


### PR DESCRIPTION
Follow-up to the v1.5 `/c-audit` `/lua-audit` `/js-audit` (all four findings were **Low**; no Critical/High/Medium, and v1.5 touched zero C). Both runtimes, full parity.

- **L1** `jobs.result` — guard the stored-result decode (`pcall`/`try`); a corrupted `_hull_job_results` row fails soft to the raw string instead of raising. Explicit-if (not `ok and decoded or raw`) so a decoded `false`/`null` valid result isn't mis-mapped. Verified: a handler returning `false` round-trips as boolean `false`.
- **L2** `jobs.await` — floor the poll interval at 10ms so `interval=0` can't tight-loop (Lua's `0`-is-truthy made `or 100` miss it).
- **L3** init migration — add the v1.5 columns only when absent (portable `table_columns`/`tableColumns`, mirroring `session.lua`) instead of catching a duplicate-column `ALTER`, which would abort a surrounding Postgres transaction if `jobs.init` ran inside a `db.batch`. Verified on an old-schema DB: the column is ALTER-added and `progress` works.
- **L4** add `idx_hull_jobs_throttle(queue, type, created_at)` so the throttle probe seeks instead of scanning.

No API change. `e2e_jobs` 37/37 green (column-set assertion unchanged); migration + `false`-result regression checked directly.