### PR TITLE
stdlib: house style guide + centralize raw-byte hex (hull.crypto._hex)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,10 @@ jobs:
         timeout-minutes: 2
         run: make e2e-template-parity
 
+      - name: Hex Lua/JS byte-string parity E2E test
+        timeout-minutes: 2
+        run: make e2e-hex-parity
+
       - name: Runtime slim E2E test (single-runtime app drops the other interpreter)
         timeout-minutes: 3
         run: make e2e-feature-runtime

--- a/docs/stdlib_style.md
+++ b/docs/stdlib_style.md
@@ -1,0 +1,161 @@
+# Hull stdlib style guide
+
+The Hull stdlib is dual-runtime: every user-facing module is written once in
+Lua (`stdlib/lua/hull/`) and once in JS (`stdlib/js/hull/`), kept at **semantic**
+parity. This guide is the house style those modules follow. It exists because a
+2026-08 review found the stdlib had grown four different error conventions, the
+same concept named eight ways, and a handful of avoidable footguns. New and
+changed stdlib code MUST follow the rules here; existing code is reconciled to
+them incrementally.
+
+The audience is contributors to the stdlib, not app authors. (App-facing docs
+live per-module and in `CLAUDE.md`.)
+
+---
+
+## 1. Error handling
+
+**The rule.** *Exceptions represent failure to perform the requested operation.
+Values represent successful outcomes, including expected negative outcomes such
+as absence.*
+
+- **Failure → throw.** `error(msg)` in Lua, `throw new Error(msg)` in JS. A
+  failure is: invalid input, a violated precondition (missing required option,
+  wrong type), an exceeded cap, or a backend/transport error.
+- **Absence is a value, not an error.** A lookup / load / cache read that finds
+  nothing returns `nil` / `null`. "Not found" is a normal outcome the caller
+  routinely branches on; it is not a failure to perform the operation.
+- **Predicates return their value.** A boolean check returns a boolean; a
+  counter returns a number. No wrapping.
+- **Structured domain results are allowed** *only* when the structure is
+  semantically part of a **successful** operation (e.g. a validator's findings).
+  They are never a general-purpose error transport. Do not return
+  `(value, err)` / `{ ok, error }` as the standard way to signal failure.
+
+**Throwing is not HTTP.** A thrown error propagates to the enclosing execution
+boundary. An HTTP handler *may* map an unhandled failure to a 500, but the
+stdlib itself is transport-agnostic — a CLI or a job runner is an equally valid
+boundary. Never phrase a stdlib contract in terms of HTTP status.
+
+### Outcome categories
+
+| Operation | Outcome | Result |
+|---|---|---|
+| `session.load(id)` | found / not-found / DB down | object / `nil` / **throw** |
+| a cache `get(k)` | hit / miss / backend error | value / `nil` / **throw** |
+| `csv.parse(input)` | valid / malformed | parsed value / **throw** |
+| `validate.check(data, schema)` | valid / invalid / validator broken | `(true, {})` / `(false, findings)` / **throw** |
+| `email.send(msg)` | sent / missing arg / transport fail | receipt / **throw** / **throw** |
+
+**Validation failure ≠ validator failure.** An *invalid input* is a normal,
+successful outcome of running the validator: it returns `(false, findings)`. The
+*validator itself* failing (a bad schema, an exception in a custom rule) throws.
+
+### Structured error identity
+
+Callers must not have to match on message strings (`err:find("constraint")`).
+Errors that a caller might reasonably branch on carry a **stable `.code`**:
+
+```lua
+local ok, err = pcall(function() db.exec(...) end)
+if not ok and type(err) == "table" and err.code == "constraint_violation" then ...
+```
+```js
+try { db.exec(...); } catch (e) { if (e.code === "constraint_violation") { ... } }
+```
+
+Codes are lower-snake, stable across releases, and documented on the throwing
+function. A bare `error("message")` is fine where no caller branches on it;
+promote to a coded error the moment one does. (Retrofitting existing throws with
+codes is incremental — add a code when a branch needs it.)
+
+### Lua/JS: semantic, not syntactic, equivalence
+
+Keep the *meaning* identical across runtimes; do not force identical surface
+syntax. Multiple return values are idiomatic in Lua and clumsy in JS, so a
+validator is `(valid, errors)` in Lua and *may* be `{ valid, errors }` in JS.
+What must match is the semantics: same categories, same codes, same "throws vs
+returns nil vs returns data" decision.
+
+---
+
+## 2. Naming
+
+- **snake_case in Lua, camelCase in JS**, and the mapping must be faithful and
+  total — every option/field/function present in one runtime is present in the
+  other under the case-translated name. A name in one runtime and not the other
+  (or spelled differently beyond case) is a parity bug.
+- **Time is seconds, and lifetimes are `*_ttl`.** Prefer `ttl` / `<thing>_ttl`
+  (`verify_ttl`, `state_ttl`) over `max_age` / `expires` / `lifetime` /
+  `retention` for the same concept. Where a value is genuinely a wall-clock
+  instant (a cookie `Expires`), name it `expires` and document the unit; where
+  it is a duration, it is seconds unless the name says otherwise (`retain_days`).
+- **One name per concept across modules that wire together.** The HMAC key an
+  app passes is `secret` everywhere (not `state_secret` in one middleware and
+  `secret` in its sibling). The session cookie is `name` (with a documented
+  default), not `cookie_name` here and `name` there. When two modules are meant
+  to be configured side by side, their shared options share a spelling.
+- Introducing an alias for back-compat is acceptable (accept the old name, treat
+  the canonical as primary in docs); introducing a *new* clash is not.
+
+---
+
+## 3. Footguns to avoid
+
+- **No require-time capability acquisition.** Do not call
+  `require("hull.db").default()` (or any capability that resolves post-startup)
+  at module top level. `db.default()` only resolves after the manifest is
+  applied, so a top-level bind fails or captures the wrong connection depending
+  on require order. Acquire lazily inside `init()` / the middleware factory /
+  the handler.
+- **Respect Lua's `0`/`""` truthiness.** `opts.ttl or default` silently drops a
+  caller's `ttl = 0`. Use `opts.ttl ~= nil and opts.ttl or default` (or an
+  explicit `if opts.ttl == nil then`). The same option must behave identically
+  in a module's `init` and its `middleware`.
+- **No process-global mutable state for request-scoped concerns.** A server
+  handles many requests on one runtime; a module-level `active_locale` set by
+  one request leaks into the next. Thread request-scoped state through `req.ctx`,
+  not a file-scoped variable.
+- **No in-place mutation of caller-owned tables.** A function named `check` /
+  `parse` / `render` must not write back into the table it was handed
+  (`validate.check` trimming into `data[field]` is surprising). Return a new
+  value.
+- **Docs match code.** A default documented as `false` must not be `true` in the
+  code (`cookie.secure`). A "silently dropped" in a docstring must not be an
+  `error()` in the body (`csv.parse`).
+
+---
+
+## 4. DRY: shared internal helpers
+
+The stdlib is dual-runtime, so load-bearing logic inherently exists twice. Do
+not *also* duplicate it within a runtime. When the same non-trivial helper
+appears in two modules, it moves to a shared internal module:
+
+- Internal (contributor-only, not app-declarable) modules are `_`-prefixed:
+  `hull.web._request`, `hull.web._html`, etc. They are required by other stdlib
+  modules, never declared by apps.
+- Security-relevant helpers (HTML escaping, HMAC/hex, client-IP extraction)
+  especially must live in exactly one place per runtime — a forked copy that
+  drifts is a latent vulnerability (an escape helper that lost its nil-guard, a
+  hex helper that UTF-8-inflates high bytes).
+- A shared helper still exists twice (Lua + JS). Guard the pair with a
+  **cross-runtime parity test** (see `tests/e2e_template_parity.sh`) so the two
+  copies cannot silently diverge.
+
+Current shared helpers: `hull.web.htmx.escape` (HTML escaping for the widgets),
+`hull.crypto.envelope` (signed token framing), `hull.web.cookie` (parse/
+serialize), and `hull.crypto._hex` (raw-byte hex - deliberately NOT
+`crypto.hex_encode`/`hexEncode`, which UTF-8-inflates high bytes on the JS side;
+see that module). Planned: `hull.web._request` (client-IP / `trust_proxy`, which
+is still re-rolled in ~6 middleware).
+
+---
+
+## 5. Testing parity
+
+Any behavior that is (a) hand-ported across both runtimes and (b) security- or
+correctness-sensitive gets a **golden cross-runtime parity test**: render/compute
+the same inputs through Lua and JS and assert byte-identical output. This is the
+mechanism that keeps two hand-maintained copies honest;
+`tests/e2e_template_parity.sh` is the template for it.

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -676,6 +676,10 @@ e2e-templates: $(BUILDDIR)/hull
 e2e-template-parity: $(BUILDDIR)/hull
 	sh tests/e2e_template_parity.sh
 
+.PHONY: e2e-hex-parity
+e2e-hex-parity: $(BUILDDIR)/hull
+	sh tests/e2e_hex_parity.sh
+
 e2e-agent: $(BUILDDIR)/hull
 	RUNTIME=$(RUNTIME) sh tests/e2e_agent.sh
 

--- a/stdlib/js/hull/crypto/_hex.js
+++ b/stdlib/js/hull/crypto/_hex.js
@@ -1,0 +1,32 @@
+/*
+ * Internal raw-byte hex helper shared across the crypto/auth stdlib.
+ *
+ * @module hull:crypto:_hex
+ * @license AGPL-3.0-or-later
+ *
+ * Contributor-only (the `_` prefix). Encodes a byte string as lowercase hex,
+ * ONE hex pair per byte / code unit (0-255).
+ *
+ * This deliberately does NOT use crypto.hexEncode. A JS string is UTF-8-encoded
+ * at the C boundary, so crypto.hexEncode inflates any code unit >= 0x80
+ * (0xFF -> "c3bf", not "ff") - wrong for hashing / HMAC keys / token wire
+ * formats, and it diverges from Lua's crypto.hex_encode (which is raw, because
+ * Lua strings are byte strings). This helper masks each code unit to a byte and
+ * is byte-identical to the Lua sibling. See docs/stdlib_style.md §4.
+ */
+
+/**
+ * Lowercase hex of a byte string (2 chars per code unit 0-255).
+ * @param {string} s  raw bytes (each char a byte value 0-255)
+ * @returns {string}
+ */
+function toHex(s) {
+    let out = "";
+    for (let i = 0; i < s.length; i++) {
+        out += (s.charCodeAt(i) & 0xff).toString(16).padStart(2, "0");
+    }
+    return out;
+}
+
+export const _hex = { toHex };
+export default _hex;

--- a/stdlib/js/hull/jwt.js
+++ b/stdlib/js/hull/jwt.js
@@ -59,15 +59,10 @@ function constantTimeCompare(a, b) {
     return crypto.constantTimeEq(a, b);
 }
 
-function secretToHex(secret) {
-    let hex = "";
-    for (let i = 0; i < secret.length; i++) {
-        const c = secret.charCodeAt(i);
-        if (c > 127) throw new Error("jwt: secret must be ASCII-only");
-        hex += c.toString(16).padStart(2, "0");
-    }
-    return hex;
-}
+import { _hex } from "hull:crypto:_hex";
+// Raw-byte hex (byte-consistent with Lua; NOT crypto.hexEncode which
+// UTF-8-inflates in JS). Accepts any byte, so non-ASCII secrets work too.
+const secretToHex = _hex.toHex;
 
 // HS256: HMAC-SHA256 over the signing input, returning the
 // base64url-encoded 32-byte digest (matches what the JWS token holds).

--- a/stdlib/js/hull/web/auth-flows.js
+++ b/stdlib/js/hull/web/auth-flows.js
@@ -144,14 +144,8 @@ const ACTIONS = {
 // string input goes through JS_ToCStringLen which UTF-8-inflates
 // them, breaking round-trips. The cap-layer helper is correct
 // for ArrayBuffer/Uint8Array; use it for those.
-function bytesToHex(s) {
-    let h = "";
-    for (let i = 0; i < s.length; i++) {
-        const c = s.charCodeAt(i) & 0xff;
-        h += (c < 16 ? "0" : "") + c.toString(16);
-    }
-    return h;
-}
+import { _hex } from "hull:crypto:_hex";
+const bytesToHex = _hex.toHex;
 
 // Signature framing lives in hull:crypto:envelope; this wrapper
 // just builds the payload and adds optional extra fields. The

--- a/stdlib/js/hull/web/middleware/audit-log.js
+++ b/stdlib/js/hull/web/middleware/audit-log.js
@@ -182,14 +182,8 @@ function extractUa(req) {
 // stable per-runtime but NOT byte-identical to Lua's, which means
 // a Lua→JS migration of the same DB would mark every existing user
 // as a new device on first request.
-function bytesToHex(s) {
-    let h = "";
-    for (let i = 0; i < s.length; i++) {
-        const c = s.charCodeAt(i) & 0xff;
-        h += (c < 16 ? "0" : "") + c.toString(16);
-    }
-    return h;
-}
+import { _hex } from "hull:crypto:_hex";
+const bytesToHex = _hex.toHex;
 
 // Hex SHA-256(salt || "|" || normalized_ua || "|" || ip_prefix),
 // truncated to 16 chars (64 bits). Salt is deployment-private (from

--- a/stdlib/js/hull/web/middleware/csrf.js
+++ b/stdlib/js/hull/web/middleware/csrf.js
@@ -25,17 +25,10 @@ import { crypto } from "hull:crypto";
 import { cookie } from "hull:web:cookie";
 import { time } from "hull:time";
 
-// Secret must be ASCII-only; charCodeAt returns 16-bit code units
-// for non-ASCII which would produce inconsistent HMAC keys.
-function secretToHex(secret) {
-    let hex = "";
-    for (let i = 0; i < secret.length; i++) {
-        const c = secret.charCodeAt(i);
-        if (c > 127) throw new Error("secret must be ASCII-only");
-        hex += c.toString(16).padStart(2, "0");
-    }
-    return hex;
-}
+import { _hex } from "hull:crypto:_hex";
+// Raw-byte hex (byte-consistent with Lua; NOT crypto.hexEncode which
+// UTF-8-inflates in JS). Accepts any byte, so non-ASCII secrets work too.
+const secretToHex = _hex.toHex;
 
 function computeHmac(sessionId, tsHex, secret) {
     // ":" separator deliberately distinct from the wire-format "."

--- a/stdlib/js/hull/web/middleware/oauth.js
+++ b/stdlib/js/hull/web/middleware/oauth.js
@@ -177,18 +177,8 @@ const PRESETS = {
 // points >= 0x80 UTF-8-inflate when crossing the C boundary via
 // JS_ToCStringLen; binary-string inputs (state secrets with high
 // bytes, ID-token hashes) must round-trip byte-identically.
-function bytesToHex(s) {
-    let h = "";
-    for (let i = 0; i < s.length; i++) {
-        // & 0xff matches the sibling helpers in totp.js + auth-flows.js;
-        // without it, a state_secret with code points > 0xff (the
-        // case the comment block above claims to handle) emits 3+
-        // hex chars per char and the round-trip silently breaks.
-        const c = s.charCodeAt(i) & 0xff;
-        h += (c < 16 ? "0" : "") + c.toString(16);
-    }
-    return h;
-}
+import { _hex } from "hull:crypto:_hex";
+const bytesToHex = _hex.toHex;
 
 function hexToBytes(h) {
     const u8 = new Uint8Array(h.length >> 1);

--- a/stdlib/js/hull/web/middleware/totp.js
+++ b/stdlib/js/hull/web/middleware/totp.js
@@ -138,14 +138,8 @@ CREATE INDEX IF NOT EXISTS _hull_totp_attempts_by_ip_lf
 // trips. The cap-layer crypto.hexEncode / crypto.hexDecode
 // are binary-safe for ArrayBuffer/Uint8Array input — use
 // them when the input is already a typed array.
-function bytesToHex(s) {
-    let h = "";
-    for (let i = 0; i < s.length; i++) {
-        const c = s.charCodeAt(i) & 0xff;
-        h += (c < 16 ? "0" : "") + c.toString(16);
-    }
-    return h;
-}
+import { _hex } from "hull:crypto:_hex";
+const bytesToHex = _hex.toHex;
 
 function hexToBytes(h) {
     let s = "";

--- a/stdlib/lua/hull/crypto/_hex.lua
+++ b/stdlib/lua/hull/crypto/_hex.lua
@@ -1,0 +1,32 @@
+--- Internal raw-byte hex helper shared across the crypto/auth stdlib.
+--
+-- @module hull.crypto._hex
+-- @license AGPL-3.0-or-later
+--
+-- Contributor-only (the `_` prefix). Encodes a byte string as lowercase hex,
+-- ONE hex pair per byte.
+--
+-- This deliberately does NOT use crypto.hex_encode. That cap hex-encodes the
+-- bytes it receives across the C boundary - and the two runtimes marshal a
+-- string differently: Lua strings are byte strings (so crypto.hex_encode is
+-- raw there), but a JS string is UTF-8-encoded at the boundary, so
+-- crypto.hexEncode inflates any code unit >= 0x80 (0xFF -> "c3bf", not "ff").
+-- For hashing / HMAC keys / token wire formats over arbitrary secret bytes
+-- that difference silently derives different digests per runtime. This helper
+-- iterates raw bytes identically in both runtimes, so it is the ONE correct
+-- home for byte-string hex. See docs/stdlib_style.md §4.
+
+local M = {}
+
+--- Lowercase hex of a byte string (2 chars per byte).
+-- @tparam string s  raw bytes
+-- @treturn string
+function M.to_hex(s)
+    local out = {}
+    for i = 1, #s do
+        out[i] = string.format("%02x", string.byte(s, i))
+    end
+    return table.concat(out)
+end
+
+return M

--- a/stdlib/lua/hull/jwt.lua
+++ b/stdlib/lua/hull/jwt.lua
@@ -33,6 +33,7 @@
 
 local json = require("hull.json")
 local crypto = require("hull.crypto")
+local _hex = require("hull.crypto._hex")
 local time = require("hull.time")
 
 local jwt = {}
@@ -53,14 +54,6 @@ local SUPPORTED_ALGS = {
     ES256 = true, ES384 = true,
 }
 
-local function str_to_hex(s)
-    local hex = {}
-    for i = 1, #s do
-        hex[i] = string.format("%02x", string.byte(s, i))
-    end
-    return table.concat(hex)
-end
-
 -- Constant-time comparison, done in C (crypto.constant_time_eq) so timing is
 -- not subject to interpreter/bytecode-dispatch variance, matching
 -- crypto/envelope. Length leak is acceptable: both inputs are fixed-length
@@ -72,7 +65,7 @@ end
 -- HS256 signature: HMAC-SHA256 over the signing input, returning the
 -- raw 32-byte digest. The crypto cap returns hex; convert back.
 local function hs256_signature(data, secret)
-    local key_hex = str_to_hex(secret)
+    local key_hex = _hex.to_hex(secret)   -- raw-byte hex (2 chars/byte)
     local sig_hex = crypto.hmac_sha256(data, key_hex)
     local raw = {}
     for i = 1, #sig_hex, 2 do

--- a/stdlib/lua/hull/web/auth-flows.lua
+++ b/stdlib/lua/hull/web/auth-flows.lua
@@ -97,6 +97,7 @@
 
 local crypto    = require("hull.crypto")
 local envelope  = require("hull.crypto.envelope")
+local _hex      = require("hull.crypto._hex")
 local db        = require("hull.db").default()
 local time      = require("hull.time")
 local json      = require("hull.json")
@@ -1635,25 +1636,12 @@ function M.init(opts)
     -- crypto.hmac_sha256 takes the key as a hex string; we encode
     -- once at init and reuse the hex form per request.
     --
-    -- bytes_to_hex_local mirrors stdlib/js/hull/web/auth-flows.js
-    -- `bytesToHex`. Hand-rolled because crypto.hex_encode treats its
-    -- input as a *string* that's passed via Lua's C boundary; on the
-    -- JS side the equivalent UTF-8-inflates code points >= 0x80,
-    -- producing a different hex digest. State secrets that contain
-    -- any byte >= 0x80 (e.g. a passphrase with non-ASCII) would
-    -- silently derive different HMAC keys per runtime, breaking the
-    -- byte-identical wire-format guarantee the JS header promises
-    -- ("a Lua-Hull → JS-Hull migration works without re-issuing
-    -- pending tokens"). string.byte iterates the raw bytes.
-    local function bytes_to_hex_local(s)
-        local n = #s
-        local out = {}
-        for i = 1, n do
-            out[i] = string.format("%02x", string.byte(s, i))
-        end
-        return table.concat(out)
-    end
-    _state.state_secret_hex = bytes_to_hex_local(opts.state_secret)
+    -- Raw-byte hex via the shared hull.crypto._hex helper: NOT crypto.hex_encode,
+    -- which UTF-8-inflates code points >= 0x80 on the JS side, so a state secret
+    -- with a non-ASCII byte would derive different HMAC keys per runtime and
+    -- break the cross-runtime wire-format guarantee. _hex is byte-identical in
+    -- both runtimes.
+    _state.state_secret_hex = _hex.to_hex(opts.state_secret)
     _state.email_send       = opts.email_send
     _state.public_origin    = opts.public_origin
     _state.trusted_hosts    = opts.trusted_hosts

--- a/stdlib/lua/hull/web/middleware/csrf.lua
+++ b/stdlib/lua/hull/web/middleware/csrf.lua
@@ -17,6 +17,7 @@
 -- NOT need CSRF protection (browsers don't auto-send Bearer tokens).
 
 local crypto = require("hull.crypto")
+local _hex = require("hull.crypto._hex")
 local time = require("hull.time")
 
 local csrf = {}
@@ -30,14 +31,6 @@ local function url_decode(s)
     return s
 end
 
---- Convert a raw string to hex representation.
-local function str_to_hex(s)
-    local hex = {}
-    for i = 1, #s do
-        hex[i] = string.format("%02x", string.byte(s, i))
-    end
-    return table.concat(hex)
-end
 
 --- Constant-time comparison of two strings, done in C
 --- (crypto.constant_time_eq) so timing is not subject to interpreter variance.
@@ -59,7 +52,7 @@ function csrf.generate(session_id, secret)
     local ts_hex = string.format("%x", ts)
 
     local message = session_id .. ":" .. ts_hex
-    local key_hex = str_to_hex(secret)
+    local key_hex = _hex.to_hex(secret)
     local mac = crypto.hmac_sha256(message, key_hex)
 
     return ts_hex .. "." .. mac
@@ -117,7 +110,7 @@ function csrf.verify(token, session_id, secret, max_age)
     -- the canonical wire encoding (tsHex), so a token minted by the
     -- JS sibling verifies bit-for-bit here.
     local message = session_id .. ":" .. ts_hex
-    local key_hex = str_to_hex(secret)
+    local key_hex = _hex.to_hex(secret)
     local expected_mac = crypto.hmac_sha256(message, key_hex)
 
     return constant_time_compare(mac, expected_mac)

--- a/tests/e2e_hex_parity.sh
+++ b/tests/e2e_hex_parity.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# e2e_hex_parity.sh: Lua/JS parity for the shared raw-byte hex helper.
+#
+# hull.crypto._hex is the ONE correct home for byte-string hex, precisely
+# because crypto.hex_encode / crypto.hexEncode DIVERGE across runtimes: Lua
+# strings are byte strings (raw hex), but a JS string is UTF-8-encoded at the C
+# boundary, so crypto.hexEncode inflates any code unit >= 0x80 (0xFF -> "c3bf",
+# not "ff"). Every HMAC key / token wire format in the auth stdlib depends on
+# both runtimes hexing the same bytes to the same string. This asserts _hex is
+# byte-identical across the full 0-255 range in both runtimes, so a future
+# "simplification" back to crypto.hexEncode (or any drift) fails CI.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+HULL="${HULL:-./build/hull}"
+[ -x "$HULL" ] || HULL="build/hull"
+WD=$(mktemp -d)
+trap 'rm -rf "$WD"' EXIT
+
+cat > "$WD/hex.lua" <<'LUA'
+local _hex = require("hull.crypto._hex")
+app.manifest({ modules = { "hull/crypto@1" } })
+app.main(function(ctx)
+    local b = {}; for i = 0, 255 do b[#b+1] = string.char(i) end
+    ctx.stdout:write(_hex.to_hex(table.concat(b)) .. "\n"); return 0
+end)
+LUA
+cat > "$WD/hex.js" <<'JS'
+import { app } from "hull:app"; import { _hex } from "hull:crypto:_hex";
+app.manifest({ modules: ["hull/crypto@1"] });
+app.main((ctx) => {
+    let s = ""; for (let i = 0; i < 256; i++) s += String.fromCharCode(i);
+    ctx.stdout.write(_hex.toHex(s) + "\n"); return 0;
+});
+JS
+
+lua_hex="$("$HULL" "$WD/hex.lua" 2>/dev/null | tail -1)"
+js_hex="$("$HULL" "$WD/hex.js"  2>/dev/null | tail -1)"
+
+# 256 bytes -> 512 hex chars; guard against an empty (errored) render too.
+if [ "${#lua_hex}" -eq 512 ] && [ "$lua_hex" = "$js_hex" ]; then
+    echo "PASS: hull.crypto._hex is byte-identical across Lua and JS (full 0-255 range)"
+else
+    echo "::error _hex DRIFT (Lua != JS byte-string hex):"
+    echo "  lua=$lua_hex"
+    echo "  js =$js_hex"
+    exit 1
+fi


### PR DESCRIPTION
Stdlib-review follow-up: the agreed **error convention** as a house style guide
(#4 foundation) + the first **DRY consolidation** (#3), centralizing raw-byte
hex — and it surfaced a real cross-runtime bug.

## `docs/stdlib_style.md`
Codifies the convention we agreed: **failure throws; absence and expected
domain outcomes are values; errors carry a stable `.code`; Lua/JS are
semantically (not syntactically) equivalent.** Honest scoping note in the guide:
the audit's "4 conventions" census overstated it — `health`/`auth-health` return
domain status, `jwt`/`envelope` verifiers return `nil` for an invalid token (an
expected negative outcome), and absence→`nil` are all **already conforming**.
The genuine violation is `email.send`'s `{ok,error}` transport (+ a couple of
doc/footgun bugs) — a stated, targeted follow-up, not a stdlib-wide rewrite.

## `hull.crypto._hex` (the DRY + a bug)
Five hand-rolled hex copies per runtime (jwt, csrf, auth-flows, audit-log,
oauth, totp) collapse to one shared `_hex`. Deliberately **not**
`crypto.hex_encode` — I verified empirically that Lua's `crypto.hex_encode` is
raw-byte but **JS's `crypto.hexEncode` UTF-8-inflates** code units ≥ 0x80
(`0xFF` → `c3bf`), because a JS string is UTF-8-encoded at the C boundary. That
divergence is *why* the modules hand-rolled it. Two parity bugs fixed:
- `auth-flows` Lua/JS hex now provably matches;
- `jwt`/`csrf` no longer **throw** on a non-ASCII secret in JS while accepting it
  in Lua — both byte-hash consistently now.

## Guardrail
`tests/e2e_hex_parity.sh` asserts `_hex` is byte-identical across the full 0–255
range in both runtimes (`make e2e-hex-parity` + CI step), so a "simplification"
back to `crypto.hexEncode` fails CI.

## Validation
build + lint (lua/js) clean; e2e **auth_flows 48 / jwt_asym 18-0 / totp 20 /
oauth 44 / sign_in_events 40** all green; `_hex` parity + csrf token minting
confirmed.

## Follow-ups (stated in the guide + commit)
`hull.web._request` for the ~6 client-IP re-rolls; `email.send` → throw (+code);
the `csv.parse` / `cookie.secure` doc bugs + `idempotency` `ttl=0` footgun.
