### PR TITLE
examples: durable workflow-as-code + observability

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -409,6 +409,8 @@ const wf = jobs.start("checkout", { orderId: 42, amount: 100 });
   workflow body is a determinism bug - route it through `ctx.*`. For a
   deterministic heavy *computation*, run a WASM module via `compute.call` inside a
   step. Rationale: [docs/jobs_wasm_replay_spike.md](jobs_wasm_replay_spike.md).)
+  **In JS these primitives are async** (they memoize through the step store, like
+  `ctx.step`), so `await` them: `const id = await ctx.uuid()`. Lua is synchronous.
 - **`jobs.workflow_status(id)`** (`workflowStatus`) → `{ status, name,
   steps_done, result?, error? }`, DB-derived (works even when no worker is
   running it). Fetch the final value with `jobs.await(id)` / `jobs.result(id)`.

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -1,0 +1,90 @@
+# workflows - durable workflow-as-code + observability
+
+A worked example of the durable-execution and observability features of
+`hull/jobs@1`. A **workflow** is a job whose body is ordinary code; each
+`ctx.step(name, fn)` runs once and **memoizes** its result, so a crash or retry
+resumes past completed steps instead of repeating side effects (like charging a
+card twice). The instance IS a job, so it inherits the atomic claim, retries with
+backoff, the dead-letter path, and the visibility-timeout reaper - and it runs
+unchanged on SQLite, PostgreSQL, or MySQL.
+
+The example models **order fulfillment**:
+
+```
+charge  ─▶  reserve stock  ─▶  (wait for shipping confirmation)  ─▶  notify
+                │                          ▲
+                └── saga compensation ──────┘  (release stock if the order fails)
+```
+
+| Feature | Where |
+|---|---|
+| **Memoized steps** | `ctx.step("charge", …)` / `ctx.step("reserve", …)` - re-running the body skips completed steps. |
+| **Deterministic replay** | `ctx.uuid()` / `ctx.now()` - the receipt id and timestamp stay identical across resumes. |
+| **Durable wait** | `ctx.wait_signal("shipped")` parks the workflow in the non-terminal `waiting` status (no CPU held) until `jobs.signal` wakes it - could be seconds or days later. |
+| **Saga compensation** | `ctx.step("reserve", fn, { compensate = … })` - if the workflow dead-letters after reserving, the compensation releases the stock (reverse order). |
+| **Observability** | `jobs.metrics()` - DB-derived gauges + latency percentiles + throughput. |
+
+## Run it
+
+```sh
+hull examples/workflows/app.lua -d ./wf.db        # or app.js
+```
+
+```sh
+# start an order -> returns the workflow id
+ID=$(curl -s -X POST localhost:3000/orders -d '{"sku":"A1","card":"tok_ok"}' | tr -dc 0-9)
+
+# it charges + reserves, then parks waiting for shipment
+curl localhost:3000/orders/$ID
+# {"status":"waiting","steps_done":["charge","reserve"],"waiting_for":"signal", ...}
+
+# the warehouse confirms shipment -> the signal wakes the workflow
+curl -X POST localhost:3000/orders/$ID/ship -d '{"tracking":"1Z999"}'
+
+# now it's done, with the memoized receipt and the tracking number
+curl localhost:3000/orders/$ID
+# {"status":"done","result":{"receipt":"…","tracking":"1Z999", …}, ...}
+
+# fleet-wide observability
+curl localhost:3000/metrics
+# {"totals":{"pending":0,"running":0,"waiting":1,…},
+#  "latency":{"wait_ms":{"p50":…},"run_ms":{…}},"throughput":{…}}
+```
+
+Try the failure paths:
+
+```sh
+# declined card -> dead-lettered before reserving (nothing to roll back)
+curl -X POST localhost:3000/orders -d '{"card":"tok_declined"}'
+
+# fraud -> charges + reserves, then dead-letters; the saga compensation
+# releases the reserved stock (watch the "compensated: released stock" log line)
+curl -X POST localhost:3000/orders -d '{"sku":"B2","card":"tok_fraud"}'
+```
+
+## Crash safety
+
+Kill the process at any point and restart it against the same `-d` database. A
+workflow parked on `wait_signal` is durable (it lives in `_hull_jobs`), and one
+mid-flight resumes from its last completed step - the memoized `charge` /
+`reserve` results are read back, so the card is not re-charged. This is the whole
+point of workflow-as-code: the happy path reads like a straight-line function,
+but every step is a durable checkpoint.
+
+## Execution model
+
+This example uses the **in-process poller** (`app.every` drives `jobs.work`
+inside the web app) so a single `hull app.lua` is self-contained. For higher
+throughput, run the same workflow under a **dedicated worker** process instead -
+register the workflow with `jobs.workflow(...)` inside an `app.main` that calls
+`jobs.run_worker()`, and launch it as its own process (see
+[`examples/jobs/worker.lua`](../jobs/worker.lua) for the worker pattern). The two
+models share one atomic claim, so you can add worker processes with no change to
+the workflow code.
+
+## See also
+
+- [`docs/jobs.md`](../../docs/jobs.md) - the full `hull/jobs@1` guide (workflows,
+  signals, sagas, deterministic replay, `ctx.patched` versioning, metrics).
+- [`examples/jobs`](../jobs) - the simpler queue example (handlers, retries,
+  dead-letter, the poller vs dedicated-worker models).

--- a/examples/workflows/app.js
+++ b/examples/workflows/app.js
@@ -1,0 +1,146 @@
+// examples/workflows (JS) - durable workflow-as-code + observability.
+//
+// A workflow is a job whose body is ordinary code: `await ctx.step(name, fn)`
+// runs a step ONCE and memoizes its result, so a crash or retry resumes past
+// completed steps instead of re-charging a card. `ctx.waitSignal` parks the
+// workflow durably until an external event arrives; saga `compensate` callbacks
+// roll back completed steps on terminal failure; `ctx.now/uuid` stay stable
+// across replays.
+//
+// This models order fulfillment: charge -> reserve stock -> WAIT for a shipping
+// confirmation (could be minutes or days) -> notify. The workflow instance IS a
+// job, so it survives restarts, retries with backoff, and reports progress.
+//
+// Try it:
+//   hull examples/workflows/app.js -d ./wf.db
+//   ID=$(curl -s -X POST localhost:3000/orders -d '{"sku":"A1","card":"tok_ok"}' | tr -dc 0-9)
+//   curl localhost:3000/orders/$ID                 // {status:"waiting", stepsDone:["charge","reserve"]}
+//   curl -X POST localhost:3000/orders/$ID/ship -d '{"tracking":"1Z999"}'
+//   curl localhost:3000/orders/$ID                 // {status:"done", result:{...}}
+//   curl localhost:3000/metrics                    // gauges + latency percentiles
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { app } from "hull:app";
+import { jobs } from "hull:jobs";
+import { json } from "hull:json";
+import { log } from "hull:log";
+
+app.manifest({
+    modules: [
+        "hull/jobs@1",
+        "hull/json@1",
+        "hull/http-server@1",
+        "hull/timers@1",
+        "hull/log@1",
+    ],
+});
+
+// history: true turns on the opt-in attempt-history table, which powers the
+// latency / throughput fields of jobs.metrics (gauges work without it).
+jobs.init({ history: true });
+
+// A tiny in-memory "inventory" so the saga compensation is observable. Real code
+// would use db.* here; the point is the ROLLBACK, not the store.
+const reserved = {};
+
+// ── The workflow ─────────────────────────────────────────────────────────────
+// Register once at startup. `ctx.input` is the payload from jobs.start.
+jobs.workflow("fulfill_order", async (ctx) => {
+    const order = ctx.input;
+
+    // Step 1: charge the card. Memoized: if the workflow resumes after this
+    // point, the charge is NOT repeated. A declined card returns ok=false (no
+    // charge); the body then dead-letters below. ctx.uuid()/ctx.now() are
+    // memoized (byte-identical on every replay), so the receipt id is stable.
+    const charge = await ctx.step("charge", async () => {
+        if (order.card === "tok_declined") return { ok: false };
+        // In JS the deterministic primitives are async (they memoize via the step
+        // store) - await them, like ctx.step itself.
+        return { ok: true, receipt: await ctx.uuid(), amount: order.amount || 4200, at: await ctx.now() };
+    });
+    if (!charge.ok) {
+        return jobs.DEAD;   // non-retryable; nothing reserved yet, nothing to roll back
+    }
+
+    // Step 2: reserve inventory, WITH a compensation. If the workflow fails
+    // terminally after this, `compensate` runs (reverse order) to release stock.
+    await ctx.step("reserve", () => {
+        reserved[ctx.id] = order.sku || "A1";
+        log.info(`reserved stock for order ${ctx.id}`);
+        return true;
+    }, {
+        compensate: () => {
+            delete reserved[ctx.id];
+            log.warn(`compensated: released stock for order ${ctx.id}`);
+        },
+    });
+
+    // A fraud flag fails the order AFTER reserving: returning jobs.DEAD from the
+    // body dead-letters it and runs the saga compensations (releasing the stock).
+    if (order.card === "tok_fraud") {
+        return jobs.DEAD;
+    }
+
+    // Step 3: park until the warehouse confirms shipment. The workflow yields to
+    // the durable 'waiting' status here - no worker CPU is held while it waits.
+    // jobs.signal(id, "shipped", payload) wakes it; the payload is the return.
+    const ship = await ctx.waitSignal("shipped");
+
+    // Step 4: notify the customer (memoized, so a resume won't double-send).
+    await ctx.step("notify", () => {
+        log.info(`order ${ctx.id} shipped, tracking ${ship?.tracking}`);
+        return true;
+    });
+
+    // The return value becomes the workflow result (jobs.result / jobs.await).
+    return {
+        order_id: ctx.id,
+        receipt: charge.receipt,
+        amount: charge.amount,
+        tracking: ship?.tracking,
+    };
+});
+
+// In-process execution model: an app.every timer drives jobs.work, which claims
+// and advances workflows (and fires the reaper). For a dedicated worker process
+// instead, see worker.js.
+app.every(500, () => { jobs.work({ batch: 10 }); });
+
+// ── Routes ───────────────────────────────────────────────────────────────────
+
+// Start an order-fulfillment workflow. Returns the workflow (job) id.
+app.post("/orders", (req, res) => {
+    const body = json.decode(req.body || "{}") || {};
+    const id = jobs.start("fulfill_order", body);
+    res.json({ order: id });
+});
+
+// Inspect a workflow instance: status + which steps have run + the result.
+app.get("/orders/:id", (req, res) => {
+    const st = jobs.workflowStatus(Number(req.params.id));
+    if (!st) { res.status(404).json({ error: "no such order" }); return; }
+    res.json(st);
+});
+
+// Deliver the "shipped" signal, waking a workflow parked on waitSignal.
+app.post("/orders/:id/ship", (req, res) => {
+    const body = json.decode(req.body || "{}") || {};
+    jobs.signal(Number(req.params.id), "shipped", { tracking: body.tracking });
+    res.json({ signalled: true });
+});
+
+// Observability: DB-derived fleet-correct gauges + (with history on) latency
+// percentiles and throughput. Point a dashboard at this.
+app.get("/metrics", (_req, res) => {
+    res.json(jobs.metrics());
+});
+
+// Live saga state: which orders currently hold reserved stock. A successful
+// order keeps its entry; a compensated (fraud-dead-lettered) order has its
+// entry released - so the rollback is observable right here.
+app.get("/inventory", (_req, res) => {
+    const held = {};
+    for (const id of Object.keys(reserved)) held[id] = reserved[id];
+    res.json({ reserved: held });
+});

--- a/examples/workflows/app.lua
+++ b/examples/workflows/app.lua
@@ -1,0 +1,143 @@
+-- examples/workflows (Lua) - durable workflow-as-code + observability.
+--
+-- A workflow is a job whose body is ordinary code: `ctx.step(name, fn)` runs a
+-- step ONCE and memoizes its result, so a crash or retry resumes past completed
+-- steps instead of re-charging a card. `ctx.wait_signal` parks the workflow
+-- durably until an external event arrives; saga `compensate` callbacks roll back
+-- completed steps on terminal failure; `ctx.now/uuid` stay stable across replays.
+--
+-- This models order fulfillment: charge -> reserve stock -> WAIT for a shipping
+-- confirmation (could be minutes or days) -> notify. The workflow instance IS a
+-- job, so it survives restarts, retries with backoff, and reports progress.
+--
+-- Try it:
+--   hull examples/workflows/app.lua -d ./wf.db
+--   ID=$(curl -s -X POST localhost:3000/orders -d '{"sku":"A1","card":"tok_ok"}' | tr -dc 0-9)
+--   curl localhost:3000/orders/$ID                 # {status:"waiting", steps_done:["charge","reserve"]}
+--   curl -X POST localhost:3000/orders/$ID/ship -d '{"tracking":"1Z999"}'
+--   curl localhost:3000/orders/$ID                 # {status:"done", result:{...}}
+--   curl localhost:3000/metrics                    # gauges + latency percentiles
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+
+local jobs = require("hull.jobs")
+local json = require("hull.json")
+local log  = require("hull.log")
+
+app.manifest({
+    modules = {
+        "hull/jobs@1",
+        "hull/json@1",
+        "hull/http-server@1",
+        "hull/timers@1",
+        "hull/log@1",
+    },
+})
+
+-- history = true turns on the opt-in attempt-history table, which powers the
+-- latency / throughput fields of jobs.metrics (gauges work without it).
+jobs.init({ history = true })
+
+-- A tiny in-memory "inventory" so the saga compensation is observable. Real code
+-- would use db.* here; the point is the ROLLBACK, not the store.
+local reserved = {}
+
+-- ── The workflow ─────────────────────────────────────────────────────────────
+-- Register once at startup. `ctx.input` is the payload from jobs.start.
+jobs.workflow("fulfill_order", function(ctx)
+    local order = ctx.input
+
+    -- Step 1: charge the card. Memoized: if the workflow resumes after this
+    -- point, the charge is NOT repeated - ctx.step returns the recorded result.
+    -- A declined card returns ok=false (no charge made); the body then dead-
+    -- letters below. ctx.uuid()/ctx.now() are memoized (byte-identical on every
+    -- replay), so the receipt id is stable when the body re-runs.
+    local charge = ctx.step("charge", function()
+        if order.card == "tok_declined" then return { ok = false } end
+        return { ok = true, receipt = ctx.uuid(), amount = order.amount or 4200, at = ctx.now() }
+    end)
+    if not charge.ok then
+        return jobs.DEAD   -- non-retryable; nothing reserved yet, nothing to roll back
+    end
+
+    -- Step 2: reserve inventory, WITH a compensation. If the workflow fails
+    -- terminally after this, `compensate` runs (reverse order) to release stock.
+    ctx.step("reserve", function()
+        reserved[ctx.id] = order.sku or "A1"
+        log.info("reserved stock for order " .. ctx.id)
+        return true
+    end, {
+        compensate = function()
+            reserved[ctx.id] = nil
+            log.warn("compensated: released stock for order " .. ctx.id)
+        end,
+    })
+
+    -- A fraud flag fails the order AFTER reserving: returning jobs.DEAD from the
+    -- body dead-letters it and runs the saga compensations (releasing the stock).
+    if order.card == "tok_fraud" then
+        return jobs.DEAD
+    end
+
+    -- Step 3: park until the warehouse confirms shipment. The workflow yields to
+    -- the durable 'waiting' status here - no worker CPU is held while it waits.
+    -- jobs.signal(id, "shipped", payload) wakes it; the payload is the return.
+    local ship = ctx.wait_signal("shipped")
+
+    -- Step 4: notify the customer (memoized, so a resume won't double-send).
+    ctx.step("notify", function()
+        log.info("order " .. ctx.id .. " shipped, tracking " .. tostring(ship and ship.tracking))
+        return true
+    end)
+
+    -- The return value becomes the workflow result (jobs.result / jobs.await).
+    return {
+        order_id = ctx.id,
+        receipt  = charge.receipt,
+        amount   = charge.amount,
+        tracking = ship and ship.tracking,
+    }
+end)
+
+-- In-process execution model: an app.every timer drives jobs.work, which claims
+-- and advances workflows (and fires the reaper). For a dedicated worker process
+-- instead, see worker.lua.
+app.every(500, function() jobs.work({ batch = 10 }) end)
+
+-- ── Routes ───────────────────────────────────────────────────────────────────
+
+-- Start an order-fulfillment workflow. Returns the workflow (job) id.
+app.post("/orders", function(req, res)
+    local body = json.decode(req.body or "{}") or {}
+    local id = jobs.start("fulfill_order", body)
+    res:json({ order = id })
+end)
+
+-- Inspect a workflow instance: status + which steps have run + the result.
+app.get("/orders/:id", function(req, res)
+    local st = jobs.workflow_status(tonumber(req.params.id))
+    if not st then res:status(404):json({ error = "no such order" }); return end
+    res:json(st)
+end)
+
+-- Deliver the "shipped" signal, waking a workflow parked on wait_signal.
+app.post("/orders/:id/ship", function(req, res)
+    local body = json.decode(req.body or "{}") or {}
+    jobs.signal(tonumber(req.params.id), "shipped", { tracking = body.tracking })
+    res:json({ signalled = true })
+end)
+
+-- Observability: DB-derived fleet-correct gauges + (with history on) latency
+-- percentiles and throughput. Point a dashboard at this.
+app.get("/metrics", function(req, res)
+    res:json(jobs.metrics())
+end)
+
+-- Live saga state: which orders currently hold reserved stock. A successful
+-- order keeps its entry; a compensated (fraud-dead-lettered) order has its
+-- entry released - so the rollback is observable right here.
+app.get("/inventory", function(req, res)
+    local held = {}
+    for id, sku in pairs(reserved) do held[tostring(id)] = sku end
+    res:json({ reserved = held })
+end)


### PR DESCRIPTION
## Worked example: durable workflow-as-code + observability

`examples/workflows/` demonstrates the headline v0.11.0 durable-execution features in one realistic scenario — an **order-fulfillment workflow**:

```
charge ─▶ reserve stock ─▶ (wait for shipping confirmation) ─▶ notify
             │                        ▲
             └── saga compensation ────┘  (release stock if the order fails)
```

| Feature | Shown via |
|---|---|
| Memoized steps | `ctx.step("charge"/"reserve", …)` |
| Deterministic replay | `ctx.uuid()` / `ctx.now()` — receipt id + timestamp stable across resumes |
| Durable wait | `ctx.wait_signal("shipped")` parks in `waiting` until `jobs.signal` |
| Saga compensation | `ctx.step(…, { compensate })` releases stock on terminal failure |
| Observability | `jobs.metrics()` — gauges + latency percentiles + throughput |

Both runtimes + README. The web app uses the in-process poller so `hull examples/workflows/app.lua` is self-contained; the README covers the dedicated-worker alternative and a **crash-safety walkthrough**.

### Validated by hand (both runtimes)
- Happy path: start → `waiting` → signal → `done` with the memoized receipt + tracking.
- Saga: `tok_fraud` charges + reserves, then dead-letters and the compensation releases the stock.
- **Crash safety**: kill the process mid-flight, restart against the same `-d` DB → the workflow stays `waiting`, then resumes from the last completed step with a **stable receipt** (no re-charge).
- `jobs.metrics()` returns gauges + `wait_ms`/`run_ms` percentiles + throughput.

### Also documents a real API detail
In JS the deterministic primitives (`ctx.now`/`random`/`uuid`) are **async** and must be `await`ed, like `ctx.step` (Lua is synchronous). This surfaced while writing the example (an un-awaited `ctx.uuid()` serialized as `{}`); noted in `docs/jobs.md`.

Consistent with `examples/jobs`, this reference example isn't wired into `e2e_examples` (its code paths are covered by `e2e_jobs.sh` at the unit level). Second item of the "finish hull/jobs polish" pass.
