### PR TITLE
jobs: workflow versioning via ctx.patched (Temporal-style patching)

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -319,6 +319,43 @@ const wf = jobs.start("checkout", { orderId: 42, amount: 100 });
   steps_done, result?, error? }`, DB-derived (works even when no worker is
   running it). Fetch the final value with `jobs.await(id)` / `jobs.result(id)`.
 
+### Versioning changed workflows (`ctx.patched`)
+
+A workflow instance runs to completion on the definition it *started* with, but
+your code changes while instances are still in flight (parked on a sleep or
+signal, or mid-retry). Changing a step's key or reordering steps would break
+those instances on resume - their recorded history no longer matches the new
+body. `ctx.patched` (Temporal's patching model) lets you branch old-vs-new so
+both cohorts stay correct:
+
+```lua
+if ctx.patched("use-v2-pricing") then
+    price = ctx.step("price_v2", compute_v2)   -- new instances
+else
+    price = ctx.step("price_v1", compute_v1)   -- instances already past this point
+end
+```
+```javascript
+const price = ctx.patched("use-v2-pricing")
+    ? await ctx.step("price_v2", computeV2)
+    : await ctx.step("price_v1", computeV1);
+```
+
+- `ctx.patched(patchId)` returns a boolean and takes **no `await`** (JS).
+- An instance that **already executed past this point** under the old definition
+  returns `false` (keeps the old branch). A **new** instance - or one that hadn't
+  yet reached this point - returns `true` (adopts the patch) and records the
+  decision, so every later resume of that instance stays on the new branch.
+- **Call `ctx.patched(patchId)` once per `patchId`.** Capture the result in a
+  local; don't call it twice.
+- **Rollout / deprecation.** Ship the patched code with **both** branches and
+  keep them until every pre-patch instance has drained (watch
+  `jobs.workflow_status` / `jobs.metrics`). Once none remain, you may delete the
+  old branch and the `ctx.patched` call and inline the new code - a fully-drained
+  patch is inert (the recorded markers are harmless).
+- It is durable and backend-portable (the decision lives in the step store, same
+  as `ctx.step`); no schema change.
+
 ## Handler contract
 
 `jobs.work` dispatches each claimed job to its registered handler, else the

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -1561,6 +1561,26 @@ async function runCompensations(comps, workflowId) {
 function makeCtx(job, name) {
     let sleepN = 0, detN = 0;
     const comps = [];
+    // Workflow versioning (Temporal-style patching). `frontier` = how many
+    // step-family rows this instance had recorded when THIS run began; `stepPos`
+    // counts the step-family ops executed so far this run. Sleep / wait-deadline
+    // rows are excluded from both (control rows, not body positions), so the two
+    // stay aligned regardless of how a workflow interleaves sleeps. ctx.patched
+    // compares them to decide old-vs-new (see below).
+    let stepPos = 0;
+    const frontier = (() => {
+        // Exclude the sleep / wait-deadline control rows with a prefix compare, not
+        // LIKE: '__sleep:' / '__waitdl:' contain '_' (a LIKE wildcard) and no
+        // portable ESCAPE clause exists - MySQL processes backslash escapes at the
+        // string-literal level, and "ESCAPE '\'" there is a mangled quote. substr
+        // prefix compare is wildcard-free and identical on SQLite / PG / MySQL.
+        const r = db.query(
+            "SELECT COUNT(*) AS n FROM _hull_workflow_steps WHERE workflow_id=? " +
+            "AND substr(step_key, 1, 8) <> '__sleep:' " +
+            "AND substr(step_key, 1, 9) <> '__waitdl:'",
+            [job.id]);
+        return (r[0] && r[0].n) || 0;
+    })();
     return {
         id: job.id,
         name,
@@ -1572,16 +1592,42 @@ function makeCtx(job, name) {
         // replay and break memo-key matching. These memoize via the step store, so
         // now / random / uuid return the SAME value on every replay - the supported
         // way to be non-deterministic in a workflow. Hidden from steps_done.
-        now: () => { detN += 1; return runStep(job.id, "__now:" + detN, () => time.now()); },
-        random: () => { detN += 1; return runStep(job.id, "__rand:" + detN, () => Math.random()); },
-        uuid: () => { detN += 1; return runStep(job.id, "__uuid:" + detN, () => crypto.base64urlEncode(crypto.random(16))); },
+        now: () => { detN += 1; stepPos += 1; return runStep(job.id, "__now:" + detN, () => time.now()); },
+        random: () => { detN += 1; stepPos += 1; return runStep(job.id, "__rand:" + detN, () => Math.random()); },
+        uuid: () => { detN += 1; stepPos += 1; return runStep(job.id, "__uuid:" + detN, () => crypto.base64urlEncode(crypto.random(16))); },
         step: async (stepKey, fn, opts) => {
+            stepPos += 1;
             const result = await runStep(job.id, stepKey, fn);
             if (opts && typeof opts.compensate === "function") comps.push({ key: stepKey, fn: opts.compensate });
             return result;
         },
         sleep: (seconds) => { sleepN += 1; return runSleep(job.id, sleepN, seconds); },
         waitSignal: (signalName, opts) => runWaitSignal(job.id, signalName, opts),
+        // Workflow versioning: ctx.patched(patchId) lets a changed workflow branch
+        // old-vs-new so in-flight instances finish on the definition they started.
+        // Call it ONCE per patchId (no await - returns a boolean). Semantics:
+        //   * marker already recorded for this instance -> true (memoized).
+        //   * undecided AND inside the already-recorded prefix (stepPos < frontier)
+        //     -> ran past here under the OLD definition: keep old branch, return
+        //     false, record nothing.
+        //   * undecided AND at/after the frontier -> reached fresh: adopt the
+        //     patch, record it true so every later resume returns true.
+        patched: (patchId) => {
+            if (typeof patchId !== "string" || patchId === "")
+                throw new Error("ctx.patched: patchId must be a non-empty string");
+            const key = "__patch:" + patchId;
+            const rows = db.query(
+                "SELECT status FROM _hull_workflow_steps WHERE workflow_id=? AND step_key=?",
+                [job.id, key]);
+            if (rows.length) { stepPos += 1; return true; }   // marker: only ever true
+            if (stepPos < frontier) return false;             // replaying old prefix
+            stepPos += 1;
+            db.exec(
+                "INSERT INTO _hull_workflow_steps (workflow_id, step_key, result, status, created_at) " +
+                "VALUES (?, ?, ?, 'done', ?)",
+                [job.id, key, json.encode(true), time.now()]);
+            return true;
+        },
     };
 }
 

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -1676,7 +1676,28 @@ local function make_ctx(job, name)
         trace = job.trace,   -- trace-context propagation (observability design)
         _comps = comps,
     }
+    -- Workflow versioning (Temporal-style patching). `frontier` = how many
+    -- step-family rows this instance had recorded when THIS run began; `step_pos`
+    -- counts the step-family ops executed so far this run. Sleep / wait-deadline
+    -- rows are excluded from both (they are control rows, not body positions), so
+    -- the two stay aligned regardless of how a workflow interleaves sleeps.
+    -- ctx.patched compares them to decide old-vs-new (see below).
+    local step_pos = 0
+    local frontier = (function()
+        -- Exclude the sleep / wait-deadline control rows with a prefix compare, not
+        -- LIKE: '__sleep:' / '__waitdl:' contain '_' (a LIKE wildcard) and no
+        -- portable ESCAPE clause exists - MySQL processes backslash escapes at the
+        -- string-literal level, and "ESCAPE '\'" there is a mangled quote. substr
+        -- prefix compare is wildcard-free and identical on SQLite / PG / MySQL.
+        local r = db.query(
+            "SELECT COUNT(*) AS n FROM _hull_workflow_steps WHERE workflow_id=? "
+            .. "AND substr(step_key, 1, 8) <> '__sleep:' "
+            .. "AND substr(step_key, 1, 9) <> '__waitdl:'",
+            { job.id })
+        return (r and r[1] and r[1].n) or 0
+    end)()
     ctx.step = function(step_key, fn, opts)
+        step_pos = step_pos + 1
         local result = run_step(job.id, step_key, fn)
         if opts and type(opts.compensate) == "function" then
             comps[#comps + 1] = { key = step_key, fn = opts.compensate }
@@ -1697,17 +1718,50 @@ local function make_ctx(job, name)
     -- stable across replays); the keys are hidden from workflow_status.steps_done.
     local det_n = 0
     ctx.now = function()
-        det_n = det_n + 1
+        det_n = det_n + 1; step_pos = step_pos + 1
         return run_step(job.id, "__now:" .. det_n, function() return time.now() end)
     end
     ctx.random = function()
-        det_n = det_n + 1
+        det_n = det_n + 1; step_pos = step_pos + 1
         return run_step(job.id, "__rand:" .. det_n, function() return math.random() end)
     end
     ctx.uuid = function()
-        det_n = det_n + 1
+        det_n = det_n + 1; step_pos = step_pos + 1
         return run_step(job.id, "__uuid:" .. det_n,
             function() return crypto.base64url_encode(crypto.random(16)) end)
+    end
+    -- Workflow versioning: ctx.patched(patch_id) lets a changed workflow branch
+    -- old-vs-new so in-flight instances finish on the definition they started.
+    -- Call it ONCE per patch_id. Semantics (see frontier/step_pos above):
+    --   * marker already recorded for this instance -> true (memoized).
+    --   * undecided AND this point falls inside the already-recorded prefix
+    --     (step_pos < frontier) -> the instance ran past here under the OLD
+    --     definition, so keep the old branch: return false, record nothing.
+    --   * undecided AND at/after the frontier -> reached fresh: adopt the patch,
+    --     record it true so every later resume returns true.
+    -- Result: instances already past the patch point keep old behavior; new ones
+    -- (and instances not yet at the patch point) adopt it.
+    ctx.patched = function(patch_id)
+        if type(patch_id) ~= "string" or patch_id == "" then
+            error("ctx.patched: patch_id must be a non-empty string")
+        end
+        local key = "__patch:" .. patch_id
+        local rows = db.query(
+            "SELECT status FROM _hull_workflow_steps WHERE workflow_id=? AND step_key=?",
+            { job.id, key })
+        if rows and #rows > 0 then
+            step_pos = step_pos + 1   -- the marker occupies one recorded position
+            return true               -- markers are only ever recorded true
+        end
+        if step_pos < frontier then
+            return false              -- replaying an old prefix: keep old branch
+        end
+        step_pos = step_pos + 1
+        db.exec(
+            "INSERT INTO _hull_workflow_steps (workflow_id, step_key, result, status, created_at) "
+            .. "VALUES (?, ?, ?, 'done', ?)",
+            { job.id, key, json.encode(true), time.now() })
+        return true
     end
     return ctx
 end

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -1347,6 +1347,90 @@ app.main(async (ctx) => {
 echo "== durable determinism (Phase 2): Lua =="; check_deterministic "lua" "lua" "$LUA_DET"
 echo "== durable determinism (Phase 2): JS =="; check_deterministic "js" "js" "$JS_DET"
 
+# ── workflow versioning (Temporal-style patching) ───────────────────────────
+# An instance that already ran past a patch point under the OLD definition keeps
+# the old branch; a new instance (and one not yet at the point) adopts the patch.
+# Signal-driven parking makes the resume deterministic (no wall-clock sleeps): I1
+# records s1,s2 under v1 then parks; v2 inserts ctx.patched before that step, so
+# I1 resumes on the OLD branch (s2) while a fresh I2 takes the NEW branch (s2b).
+check_patched() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"PATCH i1=old steps1=[s1,s2] i2=new steps2=[s1,s2b]"*)
+            pass "$label: workflow patching (old instance keeps old branch, new adopts)" ;;
+        *) fail "$label: workflow patching" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_PATCH='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init()
+  jobs.workflow("wf", function(w)
+    w.step("s1", function() return "a" end)
+    w.step("s2", function() return "old-step" end)
+    w.wait_signal("go")
+    return "v1"
+  end)
+  local i1 = jobs.start("wf", {})
+  jobs.work({ batch = 10 })                       -- I1 records s1,s2; parks on go
+  jobs.workflow("wf", function(w)                 -- redeploy v2: patch before s2
+    w.step("s1", function() return "a" end)
+    local p = w.patched("p1")
+    if p then w.step("s2b", function() return "new-step" end)
+    else      w.step("s2",  function() return "old-step" end) end
+    w.wait_signal("go")
+    return p and "new" or "old"
+  end)
+  local i2 = jobs.start("wf", {})
+  jobs.work({ batch = 10 })                       -- I2 (fresh) adopts the patch
+  jobs.signal(i1, "go"); jobs.signal(i2, "go")
+  jobs.work({ batch = 10 }); jobs.work({ batch = 10 })
+  local r1 = jobs.result(i1).result
+  local r2 = jobs.result(i2).result
+  local s1 = table.concat(jobs.workflow_status(i1).steps_done, ",")
+  local s2 = table.concat(jobs.workflow_status(i2).steps_done, ",")
+  ctx.stdout:write(("PATCH i1=%s steps1=[%s] i2=%s steps2=[%s]\n"):format(r1, s1, r2, s2))
+  return 0
+end)'
+
+JS_PATCH='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init();
+  jobs.workflow("wf", async (w) => {
+    await w.step("s1", () => "a");
+    await w.step("s2", () => "old-step");
+    await w.waitSignal("go");
+    return "v1";
+  });
+  const i1 = jobs.start("wf", {});
+  await jobs.work({ batch: 10 });
+  jobs.workflow("wf", async (w) => {
+    await w.step("s1", () => "a");
+    const p = w.patched("p1");
+    if (p) await w.step("s2b", () => "new-step");
+    else   await w.step("s2",  () => "old-step");
+    await w.waitSignal("go");
+    return p ? "new" : "old";
+  });
+  const i2 = jobs.start("wf", {});
+  await jobs.work({ batch: 10 });
+  jobs.signal(i1, "go"); jobs.signal(i2, "go");
+  await jobs.work({ batch: 10 }); await jobs.work({ batch: 10 });
+  const r1 = jobs.result(i1).result, r2 = jobs.result(i2).result;
+  const s1 = jobs.workflowStatus(i1).stepsDone.join(",");
+  const s2 = jobs.workflowStatus(i2).stepsDone.join(",");
+  ctx.stdout.write(`PATCH i1=${r1} steps1=[${s1}] i2=${r2} steps2=[${s2}]\n`);
+  return 0;
+});'
+
+echo "== workflow patching: Lua =="; check_patched "lua" "lua" "$LUA_PATCH"
+echo "== workflow patching: JS  =="; check_patched "js"  "js"  "$JS_PATCH"
+
 # ── observability Bet #1 Pillar A+C: jobs.metrics gauges + trace propagation ─
 # metrics() returns DB-derived per-queue gauges (pending/dead + backlog age) and
 # totals; a job enqueued with { trace } surfaces job.trace in the handler.


### PR DESCRIPTION
## Workflow versioning via `ctx.patched` (Temporal-style patching)

Stacked on #256 (per-key concurrency); the last commit is this PR's change. Part (c) of the jobs follow-ups.

A durable workflow instance runs to completion on the definition it *started* with, but the code changes while instances are still in flight (parked on a sleep/signal, or mid-retry). Reordering or re-keying a step breaks those instances on resume - their recorded history no longer matches the new body. `ctx.patched(patchId)` lets a changed workflow branch old-vs-new:

```lua
if ctx.patched("use-v2-pricing") then
    ctx.step("price_v2", compute_v2)   -- new instances
else
    ctx.step("price_v1", compute_v1)   -- instances already past here
end
```
```javascript
const p = ctx.patched("use-v2-pricing");   // no await; returns a boolean
```

### Semantics
- An instance that **already executed past the patch point** under the old definition returns `false` (keeps the old branch). A **new** instance - or one not yet at the point - returns `true`, adopts the patch, and records the decision so every later resume stays on the new branch.
- Call `ctx.patched(patchId)` **once per patchId**.

### How (no replay flag)
`makeCtx` derives old-vs-new from the durable step store:
- `frontier` = count of step-family rows recorded when this run began (sleep / wait-deadline control rows excluded via `NOT LIKE ... ESCAPE`, so the count is body-position-aligned regardless of interleaved sleeps).
- `stepPos` = step-family ops executed so far this run.
- patch position `< frontier` → ran past here already → `false` (records nothing, so the frontier is never perturbed); `>= frontier` → fresh → record `true`.

Durable + backend-portable (no schema change; the marker is a step row, hidden from `workflow_status.steps_done` like the deterministic primitives).

### Tests
New `e2e_jobs.sh` phase (both runtimes), driven **signal-first** so the resume is deterministic (no wall-clock sleeps): I1 records `s1,s2` under v1 and parks; v2 inserts `ctx.patched` before that step; I1 resumes on the **old** branch (`s2`) while a fresh I2 takes the **new** branch (`s2b`). luacheck clean. Docs cover the rollout/deprecation workflow (keep both branches until pre-patch instances drain).
