### PR TITLE
jobs: observability Pillar B - attempt history + latency/throughput

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -376,9 +376,18 @@ pull-based (no process counters), so it's correct across a whole fleet;
 `oldest_pending_age` is the backlog age of the oldest ready pending job.
 `enqueue(..., { trace })` carries a W3C `traceparent` through to the handler as
 `job.trace` (and into a durable workflow's `ctx.trace`), so app-created spans
-link across the async boundary. (Latency percentiles, throughput, and a per-job
-attempt timeline arrive with the opt-in attempt-history pillar - see
-[docs/jobs_observability_design.md](jobs_observability_design.md).)
+link across the async boundary.
+
+**Attempt history (opt-in).** `jobs.init({ history = true })` (or
+`{ history = { queues = {...} } }` for specific queues) records one row per
+attempt. `jobs.history(id)` then returns the **timeline** -
+`{ attempt_no, started_ms, finished_ms, duration_ms, wait_ms, outcome, error }`
+per attempt, oldest first - and `jobs.metrics()` gains `latency`
+(`wait_ms` = queue latency, `run_ms` = execution, each as `{ p50, p95, p99 }`)
+and `throughput` (`done_per_sec` / `dead_per_sec`) over the last `opts.window`
+seconds (default 300). It costs one write per attempt (hence opt-in); retention
+is governed by `jobs.cleanup` (or `history_retention`). Design:
+[docs/jobs_observability_design.md](jobs_observability_design.md).
 
 ## Compute-heavy jobs (WASM / GPU)
 

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -15,7 +15,7 @@
  * Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
  * catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
  * visibility-timeout reaper), the dedicated worker (jobs.runWorker +
- * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueueMany), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step / ctx.sleep / ctx.wait_signal / jobs.signal, Phase 1) add crash-safe workflow-as-code: step memoization, durable timers, external signals, and saga compensation - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md). Observability: jobs.metrics() (DB-derived per-queue gauges + backlog age) and W3C trace-context propagation (enqueue { trace } -> job.trace).
+ * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueueMany), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step / ctx.sleep / ctx.wait_signal / jobs.signal, Phase 1) add crash-safe workflow-as-code: step memoization, durable timers, external signals, and saga compensation - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md). Observability: jobs.metrics() (DB-derived per-queue gauges + backlog age) and W3C trace-context propagation (enqueue { trace } -> job.trace). Opt-in attempt history (jobs.init { history=true }) records a per-attempt timeline (jobs.history) and adds latency percentiles + throughput to jobs.metrics.
  *
  * @license AGPL-3.0-or-later
  */
@@ -38,6 +38,8 @@ const _cfg = {
     visibilityTimeout: 300,   // seconds before an orphaned `running` job is reclaimed
     reapInterval:      30,    // min seconds between reaper sweeps (0 = every work() call)
     backoff: defaultBackoff,
+    history:           false, // attempt-history recording: true | { queues:[...] } | false
+    historyRetention:  null,  // seconds to keep attempt rows (null = jobs.cleanup default)
 };
 
 // Exponential backoff: 2^attempt * 10s, capped at 1h (shared with outbox math).
@@ -92,6 +94,8 @@ function init(opts) {
     if (o.maxAttempts !== undefined) _cfg.maxAttempts = o.maxAttempts;
     if (o.visibilityTimeout !== undefined) _cfg.visibilityTimeout = o.visibilityTimeout;
     if (o.reapInterval !== undefined) _cfg.reapInterval = o.reapInterval;
+    if (o.history !== undefined) _cfg.history = o.history;
+    if (o.historyRetention !== undefined) _cfg.historyRetention = o.historyRetention;
     if (o.backoff !== undefined) _cfg.backoff = o.backoff;
 
     // Keyed/indexed text columns are VARCHAR(255) so MySQL can index them;
@@ -230,6 +234,26 @@ function init(opts) {
         "created_at  INTEGER      NOT NULL," +
         "consumed_at INTEGER," +
         "PRIMARY KEY (workflow_id, name))");
+
+    // Opt-in attempt history (jobs.init { history:true }). One row per attempt,
+    // written by jobs.work at each outcome when history is enabled for the queue.
+    // The durable timeline behind jobs.history + the latency/throughput metrics.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_job_attempts (" +
+        "attempt_id  " + db.autoincrementIdDdl + ", " +
+        "job_id      INTEGER      NOT NULL," +
+        "queue       VARCHAR(255) NOT NULL," +
+        "type        VARCHAR(255) NOT NULL," +
+        "attempt_no  INTEGER      NOT NULL," +
+        "wait_ms     INTEGER," +
+        "started_ms  INTEGER      NOT NULL," +
+        "finished_ms INTEGER      NOT NULL," +
+        "duration_ms INTEGER      NOT NULL," +
+        "outcome     VARCHAR(16)  NOT NULL," +
+        "error       TEXT," +
+        "trace_id    VARCHAR(255))");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_hull_job_attempts_job ON _hull_job_attempts(job_id, attempt_no)");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_hull_job_attempts_recent ON _hull_job_attempts(finished_ms)");
 
     // Verify the server actually parses SKIP LOCKED (the compile-time dialect
     // flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
@@ -422,7 +446,8 @@ function shape(row) {
     }
     return { id: row.id, type: row.type, data,
              attempts: row.attempts, maxAttempts: row.max_attempts,
-             trace: row.trace_context };   // trace-context propagation (null if unset)
+             trace: row.trace_context,   // trace-context propagation (null if unset)
+             queue: row.queue, createdAt: row.created_at };   // for attempt history
 }
 
 /**
@@ -592,7 +617,7 @@ function claimOne(queue, batch) {
             "attempts=attempts+1, updated_at=? WHERE id IN (" +
             "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? " +
             "ORDER BY priority DESC, id LIMIT ? " + lock + ") " +
-            "RETURNING id, type, payload, priority, attempts, max_attempts, trace_context",
+            "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at",
             [token, now, now, queue, now, batch]);
     } else if (d.supportsSkipLocked) {
         db.batch(() => {
@@ -609,7 +634,7 @@ function claimOne(queue, batch) {
                 params);
         });
         rows = db.query(
-            "SELECT id, type, payload, priority, attempts, max_attempts, trace_context FROM _hull_jobs WHERE claim_token=?",
+            "SELECT id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at FROM _hull_jobs WHERE claim_token=?",
             [token]);
     } else {
         rows = db.query(
@@ -617,7 +642,7 @@ function claimOne(queue, batch) {
             "attempts=attempts+1, updated_at=? WHERE id IN (" +
             "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? " +
             "ORDER BY priority DESC, id LIMIT ?) " +
-            "RETURNING id, type, payload, priority, attempts, max_attempts, trace_context",
+            "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at",
             [token, now, now, queue, now, batch]);
     }
 
@@ -957,6 +982,28 @@ function uncron(name) {
     return (db.exec("DELETE FROM _hull_cron WHERE name=?", [name]) || 0) > 0;
 }
 
+// Is attempt-history recording on for this queue? true = all queues; an object
+// with a `queues` list = only those.
+function historyEnabled(queue) {
+    const h = _cfg.history;
+    if (h === true) return true;
+    if (h && typeof h === "object" && Array.isArray(h.queues)) return h.queues.includes(queue);
+    return false;
+}
+
+// Record one attempt into the (opt-in) history timeline. `startedMs` is captured
+// before the handler; `outcome` is "done" | "retried" | "dead". waitMs is the
+// queue latency (start - enqueue), from the job's createdAt.
+function recordAttempt(job, startedMs, finishedMs, outcome, err) {
+    const waitMs = job.createdAt != null ? startedMs - job.createdAt * 1000 : null;
+    db.exec(
+        "INSERT INTO _hull_job_attempts (job_id, queue, type, attempt_no, wait_ms, " +
+        "started_ms, finished_ms, duration_ms, outcome, error, trace_id) " +
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [job.id, job.queue || "default", job.type, job.attempts, waitMs,
+         startedMs, finishedMs, finishedMs - startedMs, outcome, err || null, job.trace || null]);
+}
+
 /**
  * Claim a batch and run each job's handler (awaited, so sync and async handlers
  * both work), applying the outcome. Runs the reaper first. Drive from a timer
@@ -979,12 +1026,14 @@ async function work(opts) {
     for (const job of batch) {
         job.deps = loadDeps(job.id);   // workflow: dependency results, in order
         const h = _handlers[job.type] || _default;
+        const startedMs = time.nowMs();   // attempt timing (used only if history on)
+        let outcome, errStr;              // undefined outcome = a yield (not recorded)
         if (!h) {
-            const err = `no handler for job type '${job.type}'`;
-            markDead(job.id, err);
-            emit("dead", job, { error: err });
-            continue;
-        }
+            errStr = `no handler for job type '${job.type}'`;
+            markDead(job.id, errStr);
+            emit("dead", job, { error: errStr });
+            outcome = "dead";
+        } else {
         try {
             const result = await h(job);
             if (result && typeof result === "object" && result.__hullWfYield) {
@@ -1020,11 +1069,13 @@ async function work(opts) {
                         [result.wakeAt || now, now, job.id]);
                 }
             } else if (result === DEAD) {
-                markDead(job.id, "handler returned jobs.DEAD");
-                emit("dead", job, { error: "handler returned jobs.DEAD" });
+                errStr = "handler returned jobs.DEAD"; outcome = "dead";
+                markDead(job.id, errStr);
+                emit("dead", job, { error: errStr });
             } else if (result === RETRY) {
-                emit(markRetry(job, "handler requested retry"), job,
-                     { error: "handler requested retry", attempt: job.attempts });
+                errStr = "handler requested retry";
+                outcome = markRetry(job, errStr);
+                emit(outcome, job, { error: errStr, attempt: job.attempts });
             } else {
                 // undefined / true / DISCARD -> done, no result; any other return
                 // value is stored as the job's result (for dependents).
@@ -1032,10 +1083,17 @@ async function work(opts) {
                     ? result : undefined;
                 markDone(job.id, res);
                 emit("completed", job, { result: res });
+                outcome = "done";
             }
         } catch (e) {
-            const err = String((e && e.message) || e);
-            emit(markRetry(job, err), job, { error: err, attempt: job.attempts });
+            errStr = String((e && e.message) || e);
+            outcome = markRetry(job, errStr);
+            emit(outcome, job, { error: errStr, attempt: job.attempts });
+        }
+        }
+        // Opt-in attempt history (a yield leaves outcome undefined -> not recorded).
+        if (outcome && historyEnabled(job.queue)) {
+            recordAttempt(job, startedMs, time.nowMs(), outcome, errStr);
         }
     }
     return batch.length;
@@ -1115,6 +1173,15 @@ async function runWorker(opts) {
  * @param {object} [opts]  { queue }
  * @returns {{pending:number, running:number, done:number, dead:number}}
  */
+// p50/p95/p99 of a numeric list (computed host-side; portable SQL has no
+// PERCENTILE). Nearest-rank on the sorted sample.
+function percentiles(vals) {
+    if (vals.length === 0) return { p50: 0, p95: 0, p99: 0 };
+    vals.sort((a, b) => a - b);
+    const pick = (p) => vals[Math.min(vals.length - 1, Math.max(0, Math.ceil(p * vals.length) - 1))];
+    return { p50: pick(0.50), p95: pick(0.95), p99: pick(0.99) };
+}
+
 function stats(opts) {
     const o = opts || {};
     const rows = o.queue
@@ -1157,7 +1224,42 @@ function metrics(opts) {
         const q = queues[r.queue];
         if (q && r.oldest != null) q.oldestPendingAge = now - r.oldest;
     }
-    return { queues, totals };
+    const out = { queues, totals };
+    // Latency + throughput from the attempt history over the last `window`
+    // seconds (present only when attempt recording is on, i.e. there is data).
+    const window = o.window || 300;
+    const sinceMs = (now - window) * 1000;
+    const sample = o.queue
+        ? db.query("SELECT wait_ms, duration_ms, outcome FROM _hull_job_attempts WHERE finished_ms >= ? AND queue=? ORDER BY finished_ms DESC LIMIT 5000", [sinceMs, o.queue])
+        : db.query("SELECT wait_ms, duration_ms, outcome FROM _hull_job_attempts WHERE finished_ms >= ? ORDER BY finished_ms DESC LIMIT 5000", [sinceMs]);
+    if (sample.length) {
+        const waits = [], runs = []; let doneN = 0, deadN = 0;
+        for (const r of sample) {
+            if (r.wait_ms != null) waits.push(r.wait_ms);
+            runs.push(r.duration_ms);
+            if (r.outcome === "done") doneN++; else if (r.outcome === "dead") deadN++;
+        }
+        out.latency = { waitMs: percentiles(waits), runMs: percentiles(runs) };
+        out.throughput = { donePerSec: doneN / window, deadPerSec: deadN / window };
+    }
+    return out;
+}
+
+/**
+ * The attempt timeline for a job (opt-in history; empty when off / none). Each
+ * entry is `{ attemptNo, startedMs, finishedMs, durationMs, waitMs, outcome,
+ * error }`, oldest first - a queryable "what happened to this job".
+ * @param {number} id
+ * @returns {object[]}
+ */
+function history(id) {
+    const rows = db.query(
+        "SELECT attempt_no, started_ms, finished_ms, duration_ms, wait_ms, outcome, error " +
+        "FROM _hull_job_attempts WHERE job_id=? ORDER BY attempt_no, started_ms", [id]);
+    return rows.map((r) => ({
+        attemptNo: r.attempt_no, startedMs: r.started_ms, finishedMs: r.finished_ms,
+        durationMs: r.duration_ms, waitMs: r.wait_ms, outcome: r.outcome, error: r.error,
+    }));
 }
 
 // Decode an ops row into an inspection view: the handler-facing shape plus the
@@ -1614,6 +1716,10 @@ function cleanup(opts) {
     db.exec("DELETE FROM _hull_job_results WHERE job_id NOT IN (SELECT id FROM _hull_jobs)");
     db.exec("DELETE FROM _hull_workflow_steps WHERE workflow_id NOT IN (SELECT id FROM _hull_jobs)");
     db.exec("DELETE FROM _hull_workflow_signals WHERE workflow_id NOT IN (SELECT id FROM _hull_jobs)");
+    // Attempt history is retained by AGE (it outlives the job on purpose, for
+    // post-hoc metrics), not by orphan-ness.
+    const hr = _cfg.historyRetention || o.olderThan || 604800;
+    db.exec("DELETE FROM _hull_job_attempts WHERE finished_ms < ?", [(time.now() - hr) * 1000]);
     return deleted;
 }
 
@@ -1626,14 +1732,14 @@ function _tick(now) { processCron(now !== undefined ? now : time.now()); }
 
 export const jobs = {
     init, enqueue, enqueueMany, claim, handler, default: setDefault, on, work, reap,
-    stats, runWorker, stop, get, result, await: await_, progress, heartbeat, limit, metrics,
+    stats, runWorker, stop, get, result, await: await_, progress, heartbeat, limit, metrics, history,
     pause, resume, purge,
     workflow, start, signal, workflowStatus,
     dead, retry, cancel, cleanup, cron, uncron,
     RETRY, DEAD, DISCARD, _config: _cfg, _cronNext, _tick,
 };
 export { init, enqueue, enqueueMany, claim, handler, on, work, reap, stats,
-         runWorker, stop, get, result, progress, heartbeat, limit, metrics, pause, resume,
+         runWorker, stop, get, result, progress, heartbeat, limit, metrics, history, pause, resume,
          purge, workflow, start, signal, workflowStatus,
          dead, retry, cancel, cleanup, cron, uncron };
 export default jobs;

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -11,7 +11,7 @@
 -- Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
 -- catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
 -- visibility-timeout reaper), the dedicated worker (jobs.run_worker +
--- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueue_many), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step / ctx.sleep / ctx.wait_signal / jobs.signal, Phase 1) add crash-safe workflow-as-code: step memoization, durable timers, external signals, and saga compensation - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md). Observability: jobs.metrics() (DB-derived per-queue gauges + backlog age) and W3C trace-context propagation (enqueue { trace } -> job.trace).
+-- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueue_many), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step / ctx.sleep / ctx.wait_signal / jobs.signal, Phase 1) add crash-safe workflow-as-code: step memoization, durable timers, external signals, and saga compensation - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md). Observability: jobs.metrics() (DB-derived per-queue gauges + backlog age) and W3C trace-context propagation (enqueue { trace } -> job.trace). Opt-in attempt history (jobs.init { history=true }) records a per-attempt timeline (jobs.history) and adds latency percentiles + throughput to jobs.metrics.
 --
 -- Usage (target shape):
 --   local jobs = require("hull.jobs")
@@ -40,6 +40,8 @@ local _cfg = {
     max_attempts       = 25,    -- dead-letter threshold
     visibility_timeout = 300,   -- seconds before an orphaned `running` job is reclaimed
     reap_interval      = 30,    -- min seconds between reaper sweeps (0 = every work() call)
+    history            = false, -- attempt-history recording: true | { queues={...} } | false
+    history_retention  = nil,   -- seconds to keep attempt rows (nil = jobs.cleanup default)
 }
 
 -- Exponential backoff: 2^attempt * 10s, capped at 1h (shared with outbox math).
@@ -99,6 +101,8 @@ function jobs.init(opts)
     if opts.visibility_timeout ~= nil then _cfg.visibility_timeout = opts.visibility_timeout end
     if opts.reap_interval ~= nil then _cfg.reap_interval = opts.reap_interval end
     if opts.backoff ~= nil then _cfg.backoff = opts.backoff end
+    if opts.history ~= nil then _cfg.history = opts.history end
+    if opts.history_retention ~= nil then _cfg.history_retention = opts.history_retention end
 
     -- Keyed / indexed text columns are VARCHAR(255) so MySQL can index them;
     -- data-only columns (payload, last_error) stay TEXT. status/type/queue are
@@ -246,6 +250,32 @@ function jobs.init(opts)
         .. "created_at  INTEGER      NOT NULL,"
         .. "consumed_at INTEGER,"
         .. "PRIMARY KEY (workflow_id, name))")
+
+    -- Opt-in attempt history (jobs.init { history=true }). One row per attempt,
+    -- written by jobs.work at each outcome when history is enabled for the queue.
+    -- The durable timeline behind jobs.history + the latency/throughput metrics.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_job_attempts ("
+        .. "attempt_id  " .. db.autoincrement_id_ddl .. ", "
+        .. "job_id      INTEGER      NOT NULL,"
+        .. "queue       VARCHAR(255) NOT NULL,"
+        .. "type        VARCHAR(255) NOT NULL,"
+        .. "attempt_no  INTEGER      NOT NULL,"
+        .. "wait_ms     INTEGER,"
+        .. "started_ms  INTEGER      NOT NULL,"
+        .. "finished_ms INTEGER      NOT NULL,"
+        .. "duration_ms INTEGER      NOT NULL,"
+        .. "outcome     VARCHAR(16)  NOT NULL,"
+        .. "error       TEXT,"
+        .. "trace_id    VARCHAR(255))")
+    db.exec([[
+        CREATE INDEX IF NOT EXISTS idx_hull_job_attempts_job
+        ON _hull_job_attempts(job_id, attempt_no)
+    ]])
+    db.exec([[
+        CREATE INDEX IF NOT EXISTS idx_hull_job_attempts_recent
+        ON _hull_job_attempts(finished_ms)
+    ]])
 
     -- Verify the server actually parses SKIP LOCKED (the compile-time dialect
     -- flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
@@ -465,6 +495,7 @@ local function shape(row)
         id = row.id, type = row.type, data = data,
         attempts = row.attempts, max_attempts = row.max_attempts,
         trace = row.trace_context,   -- trace-context propagation (nil if unset)
+        queue = row.queue, created_at = row.created_at,   -- for attempt history
     }
 end
 
@@ -634,7 +665,7 @@ local function claim_one(queue, batch)
             .. "attempts=attempts+1, updated_at=? WHERE id IN ("
             .. "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? "
             .. "ORDER BY priority DESC, id LIMIT ? " .. lock .. ") "
-            .. "RETURNING id, type, payload, priority, attempts, max_attempts, trace_context",
+            .. "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at",
             { token, now, now, queue, now, batch })
     elseif d.supports_skip_locked then
         -- MySQL: no RETURNING. Lock + mark in one txn, then read back by token.
@@ -652,7 +683,7 @@ local function claim_one(queue, batch)
                 params)
         end)
         rows = db.query(
-            "SELECT id, type, payload, priority, attempts, max_attempts, trace_context FROM _hull_jobs WHERE claim_token=?",
+            "SELECT id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at FROM _hull_jobs WHERE claim_token=?",
             { token })
     else
         -- SQLite: single-writer serializes the claim, so the marked-running rows
@@ -662,7 +693,7 @@ local function claim_one(queue, batch)
             .. "attempts=attempts+1, updated_at=? WHERE id IN ("
             .. "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? "
             .. "ORDER BY priority DESC, id LIMIT ?) "
-            .. "RETURNING id, type, payload, priority, attempts, max_attempts, trace_context",
+            .. "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at",
             { token, now, now, queue, now, batch })
     end
 
@@ -1031,6 +1062,31 @@ jobs._cron_next = function(spec, from, offset)
 end
 jobs._tick = function(now) process_cron(now or time.now()) end
 
+-- Is attempt-history recording on for this queue? true = all queues; a table
+-- with a `queues` list = only those.
+local function history_enabled(queue)
+    local h = _cfg.history
+    if h == true then return true end
+    if type(h) == "table" and h.queues then
+        for _, q in ipairs(h.queues) do if q == queue then return true end end
+    end
+    return false
+end
+
+-- Record one attempt into the (opt-in) history timeline. `started_ms` is captured
+-- before the handler; `outcome` is "done" | "retried" | "dead". wait_ms is the
+-- queue latency (start - enqueue), computed from the job's created_at.
+local function record_attempt(job, started_ms, finished_ms, outcome, err)
+    local wait_ms
+    if job.created_at then wait_ms = started_ms - (job.created_at * 1000) end
+    db.exec(
+        "INSERT INTO _hull_job_attempts (job_id, queue, type, attempt_no, wait_ms, "
+        .. "started_ms, finished_ms, duration_ms, outcome, error, trace_id) "
+        .. "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        { job.id, job.queue or "default", job.type, job.attempts, wait_ms,
+          started_ms, finished_ms, finished_ms - started_ms, outcome, err, job.trace })
+end
+
 --- Claim a batch and run each job's handler, applying the outcome (done /
 -- retry-with-backoff / dead-letter). Runs the reaper first. Drive it from a
 -- timer (`app.every(1000, function() jobs.work() end)`) or a dedicated worker
@@ -1057,10 +1113,13 @@ function jobs.work(opts)
     for _, job in ipairs(batch) do
         job.deps = load_deps(job.id)   -- workflow: dependency results, in order
         local h = _handlers[job.type] or _default
+        local started_ms = time.now_ms()   -- attempt timing (used only if history on)
+        local outcome, err_str             -- nil outcome = a yield (not recorded)
         if not h then
-            local err = "no handler for job type '" .. tostring(job.type) .. "'"
-            mark_dead(job.id, err)
-            emit("dead", job, { error = err })
+            err_str = "no handler for job type '" .. tostring(job.type) .. "'"
+            mark_dead(job.id, err_str)
+            emit("dead", job, { error = err_str })
+            outcome = "dead"
         else
             local ok, result = pcall(h, job)
             if ok and type(result) == "table" and result.__hull_wf_yield then
@@ -1097,14 +1156,17 @@ function jobs.work(opts)
                         { result.wake_at or wf_now, wf_now, job.id })
                 end
             elseif not ok then
-                local err = tostring(result)
-                emit(mark_retry(job, err), job, { error = err, attempt = job.attempts })
+                err_str = tostring(result)
+                outcome = mark_retry(job, err_str)
+                emit(outcome, job, { error = err_str, attempt = job.attempts })
             elseif result == jobs.DEAD then
-                mark_dead(job.id, "handler returned jobs.DEAD")
-                emit("dead", job, { error = "handler returned jobs.DEAD" })
+                err_str = "handler returned jobs.DEAD"; outcome = "dead"
+                mark_dead(job.id, err_str)
+                emit("dead", job, { error = err_str })
             elseif result == jobs.RETRY then
-                emit(mark_retry(job, "handler requested retry"), job,
-                     { error = "handler requested retry", attempt = job.attempts })
+                err_str = "handler requested retry"
+                outcome = mark_retry(job, err_str)
+                emit(outcome, job, { error = err_str, attempt = job.attempts })
             else
                 -- nil / true / jobs.DISCARD -> done, no result; any other return
                 -- value is stored as the job's result (for dependents).
@@ -1114,7 +1176,12 @@ function jobs.work(opts)
                 end
                 mark_done(job.id, res)
                 emit("completed", job, { result = res })
+                outcome = "done"
             end
+        end
+        -- Opt-in attempt history (a yield leaves outcome nil -> not recorded).
+        if outcome and history_enabled(job.queue) then
+            record_attempt(job, started_ms, time.now_ms(), outcome, err_str)
         end
     end
     return #batch
@@ -1195,6 +1262,19 @@ end
 --- Count jobs by status (optionally scoped to a queue). The ops overview.
 -- @tparam[opt] table opts  { queue }
 -- @treturn table  { pending, running, done, dead }
+-- p50/p95/p99 of a numeric list (computed host-side; portable SQL has no
+-- PERCENTILE). Nearest-rank on the sorted sample.
+local function percentiles(vals)
+    if #vals == 0 then return { p50 = 0, p95 = 0, p99 = 0 } end
+    table.sort(vals)
+    local function pick(p)
+        local idx = math.ceil(p * #vals)
+        if idx < 1 then idx = 1 elseif idx > #vals then idx = #vals end
+        return vals[idx]
+    end
+    return { p50 = pick(0.50), p95 = pick(0.95), p99 = pick(0.99) }
+end
+
 function jobs.stats(opts)
     opts = opts or {}
     local rows
@@ -1249,7 +1329,47 @@ function jobs.metrics(opts)
         local q = queues[r.queue]
         if q and r.oldest then q.oldest_pending_age = now - r.oldest end
     end
-    return { queues = queues, totals = totals }
+    local out = { queues = queues, totals = totals }
+    -- Latency + throughput from the attempt history over the last `window`
+    -- seconds (present only when attempt recording is on, i.e. there is data).
+    local window = opts.window or 300
+    local sample = db.query(
+        "SELECT wait_ms, duration_ms, outcome FROM _hull_job_attempts WHERE finished_ms >= ?"
+        .. (opts.queue and " AND queue=?" or "") .. " ORDER BY finished_ms DESC LIMIT 5000",
+        opts.queue and { (now - window) * 1000, opts.queue } or { (now - window) * 1000 })
+    if sample and #sample > 0 then
+        local waits, runs, done_n, dead_n = {}, {}, 0, 0
+        for _, r in ipairs(sample) do
+            if r.wait_ms ~= nil then waits[#waits + 1] = r.wait_ms end
+            runs[#runs + 1] = r.duration_ms
+            if r.outcome == "done" then done_n = done_n + 1
+            elseif r.outcome == "dead" then dead_n = dead_n + 1 end
+        end
+        out.latency = { wait_ms = percentiles(waits), run_ms = percentiles(runs) }
+        out.throughput = { done_per_sec = done_n / window, dead_per_sec = dead_n / window }
+    end
+    return out
+end
+
+--- The attempt timeline for a job (opt-in history; empty when off / none). Each
+-- entry is `{ attempt_no, started_ms, finished_ms, duration_ms, wait_ms, outcome,
+-- error }`, oldest first - a queryable "what happened to this job".
+-- @tparam number id
+-- @treturn table  array of attempts
+function jobs.history(id)
+    local rows = db.query(
+        "SELECT attempt_no, started_ms, finished_ms, duration_ms, wait_ms, outcome, error "
+        .. "FROM _hull_job_attempts WHERE job_id=? ORDER BY attempt_no, started_ms",
+        { id })
+    local out = {}
+    for _, r in ipairs(rows or {}) do
+        out[#out + 1] = {
+            attempt_no = r.attempt_no, started_ms = r.started_ms,
+            finished_ms = r.finished_ms, duration_ms = r.duration_ms,
+            wait_ms = r.wait_ms, outcome = r.outcome, error = r.error,
+        }
+    end
+    return out
 end
 
 -- Decode an ops row into an inspection view: the handler-facing shape plus the
@@ -1719,6 +1839,10 @@ function jobs.cleanup(opts)
     db.exec("DELETE FROM _hull_job_results WHERE job_id NOT IN (SELECT id FROM _hull_jobs)")
     db.exec("DELETE FROM _hull_workflow_steps WHERE workflow_id NOT IN (SELECT id FROM _hull_jobs)")
     db.exec("DELETE FROM _hull_workflow_signals WHERE workflow_id NOT IN (SELECT id FROM _hull_jobs)")
+    -- Attempt history is retained by AGE (it outlives the job on purpose, for
+    -- post-hoc metrics), not by orphan-ness.
+    local hr = _cfg.history_retention or opts.older_than or 604800
+    db.exec("DELETE FROM _hull_job_attempts WHERE finished_ms < ?", { (time.now() - hr) * 1000 })
     return deleted
 end
 

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -1056,14 +1056,14 @@ app.main(function(ctx)
   local runs = { a=0, b=0 }
   jobs.workflow("sleeper", function(w)
     w.step("a", function() runs.a = runs.a + 1 end)
-    w.sleep(1)
+    w.sleep(3)   -- 3s: the mid-check margin absorbs any CI scheduling pause
     w.step("b", function() runs.b = runs.b + 1 end)
     return { ok = true }
   end)
   local id = jobs.start("sleeper", {})
   jobs.work({ batch = 1 })
   local mid = jobs.workflow_status(id); local mid_b = runs.b
-  hull.sleep(1200)
+  hull.sleep(3500)
   jobs.work({ batch = 1 })
   local fin = jobs.workflow_status(id)
   ctx.stdout:write(("SLEEP mid=%s mid_b=%d wait=%s fin=%s fin_b=%d steps=%s\n"):format(
@@ -1079,14 +1079,14 @@ app.main(async (ctx) => {
   const runs = { a:0, b:0 };
   jobs.workflow("sleeper", async (w) => {
     await w.step("a", () => { runs.a++; });
-    await w.sleep(1);
+    await w.sleep(3);   // 3s: the mid-check margin absorbs any CI scheduling pause
     await w.step("b", () => { runs.b++; });
     return { ok: true };
   });
   const id = jobs.start("sleeper", {});
   await jobs.work({ batch: 1 });
   const mid = jobs.workflowStatus(id); const midB = runs.b;
-  await hull.sleep(1200);
+  await hull.sleep(3500);
   await jobs.work({ batch: 1 });
   const fin = jobs.workflowStatus(id);
   ctx.stdout.write(`SLEEP mid=${mid.status} mid_b=${midB} wait=${mid.waitingFor?"yes":"no"} fin=${fin.status} fin_b=${runs.b} steps=${fin.stepsDone.join(",")}\n`);

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -1281,6 +1281,68 @@ app.main(async (ctx) => {
 echo "== observability A+C: Lua =="; check_metrics "lua" "lua" "$LUA_METRICS"
 echo "== observability A+C: JS =="; check_metrics "js" "js" "$JS_METRICS"
 
+# ── observability Bet #1 Pillar B: opt-in attempt history + latency/throughput ─
+# history OFF -> no attempt rows, no latency in metrics. history ON -> each
+# attempt is recorded (a retried-then-done job -> 2 rows [retried, done]; a dead
+# job -> [dead]); jobs.history is the timeline; jobs.metrics gains run-latency
+# percentiles + throughput.
+check_history() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"HIST off_rows=0 off_lat=no on_attempts=2 seq=retried,done dead=dead p50=yes tput=yes"*)
+            pass "$label: attempt history (opt-in timeline + latency percentiles + throughput)" ;;
+        *) fail "$label: observability B" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_HISTORY='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init({ backoff = function() return 0 end })
+  jobs.handler("ok", function(j) end)
+  local off_id = jobs.enqueue("ok", {}); jobs.work({ batch = 1 })
+  local off_rows = #jobs.history(off_id)
+  local off_lat = jobs.metrics().latency and "yes" or "no"
+  jobs.init({ history = true, backoff = function() return 0 end })
+  jobs.handler("boom", function(j) error("x") end)
+  jobs.handler("retry_once", function(j) if j.attempts == 1 then error("once") end end)
+  local rid = jobs.enqueue("retry_once", {}); local bid = jobs.enqueue("boom", {}, { max_attempts = 1 })
+  jobs.enqueue("ok", {})
+  jobs.run_worker({ drain = true, poll_ms = 1 })
+  local rh = jobs.history(rid); local bh = jobs.history(bid); local m = jobs.metrics()
+  ctx.stdout:write(("HIST off_rows=%d off_lat=%s on_attempts=%d seq=%s,%s dead=%s p50=%s tput=%s\n"):format(
+    off_rows, off_lat, #rh, rh[1] and rh[1].outcome or "-", rh[2] and rh[2].outcome or "-",
+    bh[1] and bh[1].outcome or "-",
+    (m.latency and m.latency.run_ms.p50 ~= nil) and "yes" or "no",
+    (m.throughput and m.throughput.done_per_sec > 0) and "yes" or "no"))
+  return 0
+end)'
+
+JS_HISTORY='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init({ backoff: () => 0 });
+  jobs.handler("ok", (j) => {});
+  const offId = jobs.enqueue("ok", {}); await jobs.work({ batch: 1 });
+  const offRows = jobs.history(offId).length;
+  const offLat = jobs.metrics().latency ? "yes" : "no";
+  jobs.init({ history: true, backoff: () => 0 });
+  jobs.handler("boom", (j) => { throw new Error("x"); });
+  jobs.handler("retry_once", (j) => { if (j.attempts === 1) throw new Error("once"); });
+  const rid = jobs.enqueue("retry_once", {}); const bid = jobs.enqueue("boom", {}, { maxAttempts: 1 });
+  jobs.enqueue("ok", {});
+  await jobs.runWorker({ drain: true, pollMs: 1 });
+  const rh = jobs.history(rid), bh = jobs.history(bid), m = jobs.metrics();
+  ctx.stdout.write(`HIST off_rows=${offRows} off_lat=${offLat} on_attempts=${rh.length} seq=${rh[0]?.outcome},${rh[1]?.outcome} dead=${bh[0]?.outcome} p50=${m.latency&&m.latency.runMs.p50!=null?"yes":"no"} tput=${m.throughput&&m.throughput.donePerSec>0?"yes":"no"}\n`);
+  return 0;
+});'
+
+echo "== observability B: Lua =="; check_history "lua" "lua" "$LUA_HISTORY"
+echo "== observability B: JS =="; check_history "js" "js" "$JS_HISTORY"
+
 # Fleet gate: K processes share one rate counter -> total dispatched == rate.
 echo "== v1.2 rate limit fleet ($CONC processes, one shared counter) =="
 W="$(mktemp -d)"; DB="$W/rl.db"


### PR DESCRIPTION
Bet #1 (observability) **Pillar B** from `docs/jobs_observability_design.md` — the opt-in attempt-history timeline + latency/throughput. Pure stdlib, both runtimes, **zero C**, **49/49 e2e green**, linters clean.

## What lands
- **Opt-in** via `jobs.init({ history: true })` (or `{ history: { queues: [...] } }`). A new `_hull_job_attempts` table records one row per attempt in `jobs.work` at each terminal outcome (`done`/`retried`/`dead`), ms-precise timing captured around the handler. Off by default (one write/attempt).
- **`jobs.history(id)`** → the timeline: `{ attemptNo, startedMs, finishedMs, durationMs, waitMs, outcome, error }` per attempt, oldest first.
- **`jobs.metrics()`** gains, when history has data: **latency** (`waitMs` = queue latency, `runMs` = execution, each `{ p50, p95, p99 }` computed host-side over a bounded sample) and **throughput** (`donePerSec` / `deadPerSec`) over `opts.window` (default 300s).
- Retention via `jobs.cleanup` (age-based; attempts outlive the job on purpose, for post-hoc metrics).

## Notes
- The `work()` outcome block was refactored to compute a single `outcome`/`error` and record once (yields aren't attempts → skipped) — behavior-neutral for the existing paths (all 47 prior e2e still pass).
- The claim SELECTs + `shape` now carry `queue` + `created_at` (needed for the attempt row + wait latency). No new `_hull_jobs` column.

## Observability status
Bet #1 is now complete: **Pillar A** (metrics gauges) + **C** (trace propagation) + **B** (attempt history + latency/throughput). The remaining "best in the world" item is **Bet #2 Phase 2** — deterministic WASM-replay strict mode.
