### PR TITLE
tls_client: fix SIGSEGV on teardown of a long-lived TLS connection (dangling stack allocator)

### DIFF
--- a/src/hull/shared/tls_client.c
+++ b/src/hull/shared/tls_client.c
@@ -16,6 +16,7 @@
 #include <keel/tls_mbedtls.h>
 
 #include <poll.h>
+#include <pthread.h>
 #include <stdlib.h>
 #include <unistd.h>
 
@@ -23,6 +24,25 @@ struct HlTlsClient {
     KlTlsCtx *ctx;        /* NULL when the ctx is caller-owned (cfg path) */
     KlTls    *tls;
 };
+
+/* The KlTls / KlTlsCtx capture the KlAllocator BY POINTER and dereference it at
+ * destroy time - long after the handshake function returns - so the allocator
+ * must outlive them. kl_allocator_default() is a stateless process-wide default
+ * (static stdlib wrappers, NULL ctx); hold ONE copy in static storage and hand
+ * its address to every KlTls/KlTlsCtx, instead of a stack local that dangles the
+ * moment the handshake returns. A dangling stack allocator only bit LONG-LIVED
+ * TLS connections (e.g. a pooled DB connection) whose handshake frame is gone by
+ * teardown - it surfaced as a SIGSEGV in tls_destroy's kl_free(t->alloc, ...) on
+ * a graceful `-d <postgres|mysql>://...?sslmode!=disable` process exit. SMTP
+ * frees the KlTls inside the same call stack, so its local never dangled. */
+static KlAllocator    s_default_alloc;
+static pthread_once_t s_default_alloc_once = PTHREAD_ONCE_INIT;
+static void init_default_alloc(void) { s_default_alloc = kl_allocator_default(); }
+static KlAllocator *default_alloc(void)
+{
+    pthread_once(&s_default_alloc_once, init_default_alloc);
+    return &s_default_alloc;
+}
 
 /* Drive tls->handshake to completion with a poll-based blocking wait, bounded
  * by @p timeout_ms (<= 0 = wait indefinitely). 0 on success, -1 on error/timeout. */
@@ -61,7 +81,7 @@ static HlTlsClient *tls_client_wrap(KlTlsCtx *ctx, KlTls *tls)
 HlTlsClient *hl_tls_client_handshake(int fd, const char *host,
                                      int verify, int timeout_ms)
 {
-    KlAllocator alloc = kl_allocator_default();
+    KlAllocator *alloc = default_alloc();   /* persistent; outlives the KlTls/ctx */
 
     /* verify: trust anchor = embedded CA bundle, cert chain + hostname
      * checked. Otherwise: no CA, server certificate accepted as-is. */
@@ -70,14 +90,14 @@ HlTlsClient *hl_tls_client_handshake(int fd, const char *host,
         const unsigned char *cab = NULL;
         size_t cab_len = 0;
         if (hl_embedded_ca_bundle(&cab, &cab_len) == 0)
-            ctx = kl_tls_mbedtls_client_ctx_create_from_buf(cab, cab_len, &alloc);
+            ctx = kl_tls_mbedtls_client_ctx_create_from_buf(cab, cab_len, alloc);
     } else {
-        ctx = kl_tls_mbedtls_client_ctx_create(NULL, &alloc);
+        ctx = kl_tls_mbedtls_client_ctx_create(NULL, alloc);
     }
     if (!ctx)
         return NULL;
 
-    KlTls *tls = kl_tls_mbedtls_create(ctx, &alloc);
+    KlTls *tls = kl_tls_mbedtls_create(ctx, alloc);
     if (!tls) {
         kl_tls_mbedtls_ctx_destroy(ctx);
         return NULL;
@@ -102,8 +122,7 @@ HlTlsClient *hl_tls_client_handshake_cfg(int fd, const char *host,
     if (!cfg || !cfg->factory)
         return NULL;
 
-    KlAllocator alloc = kl_allocator_default();
-    KlTls *tls = cfg->factory(cfg->ctx, &alloc);
+    KlTls *tls = cfg->factory(cfg->ctx, default_alloc());
     if (!tls)
         return NULL;
     if (host && host[0] && tls->set_hostname)


### PR DESCRIPTION
Fixes a **SIGSEGV on graceful process exit** for any long-lived TLS connection — reproduced as `hull jobs worker` (and any CLI app) on **`-d mysql://…`** (MySQL 8 defaults to TLS) or **`-d postgres://…?sslmode=require`** crashing on shutdown. Found while validating jobs on real MySQL (#254 follow-up).

## Root cause
`hl_tls_client_handshake` created the allocator on the **stack** (`KlAllocator alloc = kl_allocator_default();`) and passed `&alloc` into Keel's `kl_tls_mbedtls_create`/`_ctx_create`. Keel's `KlTls`/`KlTlsCtx` capture the allocator **by pointer** and dereference it at destroy (`tls_destroy` → `kl_free(t->alloc, t)`). After the handshake returns the pointer **dangles**; benign during the connection's life, but a pooled DB connection is freed by `hl_db_registry_destroy` at process exit — long after that stack frame is gone — so `kl_free` jumps through a garbage/NULL free pointer → `pc=0x0`.

Not backend-specific (shared TLS client). SMTP frees its `KlTls` inside the same call stack, so its local never dangled — which is why this stayed hidden.

## Fix
Hold the (stateless, process-global) default allocator in persistent **static** storage (`pthread_once`-initialized) and hand its address to every `KlTls`/`KlTlsCtx`. `kl_allocator_default()` is just static stdlib wrappers + `NULL` ctx, so one shared instance is correct and thread-safe.

## Verified
- Minimal `-d mysql` app: no more SIGSEGV; stdout (previously swallowed by the teardown crash) survives.
- Full MySQL jobs workflow runs clean.
- Unit tests **62/62** (incl. `cacert`/`smtp`/TLS); `e2e_jobs` **51/51**. The real-PG/MySQL + TLS phases in `e2e_postgres.sh`/`e2e_mysql.sh` exercise it in CI.
