### PR TITLE
jobs: durable fleet-wide events (Phases 1-3)

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -113,6 +113,84 @@ jobs.on("completed", function(job, info) metrics.inc("jobs.done", { type = job.t
 jobs.on("dead",      function(job, info) log.error("job died: " .. info.error) end)
 ```
 
+## Durable events (fleet-wide)
+
+Where `jobs.on` is in-process and lost on a crash, the **durable event log** is
+opt-in (`jobs.init({ events = true })`) and records every lifecycle transition -
+`enqueued`, `completed`, `retried`, `dead`, `cancelled` - as a row in
+`_hull_job_events`, **written in the same transaction as the state change that
+produced it**. So an event exists *iff* the transition committed: no lost events
+(crash after the change, before an external publish) and no phantom events
+(publish, then the change rolls back) - the same transactional coupling that makes
+`enqueue` a plain `INSERT`. It survives restarts and is visible to any process
+against the same DB (a dashboard, an analytics sink, a reacting service).
+
+```lua
+jobs.init({ events = true })
+
+-- Read-only tail, newest first (for a dashboard / ad-hoc inspection):
+local recent = jobs.events({ types = { "dead" }, since = last_id, limit = 100 })
+-- each: { id, ts, type, job_id, job_type, queue, data = { error?, attempt?, trace? } }
+```
+```javascript
+jobs.init({ events: true });
+const recent = jobs.events({ types: ["dead"], since: lastId, limit: 100 });
+```
+
+- **`id`** is a monotonic total order (and the subscription cursor space). Tail
+  incrementally by passing the last id you saw as `since`.
+- **`data`** is compact metadata (`error` / `attempt` / `trace`), never the full
+  result - join `jobs.result(job_id)` when you need the value.
+- **Off by default** - an app that doesn't opt in pays nothing (no log writes).
+
+### Durable subscriptions
+
+For a service that must **react** to events (not just tail them), a durable
+**subscription** delivers each event to a handler **at-least-once**, tracking its
+own cursor so it resumes exactly where it left off after a restart - fleet-wide:
+
+```lua
+-- Register on every worker (like jobs.handler). Handlers must be idempotent.
+jobs.subscribe("fulfillment", function(ev)
+    if ev.type == "completed" and ev.job_type == "charge" then webhook.notify(ev) end
+end, { types = { "completed", "dead" }, from = "now" })
+jobs.unsubscribe("fulfillment")
+```
+```javascript
+jobs.subscribe("fulfillment", (ev) => { if (ev.type === "completed") webhook.notify(ev); },
+               { types: ["completed", "dead"], from: "now" });
+```
+
+- **Drained by `jobs.work` / `jobs.run_worker`** - no separate process needed.
+  A per-subscription **lease** (a claim-token + visibility timeout, exactly like
+  the job claim) means one worker drains a subscription at a time; if that worker
+  dies, another resumes from the cursor. So delivery is **at-least-once** (a crash
+  between a handler succeeding and the cursor advancing re-delivers) - handlers
+  must be idempotent, the same contract as a job handler.
+- **`from`**: `"now"` (default) starts at the current head (skip history);
+  `"beginning"` replays the whole retained log.
+- **Ordered per subscription** (by event id); no cross-subscription order promise.
+- **Retention is subscription-aware**: `jobs.cleanup` never truncates the log past
+  the slowest subscription's cursor, so a lagging consumer keeps its unseen events.
+- **Poison events don't wedge a subscription.** By default a handler that keeps
+  throwing on one event blocks there (retried each drain). Pass
+  `max_failures = N` (`maxFailures` in JS) to **skip** that event after `N`
+  consecutive failures: the drain advances past it and records a durable
+  `subscription_skipped` event (queryable via `jobs.events({ types =
+  { "subscription_skipped" } })`), so one bad event can't stall delivery or hold
+  the log open for retention.
+
+```lua
+jobs.subscribe("reactor", handler, { types = { "completed" }, max_failures = 5 })
+```
+
+**Observability.** `jobs.metrics()` includes an `events` block when the log has
+data: `log_depth` (total events) and per-subscription `{ name, lag, failures }`,
+where `lag` = positions behind the log head (`max id − cursor`). A stuck or
+lagging subscriber shows up as high `lag` / `failures`.
+
+Design + testability: [docs/jobs_events_design.md](jobs_events_design.md).
+
 ## Recurring jobs (cron)
 
 `jobs.cron(name, spec, data?, opts?)` registers a **durable** recurring

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -40,6 +40,7 @@ const _cfg = {
     backoff: defaultBackoff,
     history:           false, // attempt-history recording: true | { queues:[...] } | false
     historyRetention:  null,  // seconds to keep attempt rows (null = jobs.cleanup default)
+    events:            false, // durable fleet-wide event log (jobs.subscribe / jobs.events)
 };
 
 // Exponential backoff: 2^attempt * 10s, capped at 1h (shared with outbox math).
@@ -96,6 +97,7 @@ function init(opts) {
     if (o.reapInterval !== undefined) _cfg.reapInterval = o.reapInterval;
     if (o.history !== undefined) _cfg.history = o.history;
     if (o.historyRetention !== undefined) _cfg.historyRetention = o.historyRetention;
+    if (o.events !== undefined) _cfg.events = o.events;
     if (o.backoff !== undefined) _cfg.backoff = o.backoff;
 
     // Keyed/indexed text columns are VARCHAR(255) so MySQL can index them;
@@ -267,6 +269,38 @@ function init(opts) {
     db.exec("CREATE INDEX IF NOT EXISTS idx_hull_job_attempts_job ON _hull_job_attempts(job_id, attempt_no)");
     db.exec("CREATE INDEX IF NOT EXISTS idx_hull_job_attempts_recent ON _hull_job_attempts(finished_ms)");
 
+    // Durable fleet-wide event log (jobs.init{events:true}). Append-only lifecycle
+    // events, written in the SAME transaction as the state change that produced
+    // them (transactional coupling: an event exists iff the transition committed).
+    // The `id` is the total order + the future subscription cursor space. `data`
+    // is small JSON metadata (error/attempt/trace), never the full result.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_job_events (" +
+        "id       " + db.autoincrementIdDdl + ", " +
+        "ts       INTEGER      NOT NULL," +
+        "type     VARCHAR(32)  NOT NULL," +
+        "job_id   INTEGER," +
+        "job_type VARCHAR(255)," +
+        "queue    VARCHAR(255)," +
+        "data     TEXT)");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_hull_job_events_type ON _hull_job_events(type, id)");
+    db.exec("CREATE INDEX IF NOT EXISTS idx_hull_job_events_ts ON _hull_job_events(ts)");
+
+    // Durable event subscriptions (jobs.subscribe). One row per named consumer:
+    // `cursor` = last delivered event id, `types` = optional comma-list filter,
+    // `lease_token`/`lease_until` = the drain lease (one worker drains at a time;
+    // a crashed drainer's lease expires and another resumes from the cursor).
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_job_subscriptions (" +
+        "name        VARCHAR(255) NOT NULL PRIMARY KEY," +
+        "cursor_id   INTEGER      NOT NULL DEFAULT 0," +
+        "types       VARCHAR(255)," +
+        "lease_token VARCHAR(255)," +
+        "lease_until INTEGER," +
+        "failures    INTEGER      NOT NULL DEFAULT 0," +
+        "max_failures INTEGER," +   // skip a poison event after N failures (NULL = never)
+        "updated_at  INTEGER      NOT NULL)");
+
     // Verify the server actually parses SKIP LOCKED (the compile-time dialect
     // flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
     // does not). A 0-row probe against the real table detects it once; the claim
@@ -343,6 +377,41 @@ function loadDeps(dependentId) {
         }
     });
     return out;
+}
+
+// Append a durable lifecycle event (opt-in via jobs.init{events:true}). Called
+// INSIDE the transition's transaction, so the event commits iff the state change
+// does (transactional coupling: no lost, no phantom events). `job` supplies
+// id/type/queue/trace; `info` is small metadata (error/attempt) - never the full
+// result (a consumer joins _hull_job_results for that).
+function emitDurable(event, job, info) {
+    if (!_cfg.events) return;
+    info = info || {};
+    let data = null;
+    if (info.error !== undefined || info.attempt !== undefined ||
+        (job.trace !== undefined && job.trace !== null)) {
+        data = json.encode({ error: info.error, attempt: info.attempt, trace: job.trace });
+    }
+    db.exec(
+        "INSERT INTO _hull_job_events (ts, type, job_id, job_type, queue, data) " +
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [time.now(), event, job.id, job.type, job.queue, data]);
+}
+
+// Apply a terminal transition and its durable event ATOMICALLY (one txn), then
+// fire the in-process listeners. `transition()` runs the markX state change and
+// returns the effective outcome ("done"|"dead"|"retried"). Wrapping in db.batch
+// both couples the event to the state change and collapses markDone's several
+// statements into one commit (fewer fsyncs, even when events are off).
+const EVENT_OF = { done: "completed", dead: "dead", retried: "retried" };
+function finish(job, info, transition) {
+    let outcome;
+    db.batch(() => {
+        outcome = transition();
+        emitDurable(EVENT_OF[outcome] || outcome, job, info);
+    });
+    emit(EVENT_OF[outcome] || outcome, job, info);
+    return outcome;
 }
 
 /**
@@ -435,6 +504,10 @@ function enqueue(jobType, data, opts) {
             else if (g.status === "dead") resolveEdge(id, dep, false, failMode);
         }
     }
+    // Durable "enqueued" event (opt-in). Emitted here so it joins the caller's
+    // db.batch when enqueue is called inside one (transactional coupling).
+    emitDurable("enqueued",
+        { id, type: jobType, queue: o.queue || "default", trace: o.trace }, {});
     return id;
 }
 
@@ -1090,6 +1163,13 @@ async function work(opts) {
     if (now - _lastReap >= interval) { reap(o); _lastReap = now; }
     // Fire due cron schedules (throttled; cron is minute-grained).
     if (now - _lastCron >= 1) { processCron(now); _lastCron = now; }
+    // Drain durable event subscriptions (throttled; the per-subscription lease
+    // makes this fleet-safe). Only workers that registered subscribers do work.
+    const subNames = Object.keys(_subscribers);
+    if (subNames.length && now - _lastEdrain >= 1) {
+        for (const name of subNames) eventsDrain(name, { now });
+        _lastEdrain = now;
+    }
     const batch = claim(o);
     for (const job of batch) {
         job.deps = loadDeps(job.id);   // workflow: dependency results, in order
@@ -1098,9 +1178,7 @@ async function work(opts) {
         let outcome, errStr;              // undefined outcome = a yield (not recorded)
         if (!h) {
             errStr = `no handler for job type '${job.type}'`;
-            markDead(job.id, errStr);
-            emit("dead", job, { error: errStr });
-            outcome = "dead";
+            outcome = finish(job, { error: errStr }, () => { markDead(job.id, errStr); return "dead"; });
         } else {
         try {
             const result = await h(job);
@@ -1137,26 +1215,23 @@ async function work(opts) {
                         [result.wakeAt || now, now, job.id]);
                 }
             } else if (result === DEAD) {
-                errStr = "handler returned jobs.DEAD"; outcome = "dead";
-                markDead(job.id, errStr);
-                emit("dead", job, { error: errStr });
+                errStr = "handler returned jobs.DEAD";
+                outcome = finish(job, { error: errStr }, () => { markDead(job.id, errStr); return "dead"; });
             } else if (result === RETRY) {
                 errStr = "handler requested retry";
-                outcome = markRetry(job, errStr);
-                emit(outcome, job, { error: errStr, attempt: job.attempts });
+                outcome = finish(job, { error: errStr, attempt: job.attempts },
+                    () => markRetry(job, errStr));
             } else {
                 // undefined / true / DISCARD -> done, no result; any other return
                 // value is stored as the job's result (for dependents).
                 const res = (result !== undefined && result !== true && result !== DISCARD)
                     ? result : undefined;
-                markDone(job.id, res);
-                emit("completed", job, { result: res });
-                outcome = "done";
+                outcome = finish(job, { result: res }, () => { markDone(job.id, res); return "done"; });
             }
         } catch (e) {
             errStr = String((e && e.message) || e);
-            outcome = markRetry(job, errStr);
-            emit(outcome, job, { error: errStr, attempt: job.attempts });
+            outcome = finish(job, { error: errStr, attempt: job.attempts },
+                () => markRetry(job, errStr));
         }
         }
         // Opt-in attempt history (a yield leaves outcome undefined -> not recorded).
@@ -1175,6 +1250,15 @@ let _running = false;
 let _lastReap = 0;
 // Unix ts of the last cron due-check (throttled to >=1s; cron is minute-grained).
 let _lastCron = 0;
+// Unix ts of the last subscription drain (throttled to >=1s in work()).
+let _lastEdrain = 0;
+// Durable event subscribers registered on THIS worker (jobs.subscribe):
+// name -> { handler(event) }. The subscription row (cursor/lease) is durable in
+// _hull_job_subscriptions; the handler is per-worker, like a job handler.
+const _subscribers = Object.create(null);
+// Lease duration (seconds) for a subscription drain (a crashed drainer's lease
+// expires after this and another worker resumes from the unadvanced cursor).
+const _EDRAIN_LEASE = 30;
 
 /**
  * Request the running runWorker loop to stop after the current iteration.
@@ -1309,6 +1393,22 @@ function metrics(opts) {
         }
         out.latency = { waitMs: percentiles(waits), runMs: percentiles(runs) };
         out.throughput = { donePerSec: doneN / window, deadPerSec: deadN / window };
+    }
+    // Durable-event log health (Phase 3): total log depth + per-subscription lag
+    // (positions behind the log head = max id - cursor) and failure count.
+    {
+        const depth = db.query("SELECT COUNT(*) AS n, MAX(id) AS mx FROM _hull_job_events");
+        const logDepth = (depth[0] && depth[0].n) || 0;
+        if (logDepth > 0) {
+            const maxId = (depth[0] && depth[0].mx) || 0;
+            const subs = db.query("SELECT name, cursor_id, failures FROM _hull_job_subscriptions ORDER BY name");
+            out.events = {
+                logDepth,
+                subscriptions: subs.map((s) => ({
+                    name: s.name, lag: maxId - (s.cursor_id || 0), failures: s.failures || 0,
+                })),
+            };
+        }
     }
     return out;
 }
@@ -1813,7 +1913,170 @@ function retry(id) {
  * @returns {boolean}
  */
 function cancel(id) {
-    return (db.exec("DELETE FROM _hull_jobs WHERE id=? AND status='pending'", [id]) || 0) > 0;
+    if (!_cfg.events) {
+        return (db.exec("DELETE FROM _hull_jobs WHERE id=? AND status='pending'", [id]) || 0) > 0;
+    }
+    // events on: capture type/queue for the "cancelled" event, delete + emit in
+    // one txn (BEGIN IMMEDIATE serializes, so the SELECT->DELETE stays consistent).
+    let cancelled = false;
+    db.batch(() => {
+        const r = db.query("SELECT type, queue FROM _hull_jobs WHERE id=? AND status='pending'", [id]);
+        if (r[0]) {
+            db.exec("DELETE FROM _hull_jobs WHERE id=? AND status='pending'", [id]);
+            emitDurable("cancelled", { id, type: r[0].type, queue: r[0].queue }, {});
+            cancelled = true;
+        }
+    });
+    return cancelled;
+}
+
+/**
+ * Read-only tail of the durable event log (jobs.init{events:true}), newest first
+ * - for a dashboard or ad-hoc inspection. Phase 2 adds durable subscriptions
+ * (jobs.subscribe) with at-least-once delivery + cursors.
+ * @param {object} [opts] { since: <event id>, types: ["dead", ...], limit: 100 }
+ * @returns {Array} of { id, ts, type, job_id, job_type, queue, data }
+ */
+function events(opts) {
+    const o = opts || {};
+    const where = ["1=1"], params = [];
+    if (o.since !== undefined) { where.push("id > ?"); params.push(o.since); }
+    if (Array.isArray(o.types) && o.types.length) {
+        where.push("type IN (" + o.types.map(() => "?").join(",") + ")");
+        for (const t of o.types) params.push(t);
+    }
+    params.push(Math.min(Number(o.limit) || 100, 1000));
+    const rows = db.query(
+        "SELECT id, ts, type, job_id, job_type, queue, data FROM _hull_job_events " +
+        "WHERE " + where.join(" AND ") + " ORDER BY id DESC LIMIT ?", params);
+    for (const r of rows) {
+        if (r.data !== undefined && r.data !== null && r.data !== "") {
+            try { r.data = json.decode(r.data); } catch (_e) { /* leave raw */ }
+        }
+    }
+    return rows;
+}
+
+/**
+ * Register a durable named subscription over the event log (Phase 2). `handler`
+ * is called once per event, in id order, AT-LEAST-ONCE (a crash between a handler
+ * succeeding and the cursor advancing re-delivers it) - so handlers must be
+ * idempotent. The cursor is durable (survives restarts); the handler is
+ * per-worker, so call jobs.subscribe on every worker (like jobs.handler). Drained
+ * by jobs.work / jobs.run_worker.
+ * @param {string} name
+ * @param {Function} handler   (event) => void
+ * @param {object} [opts] { types: ["dead", ...], from: "now" | "beginning" }
+ */
+function subscribe(name, handler, opts) {
+    if (typeof name !== "string" || name === "")
+        throw new Error("jobs.subscribe: name must be a non-empty string");
+    if (typeof handler !== "function")
+        throw new Error("jobs.subscribe: handler must be a function");
+    const o = opts || {};
+    const typesCsv = (Array.isArray(o.types) && o.types.length) ? o.types.join(",") : null;
+    const maxF = (typeof o.maxFailures === "number" && o.maxFailures > 0) ? o.maxFailures : null;
+    // Start cursor: "now" (default) skips existing history; "beginning" replays all.
+    let start = 0;
+    if (o.from !== "beginning") {
+        const m = db.query("SELECT MAX(id) AS m FROM _hull_job_events");
+        start = (m[0] && m[0].m) || 0;
+    }
+    const now = time.now();
+    const n = db.insertIfAbsent("_hull_job_subscriptions", ["name"],
+        ["name", "cursor_id", "types", "failures", "max_failures", "updated_at"],
+        [name, start, typesCsv, 0, maxF, now]);
+    if (!(n && n > 0)) {
+        db.exec("UPDATE _hull_job_subscriptions SET types=?, max_failures=?, updated_at=? WHERE name=?",
+            [typesCsv, maxF, now, name]);
+    }
+    _subscribers[name] = { handler };
+    return jobs;
+}
+
+/** Remove a subscription: this worker's handler and the durable row (cursor). */
+function unsubscribe(name) {
+    delete _subscribers[name];
+    db.exec("DELETE FROM _hull_job_subscriptions WHERE name=?", [name]);
+    return jobs;
+}
+
+// Synchronous drain seam (the Phase 2 testability keystone): lease the
+// subscription, deliver new events in id order, advance the cursor, release the
+// lease. No timers/sleeps - work() drives it. Returns { delivered, cursor,
+// leased }. Test seams: opts.now (clock), opts.batch, opts.commitCursor (false =
+// deliver but don't advance -> models a crash before the cursor write),
+// opts.releaseLease (false = hold the lease -> models a worker death mid-drain).
+function eventsDrain(name, opts) {
+    const o = opts || {};
+    const sub = _subscribers[name];
+    if (!sub) return { delivered: 0, leased: false };
+    const now = o.now !== undefined ? o.now : time.now();
+    const token = crypto.base64urlEncode(crypto.random(8));
+    // Acquire the lease (CAS): detect acquisition via RETURNING on PG/SQLite
+    // (db.exec does not surface an affected-row count on Postgres); MySQL has no
+    // RETURNING but returns the count.
+    const leaseSql = "UPDATE _hull_job_subscriptions SET lease_token=?, lease_until=?, updated_at=? " +
+        "WHERE name=? AND (lease_until IS NULL OR lease_until <= ?)";
+    const leaseParams = [token, now + _EDRAIN_LEASE, now, name, now];
+    const got = db.dialect.supportsReturning
+        ? db.query(leaseSql + " RETURNING name", leaseParams).length
+        : (db.exec(leaseSql, leaseParams) || 0);
+    if (got === 0) return { delivered: 0, leased: false };
+    const row = db.query("SELECT cursor_id, types, failures, max_failures FROM _hull_job_subscriptions WHERE name=?", [name]);
+    const cursor = row[0].cursor_id;
+    const failures = row[0].failures || 0;
+    const maxFailures = row[0].max_failures;
+    const where = ["id > ?"], params = [cursor];
+    if (row[0].types) {
+        const parts = String(row[0].types).split(",").filter((s) => s.length);
+        if (parts.length) {
+            where.push("type IN (" + parts.map(() => "?").join(",") + ")");
+            for (const t of parts) params.push(t);
+        }
+    }
+    params.push(o.batch || 100);
+    const evs = db.query(
+        "SELECT id, ts, type, job_id, job_type, queue, data FROM _hull_job_events " +
+        "WHERE " + where.join(" AND ") + " ORDER BY id LIMIT ?", params);
+    // Deliver in id order. On a handler error, stop at that event (the poison);
+    // the successful prefix is committed and the poison retried on the next drain.
+    let lastOk = cursor, delivered = 0, poison = null, poisonErr = null;
+    for (const e of evs) {
+        if (e.data !== undefined && e.data !== null && e.data !== "") {
+            try { e.data = json.decode(e.data); } catch (_e) { /* leave raw */ }
+        }
+        try { sub.handler(e); lastOk = e.id; delivered += 1; }
+        catch (err) { poison = e; poisonErr = err; break; }
+    }
+    // Failure accounting + poison skip (Phase 3). `failures` counts consecutive
+    // drains stalled on the SAME frontier event; making progress resets to a fresh
+    // 1. Once it reaches maxFailures (opt-in), skip the poison: advance past it and
+    // record a durable `subscription_skipped` event so it can't wedge the
+    // subscription (or retention) forever.
+    let newFailures = 0, newCursor = lastOk;
+    if (poison) {
+        newFailures = (delivered > 0) ? 1 : failures + 1;
+        if (maxFailures && newFailures >= maxFailures) {
+            if (poison.type !== "subscription_skipped") {   // don't chain skip-of-skip
+                emitDurable("subscription_skipped",
+                    { id: poison.job_id, type: poison.job_type, queue: poison.queue },
+                    { error: `subscription '${name}' skipped event ${poison.id} after ` +
+                        `${newFailures} failures: ${(poisonErr && poisonErr.message) || poisonErr}` });
+            }
+            newCursor = poison.id;   // advance PAST the poison
+            newFailures = 0;
+        }
+    }
+    if (o.commitCursor === false) newCursor = cursor;
+    const release = o.releaseLease !== false;
+    db.exec(
+        "UPDATE _hull_job_subscriptions SET cursor_id=?, failures=?, " +
+        (release ? "lease_token=NULL, lease_until=NULL, " : "") +
+        "updated_at=? WHERE name=? AND lease_token=?",
+        [newCursor, newFailures, now, name, token]);
+    return { delivered, cursor: newCursor, leased: true,
+             skipped: (poison !== null && newCursor === poison.id) };
 }
 
 /**
@@ -1842,6 +2105,16 @@ function cleanup(opts) {
     // post-hoc metrics), not by orphan-ness.
     const hr = _cfg.historyRetention || o.olderThan || 604800;
     db.exec("DELETE FROM _hull_job_attempts WHERE finished_ms < ?", [(time.now() - hr) * 1000]);
+    // Durable event log: retained by age, but NEVER past an unconsumed event -
+    // min(cursor) across subscriptions is the safe watermark. No subscriptions ->
+    // age only (the Phase 1 behavior).
+    const mc = db.query("SELECT MIN(cursor_id) AS m FROM _hull_job_subscriptions");
+    const watermark = mc[0] ? mc[0].m : null;
+    if (watermark === null || watermark === undefined) {
+        db.exec("DELETE FROM _hull_job_events WHERE ts < ?", [cutoff]);
+    } else {
+        db.exec("DELETE FROM _hull_job_events WHERE ts < ? AND id <= ?", [cutoff, watermark]);
+    }
     return deleted;
 }
 
@@ -1857,11 +2130,11 @@ export const jobs = {
     stats, runWorker, stop, get, result, await: await_, progress, heartbeat, limit, metrics, history,
     pause, resume, purge,
     workflow, start, signal, workflowStatus,
-    dead, retry, cancel, cleanup, cron, uncron,
-    RETRY, DEAD, DISCARD, _config: _cfg, _cronNext, _tick,
+    dead, retry, cancel, cleanup, cron, uncron, events, subscribe, unsubscribe,
+    RETRY, DEAD, DISCARD, _config: _cfg, _cronNext, _tick, _eventsDrain: eventsDrain,
 };
 export { init, enqueue, enqueueMany, claim, handler, on, work, reap, stats,
          runWorker, stop, get, result, progress, heartbeat, limit, metrics, history, pause, resume,
          purge, workflow, start, signal, workflowStatus,
-         dead, retry, cancel, cleanup, cron, uncron };
+         dead, retry, cancel, cleanup, cron, uncron, events, subscribe, unsubscribe };
 export default jobs;

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -42,6 +42,7 @@ local _cfg = {
     reap_interval      = 30,    -- min seconds between reaper sweeps (0 = every work() call)
     history            = false, -- attempt-history recording: true | { queues={...} } | false
     history_retention  = nil,   -- seconds to keep attempt rows (nil = jobs.cleanup default)
+    events             = false, -- durable fleet-wide event log (jobs.subscribe / jobs.events)
 }
 
 -- Exponential backoff: 2^attempt * 10s, capped at 1h (shared with outbox math).
@@ -68,10 +69,22 @@ local _listeners = { completed = {}, retried = {}, dead = {} }
 -- reserved-type handler that runs the workflow through a memoizing ctx.
 local _workflows = {}
 
+-- Durable event subscribers registered on THIS worker (jobs.subscribe):
+-- name -> { handler = fn(event) }. The subscription row (cursor/lease) is durable
+-- in _hull_job_subscriptions; the handler is per-worker, like jobs.handler. A
+-- homogeneous fleet re-registers every subscription at startup, so any worker can
+-- drain any subscription (the per-subscription lease serializes them).
+local _subscribers = {}
+
 -- Unix ts of the last reaper sweep (throttled in jobs.work via _cfg.reap_interval).
 local _last_reap = 0
 -- Unix ts of the last cron due-check (throttled to >=1s; cron is minute-grained).
 local _last_cron = 0
+-- Unix ts of the last subscription drain (throttled to >=1s in jobs.work).
+local _last_edrain = 0
+-- Lease duration (seconds) for a subscription drain - a crashed drainer's lease
+-- expires after this and another worker resumes from the unadvanced cursor.
+local _EDRAIN_LEASE = 30
 -- Whether the server parses SKIP LOCKED (probed in jobs.init; nil = not probed).
 local _skip_locked = nil
 -- Per-queue rate limits { [queue] = { rate, per } }, in-memory (re-registered on
@@ -103,6 +116,7 @@ function jobs.init(opts)
     if opts.backoff ~= nil then _cfg.backoff = opts.backoff end
     if opts.history ~= nil then _cfg.history = opts.history end
     if opts.history_retention ~= nil then _cfg.history_retention = opts.history_retention end
+    if opts.events ~= nil then _cfg.events = opts.events end
 
     -- Keyed / indexed text columns are VARCHAR(255) so MySQL can index them;
     -- data-only columns (payload, last_error) stay TEXT. status/type/queue are
@@ -290,6 +304,43 @@ function jobs.init(opts)
         ON _hull_job_attempts(finished_ms)
     ]])
 
+    -- Durable fleet-wide event log (jobs.init{events=true}). Append-only lifecycle
+    -- events, written in the SAME transaction as the state change that produced
+    -- them (transactional coupling: an event exists iff the transition committed).
+    -- The `id` is the total order + the future subscription cursor space. `data`
+    -- is small JSON metadata (error/attempt/trace), never the full result.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_job_events ("
+        .. "id       " .. db.autoincrement_id_ddl .. ", "
+        .. "ts       INTEGER      NOT NULL,"
+        .. "type     VARCHAR(32)  NOT NULL,"
+        .. "job_id   INTEGER,"
+        .. "job_type VARCHAR(255),"
+        .. "queue    VARCHAR(255),"
+        .. "data     TEXT)")
+    db.exec([[
+        CREATE INDEX IF NOT EXISTS idx_hull_job_events_type ON _hull_job_events(type, id)
+    ]])
+    db.exec([[
+        CREATE INDEX IF NOT EXISTS idx_hull_job_events_ts ON _hull_job_events(ts)
+    ]])
+
+    -- Durable event subscriptions (jobs.subscribe). One row per named consumer:
+    -- `cursor` = last delivered event id (the drain advances it), `types` = an
+    -- optional comma-list filter, `lease_token`/`lease_until` = the drain lease
+    -- (one worker drains a subscription at a time; a crashed drainer's lease
+    -- expires and another resumes from the cursor). Restart-durable + fleet-wide.
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS _hull_job_subscriptions ("
+        .. "name        VARCHAR(255) NOT NULL PRIMARY KEY,"
+        .. "cursor_id   INTEGER      NOT NULL DEFAULT 0,"
+        .. "types       VARCHAR(255),"
+        .. "lease_token VARCHAR(255),"
+        .. "lease_until INTEGER,"
+        .. "failures    INTEGER      NOT NULL DEFAULT 0,"
+        .. "max_failures INTEGER,"    -- skip a poison event after N failures (NULL = never)
+        .. "updated_at  INTEGER      NOT NULL)")
+
     -- Verify the server actually parses SKIP LOCKED (the compile-time dialect
     -- flag says "this backend supports it" but a MySQL<8 / MariaDB<10.6 server
     -- does not). A 0-row probe against the real table detects it once; the claim
@@ -369,6 +420,24 @@ local function load_deps(dependent_id)
         end
     end
     return out
+end
+
+-- Append a durable lifecycle event (opt-in via jobs.init{events=true}). Called
+-- INSIDE the transition's transaction, so the event commits iff the state change
+-- does (transactional coupling: no lost, no phantom events). `job` supplies
+-- id/type/queue/trace; `info` is small metadata (error/attempt) - never the full
+-- result (a consumer joins _hull_job_results for that).
+local function emit_durable(event, job, info)
+    if not _cfg.events then return end
+    info = info or {}
+    local data
+    if info.error ~= nil or info.attempt ~= nil or job.trace ~= nil then
+        data = json.encode({ error = info.error, attempt = info.attempt, trace = job.trace })
+    end
+    db.exec(
+        "INSERT INTO _hull_job_events (ts, type, job_id, job_type, queue, data) "
+        .. "VALUES (?, ?, ?, ?, ?, ?)",
+        { time.now(), event, job.id, job.type, job.queue, data })
 end
 
 --- Enqueue a job. A plain INSERT, so calling it inside a `db.batch()` commits
@@ -481,6 +550,10 @@ function jobs.enqueue(job_type, data, opts)
             end
         end
     end
+    -- Durable "enqueued" event (opt-in). Emitted here so it joins the caller's
+    -- db.batch when enqueue is called inside one (transactional coupling).
+    emit_durable("enqueued",
+        { id = id, type = job_type, queue = opts.queue or "default", trace = opts.trace }, {})
     return id
 end
 
@@ -914,6 +987,23 @@ local function emit(event, job, info)
     for i = 1, #L do pcall(L[i], job, info) end
 end
 
+-- Apply a terminal transition and its durable event ATOMICALLY (one txn), then
+-- fire the in-process listeners. `transition()` runs the mark_* state change and
+-- returns the effective outcome ("done"|"dead"|"retried"). Wrapping in db.batch
+-- both couples the event to the state change and collapses mark_done's several
+-- statements into one commit (fewer fsyncs, even when events are off). Returns
+-- the outcome.
+local EVENT_OF = { done = "completed", dead = "dead", retried = "retried" }
+local function finish(job, info, transition)
+    local outcome
+    db.batch(function()
+        outcome = transition()
+        emit_durable(EVENT_OF[outcome] or outcome, job, info)
+    end)
+    emit(EVENT_OF[outcome] or outcome, job, info)
+    return outcome
+end
+
 --- Reclaim jobs stuck in `running` past the visibility timeout - a worker that
 -- claimed them died before completing. Reset to `pending` for reclaim (their
 -- incremented attempts persist, so a job that keeps killing its worker still
@@ -1181,6 +1271,12 @@ function jobs.work(opts)
         process_cron(now)
         _last_cron = now
     end
+    -- Drain durable event subscriptions (throttled; the per-subscription lease
+    -- makes this fleet-safe). Only workers that registered subscribers do work.
+    if next(_subscribers) and now - _last_edrain >= 1 then
+        for name in pairs(_subscribers) do jobs._events_drain(name, { now = now }) end
+        _last_edrain = now
+    end
     local batch = jobs.claim(opts)
     for _, job in ipairs(batch) do
         job.deps = load_deps(job.id)   -- workflow: dependency results, in order
@@ -1189,9 +1285,9 @@ function jobs.work(opts)
         local outcome, err_str             -- nil outcome = a yield (not recorded)
         if not h then
             err_str = "no handler for job type '" .. tostring(job.type) .. "'"
-            mark_dead(job.id, err_str)
-            emit("dead", job, { error = err_str })
-            outcome = "dead"
+            outcome = finish(job, { error = err_str }, function()
+                mark_dead(job.id, err_str); return "dead"
+            end)
         else
             local ok, result = pcall(h, job)
             if ok and type(result) == "table" and result.__hull_wf_yield then
@@ -1229,16 +1325,17 @@ function jobs.work(opts)
                 end
             elseif not ok then
                 err_str = tostring(result)
-                outcome = mark_retry(job, err_str)
-                emit(outcome, job, { error = err_str, attempt = job.attempts })
+                outcome = finish(job, { error = err_str, attempt = job.attempts },
+                    function() return mark_retry(job, err_str) end)
             elseif result == jobs.DEAD then
-                err_str = "handler returned jobs.DEAD"; outcome = "dead"
-                mark_dead(job.id, err_str)
-                emit("dead", job, { error = err_str })
+                err_str = "handler returned jobs.DEAD"
+                outcome = finish(job, { error = err_str }, function()
+                    mark_dead(job.id, err_str); return "dead"
+                end)
             elseif result == jobs.RETRY then
                 err_str = "handler requested retry"
-                outcome = mark_retry(job, err_str)
-                emit(outcome, job, { error = err_str, attempt = job.attempts })
+                outcome = finish(job, { error = err_str, attempt = job.attempts },
+                    function() return mark_retry(job, err_str) end)
             else
                 -- nil / true / jobs.DISCARD -> done, no result; any other return
                 -- value is stored as the job's result (for dependents).
@@ -1246,9 +1343,9 @@ function jobs.work(opts)
                 if result ~= nil and result ~= true and result ~= jobs.DISCARD then
                     res = result
                 end
-                mark_done(job.id, res)
-                emit("completed", job, { result = res })
-                outcome = "done"
+                outcome = finish(job, { result = res }, function()
+                    mark_done(job.id, res); return "done"
+                end)
             end
         end
         -- Opt-in attempt history (a yield leaves outcome nil -> not recorded).
@@ -1419,6 +1516,22 @@ function jobs.metrics(opts)
         end
         out.latency = { wait_ms = percentiles(waits), run_ms = percentiles(runs) }
         out.throughput = { done_per_sec = done_n / window, dead_per_sec = dead_n / window }
+    end
+    -- Durable-event log health (Phase 3): total log depth + per-subscription lag
+    -- (positions behind the log head = max id - cursor) and failure count, so a
+    -- stuck / lagging subscriber is visible. Present only when the log has data.
+    local depth = db.query("SELECT COUNT(*) AS n, MAX(id) AS mx FROM _hull_job_events")
+    local log_depth = (depth[1] and depth[1].n) or 0
+    if log_depth > 0 then
+        local max_id = (depth[1] and depth[1].mx) or 0
+        local subs = db.query(
+            "SELECT name, cursor_id, failures FROM _hull_job_subscriptions ORDER BY name")
+        local sub_list = {}
+        for _, sn in ipairs(subs or {}) do
+            sub_list[#sub_list + 1] =
+                { name = sn.name, lag = max_id - (sn.cursor_id or 0), failures = sn.failures or 0 }
+        end
+        out.events = { log_depth = log_depth, subscriptions = sub_list }
     end
     return out
 end
@@ -1953,7 +2066,178 @@ end
 -- @tparam number id
 -- @treturn boolean
 function jobs.cancel(id)
-    return (db.exec("DELETE FROM _hull_jobs WHERE id=? AND status='pending'", { id }) or 0) > 0
+    if not _cfg.events then
+        return (db.exec("DELETE FROM _hull_jobs WHERE id=? AND status='pending'", { id }) or 0) > 0
+    end
+    -- events on: capture type/queue for the "cancelled" event, delete + emit in
+    -- one txn (BEGIN IMMEDIATE serializes, so the SELECT->DELETE stays consistent).
+    local cancelled = false
+    db.batch(function()
+        local r = db.query("SELECT type, queue FROM _hull_jobs WHERE id=? AND status='pending'", { id })
+        if r and r[1] then
+            db.exec("DELETE FROM _hull_jobs WHERE id=? AND status='pending'", { id })
+            emit_durable("cancelled", { id = id, type = r[1].type, queue = r[1].queue }, {})
+            cancelled = true
+        end
+    end)
+    return cancelled
+end
+
+--- Read-only tail of the durable event log (jobs.init{events=true}), newest
+-- first - for a dashboard or ad-hoc inspection. Phase 2 adds durable
+-- subscriptions (jobs.subscribe) with at-least-once delivery + cursors.
+-- @tparam[opt] table opts { since = <event id>, types = {"dead", ...}, limit = 100 }
+-- @treturn table array of { id, ts, type, job_id, job_type, queue, data }
+function jobs.events(opts)
+    opts = opts or {}
+    local where, params = { "1=1" }, {}
+    if opts.since ~= nil then where[#where + 1] = "id > ?"; params[#params + 1] = opts.since end
+    if type(opts.types) == "table" and #opts.types > 0 then
+        local ph = {}
+        for _, t in ipairs(opts.types) do ph[#ph + 1] = "?"; params[#params + 1] = t end
+        where[#where + 1] = "type IN (" .. table.concat(ph, ",") .. ")"
+    end
+    params[#params + 1] = math.min(tonumber(opts.limit) or 100, 1000)
+    local rows = db.query(
+        "SELECT id, ts, type, job_id, job_type, queue, data FROM _hull_job_events "
+        .. "WHERE " .. table.concat(where, " AND ") .. " ORDER BY id DESC LIMIT ?", params)
+    for _, r in ipairs(rows or {}) do
+        if r.data ~= nil and r.data ~= "" then
+            local ok, decoded = pcall(json.decode, r.data)
+            if ok then r.data = decoded end
+        end
+    end
+    return rows or {}
+end
+
+--- Register a durable named subscription over the event log (Phase 2). `handler`
+-- is called once per event, in id order, AT-LEAST-ONCE (a crash between a handler
+-- succeeding and the cursor advancing re-delivers it) - so handlers must be
+-- idempotent, the same contract as a job handler. The cursor is durable (survives
+-- restarts); the handler is per-worker, so call jobs.subscribe on every worker
+-- (like jobs.handler). Drained by jobs.work / jobs.run_worker.
+-- @tparam string name
+-- @tparam function handler   function(event)
+-- @tparam[opt] table opts { types = {"dead", ...}, from = "now" | "beginning",
+--                            max_failures = N }  N = skip a poison event after N
+--                            consecutive handler failures (nil = block forever)
+function jobs.subscribe(name, handler, opts)
+    if type(name) ~= "string" or name == "" then
+        error("jobs.subscribe: name must be a non-empty string")
+    end
+    if type(handler) ~= "function" then error("jobs.subscribe: handler must be a function") end
+    opts = opts or {}
+    local types_csv
+    if type(opts.types) == "table" and #opts.types > 0 then types_csv = table.concat(opts.types, ",") end
+    local max_f = (type(opts.max_failures) == "number" and opts.max_failures > 0) and opts.max_failures or nil
+    -- Start cursor: "now" (default) skips existing history; "beginning" replays all.
+    local start = 0
+    if opts.from ~= "beginning" then
+        local m = db.query("SELECT MAX(id) AS m FROM _hull_job_events")
+        start = (m[1] and m[1].m) or 0
+    end
+    local now = time.now()
+    -- Create the durable row once; a re-subscribe keeps the persisted cursor and
+    -- only refreshes the config (type filter, skip threshold).
+    local n = db.insert_if_absent("_hull_job_subscriptions", { "name" },
+        { "name", "cursor_id", "types", "failures", "max_failures", "updated_at" },
+        { name, start, types_csv, 0, max_f, now })
+    if not (n and n > 0) then
+        db.exec("UPDATE _hull_job_subscriptions SET types=?, max_failures=?, updated_at=? WHERE name=?",
+            { types_csv, max_f, now, name })
+    end
+    _subscribers[name] = { handler = handler }
+    return jobs
+end
+
+--- Remove a subscription: this worker's handler and the durable row (cursor).
+function jobs.unsubscribe(name)
+    _subscribers[name] = nil
+    db.exec("DELETE FROM _hull_job_subscriptions WHERE name=?", { name })
+    return jobs
+end
+
+-- Synchronous drain seam (the Phase 2 testability keystone): lease the
+-- subscription, deliver new events in id order, advance the cursor, release the
+-- lease. No timers/sleeps - jobs.work drives it. Returns { delivered, cursor,
+-- leased }. Test seams: opts.now (clock), opts.batch, opts.commit_cursor (false =
+-- deliver but don't advance -> models a crash before the cursor write),
+-- opts.release_lease (false = hold the lease -> models a worker death mid-drain).
+function jobs._events_drain(name, opts)
+    opts = opts or {}
+    local sub = _subscribers[name]
+    if not sub then return { delivered = 0, leased = false } end
+    local now = opts.now or time.now()
+    local token = crypto.base64url_encode(crypto.random(8))
+    -- Acquire the lease (CAS): only if free or expired. Fleet-safe, no global lock.
+    -- Detect acquisition via RETURNING on PG/SQLite (db.exec does not surface an
+    -- affected-row count on Postgres); MySQL has no RETURNING but returns the count.
+    local lease_sql = "UPDATE _hull_job_subscriptions SET lease_token=?, lease_until=?, updated_at=? "
+        .. "WHERE name=? AND (lease_until IS NULL OR lease_until <= ?)"
+    local lease_params = { token, now + _EDRAIN_LEASE, now, name, now }
+    local got
+    if db.dialect.supports_returning then
+        got = #db.query(lease_sql .. " RETURNING name", lease_params)
+    else
+        got = db.exec(lease_sql, lease_params) or 0
+    end
+    if got == 0 then return { delivered = 0, leased = false } end
+    local row = db.query(
+        "SELECT cursor_id, types, failures, max_failures FROM _hull_job_subscriptions WHERE name=?", { name })
+    local cursor = row[1].cursor_id
+    local failures = row[1].failures or 0
+    local max_failures = row[1].max_failures
+    -- Fetch events past the cursor, filtered by the subscription's types.
+    local where, params = { "id > ?" }, { cursor }
+    if row[1].types and row[1].types ~= "" then
+        local ph = {}
+        for t in tostring(row[1].types):gmatch("[^,]+") do ph[#ph + 1] = "?"; params[#params + 1] = t end
+        where[#where + 1] = "type IN (" .. table.concat(ph, ",") .. ")"
+    end
+    params[#params + 1] = opts.batch or 100
+    local evs = db.query(
+        "SELECT id, ts, type, job_id, job_type, queue, data FROM _hull_job_events "
+        .. "WHERE " .. table.concat(where, " AND ") .. " ORDER BY id LIMIT ?", params)
+    -- Deliver in id order. On a handler error, stop at that event (the poison);
+    -- the successful prefix is committed and the poison retried on the next drain.
+    local last_ok, delivered, poison, poison_err = cursor, 0, nil, nil
+    for _, e in ipairs(evs) do
+        if e.data ~= nil and e.data ~= "" then
+            local ok, d = pcall(json.decode, e.data); if ok then e.data = d end
+        end
+        local ok, herr = pcall(sub.handler, e)
+        if ok then last_ok = e.id; delivered = delivered + 1
+        else poison = e; poison_err = herr; break end
+    end
+    -- Failure accounting + poison skip. `failures` counts consecutive drains that
+    -- stalled on the SAME frontier event; making progress this drain resets it to
+    -- a fresh 1. Once it reaches max_failures (opt-in), skip the poison: advance
+    -- past it and record a durable `subscription_skipped` event so it can't wedge
+    -- the subscription (or retention) forever.
+    local new_failures, new_cursor = 0, last_ok
+    if poison then
+        new_failures = (delivered > 0) and 1 or (failures + 1)
+        if max_failures and new_failures >= max_failures then
+            -- Don't chain: skipping a subscription_skipped must not emit another.
+            if poison.type ~= "subscription_skipped" then
+                emit_durable("subscription_skipped",
+                    { id = poison.job_id, type = poison.job_type, queue = poison.queue },
+                    { error = "subscription '" .. name .. "' skipped event " .. poison.id
+                        .. " after " .. new_failures .. " failures: " .. tostring(poison_err) })
+            end
+            new_cursor = poison.id   -- advance PAST the poison
+            new_failures = 0
+        end
+    end
+    if opts.commit_cursor == false then new_cursor = cursor end
+    local release = opts.release_lease ~= false
+    db.exec(
+        "UPDATE _hull_job_subscriptions SET cursor_id=?, failures=?, "
+        .. (release and "lease_token=NULL, lease_until=NULL, " or "")
+        .. "updated_at=? WHERE name=? AND lease_token=?",
+        { new_cursor, new_failures, now, name, token })
+    return { delivered = delivered, cursor = new_cursor, leased = true,
+             skipped = (poison ~= nil and new_cursor == poison.id) or false }
 end
 
 --- Purge terminal jobs (done + dead by default) whose last update is older than
@@ -1990,6 +2274,16 @@ function jobs.cleanup(opts)
     -- post-hoc metrics), not by orphan-ness.
     local hr = _cfg.history_retention or opts.older_than or 604800
     db.exec("DELETE FROM _hull_job_attempts WHERE finished_ms < ?", { (time.now() - hr) * 1000 })
+    -- Durable event log: retained by age, but NEVER past an unconsumed event -
+    -- min(cursor) across subscriptions is the safe watermark. No subscriptions ->
+    -- age only (the Phase 1 behavior).
+    local mc = db.query("SELECT MIN(cursor_id) AS m FROM _hull_job_subscriptions")
+    local watermark = mc[1] and mc[1].m
+    if watermark == nil then
+        db.exec("DELETE FROM _hull_job_events WHERE ts < ?", { cutoff })
+    else
+        db.exec("DELETE FROM _hull_job_events WHERE ts < ? AND id <= ?", { cutoff, watermark })
+    end
     return deleted
 end
 

--- a/tests/e2e_jobs.sh
+++ b/tests/e2e_jobs.sh
@@ -664,6 +664,242 @@ app.main(async (ctx) => {
 echo "== soft per-key concurrency: Lua =="; check_perkey_conc "lua" "lua" "$LUA_PKC"
 echo "== soft per-key concurrency: JS  =="; check_perkey_conc "js"  "js"  "$JS_PKC"
 
+# ── durable fleet-wide events, Phase 1 (log + transactional emit + tail) ─────
+# jobs.init{events=true} appends a lifecycle event in the SAME transaction as the
+# state change (enqueued/completed/dead/cancelled). jobs.events tails it. Counts
+# must match committed state exactly (no phantom events); the tail filters by type.
+check_events() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"EVENTS e=4 c=1 d=2 x=1 err=yes filtered=2"*)
+            pass "$label: durable events (transactional emit + tail + type filter)" ;;
+        *) fail "$label: durable events Phase 1" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_EVENTS='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init({ events = true })
+  jobs.handler("ok",  function(j) return { r = 1 } end)
+  jobs.handler("bad", function(j) error("boom") end)
+  jobs.enqueue("ok", { x = 1 })
+  jobs.enqueue("bad", {}, { max_attempts = 1 })
+  jobs.enqueue("nohandler", {})
+  local c = jobs.enqueue("ok", {}); jobs.cancel(c)
+  for _=1,3 do jobs.work({ batch = 10 }) end
+  local n = {}
+  for _,e in ipairs(jobs.events({ limit = 100 })) do n[e.type] = (n[e.type] or 0) + 1 end
+  local deads = jobs.events({ types = { "dead" }, limit = 10 })
+  local err = (deads[1] and deads[1].data and deads[1].data.error) and "yes" or "no"
+  ctx.stdout:write(("EVENTS e=%d c=%d d=%d x=%d err=%s filtered=%d\n"):format(
+    n.enqueued or 0, n.completed or 0, n.dead or 0, n.cancelled or 0, err, #deads))
+  return 0
+end)'
+
+JS_EVENTS='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init({ events: true });
+  jobs.handler("ok",  (j) => ({ r: 1 }));
+  jobs.handler("bad", (j) => { throw new Error("boom"); });
+  jobs.enqueue("ok", { x: 1 });
+  jobs.enqueue("bad", {}, { maxAttempts: 1 });
+  jobs.enqueue("nohandler", {});
+  const c = jobs.enqueue("ok", {}); jobs.cancel(c);
+  for (let k=0;k<3;k++) await jobs.work({ batch: 10 });
+  const n = {};
+  for (const e of jobs.events({ limit: 100 })) n[e.type] = (n[e.type] || 0) + 1;
+  const deads = jobs.events({ types: ["dead"], limit: 10 });
+  const err = (deads[0] && deads[0].data && deads[0].data.error) ? "yes" : "no";
+  ctx.stdout.write(`EVENTS e=${n.enqueued||0} c=${n.completed||0} d=${n.dead||0} x=${n.cancelled||0} err=${err} filtered=${deads.length}\n`);
+  return 0;
+});'
+
+echo "== durable events Phase 1: Lua =="; check_events "lua" "lua" "$LUA_EVENTS"
+echo "== durable events Phase 1: JS  =="; check_events "js"  "js"  "$JS_EVENTS"
+
+# ── durable events Phase 2 (subscriptions: cursor + lease drain) ─────────────
+# The jobs._events_drain seam is synchronous + clock-injectable, so at-least-once,
+# lease reclaim, and retention are asserted at exact instants with NO sleeps.
+# Covers: deterministic in-order capture (T3), crash-before-cursor -> re-delivery
+# (T5a), worker-death lease reclaim (T5b), retention-never-past-min(cursor) (T6).
+check_events_p2() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"EV deliv=3 order=y recaught=0 dup=6 held=false reclaim=3 retain=y purged=y"*)
+            pass "$label: durable subscriptions (capture + at-least-once + lease reclaim + retention)" ;;
+        *) fail "$label: durable events Phase 2" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_EV2='local jobs = require("hull.jobs")
+local time = require("hull.time")
+app.manifest({ modules = { "hull/jobs@1", "hull/time@1" } })
+app.main(function(ctx)
+  jobs.init({ events = true })
+  local future = time.now() + 100   -- > every event ts, within int4 (PG-safe)
+  jobs.enqueue("ok", {}); jobs.enqueue("ok", {}); jobs.enqueue("ok", {})
+  local seen = {}
+  jobs.subscribe("cap", function(ev) seen[#seen+1] = ev.id end, { from = "beginning" })
+  local r  = jobs._events_drain("cap", { now = 1000 })
+  local re = jobs._events_drain("cap", { now = 1000 })
+  local order = (seen[1]==1 and seen[2]==2 and seen[3]==3) and "y" or "n"
+  local dc = 0
+  jobs.subscribe("dup", function() dc = dc + 1 end, { from = "beginning" })
+  jobs._events_drain("dup", { now = 1000, commit_cursor = false })
+  jobs._events_drain("dup", { now = 1000 })
+  jobs.subscribe("lease", function() end, { from = "beginning" })
+  jobs._events_drain("lease", { now = 1000, commit_cursor = false, release_lease = false })
+  local held = jobs._events_drain("lease", { now = 1000 })
+  local rec  = jobs._events_drain("lease", { now = 1040 })
+  jobs.subscribe("lag", function() end, { from = "beginning" })
+  local before = #jobs.events({ limit = 100 })
+  jobs.cleanup({ before = future })
+  local after = #jobs.events({ limit = 100 })
+  jobs._events_drain("lag", { now = 1000 })
+  jobs.cleanup({ before = future })
+  local final = #jobs.events({ limit = 100 })
+  ctx.stdout:write(("EV deliv=%d order=%s recaught=%d dup=%d held=%s reclaim=%d retain=%s purged=%s\n"):format(
+    r.delivered, order, re.delivered, dc, tostring(held.leased), rec.delivered,
+    (after==before) and "y" or "n", (final==0) and "y" or "n"))
+  return 0
+end)'
+
+JS_EV2='import { app } from "hull:app"; import { jobs } from "hull:jobs"; import { time } from "hull:time";
+app.manifest({ modules: ["hull/jobs@1", "hull/time@1"] });
+app.main(async (ctx) => {
+  jobs.init({ events: true });
+  const future = time.now() + 100;   // > every event ts, within int4 (PG-safe)
+  jobs.enqueue("ok", {}); jobs.enqueue("ok", {}); jobs.enqueue("ok", {});
+  const seen = [];
+  jobs.subscribe("cap", (ev) => seen.push(ev.id), { from: "beginning" });
+  const r  = jobs._eventsDrain("cap", { now: 1000 });
+  const re = jobs._eventsDrain("cap", { now: 1000 });
+  const order = (seen[0]===1 && seen[1]===2 && seen[2]===3) ? "y" : "n";
+  let dc = 0;
+  jobs.subscribe("dup", () => { dc++; }, { from: "beginning" });
+  jobs._eventsDrain("dup", { now: 1000, commitCursor: false });
+  jobs._eventsDrain("dup", { now: 1000 });
+  jobs.subscribe("lease", () => {}, { from: "beginning" });
+  jobs._eventsDrain("lease", { now: 1000, commitCursor: false, releaseLease: false });
+  const held = jobs._eventsDrain("lease", { now: 1000 });
+  const rec  = jobs._eventsDrain("lease", { now: 1040 });
+  jobs.subscribe("lag", () => {}, { from: "beginning" });
+  const before = jobs.events({ limit: 100 }).length;
+  jobs.cleanup({ before: future });
+  const after = jobs.events({ limit: 100 }).length;
+  jobs._eventsDrain("lag", { now: 1000 });
+  jobs.cleanup({ before: future });
+  const final = jobs.events({ limit: 100 }).length;
+  ctx.stdout.write(`EV deliv=${r.delivered} order=${order} recaught=${re.delivered} dup=${dc} held=${held.leased} reclaim=${rec.delivered} retain=${after===before?"y":"n"} purged=${final===0?"y":"n"}\n`);
+  return 0;
+});'
+
+echo "== durable events Phase 2: Lua =="; check_events_p2 "lua" "lua" "$LUA_EV2"
+echo "== durable events Phase 2: JS  =="; check_events_p2 "js"  "js"  "$JS_EV2"
+
+# Fleet gate: K processes drain ONE shared subscription. The per-subscription
+# lease + monotonic cursor mean each event is delivered exactly once across the
+# fleet - the union of per-process deliveries is all N ids, no duplicates.
+echo "== durable events fleet gate ($CONC processes, one subscription) =="
+EW="$(mktemp -d)"; EDB="$EW/e.db"
+cat > "$EW/seed.lua" <<LUA
+local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function()
+  jobs.init({ events = true })
+  for i=1,20 do jobs.enqueue("t", {}) end          -- 20 "enqueued" events
+  jobs.subscribe("g", function() end, { from = "beginning" })  -- create sub at cursor 0
+  return 0
+end)
+LUA
+cat > "$EW/drain.lua" <<'LUA'
+local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init({ events = true })
+  jobs.subscribe("g", function(ev) ctx.stdout:write(ev.id .. "\n") end, { from = "beginning" })
+  for _=1,40 do jobs._events_drain("g", {}) end     -- drain to exhaustion (lease-serialized)
+  return 0
+end)
+LUA
+"$HULL" "$EW/seed.lua" -d "$EDB" >/dev/null 2>&1
+i=1; while [ "$i" -le "$CONC" ]; do "$HULL" "$EW/drain.lua" -d "$EDB" > "$EW/out.$i" 2>/dev/null & i=$((i+1)); done
+wait
+etot="$(cat "$EW"/out.* | grep -c . || true)"
+euniq="$(cat "$EW"/out.* | sort -n | uniq | grep -c . || true)"
+if [ "$etot" -eq 20 ] && [ "$euniq" -eq 20 ]; then
+    pass "durable events fleet: $CONC processes delivered all 20 events exactly once (lease + cursor)"
+else
+    fail "durable events fleet: expected 20/20" "total=$etot uniq=$euniq"
+fi
+rm -rf "$EW"
+
+# ── durable events Phase 3 (poison-event skip-after-N + metrics) ─────────────
+# A subscription with max_failures=N skips a poison event after N consecutive
+# handler failures (advancing past it + recording a durable subscription_skipped
+# event), so one bad event can't wedge the subscription or block retention.
+# jobs.metrics gains an events block (log depth + per-subscription lag/failures).
+check_events_p3() {
+    label="$1"; ext="$2"; app="$3"
+    T="$(mktemp -d)"; printf '%s\n' "$app" > "$T/app.$ext"
+    out="$("$HULL" "$T/app.$ext" -d "$T/a.db" 2>/dev/null)" || true
+    case "$out" in
+        *"POISON seen=1,3,4 d1=1 d2skip=true skips=1 lag=0 fail=0 depth=4"*)
+            pass "$label: poison-event skip-after-N + subscription_skipped + metrics" ;;
+        *) fail "$label: durable events Phase 3" "$out" ;;
+    esac
+    rm -rf "$T"
+}
+
+LUA_EV3='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/jobs@1" } })
+app.main(function(ctx)
+  jobs.init({ events = true })
+  jobs.enqueue("ok",{}); jobs.enqueue("ok",{}); jobs.enqueue("ok",{})
+  local seen = {}
+  jobs.subscribe("p", function(ev) if ev.id == 2 then error("poison") end seen[#seen+1] = ev.id end,
+    { from = "beginning", max_failures = 2 })
+  local d1 = jobs._events_drain("p", { now = 1000 })
+  local d2 = jobs._events_drain("p", { now = 1000 })
+  jobs._events_drain("p", { now = 1000 })
+  local skips = #jobs.events({ types = { "subscription_skipped" } })
+  local m = jobs.metrics()
+  local sub = m.events and m.events.subscriptions[1]
+  ctx.stdout:write(("POISON seen=%s d1=%d d2skip=%s skips=%d lag=%s fail=%s depth=%s\n"):format(
+    table.concat(seen, ","), d1.delivered, tostring(d2.skipped), skips,
+    tostring(sub and sub.lag), tostring(sub and sub.failures), tostring(m.events and m.events.log_depth)))
+  return 0
+end)'
+
+JS_EV3='import { app } from "hull:app"; import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/jobs@1"] });
+app.main(async (ctx) => {
+  jobs.init({ events: true });
+  jobs.enqueue("ok",{}); jobs.enqueue("ok",{}); jobs.enqueue("ok",{});
+  const seen = [];
+  jobs.subscribe("p", (ev) => { if (ev.id === 2) throw new Error("poison"); seen.push(ev.id); },
+    { from: "beginning", maxFailures: 2 });
+  const d1 = jobs._eventsDrain("p", { now: 1000 });
+  const d2 = jobs._eventsDrain("p", { now: 1000 });
+  jobs._eventsDrain("p", { now: 1000 });
+  const skips = jobs.events({ types: ["subscription_skipped"] }).length;
+  const m = jobs.metrics();
+  const sub = m.events && m.events.subscriptions[0];
+  ctx.stdout.write(`POISON seen=${seen.join(",")} d1=${d1.delivered} d2skip=${d2.skipped} skips=${skips} lag=${sub&&sub.lag} fail=${sub&&sub.failures} depth=${m.events&&m.events.logDepth}\n`);
+  return 0;
+});'
+
+echo "== durable events Phase 3: Lua =="; check_events_p3 "lua" "lua" "$LUA_EV3"
+echo "== durable events Phase 3: JS  =="; check_events_p3 "js"  "js"  "$JS_EV3"
+
 # ── v1.3: queue pause / resume / purge ──────────────────────────────────────
 # A paused queue is not claimed; resume restores it; purge deletes pending.
 check_pq() {


### PR DESCRIPTION
Collapses the stacked events PRs **#262 -> #263 -> #265** into one squash for a
clean fresh-CI merge (the originals were opened during the 2026-08-06 GitHub
outage and never got a CI run).

## What lands
- **Phase 1** - append-only `_hull_job_events` log; transactional emit coupling
  via the `finish()` helper (state transition + event in one `db.batch`); `jobs.events` tail; age-based event cleanup.
- **Phase 2** - durable per-subscription cursors (`_hull_job_subscriptions`);
  `jobs.subscribe` / `jobs.unsubscribe`; leased cursor drain
  (`jobs._events_drain` seam, clock-injectable for tests); retention keyed to the min live cursor.
- **Phase 3** - poison-event skip-after-N (`max_failures`), `subscription_skipped`
  provenance event, and `jobs.metrics.events` (log depth + per-subscription lag/failures).

## Portability + testability
- DB-backend-agnostic across SQLite / Postgres / MySQL (column `cursor_id`, not
  the MySQL reserved `cursor`; lease CAS uses the `supports_returning` branch on
  PG/SQLite and rowcount on MySQL).
- Both runtimes at full parity.
- Validated locally: `e2e_jobs` 62/62 on SQLite; MySQL 8 + Postgres 16 fleet
  gates; luacheck clean.

Supersedes #262, #263, #265.
