### PR TITLE
jobs: fix + cover new features on Postgres/MySQL (RETURNING id, BIGINT ms)

### DIFF
--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -245,10 +245,10 @@ function init(opts) {
         "queue       VARCHAR(255) NOT NULL," +
         "type        VARCHAR(255) NOT NULL," +
         "attempt_no  INTEGER      NOT NULL," +
-        "wait_ms     INTEGER," +
-        "started_ms  INTEGER      NOT NULL," +
-        "finished_ms INTEGER      NOT NULL," +
-        "duration_ms INTEGER      NOT NULL," +
+        "wait_ms     BIGINT," +
+        "started_ms  BIGINT       NOT NULL," +
+        "finished_ms BIGINT       NOT NULL," +
+        "duration_ms BIGINT       NOT NULL," +
         "outcome     VARCHAR(16)  NOT NULL," +
         "error       TEXT," +
         "trace_id    VARCHAR(255))");
@@ -385,12 +385,22 @@ function enqueue(jobType, data, opts) {
     if (o.dedupKey !== undefined && o.dedupKey !== null) {
         const n = db.insertIfAbsent("_hull_jobs", ["queue", "dedup_key"], cols, vals);
         if (!(n && n > 0)) return null;   // an un-run job with this (queue, dedupKey) exists
-        id = db.lastId();
+        // Portable id fetch: the unique (queue, dedup_key) identifies the new row.
+        // (db.lastId is unsupported on Postgres, which has no last-insert-rowid.)
+        const rows = db.query("SELECT id FROM _hull_jobs WHERE queue=? AND dedup_key=?",
+            [o.queue || "default", o.dedupKey]);
+        id = rows.length ? rows[0].id : null;
     } else {
         const ph = cols.map(() => "?");
-        db.exec("INSERT INTO _hull_jobs (" + cols.join(", ") +
-            ") VALUES (" + ph.join(", ") + ")", vals);
-        id = db.lastId();
+        const sql = "INSERT INTO _hull_jobs (" + cols.join(", ") + ") VALUES (" + ph.join(", ") + ")";
+        if (db.dialect.supportsReturning) {
+            // SQLite + Postgres: read the id back from the INSERT itself.
+            const rows = db.query(sql + " RETURNING id", vals);
+            id = rows.length ? rows[0].id : null;
+        } else {
+            db.exec(sql, vals);   // MySQL: LAST_INSERT_ID via db.lastId
+            id = db.lastId();
+        }
     }
     if (hasDeps) {
         // Record edges, then re-check each dep: closes the enqueue/complete race

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -261,10 +261,10 @@ function jobs.init(opts)
         .. "queue       VARCHAR(255) NOT NULL,"
         .. "type        VARCHAR(255) NOT NULL,"
         .. "attempt_no  INTEGER      NOT NULL,"
-        .. "wait_ms     INTEGER,"
-        .. "started_ms  INTEGER      NOT NULL,"
-        .. "finished_ms INTEGER      NOT NULL,"
-        .. "duration_ms INTEGER      NOT NULL,"
+        .. "wait_ms     BIGINT,"
+        .. "started_ms  BIGINT       NOT NULL,"
+        .. "finished_ms BIGINT       NOT NULL,"
+        .. "duration_ms BIGINT       NOT NULL,"
         .. "outcome     VARCHAR(16)  NOT NULL,"
         .. "error       TEXT,"
         .. "trace_id    VARCHAR(255))")
@@ -423,13 +423,24 @@ function jobs.enqueue(job_type, data, opts)
         if not (n and n > 0) then
             return nil   -- an un-run job with this (queue, dedup_key) already exists
         end
-        id = db.last_id()
+        -- Portable id fetch: the unique (queue, dedup_key) identifies the new row.
+        -- (db.last_id is unsupported on Postgres, which has no last-insert-rowid.)
+        local rows = db.query("SELECT id FROM _hull_jobs WHERE queue=? AND dedup_key=?",
+            { opts.queue or "default", opts.dedup_key })
+        id = rows and rows[1] and rows[1].id
     else
         local ph = {}
         for i = 1, #cols do ph[i] = "?" end
-        db.exec("INSERT INTO _hull_jobs (" .. table.concat(cols, ", ")
-            .. ") VALUES (" .. table.concat(ph, ", ") .. ")", vals)
-        id = db.last_id()
+        local sql = "INSERT INTO _hull_jobs (" .. table.concat(cols, ", ")
+            .. ") VALUES (" .. table.concat(ph, ", ") .. ")"
+        if db.dialect.supports_returning then
+            -- SQLite + Postgres: read the id back from the INSERT itself.
+            local rows = db.query(sql .. " RETURNING id", vals)
+            id = rows and rows[1] and rows[1].id
+        else
+            db.exec(sql, vals)   -- MySQL: LAST_INSERT_ID via db.last_id
+            id = db.last_id()
+        end
     end
     if has_deps then
         -- Record edges first, then re-check each dependency's current state: this

--- a/tests/e2e_mysql.sh
+++ b/tests/e2e_mysql.sh
@@ -339,6 +339,42 @@ else
     echo "::error jobs concurrency: total=$jtotal uniq=$juniq (want 200/200)"; exit 1
 fi
 
+# ── hull/jobs durable execution + observability on MySQL ───────────────
+# Regression coverage for the attempt-history BIGINT fix (ms timestamps overflow
+# a 32-bit INTEGER on MySQL) plus workflows / deterministic primitives / history.
+# Asserted via DB state (not app stdout): a graceful-exit `-d mysql` app currently
+# hits a MySQL-backend connection-teardown crash that swallows the final buffered
+# stdout line - the DB writes commit first, so the state check is reliable. (The
+# teardown crash is a separate backend bug, tracked independently.)
+echo "=== jobs: durable execution + observability on MySQL (DB-state) ==="
+WFDIR=$(mktemp -d)
+cat > "$WFDIR/wf.lua" <<'LUA'
+local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init({ history = true, backoff = function() return 0 end })
+  local threw = false
+  jobs.workflow("wfm", function(w)
+    local a = w.step("charge", function() return { amt = 10 } end)
+    w.now(); w.uuid()   -- deterministic primitives (memoized)
+    if not threw then threw = true; error("retry once") end
+    return { amt = a.amt }
+  end)
+  jobs.start("wfm", {})
+  jobs.run_worker({ drain = true, poll_ms = 1 })
+  return 0
+end)
+LUA
+./build/hull "$WFDIR/wf.lua" -d "$DSN" >/dev/null 2>&1 || true
+wfstat=$(docker exec "$CONTAINER" mysql -uhull -ps3cretpw hulldb -N -se \
+  "SELECT CONCAT((SELECT status FROM _hull_jobs WHERE type='__wf:wfm' ORDER BY id DESC LIMIT 1),',',(SELECT COUNT(*) FROM _hull_workflow_steps),',',(SELECT COUNT(*) FROM _hull_job_attempts),',',CASE WHEN (SELECT MAX(finished_ms) FROM _hull_job_attempts)>1000000000000 THEN 'bigint' ELSE 'small' END)" 2>/dev/null)
+case "$wfstat" in
+    done,*bigint)
+        echo "PASS: jobs workflows + deterministic primitives + attempt history (MySQL, DB-verified: $wfstat)"
+        rm -rf "$WFDIR" ;;
+    *)  echo "::error jobs durable/observability on MySQL: got '$wfstat'"; exit 1 ;;
+esac
+
 # ── TLS + caching_sha2_password phase ─────────────────────────────────
 # MySQL 8 ships TLS on by default (auto-generated certs). Switch the user to
 # caching_sha2_password so its cache is empty, then connect over TLS: the

--- a/tests/e2e_postgres.sh
+++ b/tests/e2e_postgres.sh
@@ -341,6 +341,47 @@ else
     echo "::error jobs concurrency: total=$jtotal uniq=$juniq (want 200/200)"; exit 1
 fi
 
+# ── hull/jobs durable execution + observability on Postgres ────────────
+# Regression coverage for two Postgres-specific bugs the concurrency gate above
+# missed (it never uses the enqueue id): (1) jobs.enqueue relied on db.last_id,
+# unsupported on PG - jobs.start returned -1 and workflows/await broke; fixed to
+# INSERT ... RETURNING id. (2) attempt-history ms columns were INTEGER (int4) -
+# ms timestamps (~1.78e12) overflow on PG; fixed to BIGINT.
+echo "=== jobs: durable execution + observability on Postgres ==="
+WFDIR=$(mktemp -d)
+cat > "$WFDIR/wf.lua" <<'LUA'
+local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init({ history = true, backoff = function() return 0 end })
+  local threw = false
+  jobs.workflow("wf", function(w)
+    local a = w.step("charge", function() return { amt = 10 } end)
+    local ts = w.now(); local uid = w.uuid()   -- deterministic primitives (memoized)
+    if not threw then threw = true; error("retry once") end
+    return { amt = a.amt, ts = ts, uid = uid }
+  end)
+  local wid = jobs.start("wf", {})
+  jobs.run_worker({ drain = true, poll_ms = 1 })
+  local st = jobs.workflow_status(wid); local r = jobs.await(wid)
+  local hist = jobs.history(wid); local m = jobs.metrics()
+  local ms_ok = false
+  for _, h in ipairs(hist) do if h.finished_ms and h.finished_ms > 1000000000000 then ms_ok = true end end
+  ctx.stdout:write(("PGWF wid_valid=%s status=%s amt=%s attempts=%d hist_ms=%s run_p50=%s\n"):format(
+    (type(wid) == "number" and wid > 0) and "yes" or "no", st and st.status or "nil",
+    tostring(r and r.result and r.result.amt), #hist, ms_ok and "yes" or "no",
+    (m.latency and m.latency.run_ms and m.latency.run_ms.p50 ~= nil) and "yes" or "no"))
+  return 0
+end)
+LUA
+wfout=$(./build/hull "$WFDIR/wf.lua" -d "$DSN" 2>/dev/null)
+case "$wfout" in
+    *"PGWF wid_valid=yes status=done amt=10 attempts=2 hist_ms=yes run_p50=yes"*)
+        echo "PASS: jobs workflows + deterministic primitives + attempt history + metrics (Postgres)"
+        rm -rf "$WFDIR" ;;
+    *)  echo "::error jobs durable/observability on PG: $wfout"; exit 1 ;;
+esac
+
 # ── TLS phase (Phase 3b.2) ────────────────────────────────────────────
 # Enable SSL on the running container with a self-signed cert, then connect
 # with sslmode=require and assert (via pg_stat_ssl) the session is encrypted.


### PR DESCRIPTION
Validating the new jobs features (workflows, deterministic primitives, attempt history, metrics) against **real Postgres 16 + MySQL 8** (Docker) — task (a) — immediately surfaced **two cross-backend bugs** the existing SKIP-LOCKED gate missed (it never uses the enqueue id). Both **fixed and validated**.

## Bug 1 — `jobs.enqueue` returned an invalid id on Postgres
It read the new id via `db.last_id`, which is **unsupported on PG** (no last-insert-rowid — the backend says "use RETURNING"). So `jobs.start` returned `-1`, and **workflows / `jobs.await` / `jobs.get(id)` / `depends_on` all broke on Postgres**. Pre-existing since jobs was built; hidden because the concurrency gate ignores the returned id.
**Fix:** `INSERT ... RETURNING id` where the dialect supports it (SQLite + PG), `db.last_id` only on MySQL; the dedup path fetches the id via the unique `(queue, dedup_key)`.

## Bug 2 — attempt-history ms columns overflow int4
`started_ms`/`finished_ms`/`duration_ms`/`wait_ms` were `INTEGER` = **32-bit** on PG/MySQL; ms timestamps (~1.78e12) overflow. SQLite's dynamic 64-bit `INTEGER` hid it. **Fix:** `BIGINT`.

## Coverage added
- `e2e_postgres.sh`: a workflow (steps + `ctx.now`/`ctx.uuid` + forced replay) → asserts `status=done`, memoized steps, attempt rows, BIGINT-range `finished_ms` (stdout — PG is clean).
- `e2e_mysql.sh`: same, asserted via **DB state** (see below).

## Separate finding (flagged, not fixed here)
A **graceful-exit `-d mysql` app hits a MySQL-backend connection-teardown SIGSEGV** — reproduced with a *no-DB* app too, so it's **not jobs** and not my changes. Work commits before the crash (no data loss), but it swallows the final buffered stdout line, so the MySQL phase asserts via DB state. It matters for `hull jobs worker` on MySQL (crashes on shutdown). **Recommend a separate C-level investigation** (looks like a connection-teardown double-free/ordering bug).

Validated on real PG (fully) + MySQL (DB-state). SQLite `e2e_jobs` 51/51; both runtimes; linters clean.
