### PR TITLE
jobs: durable events Phase 3 (poison-event skip + subscription metrics)

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -171,10 +171,23 @@ jobs.subscribe("fulfillment", (ev) => { if (ev.type === "completed") webhook.not
   `"beginning"` replays the whole retained log.
 - **Ordered per subscription** (by event id); no cross-subscription order promise.
 - **Retention is subscription-aware**: `jobs.cleanup` never truncates the log past
-  the slowest subscription's cursor, so a lagging consumer keeps its unseen events
-  (watch subscription lag so a stuck one doesn't hold the log open indefinitely).
-- A handler that keeps throwing stops its subscription at that event (retried on
-  the next drain); a skip-after-N poison-event policy is the Phase 3 follow-up.
+  the slowest subscription's cursor, so a lagging consumer keeps its unseen events.
+- **Poison events don't wedge a subscription.** By default a handler that keeps
+  throwing on one event blocks there (retried each drain). Pass
+  `max_failures = N` (`maxFailures` in JS) to **skip** that event after `N`
+  consecutive failures: the drain advances past it and records a durable
+  `subscription_skipped` event (queryable via `jobs.events({ types =
+  { "subscription_skipped" } })`), so one bad event can't stall delivery or hold
+  the log open for retention.
+
+```lua
+jobs.subscribe("reactor", handler, { types = { "completed" }, max_failures = 5 })
+```
+
+**Observability.** `jobs.metrics()` includes an `events` block when the log has
+data: `log_depth` (total events) and per-subscription `{ name, lag, failures }`,
+where `lag` = positions behind the log head (`max id − cursor`). A stuck or
+lagging subscriber shows up as high `lag` / `failures`.
 
 Design + testability: [docs/jobs_events_design.md](jobs_events_design.md).
 

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -298,6 +298,7 @@ function init(opts) {
         "lease_token VARCHAR(255)," +
         "lease_until INTEGER," +
         "failures    INTEGER      NOT NULL DEFAULT 0," +
+        "max_failures INTEGER," +   // skip a poison event after N failures (NULL = never)
         "updated_at  INTEGER      NOT NULL)");
 
     // Verify the server actually parses SKIP LOCKED (the compile-time dialect
@@ -1393,6 +1394,22 @@ function metrics(opts) {
         out.latency = { waitMs: percentiles(waits), runMs: percentiles(runs) };
         out.throughput = { donePerSec: doneN / window, deadPerSec: deadN / window };
     }
+    // Durable-event log health (Phase 3): total log depth + per-subscription lag
+    // (positions behind the log head = max id - cursor) and failure count.
+    {
+        const depth = db.query("SELECT COUNT(*) AS n, MAX(id) AS mx FROM _hull_job_events");
+        const logDepth = (depth[0] && depth[0].n) || 0;
+        if (logDepth > 0) {
+            const maxId = (depth[0] && depth[0].mx) || 0;
+            const subs = db.query("SELECT name, cursor_id, failures FROM _hull_job_subscriptions ORDER BY name");
+            out.events = {
+                logDepth,
+                subscriptions: subs.map((s) => ({
+                    name: s.name, lag: maxId - (s.cursor_id || 0), failures: s.failures || 0,
+                })),
+            };
+        }
+    }
     return out;
 }
 
@@ -1958,6 +1975,7 @@ function subscribe(name, handler, opts) {
         throw new Error("jobs.subscribe: handler must be a function");
     const o = opts || {};
     const typesCsv = (Array.isArray(o.types) && o.types.length) ? o.types.join(",") : null;
+    const maxF = (typeof o.maxFailures === "number" && o.maxFailures > 0) ? o.maxFailures : null;
     // Start cursor: "now" (default) skips existing history; "beginning" replays all.
     let start = 0;
     if (o.from !== "beginning") {
@@ -1966,10 +1984,11 @@ function subscribe(name, handler, opts) {
     }
     const now = time.now();
     const n = db.insertIfAbsent("_hull_job_subscriptions", ["name"],
-        ["name", "cursor_id", "types", "failures", "updated_at"], [name, start, typesCsv, 0, now]);
+        ["name", "cursor_id", "types", "failures", "max_failures", "updated_at"],
+        [name, start, typesCsv, 0, maxF, now]);
     if (!(n && n > 0)) {
-        db.exec("UPDATE _hull_job_subscriptions SET types=?, updated_at=? WHERE name=?",
-            [typesCsv, now, name]);
+        db.exec("UPDATE _hull_job_subscriptions SET types=?, max_failures=?, updated_at=? WHERE name=?",
+            [typesCsv, maxF, now, name]);
     }
     _subscribers[name] = { handler };
     return jobs;
@@ -2004,9 +2023,10 @@ function eventsDrain(name, opts) {
         ? db.query(leaseSql + " RETURNING name", leaseParams).length
         : (db.exec(leaseSql, leaseParams) || 0);
     if (got === 0) return { delivered: 0, leased: false };
-    const row = db.query("SELECT cursor_id, types, failures FROM _hull_job_subscriptions WHERE name=?", [name]);
+    const row = db.query("SELECT cursor_id, types, failures, max_failures FROM _hull_job_subscriptions WHERE name=?", [name]);
     const cursor = row[0].cursor_id;
     const failures = row[0].failures || 0;
+    const maxFailures = row[0].max_failures;
     const where = ["id > ?"], params = [cursor];
     if (row[0].types) {
         const parts = String(row[0].types).split(",").filter((s) => s.length);
@@ -2019,22 +2039,44 @@ function eventsDrain(name, opts) {
     const evs = db.query(
         "SELECT id, ts, type, job_id, job_type, queue, data FROM _hull_job_events " +
         "WHERE " + where.join(" AND ") + " ORDER BY id LIMIT ?", params);
-    let lastOk = cursor, delivered = 0, failed = false;
+    // Deliver in id order. On a handler error, stop at that event (the poison);
+    // the successful prefix is committed and the poison retried on the next drain.
+    let lastOk = cursor, delivered = 0, poison = null, poisonErr = null;
     for (const e of evs) {
         if (e.data !== undefined && e.data !== null && e.data !== "") {
             try { e.data = json.decode(e.data); } catch (_e) { /* leave raw */ }
         }
         try { sub.handler(e); lastOk = e.id; delivered += 1; }
-        catch (_e) { failed = true; break; }
+        catch (err) { poison = e; poisonErr = err; break; }
     }
-    const newCursor = (o.commitCursor === false) ? cursor : lastOk;
+    // Failure accounting + poison skip (Phase 3). `failures` counts consecutive
+    // drains stalled on the SAME frontier event; making progress resets to a fresh
+    // 1. Once it reaches maxFailures (opt-in), skip the poison: advance past it and
+    // record a durable `subscription_skipped` event so it can't wedge the
+    // subscription (or retention) forever.
+    let newFailures = 0, newCursor = lastOk;
+    if (poison) {
+        newFailures = (delivered > 0) ? 1 : failures + 1;
+        if (maxFailures && newFailures >= maxFailures) {
+            if (poison.type !== "subscription_skipped") {   // don't chain skip-of-skip
+                emitDurable("subscription_skipped",
+                    { id: poison.job_id, type: poison.job_type, queue: poison.queue },
+                    { error: `subscription '${name}' skipped event ${poison.id} after ` +
+                        `${newFailures} failures: ${(poisonErr && poisonErr.message) || poisonErr}` });
+            }
+            newCursor = poison.id;   // advance PAST the poison
+            newFailures = 0;
+        }
+    }
+    if (o.commitCursor === false) newCursor = cursor;
     const release = o.releaseLease !== false;
     db.exec(
         "UPDATE _hull_job_subscriptions SET cursor_id=?, failures=?, " +
         (release ? "lease_token=NULL, lease_until=NULL, " : "") +
         "updated_at=? WHERE name=? AND lease_token=?",
-        [newCursor, failed ? failures + 1 : 0, now, name, token]);
-    return { delivered, cursor: newCursor, leased: true };
+        [newCursor, newFailures, now, name, token]);
+    return { delivered, cursor: newCursor, leased: true,
+             skipped: (poison !== null && newCursor === poison.id) };
 }
 
 /**

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -338,6 +338,7 @@ function jobs.init(opts)
         .. "lease_token VARCHAR(255),"
         .. "lease_until INTEGER,"
         .. "failures    INTEGER      NOT NULL DEFAULT 0,"
+        .. "max_failures INTEGER,"    -- skip a poison event after N failures (NULL = never)
         .. "updated_at  INTEGER      NOT NULL)")
 
     -- Verify the server actually parses SKIP LOCKED (the compile-time dialect
@@ -1516,6 +1517,22 @@ function jobs.metrics(opts)
         out.latency = { wait_ms = percentiles(waits), run_ms = percentiles(runs) }
         out.throughput = { done_per_sec = done_n / window, dead_per_sec = dead_n / window }
     end
+    -- Durable-event log health (Phase 3): total log depth + per-subscription lag
+    -- (positions behind the log head = max id - cursor) and failure count, so a
+    -- stuck / lagging subscriber is visible. Present only when the log has data.
+    local depth = db.query("SELECT COUNT(*) AS n, MAX(id) AS mx FROM _hull_job_events")
+    local log_depth = (depth[1] and depth[1].n) or 0
+    if log_depth > 0 then
+        local max_id = (depth[1] and depth[1].mx) or 0
+        local subs = db.query(
+            "SELECT name, cursor_id, failures FROM _hull_job_subscriptions ORDER BY name")
+        local sub_list = {}
+        for _, sn in ipairs(subs or {}) do
+            sub_list[#sub_list + 1] =
+                { name = sn.name, lag = max_id - (sn.cursor_id or 0), failures = sn.failures or 0 }
+        end
+        out.events = { log_depth = log_depth, subscriptions = sub_list }
+    end
     return out
 end
 
@@ -2101,7 +2118,9 @@ end
 -- (like jobs.handler). Drained by jobs.work / jobs.run_worker.
 -- @tparam string name
 -- @tparam function handler   function(event)
--- @tparam[opt] table opts { types = {"dead", ...}, from = "now" | "beginning" }
+-- @tparam[opt] table opts { types = {"dead", ...}, from = "now" | "beginning",
+--                            max_failures = N }  N = skip a poison event after N
+--                            consecutive handler failures (nil = block forever)
 function jobs.subscribe(name, handler, opts)
     if type(name) ~= "string" or name == "" then
         error("jobs.subscribe: name must be a non-empty string")
@@ -2110,6 +2129,7 @@ function jobs.subscribe(name, handler, opts)
     opts = opts or {}
     local types_csv
     if type(opts.types) == "table" and #opts.types > 0 then types_csv = table.concat(opts.types, ",") end
+    local max_f = (type(opts.max_failures) == "number" and opts.max_failures > 0) and opts.max_failures or nil
     -- Start cursor: "now" (default) skips existing history; "beginning" replays all.
     local start = 0
     if opts.from ~= "beginning" then
@@ -2118,12 +2138,13 @@ function jobs.subscribe(name, handler, opts)
     end
     local now = time.now()
     -- Create the durable row once; a re-subscribe keeps the persisted cursor and
-    -- only refreshes the type filter.
+    -- only refreshes the config (type filter, skip threshold).
     local n = db.insert_if_absent("_hull_job_subscriptions", { "name" },
-        { "name", "cursor_id", "types", "failures", "updated_at" }, { name, start, types_csv, 0, now })
+        { "name", "cursor_id", "types", "failures", "max_failures", "updated_at" },
+        { name, start, types_csv, 0, max_f, now })
     if not (n and n > 0) then
-        db.exec("UPDATE _hull_job_subscriptions SET types=?, updated_at=? WHERE name=?",
-            { types_csv, now, name })
+        db.exec("UPDATE _hull_job_subscriptions SET types=?, max_failures=?, updated_at=? WHERE name=?",
+            { types_csv, max_f, now, name })
     end
     _subscribers[name] = { handler = handler }
     return jobs
@@ -2162,9 +2183,10 @@ function jobs._events_drain(name, opts)
     end
     if got == 0 then return { delivered = 0, leased = false } end
     local row = db.query(
-        "SELECT cursor_id, types, failures FROM _hull_job_subscriptions WHERE name=?", { name })
+        "SELECT cursor_id, types, failures, max_failures FROM _hull_job_subscriptions WHERE name=?", { name })
     local cursor = row[1].cursor_id
     local failures = row[1].failures or 0
+    local max_failures = row[1].max_failures
     -- Fetch events past the cursor, filtered by the subscription's types.
     local where, params = { "id > ?" }, { cursor }
     if row[1].types and row[1].types ~= "" then
@@ -2176,24 +2198,46 @@ function jobs._events_drain(name, opts)
     local evs = db.query(
         "SELECT id, ts, type, job_id, job_type, queue, data FROM _hull_job_events "
         .. "WHERE " .. table.concat(where, " AND ") .. " ORDER BY id LIMIT ?", params)
-    -- Deliver in id order. On a handler error, stop - advance only past the
-    -- successful prefix; the failing event is retried on the next drain.
-    local last_ok, delivered, failed = cursor, 0, false
+    -- Deliver in id order. On a handler error, stop at that event (the poison);
+    -- the successful prefix is committed and the poison retried on the next drain.
+    local last_ok, delivered, poison, poison_err = cursor, 0, nil, nil
     for _, e in ipairs(evs) do
         if e.data ~= nil and e.data ~= "" then
             local ok, d = pcall(json.decode, e.data); if ok then e.data = d end
         end
-        if pcall(sub.handler, e) then last_ok = e.id; delivered = delivered + 1
-        else failed = true; break end
+        local ok, herr = pcall(sub.handler, e)
+        if ok then last_ok = e.id; delivered = delivered + 1
+        else poison = e; poison_err = herr; break end
     end
-    local new_cursor = (opts.commit_cursor == false) and cursor or last_ok
+    -- Failure accounting + poison skip. `failures` counts consecutive drains that
+    -- stalled on the SAME frontier event; making progress this drain resets it to
+    -- a fresh 1. Once it reaches max_failures (opt-in), skip the poison: advance
+    -- past it and record a durable `subscription_skipped` event so it can't wedge
+    -- the subscription (or retention) forever.
+    local new_failures, new_cursor = 0, last_ok
+    if poison then
+        new_failures = (delivered > 0) and 1 or (failures + 1)
+        if max_failures and new_failures >= max_failures then
+            -- Don't chain: skipping a subscription_skipped must not emit another.
+            if poison.type ~= "subscription_skipped" then
+                emit_durable("subscription_skipped",
+                    { id = poison.job_id, type = poison.job_type, queue = poison.queue },
+                    { error = "subscription '" .. name .. "' skipped event " .. poison.id
+                        .. " after " .. new_failures .. " failures: " .. tostring(poison_err) })
+            end
+            new_cursor = poison.id   -- advance PAST the poison
+            new_failures = 0
+        end
+    end
+    if opts.commit_cursor == false then new_cursor = cursor end
     local release = opts.release_lease ~= false
     db.exec(
         "UPDATE _hull_job_subscriptions SET cursor_id=?, failures=?, "
         .. (release and "lease_token=NULL, lease_until=NULL, " or "")
         .. "updated_at=? WHERE name=? AND lease_token=?",
-        { new_cursor, failed and (failures + 1) or 0, now, name, token })
-    return { delivered = delivered, cursor = new_cursor, leased = true }
+        { new_cursor, new_failures, now, name, token })
+    return { delivered = delivered, cursor = new_cursor, leased = true,
+             skipped = (poison ~= nil and new_cursor == poison.id) or false }
 end
 
 --- Purge terminal jobs (done + dead by default) whose last update is older than

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -842,6 +842,64 @@ else
 fi
 rm -rf "$EW"
 
+# ── durable events Phase 3 (poison-event skip-after-N + metrics) ─────────────
+# A subscription with max_failures=N skips a poison event after N consecutive
+# handler failures (advancing past it + recording a durable subscription_skipped
+# event), so one bad event can't wedge the subscription or block retention.
+# jobs.metrics gains an events block (log depth + per-subscription lag/failures).
+check_events_p3() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"POISON seen=1,3,4 d1=1 d2skip=true skips=1 lag=0 fail=0 depth=4"*)
+            pass "$label: poison-event skip-after-N + subscription_skipped + metrics" ;;
+        *) fail "$label: durable events Phase 3" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_EV3='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init({ events = true })
+  jobs.enqueue("ok",{}); jobs.enqueue("ok",{}); jobs.enqueue("ok",{})
+  local seen = {}
+  jobs.subscribe("p", function(ev) if ev.id == 2 then error("poison") end seen[#seen+1] = ev.id end,
+    { from = "beginning", max_failures = 2 })
+  local d1 = jobs._events_drain("p", { now = 1000 })
+  local d2 = jobs._events_drain("p", { now = 1000 })
+  jobs._events_drain("p", { now = 1000 })
+  local skips = #jobs.events({ types = { "subscription_skipped" } })
+  local m = jobs.metrics()
+  local sub = m.events and m.events.subscriptions[1]
+  ctx.stdout:write(("POISON seen=%s d1=%d d2skip=%s skips=%d lag=%s fail=%s depth=%s\n"):format(
+    table.concat(seen, ","), d1.delivered, tostring(d2.skipped), skips,
+    tostring(sub and sub.lag), tostring(sub and sub.failures), tostring(m.events and m.events.log_depth)))
+  return 0
+end)'
+
+JS_EV3='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init({ events: true });
+  jobs.enqueue("ok",{}); jobs.enqueue("ok",{}); jobs.enqueue("ok",{});
+  const seen = [];
+  jobs.subscribe("p", (ev) => { if (ev.id === 2) throw new Error("poison"); seen.push(ev.id); },
+    { from: "beginning", maxFailures: 2 });
+  const d1 = jobs._eventsDrain("p", { now: 1000 });
+  const d2 = jobs._eventsDrain("p", { now: 1000 });
+  jobs._eventsDrain("p", { now: 1000 });
+  const skips = jobs.events({ types: ["subscription_skipped"] }).length;
+  const m = jobs.metrics();
+  const sub = m.events && m.events.subscriptions[0];
+  ctx.stdout.write(`POISON seen=${seen.join(",")} d1=${d1.delivered} d2skip=${d2.skipped} skips=${skips} lag=${sub&&sub.lag} fail=${sub&&sub.failures} depth=${m.events&&m.events.logDepth}\n`);
+  return 0;
+});'
+
+echo "== durable events Phase 3: Lua =="; check_events_p3 "lua" "lua" "$LUA_EV3"
+echo "== durable events Phase 3: JS  =="; check_events_p3 "js"  "js"  "$JS_EV3"
+
 # ── v1.3: queue pause / resume / purge ──────────────────────────────────────
 # A paused queue is not claimed; resume restores it; purge deletes pending.
 check_pq() {


### PR DESCRIPTION
## Durable events — Phase 3 (poison-event skip + subscription metrics)

Third phase of #246, stacked on Phase 2 (#263). Two reliability/observability additions on the subscription drain.

### 1. Poison-event skip-after-N
By default a subscription handler that keeps throwing on one event **blocks there** (retried each drain) — a poison event can wedge the subscription *and* retention (`cleanup` won't truncate past its cursor). `jobs.subscribe` now takes `max_failures = N` (`maxFailures` in JS):

```lua
jobs.subscribe("reactor", handler, { types = { "completed" }, max_failures = 5 })
```

After N consecutive failures on the same frontier event, the drain **skips** it — advances the cursor past it and records a durable `subscription_skipped` event (queryable via `jobs.events({ types = { "subscription_skipped" } })`) carrying the skipped event id + the handler error. `failures` counts consecutive stalls on the same frontier (making progress resets it to a fresh 1; a skip resets to 0). A guard stops a `subscription_skipped` from itself chaining another skip.

### 2. `jobs.metrics` events block
When the log has data, metrics gains `events = { log_depth, subscriptions: [{ name, lag, failures }] }`, where `lag` = positions behind the log head (`max id − cursor`) — so a stuck/lagging subscriber is visible.

### Tests
One nullable column (`max_failures`) on the Phase 2 subscriptions table (unreleased, no migration). The `_events_drain` seam gains a `skipped` flag for deterministic testing. New e2e phase: a handler that poisons event 2 (`max_failures=2`) skips it after 2 failures, delivers the rest, records exactly one `subscription_skipped`, and metrics report `lag 0 / failures 0 / depth 4`. Both runtimes. **Validated on SQLite 62/62 + MySQL 8 + PostgreSQL 16** (Docker) — all identical (Phase 3 needs no exec-rowcount; the lease CAS already uses `RETURNING` on PG). luacheck clean.

Phase 4 (LISTEN/NOTIFY low latency, #235) is the last event phase.
