### PR TITLE
docs: jobs observability + durable-execution design RFCs (Bet #1, Bet #2)

### DIFF
--- a/docs/jobs_durable_execution_design.md
+++ b/docs/jobs_durable_execution_design.md
@@ -1,0 +1,349 @@
+# jobs durable execution - workflow-as-code (Bet #2)
+
+**Status:** PROPOSED / design RFC. Not scheduled. The flagship differentiator.
+**Target:** `hull/jobs@1` (a multi-phase epic, not a single release).
+**Decisions (from review):**
+- **Phased execution model:** Phase 1 ships **step-memoization** (DBOS/Restate
+  style); Phase 2 adds an opt-in **deterministic-WASM-replay** "strict mode"
+  (Temporal style) for workflows that need bulletproof determinism.
+- **Phase 1 surface:** `ctx.step` + **durable timers** (`ctx.sleep`) +
+  **signals** (`ctx.wait_signal` / `jobs.signal`) + **queries**
+  (`jobs.workflow_status`). Saga **compensation** included. Child workflows
+  deferred.
+- Full parity Lua + JS. Rides the existing job infrastructure (claim / reap /
+  retry / worker / result / await) - a durable workflow is **"just a job that
+  yields."** Minimal/zero new C.
+
+> **Why Hull, uniquely.** Durable execution (Temporal / DBOS / Restate) is the
+> current frontier for orchestration, and Hull is uniquely positioned: it already
+> has a **transactional queue** fused with the app's data AND a **deterministic,
+> gas-metered, sandboxed compute engine** (WASM) next to it. Deterministic replay
+> is the hard part of Temporal - and the WASM sandbox is exactly the deterministic
+> executor that makes Phase 2 credible. No other job runner has both halves.
+
+---
+
+## 1. The model
+
+A **durable workflow** is a long-lived process expressed as a normal Lua/JS
+function `fn(ctx)`. It can loop, branch, sleep for days, and wait for external
+signals, and it **survives crashes and restarts**: on recovery it resumes where
+it left off, without re-doing completed work.
+
+The mechanism is **step-memoization**, not full replay:
+
+- The workflow function is **re-entered from the top** on every resume.
+- Each `ctx.step(name, fn)` checks a durable store: if this step already
+  completed, it **returns the memoized result** without re-running `fn`; else it
+  runs `fn`, persists the result, and returns it.
+- So the code *between* steps re-runs on each resume (must be cheap and
+  side-effect-free); all side effects live inside steps and run **once**
+  (see §4 for the exactly-once vs at-least-once contract).
+
+This is weaker than Temporal's whole-body determinism but far more ergonomic for
+Lua/JS: only the **sequence of `ctx.step` calls** must be stable across resumes,
+not the entire body. Phase 2 (§11) tightens this to full determinism for WASM
+workflows.
+
+A workflow instance **is a row in `_hull_jobs`** (a job with a workflow marker),
+so it is claimed, reaped, retried, and drained by the exact same worker
+infrastructure. "Yielding" (sleep / wait) is just rescheduling that job.
+
+## 2. API
+
+```lua
+-- Define a workflow (like jobs.handler, but the fn receives a durable ctx):
+jobs.workflow("order_fulfillment", function(ctx)
+  local charge = ctx.step("charge", function()
+    return payments.charge(ctx.input.order_id, ctx.input.amount)   -- runs once
+  end)
+
+  ctx.sleep(24 * 3600)                          -- durable: survives restarts/redeploys
+
+  local approval = ctx.wait_signal("manager_approval")   -- pause until signalled
+
+  ctx.step("ship", function()
+    return shipping.dispatch(ctx.input.order_id, approval.by)
+  end, { compensate = function() shipping.recall(ctx.input.order_id) end })
+
+  return { shipped = true, charge = charge.id }
+end)
+
+-- Start an instance (returns a workflow id = a job id):
+local wf = jobs.start("order_fulfillment", { order_id = 42, amount = 100 })
+
+-- Deliver a signal from anywhere (e.g. an HTTP approval handler):
+jobs.signal(wf, "manager_approval", { by = "alice" })
+
+-- Query progress (DB-derived; no live process needed):
+local st = jobs.workflow_status(wf)
+-- { status="running", steps_done={"charge"}, waiting_for="signal:manager_approval", started_at=.. }
+
+-- Await / fetch the final result (reuses the v1.5 result backend):
+local r = jobs.await(wf)          -- { status="done", result={ shipped=true, ... } }
+```
+
+```javascript
+jobs.workflow("order_fulfillment", async (ctx) => {
+  const charge = await ctx.step("charge", () => payments.charge(ctx.input.orderId, ctx.input.amount));
+  await ctx.sleep(24 * 3600);
+  const approval = await ctx.waitSignal("manager_approval");
+  await ctx.step("ship", () => shipping.dispatch(ctx.input.orderId, approval.by),
+                 { compensate: () => shipping.recall(ctx.input.orderId) });
+  return { shipped: true, charge: charge.id };
+});
+const wf = jobs.start("order_fulfillment", { orderId: 42, amount: 100 });
+jobs.signal(wf, "manager_approval", { by: "alice" });
+const st = jobs.workflowStatus(wf);
+const r = await jobs.await(wf);
+```
+
+**The `ctx` object:**
+- `ctx.input` - the payload passed to `jobs.start`.
+- `ctx.id` - the workflow id (job id).
+- `ctx.step(name, fn, opts?)` - run-once-and-memoize; `opts.compensate` registers
+  a saga rollback (§8). `name` is unique per workflow instance.
+- `ctx.sleep(seconds)` - durable timer (§6).
+- `ctx.wait_signal(name, opts?)` / `ctx.waitSignal` - block until a signal (§7);
+  `opts.timeout` optional.
+- `ctx.trace` - the propagated trace context (Bet #1, pillar C).
+
+**Module functions:**
+- `jobs.workflow(name, fn)` - register a definition (a specialized handler).
+- `jobs.start(name, input, opts?)` - start an instance -> workflow id. `opts` are
+  the usual enqueue opts (queue, priority, dedup_key for idempotent start, trace).
+- `jobs.signal(id, name, payload)` - deliver a signal; unblocks a waiting
+  workflow.
+- `jobs.workflow_status(id)` / `jobs.workflowStatus` - query state.
+- `jobs.await(id)` / `jobs.result(id)` - reuse the v1.5 result backend for the
+  final return value.
+
+## 3. How a workflow rides the job loop
+
+`jobs.workflow(name, fn)` registers, under the hood, a normal job **handler** for
+a reserved type (`__wf:<name>`). `jobs.start` enqueues a job of that type with a
+`workflow_name` marker and the input as payload. `jobs.work` claims and dispatches
+it exactly like any job; the handler is the **workflow runner** that builds `ctx`
+and calls `fn(ctx)`. The runner interprets the three yield points:
+
+- `fn` returns normally -> the runner returns its value -> `mark_done` stores it
+  as the workflow result (reuses `_hull_job_results` + `jobs.await`).
+- `fn` raises -> retry/backoff/dead exactly like any job; on dead, saga
+  compensations run (§8).
+- `fn` hits an unsatisfied `ctx.sleep` / `ctx.wait_signal` -> the runner **yields**
+  (§5): the job is rescheduled/blocked and re-run later; **no terminal event**.
+
+So durable workflows inherit at-least-once dispatch, the visibility-timeout
+reaper (a crashed workflow mid-step is reclaimed and resumed), backoff, priority,
+queues, concurrency, and `run_worker` - for free.
+
+## 4. Execution contract
+
+- **Steps are at-least-once by default.** A step's `fn` runs, then its result is
+  persisted. If the worker crashes *between* the side effect and the persist, the
+  step re-runs on resume. So a step with an external side effect (an HTTP POST)
+  must be **idempotent**, same rule as a job handler.
+- **Steps can be exactly-once when the effect is DB-local.** A step that does its
+  work and records its result in the **same `db.batch`** commits atomically -
+  either both or neither - giving exactly-once for DB-transactional steps. The
+  runner exposes this: `ctx.step(name, fn, { transactional = true })` wraps the
+  fn + the result-write in one transaction.
+- **The step-call sequence must be stable across resumes.** Branching on
+  `ctx.input` or on prior step *results* is fine (those are stable); branching on
+  ambient non-determinism (wall-clock, RNG, external reads done *outside* a step)
+  can change which steps are reached and break memo-key matching. Rule:
+  **all non-determinism goes inside a `ctx.step`.** (`ctx.sleep` uses the clock
+  safely on the runner's behalf.) Phase 2 enforces this structurally for WASM.
+- **Between-step code re-runs on every resume** - keep it pure and cheap. Heavy
+  or effectful work belongs in a step.
+
+## 5. The yield mechanism
+
+`work()` gains one internal outcome beyond done/retry/dead: **yield**. The
+workflow runner signals it (a private sentinel, not part of the public
+handler-return contract) carrying either a wake time (sleep) or a block reason
+(signal). On yield, `work()`:
+
+- for a **sleep**: sets the job `pending` with `run_at = wake_at` (reuses the
+  `mark_retry` reschedule path; no attempt increment, no backoff) - the durable
+  timer is just a future-dated pending job;
+- for a **signal wait**: sets the job `status = 'waiting'` (a new non-terminal
+  status, invisible to the claim query) - it is re-activated to `pending` only by
+  `jobs.signal`;
+
+and emits **no** `completed`/`dead` event (those fire only on true termination).
+
+## 6. Durable timers - `ctx.sleep`
+
+`ctx.sleep(seconds)` is a memoized step whose stored value is its **wake time**:
+
+1. First encounter: record `sleep:<n>` with `wake_at = now + seconds`; **yield**
+   (reschedule the job to `run_at = wake_at`).
+2. On resume, the body re-runs; `ctx.sleep` finds the recorded `wake_at`. If
+   `now >= wake_at`, it returns (continue past it); else it yields again (a
+   spurious early wake just re-sleeps).
+
+Because the sleeping workflow is only a future-dated pending job, sleeps of
+arbitrary length survive process restarts, redeploys, and crashes at zero cost
+(no held thread, no timer in memory).
+
+## 7. Signals - `ctx.wait_signal` + `jobs.signal`
+
+The human-in-the-loop / wait-for-webhook / approval primitive.
+
+- `ctx.wait_signal(name)`: if a signal row `(workflow_id, name)` exists, return
+  its payload (memoized - consumed once); else **yield** with `status='waiting'`.
+- `jobs.signal(id, name, payload)`: INSERT the signal row, then flip the workflow
+  job `waiting -> pending` so a worker re-runs it; the `wait_signal` now finds the
+  signal and proceeds. Idempotent-ish: a duplicate signal name is either ignored
+  or last-wins (design choice; default: first delivery wins, extras ignored).
+- `opts.timeout`: a `wait_signal` with a timeout also arms a `ctx.sleep`-style
+  wake, returning `nil` / a timeout marker if no signal arrives in time.
+- Signals can be delivered **before** the workflow reaches the wait (stored and
+  consumed when it gets there) - no lost-signal race.
+
+## 8. Saga / compensation
+
+`ctx.step(name, fn, { compensate = cfn })` registers `cfn` as the rollback for a
+successful step. If the workflow later **fails terminally** (dead), the runner
+runs the registered compensations of **completed** steps in **reverse order**
+before finalizing - the saga pattern (undo the charge if shipping can't be
+arranged). Compensations are themselves at-least-once (idempotent) and their
+execution is recorded so a crash mid-compensation resumes correctly.
+
+## 9. Queries - `jobs.workflow_status`
+
+Because all progress is persisted (step results, current status, pending waits),
+querying a workflow is a **DB read**, not a message to a live process (an
+advantage over Temporal's in-memory queries - it works even when no worker is
+currently running the instance):
+
+```lua
+jobs.workflow_status(id) -> {
+  status      = "running" | "waiting" | "sleeping" | "done" | "dead",
+  name        = "order_fulfillment",
+  steps_done  = { "charge" },              -- completed step names, in order
+  waiting_for = "signal:manager_approval", -- or "sleep:<wake_at>" or nil
+  started_at  = <ts>, updated_at = <ts>,
+  result      = <value>,                   -- when done (via _hull_job_results)
+  error       = <string>,                  -- when dead
+}
+```
+
+## 10. Storage
+
+Two new tables + one marker column; the workflow instance itself reuses
+`_hull_jobs`.
+
+```
+_hull_workflow_steps(
+  workflow_id  INTEGER NOT NULL,
+  step_key     VARCHAR(255) NOT NULL,   -- ctx.step name / "sleep:<n>" / "signal:<name>"
+  result       TEXT,                    -- JSON step result (or wake_at for sleeps)
+  status       VARCHAR(16) NOT NULL,    -- 'done' | 'compensated'
+  created_at   INTEGER NOT NULL,
+  PRIMARY KEY (workflow_id, step_key)
+)
+_hull_workflow_signals(
+  workflow_id  INTEGER NOT NULL,
+  name         VARCHAR(255) NOT NULL,
+  payload      TEXT,
+  created_at   INTEGER NOT NULL,
+  consumed_at  INTEGER,
+  PRIMARY KEY (workflow_id, name)
+)
+-- _hull_jobs gains: workflow_name VARCHAR(255)  (nullable marker; appended via ensure_column)
+-- _hull_jobs.status gains a non-terminal value: 'waiting' (excluded by the claim query)
+```
+
+Cleanup: `jobs.cleanup` sweeps step/signal rows whose workflow job is gone
+(mirrors the existing `_hull_job_results` orphan sweep).
+
+## 11. Phase 2 - deterministic WASM replay (strict mode)
+
+Phase 1's contract ("keep non-determinism in steps") is a discipline the
+developer must follow. Phase 2 makes it **structural** for workflows that opt in
+by running the workflow body as a **WASM compute module**:
+
+- The body executes in the gas-metered WASM sandbox with **no ambient I/O, clock,
+  or RNG** - every effect is a host-call that maps to a `ctx.step` (memoized) or a
+  yield. Determinism is enforced by the sandbox, not by convention.
+- Re-execution is true **deterministic replay**: the same inputs + the memoized
+  step log reproduce the exact same execution, so the body *cannot* drift.
+- This is the Temporal guarantee, achieved with the compute engine Hull already
+  ships. `jobs.workflow(name, fn, { strict = true })` (or a `.wasm` workflow
+  module) selects it.
+
+Deferred: the host-call ABI for the WASM<->step bridge, the workflow-to-WASM
+build path, and replay tooling are their own design pass.
+
+## 12. Relationship to existing `depends_on` workflows (v1.4)
+
+Two complementary orchestration models, both first-class:
+
+| | Declarative DAG (`depends_on`, v1.4) | Durable execution (this doc) |
+|---|---|---|
+| Shape | static graph of independent jobs | imperative code-as-workflow |
+| Best for | known fan-out/fan-in pipelines | dynamic control flow, long-running, human-in-the-loop |
+| Time | each node runs to completion | can sleep days, wait for signals |
+| Result flow | injected as `job.deps` | `ctx.step` return values in-line |
+
+They interoperate: a durable workflow's step may enqueue DAG jobs (and
+`ctx.step` await their results via `jobs.await`), and a DAG node may `jobs.start`
+a workflow.
+
+## 13. Observability integration (Bet #1)
+
+- Each `ctx.step` records to the attempt-history timeline (when history is on), so
+  `jobs.history(workflow_id)` shows the step-by-step execution with durations.
+- `jobs.metrics` counts running/waiting/sleeping workflows and step latencies.
+- Trace context (`ctx.trace`) flows from `jobs.start` through steps to any child
+  jobs - one trace per business process.
+
+## 14. Reused infrastructure (what we do NOT rebuild)
+
+Claim / atomic dispatch, the visibility-timeout reaper (resumes a crashed
+in-step workflow), retry + backoff, priority, named + multi queues, concurrency,
+`run_worker` + `hull jobs worker`, rate limiting, pause/resume, the result
+backend (`await`/`result`), and cleanup - all apply to workflows unchanged,
+because a workflow instance *is* a job.
+
+## 15. Testing
+
+- **Step memoization:** a workflow with 3 steps; kill it after step 2 (simulate
+  by throwing post-step-2 and re-claiming via the reaper); on resume steps 1-2
+  return memoized results (their `fn`s do not re-run - assert via a side-effect
+  counter), step 3 runs; final result correct. Both runtimes.
+- **Durable timer:** `ctx.sleep(2)` -> the job is future-dated pending, not
+  running; after the delay it resumes and completes. Survives a process restart
+  (run in one process, resume in another against a file DB).
+- **Signals:** `ctx.wait_signal` yields to `waiting`; `jobs.signal` before AND
+  after the wait both deliver; timeout path returns the timeout marker.
+- **Saga:** a workflow that fails after a compensated step runs the compensation
+  in reverse (assert order + idempotency on re-run).
+- **Queries:** `jobs.workflow_status` reports steps_done / waiting_for / result
+  across the lifecycle.
+- **Exactly-once DB step:** a `transactional` step + a crash between effect and
+  persist does not double-apply (the effect + result commit atomically).
+- **Interop:** a workflow step enqueues a DAG job and awaits it.
+
+## 16. Phasing
+
+1. **Phase 1a - steps + result:** `jobs.workflow`/`start`, `ctx.step` +
+   memoization, the yield outcome, `_hull_workflow_steps`, `jobs.workflow_status`,
+   `jobs.await` on a workflow. The core.
+2. **Phase 1b - durable timers:** `ctx.sleep` (reschedule via `run_at`).
+3. **Phase 1c - signals + queries:** `ctx.wait_signal` / `jobs.signal`, the
+   `waiting` status, `_hull_workflow_signals`, timeouts.
+4. **Phase 1d - saga:** `ctx.step` compensation on terminal failure.
+5. **Phase 2 - strict mode:** deterministic WASM-replay workflows (separate
+   design pass).
+6. (Later) child/sub-workflows.
+
+## 17. Scope discipline
+
+**Do:** durable steps, timers, signals, queries, sagas, the WASM strict-mode path
+(Phase 2). **Don't** (for now): a visual workflow designer, child-workflow trees
+(deferred), cross-workflow transactions, or a bespoke workflow DSL - workflows are
+plain Lua/JS functions. Keep the core dependency-free and riding the existing job
+loop.

--- a/docs/jobs_observability_design.md
+++ b/docs/jobs_observability_design.md
@@ -1,0 +1,182 @@
+# jobs observability - metrics, attempt history, trace propagation (Bet #1)
+
+**Status:** PROPOSED / design RFC. Not scheduled.
+**Target:** `hull/jobs@1` v1.6-ish. Builds on the v1.5 surface (docs/jobs.md).
+**Decisions (from review):** attempt history is **opt-in** via config; the
+metrics/trace surface is **pull-based `jobs.metrics()` + W3C trace-context
+propagation** - stdlib-heavy, **no C**, no built-in Prometheus/OTLP exporter
+(those can arrive later as pure-stdlib helpers). Full parity Lua + JS.
+
+Observability is where a job runner is judged in production ("did it run?" ->
+"here is exactly what happened, traced end to end"). DB-backed makes it cheap:
+history is rows, metrics are queries. Three pillars.
+
+---
+
+## Pillar A - pull metrics: `jobs.metrics(opts?)`
+
+A single DB-derived snapshot the app exposes however it wants (log line, a
+`/metrics` route, a dashboard). No ambient exporter, no new dependency.
+
+```lua
+jobs.metrics({ queue = "emails", window = 300 })   -- opts both optional
+```
+```javascript
+jobs.metrics({ queue: "emails", window: 300 });
+```
+
+Return shape (Lua; JS camelCase mirror):
+
+```lua
+{
+  queues = {
+    default = { pending=10, running=2, blocked=0, dead=1, oldest_pending_age=42 },
+    emails  = { pending=3,  running=1, blocked=0, dead=0, oldest_pending_age=5  },
+  },
+  totals  = { pending=13, running=3, blocked=0, dead=1,
+              done_window=812, dead_window=4, failure_rate=0.0049 },
+  -- latency + throughput only when attempt history (Pillar B) is enabled:
+  latency = {
+    wait_ms = { p50=12, p95=340, p99=1200 },   -- enqueue -> first start
+    run_ms  = { p50=8,  p95=95,  p99=410  },   -- start -> finish
+  },
+  throughput = { done_per_sec=2.7, dead_per_sec=0.01 },   -- over `window`
+}
+```
+
+- **Gauges** (`pending`/`running`/`blocked`/`dead` counts, `oldest_pending_age`
+  = `now - min(created_at)` over pending) come straight from `_hull_jobs` with
+  the existing claim index - cheap, always available.
+- **Windowed counts / failure rate / latency / throughput** need durable
+  completion records. `_hull_jobs` terminal rows are transient (`jobs.cleanup`
+  deletes them), so these are computed from the **attempt-history table**
+  (Pillar B) over the last `window` seconds - and are simply **absent** when
+  history is off (documented; `jobs.metrics()` still returns gauges).
+- **Percentiles**: portable SQL has no `PERCENTILE`, so `jobs.metrics` pulls a
+  bounded sample of recent attempt durations (last `window` or a cap, e.g.
+  2000 rows) and computes p50/p95/p99 in Lua/JS (sort + index). Bounded work.
+- No metric is a monotonic process counter (that would reset per process); every
+  value is a DB-derived snapshot, so it is correct across a fleet of workers.
+
+**Prometheus / OTLP:** intentionally NOT built in. A later pure-stdlib
+`hull.jobs.prometheus` helper can format `jobs.metrics()` as text; the app owns
+the scrape route. Keeps the core dependency-free and the taxonomy honest.
+
+## Pillar B - attempt history / timeline (opt-in)
+
+A durable, queryable record of every attempt - the Temporal-grade "what happened
+to this job" timeline, and the source for the latency/throughput metrics above.
+**Opt-in** because it is one write per attempt (amplification on high volume).
+
+Enable globally or per queue:
+
+```lua
+jobs.init({ history = true })                 -- record every attempt
+jobs.init({ history = { queues = { "critical" } } })   -- only these queues
+```
+
+New table (created by `init` only when history is ever enabled):
+
+```
+_hull_job_attempts(
+  attempt_id   <autoincrement PK>,
+  job_id       INTEGER NOT NULL,      -- the _hull_jobs.id (not an enforced FK, for portability)
+  queue        VARCHAR(255) NOT NULL,
+  type         VARCHAR(255) NOT NULL,
+  attempt_no   INTEGER NOT NULL,      -- job.attempts at run time
+  started_ms   INTEGER NOT NULL,      -- time.now_ms() captured when work() begins the handler
+  finished_ms  INTEGER NOT NULL,      -- time.now_ms() after the outcome
+  duration_ms  INTEGER NOT NULL,      -- finished_ms - started_ms
+  outcome      VARCHAR(16) NOT NULL,  -- 'done' | 'retried' | 'dead'
+  error        TEXT,                  -- on retried/dead
+  worker       VARCHAR(255),          -- optional worker id (from run_worker opts.id)
+  trace_id     VARCHAR(255)           -- Pillar C correlation, if present
+)
+-- index: (job_id, attempt_no)  for jobs.history(id)
+-- index: (queue, finished_ms)  for windowed metrics
+```
+
+Recorded in `work()` at each outcome, right where the v1.5 lifecycle events fire
+(one INSERT, only when history is enabled for that queue). Millisecond timing is
+captured in `work()` via `time.now_ms()` around the handler call - accurate
+execution duration independent of the second-resolution `claimed_at`.
+
+Read the timeline:
+
+```lua
+jobs.history(id)   -- array of attempts, oldest first:
+-- { { attempt_no=1, started_ms=.., finished_ms=.., duration_ms=8, outcome="retried", error="timeout" },
+--   { attempt_no=2, started_ms=.., finished_ms=.., duration_ms=6, outcome="done" } }
+```
+
+**Retention:** `jobs.cleanup` gains an attempt sweep (default same `older_than`;
+an explicit `history_retention` overrides). A hard cap can bound the table under
+sustained load. Attempts outlive the job row deliberately (a `done` job pruned by
+cleanup can still have its history for a retention window, for post-hoc metrics).
+
+## Pillar C - trace-context propagation
+
+Carry a W3C `traceparent` from enqueue into the handler so an app's spans link
+across the async boundary. Hull has no ambient tracer, so this is **explicit and
+minimal**: jobs stores and hands back the context; the app creates the spans.
+
+- New nullable column `trace_context VARCHAR(255)` on `_hull_jobs` (appended;
+  idempotent `ensure_column` migration, the v1.5 pattern).
+- `jobs.enqueue(type, data, { trace = "<traceparent>" })` stores it. (A helper
+  can default it from a per-request convention, e.g. `req.ctx.traceparent`.)
+- The claimed `job.trace` is exposed to the handler; the handler starts its span
+  as a child of that context and/or stamps it into log lines (pairs naturally
+  with the logger middleware's `request_id`).
+- **Workflow inheritance:** a durable workflow (Bet #2) and any jobs it enqueues
+  inherit the parent's `trace_context`, so a whole process is one trace.
+- Copied into `_hull_job_attempts.trace_id` for correlation between the timeline
+  and the trace.
+
+No span creation or OTLP export in core - propagation only. A later stdlib
+`hull.jobs.otel` could turn `job.trace` + attempt rows into real spans.
+
+## Config + API summary
+
+```lua
+jobs.init({ history = true|false|{ queues={...} }, history_retention = <sec> })
+jobs.metrics(opts?)      -- { queue?, window? } -> snapshot (gauges always; latency/throughput when history on)
+jobs.history(id)         -- attempt timeline for one job ([] if history off / none)
+jobs.enqueue(t, d, { trace = "<traceparent>" })   -- + job.trace in the handler
+```
+JS: `jobs.metrics` / `jobs.history` (camelCase fields), `enqueue(t,d,{ trace })`.
+
+## Storage / build
+
+- One opt-in table `_hull_job_attempts` + one nullable column
+  `_hull_jobs.trace_context`, both via the portable `ensure_column` /
+  create-if-enabled path. **Zero C.** Pure stdlib, both runtimes.
+- `time.now_ms()` (already bound) for ms timing; percentiles computed in Lua/JS
+  over a bounded sample.
+
+## Testing
+
+- `jobs.metrics` gauges (counts/age) on a seeded DB, both runtimes.
+- History off -> no `_hull_job_attempts` table, `jobs.history` returns empty,
+  metrics omit latency/throughput.
+- History on -> a job that retries-then-dies records N attempt rows with correct
+  `attempt_no`/`outcome`/`duration_ms`; `jobs.history` returns the timeline;
+  `jobs.metrics` latency percentiles computed.
+- Trace: `enqueue({ trace })` -> `job.trace` in the handler -> `trace_id` on the
+  attempt row.
+- Retention: `jobs.cleanup` prunes old attempts.
+
+## Phasing
+
+1. **Pillar A + C** (metrics gauges + trace propagation) - tiny, no new table
+   (trace_context column only). Immediate value.
+2. **Pillar B** (opt-in attempt history) + wire latency/throughput into
+   `jobs.metrics` + `jobs.history` + retention.
+3. (Later, stdlib) Prometheus text + OTel span exporters as optional helpers.
+
+## Integration
+
+- **Bet #2 (durable execution):** each `ctx.step` can record as an attempt-like
+  row (or a step timeline), so a workflow's internal timeline shows in
+  `jobs.history` / metrics. Trace context flows parent -> steps -> child jobs.
+- **v1.5 events:** `jobs.on` hooks and attempt history are complementary - hooks
+  are live/in-process, history is durable/queryable.


### PR DESCRIPTION
Two design RFCs (doc-only) for the two bets toward making `hull/jobs` best-in-class. Not scheduling implementation here — these are for review.

## Bet #1 — `docs/jobs_observability_design.md`
- **Pull metrics** `jobs.metrics()` — DB-derived gauges (depth/age/status counts) always; latency percentiles + throughput + failure-rate when history is on. No process counters (fleet-correct). No built-in Prometheus/OTLP (composable later, stdlib).
- **Opt-in attempt history** `_hull_job_attempts` (one row/attempt, recorded in `work()`, ms timing) → `jobs.history(id)` timeline; retention via `jobs.cleanup`.
- **Trace propagation** — a `trace_context` column carries a W3C `traceparent` enqueue → handler → child jobs; app creates the spans. Zero C.

## Bet #2 — `docs/jobs_durable_execution_design.md` (the flagship)
Workflow-as-code, **phased**:
- **Phase 1**: step-memoization (`ctx.step`), durable timers (`ctx.sleep` via `run_at`), signals (`ctx.wait_signal` / `jobs.signal`, a new `waiting` status), queries (`jobs.workflow_status`, DB-derived), and saga **compensation**.
- **Phase 2**: deterministic **WASM-replay** strict mode — the uniquely-Hull bet (a deterministic gas-metered sandbox next to a transactional queue is exactly what durable execution needs).
- A workflow instance **is a job that yields**, so it rides the existing claim/reap/retry/worker/result/await infra — minimal/zero new C.
- Coexists with the v1.4 declarative `depends_on` DAG (two complementary models).

Both lean on Hull's structural moats (transactional enqueue, sandboxed compute, DB-backed) rather than chasing feature parity. Open questions are captured inline in each doc.
