### PR TITLE
stdlib: fix cross-runtime drift (validate, jwt) + interop parity tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,14 @@ jobs:
         timeout-minutes: 2
         run: make e2e-email
 
+      - name: Validate Lua/JS parity E2E test
+        timeout-minutes: 2
+        run: make e2e-validate-parity
+
+      - name: Token wire-format interop E2E test (jwt/envelope/csrf mint<->verify)
+        timeout-minutes: 2
+        run: make e2e-token-interop
+
       - name: Runtime slim E2E test (single-runtime app drops the other interpreter)
         timeout-minutes: 3
         run: make e2e-feature-runtime

--- a/docs/stdlib_style.md
+++ b/docs/stdlib_style.md
@@ -108,10 +108,15 @@ returns nil vs returns data" decision.
   applied, so a top-level bind fails or captures the wrong connection depending
   on require order. Acquire lazily inside `init()` / the middleware factory /
   the handler.
-- **Respect Lua's `0`/`""` truthiness.** `opts.ttl or default` silently drops a
-  caller's `ttl = 0`. Use `opts.ttl ~= nil and opts.ttl or default` (or an
-  explicit `if opts.ttl == nil then`). The same option must behave identically
-  in a module's `init` and its `middleware`.
+- **`or` defaulting differs between the runtimes — mind which value it drops.**
+  In Lua only `nil` and `false` are falsy, so `opts.x or default` keeps `0` and
+  `""` (unlike JS `||`, which drops them) but silently drops a legitimate
+  `false` — a real bug for a boolean option (`opts.secure or true` can never be
+  `false`). In JS `opts.x || default` drops `0`, `""`, AND `false`. For any
+  option whose valid values include `0`/`""`/`false`, use an explicit nil check
+  — Lua `opts.x ~= nil and opts.x or default` / `if opts.x == nil then`, JS
+  `opts.x !== undefined ? opts.x : default`. The same option must default
+  identically in a module's `init` and its `middleware`, and across runtimes.
 - **No process-global mutable state for request-scoped concerns.** A server
   handles many requests on one runtime; a module-level `active_locale` set by
   one request leaks into the next. Thread request-scoped state through `req.ctx`,

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -688,6 +688,14 @@ e2e-client-ip-parity: $(BUILDDIR)/hull
 e2e-email: $(BUILDDIR)/hull
 	sh tests/e2e_email.sh
 
+.PHONY: e2e-validate-parity
+e2e-validate-parity: $(BUILDDIR)/hull
+	sh tests/e2e_validate_parity.sh
+
+.PHONY: e2e-token-interop
+e2e-token-interop: $(BUILDDIR)/hull
+	sh tests/e2e_token_interop.sh
+
 e2e-agent: $(BUILDDIR)/hull
 	RUNTIME=$(RUNTIME) sh tests/e2e_agent.sh
 

--- a/stdlib/js/hull/jwt.js
+++ b/stdlib/js/hull/jwt.js
@@ -69,10 +69,18 @@ const secretToHex = _hex.toHex;
 function hs256SignatureB64(signingInput, secret) {
     const keyHex = secretToHex(secret);
     const sigHex = crypto.hmacSha256(signingInput, keyHex);
-    let raw = "";
-    for (let i = 0; i < sigHex.length; i += 2)
-        raw += String.fromCharCode(parseInt(sigHex.substring(i, i + 2), 16));
-    return crypto.base64urlEncode(raw);
+    // Base64url the 32 raw digest bytes via an ArrayBuffer, NOT via a JS string.
+    // Building the digest into a String (String.fromCharCode) and passing it to
+    // crypto.base64urlEncode UTF-8-inflates every byte >= 0x80 at the C boundary,
+    // so the signature differs from the Lua sibling's raw-byte base64url for
+    // essentially every token - a real HS256 cross-runtime interop break (a
+    // Lua-Hull could not verify a JS-Hull JWT and vice-versa). base64urlEncode
+    // is binary-safe for an ArrayBuffer. Guarded by tests/e2e_token_interop.sh.
+    const n = sigHex.length >> 1;
+    const u8 = new Uint8Array(n);
+    for (let i = 0; i < n; i++)
+        u8[i] = parseInt(sigHex.substring(i * 2, i * 2 + 2), 16);
+    return crypto.base64urlEncode(u8.buffer);
 }
 
 /**
@@ -210,10 +218,14 @@ function verifySignature(alg, key, signingInput, sigB64) {
  *   `[null, reason]` on failure.
  */
 function verify(token, keyOrResolver, opts) {
+    // A missing KEY is a precondition failure (you cannot verify without one) ->
+    // throw, matching the Lua sibling (docs/stdlib_style.md section 1). A
+    // missing/malformed TOKEN is untrusted input -> return [null, reason], the
+    // expected-negative outcome a verifier reports.
+    if (keyOrResolver === undefined || keyOrResolver === null)
+        throw new Error("jwt.verify: key is required");
     if (!token || typeof token !== "string")
         return [null, "invalid token"];
-    if (!keyOrResolver)
-        return [null, "key is required"];
     opts = opts || {};
     const allowed = opts.algs || ["HS256"];
 

--- a/stdlib/js/hull/validate.js
+++ b/stdlib/js/hull/validate.js
@@ -14,7 +14,25 @@
  * if (!ok) return res.status(422).json({ errors });
  */
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// Practical RFC-5322 subset. Kept byte-for-byte semantically identical to the
+// Lua sibling's email_ok (stdlib/lua/hull/validate.lua): local part starts
+// alphanumeric and allows . _ % + -, a single '@', domain starts alphanumeric
+// with at least one '.', TLD >= 2 letters. A secondary pass rejects "..",
+// leading ".", ".@", "@." which the regex alone would let through. A prior bare
+// /^[^\s@]+@[^\s@]+\.[^\s@]+$/ here was materially weaker than Lua (no length
+// cap, no ".." / dot-edge rejection, digit TLDs accepted); guarded by
+// tests/e2e_validate_parity.sh.
+const EMAIL_RE =
+    /^[A-Za-z0-9][A-Za-z0-9._+-]*@[A-Za-z0-9][A-Za-z0-9.-]*\.[A-Za-z][A-Za-z]+$/;
+
+function emailOk(s) {
+    if (typeof s !== "string") return false;
+    if (s.length > 254) return false;
+    if (!EMAIL_RE.test(s)) return false;
+    if (s.indexOf("..") !== -1) return false;
+    if (/^\./.test(s) || s.indexOf(".@") !== -1 || s.indexOf("@.") !== -1) return false;
+    return true;
+}
 
 /**
  * Validate a data object against a schema.
@@ -151,7 +169,7 @@ function check(data, schema) {
 
         // 8. email
         if (rules.email) {
-            if (typeof value !== "string" || !EMAIL_RE.test(value))
+            if (!emailOk(value))
                 err = customMsg || "is not a valid email";
         }
 

--- a/stdlib/js/hull/web/middleware/csp.js
+++ b/stdlib/js/hull/web/middleware/csp.js
@@ -45,10 +45,11 @@ function nonceB64url(nBytes) {
     nBytes = nBytes || 16;
     const ab = crypto.random(nBytes);
     if (!ab || ab.byteLength !== nBytes) return null;
-    const bytes = new Uint8Array(ab);
-    let bin = "";
-    for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
-    const b64 = crypto.base64urlEncode(bin);
+    // Base64url the ArrayBuffer directly - binary-safe. Going through a
+    // String.fromCharCode byte-string and then crypto.base64urlEncode would
+    // UTF-8-inflate every byte >= 0x80 (harmless for a per-response opaque
+    // nonce, but wasteful and the same footgun the jwt HS256 signature hit).
+    const b64 = crypto.base64urlEncode(ab);
     if (!b64) return null;
     // Defensive: strip trailing '=' if the encoder ever returns padded.
     return b64.replace(/=+$/, "");

--- a/stdlib/lua/hull/jwt.lua
+++ b/stdlib/lua/hull/jwt.lua
@@ -80,8 +80,15 @@ end
 -- @tparam string secret  HMAC-SHA256 key.
 -- @treturn string  JWT in compact form.
 function jwt.sign(payload, secret)
-    if not payload or not secret then
-        return nil, "payload and secret are required"
+    -- Minting is the trusted-caller path: a missing/wrong-typed arg is a
+    -- precondition failure (a programming bug), so throw rather than return a
+    -- nil,err tuple (docs/stdlib_style.md section 1). Matches the JS sibling,
+    -- which already threw - this was a live Lua/JS drift.
+    if type(payload) ~= "table" then
+        error("jwt.sign: payload must be a table")
+    end
+    if type(secret) ~= "string" or secret == "" then
+        error("jwt.sign: secret is required")
     end
     -- SECURITY: use a 32+ byte random HMAC key. A short (<16 byte) HS256 secret
     -- is brute-forceable. Not hard-rejected here (would break existing apps),
@@ -146,8 +153,15 @@ end
 -- @treturn ?table payload  Decoded claims on success.
 -- @treturn ?string err     Reason on failure (when payload is nil).
 function jwt.verify(token, key_or_resolver, opts)
-    if not token or not key_or_resolver then
-        return nil, "token and key are required"
+    -- A missing KEY is a precondition failure (you cannot verify without one) ->
+    -- throw. A missing/malformed TOKEN is untrusted input -> return nil, the
+    -- expected-negative outcome a verifier reports (docs/stdlib_style.md
+    -- section 1). Both runtimes behave identically.
+    if key_or_resolver == nil then
+        error("jwt.verify: key is required")
+    end
+    if type(token) ~= "string" or token == "" then
+        return nil, "invalid token"
     end
     opts = opts or {}
     local allowed = opts.algs or { "HS256" }

--- a/tests/e2e_token_interop.sh
+++ b/tests/e2e_token_interop.sh
@@ -1,0 +1,166 @@
+#!/bin/sh
+# e2e_token_interop.sh: cross-runtime wire-format interop for the shared token
+# schemes (jwt, crypto.envelope, csrf) + jwt precondition-throw parity.
+#
+# These wire formats are dual-implemented (Lua + JS) and are explicitly meant to
+# interoperate - e.g. a JS-Hull deployment must verify tokens a Lua-Hull minted
+# from the same DB/secret, and vice-versa. Nothing tested that. This mints a
+# token in one runtime and verifies it in the OTHER (both directions) for each
+# scheme, so a signing/framing drift fails CI instead of silently rejecting
+# every cross-runtime token.
+#
+# It also asserts the recently-fixed jwt precondition convention holds in BOTH
+# runtimes: jwt.sign throws on a missing arg; jwt.verify throws on a missing key
+# but returns a value for a bad token.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+HULL="${HULL:-./build/hull}"
+[ -x "$HULL" ] || HULL="build/hull"
+WD=$(mktemp -d)
+trap 'rm -rf "$WD"' EXIT
+
+# Fixed shared inputs (no shell/JS/Lua-string-special chars).
+SECRET="hull-parity-secret-0123456789abcdef"
+HEXSECRET="00112233445566778899aabbccddeeff"
+SID="session-abc-123"
+
+pass=0; fail=0
+check() { # label got want
+    if [ "$2" = "$3" ]; then pass=$((pass+1));
+    else fail=$((fail+1)); echo "  FAIL: $1: got [$2] want [$3]"; fi
+}
+run() { "$HULL" "$1" 2>/dev/null | tail -1; }
+
+# ── mint apps (quoted heredocs; secret hardcoded) ───────────────────────────
+cat > "$WD/jwt_mint.lua" <<'LUA'
+local jwt = require("hull.jwt")
+app.manifest({ modules = { "hull/jwt@1" } })
+app.main(function(ctx)
+    ctx.stdout:write(jwt.sign({ sub = "u1" }, "hull-parity-secret-0123456789abcdef") .. "\n"); return 0
+end)
+LUA
+cat > "$WD/jwt_mint.js" <<'JS'
+import { app } from "hull:app"; import { jwt } from "hull:jwt";
+app.manifest({ modules: ["hull/jwt@1"] });
+app.main((ctx) => { ctx.stdout.write(jwt.sign({ sub: "u1" }, "hull-parity-secret-0123456789abcdef") + "\n"); return 0; });
+JS
+cat > "$WD/env_mint.lua" <<'LUA'
+local env = require("hull.crypto.envelope")
+app.manifest({ modules = { "hull/crypto/envelope@1" } })
+app.main(function(ctx)
+    ctx.stdout:write(env.sign({ sub = "u1" }, "00112233445566778899aabbccddeeff") .. "\n"); return 0
+end)
+LUA
+cat > "$WD/env_mint.js" <<'JS'
+import { app } from "hull:app"; import { envelope } from "hull:crypto:envelope";
+app.manifest({ modules: ["hull/crypto/envelope@1"] });
+app.main((ctx) => { ctx.stdout.write(envelope.sign({ sub: "u1" }, "00112233445566778899aabbccddeeff") + "\n"); return 0; });
+JS
+cat > "$WD/csrf_mint.lua" <<'LUA'
+local csrf = require("hull.web.middleware.csrf")
+app.manifest({ modules = { "hull/web/middleware/csrf@1", "hull/web/cookie@1" } })
+app.main(function(ctx)
+    ctx.stdout:write(csrf.generate("session-abc-123", "hull-parity-secret-0123456789abcdef") .. "\n"); return 0
+end)
+LUA
+cat > "$WD/csrf_mint.js" <<'JS'
+import { app } from "hull:app"; import { csrf } from "hull:web:middleware:csrf";
+app.manifest({ modules: ["hull/web/middleware/csrf@1", "hull/web/cookie@1"] });
+app.main((ctx) => { ctx.stdout.write(csrf.generate("session-abc-123", "hull-parity-secret-0123456789abcdef") + "\n"); return 0; });
+JS
+
+# ── verify apps take the minted token via unquoted-heredoc interpolation ─────
+verify_jwt_lua() { cat > "$WD/vjwt.lua" <<LUA
+local jwt = require("hull.jwt")
+app.manifest({ modules = { "hull/jwt@1" } })
+app.main(function(ctx)
+    local p, err = jwt.verify("$1", "$SECRET", { algs = { "HS256" } })
+    ctx.stdout:write((p and ("OK:" .. p.sub) or ("FAIL:" .. tostring(err))) .. "\n"); return 0
+end)
+LUA
+run "$WD/vjwt.lua"; }
+verify_jwt_js() { cat > "$WD/vjwt.js" <<JS
+import { app } from "hull:app"; import { jwt } from "hull:jwt";
+app.manifest({ modules: ["hull/jwt@1"] });
+app.main((ctx) => {
+    const r = jwt.verify("$1", "$SECRET", { algs: ["HS256"] });
+    ctx.stdout.write((r[0] ? "OK:" + r[0].sub : "FAIL:" + r[1]) + "\n"); return 0;
+});
+JS
+run "$WD/vjwt.js"; }
+verify_env_lua() { cat > "$WD/venv.lua" <<LUA
+local env = require("hull.crypto.envelope")
+app.manifest({ modules = { "hull/crypto/envelope@1" } })
+app.main(function(ctx)
+    local p, err = env.verify("$1", "$HEXSECRET")
+    ctx.stdout:write((p and ("OK:" .. p.sub) or ("FAIL:" .. tostring(err))) .. "\n"); return 0
+end)
+LUA
+run "$WD/venv.lua"; }
+verify_env_js() { cat > "$WD/venv.js" <<JS
+import { app } from "hull:app"; import { envelope } from "hull:crypto:envelope";
+app.manifest({ modules: ["hull/crypto/envelope@1"] });
+app.main((ctx) => {
+    const r = envelope.verify("$1", "$HEXSECRET");
+    ctx.stdout.write((r[0] ? "OK:" + r[0].sub : "FAIL:" + r[1]) + "\n"); return 0;
+});
+JS
+run "$WD/venv.js"; }
+verify_csrf_lua() { cat > "$WD/vcsrf.lua" <<LUA
+local csrf = require("hull.web.middleware.csrf")
+app.manifest({ modules = { "hull/web/middleware/csrf@1", "hull/web/cookie@1" } })
+app.main(function(ctx)
+    ctx.stdout:write((csrf.verify("$1", "$SID", "$SECRET", 3600) and "OK" or "FAIL") .. "\n"); return 0
+end)
+LUA
+run "$WD/vcsrf.lua"; }
+verify_csrf_js() { cat > "$WD/vcsrf.js" <<JS
+import { app } from "hull:app"; import { csrf } from "hull:web:middleware:csrf";
+app.manifest({ modules: ["hull/web/middleware/csrf@1", "hull/web/cookie@1"] });
+app.main((ctx) => { ctx.stdout.write((csrf.verify("$1", "$SID", "$SECRET", 3600) ? "OK" : "FAIL") + "\n"); return 0; });
+JS
+run "$WD/vcsrf.js"; }
+
+# ── interop matrix ──────────────────────────────────────────────────────────
+check "jwt lua->js"      "$(verify_jwt_js  "$(run "$WD/jwt_mint.lua")")"  "OK:u1"
+check "jwt js->lua"      "$(verify_jwt_lua "$(run "$WD/jwt_mint.js")")"   "OK:u1"
+check "envelope lua->js" "$(verify_env_js  "$(run "$WD/env_mint.lua")")"  "OK:u1"
+check "envelope js->lua" "$(verify_env_lua "$(run "$WD/env_mint.js")")"   "OK:u1"
+check "csrf lua->js"     "$(verify_csrf_js  "$(run "$WD/csrf_mint.lua")")" "OK"
+check "csrf js->lua"     "$(verify_csrf_lua "$(run "$WD/csrf_mint.js")")"  "OK"
+
+# ── jwt precondition-throw parity ───────────────────────────────────────────
+cat > "$WD/throw.lua" <<'LUA'
+local jwt = require("hull.jwt")
+app.manifest({ modules = { "hull/jwt@1" } })
+app.main(function(ctx)
+    local s = pcall(jwt.sign, { sub = "x" }, nil) and "N" or "T"        -- sign missing secret -> throw
+    local v = pcall(jwt.verify, "a.b.c", nil) and "N" or "T"            -- verify missing key -> throw
+    -- bad token WITH a key must NOT throw (returns nil): pcall ok=true
+    local btok_ok = pcall(jwt.verify, "not-a-jwt", "k", { algs = { "HS256" } })
+    ctx.stdout:write(s .. v .. (btok_ok and "R" or "X") .. "\n"); return 0
+end)
+LUA
+cat > "$WD/throw.js" <<'JS'
+import { app } from "hull:app"; import { jwt } from "hull:jwt";
+app.manifest({ modules: ["hull/jwt@1"] });
+function threw(fn) { try { fn(); return "N"; } catch (e) { return "T"; } }
+app.main((ctx) => {
+    const s = threw(() => jwt.sign({ sub: "x" }, null));
+    const v = threw(() => jwt.verify("a.b.c", null));
+    let btokOk = true; try { jwt.verify("not-a-jwt", "k", { algs: ["HS256"] }); } catch (e) { btokOk = false; }
+    ctx.stdout.write(s + v + (btokOk ? "R" : "X") + "\n"); return 0;
+});
+JS
+# T (sign throws) T (verify-missing-key throws) R (bad-token returns, no throw)
+check "jwt throw parity lua" "$(run "$WD/throw.lua")" "TTR"
+check "jwt throw parity js"  "$(run "$WD/throw.js")"  "TTR"
+
+echo "----"
+if [ "$fail" -eq 0 ]; then
+    echo "PASS: token wire formats interoperate across Lua<->JS ($pass checks)"
+else
+    echo "::error token interop: $fail failing check(s)"; exit 1
+fi

--- a/tests/e2e_validate_parity.sh
+++ b/tests/e2e_validate_parity.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# e2e_validate_parity.sh: Lua/JS parity for hull.validate.
+#
+# The email validator had DRIFTED: the JS side was a bare
+# /^[^\s@]+@[^\s@]+\.[^\s@]+$/ while Lua enforced length <= 254, rejected "..",
+# leading/edge dots, and required a >=2-LETTER TLD. Same address validated
+# differently across runtimes - a real trust/anti-abuse gap. This runs an
+# identical case matrix (email edge cases + a few type/min/oneof cases) through
+# BOTH runtimes and asserts the pass/fail vector is exact and identical, so the
+# validators can't silently diverge again.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+HULL="${HULL:-./build/hull}"
+[ -x "$HULL" ] || HULL="build/hull"
+WD=$(mktemp -d)
+trap 'rm -rf "$WD"' EXIT
+
+cat > "$WD/v.lua" <<'LUA'
+local validate = require("hull.validate")
+app.manifest({ modules = { "hull/validate@1" } })
+local function b(v) return v and "T" or "F" end
+app.main(function(ctx)
+    local emails = {
+        "a@b.co", "bad", "a..b@x.co", ".x@y.co", "x@.y.co",
+        "user@host.123", "foo@bar.c", "A@B.CO",
+        string.rep("a", 250) .. "@x.co",
+    }
+    local out = {}
+    for _, e in ipairs(emails) do
+        out[#out + 1] = b(validate.check({ e = e }, { e = { required = true, email = true } }))
+    end
+    out[#out + 1] = b(validate.check({ n = 5 },  { n = { type = "integer", min = 1, max = 10 } }))
+    out[#out + 1] = b(validate.check({ n = 20 }, { n = { type = "integer", min = 1, max = 10 } }))
+    out[#out + 1] = b(validate.check({ s = "hi" }, { s = { oneof = { "hi", "yo" } } }))
+    out[#out + 1] = b(validate.check({ s = "no" }, { s = { oneof = { "hi", "yo" } } }))
+    ctx.stdout:write(table.concat(out, "") .. "\n"); return 0
+end)
+LUA
+
+cat > "$WD/v.js" <<'JS'
+import { app } from "hull:app";
+import { validate } from "hull:validate";
+app.manifest({ modules: ["hull/validate@1"] });
+const b = (v) => v ? "T" : "F";
+app.main((ctx) => {
+    const emails = [
+        "a@b.co", "bad", "a..b@x.co", ".x@y.co", "x@.y.co",
+        "user@host.123", "foo@bar.c", "A@B.CO",
+        "a".repeat(250) + "@x.co",
+    ];
+    let out = "";
+    for (const e of emails) {
+        out += b(validate.check({ e }, { e: { required: true, email: true } })[0]);
+    }
+    out += b(validate.check({ n: 5 },  { n: { type: "integer", min: 1, max: 10 } })[0]);
+    out += b(validate.check({ n: 20 }, { n: { type: "integer", min: 1, max: 10 } })[0]);
+    out += b(validate.check({ s: "hi" }, { s: { oneof: ["hi", "yo"] } })[0]);
+    out += b(validate.check({ s: "no" }, { s: { oneof: ["hi", "yo"] } })[0]);
+    ctx.stdout.write(out + "\n"); return 0;
+});
+JS
+
+lua_out="$("$HULL" "$WD/v.lua" 2>/dev/null | tail -1)"
+js_out="$("$HULL" "$WD/v.js"  2>/dev/null | tail -1)"
+
+# valid / invalid / dbl-dot / leading-dot / dot-at / digit-TLD / short-TLD /
+# uppercase-valid / too-long ; then int-in-range / int-out / oneof-hit / oneof-miss
+expect="TFFFFFFTFTFTF"
+
+if [ "$lua_out" = "$expect" ] && [ "$lua_out" = "$js_out" ]; then
+    echo "PASS: hull.validate is byte-identical across Lua and JS"
+else
+    echo "::error hull.validate DRIFT:"
+    echo "  expect=$expect"
+    echo "  lua   =$lua_out"
+    echo "  js    =$js_out"
+    exit 1
+fi


### PR DESCRIPTION
## What

The drift-fix batch from the stdlib review. Fixes the dual-runtime divergences
that the "written twice, held by discipline" model let slip — two the review
named, plus **a deeper jwt HS256 wire-format break the new interop test
uncovered** — and adds the interop parity tests that make the next drift fail CI.

## The three fixes

**1. `validate` email validator (real drift).** JS was a bare
`/^[^\s@]+@[^\s@]+\.[^\s@]+$/`; Lua enforced length ≤254, rejected `..` / leading
+ edge dots, and required a ≥2-**letter** TLD. `a..b@x.co`, `user@host.123`, a
300-char address all passed on JS and failed on Lua — a real anti-abuse gap. JS
now mirrors Lua's `email_ok` exactly.

**2. `jwt` preconditions (real drift + style).** Lua `jwt.sign` returned a
`(nil, err)` tuple on a missing arg while JS threw. Both runtimes now: `sign`
throws on a missing/wrong-typed arg; `verify` throws on a missing **key** (a
config precondition) but returns `nil` for a missing/malformed **token**
(untrusted input — the expected-negative a verifier reports). Conforms to the
style guide's error convention.

**3. `jwt` HS256 signatures were NOT cross-runtime interoperable (found by the
new interop test).** `jwt.js` built the 32 raw digest bytes into a JS string
(`String.fromCharCode`) then called `crypto.base64urlEncode`, which
**UTF-8-inflates every byte ≥ 0x80** at the C boundary — so a JS-Hull HS256
signature differed from Lua's raw-byte base64url for essentially every token. **A
Lua-Hull could not verify a JS-Hull JWT, and vice-versa.** Fixed by base64url-ing
the ArrayBuffer directly (binary-safe). `csp.js` had the identical
byte-string-base64url footgun for its per-response nonce (harmless — a nonce
needs no interop — but wasteful); simplified to encode the ArrayBuffer directly.

## Guardrails (the durable fix for the drift risk)

- **`tests/e2e_validate_parity.sh`** — identical case matrix through both
  runtimes; asserts a byte-identical pass/fail vector.
- **`tests/e2e_token_interop.sh`** — mints a `jwt` / `crypto.envelope` / `csrf`
  token in one runtime and verifies it in the **other** (both directions), plus
  the jwt precondition-throw parity. This is what caught fix #3.

Both wired as `make` targets + CI steps (alongside the existing template/hex/
client-IP parity tests).

## Also

Corrected style-guide footgun #2, which described JS `||` falsiness as if it were
Lua `or`. In Lua only `nil`/`false` are falsy, so `x or default` keeps `0`/`""`
(unlike JS) but drops a legitimate `false`. The guide now states each runtime's
actual behavior. (Consequently the earlier-flagged `inbox` `ttl=0` is a
non-issue — Lua's `or` already preserves `0` — so it's not touched.)

## Safety

No stdlib module consumes `hull.validate`/`jwt` in a way this breaks; the jwt
precondition throw only fires on caller bugs (missing key/secret), never on the
internal `auth.jwt_middleware` / `oauth` call sites, which always pass a key.
Local: `make test` 62/62; `e2e_jwt_asym` (18/0), `e2e_oauth` (44/0),
`e2e_auth_flows` (48/0), and both new parity tests green.

## Follow-up noted (not in this PR)

`csrf.js` statically imports `hull/web/cookie` at top-of-file, so a JS app
declaring only `hull/web/middleware/csrf` fails module resolution ("cookie not
declared") while the Lua sibling (which lazy-requires cookie) does not. That's a
registry-dep gap worth a separate small fix.
