### PR TITLE
jobs: durable workflows - workflow-as-code (Phase 1: steps, timers, signals, saga)

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -216,6 +216,50 @@ jobs.enqueue("merge", {}, { depends_on = { p1, p2 } })   -- job.deps = { r1, r2 
 - Depend on job **ids** returned from `enqueue`; enqueue parents first. Unknown /
   already-cleaned-up dependency ids are treated as satisfied.
 
+## Durable workflows (workflow-as-code)
+
+The `depends_on` DAG above is a *static* graph of independent jobs. For a
+*dynamic*, long-running process - loops, conditionals, resumable across crashes -
+use a **durable workflow**: a normal function whose steps are memoized, so a
+crashed or retried workflow resumes past the work it already did. (Phase 1a:
+steps; durable timers, signals, and saga compensation are on the roadmap - see
+[docs/jobs_durable_execution_design.md](jobs_durable_execution_design.md).)
+
+```lua
+jobs.workflow("checkout", function(ctx)
+  local charge = ctx.step("charge", function()   -- runs once, result persisted
+      return payments.charge(ctx.input.order_id, ctx.input.amount)
+  end)
+  ctx.step("ship", function() return shipping.dispatch(ctx.input.order_id) end)
+  return { charged = charge.id }
+end)
+
+local wf = jobs.start("checkout", { order_id = 42, amount = 100 })   -- returns a job id
+```
+```javascript
+jobs.workflow("checkout", async (ctx) => {
+  const charge = await ctx.step("charge", () => payments.charge(ctx.input.orderId, ctx.input.amount));
+  await ctx.step("ship", () => shipping.dispatch(ctx.input.orderId));
+  return { charged: charge.id };
+});
+const wf = jobs.start("checkout", { orderId: 42, amount: 100 });
+```
+
+- **A workflow instance is a job** (reserved type `__wf:<name>`), so it rides the
+  same claim / visibility-reaper / retry / worker / result machinery. If a
+  worker crashes mid-workflow, the reaper reclaims it and it resumes.
+- **`ctx.step(name, fn)`** runs `fn` once and stores the result in
+  `_hull_workflow_steps`; on any re-run (retry or crash-resume) the step returns
+  the stored result **without** re-executing `fn`. Steps are **at-least-once**
+  (idempotent, same contract as a handler): a crash between the side effect and
+  the memo write re-runs the step.
+- **`ctx.input`** is the payload from `jobs.start`; **`ctx.id`** is the workflow
+  id. The body between steps re-runs on each resume, so keep it cheap and put all
+  side effects inside steps.
+- **`jobs.workflow_status(id)`** (`workflowStatus`) → `{ status, name,
+  steps_done, result?, error? }`, DB-derived (works even when no worker is
+  running it). Fetch the final value with `jobs.await(id)` / `jobs.result(id)`.
+
 ## Handler contract
 
 `jobs.work` dispatches each claimed job to its registered handler, else the

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -221,9 +221,10 @@ jobs.enqueue("merge", {}, { depends_on = { p1, p2 } })   -- job.deps = { r1, r2 
 The `depends_on` DAG above is a *static* graph of independent jobs. For a
 *dynamic*, long-running process - loops, conditionals, resumable across crashes -
 use a **durable workflow**: a normal function whose steps are memoized, so a
-crashed or retried workflow resumes past the work it already did. (Phases 1a-1b:
-steps + durable timers; signals and saga compensation are on the roadmap - see
-[docs/jobs_durable_execution_design.md](jobs_durable_execution_design.md).)
+crashed or retried workflow resumes past the work it already did. It can sleep for
+days, wait for external signals, and roll back on failure. (See
+[docs/jobs_durable_execution_design.md](jobs_durable_execution_design.md);
+deterministic WASM-replay strict mode is the remaining Phase 2.)
 
 ```lua
 jobs.workflow("checkout", function(ctx)
@@ -262,6 +263,19 @@ const wf = jobs.start("checkout", { orderId: 42, amount: 100 });
   in-memory timer. A worker must be running when it is due. A sleep does not
   consume the retry budget. `workflow_status` reports `waiting_for = "sleep:<ts>"`
   while it waits.
+- **`ctx.wait_signal(name, opts?)`** (`waitSignal`) pauses the workflow until
+  `jobs.signal(id, name, payload)` (`workflowStatus` shows `waiting_for =
+  "signal"`); it returns the delivered payload. The workflow parks in a
+  non-terminal `waiting` status (claimed by nobody) and is re-activated on
+  delivery - the human-in-the-loop / wait-for-webhook / approval primitive. A
+  signal delivered **before** the workflow reaches the wait is stored and
+  consumed when it gets there (no lost-signal race). `opts.timeout` (seconds)
+  makes the wait return `nil` if no signal arrives in time.
+- **Saga compensation:** `ctx.step(name, fn, { compensate = cfn })` registers a
+  rollback. If the workflow **fails terminally** (dead-letters), the completed
+  steps' `compensate` functions run in **reverse order** (undo the charge if
+  shipping can't be arranged). Compensations are at-least-once (idempotent) and
+  recorded, so a crash mid-rollback resumes.
 - **`jobs.workflow_status(id)`** (`workflowStatus`) → `{ status, name,
   steps_done, result?, error? }`, DB-derived (works even when no worker is
   running it). Fetch the final value with `jobs.await(id)` / `jobs.result(id)`.

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -221,8 +221,8 @@ jobs.enqueue("merge", {}, { depends_on = { p1, p2 } })   -- job.deps = { r1, r2 
 The `depends_on` DAG above is a *static* graph of independent jobs. For a
 *dynamic*, long-running process - loops, conditionals, resumable across crashes -
 use a **durable workflow**: a normal function whose steps are memoized, so a
-crashed or retried workflow resumes past the work it already did. (Phase 1a:
-steps; durable timers, signals, and saga compensation are on the roadmap - see
+crashed or retried workflow resumes past the work it already did. (Phases 1a-1b:
+steps + durable timers; signals and saga compensation are on the roadmap - see
 [docs/jobs_durable_execution_design.md](jobs_durable_execution_design.md).)
 
 ```lua
@@ -256,6 +256,12 @@ const wf = jobs.start("checkout", { orderId: 42, amount: 100 });
 - **`ctx.input`** is the payload from `jobs.start`; **`ctx.id`** is the workflow
   id. The body between steps re-runs on each resume, so keep it cheap and put all
   side effects inside steps.
+- **`ctx.sleep(seconds)`** is a **durable timer**: the workflow yields and is
+  rescheduled to wake later (it becomes a future-dated `pending` job), so a sleep
+  survives restarts, redeploys, and crashes at zero cost - no held thread, no
+  in-memory timer. A worker must be running when it is due. A sleep does not
+  consume the retry budget. `workflow_status` reports `waiting_for = "sleep:<ts>"`
+  while it waits.
 - **`jobs.workflow_status(id)`** (`workflowStatus`) → `{ status, name,
   steps_done, result?, error? }`, DB-derived (works even when no worker is
   running it). Fetch the final value with `jobs.await(id)` / `jobs.result(id)`.

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -15,7 +15,7 @@
  * Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
  * catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
  * visibility-timeout reaper), the dedicated worker (jobs.runWorker +
- * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueueMany), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step / ctx.sleep, Phases 1a-1b) add crash-safe resumable step memoization + durable timers - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md).
+ * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueueMany), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step / ctx.sleep / ctx.wait_signal / jobs.signal, Phase 1) add crash-safe workflow-as-code: step memoization, durable timers, external signals, and saga compensation - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md).
  *
  * @license AGPL-3.0-or-later
  */
@@ -216,6 +216,18 @@ function init(opts) {
         "status      VARCHAR(16)  NOT NULL DEFAULT 'done'," +
         "created_at  INTEGER      NOT NULL," +
         "PRIMARY KEY (workflow_id, step_key))");
+
+    // Durable-execution signals (jobs.signal / ctx.waitSignal). One row per
+    // (workflow, signal name); the payload is consumed once. Composite PK makes a
+    // duplicate delivery a no-op (first wins).
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_workflow_signals (" +
+        "workflow_id INTEGER      NOT NULL," +
+        "name        VARCHAR(255) NOT NULL," +
+        "payload     TEXT," +
+        "created_at  INTEGER      NOT NULL," +
+        "consumed_at INTEGER," +
+        "PRIMARY KEY (workflow_id, name))");
 
     // Verify the server actually parses SKIP LOCKED (the compile-time dialect
     // flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
@@ -749,6 +761,13 @@ function reap(opts) {
     const o = opts || {};
     const vt = o.visibilityTimeout !== undefined ? o.visibilityTimeout : _cfg.visibilityTimeout;
     const now = time.now();
+    // Wake durable-workflow signal waits whose timeout (run_at > 0) has passed, so
+    // they re-run and return null from ctx.waitSignal. run_at = 0 means "no
+    // timeout" (wait forever) and is left alone - only jobs.signal wakes it.
+    db.exec(
+        "UPDATE _hull_jobs SET status='pending', updated_at=? " +
+        "WHERE status='waiting' AND run_at > 0 AND run_at <= ?",
+        [now, now]);
     return db.exec(
         "UPDATE _hull_jobs SET status='pending', claim_token=NULL, updated_at=? " +
         "WHERE status='running' AND claimed_at <= ?",
@@ -963,17 +982,38 @@ async function work(opts) {
         }
         try {
             const result = await h(job);
-            if (result && typeof result === "object" && result.__hullWfYield !== undefined) {
-                // Durable workflow yielded (ctx.sleep): reschedule to the wake
-                // time and continue later - no terminal outcome, no event. A
+            if (result && typeof result === "object" && result.__hullWfYield) {
+                // Durable workflow yielded - no terminal outcome, no event. A
                 // yield is not a failed attempt, so undo the claim's attempt
-                // increment (a workflow may sleep/resume many times without
-                // exhausting maxAttempts). The future run_at keeps it out of the
-                // claim set until it is due.
+                // increment (a workflow may sleep / wait many times without
+                // exhausting maxAttempts).
                 const now = time.now();
-                db.exec("UPDATE _hull_jobs SET status='pending', run_at=?, " +
-                    "attempts=attempts-1, claim_token=NULL, updated_at=? WHERE id=?",
-                    [result.__hullWfYield, now, job.id]);
+                if (result.waiting) {
+                    // ctx.waitSignal: park in the non-terminal 'waiting' status
+                    // (excluded by the claim query). run_at carries the optional
+                    // timeout deadline (0 = none); the reaper wakes a timed-out
+                    // wait, jobs.signal wakes a delivered one.
+                    db.exec("UPDATE _hull_jobs SET status='waiting', run_at=?, " +
+                        "attempts=attempts-1, claim_token=NULL, updated_at=? WHERE id=?",
+                        [result.deadline || 0, now, job.id]);
+                    // Close the deliver-before-park race: a signal delivered in the
+                    // check->park window couldn't re-activate us (we were 'running'),
+                    // so re-check now that we are 'waiting'.
+                    if (result.signalName) {
+                        const sig = db.query("SELECT 1 AS x FROM _hull_workflow_signals " +
+                            "WHERE workflow_id=? AND name=? AND consumed_at IS NULL",
+                            [job.id, result.signalName]);
+                        if (sig.length) {
+                            db.exec("UPDATE _hull_jobs SET status='pending', run_at=?, " +
+                                "updated_at=? WHERE id=? AND status='waiting'", [now, now, job.id]);
+                        }
+                    }
+                } else {
+                    // ctx.sleep: future-dated pending job.
+                    db.exec("UPDATE _hull_jobs SET status='pending', run_at=?, " +
+                        "attempts=attempts-1, claim_token=NULL, updated_at=? WHERE id=?",
+                        [result.wakeAt || now, now, job.id]);
+                }
             } else if (result === DEAD) {
                 markDead(job.id, "handler returned jobs.DEAD");
                 emit("dead", job, { error: "handler returned jobs.DEAD" });
@@ -1247,17 +1287,83 @@ function runSleep(workflowId, n, seconds) {
     throw e;
 }
 
-// Build the durable ctx handed to a workflow function. `sleepN` is a per-run
-// counter captured by ctx.sleep, giving each sleep a stable ordinal key.
+// Wait for an external signal (jobs.signal). If the named signal is present it is
+// consumed and its payload returned; otherwise the workflow yields to the
+// non-terminal 'waiting' status (re-activated by jobs.signal). With opts.timeout
+// the wait also arms a deadline (stored once, stable across resumes) so the
+// reaper wakes it if no signal arrives; a timed-out wait returns null.
+function runWaitSignal(workflowId, name, opts) {
+    if (typeof name !== "string" || name === "")
+        throw new Error("ctx.waitSignal: name must be a non-empty string");
+    const rows = db.query(
+        "SELECT payload FROM _hull_workflow_signals WHERE workflow_id=? AND name=? AND consumed_at IS NULL",
+        [workflowId, name]);
+    if (rows.length) {
+        db.exec("UPDATE _hull_workflow_signals SET consumed_at=? WHERE workflow_id=? AND name=?",
+            [time.now(), workflowId, name]);
+        if (rows[0].payload == null) return null;
+        try { return JSON.parse(rows[0].payload); } catch (e) { return rows[0].payload; }
+    }
+    let deadline = 0;
+    if (opts && opts.timeout) {
+        const key = "__waitdl:" + name;
+        const drows = db.query(
+            "SELECT result FROM _hull_workflow_steps WHERE workflow_id=? AND step_key=?",
+            [workflowId, key]);
+        if (drows.length) {
+            deadline = Number(drows[0].result) || 0;
+        } else {
+            deadline = time.now() + opts.timeout;
+            db.exec(
+                "INSERT INTO _hull_workflow_steps (workflow_id, step_key, result, status, created_at) " +
+                "VALUES (?, ?, ?, 'waiting', ?)",
+                [workflowId, key, String(deadline), time.now()]);
+        }
+        if (time.now() >= deadline) return null;   // timed out, no signal
+    }
+    const e = new Error("__hull_yield");
+    e.__hullYield = true;
+    e.waiting = true;
+    e.signalName = name;
+    e.deadline = deadline;
+    throw e;
+}
+
+// Run the compensations of completed steps in reverse order (saga rollback). Each
+// runs at most once (marked 'compensated'), so a crash mid-rollback resumes.
+async function runCompensations(comps, workflowId) {
+    for (let i = comps.length - 1; i >= 0; i--) {
+        const c = comps[i];
+        const done = db.query(
+            "SELECT status FROM _hull_workflow_steps WHERE workflow_id=? AND step_key=?",
+            [workflowId, c.key]);
+        if (!(done.length && done[0].status === "compensated")) {
+            try { await c.fn(); } catch (e) { /* at-least-once; must be idempotent */ }
+            db.exec("UPDATE _hull_workflow_steps SET status='compensated' WHERE workflow_id=? AND step_key=?",
+                [workflowId, c.key]);
+        }
+    }
+}
+
+// Build the durable ctx handed to a workflow function. `sleepN` counts sleeps;
+// `comps` collects saga compensations (registered by every ctx.step call that has
+// one, so on the terminal-failure run the list covers all completed steps).
 function makeCtx(job, name) {
     let sleepN = 0;
+    const comps = [];
     return {
         id: job.id,
         name,
         input: job.data,
         trace: job.trace,   // trace-context propagation (observability design)
-        step: (stepKey, fn) => runStep(job.id, stepKey, fn),
+        _comps: comps,
+        step: async (stepKey, fn, opts) => {
+            const result = await runStep(job.id, stepKey, fn);
+            if (opts && typeof opts.compensate === "function") comps.push({ key: stepKey, fn: opts.compensate });
+            return result;
+        },
         sleep: (seconds) => { sleepN += 1; return runSleep(job.id, sleepN, seconds); },
+        waitSignal: (signalName, opts) => runWaitSignal(job.id, signalName, opts),
     };
 }
 
@@ -1278,14 +1384,25 @@ function workflow(name, fn) {
         throw new Error("jobs.workflow: name must be a non-empty string");
     if (typeof fn !== "function") throw new Error("jobs.workflow: fn must be a function");
     _workflows[name] = fn;
-    // A ctx.sleep (or other yield) throws the yield sentinel; catch it and hand
-    // work() the reschedule marker. A real error re-throws for the retry path.
+    // A ctx.sleep / ctx.waitSignal throws the yield sentinel; catch it and hand
+    // work() the yield marker (sleep -> reschedule pending; signal -> 'waiting').
+    // A real error re-throws for the retry path - but on the LAST attempt (about
+    // to dead-letter) or an explicit jobs.DEAD, run the saga compensations first.
     handler(WF_PREFIX + name, async (job) => {
-        try { return await fn(makeCtx(job, name)); }
+        const ctx = makeCtx(job, name);
+        let res;
+        try { res = await fn(ctx); }
         catch (e) {
-            if (e && e.__hullYield) return { __hullWfYield: e.wakeAt };
+            if (e && e.__hullYield) {
+                return { __hullWfYield: true, wakeAt: e.wakeAt,
+                         waiting: e.waiting, signalName: e.signalName, deadline: e.deadline };
+            }
+            const max = (job.maxAttempts != null) ? job.maxAttempts : _cfg.maxAttempts;
+            if ((job.attempts || 0) >= max) await runCompensations(ctx._comps, job.id);
             throw e;
         }
+        if (res === DEAD) await runCompensations(ctx._comps, job.id);
+        return res;
     });
     return jobs;
 }
@@ -1304,6 +1421,30 @@ function start(name, input, opts) {
     if (!_workflows[name])
         throw new Error(`jobs.start: unknown workflow '${name}' (register it with jobs.workflow)`);
     return enqueue(WF_PREFIX + name, input, opts);
+}
+
+/**
+ * Deliver a signal to a durable workflow (see ctx.waitSignal). Records the named
+ * payload (first delivery per name wins) and re-activates the workflow if it is
+ * parked waiting for it. Safe to call before the workflow reaches the wait (the
+ * signal is stored and consumed when it gets there) - no lost-signal race.
+ * @param {number} id       the workflow id
+ * @param {string} name     the signal name
+ * @param {*} [payload]
+ * @returns {boolean}
+ */
+function signal(id, name, payload) {
+    if (typeof name !== "string" || name === "")
+        throw new Error("jobs.signal: name must be a non-empty string");
+    const enc = payload !== undefined && payload !== null ? json.encode(payload) : null;
+    const now = time.now();
+    db.insertIfAbsent("_hull_workflow_signals", ["workflow_id", "name"],
+        ["workflow_id", "name", "payload", "created_at"], [id, name, enc, now]);
+    // Re-activate a parked wait (waiting -> pending). A 'running' or unrelated
+    // 'pending' workflow is left alone: it finds the stored signal on its own.
+    db.exec("UPDATE _hull_jobs SET status='pending', run_at=?, updated_at=? " +
+        "WHERE id=? AND status='waiting'", [now, now, id]);
+    return true;
 }
 
 /**
@@ -1327,8 +1468,11 @@ function workflowStatus(id) {
         startedAt: job.createdAt,
         updatedAt: job.updatedAt,
     };
-    // A pending workflow with a future run_at is sleeping on a durable timer.
-    if (job.status === "pending" && job.runAt && job.runAt > time.now()) {
+    // What the workflow is parked on: a signal ('waiting') or a durable timer
+    // (pending with a future run_at).
+    if (job.status === "waiting") {
+        out.waitingFor = "signal";
+    } else if (job.status === "pending" && job.runAt && job.runAt > time.now()) {
         out.waitingFor = "sleep:" + job.runAt;
     }
     if (job.status === "done") {
@@ -1429,6 +1573,7 @@ function cleanup(opts) {
     // Drop results whose producing job is gone (workflow result store hygiene).
     db.exec("DELETE FROM _hull_job_results WHERE job_id NOT IN (SELECT id FROM _hull_jobs)");
     db.exec("DELETE FROM _hull_workflow_steps WHERE workflow_id NOT IN (SELECT id FROM _hull_jobs)");
+    db.exec("DELETE FROM _hull_workflow_signals WHERE workflow_id NOT IN (SELECT id FROM _hull_jobs)");
     return deleted;
 }
 
@@ -1443,12 +1588,12 @@ export const jobs = {
     init, enqueue, enqueueMany, claim, handler, default: setDefault, on, work, reap,
     stats, runWorker, stop, get, result, await: await_, progress, heartbeat, limit,
     pause, resume, purge,
-    workflow, start, workflowStatus,
+    workflow, start, signal, workflowStatus,
     dead, retry, cancel, cleanup, cron, uncron,
     RETRY, DEAD, DISCARD, _config: _cfg, _cronNext, _tick,
 };
 export { init, enqueue, enqueueMany, claim, handler, on, work, reap, stats,
          runWorker, stop, get, result, progress, heartbeat, limit, pause, resume,
-         purge, workflow, start, workflowStatus,
+         purge, workflow, start, signal, workflowStatus,
          dead, retry, cancel, cleanup, cron, uncron };
 export default jobs;

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -15,7 +15,7 @@
  * Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
  * catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
  * visibility-timeout reaper), the dedicated worker (jobs.runWorker +
- * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueueMany), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron).
+ * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueueMany), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step, Phase 1a) add crash-safe resumable step memoization - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md).
  *
  * @license AGPL-3.0-or-later
  */
@@ -58,6 +58,10 @@ let _default = null;
 // worker that processed the job, for jobs THAT worker ran. Not fleet-wide - a
 // durable cross-process event stream is the LISTEN/NOTIFY epic (#235).
 const _listeners = { completed: [], retried: [], dead: [] };
+
+// Registered durable workflows: name -> fn(ctx). jobs.workflow registers a
+// reserved-type handler that runs the workflow through a memoizing ctx.
+const _workflows = Object.create(null);
 
 // Whether the server parses SKIP LOCKED (probed in init(); null = not probed).
 let _skipLocked = null;
@@ -200,6 +204,18 @@ function init(opts) {
         "CREATE TABLE IF NOT EXISTS _hull_job_results (" +
         "job_id INTEGER NOT NULL PRIMARY KEY," +
         "result TEXT)");
+
+    // Durable-execution step memo (jobs.workflow / ctx.step). One row per
+    // completed step of a workflow instance; a re-run of the workflow (crash or
+    // retry) reads these to skip already-done steps. Composite PK = idempotent.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_workflow_steps (" +
+        "workflow_id INTEGER      NOT NULL," +
+        "step_key    VARCHAR(255) NOT NULL," +
+        "result      TEXT," +
+        "status      VARCHAR(16)  NOT NULL DEFAULT 'done'," +
+        "created_at  INTEGER      NOT NULL," +
+        "PRIMARY KEY (workflow_id, step_key))");
 
     // Verify the server actually parses SKIP LOCKED (the compile-time dialect
     // flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
@@ -1159,6 +1175,117 @@ async function await_(id, opts) {
     }
 }
 
+// ── Durable execution: workflow-as-code (Phase 1a) ──────────────────────────
+// A durable workflow is a function fn(ctx) run as a job of the reserved type
+// "__wf:<name>". Each `await ctx.step(name, fn)` memoizes its result in
+// _hull_workflow_steps; if the workflow re-runs (crash or retry re-enters it from
+// the top), completed steps return their stored result instead of re-executing,
+// so the body resumes where it left off. Design:
+// docs/jobs_durable_execution_design.md.
+const WF_PREFIX = "__wf:";
+
+// Run (or replay) one memoized step. Returns fn()'s value; on a re-run of the
+// workflow the value comes from the store and fn is NOT called again.
+async function runStep(workflowId, stepKey, fn) {
+    if (typeof stepKey !== "string" || stepKey === "")
+        throw new Error("ctx.step: name must be a non-empty string");
+    if (typeof fn !== "function") throw new Error("ctx.step: fn must be a function");
+    const rows = db.query(
+        "SELECT result FROM _hull_workflow_steps WHERE workflow_id=? AND step_key=?",
+        [workflowId, stepKey]);
+    if (rows.length) {
+        if (rows[0].result == null) return undefined;
+        try { return JSON.parse(rows[0].result); } catch (e) { return rows[0].result; }
+    }
+    // First execution: run, then persist. At-least-once - a crash between the
+    // side effect and this INSERT re-runs the step on resume (steps must be
+    // idempotent, same contract as a job handler).
+    const res = await fn();
+    const enc = res !== undefined ? json.encode(res) : null;
+    db.exec(
+        "INSERT INTO _hull_workflow_steps (workflow_id, step_key, result, status, created_at) " +
+        "VALUES (?, ?, ?, 'done', ?)",
+        [workflowId, stepKey, enc, time.now()]);
+    return res;
+}
+
+// Build the durable ctx handed to a workflow function.
+function makeCtx(job, name) {
+    return {
+        id: job.id,
+        name,
+        input: job.data,
+        trace: job.trace,   // trace-context propagation (observability design)
+        step: (stepKey, fn) => runStep(job.id, stepKey, fn),
+    };
+}
+
+/**
+ * Register a durable workflow. `fn(ctx)` is the workflow body; its return value
+ * becomes the workflow's result (fetch via jobs.await / jobs.result). Inside it,
+ * `await ctx.step(name, fn)` runs `fn` once and memoizes the result, so a crashed
+ * or retried workflow resumes past completed steps. `ctx.input` is the payload
+ * from jobs.start, `ctx.id` the workflow id. A workflow instance IS a job
+ * (reserved type "__wf:<name>"), so it inherits claim / reaper / retry / worker /
+ * result.
+ * @param {string} name
+ * @param {Function} fn   (ctx) => result   (may be async)
+ * @returns {object} the jobs module (for chaining)
+ */
+function workflow(name, fn) {
+    if (typeof name !== "string" || name === "")
+        throw new Error("jobs.workflow: name must be a non-empty string");
+    if (typeof fn !== "function") throw new Error("jobs.workflow: fn must be a function");
+    _workflows[name] = fn;
+    handler(WF_PREFIX + name, (job) => fn(makeCtx(job, name)));
+    return jobs;
+}
+
+/**
+ * Start a durable workflow instance. Returns the workflow id (a job id); the
+ * input is the workflow's `ctx.input`. Accepts the usual enqueue opts (queue,
+ * priority, dedupKey for an idempotent start, delay/at). Poll jobs.workflowStatus
+ * (id) or jobs.await(id) for the outcome.
+ * @param {string} name
+ * @param {*} [input]
+ * @param {object} [opts]   enqueue options
+ * @returns {number|null}   the workflow id, or null if a dedupKey collapsed it
+ */
+function start(name, input, opts) {
+    if (!_workflows[name])
+        throw new Error(`jobs.start: unknown workflow '${name}' (register it with jobs.workflow)`);
+    return enqueue(WF_PREFIX + name, input, opts);
+}
+
+/**
+ * Query a workflow instance's state (DB-derived, so it works even when no worker
+ * is currently running it). Returns null for an unknown id, else
+ * { status, name, stepsDone, startedAt, updatedAt, result?, error? }.
+ * @param {number} id
+ * @returns {object|null}
+ */
+function workflowStatus(id) {
+    const job = get(id);
+    if (!job) return null;
+    const rows = db.query(
+        "SELECT step_key FROM _hull_workflow_steps WHERE workflow_id=? ORDER BY created_at, step_key",
+        [id]);
+    const out = {
+        status: job.status,
+        name: String(job.type).startsWith(WF_PREFIX) ? String(job.type).slice(WF_PREFIX.length) : job.type,
+        stepsDone: rows.map((r) => r.step_key),
+        startedAt: job.createdAt,
+        updatedAt: job.updatedAt,
+    };
+    if (job.status === "done") {
+        const r = result(id);
+        if (r) out.result = r.result;
+    } else if (job.status === "dead") {
+        out.error = job.lastError;
+    }
+    return out;
+}
+
 /**
  * Extend the claim on a job the current handler is processing (heartbeat). A
  * handler whose work may exceed `visibilityTimeout` should call this
@@ -1247,6 +1374,7 @@ function cleanup(opts) {
     const deleted = db.exec(sql, params) || 0;
     // Drop results whose producing job is gone (workflow result store hygiene).
     db.exec("DELETE FROM _hull_job_results WHERE job_id NOT IN (SELECT id FROM _hull_jobs)");
+    db.exec("DELETE FROM _hull_workflow_steps WHERE workflow_id NOT IN (SELECT id FROM _hull_jobs)");
     return deleted;
 }
 
@@ -1261,10 +1389,12 @@ export const jobs = {
     init, enqueue, enqueueMany, claim, handler, default: setDefault, on, work, reap,
     stats, runWorker, stop, get, result, await: await_, progress, heartbeat, limit,
     pause, resume, purge,
+    workflow, start, workflowStatus,
     dead, retry, cancel, cleanup, cron, uncron,
     RETRY, DEAD, DISCARD, _config: _cfg, _cronNext, _tick,
 };
 export { init, enqueue, enqueueMany, claim, handler, on, work, reap, stats,
          runWorker, stop, get, result, progress, heartbeat, limit, pause, resume,
-         purge, dead, retry, cancel, cleanup, cron, uncron };
+         purge, workflow, start, workflowStatus,
+         dead, retry, cancel, cleanup, cron, uncron };
 export default jobs;

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -15,7 +15,7 @@
  * Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
  * catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
  * visibility-timeout reaper), the dedicated worker (jobs.runWorker +
- * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueueMany), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step, Phase 1a) add crash-safe resumable step memoization - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md).
+ * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueueMany), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step / ctx.sleep, Phases 1a-1b) add crash-safe resumable step memoization + durable timers - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md).
  *
  * @license AGPL-3.0-or-later
  */
@@ -963,7 +963,18 @@ async function work(opts) {
         }
         try {
             const result = await h(job);
-            if (result === DEAD) {
+            if (result && typeof result === "object" && result.__hullWfYield !== undefined) {
+                // Durable workflow yielded (ctx.sleep): reschedule to the wake
+                // time and continue later - no terminal outcome, no event. A
+                // yield is not a failed attempt, so undo the claim's attempt
+                // increment (a workflow may sleep/resume many times without
+                // exhausting maxAttempts). The future run_at keeps it out of the
+                // claim set until it is due.
+                const now = time.now();
+                db.exec("UPDATE _hull_jobs SET status='pending', run_at=?, " +
+                    "attempts=attempts-1, claim_token=NULL, updated_at=? WHERE id=?",
+                    [result.__hullWfYield, now, job.id]);
+            } else if (result === DEAD) {
                 markDead(job.id, "handler returned jobs.DEAD");
                 emit("dead", job, { error: "handler returned jobs.DEAD" });
             } else if (result === RETRY) {
@@ -1209,14 +1220,44 @@ async function runStep(workflowId, stepKey, fn) {
     return res;
 }
 
-// Build the durable ctx handed to a workflow function.
+// Durable timer. `n` is the ordinal of this sleep in the workflow body (stable
+// across re-runs). On first encounter it records the wake time and throws the
+// yield sentinel (the runner reschedules the job to run_at = wake_at); on a
+// resume the recorded wake time is read, and once it has passed the call returns
+// so the body continues past it.
+function runSleep(workflowId, n, seconds) {
+    const key = "__sleep:" + n;
+    const rows = db.query(
+        "SELECT result FROM _hull_workflow_steps WHERE workflow_id=? AND step_key=?",
+        [workflowId, key]);
+    let wakeAt;
+    if (rows.length) {
+        wakeAt = Number(rows[0].result);
+    } else {
+        wakeAt = time.now() + (Number(seconds) || 0);
+        db.exec(
+            "INSERT INTO _hull_workflow_steps (workflow_id, step_key, result, status, created_at) " +
+            "VALUES (?, ?, ?, 'sleeping', ?)",
+            [workflowId, key, String(wakeAt), time.now()]);
+    }
+    if (time.now() >= wakeAt) return;   // elapsed: continue
+    const e = new Error("__hull_yield");   // caught by the runner (Error carries the marker)
+    e.__hullYield = true;
+    e.wakeAt = wakeAt;
+    throw e;
+}
+
+// Build the durable ctx handed to a workflow function. `sleepN` is a per-run
+// counter captured by ctx.sleep, giving each sleep a stable ordinal key.
 function makeCtx(job, name) {
+    let sleepN = 0;
     return {
         id: job.id,
         name,
         input: job.data,
         trace: job.trace,   // trace-context propagation (observability design)
         step: (stepKey, fn) => runStep(job.id, stepKey, fn),
+        sleep: (seconds) => { sleepN += 1; return runSleep(job.id, sleepN, seconds); },
     };
 }
 
@@ -1237,7 +1278,15 @@ function workflow(name, fn) {
         throw new Error("jobs.workflow: name must be a non-empty string");
     if (typeof fn !== "function") throw new Error("jobs.workflow: fn must be a function");
     _workflows[name] = fn;
-    handler(WF_PREFIX + name, (job) => fn(makeCtx(job, name)));
+    // A ctx.sleep (or other yield) throws the yield sentinel; catch it and hand
+    // work() the reschedule marker. A real error re-throws for the retry path.
+    handler(WF_PREFIX + name, async (job) => {
+        try { return await fn(makeCtx(job, name)); }
+        catch (e) {
+            if (e && e.__hullYield) return { __hullWfYield: e.wakeAt };
+            throw e;
+        }
+    });
     return jobs;
 }
 
@@ -1273,10 +1322,15 @@ function workflowStatus(id) {
     const out = {
         status: job.status,
         name: String(job.type).startsWith(WF_PREFIX) ? String(job.type).slice(WF_PREFIX.length) : job.type,
-        stepsDone: rows.map((r) => r.step_key),
+        // Hide internal keys (durable-sleep markers "__sleep:N"); only user steps.
+        stepsDone: rows.map((r) => r.step_key).filter((k) => !String(k).startsWith("__")),
         startedAt: job.createdAt,
         updatedAt: job.updatedAt,
     };
+    // A pending workflow with a future run_at is sleeping on a durable timer.
+    if (job.status === "pending" && job.runAt && job.runAt > time.now()) {
+        out.waitingFor = "sleep:" + job.runAt;
+    }
     if (job.status === "done") {
         const r = result(id);
         if (r) out.result = r.result;

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -1061,7 +1061,7 @@ function jobs.work(opts)
                 -- yield is not a failed attempt, so undo the claim's attempt
                 -- increment (a workflow may sleep / wait many times without
                 -- exhausting max_attempts).
-                local now = time.now()
+                local wf_now = time.now()
                 if result.waiting then
                     -- ctx.wait_signal: park in the non-terminal 'waiting' status
                     -- (excluded by the claim query). run_at carries the optional
@@ -1069,7 +1069,7 @@ function jobs.work(opts)
                     -- wait, jobs.signal wakes a delivered one.
                     db.exec("UPDATE _hull_jobs SET status='waiting', run_at=?, "
                         .. "attempts=attempts-1, claim_token=NULL, updated_at=? WHERE id=?",
-                        { result.deadline or 0, now, job.id })
+                        { result.deadline or 0, wf_now, job.id })
                     -- Close the deliver-before-park race: a signal delivered in the
                     -- check->park window couldn't re-activate us (we were 'running'),
                     -- so re-check now that we are 'waiting'.
@@ -1080,14 +1080,14 @@ function jobs.work(opts)
                         if sig and #sig > 0 then
                             db.exec("UPDATE _hull_jobs SET status='pending', run_at=?, "
                                 .. "updated_at=? WHERE id=? AND status='waiting'",
-                                { now, now, job.id })
+                                { wf_now, wf_now, job.id })
                         end
                     end
                 else
                     -- ctx.sleep: future-dated pending job.
                     db.exec("UPDATE _hull_jobs SET status='pending', run_at=?, "
                         .. "attempts=attempts-1, claim_token=NULL, updated_at=? WHERE id=?",
-                        { result.wake_at or now, now, job.id })
+                        { result.wake_at or wf_now, wf_now, job.id })
                 end
             elseif not ok then
                 local err = tostring(result)

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -11,7 +11,7 @@
 -- Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
 -- catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
 -- visibility-timeout reaper), the dedicated worker (jobs.run_worker +
--- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueue_many), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step, Phase 1a) add crash-safe resumable step memoization - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md).
+-- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueue_many), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step / ctx.sleep, Phases 1a-1b) add crash-safe resumable step memoization + durable timers - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md).
 --
 -- Usage (target shape):
 --   local jobs = require("hull.jobs")
@@ -1037,7 +1037,18 @@ function jobs.work(opts)
             emit("dead", job, { error = err })
         else
             local ok, result = pcall(h, job)
-            if not ok then
+            if ok and type(result) == "table" and result.__hull_wf_yield then
+                -- Durable workflow yielded (ctx.sleep): reschedule to the wake
+                -- time and continue later - no terminal outcome, no event. A
+                -- yield is not a failed attempt, so undo the claim's attempt
+                -- increment (a workflow may sleep/resume many times without
+                -- exhausting max_attempts). The future run_at keeps it out of
+                -- the claim set until it is due.
+                local now = time.now()
+                db.exec("UPDATE _hull_jobs SET status='pending', run_at=?, "
+                    .. "attempts=attempts-1, claim_token=NULL, updated_at=? WHERE id=?",
+                    { result.__hull_wf_yield, now, job.id })
+            elseif not ok then
                 local err = tostring(result)
                 emit(mark_retry(job, err), job, { error = err, attempt = job.attempts })
             elseif result == jobs.DEAD then
@@ -1290,15 +1301,45 @@ local function run_step(workflow_id, step_key, fn)
     return result
 end
 
--- Build the durable ctx handed to a workflow function.
+-- Durable timer. `n` is the ordinal of this sleep in the workflow body (stable
+-- across re-runs, since the step-call sequence is stable). On first encounter it
+-- records the wake time and raises the yield sentinel (the runner reschedules the
+-- job to run_at = wake_at); on a resume the recorded wake time is read, and once
+-- it has passed the call returns and the body continues past it.
+local function run_sleep(workflow_id, n, seconds)
+    local key = "__sleep:" .. n
+    local rows = db.query(
+        "SELECT result FROM _hull_workflow_steps WHERE workflow_id=? AND step_key=?",
+        { workflow_id, key })
+    local wake_at
+    if rows and #rows > 0 then
+        wake_at = tonumber(rows[1].result)
+    else
+        wake_at = time.now() + (tonumber(seconds) or 0)
+        db.exec(
+            "INSERT INTO _hull_workflow_steps (workflow_id, step_key, result, status, created_at) "
+            .. "VALUES (?, ?, ?, 'sleeping', ?)",
+            { workflow_id, key, tostring(wake_at), time.now() })
+    end
+    if time.now() >= wake_at then return end   -- elapsed: continue
+    error({ __hull_yield = true, wake_at = wake_at })   -- caught by the runner
+end
+
+-- Build the durable ctx handed to a workflow function. `sleep_n` is a per-run
+-- counter captured by ctx.sleep, giving each sleep a stable ordinal key.
 local function make_ctx(job, name)
+    local sleep_n = 0
     local ctx = {
         id    = job.id,
         name  = name,
         input = job.data,
         trace = job.trace,   -- trace-context propagation (observability design)
     }
-    ctx.step = function(step_key, fn) return run_step(job.id, step_key, fn) end
+    ctx.step  = function(step_key, fn) return run_step(job.id, step_key, fn) end
+    ctx.sleep = function(seconds)
+        sleep_n = sleep_n + 1
+        return run_sleep(job.id, sleep_n, seconds)
+    end
     return ctx
 end
 
@@ -1316,9 +1357,16 @@ function jobs.workflow(name, fn)
     end
     if type(fn) ~= "function" then error("jobs.workflow: fn must be a function") end
     _workflows[name] = fn
-    -- The workflow runs as a normal handler for its reserved type.
+    -- The workflow runs as a normal handler for its reserved type. A ctx.sleep
+    -- (or other yield) raises the yield sentinel; catch it and hand work() the
+    -- reschedule marker. A real error re-raises for the normal retry path.
     jobs.handler(WF_PREFIX .. name, function(job)
-        return fn(make_ctx(job, name))
+        local ok, res = pcall(fn, make_ctx(job, name))
+        if ok then return res end
+        if type(res) == "table" and res.__hull_yield then
+            return { __hull_wf_yield = res.wake_at }
+        end
+        error(res, 0)
     end)
     return jobs
 end
@@ -1350,7 +1398,12 @@ function jobs.workflow_status(id)
         "SELECT step_key FROM _hull_workflow_steps WHERE workflow_id=? ORDER BY created_at, step_key",
         { id })
     local steps_done = {}
-    for _, s in ipairs(rows or {}) do steps_done[#steps_done + 1] = s.step_key end
+    for _, s in ipairs(rows or {}) do
+        -- Hide internal keys (durable-sleep markers "__sleep:N"); only user steps.
+        if not tostring(s.step_key):match("^__") then
+            steps_done[#steps_done + 1] = s.step_key
+        end
+    end
     local out = {
         status     = job.status,
         name       = tostring(job.type):match("^" .. WF_PREFIX .. "(.+)$") or job.type,
@@ -1358,6 +1411,10 @@ function jobs.workflow_status(id)
         started_at = job.created_at,
         updated_at = job.updated_at,
     }
+    -- A pending workflow with a future run_at is sleeping on a durable timer.
+    if job.status == "pending" and job.run_at and job.run_at > time.now() then
+        out.waiting_for = "sleep:" .. job.run_at
+    end
     if job.status == "done" then
         local r = jobs.result(id)
         if r then out.result = r.result end

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -11,7 +11,7 @@
 -- Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
 -- catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
 -- visibility-timeout reaper), the dedicated worker (jobs.run_worker +
--- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueue_many), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step / ctx.sleep, Phases 1a-1b) add crash-safe resumable step memoization + durable timers - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md).
+-- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueue_many), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step / ctx.sleep / ctx.wait_signal / jobs.signal, Phase 1) add crash-safe workflow-as-code: step memoization, durable timers, external signals, and saga compensation - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md).
 --
 -- Usage (target shape):
 --   local jobs = require("hull.jobs")
@@ -232,6 +232,18 @@ function jobs.init(opts)
         .. "status      VARCHAR(16)  NOT NULL DEFAULT 'done',"
         .. "created_at  INTEGER      NOT NULL,"
         .. "PRIMARY KEY (workflow_id, step_key))")
+
+    -- Durable-execution signals (jobs.signal / ctx.wait_signal). One row per
+    -- (workflow, signal name); the payload is consumed once. Composite PK makes a
+    -- duplicate delivery a no-op (first wins).
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_workflow_signals ("
+        .. "workflow_id INTEGER      NOT NULL,"
+        .. "name        VARCHAR(255) NOT NULL,"
+        .. "payload     TEXT,"
+        .. "created_at  INTEGER      NOT NULL,"
+        .. "consumed_at INTEGER,"
+        .. "PRIMARY KEY (workflow_id, name))")
 
     -- Verify the server actually parses SKIP LOCKED (the compile-time dialect
     -- flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
@@ -801,6 +813,13 @@ function jobs.reap(opts)
     opts = opts or {}
     local vt = opts.visibility_timeout or _cfg.visibility_timeout
     local now = time.now()
+    -- Wake durable-workflow signal waits whose timeout (run_at > 0) has passed, so
+    -- they re-run and return nil from ctx.wait_signal. run_at = 0 means "no
+    -- timeout" (wait forever) and is left alone - only jobs.signal wakes it.
+    db.exec(
+        "UPDATE _hull_jobs SET status='pending', updated_at=? "
+        .. "WHERE status='waiting' AND run_at > 0 AND run_at <= ?",
+        { now, now })
     return db.exec(
         "UPDATE _hull_jobs SET status='pending', claim_token=NULL, updated_at=? "
         .. "WHERE status='running' AND claimed_at <= ?",
@@ -1038,16 +1057,38 @@ function jobs.work(opts)
         else
             local ok, result = pcall(h, job)
             if ok and type(result) == "table" and result.__hull_wf_yield then
-                -- Durable workflow yielded (ctx.sleep): reschedule to the wake
-                -- time and continue later - no terminal outcome, no event. A
+                -- Durable workflow yielded - no terminal outcome, no event. A
                 -- yield is not a failed attempt, so undo the claim's attempt
-                -- increment (a workflow may sleep/resume many times without
-                -- exhausting max_attempts). The future run_at keeps it out of
-                -- the claim set until it is due.
+                -- increment (a workflow may sleep / wait many times without
+                -- exhausting max_attempts).
                 local now = time.now()
-                db.exec("UPDATE _hull_jobs SET status='pending', run_at=?, "
-                    .. "attempts=attempts-1, claim_token=NULL, updated_at=? WHERE id=?",
-                    { result.__hull_wf_yield, now, job.id })
+                if result.waiting then
+                    -- ctx.wait_signal: park in the non-terminal 'waiting' status
+                    -- (excluded by the claim query). run_at carries the optional
+                    -- timeout deadline (0 = none); the reaper wakes a timed-out
+                    -- wait, jobs.signal wakes a delivered one.
+                    db.exec("UPDATE _hull_jobs SET status='waiting', run_at=?, "
+                        .. "attempts=attempts-1, claim_token=NULL, updated_at=? WHERE id=?",
+                        { result.deadline or 0, now, job.id })
+                    -- Close the deliver-before-park race: a signal delivered in the
+                    -- check->park window couldn't re-activate us (we were 'running'),
+                    -- so re-check now that we are 'waiting'.
+                    if result.signal_name then
+                        local sig = db.query("SELECT 1 AS x FROM _hull_workflow_signals "
+                            .. "WHERE workflow_id=? AND name=? AND consumed_at IS NULL",
+                            { job.id, result.signal_name })
+                        if sig and #sig > 0 then
+                            db.exec("UPDATE _hull_jobs SET status='pending', run_at=?, "
+                                .. "updated_at=? WHERE id=? AND status='waiting'",
+                                { now, now, job.id })
+                        end
+                    end
+                else
+                    -- ctx.sleep: future-dated pending job.
+                    db.exec("UPDATE _hull_jobs SET status='pending', run_at=?, "
+                        .. "attempts=attempts-1, claim_token=NULL, updated_at=? WHERE id=?",
+                        { result.wake_at or now, now, job.id })
+                end
             elseif not ok then
                 local err = tostring(result)
                 emit(mark_retry(job, err), job, { error = err, attempt = job.attempts })
@@ -1325,21 +1366,87 @@ local function run_sleep(workflow_id, n, seconds)
     error({ __hull_yield = true, wake_at = wake_at })   -- caught by the runner
 end
 
+-- Wait for an external signal (jobs.signal). If the named signal is present it is
+-- consumed and its payload returned; otherwise the workflow yields to the
+-- non-terminal 'waiting' status (re-activated by jobs.signal). With opts.timeout
+-- the wait also arms a deadline (stored once, stable across resumes) so the
+-- reaper wakes it if no signal arrives; a timed-out wait returns nil.
+local function run_wait_signal(workflow_id, name, opts)
+    if type(name) ~= "string" or name == "" then
+        error("ctx.wait_signal: name must be a non-empty string")
+    end
+    local rows = db.query(
+        "SELECT payload FROM _hull_workflow_signals WHERE workflow_id=? AND name=? AND consumed_at IS NULL",
+        { workflow_id, name })
+    if rows and #rows > 0 then
+        db.exec("UPDATE _hull_workflow_signals SET consumed_at=? WHERE workflow_id=? AND name=?",
+            { time.now(), workflow_id, name })
+        if rows[1].payload == nil then return nil end
+        local ok, decoded = pcall(json.decode, rows[1].payload)
+        if ok then return decoded else return rows[1].payload end
+    end
+    local deadline = 0
+    if opts and opts.timeout then
+        local key = "__waitdl:" .. name
+        local drows = db.query(
+            "SELECT result FROM _hull_workflow_steps WHERE workflow_id=? AND step_key=?",
+            { workflow_id, key })
+        if drows and #drows > 0 then
+            deadline = tonumber(drows[1].result) or 0
+        else
+            deadline = time.now() + opts.timeout
+            db.exec(
+                "INSERT INTO _hull_workflow_steps (workflow_id, step_key, result, status, created_at) "
+                .. "VALUES (?, ?, ?, 'waiting', ?)",
+                { workflow_id, key, tostring(deadline), time.now() })
+        end
+        if time.now() >= deadline then return nil end   -- timed out, no signal
+    end
+    error({ __hull_yield = true, waiting = true, signal_name = name, deadline = deadline })
+end
+
+-- Run the compensations of completed steps in reverse order (saga rollback). Each
+-- runs at most once (marked 'compensated'), so a crash mid-rollback resumes.
+local function run_compensations(comps, workflow_id)
+    for i = #comps, 1, -1 do
+        local c = comps[i]
+        local done = db.query(
+            "SELECT status FROM _hull_workflow_steps WHERE workflow_id=? AND step_key=?",
+            { workflow_id, c.key })
+        if not (done and #done > 0 and done[1].status == "compensated") then
+            pcall(c.fn)   -- at-least-once; compensations must be idempotent
+            db.exec("UPDATE _hull_workflow_steps SET status='compensated' WHERE workflow_id=? AND step_key=?",
+                { workflow_id, c.key })
+        end
+    end
+end
+
 -- Build the durable ctx handed to a workflow function. `sleep_n` is a per-run
--- counter captured by ctx.sleep, giving each sleep a stable ordinal key.
+-- counter captured by ctx.sleep; `comps` collects saga compensations (registered
+-- by every ctx.step call that has one, so on the terminal-failure run the list
+-- covers all completed steps).
 local function make_ctx(job, name)
     local sleep_n = 0
+    local comps = {}
     local ctx = {
         id    = job.id,
         name  = name,
         input = job.data,
         trace = job.trace,   -- trace-context propagation (observability design)
+        _comps = comps,
     }
-    ctx.step  = function(step_key, fn) return run_step(job.id, step_key, fn) end
+    ctx.step = function(step_key, fn, opts)
+        local result = run_step(job.id, step_key, fn)
+        if opts and type(opts.compensate) == "function" then
+            comps[#comps + 1] = { key = step_key, fn = opts.compensate }
+        end
+        return result
+    end
     ctx.sleep = function(seconds)
         sleep_n = sleep_n + 1
         return run_sleep(job.id, sleep_n, seconds)
     end
+    ctx.wait_signal = function(signal_name, opts) return run_wait_signal(job.id, signal_name, opts) end
     return ctx
 end
 
@@ -1357,15 +1464,25 @@ function jobs.workflow(name, fn)
     end
     if type(fn) ~= "function" then error("jobs.workflow: fn must be a function") end
     _workflows[name] = fn
-    -- The workflow runs as a normal handler for its reserved type. A ctx.sleep
-    -- (or other yield) raises the yield sentinel; catch it and hand work() the
-    -- reschedule marker. A real error re-raises for the normal retry path.
+    -- The workflow runs as a normal handler for its reserved type. A ctx.sleep /
+    -- ctx.wait_signal raises the yield sentinel; catch it and hand work() the
+    -- yield marker (sleep -> reschedule pending; signal -> 'waiting'). A real
+    -- error re-raises for the normal retry path - but on the LAST attempt (about
+    -- to dead-letter) or an explicit jobs.DEAD, run the saga compensations first.
     jobs.handler(WF_PREFIX .. name, function(job)
-        local ok, res = pcall(fn, make_ctx(job, name))
-        if ok then return res end
-        if type(res) == "table" and res.__hull_yield then
-            return { __hull_wf_yield = res.wake_at }
+        local ctx = make_ctx(job, name)
+        local ok, res = pcall(fn, ctx)
+        if ok then
+            if res == jobs.DEAD then run_compensations(ctx._comps, job.id) end
+            return res
         end
+        if type(res) == "table" and res.__hull_yield then
+            return { __hull_wf_yield = true, wake_at = res.wake_at,
+                     waiting = res.waiting, signal_name = res.signal_name,
+                     deadline = res.deadline }
+        end
+        local max = job.max_attempts or _cfg.max_attempts
+        if (job.attempts or 0) >= max then run_compensations(ctx._comps, job.id) end
         error(res, 0)
     end)
     return jobs
@@ -1384,6 +1501,30 @@ function jobs.start(name, input, opts)
         error("jobs.start: unknown workflow '" .. tostring(name) .. "' (register it with jobs.workflow)")
     end
     return jobs.enqueue(WF_PREFIX .. name, input, opts)
+end
+
+--- Deliver a signal to a durable workflow (see ctx.wait_signal). Records the
+-- named payload (first delivery per name wins) and re-activates the workflow if
+-- it is parked waiting for it. Safe to call before the workflow reaches the wait
+-- (the signal is stored and consumed when it gets there) - no lost-signal race.
+-- Returns true.
+-- @tparam number id       the workflow id
+-- @tparam string name     the signal name
+-- @tparam[opt] any payload
+-- @treturn boolean
+function jobs.signal(id, name, payload)
+    if type(name) ~= "string" or name == "" then
+        error("jobs.signal: name must be a non-empty string")
+    end
+    local enc = payload ~= nil and json.encode(payload) or nil
+    local now = time.now()
+    db.insert_if_absent("_hull_workflow_signals", { "workflow_id", "name" },
+        { "workflow_id", "name", "payload", "created_at" }, { id, name, enc, now })
+    -- Re-activate a parked wait (waiting -> pending). A 'running' or unrelated
+    -- 'pending' workflow is left alone: it finds the stored signal on its own.
+    db.exec("UPDATE _hull_jobs SET status='pending', run_at=?, updated_at=? "
+        .. "WHERE id=? AND status='waiting'", { now, now, id })
+    return true
 end
 
 --- Query a workflow instance's state (DB-derived, so it works even when no
@@ -1411,8 +1552,11 @@ function jobs.workflow_status(id)
         started_at = job.created_at,
         updated_at = job.updated_at,
     }
-    -- A pending workflow with a future run_at is sleeping on a durable timer.
-    if job.status == "pending" and job.run_at and job.run_at > time.now() then
+    -- What the workflow is parked on: a signal ('waiting') or a durable timer
+    -- (pending with a future run_at).
+    if job.status == "waiting" then
+        out.waiting_for = "signal"
+    elseif job.status == "pending" and job.run_at and job.run_at > time.now() then
         out.waiting_for = "sleep:" .. job.run_at
     end
     if job.status == "done" then
@@ -1525,6 +1669,7 @@ function jobs.cleanup(opts)
     -- Drop results + workflow steps whose producing job is gone (store hygiene).
     db.exec("DELETE FROM _hull_job_results WHERE job_id NOT IN (SELECT id FROM _hull_jobs)")
     db.exec("DELETE FROM _hull_workflow_steps WHERE workflow_id NOT IN (SELECT id FROM _hull_jobs)")
+    db.exec("DELETE FROM _hull_workflow_signals WHERE workflow_id NOT IN (SELECT id FROM _hull_jobs)")
     return deleted
 end
 

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -11,7 +11,7 @@
 -- Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
 -- catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
 -- visibility-timeout reaper), the dedicated worker (jobs.run_worker +
--- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueue_many), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron).
+-- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueue_many), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step, Phase 1a) add crash-safe resumable step memoization - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md).
 --
 -- Usage (target shape):
 --   local jobs = require("hull.jobs")
@@ -61,6 +61,10 @@ local _default = nil
 -- the worker that processed the job, for jobs THAT worker ran. Not fleet-wide -
 -- a durable cross-process event stream is the LISTEN/NOTIFY epic (#235).
 local _listeners = { completed = {}, retried = {}, dead = {} }
+
+-- Registered durable workflows: name -> fn(ctx). jobs.workflow registers a
+-- reserved-type handler that runs the workflow through a memoizing ctx.
+local _workflows = {}
 
 -- Unix ts of the last reaper sweep (throttled in jobs.work via _cfg.reap_interval).
 local _last_reap = 0
@@ -216,6 +220,18 @@ function jobs.init(opts)
         "CREATE TABLE IF NOT EXISTS _hull_job_results ("
         .. "job_id INTEGER NOT NULL PRIMARY KEY,"
         .. "result TEXT)")
+
+    -- Durable-execution step memo (jobs.workflow / ctx.step). One row per
+    -- completed step of a workflow instance; a re-run of the workflow (crash or
+    -- retry) reads these to skip already-done steps. Composite PK = idempotent.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_workflow_steps ("
+        .. "workflow_id INTEGER      NOT NULL,"
+        .. "step_key    VARCHAR(255) NOT NULL,"
+        .. "result      TEXT,"
+        .. "status      VARCHAR(16)  NOT NULL DEFAULT 'done',"
+        .. "created_at  INTEGER      NOT NULL,"
+        .. "PRIMARY KEY (workflow_id, step_key))")
 
     -- Verify the server actually parses SKIP LOCKED (the compile-time dialect
     -- flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
@@ -1238,6 +1254,119 @@ function jobs.await(id, opts)
     end
 end
 
+-- ── Durable execution: workflow-as-code (Phase 1a) ──────────────────────────
+-- A durable workflow is a normal function fn(ctx) run as a job of the reserved
+-- type "__wf:<name>". Each ctx.step(name, fn) memoizes its result in
+-- _hull_workflow_steps; if the workflow re-runs (a crash or a retry re-enters it
+-- from the top), completed steps return their stored result instead of
+-- re-executing, so the body resumes where it left off. Design:
+-- docs/jobs_durable_execution_design.md.
+local WF_PREFIX = "__wf:"
+
+-- Run (or replay) one memoized step. Returns fn()'s value; on a re-run of the
+-- workflow the value comes from the store and fn is NOT called again.
+local function run_step(workflow_id, step_key, fn)
+    if type(step_key) ~= "string" or step_key == "" then
+        error("ctx.step: name must be a non-empty string")
+    end
+    if type(fn) ~= "function" then error("ctx.step: fn must be a function") end
+    local rows = db.query(
+        "SELECT result FROM _hull_workflow_steps WHERE workflow_id=? AND step_key=?",
+        { workflow_id, step_key })
+    if rows and #rows > 0 then
+        if rows[1].result == nil then return nil end
+        local ok, decoded = pcall(json.decode, rows[1].result)
+        if ok then return decoded else return rows[1].result end
+    end
+    -- First execution: run, then persist. At-least-once - a crash between the
+    -- side effect and this INSERT re-runs the step on resume (steps must be
+    -- idempotent, same contract as a job handler).
+    local result = fn()
+    local enc = result ~= nil and json.encode(result) or nil
+    db.exec(
+        "INSERT INTO _hull_workflow_steps (workflow_id, step_key, result, status, created_at) "
+        .. "VALUES (?, ?, ?, 'done', ?)",
+        { workflow_id, step_key, enc, time.now() })
+    return result
+end
+
+-- Build the durable ctx handed to a workflow function.
+local function make_ctx(job, name)
+    local ctx = {
+        id    = job.id,
+        name  = name,
+        input = job.data,
+        trace = job.trace,   -- trace-context propagation (observability design)
+    }
+    ctx.step = function(step_key, fn) return run_step(job.id, step_key, fn) end
+    return ctx
+end
+
+--- Register a durable workflow. `fn(ctx)` is the workflow body; its return value
+-- becomes the workflow's result (fetch via jobs.await / jobs.result). Inside it,
+-- `ctx.step(name, fn)` runs `fn` once and memoizes the result, so a crashed or
+-- retried workflow resumes past completed steps. `ctx.input` is the payload from
+-- jobs.start, `ctx.id` the workflow id. A workflow instance IS a job (reserved
+-- type "__wf:<name>"), so it inherits claim / reaper / retry / worker / result.
+-- @tparam string name
+-- @tparam function fn   function(ctx) -> result
+function jobs.workflow(name, fn)
+    if type(name) ~= "string" or name == "" then
+        error("jobs.workflow: name must be a non-empty string")
+    end
+    if type(fn) ~= "function" then error("jobs.workflow: fn must be a function") end
+    _workflows[name] = fn
+    -- The workflow runs as a normal handler for its reserved type.
+    jobs.handler(WF_PREFIX .. name, function(job)
+        return fn(make_ctx(job, name))
+    end)
+    return jobs
+end
+
+--- Start a durable workflow instance. Returns the workflow id (a job id); the
+-- input is the workflow's `ctx.input`. Accepts the usual enqueue opts (queue,
+-- priority, dedup_key for an idempotent start, delay/at). Poll jobs.workflow_
+-- status(id) or jobs.await(id) for the outcome.
+-- @tparam string name
+-- @tparam[opt] table input
+-- @tparam[opt] table opts   enqueue options
+-- @treturn number|nil  the workflow id, or nil if a dedup_key collapsed it
+function jobs.start(name, input, opts)
+    if not _workflows[name] then
+        error("jobs.start: unknown workflow '" .. tostring(name) .. "' (register it with jobs.workflow)")
+    end
+    return jobs.enqueue(WF_PREFIX .. name, input, opts)
+end
+
+--- Query a workflow instance's state (DB-derived, so it works even when no
+-- worker is currently running it). Returns nil for an unknown id, else
+-- { status, name, steps_done, started_at, updated_at, result?, error? }.
+-- @tparam number id
+-- @treturn table|nil
+function jobs.workflow_status(id)
+    local job = jobs.get(id)
+    if not job then return nil end
+    local rows = db.query(
+        "SELECT step_key FROM _hull_workflow_steps WHERE workflow_id=? ORDER BY created_at, step_key",
+        { id })
+    local steps_done = {}
+    for _, s in ipairs(rows or {}) do steps_done[#steps_done + 1] = s.step_key end
+    local out = {
+        status     = job.status,
+        name       = tostring(job.type):match("^" .. WF_PREFIX .. "(.+)$") or job.type,
+        steps_done = steps_done,
+        started_at = job.created_at,
+        updated_at = job.updated_at,
+    }
+    if job.status == "done" then
+        local r = jobs.result(id)
+        if r then out.result = r.result end
+    elseif job.status == "dead" then
+        out.error = job.last_error
+    end
+    return out
+end
+
 --- Extend the claim on a job the current handler is processing (heartbeat). A
 -- handler whose work may exceed `visibility_timeout` should call this
 -- periodically (at least every visibility_timeout/2 s) so the reaper doesn't
@@ -1336,8 +1465,9 @@ function jobs.cleanup(opts)
         params[#params + 1] = opts.queue
     end
     local deleted = db.exec(sql, params) or 0
-    -- Drop results whose producing job is gone (workflow result store hygiene).
+    -- Drop results + workflow steps whose producing job is gone (store hygiene).
     db.exec("DELETE FROM _hull_job_results WHERE job_id NOT IN (SELECT id FROM _hull_jobs)")
+    db.exec("DELETE FROM _hull_workflow_steps WHERE workflow_id NOT IN (SELECT id FROM _hull_jobs)")
     return deleted
 end
 

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -1032,6 +1032,70 @@ app.main(async (ctx) => {
 echo "== durable workflow (Phase 1a): Lua =="; check_workflow "lua" "lua" "$LUA_WORKFLOW"
 echo "== durable workflow (Phase 1a): JS =="; check_workflow "js" "js" "$JS_WORKFLOW"
 
+# ── durable execution (Phase 1b): ctx.sleep durable timer ───────────────────
+# A workflow sleeps between step a and b. The first work() runs a and YIELDS (the
+# workflow goes pending with a future run_at = "sleeping"; b has NOT run). After
+# the timer elapses a second work() resumes: a is memoized, the sleep is
+# satisfied, b runs, done. A sleep must not consume the retry budget.
+check_sleep() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"SLEEP mid=pending mid_b=0 wait=yes fin=done fin_b=1 steps=a,b"*)
+            pass "$label: ctx.sleep durable timer (yield -> reschedule -> resume, b gated)" ;;
+        *) fail "$label: durable timer (Phase 1b)" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_SLEEP='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init({ backoff = function() return 0 end })
+  local runs = { a=0, b=0 }
+  jobs.workflow("sleeper", function(w)
+    w.step("a", function() runs.a = runs.a + 1 end)
+    w.sleep(1)
+    w.step("b", function() runs.b = runs.b + 1 end)
+    return { ok = true }
+  end)
+  local id = jobs.start("sleeper", {})
+  jobs.work({ batch = 1 })
+  local mid = jobs.workflow_status(id); local mid_b = runs.b
+  hull.sleep(1200)
+  jobs.work({ batch = 1 })
+  local fin = jobs.workflow_status(id)
+  ctx.stdout:write(("SLEEP mid=%s mid_b=%d wait=%s fin=%s fin_b=%d steps=%s\n"):format(
+    mid.status, mid_b, (mid.waiting_for and "yes" or "no"), fin.status, runs.b,
+    table.concat(fin.steps_done, ",")))
+  return 0
+end)'
+
+JS_SLEEP='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init({ backoff: () => 0 });
+  const runs = { a:0, b:0 };
+  jobs.workflow("sleeper", async (w) => {
+    await w.step("a", () => { runs.a++; });
+    await w.sleep(1);
+    await w.step("b", () => { runs.b++; });
+    return { ok: true };
+  });
+  const id = jobs.start("sleeper", {});
+  await jobs.work({ batch: 1 });
+  const mid = jobs.workflowStatus(id); const midB = runs.b;
+  await hull.sleep(1200);
+  await jobs.work({ batch: 1 });
+  const fin = jobs.workflowStatus(id);
+  ctx.stdout.write(`SLEEP mid=${mid.status} mid_b=${midB} wait=${mid.waitingFor?"yes":"no"} fin=${fin.status} fin_b=${runs.b} steps=${fin.stepsDone.join(",")}\n`);
+  return 0;
+});'
+
+echo "== durable timer (Phase 1b): Lua =="; check_sleep "lua" "lua" "$LUA_SLEEP"
+echo "== durable timer (Phase 1b): JS =="; check_sleep "js" "js" "$JS_SLEEP"
+
 # Fleet gate: K processes share one rate counter -> total dispatched == rate.
 echo "== v1.2 rate limit fleet ($CONC processes, one shared counter) =="
 W="$(mktemp -d)"; DB="$W/rl.db"

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -1096,6 +1096,133 @@ app.main(async (ctx) => {
 echo "== durable timer (Phase 1b): Lua =="; check_sleep "lua" "lua" "$LUA_SLEEP"
 echo "== durable timer (Phase 1b): JS =="; check_sleep "js" "js" "$JS_SLEEP"
 
+# ── durable execution (Phase 1c): signals - ctx.wait_signal / jobs.signal ───
+# Instance A parks on wait_signal ('waiting'); jobs.signal re-activates it
+# (waiting -> pending) and it resumes with the payload. Instance B is signalled
+# BEFORE it reaches the wait - the signal is stored and consumed when it gets
+# there (no lost-signal race).
+check_signals() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"SIG mid=waiting wait=signal after=pending finA=done byA=alice finB=done byB=bob"*)
+            pass "$label: signals (park->signal->resume + deliver-before-wait, no lost signal)" ;;
+        *) fail "$label: durable signals (Phase 1c)" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_SIGNALS='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init({ backoff = function() return 0 end })
+  local got = {}
+  jobs.workflow("approve", function(w)
+    w.step("s", function() return 1 end)
+    local a = w.wait_signal("ok")
+    got[w.id] = a and a.by or "nil"
+    return { done = true }
+  end)
+  local a = jobs.start("approve", {})
+  jobs.work({ batch = 1 })
+  local mid = jobs.workflow_status(a)
+  jobs.signal(a, "ok", { by = "alice" })
+  local after = jobs.get(a).status
+  jobs.work({ batch = 1 })
+  local finA = jobs.workflow_status(a)
+  local b = jobs.start("approve", {})
+  jobs.signal(b, "ok", { by = "bob" })   -- delivered BEFORE the wait
+  jobs.work({ batch = 1 })
+  local finB = jobs.workflow_status(b)
+  ctx.stdout:write(("SIG mid=%s wait=%s after=%s finA=%s byA=%s finB=%s byB=%s\n"):format(
+    mid.status, tostring(mid.waiting_for), after, finA.status, tostring(got[a]),
+    finB.status, tostring(got[b])))
+  return 0
+end)'
+
+JS_SIGNALS='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init({ backoff: () => 0 });
+  const got = {};
+  jobs.workflow("approve", async (w) => {
+    await w.step("s", () => 1);
+    const a = await w.waitSignal("ok");
+    got[w.id] = a ? a.by : "nil";
+    return { done: true };
+  });
+  const a = jobs.start("approve", {});
+  await jobs.work({ batch: 1 });
+  const mid = jobs.workflowStatus(a);
+  jobs.signal(a, "ok", { by: "alice" });
+  const after = jobs.get(a).status;
+  await jobs.work({ batch: 1 });
+  const finA = jobs.workflowStatus(a);
+  const b = jobs.start("approve", {});
+  jobs.signal(b, "ok", { by: "bob" });
+  await jobs.work({ batch: 1 });
+  const finB = jobs.workflowStatus(b);
+  ctx.stdout.write(`SIG mid=${mid.status} wait=${mid.waitingFor} after=${after} finA=${finA.status} byA=${got[a]} finB=${finB.status} byB=${got[b]}\n`);
+  return 0;
+});'
+
+echo "== durable signals (Phase 1c): Lua =="; check_signals "lua" "lua" "$LUA_SIGNALS"
+echo "== durable signals (Phase 1c): JS =="; check_signals "js" "js" "$JS_SIGNALS"
+
+# ── durable execution (Phase 1d): saga compensation ─────────────────────────
+# A workflow charges (a compensable step), then a later step fails terminally
+# (max_attempts=1). On dead-letter the completed steps' compensations run in
+# reverse: charge -> ship(fails) -> uncharge; the workflow ends dead.
+check_saga() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"SAGA status=dead log=charge,ship,uncharge"*)
+            pass "$label: saga compensation (reverse-order rollback on terminal failure)" ;;
+        *) fail "$label: durable saga (Phase 1d)" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_SAGA='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init({ backoff = function() return 0 end })
+  local log = {}
+  jobs.workflow("saga", function(w)
+    w.step("charge", function() log[#log+1]="charge" end, { compensate = function() log[#log+1]="uncharge" end })
+    w.step("ship", function() log[#log+1]="ship"; error("no stock") end)
+    return { ok = true }
+  end)
+  local sid = jobs.start("saga", {}, { max_attempts = 1 })
+  jobs.run_worker({ drain = true, poll_ms = 1 })
+  local st = jobs.workflow_status(sid)
+  ctx.stdout:write(("SAGA status=%s log=%s\n"):format(st.status, table.concat(log, ",")))
+  return 0
+end)'
+
+JS_SAGA='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init({ backoff: () => 0 });
+  const log = [];
+  jobs.workflow("saga", async (w) => {
+    await w.step("charge", () => { log.push("charge"); }, { compensate: () => { log.push("uncharge"); } });
+    await w.step("ship", () => { log.push("ship"); throw new Error("no stock"); });
+    return { ok: true };
+  });
+  const sid = jobs.start("saga", {}, { maxAttempts: 1 });
+  await jobs.runWorker({ drain: true, pollMs: 1 });
+  const st = jobs.workflowStatus(sid);
+  ctx.stdout.write(`SAGA status=${st.status} log=${log.join(",")}\n`);
+  return 0;
+});'
+
+echo "== durable saga (Phase 1d): Lua =="; check_saga "lua" "lua" "$LUA_SAGA"
+echo "== durable saga (Phase 1d): JS =="; check_saga "js" "js" "$JS_SAGA"
+
 # Fleet gate: K processes share one rate counter -> total dispatched == rate.
 echo "== v1.2 rate limit fleet ($CONC processes, one shared counter) =="
 W="$(mktemp -d)"; DB="$W/rl.db"

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -971,6 +971,67 @@ app.main((ctx) => {
 echo "== v1.5 polish: Lua =="; check_polish "lua" "lua" "$LUA_POLISH"
 echo "== v1.5 polish: JS =="; check_polish "js" "js" "$JS_POLISH"
 
+# ── durable execution (Phase 1a): jobs.workflow / ctx.step memoization ──────
+# A workflow fails once after steps a+b, is retried (backoff 0 => immediate), and
+# on the re-run a+b return memoized results (their fn does NOT run again - proven
+# by per-step run counters), c runs, result is correct. Unknown start is rejected.
+check_workflow() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"WF a=1 b=1 c=1 total=115 status=done steps=a,b,c unknown_reject=true"*)
+            pass "$label: workflow step-memoization across a retry (run-once, resume, status/steps)" ;;
+        *) fail "$label: durable workflow (Phase 1a)" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_WORKFLOW='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init({ backoff = function() return 0 end })
+  local runs = { a=0, b=0, c=0 }; local threw = false
+  jobs.workflow("wf", function(w)
+    local a = w.step("a", function() runs.a = runs.a + 1; return 10 end)
+    local b = w.step("b", function() runs.b = runs.b + 1; return a + 5 end)
+    if not threw then threw = true; error("boom after b") end
+    local c = w.step("c", function() runs.c = runs.c + 1; return b + 100 end)
+    return { total = c }
+  end)
+  local ok_unknown = pcall(function() jobs.start("nope", {}) end)
+  local id = jobs.start("wf", { hello = 1 })
+  jobs.run_worker({ drain = true, poll_ms = 1 })
+  local st = jobs.workflow_status(id); local r = jobs.await(id)
+  ctx.stdout:write(("WF a=%d b=%d c=%d total=%s status=%s steps=%s unknown_reject=%s\n"):format(
+    runs.a, runs.b, runs.c, tostring(r.result.total), st.status,
+    table.concat(st.steps_done, ","), tostring(not ok_unknown)))
+  return 0
+end)'
+
+JS_WORKFLOW='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init({ backoff: () => 0 });
+  const runs = { a:0, b:0, c:0 }; let threw = false;
+  jobs.workflow("wf", async (w) => {
+    const a = await w.step("a", () => { runs.a++; return 10; });
+    const b = await w.step("b", () => { runs.b++; return a + 5; });
+    if (!threw) { threw = true; throw new Error("boom after b"); }
+    const c = await w.step("c", () => { runs.c++; return b + 100; });
+    return { total: c };
+  });
+  let okUnknown = true; try { jobs.start("nope", {}); } catch(e){ okUnknown = false; }
+  const id = jobs.start("wf", { hello: 1 });
+  await jobs.runWorker({ drain: true, pollMs: 1 });
+  const st = jobs.workflowStatus(id); const r = await jobs.await(id);
+  ctx.stdout.write(`WF a=${runs.a} b=${runs.b} c=${runs.c} total=${r.result.total} status=${st.status} steps=${st.stepsDone.join(",")} unknown_reject=${!okUnknown}\n`);
+  return 0;
+});'
+
+echo "== durable workflow (Phase 1a): Lua =="; check_workflow "lua" "lua" "$LUA_WORKFLOW"
+echo "== durable workflow (Phase 1a): JS =="; check_workflow "js" "js" "$JS_WORKFLOW"
+
 # Fleet gate: K processes share one rate counter -> total dispatched == rate.
 echo "== v1.2 rate limit fleet ($CONC processes, one shared counter) =="
 W="$(mktemp -d)"; DB="$W/rl.db"


### PR DESCRIPTION
The full **Phase 1** of the durable-execution RFC (`docs/jobs_durable_execution_design.md`, #247): **workflow-as-code** built on the existing job loop. Both runtimes, full parity, **45/45 e2e green**, unit green. **Zero C** — pure stdlib.

## What lands (1a–1d)
- **1a — steps + memoization.** `jobs.workflow` / `jobs.start` / `ctx.step` (run-once, memoized into `_hull_workflow_steps`) / `jobs.workflow_status`. On any re-run a completed step returns its stored result without re-running `fn`, so the body resumes where it left off.
- **1b — durable timers.** `ctx.sleep(seconds)` yields and reschedules the workflow to wake later (a future-dated `pending` job) — survives restarts/redeploys/crashes at zero cost, doesn't consume the retry budget.
- **1c — signals.** `ctx.wait_signal(name, opts?)` parks the workflow in a non-terminal `waiting` status until `jobs.signal(id, name, payload)` delivers (the human-in-the-loop / approval / wait-for-webhook primitive). A signal delivered *before* the wait is stored and consumed when reached (no lost-signal race; the deliver-before-park race is closed by a re-check). `opts.timeout` → returns `nil` if none arrives (reaper wakes it).
- **1d — saga compensation.** `ctx.step(name, fn, { compensate })` registers a rollback; on terminal failure the completed steps' compensations run in **reverse order**, at-least-once, resumable mid-rollback.

## The key idea
A workflow instance **is a job** (`__wf:<name>`), so it rides the existing **claim / visibility-reaper / retry / worker / result** machinery unchanged — a worker that crashes mid-workflow is reclaimed and **resumes past completed steps**. No new dispatch path, no new C. New non-terminal `waiting` status; new `_hull_workflow_steps` + `_hull_workflow_signals` tables (swept by `cleanup`).

## Proven by e2e
Step memoization across a retry (each `fn` runs exactly once); a durable timer gating a later step; `park → signal → resume` + deliver-before-wait; reverse-order saga rollback on dead.

## Remaining
Deterministic **WASM-replay strict mode** → Phase 2 (a separate design pass in #247).
