### PR TITLE
stdlib: centralize client-IP extraction into hull.web._request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,10 @@ jobs:
         timeout-minutes: 2
         run: make e2e-hex-parity
 
+      - name: Client-IP Lua/JS parity E2E test
+        timeout-minutes: 2
+        run: make e2e-client-ip-parity
+
       - name: Runtime slim E2E test (single-runtime app drops the other interpreter)
         timeout-minutes: 3
         run: make e2e-feature-runtime

--- a/docs/stdlib_style.md
+++ b/docs/stdlib_style.md
@@ -145,10 +145,12 @@ appears in two modules, it moves to a shared internal module:
 
 Current shared helpers: `hull.web.htmx.escape` (HTML escaping for the widgets),
 `hull.crypto.envelope` (signed token framing), `hull.web.cookie` (parse/
-serialize), and `hull.crypto._hex` (raw-byte hex - deliberately NOT
+serialize), `hull.crypto._hex` (raw-byte hex - deliberately NOT
 `crypto.hex_encode`/`hexEncode`, which UTF-8-inflates high bytes on the JS side;
-see that module). Planned: `hull.web._request` (client-IP / `trust_proxy`, which
-is still re-rolled in ~6 middleware).
+see that module), and `hull.web._request` (`client_ip(req, trust_proxy)`:
+XFF-first when trusted, `remote_addr` fallback, 64-char cap - the canonical
+source for the client IP that `session` / `audit-log` / `totp` / `auth-flows`
+each used to hand-roll subtly differently).
 
 ---
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -680,6 +680,10 @@ e2e-template-parity: $(BUILDDIR)/hull
 e2e-hex-parity: $(BUILDDIR)/hull
 	sh tests/e2e_hex_parity.sh
 
+.PHONY: e2e-client-ip-parity
+e2e-client-ip-parity: $(BUILDDIR)/hull
+	sh tests/e2e_client_ip_parity.sh
+
 e2e-agent: $(BUILDDIR)/hull
 	RUNTIME=$(RUNTIME) sh tests/e2e_agent.sh
 

--- a/stdlib/js/hull/web/_request.js
+++ b/stdlib/js/hull/web/_request.js
@@ -1,0 +1,43 @@
+/*
+ * Internal request helpers shared across the web stdlib.
+ *
+ * @module hull:web:_request
+ * @license AGPL-3.0-or-later
+ *
+ * Contributor-only (the `_` prefix): imported by other stdlib modules, never
+ * declared by apps. Centralizes request-derived values that several middleware
+ * (session, audit-log, totp, auth-flows) each extracted by hand - subtly
+ * differently. See docs/stdlib_style.md §4.
+ */
+
+/**
+ * The client's source IP, honoring a `trustProxy` policy.
+ *
+ * With `trustProxy` false (the safe default), returns the un-spoofable socket
+ * peer (`req.remote_addr`). With `trustProxy` true - only correct behind a
+ * trusted reverse proxy that sets it - returns the FIRST address of the
+ * `X-Forwarded-For` chain (the original client), trimmed, falling back to the
+ * socket peer. Capped at 64 chars (IPv6 with headroom) so a hostile
+ * multi-kilobyte XFF header can't land in an indexed column or a rate key.
+ *
+ * @param {object} req
+ * @param {boolean} [trustProxy=false]
+ * @returns {string|null}  the client IP, or null if unavailable
+ */
+function clientIp(req, trustProxy) {
+    if (!req || !req.headers) return null;
+    let ip;
+    const xff = req.headers["x-forwarded-for"];
+    if (trustProxy && typeof xff === "string" && xff !== "") {
+        const first = (xff.split(",")[0] || "").trim();
+        if (first) ip = first;
+    }
+    if (!ip && typeof req.remote_addr === "string" && req.remote_addr !== "") {
+        ip = req.remote_addr;
+    }
+    if (typeof ip === "string" && ip.length > 64) ip = ip.slice(0, 64);
+    return ip || null;
+}
+
+export const _request = { clientIp };
+export default _request;

--- a/stdlib/js/hull/web/auth-flows.js
+++ b/stdlib/js/hull/web/auth-flows.js
@@ -21,6 +21,7 @@ import { pwned }     from "hull:web:pwned";
 import { auditLog }  from "hull:web:middleware:audit-log";
 import { log }       from "hull:log";
 import { ratelimit } from "hull:web:middleware:ratelimit";
+import { _request }  from "hull:web:_request";
 import { db as dbModule } from "hull:db";
 const db = dbModule.default();
 import { time }     from "hull:time";
@@ -994,25 +995,17 @@ function registerRoutes(app) {
     if (_state.loginRatelimit) {
         const rlOpts = typeof _state.loginRatelimit === "object"
             ? _state.loginRatelimit : {};
-        // Per-IP key. X-Forwarded-For can be a chain
-        // ("client, proxy1, proxy2") when behind multiple
-        // reverse proxies; the leftmost entry is the client IP
-        // the edge proxy observed. Using the whole chain as the
-        // bucket key would let a single client with rotating
-        // downstream proxies mint a new bucket per request.
-        // Take the first comma-separated value and trim. App-
-        // supplied opts.key still wins.
+        // Per-IP key via the shared hull:web:_request helper
+        // (trustProxy -> leftmost XFF entry -> remote_addr). Using
+        // the whole XFF chain as the bucket key would let a client
+        // with rotating downstream proxies mint a new bucket per
+        // request; the leftmost entry pins it to the client the
+        // edge proxy observed. App-supplied opts.key still wins.
         const mw = ratelimit.middleware({
             limit:  rlOpts.limit  || 20,
             window: rlOpts.window || 300,
-            key:    rlOpts.key || ((req) => {
-                const xff = req.headers && req.headers["x-forwarded-for"];
-                if (_state.trustProxy && xff) {
-                    const first = xff.split(",")[0].trim();
-                    if (first) return first;
-                }
-                return req.remote_addr || "_anon";
-            }),
+            key:    rlOpts.key || ((req) =>
+                _request.clientIp(req, _state.trustProxy) || "_anon"),
         });
         app.use("POST", p + "/register", mw);
         app.use("POST", p + "/login", mw);

--- a/stdlib/js/hull/web/middleware/audit-log.js
+++ b/stdlib/js/hull/web/middleware/audit-log.js
@@ -25,6 +25,7 @@ import { time }   from "hull:time";
 import { json }   from "hull:json";
 import { app }    from "hull:app";
 import { log }    from "hull:log";
+import { _request } from "hull:web:_request";
 
 const _state = {
     retainDays: 365,
@@ -157,16 +158,11 @@ function ipPrefix(ip) {
 }
 
 function extractIp(req) {
-    if (!req || !req.headers) return null;
-    let ip;
-    const xff = req.headers["x-forwarded-for"];
-    if (_state.trustProxy && xff) ip = (xff.split(",")[0] || xff).trim();
-    else ip = req.remote_addr || null;
-    // Round-9 MEDIUM-7: cap IP. See Lua sibling.
-    if (typeof ip === "string" && ip.length > 64) {
-        ip = ip.substring(0, 64);
-    }
-    return ip;
+    // Delegates to the shared hull:web:_request helper (trustProxy ->
+    // XFF-first -> remote_addr, capped at 64 chars). This module's
+    // extractIp was the canonical implementation the helper was lifted
+    // from; see docs/stdlib_style.md section 4.
+    return _request.clientIp(req, _state.trustProxy);
 }
 
 function extractUa(req) {

--- a/stdlib/js/hull/web/middleware/session.js
+++ b/stdlib/js/hull/web/middleware/session.js
@@ -17,6 +17,7 @@ import { time } from "hull:time";
 import { json } from "hull:json";
 import { app } from "hull:app";
 import { log } from "hull:log";
+import { _request } from "hull:web:_request";
 
 let sessionTtl = 86400;
 // Round-8 MEDIUM-8: absolute (hard) TTL cap from created_at.
@@ -172,9 +173,7 @@ function create(data, opts) {
     let ip = null, ua = null;
     if (opts && opts.req) {
         const h = opts.req.headers || {};
-        const xff = h["x-forwarded-for"];
-        if (trustProxy && xff) ip = (xff.split(",")[0] || xff).trim();
-        else ip = opts.req.remote_addr || null;
+        ip = _request.clientIp(opts.req, trustProxy);
         ua = h["user-agent"] || null;
         // Real UAs top out around 500 chars; bots and scanners can
         // send 100KB UAs. Cap to bound the row size — the value is

--- a/stdlib/js/hull/web/middleware/totp.js
+++ b/stdlib/js/hull/web/middleware/totp.js
@@ -33,6 +33,7 @@ import { time }   from "hull:time";
 import { qrcode } from "hull:qrcode";
 import { app }    from "hull:app";
 import { log }    from "hull:log";
+import { _request } from "hull:web:_request";
 
 // ── Module state ───────────────────────────────────────────────────
 
@@ -557,16 +558,9 @@ function clearFailedAttemptsIp(ip) {
 let _xffWarnDone = false;
 function extractIp(req) {
     if (!req || typeof req !== "object") return null;
-    const h = req.headers || {};
-    const xff = h["x-forwarded-for"];
-    if (_state.trustXff) {
-        if (typeof xff === "string" && xff !== "") {
-            const comma = xff.indexOf(",");
-            const first = comma >= 0 ? xff.substring(0, comma) : xff;
-            const trimmed = first.trim();
-            if (trimmed !== "") return trimmed;
-        }
-    } else if (typeof xff === "string" && xff !== "" && !_xffWarnDone) {
+    const xff = (req.headers || {})["x-forwarded-for"];
+    if (!_state.trustXff && typeof xff === "string" && xff !== ""
+        && !_xffWarnDone) {
         // Round-11 MEDIUM-8: one-shot warn. See Lua sibling.
         _xffWarnDone = true;
         log.warn("totp: X-Forwarded-For seen but trustXff = false; "
@@ -575,10 +569,9 @@ function extractIp(req) {
             + "that normalizes XFF, set totp.init({trustXff: true}) "
             + "so each upstream client gets its own bucket.");
     }
-    if (typeof req.remote_addr === "string" && req.remote_addr !== "") {
-        return req.remote_addr;
-    }
-    return null;
+    // Core extraction (trustXff -> XFF-first -> remote_addr, 64-cap)
+    // via the shared hull:web:_request helper; see docs/stdlib_style.md.
+    return _request.clientIp(req, _state.trustXff);
 }
 
 // ── Public API ─────────────────────────────────────────────────────

--- a/stdlib/lua/hull/web/_request.lua
+++ b/stdlib/lua/hull/web/_request.lua
@@ -1,0 +1,46 @@
+--- Internal request helpers shared across the web stdlib.
+--
+-- @module hull.web._request
+-- @license AGPL-3.0-or-later
+--
+-- Contributor-only (the `_` prefix): required by other stdlib modules, never
+-- declared by apps. Centralizes request-derived values that several middleware
+-- (session, audit-log, totp, auth-flows) each extracted by hand - subtly
+-- differently (some capped the length, some did not; some named the trust flag
+-- `trust_proxy`, one `trust_xff`). See docs/stdlib_style.md §4.
+
+local M = {}
+
+--- The client's source IP, honoring a `trust_proxy` policy.
+--
+-- With `trust_proxy` false (the safe default), returns the un-spoofable socket
+-- peer (`req.remote_addr`). With `trust_proxy` true - only correct behind a
+-- trusted reverse proxy that sets it - returns the FIRST address of the
+-- `X-Forwarded-For` chain (the original client), whitespace-trimmed, falling
+-- back to the socket peer. Capped at 64 chars (IPv6 with headroom) so a hostile
+-- multi-kilobyte XFF header can't land in an indexed column or a rate key.
+--
+-- @tparam table req            request object
+-- @tparam[opt=false] boolean trust_proxy
+-- @treturn string|nil          the client IP, or nil if unavailable
+function M.client_ip(req, trust_proxy)
+    if not (req and req.headers) then return nil end
+    local ip
+    local xff = req.headers["x-forwarded-for"]
+    if trust_proxy and type(xff) == "string" and xff ~= "" then
+        local first = xff:match("^([^,]+)")
+        if first then
+            local trimmed = first:gsub("^%s+", ""):gsub("%s+$", "")
+            if trimmed ~= "" then ip = trimmed end
+        end
+    end
+    if not ip and type(req.remote_addr) == "string" and req.remote_addr ~= "" then
+        ip = req.remote_addr
+    end
+    if type(ip) == "string" and #ip > 64 then
+        ip = ip:sub(1, 64)
+    end
+    return ip
+end
+
+return M

--- a/stdlib/lua/hull/web/auth-flows.lua
+++ b/stdlib/lua/hull/web/auth-flows.lua
@@ -104,6 +104,7 @@ local json      = require("hull.json")
 local pwned     = require("hull.web.pwned")
 local audit_log = require("hull.web.middleware.audit-log")
 local ratelimit = require("hull.web.middleware.ratelimit")
+local _request  = require("hull.web._request")
 
 local M = {}
 
@@ -1382,23 +1383,16 @@ local function register_routes(app)
         local mw = ratelimit.middleware({
             limit  = rl_opts.limit  or 20,
             window = rl_opts.window or 300,  -- 5 min
-            -- Per-IP key. X-Forwarded-For can be a chain
-            -- ("client, proxy1, proxy2") when behind multiple
-            -- reverse proxies; the leftmost entry is the client
-            -- IP the edge proxy observed. Using the whole chain
-            -- as the bucket key would let a single client with
-            -- rotating downstream proxies mint a new bucket per
-            -- request. Take the first comma-separated value and
-            -- trim whitespace. App-supplied opts.key still wins.
+            -- Per-IP key via the shared hull.web._request helper
+            -- (trust_proxy -> leftmost XFF entry -> remote_addr). Using
+            -- the whole XFF chain as the bucket key would let a client
+            -- with rotating downstream proxies mint a new bucket per
+            -- request; taking the leftmost entry pins it to the client
+            -- the edge proxy observed. Falls back to the literal
+            -- "_anon" so a malformed request can't escape the bucket
+            -- entirely. App-supplied opts.key still wins.
             key    = rl_opts.key or function(req)
-                local xff = req.headers and req.headers["x-forwarded-for"]
-                if _state.trust_proxy and xff and xff ~= "" then
-                    local comma = xff:find(",", 1, true)
-                    local first = comma and xff:sub(1, comma - 1) or xff
-                    local trimmed = first:match("^%s*(.-)%s*$")
-                    if trimmed and trimmed ~= "" then return trimmed end
-                end
-                return req.remote_addr or "_anon"
+                return _request.client_ip(req, _state.trust_proxy) or "_anon"
             end,
         })
         app.use("POST", p .. "/register", mw)

--- a/stdlib/lua/hull/web/middleware/audit-log.lua
+++ b/stdlib/lua/hull/web/middleware/audit-log.lua
@@ -28,6 +28,7 @@ local db     = require("hull.db").default()
 local time   = require("hull.time")
 local json   = require("hull.json")
 local log    = require("hull.log")
+local _request = require("hull.web._request")
 
 local audit_log = {}
 
@@ -214,24 +215,11 @@ local function ip_prefix(ip)
 end
 
 local function extract_ip(req)
-    if not (req and req.headers) then return nil end
-    local ip
-    local xff = req.headers["x-forwarded-for"]
-    if _state.trust_proxy and xff then
-        local first = xff:match("^([^,]+)")
-        if first then
-            ip = first:gsub("^%s+", ""):gsub("%s+$", "")
-        end
-    end
-    ip = ip or req.remote_addr
-    -- Round-9 MEDIUM-7: cap IP length. Same rationale as the
-    -- session.create cap — an attacker submitting a 64 KiB XFF
-    -- header would land the whole string in the indexed _hull_
-    -- audit_log.ip column. 64 chars covers IPv6 with headroom.
-    if type(ip) == "string" and #ip > 64 then
-        ip = ip:sub(1, 64)
-    end
-    return ip
+    -- Delegates to the shared hull.web._request helper (trust_proxy ->
+    -- XFF-first -> remote_addr, capped at 64 chars). This module's
+    -- extract_ip was the canonical implementation the helper was lifted
+    -- from; see docs/stdlib_style.md section 4.
+    return _request.client_ip(req, _state.trust_proxy)
 end
 
 local function extract_ua(req)

--- a/stdlib/lua/hull/web/middleware/session.lua
+++ b/stdlib/lua/hull/web/middleware/session.lua
@@ -12,6 +12,7 @@ local json = require("hull.json")
 local crypto = require("hull.crypto")
 local db = require("hull.db").default()
 local time = require("hull.time")
+local _request = require("hull.web._request")
 
 local session = {}
 
@@ -206,12 +207,7 @@ function session.create(data, opts)
     local ip, ua
     if opts and opts.req then
         local h = opts.req.headers
-        local xff = h and h["x-forwarded-for"]
-        if _trust_proxy and xff then
-            ip = (xff:match("^([^,]+)") or xff):gsub("^%s+", ""):gsub("%s+$", "")
-        else
-            ip = opts.req.remote_addr
-        end
+        ip = _request.client_ip(opts.req, _trust_proxy)
         ua = h and h["user-agent"]
         -- Real UAs top out around 500 chars; bots and scanners can
         -- send 100KB UAs. Cap to bound the row size — the value is

--- a/stdlib/lua/hull/web/middleware/totp.lua
+++ b/stdlib/lua/hull/web/middleware/totp.lua
@@ -92,6 +92,7 @@ local crypto = require("hull.crypto")
 local db     = require("hull.db").default()
 local time   = require("hull.time")
 local qrcode = require("hull.qrcode")
+local _request = require("hull.web._request")
 
 local totp = {}
 
@@ -689,16 +690,9 @@ end
 local _xff_warn_done = false
 local function extract_ip(req)
     if type(req) ~= "table" then return nil end
-    local h = req.headers or {}
-    local xff = h["x-forwarded-for"]
-    if _state.trust_xff then
-        if type(xff) == "string" and xff ~= "" then
-            local comma = xff:find(",", 1, true)
-            local first = comma and xff:sub(1, comma - 1) or xff
-            local trimmed = first:match("^%s*(.-)%s*$")
-            if trimmed and trimmed ~= "" then return trimmed end
-        end
-    elseif type(xff) == "string" and xff ~= "" and not _xff_warn_done then
+    local xff = (req.headers or {})["x-forwarded-for"]
+    if not _state.trust_xff and type(xff) == "string" and xff ~= ""
+       and not _xff_warn_done then
         -- Round-11 MEDIUM-8: one-shot warn. trust_xff = false is
         -- the safer default against XFF spoofing on direct-exposed
         -- apps, but apps behind a proxy stripping/setting XFF would
@@ -714,10 +708,9 @@ local function extract_ip(req)
               .. "= true}) so each upstream client gets its own "
               .. "bucket.")
     end
-    if type(req.remote_addr) == "string" and req.remote_addr ~= "" then
-        return req.remote_addr
-    end
-    return nil
+    -- Core extraction (trust_xff -> XFF-first -> remote_addr, 64-cap)
+    -- via the shared hull.web._request helper; see docs/stdlib_style.md.
+    return _request.client_ip(req, _state.trust_xff)
 end
 
 -- ── Public API ─────────────────────────────────────────────────────

--- a/tests/e2e_client_ip_parity.sh
+++ b/tests/e2e_client_ip_parity.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# e2e_client_ip_parity.sh: Lua/JS parity for the shared client-IP helper.
+#
+# hull.web._request.client_ip / clientIp is the ONE home for deriving a
+# request's source IP under a trust_proxy policy (XFF-first when trusted,
+# remote_addr fallback, 64-char cap). Four middleware (session, audit-log,
+# totp, auth-flows) delegate to it; before it existed each hand-rolled the
+# extraction and they had already drifted (some capped the length, some did
+# not; some named the flag trust_proxy, one trust_xff). This asserts the two
+# runtimes agree byte-for-byte across the branch matrix, so a future re-roll
+# or drift fails CI.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+HULL="${HULL:-./build/hull}"
+[ -x "$HULL" ] || HULL="build/hull"
+WD=$(mktemp -d)
+trap 'rm -rf "$WD"' EXIT
+
+cat > "$WD/ip.lua" <<'LUA'
+local _request = require("hull.web._request")
+app.manifest({ modules = {} })
+local function s(v) return v == nil and "(nil)" or v end
+app.main(function(ctx)
+    local cases = {
+        { { headers = {}, remote_addr = "10.0.0.1" }, false },
+        { { headers = { ["x-forwarded-for"] = "1.1.1.1" }, remote_addr = "10.0.0.1" }, false },
+        { { headers = { ["x-forwarded-for"] = "a, b, c" }, remote_addr = "10.0.0.1" }, true },
+        { { headers = { ["x-forwarded-for"] = " 1.2.3.4 , x" }, remote_addr = "10.0.0.1" }, true },
+        { { headers = {}, remote_addr = "10.0.0.1" }, true },
+        { { headers = { ["x-forwarded-for"] = "" }, remote_addr = "10.0.0.1" }, true },
+        { { headers = {} }, false },
+        { { headers = {}, remote_addr = string.rep("a", 100) }, false },
+    }
+    local out = {}
+    for _, c in ipairs(cases) do out[#out + 1] = s(_request.client_ip(c[1], c[2])) end
+    out[#out + 1] = s(_request.client_ip(nil, true))
+    ctx.stdout:write(table.concat(out, "|") .. "\n"); return 0
+end)
+LUA
+
+cat > "$WD/ip.js" <<'JS'
+import { app } from "hull:app";
+import { _request } from "hull:web:_request";
+app.manifest({ modules: [] });
+const s = (v) => (v === null || v === undefined) ? "(nil)" : v;
+app.main((ctx) => {
+    const cases = [
+        [{ headers: {}, remote_addr: "10.0.0.1" }, false],
+        [{ headers: { "x-forwarded-for": "1.1.1.1" }, remote_addr: "10.0.0.1" }, false],
+        [{ headers: { "x-forwarded-for": "a, b, c" }, remote_addr: "10.0.0.1" }, true],
+        [{ headers: { "x-forwarded-for": " 1.2.3.4 , x" }, remote_addr: "10.0.0.1" }, true],
+        [{ headers: {}, remote_addr: "10.0.0.1" }, true],
+        [{ headers: { "x-forwarded-for": "" }, remote_addr: "10.0.0.1" }, true],
+        [{ headers: {} }, false],
+        [{ headers: {}, remote_addr: "a".repeat(100) }, false],
+    ];
+    const out = cases.map((c) => s(_request.clientIp(c[0], c[1])));
+    out.push(s(_request.clientIp(null, true)));
+    ctx.stdout.write(out.join("|") + "\n"); return 0;
+});
+JS
+
+lua_ip="$("$HULL" "$WD/ip.lua" 2>/dev/null | tail -1)"
+js_ip="$("$HULL" "$WD/ip.js"  2>/dev/null | tail -1)"
+
+# Expected: remote_addr / remote_addr (xff untrusted) / first-of-chain /
+# trimmed-first / remote_addr fallback / remote_addr (empty xff) / (nil) /
+# 64-char cap / (nil) for a nil req.
+cap64="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+expect="10.0.0.1|10.0.0.1|a|1.2.3.4|10.0.0.1|10.0.0.1|(nil)|${cap64}|(nil)"
+
+if [ "$lua_ip" = "$expect" ] && [ "$lua_ip" = "$js_ip" ]; then
+    echo "PASS: hull.web._request client-IP helper is byte-identical across Lua and JS"
+else
+    echo "::error client_ip DRIFT:"
+    echo "  expect=$expect"
+    echo "  lua   =$lua_ip"
+    echo "  js    =$js_ip"
+    exit 1
+fi


### PR DESCRIPTION
## What

Lifts the "derive the client IP under a `trust_proxy` policy" logic that four
middleware each hand-rolled into a single shared internal helper,
`hull.web._request` (`client_ip(req, trust_proxy)` / `clientIp(req, trustProxy)`).

This is review rec from the stdlib-wide audit (the client-IP re-roll, ~4 real
consumers). Companion to `hull.crypto._hex` (#277) and the `htmx.escape` dedup
(#276): the same "one internal `_`-prefixed helper, guarded by a cross-runtime
parity test" pattern.

## Why

The four copies had drifted:

| Consumer | trust flag | XFF-first | 64-char cap |
|---|---|---|---|
| audit-log | `trust_proxy` | yes | **yes** |
| session | `trust_proxy` | yes | no |
| totp | `trust_xff` | yes | no |
| auth-flows (ratelimit key) | `trust_proxy` | yes | no |

The helper adopts audit-log's canonical logic: XFF-first (leftmost, trimmed)
when trusted, `remote_addr` fallback, **64-char cap**. Each consumer passes its
own trust flag and keeps its own peripheral (totp's one-shot XFF misconfig
warning; auth-flows' `"_anon"` bucket fallback).

## Behavior change (breaking, in the safe direction)

`session`, `totp`, and `auth-flows` now also apply the 64-char cap. A hostile
multi-kilobyte `X-Forwarded-For` header can no longer land in an indexed column
or a rate-limit key. `audit-log` is unchanged. Both runtimes now extract
byte-identical values.

## Mechanism

`_request` is a contributor-only (`_` prefix), unregistered module: it
auto-embeds via the Makefile glob and any stdlib module can `require`/`import`
it without a registry change, exactly like `hull.crypto._hex`.

## Guardrail

`tests/e2e_client_ip_parity.sh` runs the same branch matrix (untrusted /
XFF-chain / trimmed / fallback / empty-XFF / nil-req / cap) through both
runtimes and asserts byte-identical output. Wired as `make e2e-client-ip-parity`
+ a CI step. `docs/stdlib_style.md` section 4 records `_request` as shipped.

## Validated locally

- `e2e_client_ip_parity` (new), `e2e_sign_in_events` (40/40), `e2e_auth_flows`
  (48/48), `e2e_auth_flows_2fa` (30/30), `e2e_auth_flows_hardening` (42/42) - all
  green, both runtimes.
