### PR TITLE
worker_db: reconnect a dropped LISTEN connection (Phase 4 follow-up)

### DIFF
--- a/include/hull/worker_db.h
+++ b/include/hull/worker_db.h
@@ -55,6 +55,16 @@ HlWorkerDb *hl_worker_db_get(void);
 HlWorkerDb *hl_worker_db_get_for(const char *dsn);
 
 /*
+ * Drop this thread's cached connection to @p dsn (NULL = default), closing it,
+ * so the next hl_worker_db_get_for(@p dsn) reopens a fresh one. Used to recover
+ * a connection the caller found dead (e.g. a LISTEN/NOTIFY wait that returned
+ * "connection lost"): the next use reconnects and re-establishes any per-
+ * connection state (LISTEN). A no-op if this thread has no such cached
+ * connection. Thread-safe: touches only the calling thread's local cache.
+ */
+void hl_worker_db_invalidate(const char *dsn);
+
+/*
  * Shared "get worker DB + check internal-table namespace" helper for the
  * per-thread runtime bindings (runtime/{lua,js}/worker_db.c). Returns the
  * worker's backend handle on success, or NULL with *out_err set to a static

--- a/src/hull/worker_db.c
+++ b/src/hull/worker_db.c
@@ -178,6 +178,35 @@ HlWorkerDb *hl_worker_db_get_for(const char *dsn)
     return &node->wdb;
 }
 
+void hl_worker_db_invalidate(const char *dsn)
+{
+    if (!dsn) dsn = worker_db_dsn;
+    if (!dsn) return;
+
+    const HlDbBackend *be = hl_db_backend_select(dsn, NULL);
+    if (!be) return;
+
+    char keybuf[PATH_MAX];
+    const char *key = worker_db_resolve_key(dsn, be, keybuf);
+
+    WorkerConnNode *head = (WorkerConnNode *)pthread_getspecific(worker_db_key);
+    WorkerConnNode *prev = NULL;
+    for (WorkerConnNode *n = head; n; prev = n, n = n->next) {
+        if (n->dsn && strcmp(n->dsn, key) == 0) {
+            if (prev) {
+                prev->next = n->next;
+            } else {
+                pthread_setspecific(worker_db_key, n->next);
+            }
+            if (n->wdb.handle.backend)
+                n->wdb.handle.backend->close(&n->wdb.handle);
+            free(n->dsn);
+            free(n);
+            return;
+        }
+    }
+}
+
 HlWorkerDb *hl_worker_db_get(void)
 {
     return hl_worker_db_get_for(NULL);
@@ -349,10 +378,16 @@ static void db_work_fn(void *ud)
          * own connection. A -1 (dead connection / unsupported) is reported as
          * a not-notified timeout, NOT an error: the wait is latency-only, and
          * the caller (jobs run_worker) treats false exactly like a poll
-         * timeout, so a dropped connection just falls back to polling. The
-         * per-thread connection cache reopens on the next call. */
+         * timeout, so a dropped connection just falls back to polling. */
         int n = hl_db_wait_notify(h, op->channel, op->timeout_ms);
         op->notified = (n == 1) ? 1 : 0;
+        /* A dead LISTEN connection (-1) would otherwise stay cached and keep
+         * returning -1 immediately, spinning the idle loop. Drop it so the next
+         * wait reopens a fresh connection and re-issues LISTEN (R2). Reopen
+         * failure (DB still down) surfaces as an op error on the next call,
+         * which run_worker degrades to a plain sleep. */
+        if (n < 0)
+            hl_worker_db_invalidate(op->dsn);
         return;
     }
 

--- a/tests/e2e_postgres.sh
+++ b/tests/e2e_postgres.sh
@@ -540,6 +540,48 @@ echo "=== jobs low-latency pickup (run_worker wakes on enqueue NOTIFY) ==="
 check_notify_latency "lua" "lua" "$LUA_LAT_WORKER" "$LUA_LAT_ENQ"
 check_notify_latency "js"  "js"  "$JS_LAT_WORKER"  "$JS_LAT_ENQ"
 
+# ── LISTEN reconnect after a dropped connection (Phase 4, R2) ──────────
+# Kill the worker's LISTEN backend mid-run; the worker must reopen its
+# connection, re-issue LISTEN, and catch a SUBSEQUENT NOTIFY (RECOVERED=true).
+# Without the reconnect (hl_worker_db_invalidate on a -1 wait) it would stay on
+# the dead connection and spin/return false forever, never waking. The reconnect
+# lives in the C worker layer (db_work_fn), shared by both runtimes, so one
+# runtime proves it.
+check_reconnect() {
+    _label="$1"; _ext="$2"; _worker="$3"
+    RD=$(mktemp -d)
+    printf '%s\n' "$_worker" > "$RD/worker.$_ext"
+    ./build/hull "$RD/worker.$_ext" -d "$DSN" > "$RD/w.out" 2>/dev/null &
+    _wpid=$!
+    sleep 3   # worker LISTENing on its first wait
+    docker exec "$CONTAINER" psql -U hull -d hulldb -tAc \
+        "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query = 'LISTEN hull_jobs'" \
+        >/dev/null 2>&1 || true
+    sleep 3   # worker hits the dead conn -> invalidate -> reopen -> re-LISTEN
+    docker exec "$CONTAINER" psql -U hull -d hulldb -tAc "NOTIFY hull_jobs" >/dev/null 2>&1 || true
+    wait "$_wpid" || true
+    case "$(cat "$RD/w.out")" in
+        *"RECOVERED=true"*)
+            echo "PASS: $_label wait_notify reconnects after a dropped LISTEN connection" ;;
+        *)  echo "::error $_label reconnect: $(cat "$RD/w.out")"; exit 1 ;;
+    esac
+    rm -rf "$RD"
+}
+
+LUA_RC_WORKER='local db = require("hull.db").default()
+app.manifest({ modules = { "hull/db@1" } })
+app.main(function(ctx)
+  local ok = false
+  for _ = 1, 12 do
+    if db.wait_notify("hull_jobs", 1500) then ok = true break end
+  end
+  ctx.stdout:write(("RECOVERED=%s\n"):format(tostring(ok)))
+  return 0
+end)'
+
+echo "=== LISTEN reconnect after a dropped connection ==="
+check_reconnect "lua" "lua" "$LUA_RC_WORKER"
+
 # ── TLS phase (Phase 3b.2) ────────────────────────────────────────────
 # Enable SSL on the running container with a self-signed cert, then connect
 # with sslmode=require and assert (via pg_stat_ssl) the session is encrypted.


### PR DESCRIPTION
The Phase 4 follow-up. Closes the last gap in the jobs LISTEN/NOTIFY epic (#235).

## The bug
A LISTEN connection dropped by the server / a proxy / a network blip made
`hl_pg_wait_notify` return `-1`, which the worker mapped to a not-notified
`false`. But the **dead connection stayed cached**, so every subsequent wait
returned `-1` immediately - a **busy-spin** on the idle loop that never woke
again (it degraded to a hot loop, not to polling).

## The fix
`hl_worker_db_invalidate(dsn)` closes + drops this thread's cached connection to
that DSN, so the next `hl_worker_db_get_for` reopens a fresh one. `db_work_fn`
calls it whenever a `WAIT_NOTIFY` op returns `-1`, so the next wait reconnects
and re-issues `LISTEN` (R2). Reopen failure (DB still down) surfaces as an op
error on the next call, which `run_worker` degrades to a plain sleep - so a
**persistent outage falls back to polling, and a transient drop self-heals**.

Backend-agnostic (invalidate closes via the vtable); no behavior change for
query/exec, which already reopen through a cache miss on the next call.

## Testability
`e2e_postgres` kills the worker's LISTEN backend mid-run
(`pg_terminate_backend WHERE query = 'LISTEN hull_jobs'`), then `NOTIFY`s; the
worker must reopen, re-`LISTEN`, and catch it (`RECOVERED=true`). Without the fix
it stays on the dead connection and never wakes. The reconnect is in the shared
C worker layer, so one runtime proves it.

Full `e2e_postgres` green locally (11 PASS incl. all three Phase-4 phases:
wait_notify round trip, low-latency pickup, reconnect). Completes Phase 4.
