### PR TITLE
jobs: durable events Phase 2 (subscriptions - cursor + lease drain)

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -137,17 +137,46 @@ jobs.init({ events: true });
 const recent = jobs.events({ types: ["dead"], since: lastId, limit: 100 });
 ```
 
-- **`id`** is a monotonic total order (and the cursor space Phase 2 subscriptions
-  will use). Tail incrementally by passing the last id you saw as `since`.
+- **`id`** is a monotonic total order (and the subscription cursor space). Tail
+  incrementally by passing the last id you saw as `since`.
 - **`data`** is compact metadata (`error` / `attempt` / `trace`), never the full
   result - join `jobs.result(job_id)` when you need the value.
-- **Retention** is by age via `jobs.cleanup` (same window as terminal rows).
 - **Off by default** - an app that doesn't opt in pays nothing (no log writes).
-- This is **Phase 1** (the log + a pollable tail, enough to power a dashboard).
-  Phase 2 adds **durable subscriptions** (`jobs.subscribe(name, handler)`) with
-  at-least-once delivery + per-consumer cursors, so a reacting service processes
-  every event exactly-once-effectively across the fleet. Design:
-  [docs/jobs_events_design.md](jobs_events_design.md).
+
+### Durable subscriptions
+
+For a service that must **react** to events (not just tail them), a durable
+**subscription** delivers each event to a handler **at-least-once**, tracking its
+own cursor so it resumes exactly where it left off after a restart - fleet-wide:
+
+```lua
+-- Register on every worker (like jobs.handler). Handlers must be idempotent.
+jobs.subscribe("fulfillment", function(ev)
+    if ev.type == "completed" and ev.job_type == "charge" then webhook.notify(ev) end
+end, { types = { "completed", "dead" }, from = "now" })
+jobs.unsubscribe("fulfillment")
+```
+```javascript
+jobs.subscribe("fulfillment", (ev) => { if (ev.type === "completed") webhook.notify(ev); },
+               { types: ["completed", "dead"], from: "now" });
+```
+
+- **Drained by `jobs.work` / `jobs.run_worker`** - no separate process needed.
+  A per-subscription **lease** (a claim-token + visibility timeout, exactly like
+  the job claim) means one worker drains a subscription at a time; if that worker
+  dies, another resumes from the cursor. So delivery is **at-least-once** (a crash
+  between a handler succeeding and the cursor advancing re-delivers) - handlers
+  must be idempotent, the same contract as a job handler.
+- **`from`**: `"now"` (default) starts at the current head (skip history);
+  `"beginning"` replays the whole retained log.
+- **Ordered per subscription** (by event id); no cross-subscription order promise.
+- **Retention is subscription-aware**: `jobs.cleanup` never truncates the log past
+  the slowest subscription's cursor, so a lagging consumer keeps its unseen events
+  (watch subscription lag so a stuck one doesn't hold the log open indefinitely).
+- A handler that keeps throwing stops its subscription at that event (retried on
+  the next drain); a skip-after-N poison-event policy is the Phase 3 follow-up.
+
+Design + testability: [docs/jobs_events_design.md](jobs_events_design.md).
 
 ## Recurring jobs (cron)
 

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -286,6 +286,20 @@ function init(opts) {
     db.exec("CREATE INDEX IF NOT EXISTS idx_hull_job_events_type ON _hull_job_events(type, id)");
     db.exec("CREATE INDEX IF NOT EXISTS idx_hull_job_events_ts ON _hull_job_events(ts)");
 
+    // Durable event subscriptions (jobs.subscribe). One row per named consumer:
+    // `cursor` = last delivered event id, `types` = optional comma-list filter,
+    // `lease_token`/`lease_until` = the drain lease (one worker drains at a time;
+    // a crashed drainer's lease expires and another resumes from the cursor).
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_job_subscriptions (" +
+        "name        VARCHAR(255) NOT NULL PRIMARY KEY," +
+        "cursor_id   INTEGER      NOT NULL DEFAULT 0," +
+        "types       VARCHAR(255)," +
+        "lease_token VARCHAR(255)," +
+        "lease_until INTEGER," +
+        "failures    INTEGER      NOT NULL DEFAULT 0," +
+        "updated_at  INTEGER      NOT NULL)");
+
     // Verify the server actually parses SKIP LOCKED (the compile-time dialect
     // flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
     // does not). A 0-row probe against the real table detects it once; the claim
@@ -1148,6 +1162,13 @@ async function work(opts) {
     if (now - _lastReap >= interval) { reap(o); _lastReap = now; }
     // Fire due cron schedules (throttled; cron is minute-grained).
     if (now - _lastCron >= 1) { processCron(now); _lastCron = now; }
+    // Drain durable event subscriptions (throttled; the per-subscription lease
+    // makes this fleet-safe). Only workers that registered subscribers do work.
+    const subNames = Object.keys(_subscribers);
+    if (subNames.length && now - _lastEdrain >= 1) {
+        for (const name of subNames) eventsDrain(name, { now });
+        _lastEdrain = now;
+    }
     const batch = claim(o);
     for (const job of batch) {
         job.deps = loadDeps(job.id);   // workflow: dependency results, in order
@@ -1228,6 +1249,15 @@ let _running = false;
 let _lastReap = 0;
 // Unix ts of the last cron due-check (throttled to >=1s; cron is minute-grained).
 let _lastCron = 0;
+// Unix ts of the last subscription drain (throttled to >=1s in work()).
+let _lastEdrain = 0;
+// Durable event subscribers registered on THIS worker (jobs.subscribe):
+// name -> { handler(event) }. The subscription row (cursor/lease) is durable in
+// _hull_job_subscriptions; the handler is per-worker, like a job handler.
+const _subscribers = Object.create(null);
+// Lease duration (seconds) for a subscription drain (a crashed drainer's lease
+// expires after this and another worker resumes from the unadvanced cursor).
+const _EDRAIN_LEASE = 30;
 
 /**
  * Request the running runWorker loop to stop after the current iteration.
@@ -1911,6 +1941,103 @@ function events(opts) {
 }
 
 /**
+ * Register a durable named subscription over the event log (Phase 2). `handler`
+ * is called once per event, in id order, AT-LEAST-ONCE (a crash between a handler
+ * succeeding and the cursor advancing re-delivers it) - so handlers must be
+ * idempotent. The cursor is durable (survives restarts); the handler is
+ * per-worker, so call jobs.subscribe on every worker (like jobs.handler). Drained
+ * by jobs.work / jobs.run_worker.
+ * @param {string} name
+ * @param {Function} handler   (event) => void
+ * @param {object} [opts] { types: ["dead", ...], from: "now" | "beginning" }
+ */
+function subscribe(name, handler, opts) {
+    if (typeof name !== "string" || name === "")
+        throw new Error("jobs.subscribe: name must be a non-empty string");
+    if (typeof handler !== "function")
+        throw new Error("jobs.subscribe: handler must be a function");
+    const o = opts || {};
+    const typesCsv = (Array.isArray(o.types) && o.types.length) ? o.types.join(",") : null;
+    // Start cursor: "now" (default) skips existing history; "beginning" replays all.
+    let start = 0;
+    if (o.from !== "beginning") {
+        const m = db.query("SELECT MAX(id) AS m FROM _hull_job_events");
+        start = (m[0] && m[0].m) || 0;
+    }
+    const now = time.now();
+    const n = db.insertIfAbsent("_hull_job_subscriptions", ["name"],
+        ["name", "cursor_id", "types", "failures", "updated_at"], [name, start, typesCsv, 0, now]);
+    if (!(n && n > 0)) {
+        db.exec("UPDATE _hull_job_subscriptions SET types=?, updated_at=? WHERE name=?",
+            [typesCsv, now, name]);
+    }
+    _subscribers[name] = { handler };
+    return jobs;
+}
+
+/** Remove a subscription: this worker's handler and the durable row (cursor). */
+function unsubscribe(name) {
+    delete _subscribers[name];
+    db.exec("DELETE FROM _hull_job_subscriptions WHERE name=?", [name]);
+    return jobs;
+}
+
+// Synchronous drain seam (the Phase 2 testability keystone): lease the
+// subscription, deliver new events in id order, advance the cursor, release the
+// lease. No timers/sleeps - work() drives it. Returns { delivered, cursor,
+// leased }. Test seams: opts.now (clock), opts.batch, opts.commitCursor (false =
+// deliver but don't advance -> models a crash before the cursor write),
+// opts.releaseLease (false = hold the lease -> models a worker death mid-drain).
+function eventsDrain(name, opts) {
+    const o = opts || {};
+    const sub = _subscribers[name];
+    if (!sub) return { delivered: 0, leased: false };
+    const now = o.now !== undefined ? o.now : time.now();
+    const token = crypto.base64urlEncode(crypto.random(8));
+    // Acquire the lease (CAS): detect acquisition via RETURNING on PG/SQLite
+    // (db.exec does not surface an affected-row count on Postgres); MySQL has no
+    // RETURNING but returns the count.
+    const leaseSql = "UPDATE _hull_job_subscriptions SET lease_token=?, lease_until=?, updated_at=? " +
+        "WHERE name=? AND (lease_until IS NULL OR lease_until <= ?)";
+    const leaseParams = [token, now + _EDRAIN_LEASE, now, name, now];
+    const got = db.dialect.supportsReturning
+        ? db.query(leaseSql + " RETURNING name", leaseParams).length
+        : (db.exec(leaseSql, leaseParams) || 0);
+    if (got === 0) return { delivered: 0, leased: false };
+    const row = db.query("SELECT cursor_id, types, failures FROM _hull_job_subscriptions WHERE name=?", [name]);
+    const cursor = row[0].cursor_id;
+    const failures = row[0].failures || 0;
+    const where = ["id > ?"], params = [cursor];
+    if (row[0].types) {
+        const parts = String(row[0].types).split(",").filter((s) => s.length);
+        if (parts.length) {
+            where.push("type IN (" + parts.map(() => "?").join(",") + ")");
+            for (const t of parts) params.push(t);
+        }
+    }
+    params.push(o.batch || 100);
+    const evs = db.query(
+        "SELECT id, ts, type, job_id, job_type, queue, data FROM _hull_job_events " +
+        "WHERE " + where.join(" AND ") + " ORDER BY id LIMIT ?", params);
+    let lastOk = cursor, delivered = 0, failed = false;
+    for (const e of evs) {
+        if (e.data !== undefined && e.data !== null && e.data !== "") {
+            try { e.data = json.decode(e.data); } catch (_e) { /* leave raw */ }
+        }
+        try { sub.handler(e); lastOk = e.id; delivered += 1; }
+        catch (_e) { failed = true; break; }
+    }
+    const newCursor = (o.commitCursor === false) ? cursor : lastOk;
+    const release = o.releaseLease !== false;
+    db.exec(
+        "UPDATE _hull_job_subscriptions SET cursor_id=?, failures=?, " +
+        (release ? "lease_token=NULL, lease_until=NULL, " : "") +
+        "updated_at=? WHERE name=? AND lease_token=?",
+        [newCursor, failed ? failures + 1 : 0, now, name, token]);
+    return { delivered, cursor: newCursor, leased: true };
+}
+
+/**
  * Purge terminal jobs (done + dead by default) whose last update is older than
  * a retention age. Run from app.daily to bound table growth. Only touches
  * terminal rows, so it never races a pending / running job.
@@ -1936,9 +2063,16 @@ function cleanup(opts) {
     // post-hoc metrics), not by orphan-ness.
     const hr = _cfg.historyRetention || o.olderThan || 604800;
     db.exec("DELETE FROM _hull_job_attempts WHERE finished_ms < ?", [(time.now() - hr) * 1000]);
-    // Durable event log retained by age. Phase 1 has no subscription cursors, so a
-    // pure time window; Phase 2 will additionally never truncate past min(cursor).
-    db.exec("DELETE FROM _hull_job_events WHERE ts < ?", [cutoff]);
+    // Durable event log: retained by age, but NEVER past an unconsumed event -
+    // min(cursor) across subscriptions is the safe watermark. No subscriptions ->
+    // age only (the Phase 1 behavior).
+    const mc = db.query("SELECT MIN(cursor_id) AS m FROM _hull_job_subscriptions");
+    const watermark = mc[0] ? mc[0].m : null;
+    if (watermark === null || watermark === undefined) {
+        db.exec("DELETE FROM _hull_job_events WHERE ts < ?", [cutoff]);
+    } else {
+        db.exec("DELETE FROM _hull_job_events WHERE ts < ? AND id <= ?", [cutoff, watermark]);
+    }
     return deleted;
 }
 
@@ -1954,11 +2088,11 @@ export const jobs = {
     stats, runWorker, stop, get, result, await: await_, progress, heartbeat, limit, metrics, history,
     pause, resume, purge,
     workflow, start, signal, workflowStatus,
-    dead, retry, cancel, cleanup, cron, uncron, events,
-    RETRY, DEAD, DISCARD, _config: _cfg, _cronNext, _tick,
+    dead, retry, cancel, cleanup, cron, uncron, events, subscribe, unsubscribe,
+    RETRY, DEAD, DISCARD, _config: _cfg, _cronNext, _tick, _eventsDrain: eventsDrain,
 };
 export { init, enqueue, enqueueMany, claim, handler, on, work, reap, stats,
          runWorker, stop, get, result, progress, heartbeat, limit, metrics, history, pause, resume,
          purge, workflow, start, signal, workflowStatus,
-         dead, retry, cancel, cleanup, cron, uncron, events };
+         dead, retry, cancel, cleanup, cron, uncron, events, subscribe, unsubscribe };
 export default jobs;

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -69,10 +69,22 @@ local _listeners = { completed = {}, retried = {}, dead = {} }
 -- reserved-type handler that runs the workflow through a memoizing ctx.
 local _workflows = {}
 
+-- Durable event subscribers registered on THIS worker (jobs.subscribe):
+-- name -> { handler = fn(event) }. The subscription row (cursor/lease) is durable
+-- in _hull_job_subscriptions; the handler is per-worker, like jobs.handler. A
+-- homogeneous fleet re-registers every subscription at startup, so any worker can
+-- drain any subscription (the per-subscription lease serializes them).
+local _subscribers = {}
+
 -- Unix ts of the last reaper sweep (throttled in jobs.work via _cfg.reap_interval).
 local _last_reap = 0
 -- Unix ts of the last cron due-check (throttled to >=1s; cron is minute-grained).
 local _last_cron = 0
+-- Unix ts of the last subscription drain (throttled to >=1s in jobs.work).
+local _last_edrain = 0
+-- Lease duration (seconds) for a subscription drain - a crashed drainer's lease
+-- expires after this and another worker resumes from the unadvanced cursor.
+local _EDRAIN_LEASE = 30
 -- Whether the server parses SKIP LOCKED (probed in jobs.init; nil = not probed).
 local _skip_locked = nil
 -- Per-queue rate limits { [queue] = { rate, per } }, in-memory (re-registered on
@@ -312,6 +324,21 @@ function jobs.init(opts)
     db.exec([[
         CREATE INDEX IF NOT EXISTS idx_hull_job_events_ts ON _hull_job_events(ts)
     ]])
+
+    -- Durable event subscriptions (jobs.subscribe). One row per named consumer:
+    -- `cursor` = last delivered event id (the drain advances it), `types` = an
+    -- optional comma-list filter, `lease_token`/`lease_until` = the drain lease
+    -- (one worker drains a subscription at a time; a crashed drainer's lease
+    -- expires and another resumes from the cursor). Restart-durable + fleet-wide.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_job_subscriptions ("
+        .. "name        VARCHAR(255) NOT NULL PRIMARY KEY,"
+        .. "cursor_id   INTEGER      NOT NULL DEFAULT 0,"
+        .. "types       VARCHAR(255),"
+        .. "lease_token VARCHAR(255),"
+        .. "lease_until INTEGER,"
+        .. "failures    INTEGER      NOT NULL DEFAULT 0,"
+        .. "updated_at  INTEGER      NOT NULL)")
 
     -- Verify the server actually parses SKIP LOCKED (the compile-time dialect
     -- flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
@@ -1243,6 +1270,12 @@ function jobs.work(opts)
         process_cron(now)
         _last_cron = now
     end
+    -- Drain durable event subscriptions (throttled; the per-subscription lease
+    -- makes this fleet-safe). Only workers that registered subscribers do work.
+    if next(_subscribers) and now - _last_edrain >= 1 then
+        for name in pairs(_subscribers) do jobs._events_drain(name, { now = now }) end
+        _last_edrain = now
+    end
     local batch = jobs.claim(opts)
     for _, job in ipairs(batch) do
         job.deps = load_deps(job.id)   -- workflow: dependency results, in order
@@ -2060,6 +2093,109 @@ function jobs.events(opts)
     return rows or {}
 end
 
+--- Register a durable named subscription over the event log (Phase 2). `handler`
+-- is called once per event, in id order, AT-LEAST-ONCE (a crash between a handler
+-- succeeding and the cursor advancing re-delivers it) - so handlers must be
+-- idempotent, the same contract as a job handler. The cursor is durable (survives
+-- restarts); the handler is per-worker, so call jobs.subscribe on every worker
+-- (like jobs.handler). Drained by jobs.work / jobs.run_worker.
+-- @tparam string name
+-- @tparam function handler   function(event)
+-- @tparam[opt] table opts { types = {"dead", ...}, from = "now" | "beginning" }
+function jobs.subscribe(name, handler, opts)
+    if type(name) ~= "string" or name == "" then
+        error("jobs.subscribe: name must be a non-empty string")
+    end
+    if type(handler) ~= "function" then error("jobs.subscribe: handler must be a function") end
+    opts = opts or {}
+    local types_csv
+    if type(opts.types) == "table" and #opts.types > 0 then types_csv = table.concat(opts.types, ",") end
+    -- Start cursor: "now" (default) skips existing history; "beginning" replays all.
+    local start = 0
+    if opts.from ~= "beginning" then
+        local m = db.query("SELECT MAX(id) AS m FROM _hull_job_events")
+        start = (m[1] and m[1].m) or 0
+    end
+    local now = time.now()
+    -- Create the durable row once; a re-subscribe keeps the persisted cursor and
+    -- only refreshes the type filter.
+    local n = db.insert_if_absent("_hull_job_subscriptions", { "name" },
+        { "name", "cursor_id", "types", "failures", "updated_at" }, { name, start, types_csv, 0, now })
+    if not (n and n > 0) then
+        db.exec("UPDATE _hull_job_subscriptions SET types=?, updated_at=? WHERE name=?",
+            { types_csv, now, name })
+    end
+    _subscribers[name] = { handler = handler }
+    return jobs
+end
+
+--- Remove a subscription: this worker's handler and the durable row (cursor).
+function jobs.unsubscribe(name)
+    _subscribers[name] = nil
+    db.exec("DELETE FROM _hull_job_subscriptions WHERE name=?", { name })
+    return jobs
+end
+
+-- Synchronous drain seam (the Phase 2 testability keystone): lease the
+-- subscription, deliver new events in id order, advance the cursor, release the
+-- lease. No timers/sleeps - jobs.work drives it. Returns { delivered, cursor,
+-- leased }. Test seams: opts.now (clock), opts.batch, opts.commit_cursor (false =
+-- deliver but don't advance -> models a crash before the cursor write),
+-- opts.release_lease (false = hold the lease -> models a worker death mid-drain).
+function jobs._events_drain(name, opts)
+    opts = opts or {}
+    local sub = _subscribers[name]
+    if not sub then return { delivered = 0, leased = false } end
+    local now = opts.now or time.now()
+    local token = crypto.base64url_encode(crypto.random(8))
+    -- Acquire the lease (CAS): only if free or expired. Fleet-safe, no global lock.
+    -- Detect acquisition via RETURNING on PG/SQLite (db.exec does not surface an
+    -- affected-row count on Postgres); MySQL has no RETURNING but returns the count.
+    local lease_sql = "UPDATE _hull_job_subscriptions SET lease_token=?, lease_until=?, updated_at=? "
+        .. "WHERE name=? AND (lease_until IS NULL OR lease_until <= ?)"
+    local lease_params = { token, now + _EDRAIN_LEASE, now, name, now }
+    local got
+    if db.dialect.supports_returning then
+        got = #db.query(lease_sql .. " RETURNING name", lease_params)
+    else
+        got = db.exec(lease_sql, lease_params) or 0
+    end
+    if got == 0 then return { delivered = 0, leased = false } end
+    local row = db.query(
+        "SELECT cursor_id, types, failures FROM _hull_job_subscriptions WHERE name=?", { name })
+    local cursor = row[1].cursor_id
+    local failures = row[1].failures or 0
+    -- Fetch events past the cursor, filtered by the subscription's types.
+    local where, params = { "id > ?" }, { cursor }
+    if row[1].types and row[1].types ~= "" then
+        local ph = {}
+        for t in tostring(row[1].types):gmatch("[^,]+") do ph[#ph + 1] = "?"; params[#params + 1] = t end
+        where[#where + 1] = "type IN (" .. table.concat(ph, ",") .. ")"
+    end
+    params[#params + 1] = opts.batch or 100
+    local evs = db.query(
+        "SELECT id, ts, type, job_id, job_type, queue, data FROM _hull_job_events "
+        .. "WHERE " .. table.concat(where, " AND ") .. " ORDER BY id LIMIT ?", params)
+    -- Deliver in id order. On a handler error, stop - advance only past the
+    -- successful prefix; the failing event is retried on the next drain.
+    local last_ok, delivered, failed = cursor, 0, false
+    for _, e in ipairs(evs) do
+        if e.data ~= nil and e.data ~= "" then
+            local ok, d = pcall(json.decode, e.data); if ok then e.data = d end
+        end
+        if pcall(sub.handler, e) then last_ok = e.id; delivered = delivered + 1
+        else failed = true; break end
+    end
+    local new_cursor = (opts.commit_cursor == false) and cursor or last_ok
+    local release = opts.release_lease ~= false
+    db.exec(
+        "UPDATE _hull_job_subscriptions SET cursor_id=?, failures=?, "
+        .. (release and "lease_token=NULL, lease_until=NULL, " or "")
+        .. "updated_at=? WHERE name=? AND lease_token=?",
+        { new_cursor, failed and (failures + 1) or 0, now, name, token })
+    return { delivered = delivered, cursor = new_cursor, leased = true }
+end
+
 --- Purge terminal jobs (done + dead by default) whose last update is older than
 -- a retention age. Run it from `app.daily` to bound table growth. Only touches
 -- terminal rows, so it never races a pending / running job.
@@ -2094,9 +2230,16 @@ function jobs.cleanup(opts)
     -- post-hoc metrics), not by orphan-ness.
     local hr = _cfg.history_retention or opts.older_than or 604800
     db.exec("DELETE FROM _hull_job_attempts WHERE finished_ms < ?", { (time.now() - hr) * 1000 })
-    -- Durable event log retained by age. Phase 1 has no subscription cursors, so a
-    -- pure time window; Phase 2 will additionally never truncate past min(cursor).
-    db.exec("DELETE FROM _hull_job_events WHERE ts < ?", { cutoff })
+    -- Durable event log: retained by age, but NEVER past an unconsumed event -
+    -- min(cursor) across subscriptions is the safe watermark. No subscriptions ->
+    -- age only (the Phase 1 behavior).
+    local mc = db.query("SELECT MIN(cursor_id) AS m FROM _hull_job_subscriptions")
+    local watermark = mc[1] and mc[1].m
+    if watermark == nil then
+        db.exec("DELETE FROM _hull_job_events WHERE ts < ?", { cutoff })
+    else
+        db.exec("DELETE FROM _hull_job_events WHERE ts < ? AND id <= ?", { cutoff, watermark })
+    end
     return deleted
 end
 

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -722,6 +722,126 @@ app.main(async (ctx) => {
 echo "== durable events Phase 1: Lua =="; check_events "lua" "lua" "$LUA_EVENTS"
 echo "== durable events Phase 1: JS  =="; check_events "js"  "js"  "$JS_EVENTS"
 
+# ── durable events Phase 2 (subscriptions: cursor + lease drain) ─────────────
+# The jobs._events_drain seam is synchronous + clock-injectable, so at-least-once,
+# lease reclaim, and retention are asserted at exact instants with NO sleeps.
+# Covers: deterministic in-order capture (T3), crash-before-cursor -> re-delivery
+# (T5a), worker-death lease reclaim (T5b), retention-never-past-min(cursor) (T6).
+check_events_p2() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"EV deliv=3 order=y recaught=0 dup=6 held=false reclaim=3 retain=y purged=y"*)
+            pass "$label: durable subscriptions (capture + at-least-once + lease reclaim + retention)" ;;
+        *) fail "$label: durable events Phase 2" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_EV2='local jobs = require("hull.jobs")
+local time = require("hull.time")
+app.manifest({ modules = { "hull/jobs@1", "hull/time@1" } })
+app.main(function(ctx)
+  jobs.init({ events = true })
+  local future = time.now() + 100   -- > every event ts, within int4 (PG-safe)
+  jobs.enqueue("ok", {}); jobs.enqueue("ok", {}); jobs.enqueue("ok", {})
+  local seen = {}
+  jobs.subscribe("cap", function(ev) seen[#seen+1] = ev.id end, { from = "beginning" })
+  local r  = jobs._events_drain("cap", { now = 1000 })
+  local re = jobs._events_drain("cap", { now = 1000 })
+  local order = (seen[1]==1 and seen[2]==2 and seen[3]==3) and "y" or "n"
+  local dc = 0
+  jobs.subscribe("dup", function() dc = dc + 1 end, { from = "beginning" })
+  jobs._events_drain("dup", { now = 1000, commit_cursor = false })
+  jobs._events_drain("dup", { now = 1000 })
+  jobs.subscribe("lease", function() end, { from = "beginning" })
+  jobs._events_drain("lease", { now = 1000, commit_cursor = false, release_lease = false })
+  local held = jobs._events_drain("lease", { now = 1000 })
+  local rec  = jobs._events_drain("lease", { now = 1040 })
+  jobs.subscribe("lag", function() end, { from = "beginning" })
+  local before = #jobs.events({ limit = 100 })
+  jobs.cleanup({ before = future })
+  local after = #jobs.events({ limit = 100 })
+  jobs._events_drain("lag", { now = 1000 })
+  jobs.cleanup({ before = future })
+  local final = #jobs.events({ limit = 100 })
+  ctx.stdout:write(("EV deliv=%d order=%s recaught=%d dup=%d held=%s reclaim=%d retain=%s purged=%s\n"):format(
+    r.delivered, order, re.delivered, dc, tostring(held.leased), rec.delivered,
+    (after==before) and "y" or "n", (final==0) and "y" or "n"))
+  return 0
+end)'
+
+JS_EV2='import { app } from "hull:app"; import { jobs } from "hull:jobs"; import { time } from "hull:time";
+app.manifest({ modules: ["hull/jobs@1", "hull/time@1"] });
+app.main(async (ctx) => {
+  jobs.init({ events: true });
+  const future = time.now() + 100;   // > every event ts, within int4 (PG-safe)
+  jobs.enqueue("ok", {}); jobs.enqueue("ok", {}); jobs.enqueue("ok", {});
+  const seen = [];
+  jobs.subscribe("cap", (ev) => seen.push(ev.id), { from: "beginning" });
+  const r  = jobs._eventsDrain("cap", { now: 1000 });
+  const re = jobs._eventsDrain("cap", { now: 1000 });
+  const order = (seen[0]===1 && seen[1]===2 && seen[2]===3) ? "y" : "n";
+  let dc = 0;
+  jobs.subscribe("dup", () => { dc++; }, { from: "beginning" });
+  jobs._eventsDrain("dup", { now: 1000, commitCursor: false });
+  jobs._eventsDrain("dup", { now: 1000 });
+  jobs.subscribe("lease", () => {}, { from: "beginning" });
+  jobs._eventsDrain("lease", { now: 1000, commitCursor: false, releaseLease: false });
+  const held = jobs._eventsDrain("lease", { now: 1000 });
+  const rec  = jobs._eventsDrain("lease", { now: 1040 });
+  jobs.subscribe("lag", () => {}, { from: "beginning" });
+  const before = jobs.events({ limit: 100 }).length;
+  jobs.cleanup({ before: future });
+  const after = jobs.events({ limit: 100 }).length;
+  jobs._eventsDrain("lag", { now: 1000 });
+  jobs.cleanup({ before: future });
+  const final = jobs.events({ limit: 100 }).length;
+  ctx.stdout.write(`EV deliv=${r.delivered} order=${order} recaught=${re.delivered} dup=${dc} held=${held.leased} reclaim=${rec.delivered} retain=${after===before?"y":"n"} purged=${final===0?"y":"n"}\n`);
+  return 0;
+});'
+
+echo "== durable events Phase 2: Lua =="; check_events_p2 "lua" "lua" "$LUA_EV2"
+echo "== durable events Phase 2: JS  =="; check_events_p2 "js"  "js"  "$JS_EV2"
+
+# Fleet gate: K processes drain ONE shared subscription. The per-subscription
+# lease + monotonic cursor mean each event is delivered exactly once across the
+# fleet - the union of per-process deliveries is all N ids, no duplicates.
+echo "== durable events fleet gate ($CONC processes, one subscription) =="
+EW="$(mktemp -d)"; EDB="$EW/e.db"
+cat > "$EW/seed.lua" <<LUA
+local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function()
+  jobs.init({ events = true })
+  for i=1,20 do jobs.enqueue("t", {}) end          -- 20 "enqueued" events
+  jobs.subscribe("g", function() end, { from = "beginning" })  -- create sub at cursor 0
+  return 0
+end)
+LUA
+cat > "$EW/drain.lua" <<'LUA'
+local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init({ events = true })
+  jobs.subscribe("g", function(ev) ctx.stdout:write(ev.id .. "\n") end, { from = "beginning" })
+  for _=1,40 do jobs._events_drain("g", {}) end     -- drain to exhaustion (lease-serialized)
+  return 0
+end)
+LUA
+"$HULL" "$EW/seed.lua" -d "$EDB" >/dev/null 2>&1
+i=1; while [ "$i" -le "$CONC" ]; do "$HULL" "$EW/drain.lua" -d "$EDB" > "$EW/out.$i" 2>/dev/null & i=$((i+1)); done
+wait
+etot="$(cat "$EW"/out.* | grep -c . || true)"
+euniq="$(cat "$EW"/out.* | sort -n | uniq | grep -c . || true)"
+if [ "$etot" -eq 20 ] && [ "$euniq" -eq 20 ]; then
+    pass "durable events fleet: $CONC processes delivered all 20 events exactly once (lease + cursor)"
+else
+    fail "durable events fleet: expected 20/20" "total=$etot uniq=$euniq"
+fi
+rm -rf "$EW"
+
 # ── v1.3: queue pause / resume / purge ──────────────────────────────────────
 # A paused queue is not claimed; resume restores it; purge deletes pending.
 check_pq() {


### PR DESCRIPTION
## Durable events — Phase 2 (subscriptions: cursor + lease drain)

Second phase of #246, stacked on Phase 1 (#262). Adds durable, fleet-wide event **subscriptions**: `jobs.subscribe(name, handler, {types, from})` / `jobs.unsubscribe`. Each event is delivered **at-least-once**, in id order, with the subscription tracking its own durable cursor (`_hull_job_subscriptions`) so it resumes exactly where it left off after a restart.

### Fleet-safe, no global lock
A per-subscription **lease** (claim-token + visibility timeout — the same mechanism as the job claim/reaper) means one worker drains a subscription at a time; a crashed drainer's lease expires and another resumes from the unadvanced cursor. Drained by `jobs.work` / `run_worker` (throttled; only workers that registered subscribers do work). Retention is now **subscription-aware** — `jobs.cleanup` never truncates past `min(cursor)`.

### Testability keystone
`jobs._events_drain(name, {now, batch, commit_cursor, release_lease})` — a **synchronous, clock-injectable** seam (no timers/sleeps). Every guarantee is asserted at exact instants:
- deterministic in-order capture;
- crash-before-cursor → re-delivery (`commit_cursor=false`);
- worker-death lease reclaim (`release_lease=false` + advanced `now`);
- retention-never-past-`min(cursor)`;
- plus a real multi-process **fleet gate** (K `hull` processes drain one subscription → every event delivered exactly once).

### Cross-backend
Both runtimes, full parity. **SQLite 60/60 + MySQL 8 + PostgreSQL 16** (Docker). The 3-backend pass caught three portability issues, all fixed:
- `cursor` is a **MySQL reserved word** → `cursor_id`;
- the lease CAS must detect acquisition via `UPDATE … RETURNING` on PG/SQLite because **`db.exec` doesn't surface an affected-row count on Postgres** (MySQL returns it);
- the test's cleanup cutoff must stay within int4 (second-resolution `ts` columns are INTEGER jobs-wide, per convention).

**Discovered follow-up (pre-existing, out of scope):** the same pg `db.exec`-rowcount gap means `jobs.cancel`/`retry`/`reap` report wrong *counts* on Postgres (the statements still execute). Worth a pg-backend fix.

Phase 3 (failing-subscriber skip/backoff + lag metrics) and Phase 4 (LISTEN/NOTIFY, #235) are next.
