### PR TITLE
jobs: durable workflows - Phase 2 deterministic-replay primitives

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -276,6 +276,14 @@ const wf = jobs.start("checkout", { orderId: 42, amount: 100 });
   steps' `compensate` functions run in **reverse order** (undo the charge if
   shipping can't be arranged). Compensations are at-least-once (idempotent) and
   recorded, so a crash mid-rollback resumes.
+- **Deterministic replay** - the body re-runs from the top on every resume, so
+  reading the clock or RNG **directly** would differ each replay and break the
+  memo matching. Use the memoized primitives **`ctx.now()`**, **`ctx.random()`**,
+  **`ctx.uuid()`** instead: each records its value on first run and returns the
+  **same** value on every replay. (A direct `time.now` / `math.random` in a
+  workflow body is a determinism bug - route it through `ctx.*`. For a
+  deterministic heavy *computation*, run a WASM module via `compute.call` inside a
+  step. Rationale: [docs/jobs_wasm_replay_spike.md](jobs_wasm_replay_spike.md).)
 - **`jobs.workflow_status(id)`** (`workflowStatus`) → `{ status, name,
   steps_done, result?, error? }`, DB-derived (works even when no worker is
   running it). Fetch the final value with `jobs.await(id)` / `jobs.result(id)`.

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -15,7 +15,7 @@
  * Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
  * catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
  * visibility-timeout reaper), the dedicated worker (jobs.runWorker +
- * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueueMany), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step / ctx.sleep / ctx.wait_signal / jobs.signal, Phase 1) add crash-safe workflow-as-code: step memoization, durable timers, external signals, and saga compensation - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md). Observability: jobs.metrics() (DB-derived per-queue gauges + backlog age) and W3C trace-context propagation (enqueue { trace } -> job.trace). Opt-in attempt history (jobs.init { history=true }) records a per-attempt timeline (jobs.history) and adds latency percentiles + throughput to jobs.metrics.
+ * `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueueMany), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step / ctx.sleep / ctx.wait_signal / jobs.signal, Phase 1) add crash-safe workflow-as-code: step memoization, durable timers, external signals, and saga compensation, plus deterministic-replay primitives (ctx.now / ctx.random / ctx.uuid, memoized) - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md). Observability: jobs.metrics() (DB-derived per-queue gauges + backlog age) and W3C trace-context propagation (enqueue { trace } -> job.trace). Opt-in attempt history (jobs.init { history=true }) records a per-attempt timeline (jobs.history) and adds latency percentiles + throughput to jobs.metrics.
  *
  * @license AGPL-3.0-or-later
  */
@@ -1491,7 +1491,7 @@ async function runCompensations(comps, workflowId) {
 // `comps` collects saga compensations (registered by every ctx.step call that has
 // one, so on the terminal-failure run the list covers all completed steps).
 function makeCtx(job, name) {
-    let sleepN = 0;
+    let sleepN = 0, detN = 0;
     const comps = [];
     return {
         id: job.id,
@@ -1499,6 +1499,14 @@ function makeCtx(job, name) {
         input: job.data,
         trace: job.trace,   // trace-context propagation (observability design)
         _comps: comps,
+        // Deterministic primitives (Phase 2): a workflow body re-runs from the top
+        // on every resume, so reading the clock / RNG directly would differ each
+        // replay and break memo-key matching. These memoize via the step store, so
+        // now / random / uuid return the SAME value on every replay - the supported
+        // way to be non-deterministic in a workflow. Hidden from steps_done.
+        now: () => { detN += 1; return runStep(job.id, "__now:" + detN, () => time.now()); },
+        random: () => { detN += 1; return runStep(job.id, "__rand:" + detN, () => Math.random()); },
+        uuid: () => { detN += 1; return runStep(job.id, "__uuid:" + detN, () => crypto.base64urlEncode(crypto.random(16))); },
         step: async (stepKey, fn, opts) => {
             const result = await runStep(job.id, stepKey, fn);
             if (opts && typeof opts.compensate === "function") comps.push({ key: stepKey, fn: opts.compensate });

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -11,7 +11,7 @@
 -- Full surface: schema + jobs.init, enqueue, the atomic claim, per-type +
 -- catch-all handlers, the work loop (retry-with-backoff, dead-letter, and the
 -- visibility-timeout reaper), the dedicated worker (jobs.run_worker +
--- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueue_many), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step / ctx.sleep / ctx.wait_signal / jobs.signal, Phase 1) add crash-safe workflow-as-code: step memoization, durable timers, external signals, and saga compensation - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md). Observability: jobs.metrics() (DB-derived per-queue gauges + backlog age) and W3C trace-context propagation (enqueue { trace } -> job.trace). Opt-in attempt history (jobs.init { history=true }) records a per-attempt timeline (jobs.history) and adds latency percentiles + throughput to jobs.metrics.
+-- `hull jobs worker`), and the ops surface (jobs.stats / dead / retry / cancel / cleanup). v1.1 adds durable cron (jobs.cron / uncron) and intra-process concurrency (run_worker concurrency=N), jobs.get(id), jobs.heartbeat for long jobs, fleet-wide rate limiting (jobs.limit), queue pause/resume/purge, and workflows (depends_on + result passing). v1.5 adds the standalone result backend (jobs.result / jobs.await), multi-queue draining (opts.queues, strict list or weighted map), bulk enqueue (jobs.enqueue_many), in-process lifecycle hooks (jobs.on completed/retried/dead), and polish (absolute at, jobs.progress, throttle window, fixed-offset tz cron). Durable workflows (jobs.workflow / jobs.start / ctx.step / ctx.sleep / ctx.wait_signal / jobs.signal, Phase 1) add crash-safe workflow-as-code: step memoization, durable timers, external signals, and saga compensation, plus deterministic-replay primitives (ctx.now / ctx.random / ctx.uuid, memoized) - a workflow instance is a job that rides the same claim/reaper/retry/result machinery (docs/jobs_durable_execution_design.md). Observability: jobs.metrics() (DB-derived per-queue gauges + backlog age) and W3C trace-context propagation (enqueue { trace } -> job.trace). Opt-in attempt history (jobs.init { history=true }) records a per-attempt timeline (jobs.history) and adds latency percentiles + throughput to jobs.metrics.
 --
 -- Usage (target shape):
 --   local jobs = require("hull.jobs")
@@ -1616,6 +1616,27 @@ local function make_ctx(job, name)
         return run_sleep(job.id, sleep_n, seconds)
     end
     ctx.wait_signal = function(signal_name, opts) return run_wait_signal(job.id, signal_name, opts) end
+    -- Deterministic primitives (Phase 2). A workflow body re-runs from the top on
+    -- every resume; reading the clock / RNG directly would return a different
+    -- value each replay and break memo-key matching. These memoize their value
+    -- via the step store, so ctx.now / ctx.random / ctx.uuid return the SAME
+    -- value on every replay - the supported way to be non-deterministic in a
+    -- workflow. `det_n` gives each call a stable ordinal key (the call sequence is
+    -- stable across replays); the keys are hidden from workflow_status.steps_done.
+    local det_n = 0
+    ctx.now = function()
+        det_n = det_n + 1
+        return run_step(job.id, "__now:" .. det_n, function() return time.now() end)
+    end
+    ctx.random = function()
+        det_n = det_n + 1
+        return run_step(job.id, "__rand:" .. det_n, function() return math.random() end)
+    end
+    ctx.uuid = function()
+        det_n = det_n + 1
+        return run_step(job.id, "__uuid:" .. det_n,
+            function() return crypto.base64url_encode(crypto.random(16)) end)
+    end
     return ctx
 end
 

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -1223,6 +1223,60 @@ app.main(async (ctx) => {
 echo "== durable saga (Phase 1d): Lua =="; check_saga "lua" "lua" "$LUA_SAGA"
 echo "== durable saga (Phase 1d): JS =="; check_saga "js" "js" "$JS_SAGA"
 
+# ── durable execution (Phase 2): deterministic primitives (replay-stable) ────
+# ctx.now / ctx.random / ctx.uuid memoize via the step store, so a workflow that
+# fails its first attempt and REPLAYS sees byte-identical values -> deterministic
+# replay without WASM. Design: docs/jobs_wasm_replay_spike.md.
+check_deterministic() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"DET identical=YES status=done"*)
+            pass "$label: deterministic ctx.now/random/uuid (byte-identical across replay)" ;;
+        *) fail "$label: durable determinism (Phase 2)" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_DET='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init({ backoff = function() return 0 end })
+  local runs = {}
+  jobs.workflow("det", function(w)
+    local sig = tostring(w.now()) .. "|" .. string.format("%.6f", w.random()) .. "|" .. w.uuid()
+    runs[#runs+1] = sig
+    if #runs == 1 then error("force replay") end
+    return { ok = true }
+  end)
+  local id = jobs.start("det", {})
+  jobs.run_worker({ drain = true, poll_ms = 1 })
+  ctx.stdout:write(("DET identical=%s status=%s\n"):format(
+    (runs[1] == runs[2]) and "YES" or "NO", jobs.workflow_status(id).status))
+  return 0
+end)'
+
+JS_DET='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init({ backoff: () => 0 });
+  const runs = [];
+  jobs.workflow("det", async (w) => {
+    const sig = (await w.now()) + "|" + (await w.random()).toFixed(6) + "|" + (await w.uuid());
+    runs.push(sig);
+    if (runs.length === 1) throw new Error("force replay");
+    return { ok: true };
+  });
+  const id = jobs.start("det", {});
+  await jobs.runWorker({ drain: true, pollMs: 1 });
+  ctx.stdout.write(`DET identical=${runs[0]===runs[1]?"YES":"NO"} status=${jobs.workflowStatus(id).status}\n`);
+  return 0;
+});'
+
+echo "== durable determinism (Phase 2): Lua =="; check_deterministic "lua" "lua" "$LUA_DET"
+echo "== durable determinism (Phase 2): JS =="; check_deterministic "js" "js" "$JS_DET"
+
 # ── observability Bet #1 Pillar A+C: jobs.metrics gauges + trace propagation ─
 # metrics() returns DB-derived per-queue gauges (pending/dead + backlog age) and
 # totals; a job enqueued with { trace } surfaces job.trace in the handler.


### PR DESCRIPTION
Phase 2 of the durable-execution RFC — built the **lighter way the spike (#251) recommended**: not a WASM-replay rewrite, but memoized deterministic primitives on the Phase-1 step engine. Both runtimes, **zero C**, **51/51 e2e green**, linters clean.

## What lands
- **`ctx.now()` / `ctx.random()` / `ctx.uuid()`** — memoize their value via the step store, so a workflow that re-runs from the top on resume gets the **same** clock reading, random draw, and id on every replay. This is the supported way to be non-deterministic in a workflow body (a direct `time.now`/`math.random` in a body differs each replay and breaks memo matching). Keys are hidden from `workflow_status.steps_done` and swept by `cleanup`, like other internal `__` keys.

## Refinement of the spike
The spike floated an optional `strict` **trap** shadowing ambient `time.now`/`math.random` during the body. Implementing it revealed it's **unsafe for async bodies** — a global monkeypatch leaks across an `await` to concurrent code. So Phase 2 ships the memoized primitives + docs guidance instead of a leaky trap. Deterministic *heavy compute* stays `compute.call` inside a step (already available).

## Proven by e2e
A workflow that fails its first attempt (forcing a replay) sees **byte-identical** `ctx.now()`+`ctx.random()`+`ctx.uuid()` across attempts and completes: `DET identical=YES status=done`.

## Also in this PR
Nothing else — the Phase 1b durable-timer de-flake (1s→3s) already landed with #250.

---
**This completes the durable-execution + observability arc** we scoped: durable execution (steps, timers, signals, saga, **determinism**) + observability (metrics gauges, trace, attempt history/latency).
