### PR TITLE
stdlib: fix template XSS drift, dedup htmx escaping, add Lua/JS parity test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,10 @@ jobs:
         timeout-minutes: 3
         run: make e2e-multipart
 
+      - name: Template Lua/JS escaping-parity E2E test
+        timeout-minutes: 2
+        run: make e2e-template-parity
+
       - name: Runtime slim E2E test (single-runtime app drops the other interpreter)
         timeout-minutes: 3
         run: make e2e-feature-runtime

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -672,6 +672,10 @@ e2e-mysql:
 e2e-templates: $(BUILDDIR)/hull
 	RUNTIME=$(RUNTIME) sh tests/e2e_templates.sh
 
+.PHONY: e2e-template-parity
+e2e-template-parity: $(BUILDDIR)/hull
+	sh tests/e2e_template_parity.sh
+
 e2e-agent: $(BUILDDIR)/hull
 	RUNTIME=$(RUNTIME) sh tests/e2e_agent.sh
 

--- a/stdlib/js/hull/web/htmx.js
+++ b/stdlib/js/hull/web/htmx.js
@@ -27,6 +27,26 @@
  * @license AGPL-3.0-or-later
  */
 
+// ── Shared HTML escape ────────────────────────────────────────────────
+//
+// The htmx widgets render user data into element text and double-quoted
+// attributes, so they all need HTML escaping. It lives here, once, rather
+// than being re-rolled in each widget. Escapes the five HTML metacharacters
+// plus the backtick (unquoted-attribute contexts), matching hull.template.
+const _escapeMap = {
+    "&": "&amp;", "<": "&lt;", ">": "&gt;",
+    '"': "&quot;", "'": "&#39;", "`": "&#96;",
+};
+
+/**
+ * HTML-escape a value for safe interpolation into element text or a
+ * double-quoted attribute. null/undefined become the empty string.
+ */
+function escape(s) {
+    if (s === null || s === undefined) return "";
+    return String(s).replace(/[&<>"'`]/g, (ch) => _escapeMap[ch]);
+}
+
 /** True if the request was sent by the htmx client runtime. */
 function is(req) {
     if (!req || !req.headers) return false;
@@ -167,6 +187,7 @@ function location(res, pathOrOpts) {
 }
 
 export const htmx = {
+    escape,
     is, boosted, currentUrl, target, triggerName,
     redirect, retarget, reswap,
     trigger,

--- a/stdlib/js/hull/web/htmx/confirm.js
+++ b/stdlib/js/hull/web/htmx/confirm.js
@@ -17,12 +17,9 @@
  * Lua parity: same surface as `hull.web.htmx.confirm`.
  */
 
-// HTML attribute-value escaping. Covers the five characters that
-// can break out of a double-quoted attribute value.
-const ESC = { "&": "&amp;", '"': "&quot;", "<": "&lt;", ">": "&gt;", "'": "&#39;" };
-function attrEscape(s) {
-    return String(s == null ? "" : s).replace(/[&"<>']/g, (c) => ESC[c]);
-}
+// HTML attribute-value escaping (shared across the htmx widgets).
+import { htmx } from "hull:web:htmx";
+const attrEscape = htmx.escape;
 
 /**
  * Render htmx + data attributes for a confirm dialog.

--- a/stdlib/js/hull/web/htmx/form.js
+++ b/stdlib/js/hull/web/htmx/form.js
@@ -20,10 +20,9 @@
  * snake_case (Lua) → camelCase (JS) per Hull convention.
  */
 
-const BODY_ESC = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" };
-function esc(s) {
-    return String(s == null ? "" : s).replace(/[&<>"']/g, (c) => BODY_ESC[c]);
-}
+// HTML escaping (shared across the htmx widgets).
+import { htmx } from "hull:web:htmx";
+const esc = htmx.escape;
 // Field names from validate.check() are already constrained to
 // ASCII identifiers; we collapse anything outside [A-Za-z0-9_-]
 // to "_" as defense in depth in case a future caller passes a

--- a/stdlib/js/hull/web/htmx/inline-edit.js
+++ b/stdlib/js/hull/web/htmx/inline-edit.js
@@ -24,10 +24,9 @@
  * map snake_case (Lua) → camelCase (JS).
  */
 
-const ESC = { "&": "&amp;", '"': "&quot;", "<": "&lt;", ">": "&gt;", "'": "&#39;" };
-function esc(s) {
-    return String(s == null ? "" : s).replace(/[&"<>']/g, (c) => ESC[c]);
-}
+// HTML escaping (shared across the htmx widgets).
+import { htmx } from "hull:web:htmx";
+const esc = htmx.escape;
 
 /**
  * Render the display-mode cell (read-only span that swaps to

--- a/stdlib/js/hull/web/htmx/pagination.js
+++ b/stdlib/js/hull/web/htmx/pagination.js
@@ -18,11 +18,10 @@
  */
 
 import { pagination as basePagination } from "hull:web:pagination";
+import { htmx } from "hull:web:htmx";
 
-const ESC = { "&": "&amp;", '"': "&quot;", "<": "&lt;", ">": "&gt;", "'": "&#39;" };
-function attrEscape(s) {
-    return String(s == null ? "" : s).replace(/[&"<>']/g, (c) => ESC[c]);
-}
+// HTML attribute-value escaping (shared across the htmx widgets).
+const attrEscape = htmx.escape;
 
 function linkAttrs(url, target, pushUrl) {
     const parts = [

--- a/stdlib/js/hull/web/htmx/search.js
+++ b/stdlib/js/hull/web/htmx/search.js
@@ -41,10 +41,9 @@
  *     });
  */
 
-const ESC = { "&": "&amp;", '"': "&quot;", "<": "&lt;", ">": "&gt;", "'": "&#39;" };
-function attrEscape(s) {
-    return String(s == null ? "" : s).replace(/[&"<>']/g, (c) => ESC[c]);
-}
+// HTML attribute-value escaping (shared across the htmx widgets).
+import { htmx } from "hull:web:htmx";
+const attrEscape = htmx.escape;
 
 /**
  * Render the htmx attribute set for a debounced search input.

--- a/stdlib/js/hull/web/htmx/sort.js
+++ b/stdlib/js/hull/web/htmx/sort.js
@@ -19,10 +19,9 @@
  * URLs round-trip and stay bookmarkable.
  */
 
-const ESC = { "&": "&amp;", '"': "&quot;", "<": "&lt;", ">": "&gt;", "'": "&#39;" };
-function attrEscape(s) {
-    return String(s == null ? "" : s).replace(/[&"<>']/g, (c) => ESC[c]);
-}
+// HTML attribute-value escaping (shared across the htmx widgets).
+import { htmx } from "hull:web:htmx";
+const attrEscape = htmx.escape;
 function safeColumn(s) {
     if (s == null) return "";
     return String(s).replace(/[^A-Za-z0-9_-]/g, "");

--- a/stdlib/js/hull/web/htmx/table.js
+++ b/stdlib/js/hull/web/htmx/table.js
@@ -18,11 +18,10 @@
 
 import { sort as sortWidget } from "hull:web:htmx:sort";
 import { inlineEdit } from "hull:web:htmx:inline-edit";
+import { htmx } from "hull:web:htmx";
 
-const ESC = { "&": "&amp;", '"': "&quot;", "<": "&lt;", ">": "&gt;", "'": "&#39;" };
-function esc(s) {
-    return String(s == null ? "" : s).replace(/[&"<>']/g, (c) => ESC[c]);
-}
+// HTML escaping (shared across the htmx widgets).
+const esc = htmx.escape;
 
 /**
  * Render a sortable, inline-editable `<table>` from rows + schema.

--- a/stdlib/lua/hull/template.lua
+++ b/stdlib/lua/hull/template.lua
@@ -68,12 +68,13 @@ local escape_map = {
     [">"] = "&gt;",
     ['"'] = "&quot;",
     ["'"] = "&#39;",
+    ["`"] = "&#96;",   -- backtick: unquoted-attribute contexts (parity with JS)
 }
 
 local function html_escape(s)
     if s == nil then return "" end
     s = tostring(s)
-    return (s:gsub("[&<>\"']", escape_map))
+    return (s:gsub("[&<>\"'`]", escape_map))
 end
 
 -- ── Built-in filters ────────────────────────────────────────────────
@@ -93,7 +94,15 @@ function filters.trim(val)
 end
 
 function filters.length(val)
-    if type(val) == "table" then return #val end
+    if type(val) == "table" then
+        local n = #val
+        if n > 0 then return n end
+        -- Hash-style table (no array part): count keys, matching the JS
+        -- Object.keys(val).length behavior (#val is 0 for a pure hash).
+        local count = 0
+        for _ in pairs(val) do count = count + 1 end
+        return count
+    end
     return #tostring(val or "")
 end
 
@@ -105,7 +114,9 @@ function filters.default(val, fallback)
 end
 
 function filters.json(val)
-    return json.encode(val)
+    -- Post-escape "<" so `{{ data | json }}` embedded in a <script> block
+    -- cannot break out via "</script>" (parity with JS's < escaping).
+    return (json.encode(val):gsub("<", "\\u003c"))
 end
 
 function filters.raw(val)
@@ -675,7 +686,12 @@ local function codegen(ast)
 
             elseif node.kind == "for" then
                 validate_ident(node.var, "for loop variable")
-                emit("for _, " .. node.var .. " in ipairs(" .. gen_dot_path(node.expr, nil, locals_set) .. " or {}) do")
+                -- Coerce a non-table source (nil/string/number) to {} rather
+                -- than error, matching JS's `Array.isArray(it) ? it : []`.
+                -- The dot-path is pure, so evaluating it twice is safe.
+                local for_src = gen_dot_path(node.expr, nil, locals_set)
+                emit("for _, " .. node.var .. " in ipairs(type(" .. for_src ..
+                     ") == \"table\" and " .. for_src .. " or {}) do")
                 locals_set[node.var] = (locals_set[node.var] or 0) + 1
                 indent = indent + 1
                 gen_body(node.body)
@@ -687,7 +703,9 @@ local function codegen(ast)
             elseif node.kind == "for_kv" then
                 validate_ident(node.key, "for loop key")
                 validate_ident(node.val, "for loop value")
-                emit("for " .. node.key .. ", " .. node.val .. " in pairs(" .. gen_dot_path(node.expr, nil, locals_set) .. " or {}) do")
+                local forkv_src = gen_dot_path(node.expr, nil, locals_set)
+                emit("for " .. node.key .. ", " .. node.val .. " in pairs(type(" .. forkv_src ..
+                     ") == \"table\" and " .. forkv_src .. " or {}) do")
                 locals_set[node.key] = (locals_set[node.key] or 0) + 1
                 locals_set[node.val] = (locals_set[node.val] or 0) + 1
                 indent = indent + 1

--- a/stdlib/lua/hull/web/htmx.lua
+++ b/stdlib/lua/hull/web/htmx.lua
@@ -26,6 +26,27 @@
 
 local htmx = {}
 
+-- ── Shared HTML escape ────────────────────────────────────────────────
+--
+-- The htmx widgets render user data into element text and double-quoted
+-- attributes, so they all need HTML escaping. It lives here, once, rather
+-- than being re-rolled in each widget (where copies had already drifted -
+-- some missed the nil guard). Escapes the five HTML metacharacters plus the
+-- backtick (unquoted-attribute contexts), matching hull.template.
+local _escape_map = {
+    ["&"] = "&amp;", ["<"] = "&lt;", [">"] = "&gt;",
+    ['"'] = "&quot;", ["'"] = "&#39;", ["`"] = "&#96;",
+}
+
+--- HTML-escape a value for safe interpolation into element text or a
+--- double-quoted attribute. `nil` becomes the empty string.
+-- @tparam any s
+-- @treturn string
+function htmx.escape(s)
+    if s == nil then return "" end
+    return (tostring(s):gsub("[&<>\"'`]", _escape_map))
+end
+
 --- True if the request was sent by the htmx client runtime.
 --
 -- Checks for `HX-Request: true`. HTMX sets this on every AJAX request

--- a/stdlib/lua/hull/web/htmx/confirm.lua
+++ b/stdlib/lua/hull/web/htmx/confirm.lua
@@ -47,20 +47,8 @@
 
 local confirm = {}
 
--- HTML attribute-value escaping. Covers the five characters that
--- can break out of a double-quoted attribute value (& and " are
--- the load-bearing ones; <, >, ' included for defense in depth and
--- to render correctly inside any container context).
-local ESC = {
-    ["&"] = "&amp;",
-    ['"'] = "&quot;",
-    ["<"] = "&lt;",
-    [">"] = "&gt;",
-    ["'"] = "&#39;",
-}
-local function attr_escape(s)
-    return (tostring(s):gsub('[&"<>\']', ESC))
-end
+-- HTML attribute-value escaping (shared across the htmx widgets).
+local attr_escape = require("hull.web.htmx").escape
 
 --- Render htmx + data attributes for a confirm dialog.
 --

--- a/stdlib/lua/hull/web/htmx/form.lua
+++ b/stdlib/lua/hull/web/htmx/form.lua
@@ -59,19 +59,8 @@
 
 local form = {}
 
--- Minimal HTML body escape — covers the four characters that
--- terminate an element body context. Apostrophe included for the
--- inline-attribute case some downstream templates wrap us in.
-local BODY_ESC = {
-    ["&"] = "&amp;",
-    ["<"] = "&lt;",
-    [">"] = "&gt;",
-    ['"'] = "&quot;",
-    ["'"] = "&#39;",
-}
-local function esc(s)
-    return (tostring(s):gsub('[&<>"\']', BODY_ESC))
-end
+-- HTML escaping (shared across the htmx widgets).
+local esc = require("hull.web.htmx").escape
 
 -- Stable per-field id used by `aria-describedby` <-> error span.
 -- Field names from validate.check() are already constrained to

--- a/stdlib/lua/hull/web/htmx/inline-edit.lua
+++ b/stdlib/lua/hull/web/htmx/inline-edit.lua
@@ -91,17 +91,8 @@
 
 local inline_edit = {}
 
--- HTML body / attribute escape (covers both contexts; safest).
-local ESC = {
-    ["&"] = "&amp;",
-    ['"'] = "&quot;",
-    ["<"] = "&lt;",
-    [">"] = "&gt;",
-    ["'"] = "&#39;",
-}
-local function esc(s)
-    return (tostring(s == nil and "" or s):gsub('[&"<>\']', ESC))
-end
+-- HTML body / attribute escape (shared across the htmx widgets).
+local esc = require("hull.web.htmx").escape
 
 -- Reject non-string/number values at entry points so a caller
 -- passing a table accidentally produces a clear error rather than

--- a/stdlib/lua/hull/web/htmx/pagination.lua
+++ b/stdlib/lua/hull/web/htmx/pagination.lua
@@ -57,16 +57,8 @@ local base_pagination = require("hull.web.pagination")
 
 local pagination = {}
 
-local ESC = {
-    ["&"] = "&amp;",
-    ['"'] = "&quot;",
-    ["<"] = "&lt;",
-    [">"] = "&gt;",
-    ["'"] = "&#39;",
-}
-local function attr_escape(s)
-    return (tostring(s == nil and "" or s):gsub('[&"<>\']', ESC))
-end
+-- HTML attribute-value escaping (shared across the htmx widgets).
+local attr_escape = require("hull.web.htmx").escape
 
 -- Render the attrs that go on every active page link. Same set on
 -- prev / next / numbered pages so the htmx behavior is uniform.

--- a/stdlib/lua/hull/web/htmx/search.lua
+++ b/stdlib/lua/hull/web/htmx/search.lua
@@ -54,18 +54,8 @@
 
 local search = {}
 
--- HTML attribute-value escaping. Same shape as the confirm widget;
--- duplicated here to avoid a cross-module dep on a tiny helper.
-local ESC = {
-    ["&"] = "&amp;",
-    ['"'] = "&quot;",
-    ["<"] = "&lt;",
-    [">"] = "&gt;",
-    ["'"] = "&#39;",
-}
-local function attr_escape(s)
-    return (tostring(s):gsub('[&"<>\']', ESC))
-end
+-- HTML attribute-value escaping (shared across the htmx widgets).
+local attr_escape = require("hull.web.htmx").escape
 
 --- Render the htmx attribute set for a debounced search input.
 --

--- a/stdlib/lua/hull/web/htmx/sort.lua
+++ b/stdlib/lua/hull/web/htmx/sort.lua
@@ -95,17 +95,8 @@
 
 local sort = {}
 
--- HTML attribute-value escaping; same shape as the other widgets.
-local ESC = {
-    ["&"] = "&amp;",
-    ['"'] = "&quot;",
-    ["<"] = "&lt;",
-    [">"] = "&gt;",
-    ["'"] = "&#39;",
-}
-local function attr_escape(s)
-    return (tostring(s == nil and "" or s):gsub('[&"<>\']', ESC))
-end
+-- HTML attribute-value escaping (shared across the htmx widgets).
+local attr_escape = require("hull.web.htmx").escape
 
 -- Column-name safety: only [A-Za-z0-9_-] reaches the URL or the SQL
 -- ORDER BY (after the app's allowlist check). Defense in depth

--- a/stdlib/lua/hull/web/htmx/table.lua
+++ b/stdlib/lua/hull/web/htmx/table.lua
@@ -78,16 +78,8 @@ local inline_edit = require("hull.web.htmx.inline-edit")
 
 local M = {}
 
-local ESC = {
-    ["&"] = "&amp;",
-    ['"'] = "&quot;",
-    ["<"] = "&lt;",
-    [">"] = "&gt;",
-    ["'"] = "&#39;",
-}
-local function esc(s)
-    return (tostring(s == nil and "" or s):gsub('[&"<>\']', ESC))
-end
+-- HTML escaping (shared across the htmx widgets).
+local esc = require("hull.web.htmx").escape
 
 local function check_required_opt(opts, name)
     if not opts or opts[name] == nil then

--- a/tests/e2e_template_parity.sh
+++ b/tests/e2e_template_parity.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# e2e_template_parity.sh: Lua/JS golden-parity for the (security-relevant)
+# escaping + template-filter behavior.
+#
+# Hull's stdlib is dual-runtime: template.lua/template.js and the htmx widgets
+# are hand-ported, so a hardening or a fix can land in one runtime and silently
+# miss the other. That already happened (JS escaped backtick and the json filter's
+# "<", Lua did not). This test renders an IDENTICAL battery of cases through the
+# Lua and the JS runtime and asserts the two outputs are byte-for-byte identical,
+# so any future escaping/filter drift fails CI instead of shipping.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+HULL="${HULL:-./build/hull}"
+[ -x "$HULL" ] || HULL="build/hull"
+
+WD=$(mktemp -d)
+trap 'rm -rf "$WD"' EXIT
+
+# The two apps below MUST emit the same KEY=value lines for the same inputs.
+# Cases target the exact drift class: HTML escaping (incl. backtick), the json
+# filter's "<" escape, length on object/array/string, and for-loop coercion of a
+# non-table source. Plus the shared htmx.escape and a widget that uses it, so the
+# 16-copies-collapsed-to-one escape stays identical across runtimes.
+
+cat > "$WD/parity.lua" <<'LUA'
+local t     = require("hull.template")
+local htmx  = require("hull.web.htmx")
+local confirm = require("hull.web.htmx.confirm")
+app.manifest({ modules = {
+    "hull/template@1", "hull/web/htmx@1", "hull/web/htmx/confirm@1",
+} })
+app.main(function(ctx)
+    local function w(k, v) ctx.stdout:write(k .. "=" .. v .. "\n") end
+    w("esc_all",  t.render_string("{{ x }}", { x = "&<>\"'`z" }))
+    w("json_lt",  t.render_string("{{{ d | json }}}", { d = { a = "</script>" } }))
+    w("len_obj",  t.render_string("{{ o | length }}", { o = { a = 1, b = 2, c = 3 } }))
+    w("len_arr",  t.render_string("{{ a | length }}", { a = { 10, 20 } }))
+    w("len_str",  t.render_string("{{ s | length }}", { s = "hello" }))
+    w("for_str",  "[" .. t.render_string("{% for i in s %}{{ i }}{% end %}", { s = "nope" }) .. "]")
+    w("forkv_str","[" .. t.render_string("{% for k, v in s %}x{% end %}", { s = "nope" }) .. "]")
+    w("default",  t.render_string("{{ m | default: \"fb\" }}", {}))
+    w("upper",    t.render_string("{{ p | upper }}", { p = "aB" }))
+    w("trim",     t.render_string("{{ p | trim }}", { p = "  hi  " }))
+    w("htmx_esc", htmx.escape("a\"<b>&'`"))
+    w("htmx_nil", "[" .. htmx.escape(nil) .. "]")
+    w("widget",   confirm.attrs("a\"<b`"))
+    return 0
+end)
+LUA
+
+cat > "$WD/parity.js" <<'JS'
+import { app } from "hull:app";
+import { template as t } from "hull:template";
+import { htmx } from "hull:web:htmx";
+import { confirm } from "hull:web:htmx:confirm";
+app.manifest({ modules: [
+    "hull/template@1", "hull/web/htmx@1", "hull/web/htmx/confirm@1",
+] });
+app.main((ctx) => {
+    const w = (k, v) => ctx.stdout.write(k + "=" + v + "\n");
+    w("esc_all",  t.renderString("{{ x }}", { x: "&<>\"'`z" }));
+    w("json_lt",  t.renderString("{{{ d | json }}}", { d: { a: "</script>" } }));
+    w("len_obj",  t.renderString("{{ o | length }}", { o: { a: 1, b: 2, c: 3 } }));
+    w("len_arr",  t.renderString("{{ a | length }}", { a: [10, 20] }));
+    w("len_str",  t.renderString("{{ s | length }}", { s: "hello" }));
+    w("for_str",  "[" + t.renderString("{% for i in s %}{{ i }}{% end %}", { s: "nope" }) + "]");
+    w("forkv_str","[" + t.renderString("{% for k, v in s %}x{% end %}", { s: "nope" }) + "]");
+    w("default",  t.renderString('{{ m | default: "fb" }}', {}));
+    w("upper",    t.renderString("{{ p | upper }}", { p: "aB" }));
+    w("trim",     t.renderString("{{ p | trim }}", { p: "  hi  " }));
+    w("htmx_esc", htmx.escape("a\"<b>&'`"));
+    w("htmx_nil", "[" + htmx.escape(null) + "]");
+    w("widget",   confirm.attrs("a\"<b`"));
+    return 0;
+});
+JS
+
+echo "=== rendering the parity battery through both runtimes ==="
+"$HULL" "$WD/parity.lua" 2>/dev/null | grep '=' | sort > "$WD/lua.out"
+"$HULL" "$WD/parity.js"  2>/dev/null | grep '=' | sort > "$WD/js.out"
+
+lua_n=$(grep -c '=' "$WD/lua.out" || true)
+js_n=$(grep -c '=' "$WD/js.out"  || true)
+echo "  lua emitted $lua_n cases, js emitted $js_n cases"
+
+if [ "$lua_n" -lt 13 ] || [ "$js_n" -lt 13 ]; then
+    echo "::error one runtime produced too few cases (lua=$lua_n js=$js_n) - a render errored"
+    echo "--- lua ---"; cat "$WD/lua.out"
+    echo "--- js ---";  cat "$WD/js.out"
+    exit 1
+fi
+
+if diff -u "$WD/lua.out" "$WD/js.out" > "$WD/diff.txt" 2>&1; then
+    echo "PASS: Lua and JS escaping/template output is byte-identical ($lua_n cases)"
+else
+    echo "::error Lua/JS template parity DRIFT - escaping/filter output differs:"
+    cat "$WD/diff.txt"
+    exit 1
+fi


### PR DESCRIPTION
Stdlib-review follow-up (items #1 + #2 from the honest review): close a real
dual-runtime escaping drift and install the guardrail that stops the next one.

## The drift (security)
`template.js` had hardenings that never reached `template.lua` - two **latent
XSS in Lua only**:
- **backtick** escaped in JS, not Lua (unquoted-attribute contexts)
- the **`json` filter** escaped `<` -> `<` in JS, not Lua (so
  `{{ data | json }}` inside `<script>` could break out via `</script>`)

Plus two behavior divergences: `length` on a hash returned `0` in Lua (JS counts
keys); a for-loop over a non-table source **errored** in Lua (JS coerces to
`[]`). All four are now ported to `template.lua` - both runtimes escape + filter
identically.

## The 16 copies (DRY + a latent crash)
The HTML-escape function was copy-pasted into all 8 htmx widgets x 2 runtimes,
and had **already drifted** - `confirm`/`form`/`search` were **not nil-guarded**
(crash on `nil`) while the rest were. Extracted one `htmx.escape` into the base
`hull.web.htmx` / `hull:web:htmx` module (nil-safe, includes backtick, matches
`template`) and pointed every widget at it. **16 copies -> 2 shared helpers**,
and the nil-crash is gone. Every widget already declares the base htmx dep, so no
registry change.

## The guardrail (#2)
`tests/e2e_template_parity.sh` renders an identical battery of escaping / filter
/ loop cases + the shared `htmx.escape` + a widget through **both runtimes** and
asserts byte-for-byte-identical output (13 cases). Wired as
`make e2e-template-parity` + a CI step, so any future Lua/JS escaping drift
**fails CI instead of shipping**. (Note: `e2e_templates` itself wasn't in the CI
matrix - this adds the first CI coverage of template-escaping parity.)

## Validation
`e2e_templates` 42/42, `make test` 62/62, `lint-lua` + `lint-js` clean, and the
new parity test green (Lua == JS across all 13 cases, incl. the previously-XSS
backtick + json cases). Test-only + stdlib; no C changes.
