### PR TITLE
db: conn.wait_notify - db-cap LISTEN/NOTIFY surface (jobs events Phase 4.2)

### DIFF
--- a/include/hull/cap/db_backend.h
+++ b/include/hull/cap/db_backend.h
@@ -77,6 +77,15 @@ typedef struct HlDbDialect {
      * claim shape per backend. See docs/jobs_design.md. */
     unsigned char supports_skip_locked;
 
+    /* Whether the backend supports a low-latency LISTEN/NOTIFY wakeup (the
+     * optional wait_notify vtable method below). 1 = Postgres; 0 = SQLite /
+     * MySQL / DuckDB, which keep polling. Read by hull/jobs (via
+     * conn.dialect.supports_notify) to decide whether an idle worker parks on
+     * a NOTIFY-wait or a plain sleep. Latency only, never a correctness
+     * dependency: every wait is bounded by a poll timeout. See
+     * docs/jobs_events_phase4_design.md. */
+    unsigned char supports_notify;
+
     /* Inline DDL fragment declaring an auto-increment integer primary-key
      * column. SQLite: "INTEGER PRIMARY KEY AUTOINCREMENT". Postgres:
      * "BIGSERIAL PRIMARY KEY". MySQL: "BIGINT AUTO_INCREMENT PRIMARY KEY".
@@ -177,6 +186,15 @@ typedef struct HlDbBackend {
      * or NULL. Consumers key off native_tag to know the concrete type; this
      * replaces the per-backend hl_db_<x>_raw accessors. NULL = none exposed. */
     void  *(*native_handle)(HlDbHandle *h);
+
+    /* Optional low-latency wakeup: LISTEN on @p channel (idempotent per
+     * connection) then block up to @p timeout_ms for a notification. Returns
+     * 1 if notified, 0 on timeout, -1 on a dead connection. NULL where the
+     * backend has no such primitive (SQLite / MySQL / DuckDB) - callers gate
+     * on dialect.supports_notify. This is a blocking call, meant to run on the
+     * db.async worker pool, not the event-loop thread. See
+     * docs/jobs_events_phase4_design.md. */
+    int    (*wait_notify)(HlDbHandle *h, const char *channel, int timeout_ms);
 } HlDbBackend;
 
 struct HlDbHandle {
@@ -245,6 +263,17 @@ static inline void hl_db_guard_stale_txn(HlDbHandle *h)
 {
     if (!h || !h->backend || !h->backend->guard_stale_txn) return;
     h->backend->guard_stale_txn(h);
+}
+
+/* Low-latency LISTEN/NOTIFY wait. Returns 1 (notified), 0 (timeout), or -1
+ * (dead connection / backend has no wait_notify). Callers gate on
+ * dialect.supports_notify; a -1 from an unsupported backend is a caller bug,
+ * not a runtime path (hull/jobs never calls this unless supports_notify). */
+static inline int hl_db_wait_notify(HlDbHandle *h, const char *channel,
+                                    int timeout_ms)
+{
+    if (!h || !h->backend || !h->backend->wait_notify) return -1;
+    return h->backend->wait_notify(h, channel, timeout_ms);
 }
 
 static inline const char *hl_db_autoincrement_id_ddl(HlDbHandle *h)

--- a/include/hull/worker_db.h
+++ b/include/hull/worker_db.h
@@ -86,7 +86,8 @@ void hl_db_result_free(HlDbResult *r);
 
 /* ── Worker DB operation ───────────────────────────────────────────── */
 
-typedef enum { HL_WORK_DB_QUERY, HL_WORK_DB_EXEC } HlWorkerDbKind;
+typedef enum { HL_WORK_DB_QUERY, HL_WORK_DB_EXEC,
+               HL_WORK_DB_WAIT_NOTIFY } HlWorkerDbKind;
 
 typedef struct HlWorkerDbOp {
     HlWorkerDbKind kind;
@@ -103,10 +104,15 @@ typedef struct HlWorkerDbOp {
     HlValue       *params;
     int            nparams;
 
+    /* WAIT_NOTIFY input: LISTEN channel (owned) + wait bound in ms. */
+    char          *channel;
+    int            timeout_ms;
+
     /* Output (set by worker thread) */
     HlDbResult     result;        /* DB_QUERY */
     int            exec_changes;  /* DB_EXEC */
     int64_t        last_id;       /* DB_EXEC */
+    int            notified;      /* DB_WAIT_NOTIFY: 1 notified, 0 timeout */
     int            error;
     char           error_msg[HL_WORKER_ERR_SIZE];
     int            cancelled;     /* set by async cancel, checked by done_fn */

--- a/src/hull/cap/db_postgres.c
+++ b/src/hull/cap/db_postgres.c
@@ -28,6 +28,7 @@
 typedef struct HlDbPgCtx {
     HlPgConn     conn;
     HlAllocator *alloc;
+    int          listening;   /* 1 once LISTEN was issued on this connection */
 } HlDbPgCtx;
 
 static int hexval(char c)
@@ -473,6 +474,48 @@ static int pg_table_columns(HlDbHandle *h, const char *table,
         &p, 1, pg_table_columns_row, &fwd, NULL);
 }
 
+/* ── Low-latency LISTEN/NOTIFY wait (Phase 4) ─────────────────────── */
+
+/* A LISTEN channel is an SQL identifier, not a bind param, so an unsafe name
+ * would be an injection vector. Accept only [A-Za-z_][A-Za-z0-9_]{0,62} (the
+ * Postgres 63-char identifier limit). hull/jobs passes the fixed literal
+ * "hull_jobs"; this guard is defense in depth for any other caller. */
+static int pg_channel_ok(const char *ch)
+{
+    if (!ch) return 0;
+    char c0 = ch[0];
+    if (!((c0 >= 'a' && c0 <= 'z') || (c0 >= 'A' && c0 <= 'Z') || c0 == '_'))
+        return 0;
+    size_t n = 1;
+    for (const char *p = ch + 1; *p; p++, n++) {
+        char c = *p;
+        if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+              (c >= '0' && c <= '9') || c == '_'))
+            return 0;
+        if (n >= 63) return 0;
+    }
+    return 1;
+}
+
+/* Optional low-latency wakeup. LISTEN once per connection, then block up to
+ * timeout_ms for a NotificationResponse. Returns 1 (notified), 0 (timeout),
+ * -1 (bad channel or dead connection). Blocking: runs on the db.async worker
+ * pool, never the event-loop thread. On a -1 from the wait the connection is
+ * dead; the worker's per-DSN cache reopens a fresh handle (listening resets to
+ * 0 on the new ctx) and re-LISTENs on the next call. */
+static int pg_wait_notify(HlDbHandle *h, const char *channel, int timeout_ms)
+{
+    HlDbPgCtx *s = h->ctx;
+    if (!pg_channel_ok(channel)) return -1;
+    if (!s->listening) {
+        char sql[80];
+        snprintf(sql, sizeof sql, "LISTEN %s", channel);
+        if (hl_pg_exec_simple(&s->conn, sql) != 0) return -1;
+        s->listening = 1;
+    }
+    return hl_pg_wait_notify(&s->conn, timeout_ms);
+}
+
 /* ── Vtable (const, lands in .rodata) ─────────────────────────────── */
 
 static const char *const pg_schemes[] = { "postgres", "postgresql", NULL };
@@ -487,6 +530,7 @@ const HlDbBackend hl_db_backend_postgres = {
         .supports_returning           = 1,
         .supports_index_if_not_exists = 1,
         .supports_skip_locked         = 1,   /* Postgres 9.5+ */
+        .supports_notify              = 1,   /* LISTEN/NOTIFY */
         .identity_column              = "BIGSERIAL PRIMARY KEY",
         .identity_sequence            = NULL,
     },
@@ -508,6 +552,7 @@ const HlDbBackend hl_db_backend_postgres = {
     .insert_if_absent     = pg_insert_if_absent,
     .upsert               = pg_upsert,
     .table_columns        = pg_table_columns,
+    .wait_notify          = pg_wait_notify,
 };
 
 #endif /* HL_ENABLE_POSTGRES */

--- a/src/hull/runtime/js/mod_db.c
+++ b/src/hull/runtime/js/mod_db.c
@@ -644,6 +644,10 @@ static JSValue js_push_worker_db_result(JSContext *ctx, void *driver)
         return JS_ThrowInternalError(ctx, "db.async: %s", op->error_msg);
     }
 
+    if (op->kind == HL_WORK_DB_WAIT_NOTIFY) {
+        return JS_NewBool(ctx, op->notified);
+    }
+
     if (op->kind == HL_WORK_DB_EXEC) {
         JSValue obj = JS_NewObject(ctx);
         JS_SetPropertyStr(ctx, obj, "changes",
@@ -709,60 +713,90 @@ static JSValue js_db_async_common(JSContext *ctx, JSValueConst this_val,
     if (!js_call_handle(ctx, this_val))
         return JS_ThrowInternalError(ctx, "database not available");
 
-    if (argc < 1)
-        return JS_ThrowTypeError(ctx, "db.async requires (sql, params?)");
+    /* Input differs by kind: WAIT_NOTIFY takes (channel, timeoutMs); the
+     * query/exec kinds take (sql, params). */
+    HlWorkerDbOp *op = NULL;
 
-    const char *sql = JS_ToCString(ctx, argv[0]);
-    if (!sql)
-        return JS_EXCEPTION;
-
-    if (!js_is_stdlib_caller(ctx) && hl_cap_db_check_namespace(sql) != 0) {
-        JS_FreeCString(ctx, sql);
-        return JS_ThrowInternalError(ctx,
-            "access denied: _hull_* tables are reserved");
-    }
-
-    /* Parse params */
-    HlValue *params = NULL;
-    int nparams = 0;
-    if (argc >= 2) {
-        if (js_to_hl_values(ctx, argv[1], &params, &nparams) != 0) {
-            JS_FreeCString(ctx, sql);
-            return JS_ThrowTypeError(ctx, "params must be an array");
+    if (kind == HL_WORK_DB_WAIT_NOTIFY) {
+        if (argc < 1)
+            return JS_ThrowTypeError(ctx, "waitNotify requires (channel, timeoutMs?)");
+        const char *channel = JS_ToCString(ctx, argv[0]);
+        if (!channel)
+            return JS_EXCEPTION;
+        int32_t timeout_ms = 1000;
+        if (argc >= 2 && !JS_IsUndefined(argv[1]) && !JS_IsNull(argv[1]))
+            JS_ToInt32(ctx, &timeout_ms, argv[1]);
+        op = calloc(1, sizeof(HlWorkerDbOp));
+        if (!op) {
+            JS_FreeCString(ctx, channel);
+            return JS_ThrowInternalError(ctx, "db.async: out of memory");
         }
-    }
-
-    /* Allocate op */
-    HlWorkerDbOp *op = calloc(1, sizeof(HlWorkerDbOp));
-    if (!op) {
-        js_free_hl_values(ctx, params, nparams);
-        JS_FreeCString(ctx, sql);
-        return JS_ThrowInternalError(ctx, "db.async: out of memory");
-    }
-
-    op->kind = kind;
-    op->server = js->server;
-    op->alloc = js->base.alloc;
-    op->sql = strdup(sql);
-    JS_FreeCString(ctx, sql);
-    if (!op->sql) {
-        js_free_hl_values(ctx, params, nparams);
-        free(op);
-        return JS_ThrowInternalError(ctx, "db.async: out of memory");
-    }
-
-    /* Deep-copy params */
-    if (nparams > 0) {
-        op->params = hl_deep_copy_params(params, nparams);
-        op->nparams = nparams;
-        if (!op->params) {
-            js_free_hl_values(ctx, params, nparams);
-            free(op->sql);
+        op->kind = kind;
+        op->server = js->server;
+        op->alloc = js->base.alloc;
+        op->channel = strdup(channel);
+        op->timeout_ms = (int)timeout_ms;
+        JS_FreeCString(ctx, channel);
+        if (!op->channel) {
             free(op);
             return JS_ThrowInternalError(ctx, "db.async: out of memory");
         }
+    } else {
+        if (argc < 1)
+            return JS_ThrowTypeError(ctx, "db.async requires (sql, params?)");
+
+        const char *sql = JS_ToCString(ctx, argv[0]);
+        if (!sql)
+            return JS_EXCEPTION;
+
+        if (!js_is_stdlib_caller(ctx) && hl_cap_db_check_namespace(sql) != 0) {
+            JS_FreeCString(ctx, sql);
+            return JS_ThrowInternalError(ctx,
+                "access denied: _hull_* tables are reserved");
+        }
+
+        /* Parse params */
+        HlValue *params = NULL;
+        int nparams = 0;
+        if (argc >= 2) {
+            if (js_to_hl_values(ctx, argv[1], &params, &nparams) != 0) {
+                JS_FreeCString(ctx, sql);
+                return JS_ThrowTypeError(ctx, "params must be an array");
+            }
+        }
+
+        /* Allocate op */
+        op = calloc(1, sizeof(HlWorkerDbOp));
+        if (!op) {
+            js_free_hl_values(ctx, params, nparams);
+            JS_FreeCString(ctx, sql);
+            return JS_ThrowInternalError(ctx, "db.async: out of memory");
+        }
+
+        op->kind = kind;
+        op->server = js->server;
+        op->alloc = js->base.alloc;
+        op->sql = strdup(sql);
+        JS_FreeCString(ctx, sql);
+        if (!op->sql) {
+            js_free_hl_values(ctx, params, nparams);
+            free(op);
+            return JS_ThrowInternalError(ctx, "db.async: out of memory");
+        }
+
+        /* Deep-copy params */
+        if (nparams > 0) {
+            op->params = hl_deep_copy_params(params, nparams);
+            op->nparams = nparams;
+            if (!op->params) {
+                js_free_hl_values(ctx, params, nparams);
+                free(op->sql);
+                free(op);
+                return JS_ThrowInternalError(ctx, "db.async: out of memory");
+            }
+        }
+        js_free_hl_values(ctx, params, nparams);
     }
-    js_free_hl_values(ctx, params, nparams);
 
     /* Target the database this async call is bound to: db.connect(name).async
      * hits that named connection's DSN; db.open(dsn).async its dynamic DSN;
@@ -862,6 +896,16 @@ static JSValue js_db_async_exec(JSContext *ctx, JSValueConst this_val,
     return js_db_async_common(ctx, this_val, argc, argv, HL_WORK_DB_EXEC);
 }
 
+/* conn.waitNotify(channel, timeoutMs) -> Promise<boolean>. Yielding
+ * low-latency wakeup: parks on the db.async worker pool while a worker blocks
+ * on the backend's LISTEN/NOTIFY primitive; resolves true (notified) or false
+ * (timeout / unsupported backend). Callers gate on conn.dialect.supportsNotify. */
+static JSValue js_db_wait_notify(JSContext *ctx, JSValueConst this_val,
+                                 int argc, JSValueConst *argv)
+{
+    return js_db_async_common(ctx, this_val, argc, argv, HL_WORK_DB_WAIT_NOTIFY);
+}
+
 /* ── db.udf — user-defined SQL functions (JS) ────────────────────────── */
 /* The SQLite UDF bindings live in the composed per-runtime bridge
  * (mod_db_udf.c → libhull_feature-sqlite-js.a) so THIS base runtime archive
@@ -915,6 +959,8 @@ static void js_set_dialect(JSContext *ctx, JSValue obj, const HlDbBackend *be)
                       JS_NewBool(ctx, be && be->dialect.supports_index_if_not_exists));
     JS_SetPropertyStr(ctx, d, "supportsSkipLocked",
                       JS_NewBool(ctx, be && be->dialect.supports_skip_locked));
+    JS_SetPropertyStr(ctx, d, "supportsNotify",
+                      JS_NewBool(ctx, be && be->dialect.supports_notify));
     JS_SetPropertyStr(ctx, d, "identityColumn",
                       JS_NewString(ctx, (be && be->dialect.identity_column)
                                         ? be->dialect.identity_column
@@ -949,6 +995,8 @@ static JSValue push_conn_object(JSContext *ctx, HlDbHandle *h)
     JS_SetPropertyStr(ctx, obj, "quoteIdentifier",
                       JS_NewCFunction(ctx, js_db_quote_identifier,
                                        "quoteIdentifier", 1));
+    JS_SetPropertyStr(ctx, obj, "waitNotify",
+                      JS_NewCFunction(ctx, js_db_wait_notify, "waitNotify", 2));
     /* async targets this connection's database via the worker pool's per-DSN
      * connections; udf registers on this connection's SQLite handle (a udf on
      * a non-SQLite connection errors at call time). Both sub-objects share the
@@ -1057,6 +1105,8 @@ static JSValue push_owned_conn_object(JSContext *ctx, HlDbHandle *h,
     JS_SetPropertyStr(ctx, obj, "quoteIdentifier",
                       JS_NewCFunction(ctx, js_db_quote_identifier,
                                        "quoteIdentifier", 1));
+    JS_SetPropertyStr(ctx, obj, "waitNotify",
+                      JS_NewCFunction(ctx, js_db_wait_notify, "waitNotify", 2));
     JS_SetPropertyStr(ctx, obj, "close",
                       JS_NewCFunction(ctx, js_db_owned_close, "close", 0));
 

--- a/src/hull/runtime/lua/mod_db.c
+++ b/src/hull/runtime/lua/mod_db.c
@@ -606,6 +606,11 @@ static void lua_push_worker_db_result(lua_State *L, void *driver)
         return; /* unreachable */
     }
 
+    if (op->kind == HL_WORK_DB_WAIT_NOTIFY) {
+        lua_pushboolean(L, op->notified);
+        return;
+    }
+
     if (op->kind == HL_WORK_DB_EXEC) {
         lua_newtable(L);
         lua_pushinteger(L, op->exec_changes);
@@ -664,17 +669,24 @@ static int lua_db_async_common(lua_State *L, HlWorkerDbKind kind)
     if (!db_call_handle(L))
         return luaL_error(L, "database not available");
 
-    const char *sql = luaL_checkstring(L, 1);
-
-    if (!lua_is_stdlib_caller(L) && hl_cap_db_check_namespace(sql) != 0)
-        return luaL_error(L, "access denied: _hull_* tables are reserved");
-
-    /* Parse params */
+    /* Input differs by kind: WAIT_NOTIFY takes (channel, timeout_ms); the
+     * query/exec kinds take (sql, params). */
+    const char *sql = NULL, *channel = NULL;
+    int timeout_ms = 0;
     HlValue *params = NULL;
     int nparams = 0;
-    if (lua_gettop(L) >= 2 && !lua_isnil(L, 2)) {
-        if (lua_to_hl_values(L, 2, &params, &nparams) != 0)
-            return luaL_error(L, "params must be a table");
+
+    if (kind == HL_WORK_DB_WAIT_NOTIFY) {
+        channel = luaL_checkstring(L, 1);
+        timeout_ms = (int)luaL_optinteger(L, 2, 1000);
+    } else {
+        sql = luaL_checkstring(L, 1);
+        if (!lua_is_stdlib_caller(L) && hl_cap_db_check_namespace(sql) != 0)
+            return luaL_error(L, "access denied: _hull_* tables are reserved");
+        if (lua_gettop(L) >= 2 && !lua_isnil(L, 2)) {
+            if (lua_to_hl_values(L, 2, &params, &nparams) != 0)
+                return luaL_error(L, "params must be a table");
+        }
     }
 
     /* Allocate op */
@@ -687,25 +699,34 @@ static int lua_db_async_common(lua_State *L, HlWorkerDbKind kind)
     op->kind = kind;
     op->server = lua->server;
     op->alloc = lua->base.alloc;
-    op->sql = strdup(sql);
-    if (!op->sql) {
-        lua_free_hl_values(L, params, nparams);
-        free(op);
-        return luaL_error(L, "db.async: out of memory");
-    }
 
-    /* Deep-copy params (they need to outlive this stack frame) */
-    if (nparams > 0) {
-        op->params = hl_deep_copy_params(params, nparams);
-        op->nparams = nparams;
-        if (!op->params) {
-            lua_free_hl_values(L, params, nparams);
-            free(op->sql);
+    if (kind == HL_WORK_DB_WAIT_NOTIFY) {
+        op->channel = strdup(channel);
+        op->timeout_ms = timeout_ms;
+        if (!op->channel) {
             free(op);
             return luaL_error(L, "db.async: out of memory");
         }
+    } else {
+        op->sql = strdup(sql);
+        if (!op->sql) {
+            lua_free_hl_values(L, params, nparams);
+            free(op);
+            return luaL_error(L, "db.async: out of memory");
+        }
+        /* Deep-copy params (they need to outlive this stack frame) */
+        if (nparams > 0) {
+            op->params = hl_deep_copy_params(params, nparams);
+            op->nparams = nparams;
+            if (!op->params) {
+                lua_free_hl_values(L, params, nparams);
+                free(op->sql);
+                free(op);
+                return luaL_error(L, "db.async: out of memory");
+            }
+        }
+        lua_free_hl_values(L, params, nparams);
     }
-    lua_free_hl_values(L, params, nparams);
 
     /* Target the database this async call is bound to: db.connect(name).async
      * hits that named connection's DSN; db.default().async (and the bare
@@ -784,6 +805,16 @@ static int lua_db_async_exec(lua_State *L)
     return lua_db_async_common(L, HL_WORK_DB_EXEC);
 }
 
+/* conn.wait_notify(channel, timeout_ms) - yielding low-latency wakeup. Parks
+ * the coroutine on the db.async worker pool while a worker blocks on the
+ * backend's LISTEN/NOTIFY primitive; returns true (notified) or false
+ * (timeout / unsupported backend). Latency only: false is indistinguishable
+ * from a plain sleep, so callers gate on conn.dialect.supports_notify. */
+static int lua_db_wait_notify(lua_State *L)
+{
+    return lua_db_async_common(L, HL_WORK_DB_WAIT_NOTIFY);
+}
+
 static const luaL_Reg db_async_funcs[] = {
     {"query", lua_db_async_query},
     {"exec",  lua_db_async_exec},
@@ -818,6 +849,7 @@ static const luaL_Reg db_conn_methods[] = {
     {"upsert",           lua_db_upsert},
     {"table_columns",    lua_db_table_columns},
     {"quote_identifier", lua_db_quote_identifier},
+    {"wait_notify",      lua_db_wait_notify},
     {NULL, NULL}
 };
 
@@ -842,7 +874,7 @@ static void push_bound_subtable(lua_State *L, const luaL_Reg *funcs,
  * and identity DDL that the query / schema builders read. */
 static void push_dialect_table(lua_State *L, const HlDbBackend *be)
 {
-    lua_createtable(L, 0, 7);
+    lua_createtable(L, 0, 8);
     char qs[2] = { (be && be->dialect.identifier_quote)
                    ? be->dialect.identifier_quote : '"', '\0' };
     lua_pushstring(L, qs);
@@ -858,6 +890,8 @@ static void push_dialect_table(lua_State *L, const HlDbBackend *be)
     lua_setfield(L, -2, "supports_index_if_not_exists");
     lua_pushboolean(L, be && be->dialect.supports_skip_locked);
     lua_setfield(L, -2, "supports_skip_locked");
+    lua_pushboolean(L, be && be->dialect.supports_notify);
+    lua_setfield(L, -2, "supports_notify");
     lua_pushstring(L, (be && be->dialect.identity_column)
                        ? be->dialect.identity_column : "INTEGER PRIMARY KEY");
     lua_setfield(L, -2, "identity_column");
@@ -871,7 +905,7 @@ static void push_dialect_table(lua_State *L, const HlDbBackend *be)
 /* Push a fresh connection-object table whose methods carry @p h as upvalue 1. */
 static int push_conn_object(lua_State *L, HlDbHandle *h)
 {
-    lua_createtable(L, 0, 11);
+    lua_createtable(L, 0, 12);
     for (const luaL_Reg *m = db_conn_methods; m->name; m++) {
         lua_pushlightuserdata(L, h);
         lua_pushcclosure(L, m->func, 1);

--- a/src/hull/worker_db.c
+++ b/src/hull/worker_db.c
@@ -344,6 +344,18 @@ static void db_work_fn(void *ud)
         return;
     }
 
+    if (op->kind == HL_WORK_DB_WAIT_NOTIFY) {
+        /* Block up to timeout_ms for a LISTEN/NOTIFY wakeup on this worker's
+         * own connection. A -1 (dead connection / unsupported) is reported as
+         * a not-notified timeout, NOT an error: the wait is latency-only, and
+         * the caller (jobs run_worker) treats false exactly like a poll
+         * timeout, so a dropped connection just falls back to polling. The
+         * per-thread connection cache reopens on the next call. */
+        int n = hl_db_wait_notify(h, op->channel, op->timeout_ms);
+        op->notified = (n == 1) ? 1 : 0;
+        return;
+    }
+
     /* HL_WORK_DB_QUERY: materialize all rows through the vtable. */
     HlDbResult *r = &op->result;
     memset(r, 0, sizeof(*r));
@@ -441,6 +453,7 @@ void hl_worker_db_op_free(HlWorkerDbOp *op)
     if (!op) return;
     free(op->sql);
     free(op->dsn);
+    free(op->channel);
     if (op->params) {
         for (int i = 0; i < op->nparams; i++) {
             if ((op->params[i].type == HL_TYPE_TEXT ||

--- a/tests/e2e_postgres.sh
+++ b/tests/e2e_postgres.sh
@@ -414,6 +414,68 @@ case "$rcout" in
     *)  echo "::error db.exec affected-row count on PG: $rcout"; exit 1 ;;
 esac
 
+# ── conn.wait_notify: low-latency LISTEN/NOTIFY (Phase 4.2) ────────────
+# A waiter app parks on conn.wait_notify (yielding on the db.async worker pool);
+# a SECOND connection issues pg_notify; the waiter must wake with notified=true
+# well under its timeout - proving the yielding worker-pool wait + cross-
+# connection NOTIFY delivery. Latency-only: a follow-up wait with no NOTIFY
+# times out to false (the poll-fallback shape). Runs for both runtimes.
+check_wait_notify() {
+    _label="$1"; _ext="$2"; _waiter="$3"; _notifier="$4"
+    WND=$(mktemp -d)
+    printf '%s\n' "$_waiter"   > "$WND/waiter.$_ext"
+    printf '%s\n' "$_notifier" > "$WND/notifier.$_ext"
+    ./build/hull "$WND/waiter.$_ext" -d "$DSN" > "$WND/w.out" 2>/dev/null &
+    _wpid=$!
+    sleep 3   # let the waiter connect + LISTEN + park before we notify
+    ./build/hull "$WND/notifier.$_ext" -d "$DSN" >/dev/null 2>&1 || true
+    wait "$_wpid" || true
+    _out="$(cat "$WND/w.out")"
+    case "$_out" in
+        *"WN notified=true"*"WN2 timeout_false=true"*)
+            echo "PASS: $_label conn.wait_notify wakes on NOTIFY + times out to false" ;;
+        *)  echo "::error $_label wait_notify on PG: $_out"; exit 1 ;;
+    esac
+    rm -rf "$WND"
+}
+
+LUA_WN_WAITER='local db = require("hull.db").default()
+local t = require("hull.time")
+app.manifest({ modules = { "hull/db@1", "hull/time@1" } })
+app.main(function(ctx)
+  local a = t.now_ms()
+  local got = db.wait_notify("hull_jobs", 10000)
+  ctx.stdout:write(("WN notified=%s waited_ms=%d\n"):format(tostring(got), t.now_ms()-a))
+  local none = db.wait_notify("hull_jobs", 300)
+  ctx.stdout:write(("WN2 timeout_false=%s\n"):format(tostring(none == false)))
+  return 0
+end)'
+LUA_WN_NOTIFIER='local db = require("hull.db").default()
+app.manifest({ modules = { "hull/db@1" } })
+app.main(function() db.exec("SELECT pg_notify(?, ?)", { "hull_jobs", "" }) return 0 end)'
+
+JS_WN_WAITER='import { app } from "hull:app";
+import { db as dbm } from "hull:db";
+import { time } from "hull:time";
+app.manifest({ modules: ["hull/db@1", "hull/time@1"] });
+app.main(async (ctx) => {
+  const db = dbm.default();
+  const a = time.nowMs();
+  const got = await db.waitNotify("hull_jobs", 10000);
+  ctx.stdout.write(`WN notified=${got} waited_ms=${time.nowMs()-a}\n`);
+  const none = await db.waitNotify("hull_jobs", 300);
+  ctx.stdout.write(`WN2 timeout_false=${none === false}\n`);
+  return 0;
+});'
+JS_WN_NOTIFIER='import { app } from "hull:app";
+import { db as dbm } from "hull:db";
+app.manifest({ modules: ["hull/db@1"] });
+app.main((ctx) => { dbm.default().exec("SELECT pg_notify(?, ?)", ["hull_jobs", ""]); return 0; });'
+
+echo "=== conn.wait_notify LISTEN/NOTIFY round trip ==="
+check_wait_notify "lua" "lua" "$LUA_WN_WAITER" "$LUA_WN_NOTIFIER"
+check_wait_notify "js"  "js"  "$JS_WN_WAITER"  "$JS_WN_NOTIFIER"
+
 # ── TLS phase (Phase 3b.2) ────────────────────────────────────────────
 # Enable SSL on the running container with a self-signed cert, then connect
 # with sslmode=require and assert (via pg_stat_ssl) the session is encrypted.

--- a/tests/hull/cap/test_db_backend.c
+++ b/tests/hull/cap/test_db_backend.c
@@ -66,6 +66,22 @@ UTEST(db_backend, sqlite_open_close)
     hl_db_backend_sqlite.close(&h);
 }
 
+/* Backend safety for the Phase 4 LISTEN/NOTIFY surface: SQLite has no such
+ * primitive, so it must advertise supports_notify == 0 AND leave wait_notify
+ * NULL. The generic hl_db_wait_notify wrapper then fails closed (-1), which the
+ * worker maps to a not-notified false - never a bogus wakeup. Guards against a
+ * backend claiming NOTIFY support without wiring an implementation. */
+UTEST(db_backend, sqlite_no_notify)
+{
+    ASSERT_EQ(hl_db_backend_sqlite.dialect.supports_notify, (unsigned char)0);
+    ASSERT_TRUE(hl_db_backend_sqlite.wait_notify == NULL);
+
+    HlDbHandle h = { .backend = &hl_db_backend_sqlite, .ctx = NULL };
+    ASSERT_EQ(hl_db_backend_sqlite.open(&h.ctx, ":memory:", NULL), 0);
+    ASSERT_EQ(hl_db_wait_notify(&h, "hull_jobs", 0), -1);
+    hl_db_backend_sqlite.close(&h);
+}
+
 UTEST(db_backend, sqlite_exec_via_vtable)
 {
     HlDbHandle h;


### PR DESCRIPTION
Phase 4.2 of the jobs low-latency-wakeup epic (#235), on top of the merged 4.1
wire primitive (#267). Builds the **db-capability surface** for LISTEN/NOTIFY;
Phase 4.3 will wire it into `jobs` (emit NOTIFY on append/enqueue + `run_worker`
idle wait).

## The one inviolable rule
NOTIFY is a **latency optimization, never a correctness dependency**. Every wait
is bounded by a timeout and a dead/unsupported connection returns `false` -
identical to a poll timeout - so a missed / dropped / unsupported notification
only costs latency, never an event. The suite stays green on SQLite/MySQL with
no NOTIFY at all.

## What lands
- **db-cap** (`db_backend.h`): a `supports_notify` dialect flag + an optional
  `wait_notify(h, channel, timeout_ms)` vtable method + the generic
  `hl_db_wait_notify` wrapper (fails closed `-1` when the slot is NULL).
- **Postgres** (`db_postgres.c`): `pg_wait_notify` - LISTEN once per connection
  (guarded by `pg_channel_ok`, since LISTEN takes an identifier not a bind
  param), then block on `hl_pg_wait_notify`. `supports_notify = 1`.
- **Worker pool** (`worker_db.*`): `HL_WORK_DB_WAIT_NOTIFY` runs the blocking
  wait on the `db.async` thread pool; the coroutine yields, the loop stays free
  (mirrors `db.async.query`). A `-1` maps to `false`.
- **Bindings** (`mod_db.c` x2): yielding `conn.wait_notify` (Lua) /
  `conn.waitNotify` (JS `Promise`), plus `conn.dialect.supports_notify` /
  `supportsNotify`.

## Testability
- **Unit** `sqlite_no_notify`: SQLite advertises `supports_notify == 0` AND
  leaves `wait_notify` NULL (guards a backend claiming NOTIFY with no impl).
- **e2e_postgres** (both runtimes): a waiter parks on `conn.wait_notify` while a
  **second connection** `pg_notify(?, ?)`s; the waiter wakes `notified=true`
  well under its timeout, and a bare wait times out to `false`.

## Scope
Postgres-only; SQLite/MySQL/DuckDB unchanged (NULL slot, flag 0). Reconnect of a
dropped LISTEN connection is a follow-up - today a dead connection degrades to
polling (correct, higher latency), which is the safety property.

Validated locally: `make test` 62/62; `e2e_postgres` green (Lua + JS); real-PG
two-process round trip `notified=true` in both runtimes. Design:
docs/jobs_events_phase4_design.md §3.
