### PR TITLE
jobs: strict per-key concurrency (counter-backed hard cap)

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -202,14 +202,30 @@ jobs.enqueue("report", data, { concurrencyKey: "tenant-42", concurrency: 2 });
   of that key finishes, a held-back one becomes claimable. Priority and FIFO
   order within the key are preserved (the release is ranked by claim age, so it
   is deterministic fleet-wide - no two workers evict the same slot).
-- **Soft** semantics: correct under normal load, but two workers claiming the same
-  key in the same instant can briefly exceed the limit (there is no reservation
-  counter). Use it for *fairness / politeness* caps (don't let one tenant hog the
-  fleet, cap per-host outbound), not as a hard mutual-exclusion lock. A strict,
-  counter-backed variant is a planned opt-in follow-up.
-- Costs one small indexed DB read per claimed job **only for keyed jobs**;
-  unkeyed jobs are unaffected. Rate limiting and per-key concurrency compose (both
-  reconcile the same claim).
+- **Soft** (the default): correct under normal load, but two workers claiming the
+  same key in the same instant can briefly exceed the limit (there is no
+  reservation counter). Right for *fairness / politeness* caps (don't let one
+  tenant hog the fleet, cap per-host outbound), not hard mutual exclusion.
+- **Strict** (opt in with `concurrency_strict = true` / `concurrencyStrict: true`):
+  a **hard cap, no overshoot**. Each claim atomically reserves a slot in a
+  fleet-wide counter (`n < limit`), so N racing workers admit *exactly* the limit,
+  never more:
+
+  ```lua
+  jobs.enqueue("charge", data, { concurrency_key = "acct-7", concurrency = 1,
+                                 concurrency_strict = true })   -- serialize per account
+  ```
+
+  The slot is released whenever the job leaves `running` (done / dead / retry /
+  workflow yield), and the reaper reconciles the counter to the true running count
+  every sweep, so a crashed worker can't permanently leak a slot (it self-heals,
+  briefly *under*-utilizing until the next reap - the safe direction for a hard
+  cap). All jobs of a key should agree on the strict flag. Strict trades one small
+  transactional counter update per claim/completion for the guarantee; soft is a
+  single indexed read. Use strict when correctness needs a true cap (per-account
+  serialization, a license-limited external resource); soft for politeness.
+- Costs are per-keyed-job only; unkeyed jobs are unaffected. Rate limiting and
+  per-key concurrency compose (both reconcile the same claim).
 
 ## Workflows (job dependencies)
 
@@ -387,13 +403,14 @@ jobs.enqueue(type, data, {
     dedup_key    = "order-42", -- idempotent enqueue: a duplicate un-run key is a no-op
     throttle     = 60,         -- windowed: skip if a (queue,type) job was made in the last N s
     trace        = traceparent,-- W3C trace context; surfaced to the handler as job.trace
-    concurrency_key = "tenant-42", -- soft concurrency group (see Per-key concurrency)
+    concurrency_key = "tenant-42", -- concurrency group (see Per-key concurrency)
     concurrency     = 2,           -- max jobs of that group running at once
+    concurrency_strict = true,     -- hard cap (counter-backed); omit for soft
 })
 ```
 Returns the new job id, or `nil` when a `dedup_key` collapsed it (or a
 `throttle` window suppressed it). JS keys are camelCase (`runAt`, `maxAttempts`,
-`dedupKey`, `concurrencyKey`). `throttle` is best-effort (keyed by `(queue, type)`, no unique
+`dedupKey`, `concurrencyKey`, `concurrencyStrict`). `throttle` is best-effort (keyed by `(queue, type)`, no unique
 constraint - use `dedup_key` for exact-once).
 
 **Bulk enqueue.** `jobs.enqueue_many(items)` (`enqueueMany` in JS) inserts a list

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -119,10 +119,12 @@ function init(opts) {
         "updated_at   INTEGER      NOT NULL," +
         "progress     INTEGER      NOT NULL DEFAULT 0," +
         "trace_context VARCHAR(255)," +
-        // Soft per-key concurrency (jobs.enqueue concurrencyKey/concurrency):
-        // at most `concurrency_limit` jobs sharing `concurrency_key` run at once.
-        "concurrency_key   VARCHAR(255)," +
-        "concurrency_limit INTEGER)");
+        // Per-key concurrency (jobs.enqueue concurrencyKey/concurrency): at most
+        // `concurrency_limit` jobs sharing `concurrency_key` run at once. `strict`
+        // (1) opts into the counter-backed hard cap; NULL/0 is the soft default.
+        "concurrency_key    VARCHAR(255)," +
+        "concurrency_limit  INTEGER," +
+        "concurrency_strict INTEGER)");
 
     // Claim scan path: ready-to-run pending jobs in a queue, by priority then id.
     db.exec(
@@ -182,6 +184,7 @@ function init(opts) {
     ensureColumn("_hull_jobs", "trace_context", "trace_context VARCHAR(255)");
     ensureColumn("_hull_jobs", "concurrency_key", "concurrency_key VARCHAR(255)");
     ensureColumn("_hull_jobs", "concurrency_limit", "concurrency_limit INTEGER");
+    ensureColumn("_hull_jobs", "concurrency_strict", "concurrency_strict INTEGER");
     ensureColumn("_hull_cron", "tz_offset", "tz_offset INTEGER NOT NULL DEFAULT 0");
 
     // Fleet-wide rate-limit counters (jobs.limit). One row per limited queue;
@@ -192,6 +195,16 @@ function init(opts) {
         "window_start INTEGER      NOT NULL," +
         "n            INTEGER      NOT NULL)");
     _rlLock = db.backendName === "sqlite" ? "" : " FOR UPDATE";
+
+    // Strict per-key concurrency counter (jobs.enqueue concurrencyStrict). One
+    // row per strict key: `n` running slots reserved. A claim atomically reserves
+    // (n < limit -> n+1), work() releases on any exit from running, and the reaper
+    // reconciles `n` to the true running count so a crashed worker can't leak a
+    // slot. `name` (not the reserved word `key`) mirrors _hull_ratelimit.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_job_concurrency (" +
+        "name VARCHAR(255) NOT NULL PRIMARY KEY," +
+        "n    INTEGER      NOT NULL DEFAULT 0)");
 
     // Durable per-queue pause state (jobs.pause / resume). A paused queue is not
     // claimed (workers skip it); fleet-wide (in the DB) and restart-durable.
@@ -393,12 +406,15 @@ function enqueue(jobType, data, opts) {
     if (hasDeps) { cols.push("status"); vals.push("blocked"); }
     // Optional W3C trace context, carried through to the handler as job.trace.
     if (o.trace !== undefined && o.trace !== null) { cols.push("trace_context"); vals.push(o.trace); }
-    // Optional soft per-key concurrency: at most `concurrency` jobs sharing
-    // `concurrencyKey` run at once (enforced at claim via claim-then-reconcile).
+    // Optional per-key concurrency: at most `concurrency` jobs sharing
+    // `concurrencyKey` run at once. Soft (default) reconciles at claim (may
+    // briefly overshoot); `concurrencyStrict: true` opts into the counter-backed
+    // hard cap. All jobs of a key should agree on the strict flag.
     if (o.concurrencyKey !== undefined && o.concurrencyKey !== null &&
         o.concurrency && o.concurrency > 0) {
         cols.push("concurrency_key");   vals.push(o.concurrencyKey);
         cols.push("concurrency_limit"); vals.push(o.concurrency);
+        if (o.concurrencyStrict) { cols.push("concurrency_strict"); vals.push(1); }
     }
     let id;
     if (o.dedupKey !== undefined && o.dedupKey !== null) {
@@ -533,29 +549,59 @@ function rlApply(queue, out) {
     return out.slice(0, granted);   // keep the top `granted`
 }
 
-// Soft per-key concurrency (claim-then-reconcile, mirroring rlApply). A just-
-// claimed job whose `concurrency_key` already has `concurrency_limit` running
-// peers ahead of it is released back to pending (its attempt undone). "Soft":
-// correct under normal load; may briefly overshoot when workers claim the same
-// key in the same instant (no reservation counter). A strict counter-backed cap
-// is the opt-in follow-up. `now` is the claim time (== claimed_at of every job
-// in `out`), so a job's rank counts only strictly-older running peers.
+// Atomically reserve one STRICT-concurrency slot for `key`: bump n iff n < limit.
+// Returns true when reserved. Mirrors rlReserve - blocking FOR UPDATE serializes
+// reservers on PG/MySQL, SQLite's write txn serializes - so the hard cap holds
+// with no overshoot even under concurrent claimers.
+function concReserve(key, limit) {
+    db.insertIfAbsent("_hull_job_concurrency", ["name"], ["name", "n"], [key, 0]);
+    let ok = false;
+    db.batch(() => {
+        const sel = db.query("SELECT n FROM _hull_job_concurrency WHERE name=?" + _rlLock, [key]);
+        const n = (sel[0] && sel[0].n) || 0;
+        if (n < limit) {
+            ok = true;
+            db.exec("UPDATE _hull_job_concurrency SET n=n+1 WHERE name=?", [key]);
+        }
+    });
+    return ok;
+}
+
+// Release one strict-concurrency slot (floored at 0). Called when a strict-keyed
+// job leaves 'running' (any work() outcome). The reaper reconciles the counter to
+// the true running count, so a slot lost to a crashed worker self-heals.
+function concRelease(key) {
+    db.exec("UPDATE _hull_job_concurrency SET n = CASE WHEN n > 0 THEN n - 1 ELSE 0 END " +
+        "WHERE name=?", [key]);
+}
+
+// Per-key concurrency reconcile (claim-then-reconcile, mirroring rlApply). Soft
+// (default): a job with `concurrency_limit` running peers ahead is released to
+// pending (attempt undone); correct under load, may briefly overshoot under
+// same-instant races. Strict (`concurrencyStrict`): an atomic counter reserve -
+// a hard cap with no overshoot; a failed reserve releases the claim. `now` is the
+// claim time (== claimed_at of every job in `out`).
 function concApply(out, now) {
     if (out.length === 0) return out;
     const drop = new Set();
     for (const j of out) {
         const lim = j._concLimit;
         if (j._concKey !== undefined && j._concKey !== null && lim && lim > 0) {
-            // Rank = running peers strictly ahead in (claimed_at, id) order. This
-            // ordering is fleet-wide deterministic, so no two workers evict the
-            // same slot: each keyed job keeps iff its rank is under the limit.
-            const r = db.query(
-                "SELECT COUNT(*) AS n FROM _hull_jobs " +
-                "WHERE concurrency_key=? AND status='running' " +
-                "AND (claimed_at < ? OR (claimed_at = ? AND id < ?))",
-                [j._concKey, now, now, j.id]);
-            const rank = (r[0] && r[0].n) || 0;
-            if (rank >= lim) drop.add(j.id);
+            if (j._concStrict === 1) {
+                // Strict: atomic counter reserve; a full key releases the claim.
+                if (!concReserve(j._concKey, lim)) drop.add(j.id);
+            } else {
+                // Soft: rank = running peers strictly ahead in (claimed_at, id)
+                // order. Fleet-wide deterministic, so no two workers evict the
+                // same slot: each job keeps iff its rank is under the limit.
+                const r = db.query(
+                    "SELECT COUNT(*) AS n FROM _hull_jobs " +
+                    "WHERE concurrency_key=? AND status='running' " +
+                    "AND (claimed_at < ? OR (claimed_at = ? AND id < ?))",
+                    [j._concKey, now, now, j.id]);
+                const rank = (r[0] && r[0].n) || 0;
+                if (rank >= lim) drop.add(j.id);
+            }
         }
     }
     if (drop.size === 0) return out;
@@ -682,7 +728,7 @@ function claimOne(queue, batch) {
             "attempts=attempts+1, updated_at=? WHERE id IN (" +
             "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? " +
             "ORDER BY priority DESC, id LIMIT ? " + lock + ") " +
-            "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at, concurrency_key, concurrency_limit",
+            "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at, concurrency_key, concurrency_limit, concurrency_strict",
             [token, now, now, queue, now, batch]);
     } else if (d.supportsSkipLocked) {
         db.batch(() => {
@@ -699,7 +745,7 @@ function claimOne(queue, batch) {
                 params);
         });
         rows = db.query(
-            "SELECT id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at, concurrency_key, concurrency_limit FROM _hull_jobs WHERE claim_token=?",
+            "SELECT id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at, concurrency_key, concurrency_limit, concurrency_strict FROM _hull_jobs WHERE claim_token=?",
             [token]);
     } else {
         rows = db.query(
@@ -707,7 +753,7 @@ function claimOne(queue, batch) {
             "attempts=attempts+1, updated_at=? WHERE id IN (" +
             "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? " +
             "ORDER BY priority DESC, id LIMIT ?) " +
-            "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at, concurrency_key, concurrency_limit",
+            "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at, concurrency_key, concurrency_limit, concurrency_strict",
             [token, now, now, queue, now, batch]);
     }
 
@@ -718,8 +764,9 @@ function claimOne(queue, batch) {
         .map((r) => {
             const j = shape(r);
             j.claimToken = token;   // handle for jobs.heartbeat on long-running work
-            j._concKey   = r.concurrency_key;      // internal: concApply reconcile
-            j._concLimit = r.concurrency_limit;
+            j._concKey    = r.concurrency_key;     // internal: concApply reconcile
+            j._concLimit  = r.concurrency_limit;
+            j._concStrict = r.concurrency_strict;  // 1 = counter-backed hard cap
             return j;
         });
     // Reconcile the claim: fleet-wide rate limit, then soft per-key concurrency.
@@ -866,10 +913,20 @@ function reap(opts) {
         "UPDATE _hull_jobs SET status='pending', updated_at=? " +
         "WHERE status='waiting' AND run_at > 0 AND run_at <= ?",
         [now, now]);
-    return db.exec(
+    const reclaimed = db.exec(
         "UPDATE _hull_jobs SET status='pending', claim_token=NULL, updated_at=? " +
         "WHERE status='running' AND claimed_at <= ?",
         [now, now - vt]) || 0;
+    // Reconcile strict-concurrency counters to the true running count. This frees
+    // a slot leaked by a crashed worker (its job was just reclaimed) and returns a
+    // parked workflow's slot - the self-healing backstop for concReserve/release.
+    // The subquery reads _hull_jobs (a different table), so it is valid on MySQL.
+    db.exec(
+        "UPDATE _hull_job_concurrency SET n = (" +
+        "SELECT COUNT(*) FROM _hull_jobs j " +
+        "WHERE j.concurrency_key = _hull_job_concurrency.name " +
+        "AND j.concurrency_strict = 1 AND j.status = 'running')");
+    return reclaimed;
 }
 
 // ── Cron (durable recurring schedules) ──────────────────────────────────────
@@ -1162,6 +1219,12 @@ async function work(opts) {
         // Opt-in attempt history (a yield leaves outcome undefined -> not recorded).
         if (outcome && historyEnabled(job.queue)) {
             recordAttempt(job, startedMs, time.nowMs(), outcome, errStr);
+        }
+        // Release the strict-concurrency slot reserved at claim: any exit from
+        // 'running' (done / dead / retry / workflow yield) frees it. A yielded
+        // workflow re-reserves on its next claim.
+        if (job._concStrict === 1 && job._concKey !== undefined && job._concKey !== null) {
+            concRelease(job._concKey);
         }
     }
     return batch.length;

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -126,10 +126,12 @@ function jobs.init(opts)
         .. "updated_at   INTEGER      NOT NULL,"
         .. "progress     INTEGER      NOT NULL DEFAULT 0,"
         .. "trace_context VARCHAR(255),"
-        -- Soft per-key concurrency (jobs.enqueue concurrency_key/concurrency):
-        -- at most `concurrency_limit` jobs sharing `concurrency_key` run at once.
-        .. "concurrency_key   VARCHAR(255),"
-        .. "concurrency_limit INTEGER)")
+        -- Per-key concurrency (jobs.enqueue concurrency_key/concurrency): at most
+        -- `concurrency_limit` jobs sharing `concurrency_key` run at once. `strict`
+        -- (1) opts into the counter-backed hard cap; NULL/0 is the soft default.
+        .. "concurrency_key    VARCHAR(255),"
+        .. "concurrency_limit  INTEGER,"
+        .. "concurrency_strict INTEGER)")
 
     -- Claim scan path: ready-to-run pending jobs in a queue, by priority then id.
     db.exec([[
@@ -198,6 +200,7 @@ function jobs.init(opts)
     ensure_column("_hull_jobs", "trace_context", "trace_context VARCHAR(255)")
     ensure_column("_hull_jobs", "concurrency_key", "concurrency_key VARCHAR(255)")
     ensure_column("_hull_jobs", "concurrency_limit", "concurrency_limit INTEGER")
+    ensure_column("_hull_jobs", "concurrency_strict", "concurrency_strict INTEGER")
     ensure_column("_hull_cron", "tz_offset", "tz_offset INTEGER NOT NULL DEFAULT 0")
 
     -- Fleet-wide rate-limit counters (jobs.limit). One row per limited queue;
@@ -210,6 +213,16 @@ function jobs.init(opts)
     -- Blocking FOR UPDATE serializes reservers on PG/MySQL; SQLite's write txn
     -- already serializes (and rejects FOR UPDATE syntactically).
     _rl_lock = (db.backend_name == "sqlite") and "" or " FOR UPDATE"
+
+    -- Strict per-key concurrency counter (jobs.enqueue concurrency_strict). One
+    -- row per strict key: `n` running slots reserved. A claim atomically reserves
+    -- (n < limit -> n+1), work() releases on any exit from running, and the reaper
+    -- reconciles `n` to the true running count so a crashed worker can't leak a
+    -- slot. `name` (not the reserved word `key`) mirrors _hull_ratelimit.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_job_concurrency ("
+        .. "name VARCHAR(255) NOT NULL PRIMARY KEY,"
+        .. "n    INTEGER      NOT NULL DEFAULT 0)")
 
     -- Durable per-queue pause state (jobs.pause / resume). A paused queue is not
     -- claimed (workers skip it); fleet-wide (in the DB) and restart-durable.
@@ -431,11 +444,16 @@ function jobs.enqueue(job_type, data, opts)
     if opts.trace ~= nil then
         cols[#cols + 1] = "trace_context"; vals[#vals + 1] = opts.trace
     end
-    -- Optional soft per-key concurrency: at most `concurrency` jobs sharing
-    -- `concurrency_key` run at once (enforced at claim via claim-then-reconcile).
+    -- Optional per-key concurrency: at most `concurrency` jobs sharing
+    -- `concurrency_key` run at once. Soft (default) reconciles at claim (may
+    -- briefly overshoot); `concurrency_strict = true` opts into the counter-backed
+    -- hard cap. All jobs of a key should agree on the strict flag.
     if opts.concurrency_key ~= nil and opts.concurrency and opts.concurrency > 0 then
         cols[#cols + 1] = "concurrency_key";   vals[#vals + 1] = opts.concurrency_key
         cols[#cols + 1] = "concurrency_limit"; vals[#vals + 1] = opts.concurrency
+        if opts.concurrency_strict then
+            cols[#cols + 1] = "concurrency_strict"; vals[#vals + 1] = 1
+        end
     end
     local id
     if opts.dedup_key ~= nil then
@@ -684,22 +702,55 @@ end
 -- key in the same instant (no reservation counter). A strict counter-backed cap
 -- is the opt-in follow-up. `now` is the claim time (== claimed_at of every job
 -- in `out`), so a job's rank counts only strictly-older running peers.
+-- Atomically reserve one STRICT-concurrency slot for `key`: bump n iff n < limit.
+-- Returns true when reserved. Mirrors rl_reserve - blocking FOR UPDATE serializes
+-- reservers on PG/MySQL, SQLite's write txn serializes - so the hard cap holds
+-- with no overshoot even under concurrent claimers.
+local function conc_reserve(key, limit)
+    db.insert_if_absent("_hull_job_concurrency", { "name" }, { "name", "n" }, { key, 0 })
+    local ok = false
+    db.batch(function()
+        local sel = db.query("SELECT n FROM _hull_job_concurrency WHERE name=?" .. _rl_lock, { key })
+        local n = (sel[1] and sel[1].n) or 0
+        if n < limit then
+            ok = true
+            db.exec("UPDATE _hull_job_concurrency SET n=n+1 WHERE name=?", { key })
+        end
+    end)
+    return ok
+end
+
+-- Release one strict-concurrency slot (floored at 0). Called when a strict-keyed
+-- job leaves 'running' (any work() outcome). The reaper reconciles the counter to
+-- the true running count, so a slot lost to a crashed worker self-heals.
+local function conc_release(key)
+    db.exec("UPDATE _hull_job_concurrency SET n = CASE WHEN n > 0 THEN n - 1 ELSE 0 END "
+        .. "WHERE name=?", { key })
+end
+
 local function conc_apply(out, now)
     if #out == 0 then return out end
     local drop = {}
     for _, j in ipairs(out) do
         local lim = j._conc_limit
         if j._conc_key ~= nil and lim and lim > 0 then
-            -- Rank = running peers strictly ahead in (claimed_at, id) order. This
-            -- ordering is fleet-wide deterministic, so no two workers evict the
-            -- same slot: each keyed job keeps iff its rank is under the limit.
-            local r = db.query(
-                "SELECT COUNT(*) AS n FROM _hull_jobs "
-                .. "WHERE concurrency_key=? AND status='running' "
-                .. "AND (claimed_at < ? OR (claimed_at = ? AND id < ?))",
-                { j._conc_key, now, now, j.id })
-            local rank = (r and r[1] and r[1].n) or 0
-            if rank >= lim then drop[j.id] = true end
+            if j._conc_strict == 1 then
+                -- Strict: an atomic counter reserve. A failed reserve means the key
+                -- is full - release the claim (no slot was taken). Hard cap, no
+                -- overshoot.
+                if not conc_reserve(j._conc_key, lim) then drop[j.id] = true end
+            else
+                -- Soft: rank = running peers strictly ahead in (claimed_at, id)
+                -- order. This ordering is fleet-wide deterministic, so no two
+                -- workers evict the same slot: each job keeps iff rank < limit.
+                local r = db.query(
+                    "SELECT COUNT(*) AS n FROM _hull_jobs "
+                    .. "WHERE concurrency_key=? AND status='running' "
+                    .. "AND (claimed_at < ? OR (claimed_at = ? AND id < ?))",
+                    { j._conc_key, now, now, j.id })
+                local rank = (r and r[1] and r[1].n) or 0
+                if rank >= lim then drop[j.id] = true end
+            end
         end
     end
     if next(drop) == nil then return out end
@@ -734,7 +785,7 @@ local function claim_one(queue, batch)
             .. "attempts=attempts+1, updated_at=? WHERE id IN ("
             .. "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? "
             .. "ORDER BY priority DESC, id LIMIT ? " .. lock .. ") "
-            .. "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at, concurrency_key, concurrency_limit",
+            .. "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at, concurrency_key, concurrency_limit, concurrency_strict",
             { token, now, now, queue, now, batch })
     elseif d.supports_skip_locked then
         -- MySQL: no RETURNING. Lock + mark in one txn, then read back by token.
@@ -752,7 +803,7 @@ local function claim_one(queue, batch)
                 params)
         end)
         rows = db.query(
-            "SELECT id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at, concurrency_key, concurrency_limit FROM _hull_jobs WHERE claim_token=?",
+            "SELECT id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at, concurrency_key, concurrency_limit, concurrency_strict FROM _hull_jobs WHERE claim_token=?",
             { token })
     else
         -- SQLite: single-writer serializes the claim, so the marked-running rows
@@ -762,7 +813,7 @@ local function claim_one(queue, batch)
             .. "attempts=attempts+1, updated_at=? WHERE id IN ("
             .. "SELECT id FROM _hull_jobs WHERE queue=? AND status='pending' AND run_at<=? "
             .. "ORDER BY priority DESC, id LIMIT ?) "
-            .. "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at, concurrency_key, concurrency_limit",
+            .. "RETURNING id, queue, type, payload, priority, attempts, max_attempts, trace_context, created_at, concurrency_key, concurrency_limit, concurrency_strict",
             { token, now, now, queue, now, batch })
     end
 
@@ -780,8 +831,9 @@ local function claim_one(queue, batch)
     for _, r in ipairs(rows) do
         local j = shape(r)
         j.claim_token = token   -- handle for jobs.heartbeat on long-running work
-        j._conc_key   = r.concurrency_key      -- internal: conc_apply reconcile
-        j._conc_limit = r.concurrency_limit
+        j._conc_key    = r.concurrency_key     -- internal: conc_apply reconcile
+        j._conc_limit  = r.concurrency_limit
+        j._conc_strict = r.concurrency_strict  -- 1 = counter-backed hard cap
         out[#out + 1] = j
     end
     -- Reconcile the claim: fleet-wide rate limit, then soft per-key concurrency.
@@ -930,10 +982,20 @@ function jobs.reap(opts)
         "UPDATE _hull_jobs SET status='pending', updated_at=? "
         .. "WHERE status='waiting' AND run_at > 0 AND run_at <= ?",
         { now, now })
-    return db.exec(
+    local reclaimed = db.exec(
         "UPDATE _hull_jobs SET status='pending', claim_token=NULL, updated_at=? "
         .. "WHERE status='running' AND claimed_at <= ?",
         { now, now - vt }) or 0
+    -- Reconcile strict-concurrency counters to the true running count. This frees
+    -- a slot leaked by a crashed worker (its job was just reclaimed) and returns a
+    -- parked workflow's slot - the self-healing backstop for conc_reserve/release.
+    -- The subquery reads _hull_jobs (a different table), so it is valid on MySQL.
+    db.exec(
+        "UPDATE _hull_job_concurrency SET n = ("
+        .. "SELECT COUNT(*) FROM _hull_jobs j "
+        .. "WHERE j.concurrency_key = _hull_job_concurrency.name "
+        .. "AND j.concurrency_strict = 1 AND j.status = 'running')")
+    return reclaimed
 end
 
 -- ── Cron (durable recurring schedules) ─────────────────────────────────────
@@ -1254,6 +1316,12 @@ function jobs.work(opts)
         -- Opt-in attempt history (a yield leaves outcome nil -> not recorded).
         if outcome and history_enabled(job.queue) then
             record_attempt(job, started_ms, time.now_ms(), outcome, err_str)
+        end
+        -- Release the strict-concurrency slot reserved at claim: any exit from
+        -- 'running' (done / dead / retry / workflow yield) frees it. A yielded
+        -- workflow re-reserves on its next claim.
+        if job._conc_strict == 1 and job._conc_key ~= nil then
+            conc_release(job._conc_key)
         end
     end
     return #batch

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -33,7 +33,7 @@ FAIL=0
 pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
 fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1${2:+ - $2}"; }
 
-EXPECT_COLS="id,queue,type,payload,status,priority,attempts,max_attempts,run_at,claim_token,claimed_at,dedup_key,last_error,created_at,updated_at,progress,trace_context,concurrency_key,concurrency_limit"
+EXPECT_COLS="id,queue,type,payload,status,priority,attempts,max_attempts,run_at,claim_token,claimed_at,dedup_key,last_error,created_at,updated_at,progress,trace_context,concurrency_key,concurrency_limit,concurrency_strict"
 
 # ── Phase 1: init + schema; Phase 2: correctness round-trip (both runtimes) ──
 check_runtime() {
@@ -663,6 +663,91 @@ app.main(async (ctx) => {
 
 echo "== soft per-key concurrency: Lua =="; check_perkey_conc "lua" "lua" "$LUA_PKC"
 echo "== soft per-key concurrency: JS  =="; check_perkey_conc "js"  "js"  "$JS_PKC"
+
+# ── strict per-key concurrency (counter-backed hard cap) ────────────────────
+# The opt-in `concurrency_strict` path reserves a slot in _hull_job_concurrency
+# at claim (n < limit -> n+1) - a hard cap, no overshoot. Part 1: a claim of 4
+# key-A jobs (limit 2) keeps EXACTLY 2. Part 2: a fresh key B drains fully via
+# work() (the slot is released on each completion). The fleet gate below proves
+# the no-overshoot guarantee under concurrent claimers.
+check_strict_conc() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"STRICT cap_kept=2 drained=3"*)
+            pass "$label: strict per-key concurrency (hard cap + slot release/reuse)" ;;
+        *) fail "$label: strict per-key concurrency" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_STRICT='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init()
+  for i=1,4 do jobs.enqueue("t",{i=i},{concurrency_key="A",concurrency=2,concurrency_strict=true}) end
+  local c1 = jobs.claim({ batch = 10 })
+  local kept = 0; for _,j in ipairs(c1) do if j._conc_key=="A" then kept=kept+1 end end
+  jobs.handler("tb", function(j) return end)
+  for i=1,3 do jobs.enqueue("tb",{i=i},{concurrency_key="B",concurrency=2,concurrency_strict=true}) end
+  for _=1,6 do jobs.work({ batch = 10 }) end
+  local done=0; for id=5,7 do local g=jobs.get(id); if g and g.status=="done" then done=done+1 end end
+  ctx.stdout:write(("STRICT cap_kept=%d drained=%d\n"):format(kept, done))
+  return 0
+end)'
+
+JS_STRICT='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init();
+  for (let i=0;i<4;i++) jobs.enqueue("t",{i},{concurrencyKey:"A",concurrency:2,concurrencyStrict:true});
+  const c1 = jobs.claim({ batch: 10 });
+  let kept=0; for (const j of c1) if (j._concKey==="A") kept++;
+  jobs.handler("tb", (j) => {});
+  for (let i=0;i<3;i++) jobs.enqueue("tb",{i},{concurrencyKey:"B",concurrency:2,concurrencyStrict:true});
+  for (let k=0;k<6;k++) await jobs.work({ batch: 10 });
+  let done=0; for (let id=5;id<=7;id++){ const g=jobs.get(id); if (g && g.status==="done") done++; }
+  ctx.stdout.write(`STRICT cap_kept=${kept} drained=${done}\n`);
+  return 0;
+});'
+
+echo "== strict per-key concurrency: Lua =="; check_strict_conc "lua" "lua" "$LUA_STRICT"
+echo "== strict per-key concurrency: JS  =="; check_strict_conc "js"  "js"  "$JS_STRICT"
+
+# Fleet gate: K processes claim from ONE strict key (limit 2), leaving jobs
+# running. The counter is authoritative, so total distinct claimed == exactly 2
+# no matter how many claimers race (soft could overshoot here).
+echo "== strict concurrency fleet gate ($CONC processes, hard cap 2) =="
+SW="$(mktemp -d)"; SDB="$SW/s.db"
+cat > "$SW/seed.lua" <<LUA
+local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function() jobs.init()
+  for i=1,50 do jobs.enqueue("t",{},{concurrency_key="K",concurrency=2,concurrency_strict=true}) end
+  return 0 end)
+LUA
+cat > "$SW/claim.lua" <<'LUA'
+local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init()
+  local b = jobs.claim({ batch = 10 })   -- leaves them running (no complete)
+  for _,j in ipairs(b) do ctx.stdout:write(j.id .. "\n") end
+  return 0
+end)
+LUA
+"$HULL" "$SW/seed.lua" -d "$SDB" >/dev/null 2>&1
+i=1; while [ "$i" -le "$CONC" ]; do "$HULL" "$SW/claim.lua" -d "$SDB" > "$SW/out.$i" 2>/dev/null & i=$((i+1)); done
+wait
+stot="$(cat "$SW"/out.* | grep -c . || true)"
+suniq="$(cat "$SW"/out.* | sort -n | uniq | grep -c . || true)"
+if [ "$stot" -eq 2 ] && [ "$suniq" -eq 2 ]; then
+    pass "strict concurrency fleet: $CONC processes claimed exactly 2 (hard cap, no overshoot)"
+else
+    fail "strict concurrency fleet: expected exactly 2" "total=$stot uniq=$suniq"
+fi
+rm -rf "$SW"
 
 # ── v1.3: queue pause / resume / purge ──────────────────────────────────────
 # A paused queue is not claimed; resume restores it; purge deletes pending.


### PR DESCRIPTION
## Strict per-key concurrency (counter-backed hard cap)

Completes the "soft now, strict later" plan from #256. Opt into a **hard cap** with `concurrency_strict = true` (JS `concurrencyStrict: true`) on enqueue:

```lua
jobs.enqueue("charge", data, { concurrency_key = "acct-7", concurrency = 1,
                               concurrency_strict = true })   -- serialize per account
```

### Soft vs strict
- **Soft** (default, #256): reconciles a derived rank after the claim; may briefly overshoot under same-instant races. Right for fairness/politeness caps.
- **Strict** (new): reserves a slot in a fleet-wide counter (`_hull_job_concurrency`) **atomically at claim** (`n < limit -> n+1`), under the same blocking-`FOR UPDATE` / SQLite-write-txn serialization as `jobs.limit`. N racing workers admit **exactly** the limit, never more.

### Lifecycle
- Slot released whenever a job leaves `running` (done / dead / retry / workflow yield).
- The reaper **reconciles** the counter to the true running count every sweep, so a crashed worker can't permanently leak a slot — it self-heals, briefly under-utilizing until the next reap (the safe direction for a hard cap).

### Schema
One nullable column (`concurrency_strict`) + one counter table, both added idempotently for existing DBs (`ensure_column` / `CREATE TABLE IF NOT EXISTS`).

### Tests
- Single-process cap+drain (both runtimes).
- **Fleet gate**: K parallel claimers on one strict key claim *exactly* the limit — the no-overshoot guarantee soft can't make.
- **Validated locally on all three backends**: SQLite (58/58 e2e), MySQL 8, PostgreSQL 16 (Docker). The reserve, release, and the correlated-subquery reaper reconcile all run cleanly on each (the reconcile subquery reads a different table, so it's MySQL-legal — checked deliberately after the #257 `LIKE ESCAPE` lesson).

First item of the "finish hull/jobs polish" pass.
