### PR TITLE
db/jobs: audit follow-up for the LISTEN/NOTIFY surface (Low findings)

### DIFF
--- a/src/hull/cap/db_postgres.c
+++ b/src/hull/cap/db_postgres.c
@@ -477,9 +477,12 @@ static int pg_table_columns(HlDbHandle *h, const char *table,
 /* ── Low-latency LISTEN/NOTIFY wait (Phase 4) ─────────────────────── */
 
 /* A LISTEN channel is an SQL identifier, not a bind param, so an unsafe name
- * would be an injection vector. Accept only [A-Za-z_][A-Za-z0-9_]{0,62} (the
- * Postgres 63-char identifier limit). hull/jobs passes the fixed literal
- * "hull_jobs"; this guard is defense in depth for any other caller. */
+ * would be an injection vector. The channel IS app-reachable (conn.wait_notify /
+ * waitNotify is a public connection method), so this allowlist is load-bearing,
+ * not merely defensive: accept only [A-Za-z_][A-Za-z0-9_]{0,62} (the Postgres
+ * 63-char identifier limit) and reject anything else (-> -1, mapped by the
+ * worker to a not-notified false). hull/jobs itself only ever passes the fixed
+ * literal "hull_jobs". */
 static int pg_channel_ok(const char *ch)
 {
     if (!ch) return 0;

--- a/src/hull/runtime/js/mod_db.c
+++ b/src/hull/runtime/js/mod_db.c
@@ -724,8 +724,13 @@ static JSValue js_db_async_common(JSContext *ctx, JSValueConst this_val,
         if (!channel)
             return JS_EXCEPTION;
         int32_t timeout_ms = 1000;
-        if (argc >= 2 && !JS_IsUndefined(argv[1]) && !JS_IsNull(argv[1]))
-            JS_ToInt32(ctx, &timeout_ms, argv[1]);
+        if (argc >= 2 && !JS_IsUndefined(argv[1]) && !JS_IsNull(argv[1]) &&
+            JS_ToInt32(ctx, &timeout_ms, argv[1]) < 0) {
+            /* A throwing valueOf/Symbol.toPrimitive on the timeout arg left a
+             * pending exception; propagate it rather than proceeding. */
+            JS_FreeCString(ctx, channel);
+            return JS_EXCEPTION;
+        }
         op = calloc(1, sizeof(HlWorkerDbOp));
         if (!op) {
             JS_FreeCString(ctx, channel);

--- a/stdlib/js/hull/jobs.js
+++ b/stdlib/js/hull/jobs.js
@@ -1385,16 +1385,31 @@ async function runWorker(opts) {
     // (latency only, never correctness). Gated on concurrency === 1: with N
     // in-process loops all idle we would occupy N worker-pool threads on the
     // wait, so the multi-loop case keeps plain sleep (the fleet still gets the
-    // win via separate single-loop worker processes). A first wait that throws
-    // (no thread pool / event loop) disables the fast path for the rest of the
-    // run and falls back to sleep.
-    let useNotify = db.dialect.supportsNotify && concurrency === 1;
+    // win via separate single-loop worker processes).
+    //
+    // Three wait outcomes:
+    //   * true  -> work is available; return at once (the whole point).
+    //   * false at ~pollMs -> a real timeout; loop and poll.
+    //   * false well before pollMs -> a dropped-connection wait (worker_db
+    //     already invalidated it), NOT a real timeout, so sleep the remainder;
+    //     otherwise a flapping connection would spin the loop.
+    // A throw (no thread pool / event loop, or a transient DB error mid-reopen)
+    // sleeps this tick and retries next tick, so a recovered database restores
+    // the fast path without a worker restart.
+    const useNotify = db.dialect.supportsNotify && concurrency === 1;
     const idleWait = async () => {
-        if (useNotify) {
-            try { await db.waitNotify("hull_jobs", pollMs); }
-            catch (_e) { useNotify = false; await hull.sleep(pollMs); }
-        } else {
+        if (!useNotify) { await hull.sleep(pollMs); return; }
+        const t0 = time.nowMs();
+        let got;
+        try {
+            got = await db.waitNotify("hull_jobs", pollMs);
+        } catch (_e) {
             await hull.sleep(pollMs);
+            return;
+        }
+        if (got === false) {
+            const elapsed = time.nowMs() - t0;
+            if (elapsed < pollMs) await hull.sleep(pollMs - elapsed);
         }
     };
 

--- a/stdlib/lua/hull/jobs.lua
+++ b/stdlib/lua/hull/jobs.lua
@@ -1487,19 +1487,30 @@ function jobs.run_worker(opts)
     -- single-loop worker parks on conn.wait_notify, so a freshly enqueued job
     -- or appended event wakes it immediately instead of after poll_ms; the
     -- timeout is still poll_ms, so a missed/absent NOTIFY just falls back to a
-    -- poll (latency only, never correctness). Gated on concurrency == 1: with
-    -- N in-process loops all idle we would occupy N worker-pool threads on the
+    -- poll (latency only, never correctness). Gated on concurrency == 1: with N
+    -- in-process loops all idle we would occupy N worker-pool threads on the
     -- wait, so the multi-loop case keeps plain sleep (the fleet still gets the
-    -- win via separate single-loop worker processes). A first wait that throws
-    -- (no thread pool / event loop) disables the fast path for the rest of the
-    -- run and falls back to sleep.
+    -- win via separate single-loop worker processes).
+    --
+    -- Three wait outcomes:
+    --   * true  -> work is available; return at once (the whole point).
+    --   * false at ~poll_ms -> a real timeout; loop and poll.
+    --   * false well before poll_ms -> a dropped-connection wait (worker_db
+    --     already invalidated it), NOT a real timeout, so sleep the remainder;
+    --     otherwise a flapping connection would spin the loop.
+    -- A throw (no thread pool / event loop, or a transient DB error mid-reopen)
+    -- sleeps this tick and retries next tick, so a recovered database restores
+    -- the fast path without a worker restart.
     local use_notify = db.dialect.supports_notify and concurrency == 1
     local function idle_wait()
-        if use_notify then
-            local ok = pcall(db.wait_notify, "hull_jobs", poll_ms)
-            if not ok then use_notify = false; hull.sleep(poll_ms) end
-        else
+        if not use_notify then hull.sleep(poll_ms); return end
+        local t0 = time.now_ms()
+        local ok, got = pcall(db.wait_notify, "hull_jobs", poll_ms)
+        if not ok then
             hull.sleep(poll_ms)
+        elseif got == false then
+            local elapsed = time.now_ms() - t0
+            if elapsed < poll_ms then hull.sleep(poll_ms - elapsed) end
         end
     end
 


### PR DESCRIPTION
Follow-up to the pre-release **c/lua/js audit** of the Phase 4 LISTEN/NOTIFY work
(#267/#271/#272/#273). The audits found **no Critical/High/Medium** in any layer;
this addresses the actionable **Low** findings.

## C nits
1. **`js_db_async_common` (waitNotify branch)** ignored `JS_ToInt32`'s return, so
   a throwing `valueOf` / `Symbol.toPrimitive` on `timeoutMs` left a pending JS
   exception while the op proceeded with the default. Now frees the channel and
   returns `JS_EXCEPTION`, matching query/exec.
2. **`pg_channel_ok` comment** corrected: the channel is app-reachable
   (`conn.wait_notify`/`waitNotify` is public), so the identifier allowlist is
   load-bearing, not "defense in depth." Behavior unchanged (already blocked
   injection).

## `run_worker` idle-wait hardening (Lua + JS, at parity)
3. **L1 - flapping-connection spin:** a dropped LISTEN connection makes
   `wait_notify` return `false` *fast* (worker_db invalidated it), not after
   `poll_ms`. The loop ran one un-throttled `jobs.work()` before reopening -
   bounded normally, but a *flapping* connection could spin faster. Now a `false`
   that returns well before `poll_ms` sleeps the remainder (a `true` still
   returns at once, so pickup latency is unchanged); the cadence is capped at one
   poll per `poll_ms`.
4. **L2 - permanent fast-path disable:** a throw previously latched the fast path
   off for the whole run, so a transiently-down DB that recovered stayed in poll
   mode until restart. Now a throw sleeps that tick and retries, so a recovered
   database self-heals; the no-async-infra case degrades to a cheap
   immediate-throw + sleep per `poll_ms`.

The third audit note (NOTIFY on every event) is correct-by-design - drainers need
the wake - and is left unchanged.

Validated: `e2e_jobs` **65/65** on SQLite (fast path is Postgres-only, so the
SQLite path is unchanged), `e2e_postgres` green (latency still wakes ~3s << 8s
poll, reconnect still recovers, wait_notify round trip), lint + build clean both
runtimes.
