### PR TITLE
db(postgres): LISTEN/NOTIFY consumer primitive (Phase 4.1)

### DIFF
--- a/include/hull/cap/pg_conn.h
+++ b/include/hull/cap/pg_conn.h
@@ -189,4 +189,17 @@ int hl_pg_query(HlPgConn *conn, const char *sql,
  */
 int hl_pg_exec_simple(HlPgConn *conn, const char *sql);
 
+/*
+ * Wait (up to timeout_ms) for a NotificationResponse ('A') to arrive - the
+ * consumer half of LISTEN/NOTIFY. The caller must have issued `LISTEN <chan>`
+ * on this connection first (a normal hl_pg_exec_simple). Blocks on the socket
+ * via poll(2), bounded by timeout_ms total (a monotonic deadline, so stray
+ * async Notice / ParameterStatus frames don't extend it). Returns:
+ *   1  a notification arrived (drain now),
+ *   0  the timeout elapsed with no notification (fall back to a poll),
+ *  -1  the connection is dead (EOF / error; caller should reconnect + re-LISTEN).
+ * A latency primitive only: correctness must ride the timeout, never the wake.
+ */
+int hl_pg_wait_notify(HlPgConn *conn, int timeout_ms);
+
 #endif /* HL_CAP_PG_CONN_H */

--- a/include/hull/cap/pgwire.h
+++ b/include/hull/cap/pgwire.h
@@ -130,6 +130,7 @@ int            hl_pg_cursor_err(const HlPgCursor *c);
 #define HL_PG_B_CMD_COMPLETE     'C'
 #define HL_PG_B_ERROR            'E'
 #define HL_PG_B_NOTICE           'N'
+#define HL_PG_B_NOTIFY           'A'   /* NotificationResponse (LISTEN/NOTIFY) */
 #define HL_PG_B_READY            'Z'
 #define HL_PG_B_PARSE_COMPLETE   '1'
 #define HL_PG_B_BIND_COMPLETE    '2'

--- a/src/hull/cap/pg_conn.c
+++ b/src/hull/cap/pg_conn.c
@@ -29,12 +29,14 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>
+#include <poll.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/select.h>
+#include <time.h>
 #include <unistd.h>
 
 #ifdef MSG_NOSIGNAL
@@ -1300,5 +1302,74 @@ int hl_pg_exec_simple(HlPgConn *conn, const char *sql)
         default:
             break;
         }
+    }
+}
+
+/* Monotonic milliseconds for the wait deadline (not wall-clock, so it is immune
+ * to clock steps). */
+static int64_t mono_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (int64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+int hl_pg_wait_notify(HlPgConn *conn, int timeout_ms)
+{
+    if (!conn || conn->fd < 0) return -1;
+    if (timeout_ms < 0) timeout_ms = 0;
+    int64_t deadline = mono_ms() + timeout_ms;
+
+    for (;;) {
+        /* 1. Consume any COMPLETE frame already buffered. poll(2) watches the
+         * socket, not our accumulation buffer, so a frame received alongside an
+         * earlier one would be invisible to poll and must be drained here first. */
+        if (conn->consumed > 0) {
+            memmove(conn->rbuf, conn->rbuf + conn->consumed,
+                    conn->rlen - conn->consumed);
+            conn->rlen -= conn->consumed;
+            conn->consumed = 0;
+        }
+        HlPgFrame f;
+        size_t consumed = 0;
+        HlPgResult r = hl_pg_frame_next(conn->rbuf, conn->rlen, &f, &consumed);
+        if (r == HL_PG_ERR) {
+            set_err(conn->errmsg, sizeof conn->errmsg, "malformed message from server");
+            return -1;
+        }
+        if (r == HL_PG_OK) {
+            uint8_t type = f.type;
+            conn->consumed = consumed;   /* compacted at the top of the next loop */
+            if (type == HL_PG_B_NOTIFY) return 1;
+            continue;   /* a stray Notice / ParameterStatus: skip, check for more */
+        }
+
+        /* 2. NEED_MORE: poll the socket with the REMAINING time (so stray async
+         * frames can't extend the total wait past timeout_ms). */
+        int remaining = (int)(deadline - mono_ms());
+        if (remaining <= 0) return 0;   /* timed out, no notification */
+        struct pollfd pfd = { .fd = conn->fd, .events = POLLIN, .revents = 0 };
+        int pr = poll(&pfd, 1, remaining);
+        if (pr < 0) { if (errno == EINTR) continue; return -1; }
+        if (pr == 0) return 0;          /* timed out */
+        if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) return -1;   /* dead conn */
+
+        /* 3. Readable: recv one chunk into the buffer (grow if full, bounded like
+         * conn_next_frame), then loop back to parse. */
+        if (conn->rlen == conn->rcap) {
+            size_t ncap = conn->rcap ? conn->rcap * 2 : 8192;
+            if (ncap > (size_t)HL_PG_MAX_MSG + 8192) {
+                set_err(conn->errmsg, sizeof conn->errmsg, "server message exceeds limit");
+                return -1;
+            }
+            uint8_t *nb = realloc(conn->rbuf, ncap);
+            if (!nb) { set_err(conn->errmsg, sizeof conn->errmsg, "out of memory"); return -1; }
+            conn->rbuf = nb;
+            conn->rcap = ncap;
+        }
+        ssize_t n = io_recv(conn, conn->rbuf + conn->rlen, conn->rcap - conn->rlen);
+        if (n <= 0) { set_err(conn->errmsg, sizeof conn->errmsg, "connection closed by server");
+                      return -1; }
+        conn->rlen += (size_t)n;
     }
 }

--- a/tests/hull/cap/test_pg_conn.c
+++ b/tests/hull/cap/test_pg_conn.c
@@ -359,6 +359,41 @@ UTEST(pg_query, exec_affected_count)
     close(sv[0]);
 }
 
+/* hl_pg_wait_notify: the LISTEN/NOTIFY consumer primitive (Phase 4). A queued
+ * NotificationResponse ('A') returns 1; an empty socket times out to 0; a closed
+ * peer returns -1. Deterministic over a socketpair - no real Postgres. */
+UTEST(pg_query, wait_notify)
+{
+    int sv[2];
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, sv));
+
+    /* NotificationResponse: int32 pid, cstr channel, cstr payload. */
+    HlPgWriter s;
+    hl_pg_writer_init(&s);
+    size_t m = hl_pg_msg_begin(&s, 'A');
+    hl_pg_put_i32(&s, 4321);
+    hl_pg_put_cstr(&s, "hull_jobs");
+    hl_pg_put_cstr(&s, "");
+    hl_pg_msg_end(&s, m);
+    ASSERT_FALSE(s.err);
+    ASSERT_TRUE(write(sv[0], s.buf, s.len) == (ssize_t)s.len);
+    hl_pg_writer_free(&s);
+
+    HlPgConn conn;
+    memset(&conn, 0, sizeof conn);
+    conn.fd = sv[1];
+
+    /* 1. A notification is queued -> 1. */
+    ASSERT_EQ(1, hl_pg_wait_notify(&conn, 1000));
+    /* 2. Nothing more -> times out to 0 (a short bound, no real delay needed). */
+    ASSERT_EQ(0, hl_pg_wait_notify(&conn, 20));
+    /* 3. Peer closed -> connection dead -> -1. */
+    close(sv[0]);
+    ASSERT_EQ(-1, hl_pg_wait_notify(&conn, 1000));
+
+    hl_pg_conn_close(&conn);
+}
+
 UTEST(pg_query, server_error_then_ready)
 {
     int sv[2];


### PR DESCRIPTION
## pg LISTEN/NOTIFY consumer primitive (Phase 4.1)

First step of the events Phase 4 design (#266): the wire-level primitive that everything else builds on.

`hl_pg_wait_notify(conn, timeout_ms)` — the consumer half of LISTEN/NOTIFY — plus the `HL_PG_B_NOTIFY 'A'` (`NotificationResponse`) constant. It polls the connection fd bounded by a **monotonic** timeout deadline (so stray async `Notice`/`ParameterStatus` frames can't extend the wait), first draining any frame already buffered (`poll(2)` watches the socket, not our accumulation buffer), and returns `1` on a notification, `0` on timeout, `-1` on a dead connection. Reuses the existing frame reader + bounded recv, so the same length checks over untrusted bytes apply; the payload is read but ignored (we need only the *fact* of a notification).

**Pure capability, no behavior change.** Deterministic socketpair unit test (`test_pg_conn`: queued `'A'` → 1, empty → 0 at the bound, closed peer → -1) — passes under ASan, 21/21. **Postgres backend only**; the default (PG-less) build and SQLite/MySQL are untouched.

Foundation for the db-cap `conn.wait_notify` surface (4.2) and low-latency jobs wakeup (4.3).
