### PR TITLE
stdlib: fix three Lua-only convention/footgun bugs (JS was already correct)

### DIFF
--- a/stdlib/lua/hull/csv.lua
+++ b/stdlib/lua/hull/csv.lua
@@ -25,8 +25,9 @@ local STATE_QUOTE_IN_QUOTED = 4
 --     instead of an array of arrays.
 --   - `separator` (string, default `","`): field delimiter.
 --   - `quote`     (string, default `'"'`): quote character.
---   - `max_rows`  (integer, default `100_000`): hard cap; rows past this
---     are silently dropped.
+--   - `max_rows`  (integer, default `100_000`): hard cap; parsing THROWS
+--     (error) if the input exceeds it. A cap breach is a failure, not a
+--     truncated success (see docs/stdlib_style.md §1).
 --
 -- @treturn table[]  Array of row arrays (or row objects if `headers=true`).
 -- @usage

--- a/stdlib/lua/hull/web/cookie.lua
+++ b/stdlib/lua/hull/web/cookie.lua
@@ -47,7 +47,8 @@ end
 --
 --   - `path`     (string, default `"/"`)
 --   - `httponly` (boolean, default `true`)
---   - `secure`   (boolean, default `false`)
+--   - `secure`   (boolean, default `true`; set `false` explicitly for local
+--                 HTTP dev). Secure-by-default matches the code.
 --   - `samesite` (string, default `"Lax"`; one of `"Lax"|"Strict"|"None"`)
 --   - `max_age`  (integer, seconds; omits attribute if `nil`)
 --   - `domain`   (string)

--- a/stdlib/lua/hull/web/middleware/idempotency.lua
+++ b/stdlib/lua/hull/web/middleware/idempotency.lua
@@ -188,7 +188,9 @@ function idempotency.middleware(opts)
     -- L-3: dropped the leading underscore — Lua convention reserves `_x`
     -- for unused locals; this counter is actively mutated below.
     local cleanup_counter = 0
-    local ttl = opts.ttl or _ttl
+    -- `~= nil` (not `or`): a caller's ttl = 0 must override the default, matching
+    -- idempotency.init (Lua 0 is truthy, so `opts.ttl or _ttl` would drop it).
+    local ttl = opts.ttl ~= nil and opts.ttl or _ttl
     local header_name = opts.header_name or _header_name
 
     -- Build methods lookup


### PR DESCRIPTION
Stdlib-review follow-up: the three **clear, safe** convention/footgun fixes from
the style guide. All three turned out to be **Lua-only** — the JS siblings
already did the right thing — so these restore Lua/JS parity:

- **`csv.parse`**: doc said rows past `max_rows` "are silently dropped" but the
  code `error()`s. A cap breach is a failure (guide §1); doc now says it throws.
- **`cookie.serialize`**: `secure` doc said default `false`, code defaults `true`
  (secure-by-default). Doc corrected. Trusting the old doc gave you Secure
  cookies that break local HTTP dev.
- **`idempotency.middleware`**: `opts.ttl or _ttl` dropped a caller's `ttl = 0`
  (Lua `0` is truthy) while `init` honored it — now consistent via `~= nil`.

lint + build clean; idempotency builds with `ttl = 0`. Small + safe.

**Remaining reconciliation (focused follow-ups):** `email.send` → throw (its
`{ok,error}` is the one genuine error-transport violation; needs the `smtp.send`
C-cap convention handled + a test) and wiring `hull.web._request` for the ~6
client-IP re-rolls.
