### PR TITLE
stdlib: email.send throws coded errors instead of returning {ok=false}

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,10 @@ jobs:
         timeout-minutes: 2
         run: make e2e-hex-parity
 
+      - name: Email error-convention Lua/JS E2E test
+        timeout-minutes: 2
+        run: make e2e-email
+
       - name: Runtime slim E2E test (single-runtime app drops the other interpreter)
         timeout-minutes: 3
         run: make e2e-feature-runtime

--- a/docs/stdlib_style.md
+++ b/docs/stdlib_style.md
@@ -45,7 +45,7 @@ boundary. Never phrase a stdlib contract in terms of HTTP status.
 | a cache `get(k)` | hit / miss / backend error | value / `nil` / **throw** |
 | `csv.parse(input)` | valid / malformed | parsed value / **throw** |
 | `validate.check(data, schema)` | valid / invalid / validator broken | `(true, {})` / `(false, findings)` / **throw** |
-| `email.send(msg)` | sent / missing arg / transport fail | receipt / **throw** / **throw** |
+| `email.send(msg)` | sent / missing arg / transport fail | `true` / **throw** / **throw** |
 
 **Validation failure ≠ validator failure.** An *invalid input* is a normal,
 successful outcome of running the validator: it returns `(false, findings)`. The

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -680,6 +680,10 @@ e2e-template-parity: $(BUILDDIR)/hull
 e2e-hex-parity: $(BUILDDIR)/hull
 	sh tests/e2e_hex_parity.sh
 
+.PHONY: e2e-email
+e2e-email: $(BUILDDIR)/hull
+	sh tests/e2e_email.sh
+
 e2e-agent: $(BUILDDIR)/hull
 	RUNTIME=$(RUNTIME) sh tests/e2e_agent.sh
 

--- a/stdlib/js/hull/email.js
+++ b/stdlib/js/hull/email.js
@@ -15,6 +15,20 @@
  * loop. SMTP uses the C `smtp.send` cap (mbedTLS + embedded Mozilla CA
  * bundle).
  *
+ * Errors: `email.send` follows the stdlib error convention
+ * (docs/stdlib_style.md section 1) — a failure to send THROWS an `Error` with a
+ * stable `.code`; success resolves to `true`. Callers that branch use
+ * try/catch:
+ *
+ *     try { await email.send(opts); }
+ *     catch (e) { log.error(String(e));    // e.code is stable
+ *         if (e.code === "delivery_failed") { ... } }
+ *
+ * Codes: `invalid_argument` (missing/invalid opts, from, to, subject, body, or a
+ * provider's required apiKey), `unknown_provider`, `delivery_failed` (the
+ * provider attempted delivery and it failed). Composes with `hull/jobs`: a
+ * `send_email` handler that calls `email.send(job.data)` retries on a throw.
+ *
  * @license AGPL-3.0-or-later
  */
 
@@ -24,11 +38,21 @@ import { json } from "hull:json";
 
 const email = {};
 
+// Throw a coded Error. e.code is the stable, branch-on identity
+// (docs/stdlib_style.md section 1).
+function emailError(code, message) {
+    const e = new Error(message);
+    e.code = code;
+    throw e;
+}
+
+// Provider adapters: each takes (opts), returns true on success, throws on
+// failure (delivery_failed / invalid_argument).
 const providers = {};
 
 providers.smtp = function(opts) {
-    // Phase 6 audit M-3: mirror the three API providers — wrap in
-    // try/catch so the {ok, error} contract is uniform across providers.
+    // smtp.send is a thin C-cap binding that keeps its own {ok,error} shape;
+    // translate a failure (thrown or {ok:false}) into the email.send throw.
     let result;
     try {
         result = smtp.send({
@@ -46,21 +70,25 @@ providers.smtp = function(opts) {
             content_type: opts.content_type || "text/plain",
         });
     } catch (e) {
-        return { ok: false, error: "smtp: " + String(e) };
+        emailError("delivery_failed", "smtp: " + String(e));
     }
-    return result;
+    if (!result || !result.ok) {
+        emailError("delivery_failed",
+            "smtp: " + ((result && result.error) || "send failed"));
+    }
+    return true;
 };
 
 providers.postmark = async function(opts) {
     if (!opts.api_key)
-        return { ok: false, error: "postmark: api_key required" };
+        emailError("invalid_argument", "postmark: api_key required");
 
     const payload = {
         From: opts.from,
         To: opts.to,
         Subject: opts.subject,
     };
-    // M-3: accept either array or string for `cc`.
+    // Accept either array or string for `cc`.
     if (Array.isArray(opts.cc))
         payload.Cc = opts.cc.join(",");
     else if (typeof opts.cc === "string")
@@ -72,8 +100,6 @@ providers.postmark = async function(opts) {
     else
         payload.TextBody = opts.body;
 
-    // M-2: trap network exceptions and return the documented {ok, error}
-    // contract rather than throwing out of email.send().
     let resp;
     try {
         resp = await httpClient.async.post(
@@ -88,18 +114,18 @@ providers.postmark = async function(opts) {
             }
         );
     } catch (e) {
-        return { ok: false, error: "postmark: " + String(e) };
+        emailError("delivery_failed", "postmark: " + String(e));
     }
     if (!resp)
-        return { ok: false, error: "postmark: no response" };
+        emailError("delivery_failed", "postmark: no response");
     if (resp.status >= 200 && resp.status < 300)
-        return { ok: true };
-    return { ok: false, error: "postmark: " + (resp.body || "unknown error") };
+        return true;
+    emailError("delivery_failed", "postmark: " + (resp.body || "unknown error"));
 };
 
 providers.sendgrid = async function(opts) {
     if (!opts.api_key)
-        return { ok: false, error: "sendgrid: api_key required" };
+        emailError("invalid_argument", "sendgrid: api_key required");
 
     const payload = {
         personalizations: [{ to: [{ email: opts.to }] }],
@@ -126,18 +152,18 @@ providers.sendgrid = async function(opts) {
             }
         );
     } catch (e) {
-        return { ok: false, error: "sendgrid: " + String(e) };
+        emailError("delivery_failed", "sendgrid: " + String(e));
     }
     if (!resp)
-        return { ok: false, error: "sendgrid: no response" };
+        emailError("delivery_failed", "sendgrid: no response");
     if (resp.status >= 200 && resp.status < 300)
-        return { ok: true };
-    return { ok: false, error: "sendgrid: " + (resp.body || "unknown error") };
+        return true;
+    emailError("delivery_failed", "sendgrid: " + (resp.body || "unknown error"));
 };
 
 providers.resend = async function(opts) {
     if (!opts.api_key)
-        return { ok: false, error: "resend: api_key required" };
+        emailError("invalid_argument", "resend: api_key required");
 
     const payload = {
         from: opts.from,
@@ -149,8 +175,7 @@ providers.resend = async function(opts) {
     else
         payload.text = opts.body;
     if (opts.reply_to) payload.reply_to = opts.reply_to;
-    // M-3: Resend accepts cc as array of strings, but accept a single
-    // string too.
+    // Resend accepts cc as an array of strings; accept a single string too.
     if (Array.isArray(opts.cc)) payload.cc = opts.cc;
     else if (typeof opts.cc === "string") payload.cc = [opts.cc];
 
@@ -167,17 +192,23 @@ providers.resend = async function(opts) {
             }
         );
     } catch (e) {
-        return { ok: false, error: "resend: " + String(e) };
+        emailError("delivery_failed", "resend: " + String(e));
     }
     if (!resp)
-        return { ok: false, error: "resend: no response" };
+        emailError("delivery_failed", "resend: no response");
     if (resp.status >= 200 && resp.status < 300)
-        return { ok: true };
-    return { ok: false, error: "resend: " + (resp.body || "unknown error") };
+        return true;
+    emailError("delivery_failed", "resend: " + (resp.body || "unknown error"));
 };
+
+const ADDR_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 /**
  * Send an email via the selected provider.
+ *
+ * Validates `from`/`to` against a simple `local@domain.tld` pattern before
+ * dispatch. THROWS an `Error` with a stable `.code` on any failure; resolves to
+ * `true` on success. See the module header for the code list.
  *
  * @param {Object} opts
  * @param {("smtp"|"postmark"|"sendgrid"|"resend")} [opts.provider="smtp"]
@@ -194,28 +225,35 @@ providers.resend = async function(opts) {
  * @param {string}   [opts.smtp_user]
  * @param {string}   [opts.smtp_pass]
  * @param {boolean}  [opts.smtp_tls=true]
- * @returns {Promise<{ok:true} | {ok:false, error:string}>}
+ * @returns {Promise<true>}  resolves true on success; throws {code} on failure.
  *
  * @example
- * const r = await email.send({
- *     provider: "postmark",
- *     from: "app@example.com", to: "user@example.com",
- *     subject: "Hi", body: "Hello!",
- *     api_key: env.get("POSTMARK_TOKEN"),
- * });
- * if (!r.ok) log.error(r.error);
+ * try {
+ *     await email.send({
+ *         provider: "postmark",
+ *         from: "app@example.com", to: "user@example.com",
+ *         subject: "Hi", body: "Hello!",
+ *         api_key: env.get("POSTMARK_TOKEN"),
+ *     });
+ * } catch (e) { log.error(String(e)); }
  */
 email.send = async function(opts) {
-    if (!opts) return { ok: false, error: "opts required" };
-    if (!opts.from) return { ok: false, error: "from required" };
-    if (!opts.to) return { ok: false, error: "to required" };
-    if (!opts.subject) return { ok: false, error: "subject required" };
-    if (!opts.body) return { ok: false, error: "body required" };
+    if (!opts) emailError("invalid_argument", "opts required");
+    if (!opts.from) emailError("invalid_argument", "from required");
+    if (!opts.to) emailError("invalid_argument", "to required");
+    if (!opts.subject) emailError("invalid_argument", "subject required");
+    if (!opts.body) emailError("invalid_argument", "body required");
+
+    // Basic email format validation (parity with the Lua module).
+    if (!ADDR_RE.test(opts.from))
+        emailError("invalid_argument", "invalid from address");
+    if (!ADDR_RE.test(opts.to))
+        emailError("invalid_argument", "invalid to address");
 
     const provider = opts.provider || "smtp";
     const fn = providers[provider];
     if (!fn)
-        return { ok: false, error: "unknown provider: " + String(provider) };
+        emailError("unknown_provider", "unknown provider: " + String(provider));
     return await fn(opts);
 };
 

--- a/stdlib/js/hull/tests/test_email.js
+++ b/stdlib/js/hull/tests/test_email.js
@@ -1,126 +1,73 @@
 // test_email.js — Tests for hull:email
 //
 // Tests field validation and provider dispatch (no network I/O).
+// email.send follows the stdlib error convention: it THROWS an Error with a
+// stable .code on failure and resolves to true on success.
 
 import { email } from "hull:email";
 
 let pass = 0;
 let fail = 0;
 
-function test(name, fn) {
+async function test(name, fn) {
     try {
-        fn();
+        await fn();
         pass++;
     } catch (e) {
         fail++;
-        print("FAIL: " + name + ": " + e.message);
+        print("FAIL: " + name + ": " + (e && e.message));
     }
 }
 
-function assertEq(a, b, msg) {
-    if (a !== b)
-        throw new Error((msg || "") + " expected " + b + ", got " + a);
+// Assert email.send(opts) throws a coded Error whose code === wantCode and
+// (optionally) whose message contains wantMsg.
+async function expectCode(name, opts, wantCode, wantMsg) {
+    await test(name, async () => {
+        let threw = null;
+        try { await email.send(opts); }
+        catch (e) { threw = e; }
+        if (!threw) throw new Error("expected a throw");
+        if (threw.code !== wantCode)
+            throw new Error("expected code " + wantCode + ", got " + threw.code);
+        if (wantMsg && String(threw).indexOf(wantMsg) === -1)
+            throw new Error("expected message to contain '" + wantMsg + "', got: " + threw);
+    });
 }
 
-// ── validation ──────────────────────────────────────────────────────
+await (async () => {
+    // ── validation ──────────────────────────────────────────────────
+    await expectCode("undefined opts throws", undefined, "invalid_argument", "opts required");
+    await expectCode("null opts throws", null, "invalid_argument", "opts required");
+    await expectCode("missing from throws",
+        { to: "x@y.com", subject: "s", body: "b" }, "invalid_argument", "from required");
+    await expectCode("missing to throws",
+        { from: "x@y.com", subject: "s", body: "b" }, "invalid_argument", "to required");
+    await expectCode("missing subject throws",
+        { from: "x@y.com", to: "y@z.com", body: "b" }, "invalid_argument", "subject required");
+    await expectCode("missing body throws",
+        { from: "x@y.com", to: "y@z.com", subject: "s" }, "invalid_argument", "body required");
+    await expectCode("invalid from address throws",
+        { from: "bad", to: "y@z.com", subject: "s", body: "b" }, "invalid_argument", "invalid from address");
+    await expectCode("invalid to address throws",
+        { from: "x@y.com", to: "bad", subject: "s", body: "b" }, "invalid_argument", "invalid to address");
 
-test("undefined opts returns error", () => {
-    const r = email.send(undefined);
-    assertEq(r.ok, false);
-    assertEq(r.error, "opts required");
-});
+    // ── provider dispatch ───────────────────────────────────────────
+    await expectCode("unknown provider throws",
+        { provider: "unknown", from: "a@b.com", to: "c@d.com", subject: "s", body: "b" },
+        "unknown_provider", "unknown provider");
 
-test("null opts returns error", () => {
-    const r = email.send(null);
-    assertEq(r.ok, false);
-    assertEq(r.error, "opts required");
-});
+    // ── api provider validation ─────────────────────────────────────
+    await expectCode("postmark requires api_key",
+        { provider: "postmark", from: "a@b.com", to: "c@d.com", subject: "s", body: "b" },
+        "invalid_argument", "api_key required");
+    await expectCode("sendgrid requires api_key",
+        { provider: "sendgrid", from: "a@b.com", to: "c@d.com", subject: "s", body: "b" },
+        "invalid_argument", "api_key required");
+    await expectCode("resend requires api_key",
+        { provider: "resend", from: "a@b.com", to: "c@d.com", subject: "s", body: "b" },
+        "invalid_argument", "api_key required");
 
-test("missing from returns error", () => {
-    const r = email.send({ to: "x@y.com", subject: "s", body: "b" });
-    assertEq(r.ok, false);
-    assertEq(r.error, "from required");
-});
-
-test("missing to returns error", () => {
-    const r = email.send({ from: "x@y.com", subject: "s", body: "b" });
-    assertEq(r.ok, false);
-    assertEq(r.error, "to required");
-});
-
-test("missing subject returns error", () => {
-    const r = email.send({ from: "x@y.com", to: "y@z.com", body: "b" });
-    assertEq(r.ok, false);
-    assertEq(r.error, "subject required");
-});
-
-test("missing body returns error", () => {
-    const r = email.send({ from: "x@y.com", to: "y@z.com", subject: "s" });
-    assertEq(r.ok, false);
-    assertEq(r.error, "body required");
-});
-
-// ── provider dispatch ───────────────────────────────────────────────
-
-test("unknown provider returns error", () => {
-    const r = email.send({
-        provider: "unknown",
-        from: "a@b.com", to: "c@d.com",
-        subject: "s", body: "b",
-    });
-    assertEq(r.ok, false);
-    if (r.error.indexOf("unknown provider") === -1)
-        throw new Error("expected 'unknown provider' in error: " + r.error);
-});
-
-test("default provider is smtp", () => {
-    // Will fail because smtp is not configured in test env, but should not
-    // error about "unknown provider"
-    const r = email.send({
-        from: "a@b.com", to: "c@d.com",
-        subject: "s", body: "b",
-        smtp_host: "localhost",
-    });
-    if (r.error && r.error.indexOf("unknown provider") !== -1)
-        throw new Error("should dispatch to smtp, not fail with unknown provider");
-});
-
-// ── api provider validation ─────────────────────────────────────────
-
-test("postmark requires api_key", () => {
-    const r = email.send({
-        provider: "postmark",
-        from: "a@b.com", to: "c@d.com",
-        subject: "s", body: "b",
-    });
-    assertEq(r.ok, false);
-    if (r.error.indexOf("api_key required") === -1)
-        throw new Error("expected api_key required error: " + r.error);
-});
-
-test("sendgrid requires api_key", () => {
-    const r = email.send({
-        provider: "sendgrid",
-        from: "a@b.com", to: "c@d.com",
-        subject: "s", body: "b",
-    });
-    assertEq(r.ok, false);
-    if (r.error.indexOf("api_key required") === -1)
-        throw new Error("expected api_key required error: " + r.error);
-});
-
-test("resend requires api_key", () => {
-    const r = email.send({
-        provider: "resend",
-        from: "a@b.com", to: "c@d.com",
-        subject: "s", body: "b",
-    });
-    assertEq(r.ok, false);
-    if (r.error.indexOf("api_key required") === -1)
-        throw new Error("expected api_key required error: " + r.error);
-});
-
-// ── results ─────────────────────────────────────────────────────────
-
-print(pass + " passed, " + fail + " failed");
-if (fail > 0) throw new Error(fail + " test(s) failed");
+    // ── results ─────────────────────────────────────────────────────
+    print(pass + " passed, " + fail + " failed");
+    if (fail > 0) throw new Error(fail + " test(s) failed");
+})();

--- a/stdlib/lua/hull/email.lua
+++ b/stdlib/lua/hull/email.lua
@@ -11,19 +11,35 @@
 -- loop. SMTP delivery goes through the C `smtp.send()` cap which handles
 -- TLS via mbedTLS and the embedded Mozilla CA bundle.
 --
+-- **Errors.** `email.send` follows the stdlib error convention
+-- (docs/stdlib_style.md section 1): a failure to send THROWS. The thrown value
+-- is a table carrying a stable `code` and a human `message` (with a `__tostring`
+-- so an uncaught throw still prints cleanly). Success returns `true`. Callers
+-- that want to branch use `pcall`:
+--
+--     local ok, err = pcall(email.send, opts)
+--     if not ok then log.error(tostring(err))   -- err.code is stable
+--         if err.code == "delivery_failed" then ... end
+--     end
+--
+-- Codes: `invalid_argument` (missing/invalid opts, from, to, subject, body, or a
+-- provider's required api_key), `unknown_provider`, `delivery_failed` (the
+-- provider attempted delivery and it failed: transport error, no response, or a
+-- non-2xx status). This composes with `hull/jobs`: a `send_email` handler that
+-- just calls `email.send(job.data)` retries automatically on a thrown failure.
+--
 -- @module hull.email
 -- @license AGPL-3.0-or-later
 -- @usage
 --   local email = require("hull.email")
---   local result = email.send({
+--   email.send({
 --       provider = "smtp",
 --       from = "app@example.com",  to = "user@example.com",
 --       subject = "Hello",         body = "Message body",
 --       smtp_host = "smtp.example.com", smtp_port = 587,
 --       smtp_user = "apikey",      smtp_pass = env.get("SMTP_PASS"),
 --       smtp_tls  = true,
---   })
---   if not result.ok then log.error(result.error) end
+--   })   -- throws on failure; returns true on success
 
 local json = require("hull.json")
 local http_client = require("hull.http-client")
@@ -31,11 +47,19 @@ local smtp = require("hull.smtp")
 
 local email = {}
 
--- Provider adapters: each takes (opts) and returns { ok, error }
+-- Throw a coded error table. __tostring keeps an uncaught throw readable;
+-- err.code is the stable, branch-on identity (docs/stdlib_style.md section 1).
+local _err_mt = { __tostring = function(e) return e.message end }
+local function email_error(code, message)
+    error(setmetatable({ code = code, message = message }, _err_mt), 0)
+end
+
+-- Provider adapters: each takes (opts), returns true on success, throws on
+-- failure (delivery_failed / invalid_argument).
 local providers = {}
 
 function providers.smtp(opts)
-    return smtp.send({
+    local r = smtp.send({
         host = opts.smtp_host,
         port = opts.smtp_port or 587,
         username = opts.smtp_user,
@@ -49,11 +73,17 @@ function providers.smtp(opts)
         body = opts.body,
         content_type = opts.content_type or "text/plain",
     })
+    -- smtp.send is a thin C-cap binding that keeps its own {ok,error} shape;
+    -- translate a failure into the email.send throw convention here.
+    if not (r and r.ok) then
+        email_error("delivery_failed", "smtp: " .. ((r and r.error) or "send failed"))
+    end
+    return true
 end
 
 function providers.postmark(opts)
     if not opts.api_key then
-        return { ok = false, error = "postmark: api_key required" }
+        email_error("invalid_argument", "postmark: api_key required")
     end
 
     local payload = {
@@ -85,20 +115,20 @@ function providers.postmark(opts)
         }
     )
     if not ok then
-        return { ok = false, error = "postmark: " .. tostring(resp) }
+        email_error("delivery_failed", "postmark: " .. tostring(resp))
     end
     if not resp then
-        return { ok = false, error = "postmark: no response" }
+        email_error("delivery_failed", "postmark: no response")
     end
     if resp.status >= 200 and resp.status < 300 then
-        return { ok = true }
+        return true
     end
-    return { ok = false, error = "postmark: " .. (resp.body or "unknown error") }
+    email_error("delivery_failed", "postmark: " .. (resp.body or "unknown error"))
 end
 
 function providers.sendgrid(opts)
     if not opts.api_key then
-        return { ok = false, error = "sendgrid: api_key required" }
+        email_error("invalid_argument", "sendgrid: api_key required")
     end
 
     local payload = {
@@ -125,20 +155,20 @@ function providers.sendgrid(opts)
         }
     )
     if not ok then
-        return { ok = false, error = "sendgrid: " .. tostring(resp) }
+        email_error("delivery_failed", "sendgrid: " .. tostring(resp))
     end
     if not resp then
-        return { ok = false, error = "sendgrid: no response" }
+        email_error("delivery_failed", "sendgrid: no response")
     end
     if resp.status >= 200 and resp.status < 300 then
-        return { ok = true }
+        return true
     end
-    return { ok = false, error = "sendgrid: " .. (resp.body or "unknown error") }
+    email_error("delivery_failed", "sendgrid: " .. (resp.body or "unknown error"))
 end
 
 function providers.resend(opts)
     if not opts.api_key then
-        return { ok = false, error = "resend: api_key required" }
+        email_error("invalid_argument", "resend: api_key required")
     end
 
     local payload = {
@@ -165,22 +195,22 @@ function providers.resend(opts)
         }
     )
     if not ok then
-        return { ok = false, error = "resend: " .. tostring(resp) }
+        email_error("delivery_failed", "resend: " .. tostring(resp))
     end
     if not resp then
-        return { ok = false, error = "resend: no response" }
+        email_error("delivery_failed", "resend: no response")
     end
     if resp.status >= 200 and resp.status < 300 then
-        return { ok = true }
+        return true
     end
-    return { ok = false, error = "resend: " .. (resp.body or "unknown error") }
+    email_error("delivery_failed", "resend: " .. (resp.body or "unknown error"))
 end
 
 --- Send an email via the selected provider.
 --
--- Always validates `from`/`to` against a simple `local@domain.tld`
--- pattern before dispatch; provider-specific errors are surfaced as
--- `{ok=false, error="<provider>: <msg>"}`.
+-- Validates `from`/`to` against a simple `local@domain.tld` pattern before
+-- dispatch. THROWS a coded error table (`.code`, `.message`) on any failure;
+-- returns `true` on success. See the module header for the code list.
 --
 -- @function email.send
 -- @tparam table opts
@@ -200,26 +230,26 @@ end
 -- @tparam[opt] string opts.smtp_user          SMTP username.
 -- @tparam[opt] string opts.smtp_pass          SMTP password.
 -- @tparam[opt=true] boolean opts.smtp_tls     Enable STARTTLS.
--- @treturn table  `{ok = true}` on success, `{ok = false, error = "..."}` on failure.
+-- @treturn boolean  `true` on success. Throws `{code, message}` on failure.
 function email.send(opts)
-    if not opts then return { ok = false, error = "opts required" } end
-    if not opts.from then return { ok = false, error = "from required" } end
-    if not opts.to then return { ok = false, error = "to required" } end
-    if not opts.subject then return { ok = false, error = "subject required" } end
-    if not opts.body then return { ok = false, error = "body required" } end
+    if not opts then email_error("invalid_argument", "opts required") end
+    if not opts.from then email_error("invalid_argument", "from required") end
+    if not opts.to then email_error("invalid_argument", "to required") end
+    if not opts.subject then email_error("invalid_argument", "subject required") end
+    if not opts.body then email_error("invalid_argument", "body required") end
 
     -- Basic email format validation
     if not opts.from:match("^[^%s@]+@[^%s@]+%.[^%s@]+$") then
-        return { ok = false, error = "invalid from address" }
+        email_error("invalid_argument", "invalid from address")
     end
     if not opts.to:match("^[^%s@]+@[^%s@]+%.[^%s@]+$") then
-        return { ok = false, error = "invalid to address" }
+        email_error("invalid_argument", "invalid to address")
     end
 
     local provider = opts.provider or "smtp"
     local fn = providers[provider]
     if not fn then
-        return { ok = false, error = "unknown provider: " .. tostring(provider) }
+        email_error("unknown_provider", "unknown provider: " .. tostring(provider))
     end
     return fn(opts)
 end

--- a/stdlib/lua/hull/tests/test_email.lua
+++ b/stdlib/lua/hull/tests/test_email.lua
@@ -1,6 +1,8 @@
 -- test_email.lua — Tests for hull.email
 --
 -- Tests field validation and provider dispatch (no network I/O).
+-- email.send follows the stdlib error convention: it THROWS a coded error
+-- table ({ code, message }) on failure and returns true on success.
 -- Run via: the C test harness (test_lua_runtime.c) loads and executes this.
 
 local email = require('hull.email')
@@ -24,94 +26,87 @@ local function assert_eq(a, b, msg)
     end
 end
 
+-- Assert email.send(opts) throws a coded error whose code == want_code and
+-- (optionally) whose message contains want_msg.
+local function expect_code(name, opts, want_code, want_msg)
+    test(name, function()
+        local ok, err = pcall(email.send, opts)
+        assert_eq(ok, false, "expected a throw")
+        assert_eq(type(err), "table", "expected an error table")
+        assert_eq(err.code, want_code, "code")
+        if want_msg then
+            assert(tostring(err):find(want_msg, 1, true),
+                   "expected message to contain '" .. want_msg .. "', got: " .. tostring(err))
+        end
+    end)
+end
+
 -- ── validation ──────────────────────────────────────────────────────
 
-test("nil opts returns error", function()
-    local r = email.send(nil)
-    assert_eq(r.ok, false)
-    assert_eq(r.error, "opts required")
-end)
+expect_code("nil opts throws", nil, "invalid_argument", "opts required")
 
-test("missing from returns error", function()
-    local r = email.send({ to = "x@y.com", subject = "s", body = "b" })
-    assert_eq(r.ok, false)
-    assert_eq(r.error, "from required")
-end)
+expect_code("missing from throws",
+    { to = "x@y.com", subject = "s", body = "b" },
+    "invalid_argument", "from required")
 
-test("missing to returns error", function()
-    local r = email.send({ from = "x@y.com", subject = "s", body = "b" })
-    assert_eq(r.ok, false)
-    assert_eq(r.error, "to required")
-end)
+expect_code("missing to throws",
+    { from = "x@y.com", subject = "s", body = "b" },
+    "invalid_argument", "to required")
 
-test("missing subject returns error", function()
-    local r = email.send({ from = "x@y.com", to = "y@z.com", body = "b" })
-    assert_eq(r.ok, false)
-    assert_eq(r.error, "subject required")
-end)
+expect_code("missing subject throws",
+    { from = "x@y.com", to = "y@z.com", body = "b" },
+    "invalid_argument", "subject required")
 
-test("missing body returns error", function()
-    local r = email.send({ from = "x@y.com", to = "y@z.com", subject = "s" })
-    assert_eq(r.ok, false)
-    assert_eq(r.error, "body required")
-end)
+expect_code("missing body throws",
+    { from = "x@y.com", to = "y@z.com", subject = "s" },
+    "invalid_argument", "body required")
+
+expect_code("invalid from address throws",
+    { from = "not-an-email", to = "y@z.com", subject = "s", body = "b" },
+    "invalid_argument", "invalid from address")
+
+expect_code("invalid to address throws",
+    { from = "x@y.com", to = "not-an-email", subject = "s", body = "b" },
+    "invalid_argument", "invalid to address")
 
 -- ── provider dispatch ───────────────────────────────────────────────
 
-test("unknown provider returns error", function()
-    local r = email.send({
-        provider = "unknown",
-        from = "a@b.com", to = "c@d.com",
-        subject = "s", body = "b",
-    })
-    assert_eq(r.ok, false)
-    assert(r.error:find("unknown provider"), "expected 'unknown provider' in error")
-end)
+expect_code("unknown provider throws",
+    { provider = "unknown", from = "a@b.com", to = "c@d.com",
+      subject = "s", body = "b" },
+    "unknown_provider", "unknown provider")
 
 test("default provider is smtp", function()
-    -- Will fail because smtp is not configured in test env, but should not
-    -- error about "unknown provider" — it dispatches to smtp adapter
-    local r = email.send({
+    -- Dispatches to the smtp adapter (which then fails because smtp is not
+    -- configured / localhost is unreachable in the test env). The failure must
+    -- NOT be unknown_provider — that would mean it never reached smtp.
+    local ok, err = pcall(email.send, {
         from = "a@b.com", to = "c@d.com",
         subject = "s", body = "b",
         smtp_host = "localhost",
     })
-    -- Should either succeed or fail with smtp-related error, not "unknown provider"
-    assert(r.error == nil or not r.error:find("unknown provider"),
-           "should dispatch to smtp, not fail with unknown provider")
+    if not ok then
+        assert(type(err) ~= "table" or err.code ~= "unknown_provider",
+               "should dispatch to smtp, not fail with unknown_provider")
+    end
 end)
 
 -- ── api provider validation ─────────────────────────────────────────
 
-test("postmark requires api_key", function()
-    local r = email.send({
-        provider = "postmark",
-        from = "a@b.com", to = "c@d.com",
-        subject = "s", body = "b",
-    })
-    assert_eq(r.ok, false)
-    assert(r.error:find("api_key required"), "expected api_key required error")
-end)
+expect_code("postmark requires api_key",
+    { provider = "postmark", from = "a@b.com", to = "c@d.com",
+      subject = "s", body = "b" },
+    "invalid_argument", "api_key required")
 
-test("sendgrid requires api_key", function()
-    local r = email.send({
-        provider = "sendgrid",
-        from = "a@b.com", to = "c@d.com",
-        subject = "s", body = "b",
-    })
-    assert_eq(r.ok, false)
-    assert(r.error:find("api_key required"), "expected api_key required error")
-end)
+expect_code("sendgrid requires api_key",
+    { provider = "sendgrid", from = "a@b.com", to = "c@d.com",
+      subject = "s", body = "b" },
+    "invalid_argument", "api_key required")
 
-test("resend requires api_key", function()
-    local r = email.send({
-        provider = "resend",
-        from = "a@b.com", to = "c@d.com",
-        subject = "s", body = "b",
-    })
-    assert_eq(r.ok, false)
-    assert(r.error:find("api_key required"), "expected api_key required error")
-end)
+expect_code("resend requires api_key",
+    { provider = "resend", from = "a@b.com", to = "c@d.com",
+      subject = "s", body = "b" },
+    "invalid_argument", "api_key required")
 
 -- ── results ─────────────────────────────────────────────────────────
 

--- a/tests/e2e_email.sh
+++ b/tests/e2e_email.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# e2e_email.sh: hull.email error-convention + Lua/JS parity.
+#
+# email.send follows the stdlib error convention (docs/stdlib_style.md section
+# 1): a failure to send THROWS a coded error (a { code, message } table in Lua,
+# an Error with .code in JS); success returns true. This runs the full
+# validation branch matrix through the real embedded module in BOTH runtimes and
+# asserts the emitted .code values are exact and identical, so a regression back
+# to {ok=false} - or a code drift - fails CI. All cases throw before any network
+# I/O, so no live server / host allowlist is needed.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+HULL="${HULL:-./build/hull}"
+[ -x "$HULL" ] || HULL="build/hull"
+WD=$(mktemp -d)
+trap 'rm -rf "$WD"' EXIT
+
+cat > "$WD/email.lua" <<'LUA'
+local email = require("hull.email")
+app.manifest({ modules = { "hull/email@1" }, hosts = {} })
+local function code(opts)
+    local ok, err = pcall(email.send, opts)
+    if ok then return "OK" end
+    if type(err) == "table" and err.code then return err.code end
+    return "ERR"
+end
+app.main(function(ctx)
+    local out = {
+        code(nil),
+        code({ to = "a@b.com", subject = "s", body = "b" }),
+        code({ from = "a@b.com", subject = "s", body = "b" }),
+        code({ from = "a@b.com", to = "c@d.com", body = "b" }),
+        code({ from = "a@b.com", to = "c@d.com", subject = "s" }),
+        code({ from = "bad", to = "c@d.com", subject = "s", body = "b" }),
+        code({ from = "a@b.com", to = "bad", subject = "s", body = "b" }),
+        code({ provider = "nope", from = "a@b.com", to = "c@d.com", subject = "s", body = "b" }),
+        code({ provider = "postmark", from = "a@b.com", to = "c@d.com", subject = "s", body = "b" }),
+    }
+    ctx.stdout:write(table.concat(out, "|") .. "\n"); return 0
+end)
+LUA
+
+cat > "$WD/email.js" <<'JS'
+import { app } from "hull:app";
+import { email } from "hull:email";
+app.manifest({ modules: ["hull/email@1"], hosts: [] });
+async function code(opts) {
+    try { await email.send(opts); return "OK"; }
+    catch (e) { return e.code || "ERR"; }
+}
+app.main(async (ctx) => {
+    const out = [];
+    out.push(await code(undefined));
+    out.push(await code({ to: "a@b.com", subject: "s", body: "b" }));
+    out.push(await code({ from: "a@b.com", subject: "s", body: "b" }));
+    out.push(await code({ from: "a@b.com", to: "c@d.com", body: "b" }));
+    out.push(await code({ from: "a@b.com", to: "c@d.com", subject: "s" }));
+    out.push(await code({ from: "bad", to: "c@d.com", subject: "s", body: "b" }));
+    out.push(await code({ from: "a@b.com", to: "bad", subject: "s", body: "b" }));
+    out.push(await code({ provider: "nope", from: "a@b.com", to: "c@d.com", subject: "s", body: "b" }));
+    out.push(await code({ provider: "postmark", from: "a@b.com", to: "c@d.com", subject: "s", body: "b" }));
+    ctx.stdout.write(out.join("|") + "\n"); return 0;
+});
+JS
+
+lua_out="$("$HULL" "$WD/email.lua" 2>/dev/null | tail -1)"
+js_out="$("$HULL" "$WD/email.js"  2>/dev/null | tail -1)"
+
+# nil opts / missing from / to / subject / body / bad-from / bad-to =>
+# invalid_argument; unknown provider => unknown_provider; missing api_key =>
+# invalid_argument.
+expect="invalid_argument|invalid_argument|invalid_argument|invalid_argument|invalid_argument|invalid_argument|invalid_argument|unknown_provider|invalid_argument"
+
+if [ "$lua_out" = "$expect" ] && [ "$lua_out" = "$js_out" ]; then
+    echo "PASS: hull.email throws coded errors, byte-identical across Lua and JS"
+else
+    echo "::error hull.email error-convention DRIFT:"
+    echo "  expect=$expect"
+    echo "  lua   =$lua_out"
+    echo "  js    =$js_out"
+    exit 1
+fi

--- a/tests/hull/runtime/js/test_js.c
+++ b/tests/hull/runtime/js/test_js.c
@@ -3473,12 +3473,11 @@ UTEST(js_stdlib, email_validation)
         "import { app } from 'hull:app';\n"
         "app.manifest({ modules: ['hull/http-client@1'] });\n"
         "import { email } from 'hull:email';\n"
-        "var r1 = await email.send(null);\n"
-        "globalThis.__test_ev1 = (r1.ok === false && r1.error === 'opts required') ? 1 : 0;\n"
-        "var r2 = await email.send({ to: 'x@y.com', subject: 's', body: 'b' });\n"
-        "globalThis.__test_ev2 = (r2.ok === false && r2.error === 'from required') ? 1 : 0;\n"
-        "var r3 = await email.send({ from: 'x@y.com', subject: 's', body: 'b' });\n"
-        "globalThis.__test_ev3 = (r3.ok === false && r3.error === 'to required') ? 1 : 0;\n";
+        "async function code(o){ try { await email.send(o); return '_ok'; } "
+        "catch (e) { return (e.code||'_nocode') + ':' + (e.message||''); } }\n"
+        "globalThis.__test_ev1 = ((await code(null)) === 'invalid_argument:opts required') ? 1 : 0;\n"
+        "globalThis.__test_ev2 = ((await code({ to: 'x@y.com', subject: 's', body: 'b' })) === 'invalid_argument:from required') ? 1 : 0;\n"
+        "globalThis.__test_ev3 = ((await code({ from: 'x@y.com', subject: 's', body: 'b' })) === 'invalid_argument:to required') ? 1 : 0;\n";
 
     JSValue val = JS_Eval(js.ctx, code, strlen(code), "<test>",
                           JS_EVAL_TYPE_MODULE);
@@ -3503,9 +3502,11 @@ UTEST(js_stdlib, email_unknown_provider)
         "import { app } from 'hull:app';\n"
         "app.manifest({ modules: ['hull/http-client@1'] });\n"
         "import { email } from 'hull:email';\n"
-        "var r = await email.send({ provider: 'foo', from: 'a@b.com', "
+        "async function code(o){ try { await email.send(o); return '_ok'; } "
+        "catch (e) { return (e.code||'_nocode') + '|' + (e.message||''); } }\n"
+        "var r = await code({ provider: 'foo', from: 'a@b.com', "
         "to: 'c@d.com', subject: 's', body: 'b' });\n"
-        "globalThis.__test_eup = (r.ok === false && r.error.indexOf('unknown provider') >= 0) ? 1 : 0;\n";
+        "globalThis.__test_eup = (r.indexOf('unknown_provider|') === 0 && r.indexOf('unknown provider') >= 0) ? 1 : 0;\n";
 
     JSValue val = JS_Eval(js.ctx, code, strlen(code), "<test>",
                           JS_EVAL_TYPE_MODULE);
@@ -3528,9 +3529,11 @@ UTEST(js_stdlib, email_api_key_required)
         "import { app } from 'hull:app';\n"
         "app.manifest({ modules: ['hull/http-client@1'] });\n"
         "import { email } from 'hull:email';\n"
-        "var r = await email.send({ provider: 'postmark', from: 'a@b.com', "
+        "async function code(o){ try { await email.send(o); return '_ok'; } "
+        "catch (e) { return (e.code||'_nocode') + '|' + (e.message||''); } }\n"
+        "var r = await code({ provider: 'postmark', from: 'a@b.com', "
         "to: 'c@d.com', subject: 's', body: 'b' });\n"
-        "globalThis.__test_eak = (r.ok === false && r.error.indexOf('api_key required') >= 0) ? 1 : 0;\n";
+        "globalThis.__test_eak = (r.indexOf('invalid_argument|') === 0 && r.indexOf('api_key required') >= 0) ? 1 : 0;\n";
 
     JSValue val = JS_Eval(js.ctx, code, strlen(code), "<test>",
                           JS_EVAL_TYPE_MODULE);


### PR DESCRIPTION
## What

Converts `email.send` (and its four provider adapters: smtp / postmark /
sendgrid / resend) from returning `{ ok = false, error = "..." }` on failure to
**throwing a coded error**, per the stdlib error convention (`docs/stdlib_style.md`
section 1). Success returns `true`.

This is the **one real error-transport violation** the stdlib-wide review
identified: everything else the census flagged (health/auth-health domain status,
jwt/envelope verifiers returning nil for an invalid token, absence -> nil) was
already conforming.

## Error codes (stable, branch-on `.code`)

| code | when |
|---|---|
| `invalid_argument` | missing/invalid `opts`, `from`, `to`, `subject`, `body`, or a provider's required `api_key` |
| `unknown_provider` | provider not registered |
| `delivery_failed` | the provider attempted delivery and it failed (transport error, no response, non-2xx status) |

Lua throws a `{ code, message }` table with a `__tostring` (an uncaught throw
still prints cleanly); JS throws an `Error` with `.code`. Callers branch via
`pcall` / try-catch.

`smtp.send` (a separate C-cap binding module) keeps its own `{ ok, error }`
shape; `providers.smtp` translates a failure into the throw at the email
boundary.

## Why (beyond convention)

- **Composes with `hull/jobs`.** A `send_email` handler that just calls
  `email.send(job.data)` now retries automatically on a thrown failure instead of
  silently swallowing `{ ok = false }`.
- **Closes a Lua/JS parity gap.** The JS module never validated the `from`/`to`
  address format the Lua one did; both now do.

## Breaking

Yes (authorized). Callers that checked `result.ok` must switch to `pcall` /
try-catch. No stdlib module consumes `hull.email` (auth-flows takes an
app-provided `email_send` callback), so the blast radius is app code + the tests.

## Coverage

Nothing in CI exercised `hull.email` before. Added **`tests/e2e_email.sh`**: runs
the full validation branch matrix through the real embedded module in **both
runtimes** and asserts the `.code` values are exact and identical (`make
e2e-email` + a CI step). Updated the three `js_stdlib.email_*` unit tests in
`test_js.c` to the throw convention. Local: `make test` 62/62, `make e2e-email`
green.
