### PR TITLE
jobs: soft per-key concurrency (claim-then-reconcile)

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -180,6 +180,37 @@ jobs.limit("reports", { rate: 100, per: 60 });
 - Costs one extra small DB write per claim **only on limited queues**; unlimited
   queues are unaffected.
 
+## Per-key concurrency
+
+Where a rate limit caps a whole queue's *dispatch rate*, per-key concurrency caps
+how many jobs sharing a **key** run *at the same time*. The key is per job, set at
+enqueue time, so it can be a static group or a dynamic value like a tenant id:
+
+```lua
+-- at most 2 report jobs for this tenant run concurrently, fleet-wide
+jobs.enqueue("report", data, { concurrency_key = "tenant-42", concurrency = 2 })
+```
+```javascript
+jobs.enqueue("report", data, { concurrencyKey: "tenant-42", concurrency: 2 });
+```
+
+- **Fleet-wide.** The cap is enforced in the DB across every worker, not
+  per-process.
+- **Claim-then-reconcile** (same shape as rate limiting): a claim that would put a
+  key over its limit releases the over-limit jobs back to `pending`, undoing the
+  claim so a held-back job keeps its full retry budget. As soon as a running job
+  of that key finishes, a held-back one becomes claimable. Priority and FIFO
+  order within the key are preserved (the release is ranked by claim age, so it
+  is deterministic fleet-wide - no two workers evict the same slot).
+- **Soft** semantics: correct under normal load, but two workers claiming the same
+  key in the same instant can briefly exceed the limit (there is no reservation
+  counter). Use it for *fairness / politeness* caps (don't let one tenant hog the
+  fleet, cap per-host outbound), not as a hard mutual-exclusion lock. A strict,
+  counter-backed variant is a planned opt-in follow-up.
+- Costs one small indexed DB read per claimed job **only for keyed jobs**;
+  unkeyed jobs are unaffected. Rate limiting and per-key concurrency compose (both
+  reconcile the same claim).
+
 ## Workflows (job dependencies)
 
 `jobs.enqueue(type, data, { depends_on = { id1, id2 } })` makes a job **wait
@@ -319,11 +350,13 @@ jobs.enqueue(type, data, {
     dedup_key    = "order-42", -- idempotent enqueue: a duplicate un-run key is a no-op
     throttle     = 60,         -- windowed: skip if a (queue,type) job was made in the last N s
     trace        = traceparent,-- W3C trace context; surfaced to the handler as job.trace
+    concurrency_key = "tenant-42", -- soft concurrency group (see Per-key concurrency)
+    concurrency     = 2,           -- max jobs of that group running at once
 })
 ```
 Returns the new job id, or `nil` when a `dedup_key` collapsed it (or a
 `throttle` window suppressed it). JS keys are camelCase (`runAt`, `maxAttempts`,
-`dedupKey`). `throttle` is best-effort (keyed by `(queue, type)`, no unique
+`dedupKey`, `concurrencyKey`). `throttle` is best-effort (keyed by `(queue, type)`, no unique
 constraint - use `dedup_key` for exact-once).
 
 **Bulk enqueue.** `jobs.enqueue_many(items)` (`enqueueMany` in JS) inserts a list

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -118,7 +118,11 @@ function init(opts) {
         "created_at   INTEGER      NOT NULL," +
         "updated_at   INTEGER      NOT NULL," +
         "progress     INTEGER      NOT NULL DEFAULT 0," +
-        "trace_context VARCHAR(255))");
+        "trace_context VARCHAR(255)," +
+        // Soft per-key concurrency (jobs.enqueue concurrencyKey/concurrency):
+        // at most `concurrency_limit` jobs sharing `concurrency_key` run at once.
+        "concurrency_key   VARCHAR(255)," +
+        "concurrency_limit INTEGER)");
 
     // Claim scan path: ready-to-run pending jobs in a queue, by priority then id.
     db.exec(
@@ -141,6 +145,12 @@ function init(opts) {
     db.exec(
         "CREATE INDEX IF NOT EXISTS idx_hull_jobs_throttle " +
         "ON _hull_jobs(queue, type, created_at)");
+
+    // Concurrency reconcile path: running jobs of a key, ranked by claim age.
+    // The claim-then-reconcile rank probe (concApply) scans this.
+    db.exec(
+        "CREATE INDEX IF NOT EXISTS idx_hull_jobs_conc " +
+        "ON _hull_jobs(concurrency_key, status, claimed_at, id)");
 
     // Durable cron schedules (jobs.cron). A worker atomically advances a due
     // row's next_run_at (compare-and-set) and enqueues, so exactly one worker
@@ -170,6 +180,8 @@ function init(opts) {
     };
     ensureColumn("_hull_jobs", "progress", "progress INTEGER NOT NULL DEFAULT 0");
     ensureColumn("_hull_jobs", "trace_context", "trace_context VARCHAR(255)");
+    ensureColumn("_hull_jobs", "concurrency_key", "concurrency_key VARCHAR(255)");
+    ensureColumn("_hull_jobs", "concurrency_limit", "concurrency_limit INTEGER");
     ensureColumn("_hull_cron", "tz_offset", "tz_offset INTEGER NOT NULL DEFAULT 0");
 
     // Fleet-wide rate-limit counters (jobs.limit). One row per limited queue;
@@ -344,7 +356,7 @@ function loadDeps(dependentId) {
  *
  * @param {string} jobType  handler dispatch key (non-empty)
  * @param {*} [data]        JSON-encodable payload (reaches the handler as job.data)
- * @param {object} [opts]   { queue, priority, delay, runAt, maxAttempts, dedupKey, dependsOn, onDepFailure }
+ * @param {object} [opts]   { queue, priority, delay, runAt, maxAttempts, dedupKey, dependsOn, onDepFailure, concurrencyKey, concurrency }
  * @returns {number|null}   the new job id, or null when a dedupKey collapsed it
  */
 function enqueue(jobType, data, opts) {
@@ -381,6 +393,13 @@ function enqueue(jobType, data, opts) {
     if (hasDeps) { cols.push("status"); vals.push("blocked"); }
     // Optional W3C trace context, carried through to the handler as job.trace.
     if (o.trace !== undefined && o.trace !== null) { cols.push("trace_context"); vals.push(o.trace); }
+    // Optional soft per-key concurrency: at most `concurrency` jobs sharing
+    // `concurrencyKey` run at once (enforced at claim via claim-then-reconcile).
+    if (o.concurrencyKey !== undefined && o.concurrencyKey !== null &&
+        o.concurrency && o.concurrency > 0) {
+        cols.push("concurrency_key");   vals.push(o.concurrencyKey);
+        cols.push("concurrency_limit"); vals.push(o.concurrency);
+    }
     let id;
     if (o.dedupKey !== undefined && o.dedupKey !== null) {
         const n = db.insertIfAbsent("_hull_jobs", ["queue", "dedup_key"], cols, vals);
@@ -514,6 +533,42 @@ function rlApply(queue, out) {
     return out.slice(0, granted);   // keep the top `granted`
 }
 
+// Soft per-key concurrency (claim-then-reconcile, mirroring rlApply). A just-
+// claimed job whose `concurrency_key` already has `concurrency_limit` running
+// peers ahead of it is released back to pending (its attempt undone). "Soft":
+// correct under normal load; may briefly overshoot when workers claim the same
+// key in the same instant (no reservation counter). A strict counter-backed cap
+// is the opt-in follow-up. `now` is the claim time (== claimed_at of every job
+// in `out`), so a job's rank counts only strictly-older running peers.
+function concApply(out, now) {
+    if (out.length === 0) return out;
+    const drop = new Set();
+    for (const j of out) {
+        const lim = j._concLimit;
+        if (j._concKey !== undefined && j._concKey !== null && lim && lim > 0) {
+            // Rank = running peers strictly ahead in (claimed_at, id) order. This
+            // ordering is fleet-wide deterministic, so no two workers evict the
+            // same slot: each keyed job keeps iff its rank is under the limit.
+            const r = db.query(
+                "SELECT COUNT(*) AS n FROM _hull_jobs " +
+                "WHERE concurrency_key=? AND status='running' " +
+                "AND (claimed_at < ? OR (claimed_at = ? AND id < ?))",
+                [j._concKey, now, now, j.id]);
+            const rank = (r[0] && r[0].n) || 0;
+            if (rank >= lim) drop.add(j.id);
+        }
+    }
+    if (drop.size === 0) return out;
+    const params = [now];
+    const ph = [];
+    for (const id of drop) { ph.push("?"); params.push(id); }
+    db.exec(
+        "UPDATE _hull_jobs SET status='pending', claim_token=NULL, claimed_at=NULL, " +
+        "attempts=attempts-1, updated_at=? WHERE id IN (" + ph.join(",") + ")",
+        params);
+    return out.filter((j) => !drop.has(j.id));
+}
+
 // Is `queue` paused? Reads the durable state at most once/second (cached), so
 // pausing never adds a DB read to the steady claim path.
 function isPaused(queue) {
@@ -627,7 +682,7 @@ function claimOne(queue, batch) {
             "attempts=attempts+1, updated_at=? WHERE id IN (" +
             "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? " +
             "ORDER BY priority DESC, id LIMIT ? " + lock + ") " +
-            "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at",
+            "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at, concurrency_key, concurrency_limit",
             [token, now, now, queue, now, batch]);
     } else if (d.supportsSkipLocked) {
         db.batch(() => {
@@ -644,7 +699,7 @@ function claimOne(queue, batch) {
                 params);
         });
         rows = db.query(
-            "SELECT id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at FROM _hull_jobs WHERE claim_token=?",
+            "SELECT id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at, concurrency_key, concurrency_limit FROM _hull_jobs WHERE claim_token=?",
             [token]);
     } else {
         rows = db.query(
@@ -652,7 +707,7 @@ function claimOne(queue, batch) {
             "attempts=attempts+1, updated_at=? WHERE id IN (" +
             "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? " +
             "ORDER BY priority DESC, id LIMIT ?) " +
-            "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at",
+            "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at, concurrency_key, concurrency_limit",
             [token, now, now, queue, now, batch]);
     }
 
@@ -663,10 +718,13 @@ function claimOne(queue, batch) {
         .map((r) => {
             const j = shape(r);
             j.claimToken = token;   // handle for jobs.heartbeat on long-running work
+            j._concKey   = r.concurrency_key;      // internal: concApply reconcile
+            j._concLimit = r.concurrency_limit;
             return j;
         });
-    // Enforce a fleet-wide rate limit (claim-then-reconcile; requeues the excess).
-    return rlApply(queue, out);
+    // Reconcile the claim: fleet-wide rate limit, then soft per-key concurrency.
+    // Both requeue the excess (claim-then-reconcile, mirroring each other).
+    return concApply(rlApply(queue, out), now);
 }
 
 /**

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -125,7 +125,11 @@ function jobs.init(opts)
         .. "created_at   INTEGER      NOT NULL,"
         .. "updated_at   INTEGER      NOT NULL,"
         .. "progress     INTEGER      NOT NULL DEFAULT 0,"
-        .. "trace_context VARCHAR(255))")
+        .. "trace_context VARCHAR(255),"
+        -- Soft per-key concurrency (jobs.enqueue concurrency_key/concurrency):
+        -- at most `concurrency_limit` jobs sharing `concurrency_key` run at once.
+        .. "concurrency_key   VARCHAR(255),"
+        .. "concurrency_limit INTEGER)")
 
     -- Claim scan path: ready-to-run pending jobs in a queue, by priority then id.
     db.exec([[
@@ -151,6 +155,13 @@ function jobs.init(opts)
     db.exec([[
         CREATE INDEX IF NOT EXISTS idx_hull_jobs_throttle
         ON _hull_jobs(queue, type, created_at)
+    ]])
+
+    -- Concurrency reconcile path: running jobs of a key, ranked by claim age.
+    -- The claim-then-reconcile rank probe (conc_apply) scans this.
+    db.exec([[
+        CREATE INDEX IF NOT EXISTS idx_hull_jobs_conc
+        ON _hull_jobs(concurrency_key, status, claimed_at, id)
     ]])
 
     -- Durable cron schedules (jobs.cron). A worker atomically advances a due
@@ -185,6 +196,8 @@ function jobs.init(opts)
     end
     ensure_column("_hull_jobs", "progress", "progress INTEGER NOT NULL DEFAULT 0")
     ensure_column("_hull_jobs", "trace_context", "trace_context VARCHAR(255)")
+    ensure_column("_hull_jobs", "concurrency_key", "concurrency_key VARCHAR(255)")
+    ensure_column("_hull_jobs", "concurrency_limit", "concurrency_limit INTEGER")
     ensure_column("_hull_cron", "tz_offset", "tz_offset INTEGER NOT NULL DEFAULT 0")
 
     -- Fleet-wide rate-limit counters (jobs.limit). One row per limited queue;
@@ -377,6 +390,8 @@ end
 -- @tparam[opt]    number opts.run_at        absolute unix ts (overrides delay)
 -- @tparam[opt]    number opts.max_attempts  overrides the module default
 -- @tparam[opt]    string opts.dedup_key     unique per queue; a duplicate enqueue is a no-op
+-- @tparam[opt]    string opts.concurrency_key  soft concurrency group (e.g. a tenant id)
+-- @tparam[opt]    number opts.concurrency      max jobs of that group running at once
 -- @treturn number|nil  the new job id, or nil when a dedup_key collapsed it
 function jobs.enqueue(job_type, data, opts)
     if type(job_type) ~= "string" or job_type == "" then
@@ -415,6 +430,12 @@ function jobs.enqueue(job_type, data, opts)
     -- Optional W3C trace context, carried through to the handler as job.trace.
     if opts.trace ~= nil then
         cols[#cols + 1] = "trace_context"; vals[#vals + 1] = opts.trace
+    end
+    -- Optional soft per-key concurrency: at most `concurrency` jobs sharing
+    -- `concurrency_key` run at once (enforced at claim via claim-then-reconcile).
+    if opts.concurrency_key ~= nil and opts.concurrency and opts.concurrency > 0 then
+        cols[#cols + 1] = "concurrency_key";   vals[#vals + 1] = opts.concurrency_key
+        cols[#cols + 1] = "concurrency_limit"; vals[#vals + 1] = opts.concurrency
     end
     local id
     if opts.dedup_key ~= nil then
@@ -656,6 +677,43 @@ local function resolve_queue_order(opts)
     return order
 end
 
+-- Soft per-key concurrency (claim-then-reconcile, mirroring rl_apply). A just-
+-- claimed job whose `concurrency_key` already has `concurrency_limit` running
+-- peers ahead of it is released back to pending (its attempt undone). "Soft":
+-- correct under normal load; may briefly overshoot when workers claim the same
+-- key in the same instant (no reservation counter). A strict counter-backed cap
+-- is the opt-in follow-up. `now` is the claim time (== claimed_at of every job
+-- in `out`), so a job's rank counts only strictly-older running peers.
+local function conc_apply(out, now)
+    if #out == 0 then return out end
+    local drop = {}
+    for _, j in ipairs(out) do
+        local lim = j._conc_limit
+        if j._conc_key ~= nil and lim and lim > 0 then
+            -- Rank = running peers strictly ahead in (claimed_at, id) order. This
+            -- ordering is fleet-wide deterministic, so no two workers evict the
+            -- same slot: each keyed job keeps iff its rank is under the limit.
+            local r = db.query(
+                "SELECT COUNT(*) AS n FROM _hull_jobs "
+                .. "WHERE concurrency_key=? AND status='running' "
+                .. "AND (claimed_at < ? OR (claimed_at = ? AND id < ?))",
+                { j._conc_key, now, now, j.id })
+            local rank = (r and r[1] and r[1].n) or 0
+            if rank >= lim then drop[j.id] = true end
+        end
+    end
+    if next(drop) == nil then return out end
+    local ph, params = {}, { now }
+    for id in pairs(drop) do ph[#ph + 1] = "?"; params[#params + 1] = id end
+    db.exec(
+        "UPDATE _hull_jobs SET status='pending', claim_token=NULL, claimed_at=NULL, "
+        .. "attempts=attempts-1, updated_at=? WHERE id IN (" .. table.concat(ph, ",") .. ")",
+        params)
+    local kept = {}
+    for _, j in ipairs(out) do if not drop[j.id] then kept[#kept + 1] = j end end
+    return kept
+end
+
 -- Claim up to `batch` ready jobs from ONE queue (the per-backend atomic claim).
 local function claim_one(queue, batch)
     if is_paused(queue) then return {} end   -- paused: don't dispatch
@@ -676,7 +734,7 @@ local function claim_one(queue, batch)
             .. "attempts=attempts+1, updated_at=? WHERE id IN ("
             .. "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? "
             .. "ORDER BY priority DESC, id LIMIT ? " .. lock .. ") "
-            .. "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at",
+            .. "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at, concurrency_key, concurrency_limit",
             { token, now, now, queue, now, batch })
     elseif d.supports_skip_locked then
         -- MySQL: no RETURNING. Lock + mark in one txn, then read back by token.
@@ -694,7 +752,7 @@ local function claim_one(queue, batch)
                 params)
         end)
         rows = db.query(
-            "SELECT id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at FROM _hull_jobs WHERE claim_token=?",
+            "SELECT id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at, concurrency_key, concurrency_limit FROM _hull_jobs WHERE claim_token=?",
             { token })
     else
         -- SQLite: single-writer serializes the claim, so the marked-running rows
@@ -704,7 +762,7 @@ local function claim_one(queue, batch)
             .. "attempts=attempts+1, updated_at=? WHERE id IN ("
             .. "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? "
             .. "ORDER BY priority DESC, id LIMIT ?) "
-            .. "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at",
+            .. "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at, concurrency_key, concurrency_limit",
             { token, now, now, queue, now, batch })
     end
 
@@ -722,10 +780,13 @@ local function claim_one(queue, batch)
     for _, r in ipairs(rows) do
         local j = shape(r)
         j.claim_token = token   -- handle for jobs.heartbeat on long-running work
+        j._conc_key   = r.concurrency_key      -- internal: conc_apply reconcile
+        j._conc_limit = r.concurrency_limit
         out[#out + 1] = j
     end
-    -- Enforce a fleet-wide rate limit (claim-then-reconcile; requeues the excess).
-    return rl_apply(queue, out)
+    -- Reconcile the claim: fleet-wide rate limit, then soft per-key concurrency.
+    -- Both requeue the excess (claim-then-reconcile, mirroring each other).
+    return conc_apply(rl_apply(queue, out), now)
 end
 
 --- Atomically claim up to `batch` ready jobs, marking them `running`.

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -33,7 +33,7 @@ FAIL=0
 pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
 fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1${2:+ - $2}"; }
 
-EXPECT_COLS="id,queue,type,payload,status,priority,attempts,max_attempts,run_at,claim_token,claimed_at,dedup_key,last_error,created_at,updated_at,progress,trace_context"
+EXPECT_COLS="id,queue,type,payload,status,priority,attempts,max_attempts,run_at,claim_token,claimed_at,dedup_key,last_error,created_at,updated_at,progress,trace_context,concurrency_key,concurrency_limit"
 
 # ── Phase 1: init + schema; Phase 2: correctness round-trip (both runtimes) ──
 check_runtime() {
@@ -593,6 +593,76 @@ app.main(async (ctx) => {
 
 echo "== v1.2 rate limit: Lua =="; check_rl "lua" "lua" "$LUA_RL"
 echo "== v1.2 rate limit: JS =="; check_rl "js" "js" "$JS_RL"
+
+# ── soft per-key concurrency ────────────────────────────────────────────────
+# The claim caps how many jobs sharing a concurrency_key run at once (soft:
+# claim-then-reconcile, releasing the over-limit ones back to pending with the
+# attempt undone). Part 1 asserts the cap + held-back requeue; Part 2 asserts a
+# freed slot lets a held job run (drained via jobs.work).
+check_perkey_conc() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"PKC a=2 b=1 none=1 held=2 held_att=0 drained=3"*)
+            pass "$label: per-key concurrency (cap + held requeue + slot reuse)" ;;
+        *) fail "$label: soft per-key concurrency" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_PKC='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init()
+  -- Part 1: the claim cap. Jobs stay running (manual claim, never completed).
+  for i=1,3 do jobs.enqueue("t",{},{concurrency_key="A",concurrency=2}) end
+  for i=1,2 do jobs.enqueue("t",{},{concurrency_key="B",concurrency=1}) end
+  jobs.enqueue("t",{})
+  local c1 = jobs.claim({ batch = 10 })
+  local a,b,none = 0,0,0
+  for _,j in ipairs(c1) do
+    if j._conc_key=="A" then a=a+1 elseif j._conc_key=="B" then b=b+1 else none=none+1 end
+  end
+  local held, held_att = 0, 0
+  for id=1,6 do local g=jobs.get(id)
+    if g and g.status=="pending" then held=held+1; held_att=held_att+g.attempts end
+  end
+  -- Part 2: slot reuse. Fresh key C (limit 2), 3 jobs, drained via work(): the
+  -- 3rd only runs once one of the first two completes and frees its slot.
+  jobs.handler("tc", function(j) return end)
+  for i=1,3 do jobs.enqueue("tc",{},{concurrency_key="C",concurrency=2}) end
+  for _=1,5 do jobs.work({ batch = 10 }) end
+  local drained = 0
+  for id=7,9 do local g=jobs.get(id); if g and g.status=="done" then drained=drained+1 end end
+  ctx.stdout:write(("PKC a=%d b=%d none=%d held=%d held_att=%d drained=%d\n"):format(
+    a,b,none,held,held_att,drained))
+  return 0
+end)'
+
+JS_PKC='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init();
+  for (let i=0;i<3;i++) jobs.enqueue("t",{},{concurrencyKey:"A",concurrency:2});
+  for (let i=0;i<2;i++) jobs.enqueue("t",{},{concurrencyKey:"B",concurrency:1});
+  jobs.enqueue("t",{});
+  const c1 = jobs.claim({ batch: 10 });
+  let a=0,b=0,none=0;
+  for (const j of c1) { if (j._concKey==="A") a++; else if (j._concKey==="B") b++; else none++; }
+  let held=0, heldAtt=0;
+  for (let id=1; id<=6; id++) { const g=jobs.get(id); if (g && g.status==="pending") { held++; heldAtt+=g.attempts; } }
+  jobs.handler("tc", (j) => {});
+  for (let i=0;i<3;i++) jobs.enqueue("tc",{},{concurrencyKey:"C",concurrency:2});
+  for (let k=0;k<5;k++) await jobs.work({ batch: 10 });
+  let drained=0;
+  for (let id=7; id<=9; id++) { const g=jobs.get(id); if (g && g.status==="done") drained++; }
+  ctx.stdout.write(`PKC a=${a} b=${b} none=${none} held=${held} held_att=${heldAtt} drained=${drained}\n`);
+  return 0;
+});'
+
+echo "== soft per-key concurrency: Lua =="; check_perkey_conc "lua" "lua" "$LUA_PKC"
+echo "== soft per-key concurrency: JS  =="; check_perkey_conc "js"  "js"  "$JS_PKC"
 
 # ── v1.3: queue pause / resume / purge ──────────────────────────────────────
 # A paused queue is not claimed; resume restores it; purge deletes pending.


### PR DESCRIPTION
## Soft per-key concurrency

Caps how many jobs sharing a **key** run at the same time (fleet-wide), where `jobs.limit` caps a queue's dispatch *rate*. The key is per job, set at enqueue, so it can be a static group or a dynamic tenant id:

```lua
jobs.enqueue("report", data, { concurrency_key = "tenant-42", concurrency = 2 })
```
```javascript
jobs.enqueue("report", data, { concurrencyKey: "tenant-42", concurrency: 2 });
```

### How
- Enforced at the claim with the **same claim-then-reconcile shape as `jobs.limit`** (`conc_apply` runs after the atomic claim, mirroring `rl_apply`) - so the atomic claim SQL is untouched and unkeyed jobs pay nothing.
- A claim that would put a key over its limit releases the over-limit jobs back to `pending`, undoing the attempt (held jobs keep their full retry budget). The release is ranked by `(claimed_at, id)` - deterministic fleet-wide, so no two workers evict the same slot. A freed slot lets the next held job run.
- **Soft**: correct under normal load; two workers claiming the same key in the same instant can briefly overshoot (no reservation counter). Right for fairness / politeness caps, not hard mutual exclusion. A strict counter-backed opt-in is the planned follow-up (the "soft now, strict later" plan).

### Schema
Two nullable columns (`concurrency_key`, `concurrency_limit`) + one reconcile index, added idempotently for pre-existing DBs (`ensure_column`).

### Tests
New `e2e_jobs.sh` phase (both runtimes) asserting the cap, the held-back requeue (attempt undone), and slot reuse via `jobs.work`. PG/MySQL run the same reconcile SQL and are covered by `e2e_postgres` / `e2e_mysql`. `EXPECT_COLS` updated for the two new columns. luacheck clean.

Part of (c); workflow versioning (`ctx.patched`) follows in a separate PR.
