### PR TITLE
jobs: durable fleet-wide events, Phase 1 (log + transactional emit + tail)

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -113,6 +113,42 @@ jobs.on("completed", function(job, info) metrics.inc("jobs.done", { type = job.t
 jobs.on("dead",      function(job, info) log.error("job died: " .. info.error) end)
 ```
 
+## Durable events (fleet-wide)
+
+Where `jobs.on` is in-process and lost on a crash, the **durable event log** is
+opt-in (`jobs.init({ events = true })`) and records every lifecycle transition -
+`enqueued`, `completed`, `retried`, `dead`, `cancelled` - as a row in
+`_hull_job_events`, **written in the same transaction as the state change that
+produced it**. So an event exists *iff* the transition committed: no lost events
+(crash after the change, before an external publish) and no phantom events
+(publish, then the change rolls back) - the same transactional coupling that makes
+`enqueue` a plain `INSERT`. It survives restarts and is visible to any process
+against the same DB (a dashboard, an analytics sink, a reacting service).
+
+```lua
+jobs.init({ events = true })
+
+-- Read-only tail, newest first (for a dashboard / ad-hoc inspection):
+local recent = jobs.events({ types = { "dead" }, since = last_id, limit = 100 })
+-- each: { id, ts, type, job_id, job_type, queue, data = { error?, attempt?, trace? } }
+```
+```javascript
+jobs.init({ events: true });
+const recent = jobs.events({ types: ["dead"], since: lastId, limit: 100 });
+```
+
+- **`id`** is a monotonic total order (and the cursor space Phase 2 subscriptions
+  will use). Tail incrementally by passing the last id you saw as `since`.
+- **`data`** is compact metadata (`error` / `attempt` / `trace`), never the full
+  result - join `jobs.result(job_id)` when you need the value.
+- **Retention** is by age via `jobs.cleanup` (same window as terminal rows).
+- **Off by default** - an app that doesn't opt in pays nothing (no log writes).
+- This is **Phase 1** (the log + a pollable tail, enough to power a dashboard).
+  Phase 2 adds **durable subscriptions** (`jobs.subscribe(name, handler)`) with
+  at-least-once delivery + per-consumer cursors, so a reacting service processes
+  every event exactly-once-effectively across the fleet. Design:
+  [docs/jobs_events_design.md](jobs_events_design.md).
+
 ## Recurring jobs (cron)
 
 `jobs.cron(name, spec, data?, opts?)` registers a **durable** recurring

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -40,6 +40,7 @@ const _cfg = {
     backoff: defaultBackoff,
     history:           false, // attempt-history recording: true | { queues:[...] } | false
     historyRetention:  null,  // seconds to keep attempt rows (null = jobs.cleanup default)
+    events:            false, // durable fleet-wide event log (jobs.subscribe / jobs.events)
 };
 
 // Exponential backoff: 2^attempt * 10s, capped at 1h (shared with outbox math).
@@ -96,6 +97,7 @@ function init(opts) {
     if (o.reapInterval !== undefined) _cfg.reapInterval = o.reapInterval;
     if (o.history !== undefined) _cfg.history = o.history;
     if (o.historyRetention !== undefined) _cfg.historyRetention = o.historyRetention;
+    if (o.events !== undefined) _cfg.events = o.events;
     if (o.backoff !== undefined) _cfg.backoff = o.backoff;
 
     // Keyed/indexed text columns are VARCHAR(255) so MySQL can index them;
@@ -267,6 +269,23 @@ function init(opts) {
     db.exec("CREATE INDEX IF NOT EXISTS idx_hull_job_attempts_job ON _hull_job_attempts(job_id, attempt_no)");
     db.exec("CREATE INDEX IF NOT EXISTS idx_hull_job_attempts_recent ON _hull_job_attempts(finished_ms)");
 
+    // Durable fleet-wide event log (jobs.init{events:true}). Append-only lifecycle
+    // events, written in the SAME transaction as the state change that produced
+    // them (transactional coupling: an event exists iff the transition committed).
+    // The `id` is the total order + the future subscription cursor space. `data`
+    // is small JSON metadata (error/attempt/trace), never the full result.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_job_events (" +
+        "id       " + db.autoincrementIdDdl + ", " +
+        "ts       INTEGER      NOT NULL," +
+        "type     VARCHAR(32)  NOT NULL," +
+        "job_id   INTEGER," +
+        "job_type VARCHAR(255)," +
+        "queue    VARCHAR(255)," +
+        "data     TEXT)");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_hull_job_events_type ON _hull_job_events(type, id)");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_hull_job_events_ts ON _hull_job_events(ts)");
+
     // Verify the server actually parses SKIP LOCKED (the compile-time dialect
     // flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
     // does not). A 0-row probe against the real table detects it once; the claim
@@ -343,6 +362,41 @@ function loadDeps(dependentId) {
         }
     });
     return out;
+}
+
+// Append a durable lifecycle event (opt-in via jobs.init{events:true}). Called
+// INSIDE the transition's transaction, so the event commits iff the state change
+// does (transactional coupling: no lost, no phantom events). `job` supplies
+// id/type/queue/trace; `info` is small metadata (error/attempt) - never the full
+// result (a consumer joins _hull_job_results for that).
+function emitDurable(event, job, info) {
+    if (!_cfg.events) return;
+    info = info || {};
+    let data = null;
+    if (info.error !== undefined || info.attempt !== undefined ||
+        (job.trace !== undefined && job.trace !== null)) {
+        data = json.encode({ error: info.error, attempt: info.attempt, trace: job.trace });
+    }
+    db.exec(
+        "INSERT INTO _hull_job_events (ts, type, job_id, job_type, queue, data) " +
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [time.now(), event, job.id, job.type, job.queue, data]);
+}
+
+// Apply a terminal transition and its durable event ATOMICALLY (one txn), then
+// fire the in-process listeners. `transition()` runs the markX state change and
+// returns the effective outcome ("done"|"dead"|"retried"). Wrapping in db.batch
+// both couples the event to the state change and collapses markDone's several
+// statements into one commit (fewer fsyncs, even when events are off).
+const EVENT_OF = { done: "completed", dead: "dead", retried: "retried" };
+function finish(job, info, transition) {
+    let outcome;
+    db.batch(() => {
+        outcome = transition();
+        emitDurable(EVENT_OF[outcome] || outcome, job, info);
+    });
+    emit(EVENT_OF[outcome] || outcome, job, info);
+    return outcome;
 }
 
 /**
@@ -435,6 +489,10 @@ function enqueue(jobType, data, opts) {
             else if (g.status === "dead") resolveEdge(id, dep, false, failMode);
         }
     }
+    // Durable "enqueued" event (opt-in). Emitted here so it joins the caller's
+    // db.batch when enqueue is called inside one (transactional coupling).
+    emitDurable("enqueued",
+        { id, type: jobType, queue: o.queue || "default", trace: o.trace }, {});
     return id;
 }
 
@@ -1098,9 +1156,7 @@ async function work(opts) {
         let outcome, errStr;              // undefined outcome = a yield (not recorded)
         if (!h) {
             errStr = `no handler for job type '${job.type}'`;
-            markDead(job.id, errStr);
-            emit("dead", job, { error: errStr });
-            outcome = "dead";
+            outcome = finish(job, { error: errStr }, () => { markDead(job.id, errStr); return "dead"; });
         } else {
         try {
             const result = await h(job);
@@ -1137,26 +1193,23 @@ async function work(opts) {
                         [result.wakeAt || now, now, job.id]);
                 }
             } else if (result === DEAD) {
-                errStr = "handler returned jobs.DEAD"; outcome = "dead";
-                markDead(job.id, errStr);
-                emit("dead", job, { error: errStr });
+                errStr = "handler returned jobs.DEAD";
+                outcome = finish(job, { error: errStr }, () => { markDead(job.id, errStr); return "dead"; });
             } else if (result === RETRY) {
                 errStr = "handler requested retry";
-                outcome = markRetry(job, errStr);
-                emit(outcome, job, { error: errStr, attempt: job.attempts });
+                outcome = finish(job, { error: errStr, attempt: job.attempts },
+                    () => markRetry(job, errStr));
             } else {
                 // undefined / true / DISCARD -> done, no result; any other return
                 // value is stored as the job's result (for dependents).
                 const res = (result !== undefined && result !== true && result !== DISCARD)
                     ? result : undefined;
-                markDone(job.id, res);
-                emit("completed", job, { result: res });
-                outcome = "done";
+                outcome = finish(job, { result: res }, () => { markDone(job.id, res); return "done"; });
             }
         } catch (e) {
             errStr = String((e && e.message) || e);
-            outcome = markRetry(job, errStr);
-            emit(outcome, job, { error: errStr, attempt: job.attempts });
+            outcome = finish(job, { error: errStr, attempt: job.attempts },
+                () => markRetry(job, errStr));
         }
         }
         // Opt-in attempt history (a yield leaves outcome undefined -> not recorded).
@@ -1813,7 +1866,48 @@ function retry(id) {
  * @returns {boolean}
  */
 function cancel(id) {
-    return (db.exec("DELETE FROM _hull_jobs WHERE id=? AND status='pending'", [id]) || 0) > 0;
+    if (!_cfg.events) {
+        return (db.exec("DELETE FROM _hull_jobs WHERE id=? AND status='pending'", [id]) || 0) > 0;
+    }
+    // events on: capture type/queue for the "cancelled" event, delete + emit in
+    // one txn (BEGIN IMMEDIATE serializes, so the SELECT->DELETE stays consistent).
+    let cancelled = false;
+    db.batch(() => {
+        const r = db.query("SELECT type, queue FROM _hull_jobs WHERE id=? AND status='pending'", [id]);
+        if (r[0]) {
+            db.exec("DELETE FROM _hull_jobs WHERE id=? AND status='pending'", [id]);
+            emitDurable("cancelled", { id, type: r[0].type, queue: r[0].queue }, {});
+            cancelled = true;
+        }
+    });
+    return cancelled;
+}
+
+/**
+ * Read-only tail of the durable event log (jobs.init{events:true}), newest first
+ * - for a dashboard or ad-hoc inspection. Phase 2 adds durable subscriptions
+ * (jobs.subscribe) with at-least-once delivery + cursors.
+ * @param {object} [opts] { since: <event id>, types: ["dead", ...], limit: 100 }
+ * @returns {Array} of { id, ts, type, job_id, job_type, queue, data }
+ */
+function events(opts) {
+    const o = opts || {};
+    const where = ["1=1"], params = [];
+    if (o.since !== undefined) { where.push("id > ?"); params.push(o.since); }
+    if (Array.isArray(o.types) && o.types.length) {
+        where.push("type IN (" + o.types.map(() => "?").join(",") + ")");
+        for (const t of o.types) params.push(t);
+    }
+    params.push(Math.min(Number(o.limit) || 100, 1000));
+    const rows = db.query(
+        "SELECT id, ts, type, job_id, job_type, queue, data FROM _hull_job_events " +
+        "WHERE " + where.join(" AND ") + " ORDER BY id DESC LIMIT ?", params);
+    for (const r of rows) {
+        if (r.data !== undefined && r.data !== null && r.data !== "") {
+            try { r.data = json.decode(r.data); } catch (_e) { /* leave raw */ }
+        }
+    }
+    return rows;
 }
 
 /**
@@ -1842,6 +1936,9 @@ function cleanup(opts) {
     // post-hoc metrics), not by orphan-ness.
     const hr = _cfg.historyRetention || o.olderThan || 604800;
     db.exec("DELETE FROM _hull_job_attempts WHERE finished_ms < ?", [(time.now() - hr) * 1000]);
+    // Durable event log retained by age. Phase 1 has no subscription cursors, so a
+    // pure time window; Phase 2 will additionally never truncate past min(cursor).
+    db.exec("DELETE FROM _hull_job_events WHERE ts < ?", [cutoff]);
     return deleted;
 }
 
@@ -1857,11 +1954,11 @@ export const jobs = {
     stats, runWorker, stop, get, result, await: await_, progress, heartbeat, limit, metrics, history,
     pause, resume, purge,
     workflow, start, signal, workflowStatus,
-    dead, retry, cancel, cleanup, cron, uncron,
+    dead, retry, cancel, cleanup, cron, uncron, events,
     RETRY, DEAD, DISCARD, _config: _cfg, _cronNext, _tick,
 };
 export { init, enqueue, enqueueMany, claim, handler, on, work, reap, stats,
          runWorker, stop, get, result, progress, heartbeat, limit, metrics, history, pause, resume,
          purge, workflow, start, signal, workflowStatus,
-         dead, retry, cancel, cleanup, cron, uncron };
+         dead, retry, cancel, cleanup, cron, uncron, events };
 export default jobs;

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -42,6 +42,7 @@ local _cfg = {
     reap_interval      = 30,    -- min seconds between reaper sweeps (0 = every work() call)
     history            = false, -- attempt-history recording: true | { queues={...} } | false
     history_retention  = nil,   -- seconds to keep attempt rows (nil = jobs.cleanup default)
+    events             = false, -- durable fleet-wide event log (jobs.subscribe / jobs.events)
 }
 
 -- Exponential backoff: 2^attempt * 10s, capped at 1h (shared with outbox math).
@@ -103,6 +104,7 @@ function jobs.init(opts)
     if opts.backoff ~= nil then _cfg.backoff = opts.backoff end
     if opts.history ~= nil then _cfg.history = opts.history end
     if opts.history_retention ~= nil then _cfg.history_retention = opts.history_retention end
+    if opts.events ~= nil then _cfg.events = opts.events end
 
     -- Keyed / indexed text columns are VARCHAR(255) so MySQL can index them;
     -- data-only columns (payload, last_error) stay TEXT. status/type/queue are
@@ -290,6 +292,27 @@ function jobs.init(opts)
         ON _hull_job_attempts(finished_ms)
     ]])
 
+    -- Durable fleet-wide event log (jobs.init{events=true}). Append-only lifecycle
+    -- events, written in the SAME transaction as the state change that produced
+    -- them (transactional coupling: an event exists iff the transition committed).
+    -- The `id` is the total order + the future subscription cursor space. `data`
+    -- is small JSON metadata (error/attempt/trace), never the full result.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_job_events ("
+        .. "id       " .. db.autoincrement_id_ddl .. ", "
+        .. "ts       INTEGER      NOT NULL,"
+        .. "type     VARCHAR(32)  NOT NULL,"
+        .. "job_id   INTEGER,"
+        .. "job_type VARCHAR(255),"
+        .. "queue    VARCHAR(255),"
+        .. "data     TEXT)")
+    db.exec([[
+        CREATE INDEX IF NOT EXISTS idx_hull_job_events_type ON _hull_job_events(type, id)
+    ]])
+    db.exec([[
+        CREATE INDEX IF NOT EXISTS idx_hull_job_events_ts ON _hull_job_events(ts)
+    ]])
+
     -- Verify the server actually parses SKIP LOCKED (the compile-time dialect
     -- flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
     -- does not). A 0-row probe against the real table detects it once; the claim
@@ -369,6 +392,24 @@ local function load_deps(dependent_id)
         end
     end
     return out
+end
+
+-- Append a durable lifecycle event (opt-in via jobs.init{events=true}). Called
+-- INSIDE the transition's transaction, so the event commits iff the state change
+-- does (transactional coupling: no lost, no phantom events). `job` supplies
+-- id/type/queue/trace; `info` is small metadata (error/attempt) - never the full
+-- result (a consumer joins _hull_job_results for that).
+local function emit_durable(event, job, info)
+    if not _cfg.events then return end
+    info = info or {}
+    local data
+    if info.error ~= nil or info.attempt ~= nil or job.trace ~= nil then
+        data = json.encode({ error = info.error, attempt = info.attempt, trace = job.trace })
+    end
+    db.exec(
+        "INSERT INTO _hull_job_events (ts, type, job_id, job_type, queue, data) "
+        .. "VALUES (?, ?, ?, ?, ?, ?)",
+        { time.now(), event, job.id, job.type, job.queue, data })
 end
 
 --- Enqueue a job. A plain INSERT, so calling it inside a `db.batch()` commits
@@ -481,6 +522,10 @@ function jobs.enqueue(job_type, data, opts)
             end
         end
     end
+    -- Durable "enqueued" event (opt-in). Emitted here so it joins the caller's
+    -- db.batch when enqueue is called inside one (transactional coupling).
+    emit_durable("enqueued",
+        { id = id, type = job_type, queue = opts.queue or "default", trace = opts.trace }, {})
     return id
 end
 
@@ -914,6 +959,23 @@ local function emit(event, job, info)
     for i = 1, #L do pcall(L[i], job, info) end
 end
 
+-- Apply a terminal transition and its durable event ATOMICALLY (one txn), then
+-- fire the in-process listeners. `transition()` runs the mark_* state change and
+-- returns the effective outcome ("done"|"dead"|"retried"). Wrapping in db.batch
+-- both couples the event to the state change and collapses mark_done's several
+-- statements into one commit (fewer fsyncs, even when events are off). Returns
+-- the outcome.
+local EVENT_OF = { done = "completed", dead = "dead", retried = "retried" }
+local function finish(job, info, transition)
+    local outcome
+    db.batch(function()
+        outcome = transition()
+        emit_durable(EVENT_OF[outcome] or outcome, job, info)
+    end)
+    emit(EVENT_OF[outcome] or outcome, job, info)
+    return outcome
+end
+
 --- Reclaim jobs stuck in `running` past the visibility timeout - a worker that
 -- claimed them died before completing. Reset to `pending` for reclaim (their
 -- incremented attempts persist, so a job that keeps killing its worker still
@@ -1189,9 +1251,9 @@ function jobs.work(opts)
         local outcome, err_str             -- nil outcome = a yield (not recorded)
         if not h then
             err_str = "no handler for job type '" .. tostring(job.type) .. "'"
-            mark_dead(job.id, err_str)
-            emit("dead", job, { error = err_str })
-            outcome = "dead"
+            outcome = finish(job, { error = err_str }, function()
+                mark_dead(job.id, err_str); return "dead"
+            end)
         else
             local ok, result = pcall(h, job)
             if ok and type(result) == "table" and result.__hull_wf_yield then
@@ -1229,16 +1291,17 @@ function jobs.work(opts)
                 end
             elseif not ok then
                 err_str = tostring(result)
-                outcome = mark_retry(job, err_str)
-                emit(outcome, job, { error = err_str, attempt = job.attempts })
+                outcome = finish(job, { error = err_str, attempt = job.attempts },
+                    function() return mark_retry(job, err_str) end)
             elseif result == jobs.DEAD then
-                err_str = "handler returned jobs.DEAD"; outcome = "dead"
-                mark_dead(job.id, err_str)
-                emit("dead", job, { error = err_str })
+                err_str = "handler returned jobs.DEAD"
+                outcome = finish(job, { error = err_str }, function()
+                    mark_dead(job.id, err_str); return "dead"
+                end)
             elseif result == jobs.RETRY then
                 err_str = "handler requested retry"
-                outcome = mark_retry(job, err_str)
-                emit(outcome, job, { error = err_str, attempt = job.attempts })
+                outcome = finish(job, { error = err_str, attempt = job.attempts },
+                    function() return mark_retry(job, err_str) end)
             else
                 -- nil / true / jobs.DISCARD -> done, no result; any other return
                 -- value is stored as the job's result (for dependents).
@@ -1246,9 +1309,9 @@ function jobs.work(opts)
                 if result ~= nil and result ~= true and result ~= jobs.DISCARD then
                     res = result
                 end
-                mark_done(job.id, res)
-                emit("completed", job, { result = res })
-                outcome = "done"
+                outcome = finish(job, { result = res }, function()
+                    mark_done(job.id, res); return "done"
+                end)
             end
         end
         -- Opt-in attempt history (a yield leaves outcome nil -> not recorded).
@@ -1953,7 +2016,48 @@ end
 -- @tparam number id
 -- @treturn boolean
 function jobs.cancel(id)
-    return (db.exec("DELETE FROM _hull_jobs WHERE id=? AND status='pending'", { id }) or 0) > 0
+    if not _cfg.events then
+        return (db.exec("DELETE FROM _hull_jobs WHERE id=? AND status='pending'", { id }) or 0) > 0
+    end
+    -- events on: capture type/queue for the "cancelled" event, delete + emit in
+    -- one txn (BEGIN IMMEDIATE serializes, so the SELECT->DELETE stays consistent).
+    local cancelled = false
+    db.batch(function()
+        local r = db.query("SELECT type, queue FROM _hull_jobs WHERE id=? AND status='pending'", { id })
+        if r and r[1] then
+            db.exec("DELETE FROM _hull_jobs WHERE id=? AND status='pending'", { id })
+            emit_durable("cancelled", { id = id, type = r[1].type, queue = r[1].queue }, {})
+            cancelled = true
+        end
+    end)
+    return cancelled
+end
+
+--- Read-only tail of the durable event log (jobs.init{events=true}), newest
+-- first - for a dashboard or ad-hoc inspection. Phase 2 adds durable
+-- subscriptions (jobs.subscribe) with at-least-once delivery + cursors.
+-- @tparam[opt] table opts { since = <event id>, types = {"dead", ...}, limit = 100 }
+-- @treturn table array of { id, ts, type, job_id, job_type, queue, data }
+function jobs.events(opts)
+    opts = opts or {}
+    local where, params = { "1=1" }, {}
+    if opts.since ~= nil then where[#where + 1] = "id > ?"; params[#params + 1] = opts.since end
+    if type(opts.types) == "table" and #opts.types > 0 then
+        local ph = {}
+        for _, t in ipairs(opts.types) do ph[#ph + 1] = "?"; params[#params + 1] = t end
+        where[#where + 1] = "type IN (" .. table.concat(ph, ",") .. ")"
+    end
+    params[#params + 1] = math.min(tonumber(opts.limit) or 100, 1000)
+    local rows = db.query(
+        "SELECT id, ts, type, job_id, job_type, queue, data FROM _hull_job_events "
+        .. "WHERE " .. table.concat(where, " AND ") .. " ORDER BY id DESC LIMIT ?", params)
+    for _, r in ipairs(rows or {}) do
+        if r.data ~= nil and r.data ~= "" then
+            local ok, decoded = pcall(json.decode, r.data)
+            if ok then r.data = decoded end
+        end
+    end
+    return rows or {}
 end
 
 --- Purge terminal jobs (done + dead by default) whose last update is older than
@@ -1990,6 +2094,9 @@ function jobs.cleanup(opts)
     -- post-hoc metrics), not by orphan-ness.
     local hr = _cfg.history_retention or opts.older_than or 604800
     db.exec("DELETE FROM _hull_job_attempts WHERE finished_ms < ?", { (time.now() - hr) * 1000 })
+    -- Durable event log retained by age. Phase 1 has no subscription cursors, so a
+    -- pure time window; Phase 2 will additionally never truncate past min(cursor).
+    db.exec("DELETE FROM _hull_job_events WHERE ts < ?", { cutoff })
     return deleted
 end
 

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -664,6 +664,64 @@ app.main(async (ctx) => {
 echo "== soft per-key concurrency: Lua =="; check_perkey_conc "lua" "lua" "$LUA_PKC"
 echo "== soft per-key concurrency: JS  =="; check_perkey_conc "js"  "js"  "$JS_PKC"
 
+# ── durable fleet-wide events, Phase 1 (log + transactional emit + tail) ─────
+# jobs.init{events=true} appends a lifecycle event in the SAME transaction as the
+# state change (enqueued/completed/dead/cancelled). jobs.events tails it. Counts
+# must match committed state exactly (no phantom events); the tail filters by type.
+check_events() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"EVENTS e=4 c=1 d=2 x=1 err=yes filtered=2"*)
+            pass "$label: durable events (transactional emit + tail + type filter)" ;;
+        *) fail "$label: durable events Phase 1" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_EVENTS='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init({ events = true })
+  jobs.handler("ok",  function(j) return { r = 1 } end)
+  jobs.handler("bad", function(j) error("boom") end)
+  jobs.enqueue("ok", { x = 1 })
+  jobs.enqueue("bad", {}, { max_attempts = 1 })
+  jobs.enqueue("nohandler", {})
+  local c = jobs.enqueue("ok", {}); jobs.cancel(c)
+  for _=1,3 do jobs.work({ batch = 10 }) end
+  local n = {}
+  for _,e in ipairs(jobs.events({ limit = 100 })) do n[e.type] = (n[e.type] or 0) + 1 end
+  local deads = jobs.events({ types = { "dead" }, limit = 10 })
+  local err = (deads[1] and deads[1].data and deads[1].data.error) and "yes" or "no"
+  ctx.stdout:write(("EVENTS e=%d c=%d d=%d x=%d err=%s filtered=%d\n"):format(
+    n.enqueued or 0, n.completed or 0, n.dead or 0, n.cancelled or 0, err, #deads))
+  return 0
+end)'
+
+JS_EVENTS='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init({ events: true });
+  jobs.handler("ok",  (j) => ({ r: 1 }));
+  jobs.handler("bad", (j) => { throw new Error("boom"); });
+  jobs.enqueue("ok", { x: 1 });
+  jobs.enqueue("bad", {}, { maxAttempts: 1 });
+  jobs.enqueue("nohandler", {});
+  const c = jobs.enqueue("ok", {}); jobs.cancel(c);
+  for (let k=0;k<3;k++) await jobs.work({ batch: 10 });
+  const n = {};
+  for (const e of jobs.events({ limit: 100 })) n[e.type] = (n[e.type] || 0) + 1;
+  const deads = jobs.events({ types: ["dead"], limit: 10 });
+  const err = (deads[0] && deads[0].data && deads[0].data.error) ? "yes" : "no";
+  ctx.stdout.write(`EVENTS e=${n.enqueued||0} c=${n.completed||0} d=${n.dead||0} x=${n.cancelled||0} err=${err} filtered=${deads.length}\n`);
+  return 0;
+});'
+
+echo "== durable events Phase 1: Lua =="; check_events "lua" "lua" "$LUA_EVENTS"
+echo "== durable events Phase 1: JS  =="; check_events "js"  "js"  "$JS_EVENTS"
+
 # ── v1.3: queue pause / resume / purge ──────────────────────────────────────
 # A paused queue is not claimed; resume restores it; purge deletes pending.
 check_pq() {


### PR DESCRIPTION
## Durable fleet-wide events — Phase 1 (log + transactional emit + tail)

First phase of #246 (design: `docs/jobs_events_design.md`, RFC #261). Where `jobs.on` is in-process and lost on a crash, this adds an **opt-in durable event log**: `jobs.init({ events = true })` records every lifecycle transition (`enqueued` / `completed` / `retried` / `dead` / `cancelled`) as a row in `_hull_job_events`.

### The keystone: transactional coupling
The event row is written in the **same transaction** as the state change that produced it. A new `finish()` helper wraps each terminal outcome (`mark_done`/`mark_dead`/`mark_retry`) + the durable emit in one `db.batch`, so an event exists **iff** the transition committed — no lost events, no phantom events. As a bonus it collapses `mark_done`'s several statements into one commit (fewer fsyncs), a **net win even when events are off**. `enqueue` emits `enqueued` inline (joining the caller's `db.batch` when they wrap it); `cancel` emits `cancelled`. `emit_durable` no-ops when events are off, so the default path is unchanged.

### The tail
```lua
jobs.init({ events = true })
local recent = jobs.events({ types = { "dead" }, since = last_id, limit = 100 })
-- each: { id, ts, type, job_id, job_type, queue, data = { error?, attempt?, trace? } }
```
`id` is the monotonic total order (+ the future subscription cursor space); `data` is compact metadata, never the full result. `jobs.cleanup` retains the log by age. **Off by default** — an app that doesn't opt in pays nothing.

### Tests / validation
- e2e asserts the event counts match committed state **exactly** (no phantom events) + the type filter; the events-off no-op is covered by all 55 existing tests (which run events-off through the new `finish()` path).
- **SQLite 57/57 + MySQL 8 + PostgreSQL 16** (Docker) — the transactional `finish()` wrapping and the log/tail SQL run cleanly on each (validated locally, the `LIKE ESCAPE`/correlated-subquery discipline).
- Both runtimes, full parity. luacheck clean.

Ships value alone: a dashboard can poll `jobs.events`. Phase 2 (durable subscriptions with cursors + at-least-once delivery) is the next step.
