### PR TITLE
jobs: low-latency wakeup via LISTEN/NOTIFY (jobs events Phase 4.3)

### DIFF
--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -98,6 +98,20 @@ jobs.run_worker({ queues = { "critical", "default", "low" } })  -- strict priori
 jobs.run_worker({ queues = { critical = 3, default = 2, low = 1 } })  -- weighted
 ```
 
+**Low-latency pickup (Postgres).** An idle `run_worker` normally sleeps `poll_ms`
+(default 1000) between empty polls, so a freshly enqueued job waits up to that
+long before it is claimed. On a Postgres connection Hull closes that gap
+automatically with `LISTEN`/`NOTIFY`: `jobs.enqueue` (and every durable event)
+issues a `pg_notify`, and a single-loop `run_worker` parks on it, so it wakes
+**immediately** on new work instead of at the next poll. This is transparent -
+no API change, and it is **latency only, never correctness**: the wait is still
+bounded by `poll_ms`, so a missed or unsupported notification only costs latency.
+SQLite and MySQL have no `LISTEN`/`NOTIFY` and keep polling unchanged;
+`conn.dialect.supports_notify` (`supportsNotify` in JS) reports whether the fast
+path is active. The fast path applies to `concurrency == 1` loops (the common
+case, including separate worker processes); a multi-loop `run_worker({ concurrency = N })`
+keeps plain polling to avoid occupying N worker-pool threads on the wait.
+
 ## Lifecycle hooks
 
 `jobs.on(event, fn)` registers an **in-process** listener fired synchronously by

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -397,6 +397,19 @@ function loadDeps(dependentId) {
 // does (transactional coupling: no lost, no phantom events). `job` supplies
 // id/type/queue/trace; `info` is small metadata (error/attempt) - never the full
 // result (a consumer joins _hull_job_results for that).
+// Latency-only wakeup: nudge idle workers / subscription drainers parked on
+// conn.waitNotify so a freshly appended event or enqueued job wakes them
+// immediately instead of at the next poll. Postgres LISTEN/NOTIFY; a no-op on
+// backends without it (SQLite/MySQL keep polling). The channel is the fixed
+// literal every emitter and waiter shares; the payload is unused. Issued on the
+// same connection as the preceding INSERT, so inside a caller's db.batch it
+// rides the same transaction and PG delivers (and coalesces) it on commit.
+function wakeWorkers() {
+    if (db.dialect.supportsNotify) {
+        db.exec("SELECT pg_notify(?, ?)", ["hull_jobs", ""]);
+    }
+}
+
 function emitDurable(event, job, info) {
     if (!_cfg.events) return;
     info = info || {};
@@ -409,6 +422,7 @@ function emitDurable(event, job, info) {
         "INSERT INTO _hull_job_events (ts, type, job_id, job_type, queue, data) " +
         "VALUES (?, ?, ?, ?, ?, ?)",
         [time.now(), event, job.id, job.type, job.queue, data]);
+    wakeWorkers();   // wake drainers on the new event (no-op off Postgres)
 }
 
 // Apply a terminal transition and its durable event ATOMICALLY (one txn), then
@@ -524,6 +538,10 @@ function enqueue(jobType, data, opts) {
     // db.batch when enqueue is called inside one (transactional coupling).
     emitDurable("enqueued",
         { id, type: jobType, queue: o.queue || "default", trace: o.trace }, {});
+    // Low-latency job pickup: wake an idle worker on the new job. When events
+    // are on, emitDurable already issued the NOTIFY (coalesced within the
+    // transaction), so only nudge directly when it did not.
+    if (!_cfg.events) wakeWorkers();
     return id;
 }
 
@@ -1360,6 +1378,26 @@ async function runWorker(opts) {
     const concurrency = (o.concurrency && o.concurrency > 1) ? o.concurrency : 1;
     _running = true;
 
+    // Idle wait between empty polls. On a NOTIFY-capable backend (Postgres) a
+    // single-loop worker parks on conn.waitNotify, so a freshly enqueued job or
+    // appended event wakes it immediately instead of after pollMs; the timeout
+    // is still pollMs, so a missed/absent NOTIFY just falls back to a poll
+    // (latency only, never correctness). Gated on concurrency === 1: with N
+    // in-process loops all idle we would occupy N worker-pool threads on the
+    // wait, so the multi-loop case keeps plain sleep (the fleet still gets the
+    // win via separate single-loop worker processes). A first wait that throws
+    // (no thread pool / event loop) disables the fast path for the rest of the
+    // run and falls back to sleep.
+    let useNotify = db.dialect.supportsNotify && concurrency === 1;
+    const idleWait = async () => {
+        if (useNotify) {
+            try { await db.waitNotify("hull_jobs", pollMs); }
+            catch (_e) { useNotify = false; await hull.sleep(pollMs); }
+        } else {
+            await hull.sleep(pollMs);
+        }
+    };
+
     // One independent claim-loop; returns its own processed count.
     const loop = async () => {
         let processed = 0, empty = 0;
@@ -1369,7 +1407,7 @@ async function runWorker(opts) {
             if (n === 0) {
                 empty++;
                 if (maxEmpty > 0 && empty >= maxEmpty) break;
-                await hull.sleep(pollMs);
+                await idleWait();
             } else {
                 empty = 0;
             }

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -440,6 +440,19 @@ end
 -- does (transactional coupling: no lost, no phantom events). `job` supplies
 -- id/type/queue/trace; `info` is small metadata (error/attempt) - never the full
 -- result (a consumer joins _hull_job_results for that).
+-- Latency-only wakeup: nudge idle workers / subscription drainers parked on
+-- conn.wait_notify so a freshly appended event or enqueued job wakes them
+-- immediately instead of at the next poll. Postgres LISTEN/NOTIFY; a no-op on
+-- backends without it (SQLite/MySQL keep polling). The channel is the fixed
+-- literal every emitter and waiter shares; the payload is unused. Issued on the
+-- same connection as the preceding INSERT, so inside a caller's db.batch it
+-- rides the same transaction and PG delivers (and coalesces) it on commit.
+local function wake_workers()
+    if db.dialect.supports_notify then
+        db.exec("SELECT pg_notify(?, ?)", { "hull_jobs", "" })
+    end
+end
+
 local function emit_durable(event, job, info)
     if not _cfg.events then return end
     info = info or {}
@@ -451,6 +464,7 @@ local function emit_durable(event, job, info)
         "INSERT INTO _hull_job_events (ts, type, job_id, job_type, queue, data) "
         .. "VALUES (?, ?, ?, ?, ?, ?)",
         { time.now(), event, job.id, job.type, job.queue, data })
+    wake_workers()   -- wake drainers on the new event (no-op off Postgres)
 end
 
 --- Enqueue a job. A plain INSERT, so calling it inside a `db.batch()` commits
@@ -572,6 +586,10 @@ function jobs.enqueue(job_type, data, opts)
     -- db.batch when enqueue is called inside one (transactional coupling).
     emit_durable("enqueued",
         { id = id, type = job_type, queue = opts.queue or "default", trace = opts.trace }, {})
+    -- Low-latency job pickup: wake an idle worker on the new job. When events
+    -- are on, emit_durable above already issued the NOTIFY (coalesced within the
+    -- transaction), so only nudge directly when it did not.
+    if not _cfg.events then wake_workers() end
     return id
 end
 
@@ -1465,6 +1483,26 @@ function jobs.run_worker(opts)
     local concurrency = (opts.concurrency and opts.concurrency > 1) and opts.concurrency or 1
     _running = true
 
+    -- Idle wait between empty polls. On a NOTIFY-capable backend (Postgres) a
+    -- single-loop worker parks on conn.wait_notify, so a freshly enqueued job
+    -- or appended event wakes it immediately instead of after poll_ms; the
+    -- timeout is still poll_ms, so a missed/absent NOTIFY just falls back to a
+    -- poll (latency only, never correctness). Gated on concurrency == 1: with
+    -- N in-process loops all idle we would occupy N worker-pool threads on the
+    -- wait, so the multi-loop case keeps plain sleep (the fleet still gets the
+    -- win via separate single-loop worker processes). A first wait that throws
+    -- (no thread pool / event loop) disables the fast path for the rest of the
+    -- run and falls back to sleep.
+    local use_notify = db.dialect.supports_notify and concurrency == 1
+    local function idle_wait()
+        if use_notify then
+            local ok = pcall(db.wait_notify, "hull_jobs", poll_ms)
+            if not ok then use_notify = false; hull.sleep(poll_ms) end
+        else
+            hull.sleep(poll_ms)
+        end
+    end
+
     -- Shared across loops (single event-loop thread, so no data race).
     local total, active = 0, concurrency
     local function loop()
@@ -1475,7 +1513,7 @@ function jobs.run_worker(opts)
             if n == 0 then
                 empty = empty + 1
                 if max_empty > 0 and empty >= max_empty then break end
-                hull.sleep(poll_ms)
+                idle_wait()
             else
                 empty = 0
             end

--- a/tests/e2e_postgres.sh
+++ b/tests/e2e_postgres.sh
@@ -476,6 +476,70 @@ echo "=== conn.wait_notify LISTEN/NOTIFY round trip ==="
 check_wait_notify "lua" "lua" "$LUA_WN_WAITER" "$LUA_WN_NOTIFIER"
 check_wait_notify "js"  "js"  "$JS_WN_WAITER"  "$JS_WN_NOTIFIER"
 
+# ── jobs low-latency pickup via NOTIFY (Phase 4.3) ────────────────────
+# A run_worker parked idle with a LONG poll (8s) must wake and process a job
+# enqueued by a SECOND process in WELL under that poll - proving enqueue's
+# pg_notify + run_worker's idle wait_notify. On a non-NOTIFY backend the same
+# path degrades to polling (covered green by e2e_jobs on SQLite). Latency, never
+# correctness: the poll timeout is the safety net.
+check_notify_latency() {
+    _label="$1"; _ext="$2"; _worker="$3"; _enq="$4"
+    LD=$(mktemp -d)
+    printf '%s\n' "$_worker" > "$LD/worker.$_ext"
+    printf '%s\n' "$_enq"    > "$LD/enq.$_ext"
+    ./build/hull "$LD/worker.$_ext" -d "$DSN" > "$LD/w.out" 2>/dev/null &
+    _wpid=$!
+    sleep 3   # let the worker init + park idle on wait_notify
+    ./build/hull "$LD/enq.$_ext" -d "$DSN" >/dev/null 2>&1 || true
+    wait "$_wpid" || true
+    _out="$(cat "$LD/w.out")"
+    _ms=$(printf '%s' "$_out" | sed -n 's/.*elapsed_ms=\([0-9][0-9]*\).*/\1/p' | head -1)
+    if [ -n "$_ms" ] && [ "$_ms" -lt 5000 ]; then
+        echo "PASS: $_label run_worker woke on enqueue NOTIFY (${_ms}ms << 8000 poll)"
+    else
+        echo "::error $_label notify latency: $_out"; exit 1
+    fi
+    rm -rf "$LD"
+}
+
+LUA_LAT_WORKER='local jobs = require("hull.jobs")
+local t = require("hull.time")
+app.manifest({ modules = { "hull/db@1", "hull/jobs@1", "hull/time@1" } })
+app.main(function(ctx)
+  jobs.init()
+  local a = t.now_ms()
+  jobs.handler("ping", function(j)
+    ctx.stdout:write(("WORKED elapsed_ms=%d\n"):format(t.now_ms()-a))
+    jobs.stop()
+    return {}
+  end)
+  jobs.run_worker({ poll_ms = 8000 })
+  return 0
+end)'
+LUA_LAT_ENQ='local jobs = require("hull.jobs")
+app.manifest({ modules = { "hull/db@1", "hull/jobs@1" } })
+app.main(function() jobs.init() jobs.enqueue("ping", {}) return 0 end)'
+
+JS_LAT_WORKER='import { app } from "hull:app";
+import { jobs } from "hull:jobs";
+import { time } from "hull:time";
+app.manifest({ modules: ["hull/db@1", "hull/jobs@1", "hull/time@1"] });
+app.main(async (ctx) => {
+  jobs.init();
+  const a = time.nowMs();
+  jobs.handler("ping", (j) => { ctx.stdout.write(`WORKED elapsed_ms=${time.nowMs()-a}\n`); jobs.stop(); return {}; });
+  await jobs.runWorker({ pollMs: 8000 });
+  return 0;
+});'
+JS_LAT_ENQ='import { app } from "hull:app";
+import { jobs } from "hull:jobs";
+app.manifest({ modules: ["hull/db@1", "hull/jobs@1"] });
+app.main((ctx) => { jobs.init(); jobs.enqueue("ping", {}); return 0; });'
+
+echo "=== jobs low-latency pickup (run_worker wakes on enqueue NOTIFY) ==="
+check_notify_latency "lua" "lua" "$LUA_LAT_WORKER" "$LUA_LAT_ENQ"
+check_notify_latency "js"  "js"  "$JS_LAT_WORKER"  "$JS_LAT_ENQ"
+
 # ── TLS phase (Phase 3b.2) ────────────────────────────────────────────
 # Enable SSL on the running container with a self-signed cert, then connect
 # with sslmode=require and assert (via pg_stat_ssl) the session is encrypted.


### PR DESCRIPTION
Final phase of the jobs low-latency-wakeup epic (#235), on top of the 4.1 wire
primitive (#267) and the 4.2 db-cap surface (#271). Wires `conn.wait_notify`
into `jobs` so an idle worker wakes **immediately** on new work instead of at
the next poll. **Ships the latency win.**

## The rule (unchanged)
Latency, **never correctness**. Every wait stays bounded by `poll_ms`, so a
missed / absent / unsupported NOTIFY only costs latency. Postgres only;
SQLite/MySQL keep polling unchanged.

## What lands
- **`wake_workers()`**: `SELECT pg_notify(?, ?)` on the fixed `hull_jobs` channel
  when `db.dialect.supports_notify`; a no-op otherwise. Runs on the same
  connection as the preceding INSERT, so inside a caller's `db.batch` it rides
  the same transaction (PG delivers + coalesces on commit).
- **`emit_durable`** NOTIFYs on every appended event (wakes subscription
  drainers); **`enqueue`** NOTIFYs directly when events are off (job pickup wakes
  a worker even without the event log; when events are on the `enqueued` event
  already did, coalesced).
- **`run_worker`** parks a single loop on `conn.wait_notify("hull_jobs", poll_ms)`
  instead of `hull.sleep`. Gated on `concurrency == 1` (N in-process loops would
  occupy N pool threads on the wait; the fleet still wins via separate
  single-loop worker processes); a first wait that throws (no thread pool) falls
  back to sleep.

Both runtimes at parity (`db.wait_notify` / `await db.waitNotify`).

## Testability
- **No regression:** `e2e_jobs` stays **65/65 on SQLite** (`wake_workers` no-op,
  `run_worker` sleeps as before).
- **Latency win:** `e2e_postgres` adds a two-process phase (both runtimes) - a
  `run_worker` parked with `poll_ms = 8000` wakes and processes a job enqueued by
  a second process in **well under** the poll (~3s incl. startup, vs 8s).
- `docs/jobs.md` documents the transparent PG fast path.

Completes Phase 4 (design: docs/jobs_events_phase4_design.md).
