### PR TITLE
jobs: observability Pillar A+C - metrics gauges + trace propagation

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -310,6 +310,7 @@ jobs.enqueue(type, data, {
     max_attempts = 5,          -- override the module default (25)
     dedup_key    = "order-42", -- idempotent enqueue: a duplicate un-run key is a no-op
     throttle     = 60,         -- windowed: skip if a (queue,type) job was made in the last N s
+    trace        = traceparent,-- W3C trace context; surfaced to the handler as job.trace
 })
 ```
 Returns the new job id, or `nil` when a `dedup_key` collapsed it (or a
@@ -338,6 +339,7 @@ jobs.result(id)               -- terminal result: { status, result?, error? }, o
 jobs.await(id, { timeout = 5000 })   -- yield until the job is terminal, then return jobs.result
 jobs.progress(id, 42)         -- set a running job's progress 0-100 (surfaced by get(id).progress)
 jobs.stats()                  -- { pending, running, done, dead } (opts.queue to scope)
+jobs.metrics()                -- DB-derived dashboard snapshot: per-queue gauges + backlog age + totals
 jobs.dead({ limit = 50 })     -- list dead-lettered jobs (newest first) for inspection
 jobs.retry(id)                -- requeue a dead job with a fresh attempt budget; false if not dead
 jobs.cancel(id)               -- delete a still-pending (e.g. delayed) job; false if not pending
@@ -366,6 +368,17 @@ live as long as the job row (governed by `jobs.cleanup`), so read before purge.
 
 `jobs.cancel` only removes a `pending` job (a delayed/scheduled one that hasn't
 started); a `running` job is mid-flight and is left to finish or dead-letter.
+
+**Metrics & tracing.** `jobs.metrics()` returns a **DB-derived** snapshot for a
+dashboard or a `/metrics` route - `{ queues = { <q> = { pending, running,
+waiting, blocked, dead, oldest_pending_age }, ... }, totals = {...} }`. It's
+pull-based (no process counters), so it's correct across a whole fleet;
+`oldest_pending_age` is the backlog age of the oldest ready pending job.
+`enqueue(..., { trace })` carries a W3C `traceparent` through to the handler as
+`job.trace` (and into a durable workflow's `ctx.trace`), so app-created spans
+link across the async boundary. (Latency percentiles, throughput, and a per-job
+attempt timeline arrive with the opt-in attempt-history pillar - see
+[docs/jobs_observability_design.md](jobs_observability_design.md).)
 
 ## Compute-heavy jobs (WASM / GPU)
 

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -15,7 +15,7 @@
  * Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
  * catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
  * visibility-timeout reaper), the dedicated worker (jobs.runWorker +
- * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueueMany), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step / ctx.sleep / ctx.wait_signal / jobs.signal, Phase 1) add crash-safe workflow-as-code: step memoization, durable timers, external signals, and saga compensation - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md).
+ * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueueMany), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step / ctx.sleep / ctx.wait_signal / jobs.signal, Phase 1) add crash-safe workflow-as-code: step memoization, durable timers, external signals, and saga compensation - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md). Observability: jobs.metrics() (DB-derived per-queue gauges + backlog age) and W3C trace-context propagation (enqueue { trace } -> job.trace).
  *
  * @license AGPL-3.0-or-later
  */
@@ -113,7 +113,8 @@ function init(opts) {
         "last_error   TEXT," +
         "created_at   INTEGER      NOT NULL," +
         "updated_at   INTEGER      NOT NULL," +
-        "progress     INTEGER      NOT NULL DEFAULT 0)");
+        "progress     INTEGER      NOT NULL DEFAULT 0," +
+        "trace_context VARCHAR(255))");
 
     // Claim scan path: ready-to-run pending jobs in a queue, by priority then id.
     db.exec(
@@ -164,6 +165,7 @@ function init(opts) {
             db.exec(`ALTER TABLE ${tbl} ADD COLUMN ${coldef}`);
     };
     ensureColumn("_hull_jobs", "progress", "progress INTEGER NOT NULL DEFAULT 0");
+    ensureColumn("_hull_jobs", "trace_context", "trace_context VARCHAR(255)");
     ensureColumn("_hull_cron", "tz_offset", "tz_offset INTEGER NOT NULL DEFAULT 0");
 
     // Fleet-wide rate-limit counters (jobs.limit). One row per limited queue;
@@ -353,6 +355,8 @@ function enqueue(jobType, data, opts) {
     const cols = ["queue", "type", "payload", "priority", "max_attempts",
                   "run_at", "dedup_key", "created_at", "updated_at"];
     if (hasDeps) { cols.push("status"); vals.push("blocked"); }
+    // Optional W3C trace context, carried through to the handler as job.trace.
+    if (o.trace !== undefined && o.trace !== null) { cols.push("trace_context"); vals.push(o.trace); }
     let id;
     if (o.dedupKey !== undefined && o.dedupKey !== null) {
         const n = db.insertIfAbsent("_hull_jobs", ["queue", "dedup_key"], cols, vals);
@@ -417,7 +421,8 @@ function shape(row) {
         try { data = json.decode(row.payload); } catch (_e) { data = null; }
     }
     return { id: row.id, type: row.type, data,
-             attempts: row.attempts, maxAttempts: row.max_attempts };
+             attempts: row.attempts, maxAttempts: row.max_attempts,
+             trace: row.trace_context };   // trace-context propagation (null if unset)
 }
 
 /**
@@ -587,7 +592,7 @@ function claimOne(queue, batch) {
             "attempts=attempts+1, updated_at=? WHERE id IN (" +
             "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? " +
             "ORDER BY priority DESC, id LIMIT ? " + lock + ") " +
-            "RETURNING id, type, payload, priority, attempts, max_attempts",
+            "RETURNING id, type, payload, priority, attempts, max_attempts, trace_context",
             [token, now, now, queue, now, batch]);
     } else if (d.supportsSkipLocked) {
         db.batch(() => {
@@ -604,7 +609,7 @@ function claimOne(queue, batch) {
                 params);
         });
         rows = db.query(
-            "SELECT id, type, payload, priority, attempts, max_attempts FROM _hull_jobs WHERE claim_token=?",
+            "SELECT id, type, payload, priority, attempts, max_attempts, trace_context FROM _hull_jobs WHERE claim_token=?",
             [token]);
     } else {
         rows = db.query(
@@ -612,7 +617,7 @@ function claimOne(queue, batch) {
             "attempts=attempts+1, updated_at=? WHERE id IN (" +
             "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? " +
             "ORDER BY priority DESC, id LIMIT ?) " +
-            "RETURNING id, type, payload, priority, attempts, max_attempts",
+            "RETURNING id, type, payload, priority, attempts, max_attempts, trace_context",
             [token, now, now, queue, now, batch]);
     }
 
@@ -1120,6 +1125,41 @@ function stats(opts) {
     return s;
 }
 
+/**
+ * A DB-derived metrics snapshot for dashboards / a /metrics route. Pull-based (no
+ * exporter, no process counters), so it is correct across a whole fleet of
+ * workers. Returns `{ queues: { <queue>: { pending, running, waiting, blocked,
+ * dead, oldestPendingAge }, ... }, totals: { ... } }`. `oldestPendingAge` is
+ * `now - createdAt` of the oldest READY (run_at<=now) pending job in the queue -
+ * the actionable backlog age. `opts.queue` scopes to one queue. Latency
+ * percentiles and throughput are added by the attempt-history pillar (opt-in).
+ * @param {object} [opts]  { queue }
+ * @returns {object}
+ */
+function metrics(opts) {
+    const o = opts || {};
+    const now = time.now();
+    const LIVE = { pending: 1, running: 1, waiting: 1, blocked: 1, dead: 1 };
+    const newBucket = () => ({ pending: 0, running: 0, waiting: 0, blocked: 0, dead: 0 });
+    const queues = {}, totals = newBucket();
+    const rows = o.queue
+        ? db.query("SELECT queue, status, COUNT(*) AS n FROM _hull_jobs WHERE queue=? GROUP BY queue, status", [o.queue])
+        : db.query("SELECT queue, status, COUNT(*) AS n FROM _hull_jobs GROUP BY queue, status");
+    for (const r of rows) {
+        const q = queues[r.queue] || (queues[r.queue] = newBucket());
+        if (LIVE[r.status]) { q[r.status] = (q[r.status] || 0) + r.n; totals[r.status] += r.n; }
+    }
+    // Oldest ready-to-run pending job per queue -> backlog age.
+    const ages = o.queue
+        ? db.query("SELECT queue, MIN(created_at) AS oldest FROM _hull_jobs WHERE status='pending' AND run_at<=? AND queue=? GROUP BY queue", [now, o.queue])
+        : db.query("SELECT queue, MIN(created_at) AS oldest FROM _hull_jobs WHERE status='pending' AND run_at<=? GROUP BY queue", [now]);
+    for (const r of ages) {
+        const q = queues[r.queue];
+        if (q && r.oldest != null) q.oldestPendingAge = now - r.oldest;
+    }
+    return { queues, totals };
+}
+
 // Decode an ops row into an inspection view: the handler-facing shape plus the
 // bookkeeping columns an operator needs (status, queue, lastError, timestamps).
 function shapeOps(r) {
@@ -1586,14 +1626,14 @@ function _tick(now) { processCron(now !== undefined ? now : time.now()); }
 
 export const jobs = {
     init, enqueue, enqueueMany, claim, handler, default: setDefault, on, work, reap,
-    stats, runWorker, stop, get, result, await: await_, progress, heartbeat, limit,
+    stats, runWorker, stop, get, result, await: await_, progress, heartbeat, limit, metrics,
     pause, resume, purge,
     workflow, start, signal, workflowStatus,
     dead, retry, cancel, cleanup, cron, uncron,
     RETRY, DEAD, DISCARD, _config: _cfg, _cronNext, _tick,
 };
 export { init, enqueue, enqueueMany, claim, handler, on, work, reap, stats,
-         runWorker, stop, get, result, progress, heartbeat, limit, pause, resume,
+         runWorker, stop, get, result, progress, heartbeat, limit, metrics, pause, resume,
          purge, workflow, start, signal, workflowStatus,
          dead, retry, cancel, cleanup, cron, uncron };
 export default jobs;

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -11,7 +11,7 @@
 -- Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
 -- catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
 -- visibility-timeout reaper), the dedicated worker (jobs.run_worker +
--- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueue_many), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step / ctx.sleep / ctx.wait_signal / jobs.signal, Phase 1) add crash-safe workflow-as-code: step memoization, durable timers, external signals, and saga compensation - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md).
+-- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueue_many), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step / ctx.sleep / ctx.wait_signal / jobs.signal, Phase 1) add crash-safe workflow-as-code: step memoization, durable timers, external signals, and saga compensation - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md). Observability: jobs.metrics() (DB-derived per-queue gauges + backlog age) and W3C trace-context propagation (enqueue { trace } -> job.trace).
 --
 -- Usage (target shape):
 --   local jobs = require("hull.jobs")
@@ -120,7 +120,8 @@ function jobs.init(opts)
         .. "last_error   TEXT,"
         .. "created_at   INTEGER      NOT NULL,"
         .. "updated_at   INTEGER      NOT NULL,"
-        .. "progress     INTEGER      NOT NULL DEFAULT 0)")
+        .. "progress     INTEGER      NOT NULL DEFAULT 0,"
+        .. "trace_context VARCHAR(255))")
 
     -- Claim scan path: ready-to-run pending jobs in a queue, by priority then id.
     db.exec([[
@@ -179,6 +180,7 @@ function jobs.init(opts)
         db.exec("ALTER TABLE " .. tbl .. " ADD COLUMN " .. coldef)
     end
     ensure_column("_hull_jobs", "progress", "progress INTEGER NOT NULL DEFAULT 0")
+    ensure_column("_hull_jobs", "trace_context", "trace_context VARCHAR(255)")
     ensure_column("_hull_cron", "tz_offset", "tz_offset INTEGER NOT NULL DEFAULT 0")
 
     -- Fleet-wide rate-limit counters (jobs.limit). One row per limited queue;
@@ -380,6 +382,10 @@ function jobs.enqueue(job_type, data, opts)
     if has_deps then
         cols[#cols + 1] = "status"; vals[#vals + 1] = "blocked"
     end
+    -- Optional W3C trace context, carried through to the handler as job.trace.
+    if opts.trace ~= nil then
+        cols[#cols + 1] = "trace_context"; vals[#vals + 1] = opts.trace
+    end
     local id
     if opts.dedup_key ~= nil then
         -- INSERT ... ON CONFLICT(queue,dedup_key) DO NOTHING / INSERT OR IGNORE.
@@ -458,6 +464,7 @@ local function shape(row)
     return {
         id = row.id, type = row.type, data = data,
         attempts = row.attempts, max_attempts = row.max_attempts,
+        trace = row.trace_context,   -- trace-context propagation (nil if unset)
     }
 end
 
@@ -627,7 +634,7 @@ local function claim_one(queue, batch)
             .. "attempts=attempts+1, updated_at=? WHERE id IN ("
             .. "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? "
             .. "ORDER BY priority DESC, id LIMIT ? " .. lock .. ") "
-            .. "RETURNING id, type, payload, priority, attempts, max_attempts",
+            .. "RETURNING id, type, payload, priority, attempts, max_attempts, trace_context",
             { token, now, now, queue, now, batch })
     elseif d.supports_skip_locked then
         -- MySQL: no RETURNING. Lock + mark in one txn, then read back by token.
@@ -645,7 +652,7 @@ local function claim_one(queue, batch)
                 params)
         end)
         rows = db.query(
-            "SELECT id, type, payload, priority, attempts, max_attempts FROM _hull_jobs WHERE claim_token=?",
+            "SELECT id, type, payload, priority, attempts, max_attempts, trace_context FROM _hull_jobs WHERE claim_token=?",
             { token })
     else
         -- SQLite: single-writer serializes the claim, so the marked-running rows
@@ -655,7 +662,7 @@ local function claim_one(queue, batch)
             .. "attempts=attempts+1, updated_at=? WHERE id IN ("
             .. "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? "
             .. "ORDER BY priority DESC, id LIMIT ?) "
-            .. "RETURNING id, type, payload, priority, attempts, max_attempts",
+            .. "RETURNING id, type, payload, priority, attempts, max_attempts, trace_context",
             { token, now, now, queue, now, batch })
     end
 
@@ -1201,6 +1208,48 @@ function jobs.stats(opts)
     local s = { pending = 0, running = 0, done = 0, dead = 0, blocked = 0 }
     for _, r in ipairs(rows) do s[r.status] = r.c end
     return s
+end
+
+--- A DB-derived metrics snapshot for dashboards / a /metrics route. Pull-based
+-- (no exporter, no process counters), so it is correct across a whole fleet of
+-- workers. Returns `{ queues = { <queue> = { pending, running, waiting, blocked,
+-- dead, oldest_pending_age }, ... }, totals = { ... } }`. `oldest_pending_age`
+-- is `now - created_at` of the oldest READY (run_at<=now) pending job in the
+-- queue - the actionable backlog age. `opts.queue` scopes to one queue. Latency
+-- percentiles and throughput are added by the attempt-history pillar (opt-in).
+-- @tparam[opt] table opts  { queue }
+-- @treturn table
+function jobs.metrics(opts)
+    opts = opts or {}
+    local now = time.now()
+    local LIVE = { pending = true, running = true, waiting = true, blocked = true, dead = true }
+    local function new_bucket()
+        return { pending = 0, running = 0, waiting = 0, blocked = 0, dead = 0 }
+    end
+    local queues, totals = {}, new_bucket()
+    local rows = db.query(
+        "SELECT queue, status, COUNT(*) AS n FROM _hull_jobs"
+        .. (opts.queue and " WHERE queue=?" or "") .. " GROUP BY queue, status",
+        opts.queue and { opts.queue } or {})
+    for _, r in ipairs(rows or {}) do
+        local q = queues[r.queue]
+        if not q then q = new_bucket(); queues[r.queue] = q end
+        if LIVE[r.status] then
+            q[r.status] = (q[r.status] or 0) + r.n
+            totals[r.status] = totals[r.status] + r.n
+        end
+    end
+    -- Oldest ready-to-run pending job per queue -> backlog age.
+    local ages = db.query(
+        "SELECT queue, MIN(created_at) AS oldest FROM _hull_jobs "
+        .. "WHERE status='pending' AND run_at<=?"
+        .. (opts.queue and " AND queue=?" or "") .. " GROUP BY queue",
+        opts.queue and { now, opts.queue } or { now })
+    for _, r in ipairs(ages or {}) do
+        local q = queues[r.queue]
+        if q and r.oldest then q.oldest_pending_age = now - r.oldest end
+    end
+    return { queues = queues, totals = totals }
 end
 
 -- Decode an ops row into an inspection view: the handler-facing shape plus the

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -33,7 +33,7 @@ FAIL=0
 pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
 fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1${2:+ - $2}"; }
 
-EXPECT_COLS="id,queue,type,payload,status,priority,attempts,max_attempts,run_at,claim_token,claimed_at,dedup_key,last_error,created_at,updated_at,progress"
+EXPECT_COLS="id,queue,type,payload,status,priority,attempts,max_attempts,run_at,claim_token,claimed_at,dedup_key,last_error,created_at,updated_at,progress,trace_context"
 
 # ── Phase 1: init + schema; Phase 2: correctness round-trip (both runtimes) ──
 check_runtime() {
@@ -1222,6 +1222,64 @@ app.main(async (ctx) => {
 
 echo "== durable saga (Phase 1d): Lua =="; check_saga "lua" "lua" "$LUA_SAGA"
 echo "== durable saga (Phase 1d): JS =="; check_saga "js" "js" "$JS_SAGA"
+
+# ── observability Bet #1 Pillar A+C: jobs.metrics gauges + trace propagation ─
+# metrics() returns DB-derived per-queue gauges (pending/dead + backlog age) and
+# totals; a job enqueued with { trace } surfaces job.trace in the handler.
+check_metrics() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"METRICS emails=5 default=2 dq_dead=1 totp=7 totd=1 age=yes TRACE=ok"*)
+            pass "$label: metrics gauges (per-queue pending/dead + backlog age) + trace propagation" ;;
+        *) fail "$label: observability A+C" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_METRICS='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init({ backoff = function() return 0 end })
+  local seen
+  jobs.handler("traced", function(j) seen = j.trace end)
+  jobs.handler("boom", function(j) error("x") end)
+  for i=1,5 do jobs.enqueue("x", {}, { queue = "emails" }) end          -- 5 pending, never run
+  jobs.enqueue("x", {}, { queue = "default" }); jobs.enqueue("x", {}, { queue = "default" })  -- 2 pending
+  jobs.enqueue("boom", {}, { queue = "dq", max_attempts = 1 })
+  jobs.run_worker({ queues = {"dq"}, drain = true, poll_ms = 1 })       -- dq boom -> dead
+  jobs.enqueue("traced", {}, { queue = "tq", trace = "00-abc-01" })
+  jobs.work({ queue = "tq", batch = 1 })                                 -- run only the traced job
+  local m = jobs.metrics()
+  ctx.stdout:write(("METRICS emails=%d default=%s dq_dead=%s totp=%d totd=%d age=%s TRACE=%s\n"):format(
+    m.queues.emails.pending, tostring(m.queues.default.pending), tostring(m.queues.dq.dead),
+    m.totals.pending, m.totals.dead,
+    (m.queues.emails.oldest_pending_age ~= nil) and "yes" or "no",
+    (seen == "00-abc-01") and "ok" or ("bad:" .. tostring(seen))))
+  return 0
+end)'
+
+JS_METRICS='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init({ backoff: () => 0 });
+  let seen;
+  jobs.handler("traced", (j) => { seen = j.trace; });
+  jobs.handler("boom", (j) => { throw new Error("x"); });
+  for (let i=0;i<5;i++) jobs.enqueue("x", {}, { queue: "emails" });
+  jobs.enqueue("x", {}, { queue: "default" }); jobs.enqueue("x", {}, { queue: "default" });
+  jobs.enqueue("boom", {}, { queue: "dq", maxAttempts: 1 });
+  await jobs.runWorker({ queues: ["dq"], drain: true, pollMs: 1 });
+  jobs.enqueue("traced", {}, { queue: "tq", trace: "00-abc-01" });
+  await jobs.work({ queue: "tq", batch: 1 });
+  const m = jobs.metrics();
+  ctx.stdout.write(`METRICS emails=${m.queues.emails.pending} default=${m.queues.default.pending} dq_dead=${m.queues.dq.dead} totp=${m.totals.pending} totd=${m.totals.dead} age=${m.queues.emails.oldestPendingAge!=null?"yes":"no"} TRACE=${seen==="00-abc-01"?"ok":"bad:"+seen}\n`);
+  return 0;
+});'
+
+echo "== observability A+C: Lua =="; check_metrics "lua" "lua" "$LUA_METRICS"
+echo "== observability A+C: JS =="; check_metrics "js" "js" "$JS_METRICS"
 
 # Fleet gate: K processes share one rate counter -> total dispatched == rate.
 echo "== v1.2 rate limit fleet ($CONC processes, one shared counter) =="


### PR DESCRIPTION
Bet #1 (observability) **Pillar A + C** from `docs/jobs_observability_design.md`. Pure stdlib, both runtimes, **zero C**, **47/47 e2e green**, linters clean.

## Pillar A — pull metrics
- **`jobs.metrics(opts?)`** → a DB-derived snapshot: `{ queues: { <q>: { pending, running, waiting, blocked, dead, oldestPendingAge }, ... }, totals: {...} }`. **Pull-based** (no process counters), so it's correct across a whole fleet — feed a dashboard or a `/metrics` route. `oldestPendingAge` is the backlog age of the oldest *ready* pending job. `opts.queue` scopes it.
- Latency percentiles + throughput come with the opt-in **attempt-history** pillar (B), next.

## Pillar C — trace propagation
- New nullable `_hull_jobs.trace_context` column (appended, idempotent migration). **`enqueue(..., { trace })`** stores a W3C `traceparent`; the claim carries it and the handler sees **`job.trace`** (a durable workflow's `ctx.trace` already reads it), so app-created spans link across the async boundary. Propagation only — no span creation / OTLP in core.

## e2e
Per-queue pending/dead gauges + backlog age + totals, and a `{ trace }` job surfacing `job.trace` in the handler. `EXPECT_COLS` gains `trace_context`.

Next in Bet #1: **Pillar B** (opt-in `_hull_job_attempts` timeline → `jobs.history` + latency/throughput in `jobs.metrics`).
