### PR TITLE
db(postgres): surface the affected-row count from db.exec

### DIFF
--- a/src/hull/cap/db_postgres.c
+++ b/src/hull/cap/db_postgres.c
@@ -19,6 +19,7 @@
 #include "hull/cap/types.h"
 #include "hull/utils/alloc.h"
 
+#include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -276,9 +277,12 @@ static int pg_query(HlDbHandle *h, const char *sql,
     a.user_cb = cb;
     a.user_ctx = cb_ctx;
 
+    /* Capture the CommandComplete row count (parsed by the wire client) so the
+     * exec path can surface it, matching sqlite3_changes / MySQL affected_rows. */
+    int64_t affected = -1;
     int rc = hl_pg_query(&s->conn, sql, pp, nparams,
                          cb ? adapter_desc : NULL,
-                         cb ? adapter_row : NULL, &a, NULL);
+                         cb ? adapter_row : NULL, &a, &affected);
 
     if (a.names)
         for (int i = 0; i < a.nfields; i++) free(a.names[i]);
@@ -288,7 +292,15 @@ static int pg_query(HlDbHandle *h, const char *sql,
         for (int i = 0; i < nparams; i++) free(scratch[i]);
     free(scratch);
     free(pp);
-    return rc;
+
+    if (rc != 0) return rc;   /* error path unchanged */
+    /* exec path (no row callback): return the affected-row count (0 when the
+     * command has no numeric tag, e.g. BEGIN). The query path returns 0 - its
+     * rows were delivered via the callback, and callers use the row set, not
+     * this value. int cast: practical counts fit; clamp an absurd one honestly. */
+    if (cb == NULL && affected >= 0)
+        return affected > INT_MAX ? INT_MAX : (int)affected;
+    return 0;
 }
 
 static int pg_exec(HlDbHandle *h, const char *sql,

--- a/tests/e2e_postgres.sh
+++ b/tests/e2e_postgres.sh
@@ -406,7 +406,7 @@ app.main(function(ctx)
   return 0
 end)
 LUA
-rcout="$("$HULL" "$RCDIR/rc.lua" -d "$DSN" 2>/dev/null)" || true
+rcout="$(./build/hull "$RCDIR/rc.lua" -d "$DSN" 2>/dev/null)" || true
 case "$rcout" in
     *"PGRC upd=2 del=1 no=0 cancel=true"*)
         echo "PASS: db.exec returns the affected-row count on Postgres (jobs.cancel etc. correct)"

--- a/tests/e2e_postgres.sh
+++ b/tests/e2e_postgres.sh
@@ -382,6 +382,38 @@ case "$wfout" in
     *)  echo "::error jobs durable/observability on PG: $wfout"; exit 1 ;;
 esac
 
+# ── db.exec affected-row count (regression guard) ─────────────────────
+# The pg backend must surface the CommandComplete row count (like sqlite3_changes
+# / MySQL affected_rows); it previously discarded it and returned 0, which broke
+# every rowcount-based caller (jobs.cancel/retry/reap, session/ratelimit cleanup).
+RCDIR=$(mktemp -d)
+cat > "$RCDIR/rc.lua" <<'LUA'
+local db = require("hull.db").default()
+local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/db@1", "hull/jobs@1" } })
+app.main(function(ctx)
+  db.exec("DROP TABLE IF EXISTS rc_t")
+  db.exec("CREATE TABLE rc_t (id INTEGER PRIMARY KEY, n INTEGER)")
+  db.exec("INSERT INTO rc_t (id,n) VALUES (1,0),(2,0),(3,0)")
+  local upd = db.exec("UPDATE rc_t SET n=1 WHERE id<=2")       -- 2
+  local del = db.exec("DELETE FROM rc_t WHERE id=3")            -- 1
+  local no  = db.exec("UPDATE rc_t SET n=9 WHERE id=99")        -- 0
+  jobs.init()
+  local jid = jobs.enqueue("x", {}, { delay = 3600 })          -- pending
+  local ok  = jobs.cancel(jid)                                 -- true (was false on PG)
+  ctx.stdout:write(("PGRC upd=%s del=%s no=%s cancel=%s\n"):format(
+    tostring(upd), tostring(del), tostring(no), tostring(ok)))
+  return 0
+end)
+LUA
+rcout="$("$HULL" "$RCDIR/rc.lua" -d "$DSN" 2>/dev/null)" || true
+case "$rcout" in
+    *"PGRC upd=2 del=1 no=0 cancel=true"*)
+        echo "PASS: db.exec returns the affected-row count on Postgres (jobs.cancel etc. correct)"
+        rm -rf "$RCDIR" ;;
+    *)  echo "::error db.exec affected-row count on PG: $rcout"; exit 1 ;;
+esac
+
 # ── TLS phase (Phase 3b.2) ────────────────────────────────────────────
 # Enable SSL on the running container with a self-signed cert, then connect
 # with sslmode=require and assert (via pg_stat_ssl) the session is encrypted.

--- a/tests/hull/cap/test_pg_conn.c
+++ b/tests/hull/cap/test_pg_conn.c
@@ -325,6 +325,40 @@ UTEST(pg_query, select_rows_and_affected)
     close(sv[0]);
 }
 
+/* An exec-style statement (no rows, no callback) surfaces its CommandComplete
+ * row count via the `affected` out-param - the "UPDATE N" tag form, distinct from
+ * "SELECT N". This is what db.exec returns on Postgres (fixed: db_postgres.c's
+ * pg_query now threads this through instead of discarding it). */
+UTEST(pg_query, exec_affected_count)
+{
+    int sv[2];
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, sv));
+
+    HlPgWriter s;
+    hl_pg_writer_init(&s);
+    size_t m;
+    m = hl_pg_msg_begin(&s, '1'); hl_pg_msg_end(&s, m);   /* ParseComplete */
+    m = hl_pg_msg_begin(&s, '2'); hl_pg_msg_end(&s, m);   /* BindComplete  */
+    m = hl_pg_msg_begin(&s, 'C'); hl_pg_put_cstr(&s, "UPDATE 3"); hl_pg_msg_end(&s, m);
+    m = hl_pg_msg_begin(&s, 'Z'); hl_pg_put_u8(&s, 'I'); hl_pg_msg_end(&s, m);
+    ASSERT_FALSE(s.err);
+    ASSERT_TRUE(write(sv[0], s.buf, s.len) == (ssize_t)s.len);
+    hl_pg_writer_free(&s);
+
+    HlPgConn conn;
+    memset(&conn, 0, sizeof conn);
+    conn.fd = sv[1];
+
+    int64_t affected = -1;
+    ASSERT_EQ(0, hl_pg_query(&conn, "UPDATE t SET n=1 WHERE id > ?",
+                             &(HlPgParam){ .text = "0", .len = 1 }, 1,
+                             NULL, NULL, NULL, &affected));
+    ASSERT_EQ(affected, (int64_t)3);
+
+    hl_pg_conn_close(&conn);
+    close(sv[0]);
+}
+
 UTEST(pg_query, server_error_then_ready)
 {
     int sv[2];


### PR DESCRIPTION
## `db.exec` affected-row count on the PostgreSQL backend

On Postgres, `db.exec("UPDATE/DELETE/INSERT …")` returned **0** regardless of how many rows it changed — the statement executed, but the count was discarded. This broke every rowcount-based caller (`jobs.cancel`/`retry`/`reap`, `session`/`ratelimit`/`idempotency` cleanup counts) and the CAS-style `UPDATE … WHERE` + rowcount pattern, and it diverged from SQLite (`sqlite3_changes`) and MySQL (`affected_rows`), which both honor the documented *"db.exec → number of rows affected"* contract. (Surfaced while building durable-events Phase 2 #263, which had to work around it with `UPDATE … RETURNING`.)

### Root cause — a one-line oversight, not missing machinery
The wire client **already** parses the `CommandComplete` tag (`"UPDATE 3"` → `3`) into `hl_pg_query`'s `affected` out-param (overflow-guarded, with a passing wire-level test). But `db_postgres.c::pg_query` passed `NULL` for it and returned `rc` (0 on success).

### Fix (~4 lines)
Thread the out-param through `pg_query` and, **on the exec path only** (`cb == NULL`), return the count — clamped to `INT` for the int-typed vtable slot, `0` when the command has no numeric tag (`BEGIN`). The query path is untouched (its rows arrive via the callback). Aligns PG with the SQLite/MySQL contract, so correctly-written cross-backend callers behave identically — no regression surface (no caller checks `== 0` for success; `0` is truthy in Lua and SQLite already returns non-zero).

### Tests
- **Unit** (`test_pg_conn`): an `"UPDATE 3"` `CommandComplete` with no rows → `affected == 3` (the non-SELECT tag form). Deterministic, over a socketpair.
- **e2e** (`e2e_postgres.sh`): against real PG 16 — `UPDATE`→2, `DELETE`→1, no-match→0, and `jobs.cancel(pending)`→`true` (returned `false` before). The regression guard that would have caught the original gap.
- **Validated locally**: unit 21/21; the e2e probe on real Postgres returns `upd=2 del=1 no=0 cancel=true`. Default (PG-less) build + SQLite/MySQL untouched.

Fixes the pre-existing follow-up flagged in #263.
