### PR TITLE
stdlib: plumbing modules hull/uuid + hull/config (with two-gate .env)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,14 @@ jobs:
         timeout-minutes: 2
         run: make e2e-email
 
+      - name: UUID (v4/v7) E2E test
+        timeout-minutes: 2
+        run: make e2e-uuid
+
+      - name: Config (typed env + .env) Lua/JS parity E2E test
+        timeout-minutes: 2
+        run: make e2e-config-parity
+
       - name: Validate Lua/JS parity E2E test
         timeout-minutes: 2
         run: make e2e-validate-parity

--- a/include/hull/cap/env.h
+++ b/include/hull/cap/env.h
@@ -38,4 +38,20 @@ typedef struct HlEnvConfig {
  */
 const char *hl_cap_env_get(const HlEnvConfig *cfg, const char *name);
 
+/**
+ * @brief Report whether @p name is in the allowlist (regardless of whether it
+ *        is set in the process environment).
+ *
+ * Read-only introspection of the manifest allowlist — reveals membership, never
+ * a value, so it grants no new authority. Lets app code distinguish
+ * "not declared" from "declared but unset", which `hl_cap_env_get` folds
+ * together. Used by `hull/config`'s `.env` layering to apply a file value only
+ * for a name the manifest already permits.
+ *
+ * @param cfg   Env capability config.
+ * @param name  Variable name to query.
+ * @return non-zero if @p name is allowlisted, 0 otherwise.
+ */
+int hl_cap_env_allowed(const HlEnvConfig *cfg, const char *name);
+
 #endif /* HL_CAP_ENV_H */

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -688,6 +688,14 @@ e2e-client-ip-parity: $(BUILDDIR)/hull
 e2e-email: $(BUILDDIR)/hull
 	sh tests/e2e_email.sh
 
+.PHONY: e2e-uuid
+e2e-uuid: $(BUILDDIR)/hull
+	sh tests/e2e_uuid.sh
+
+.PHONY: e2e-config-parity
+e2e-config-parity: $(BUILDDIR)/hull
+	sh tests/e2e_config_parity.sh
+
 .PHONY: e2e-validate-parity
 e2e-validate-parity: $(BUILDDIR)/hull
 	sh tests/e2e_validate_parity.sh

--- a/src/hull/cap/env.c
+++ b/src/hull/cap/env.c
@@ -41,3 +41,16 @@ const char *hl_cap_env_get(const HlEnvConfig *cfg, const char *name)
     hl_audit_end(&w);
     return NULL;
 }
+
+int hl_cap_env_allowed(const HlEnvConfig *cfg, const char *name)
+{
+    if (!cfg || !name || !cfg->allowed) {
+        return 0;
+    }
+    for (int i = 0; i < cfg->count; i++) {
+        if (cfg->allowed[i] && strcmp(cfg->allowed[i], name) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}

--- a/src/hull/module_registry.c
+++ b/src/hull/module_registry.c
@@ -86,6 +86,15 @@ static const HlModuleSpec REGISTRY[] = {
         .required_caps = HL_MOD_CAP_WASM, .deps = {0},
     },
     {
+        /* Typed, fail-fast config over the env capability. The env allowlist
+         * still gates each read (config just wraps env.get). load_dotenv reads
+         * an optional .env via fs (needs manifest.fs.read) and applies only
+         * allowlisted keys, so hull/fs is a dep. */
+        .name = "hull/config",
+        .api_major = 1, .intrinsic = 0, .pure = 0,
+        .required_caps = 0, .deps = {"hull/env", "hull/fs", 0},
+    },
+    {
         .name = "hull/crypto",
         .api_major = 1, .intrinsic = 0, .pure = 0,
         .required_caps = 0, .deps = {0},
@@ -291,6 +300,13 @@ static const HlModuleSpec REGISTRY[] = {
         /* Terminal UI capability. Requires HL_ENABLE_TUI at build AND
          * tui = true in the manifest. */
         .required_caps = HL_MOD_CAP_TUI, .deps = {0},
+    },
+    {
+        /* RFC 9562 UUID v4/v7. Pure composition over crypto.random + time;
+         * no new authority. */
+        .name = "hull/uuid",
+        .api_major = 1, .intrinsic = 0, .pure = 0,
+        .required_caps = 0, .deps = {"hull/crypto", "hull/time", 0},
     },
     {
         .name = "hull/validate",

--- a/src/hull/runtime/js/mod_env.c
+++ b/src/hull/runtime/js/mod_env.c
@@ -30,6 +30,27 @@ static JSValue js_env_get(JSContext *ctx, JSValueConst this_val,
     return JS_NULL;
 }
 
+/* env.allowed(name) → boolean: is name in the manifest allowlist? (Membership
+ * only, never a value — lets callers tell "not declared" from "declared but
+ * unset", which env.get folds together. Used by hull/config.) */
+static JSValue js_env_allowed(JSContext *ctx, JSValueConst this_val,
+                              int argc, JSValueConst *argv)
+{
+    (void)this_val;
+    HlJS *js = (HlJS *)JS_GetContextOpaque(ctx);
+    if (argc < 1)
+        return JS_ThrowTypeError(ctx, "env.allowed requires (name)");
+
+    const char *name = JS_ToCString(ctx, argv[0]);
+    if (!name)
+        return JS_EXCEPTION;
+
+    int allowed = (js && js->base.env_cfg)
+        ? hl_cap_env_allowed(js->base.env_cfg, name) : 0;
+    JS_FreeCString(ctx, name);
+    return JS_NewBool(ctx, allowed);
+}
+
 static int js_env_module_init(JSContext *ctx, JSModuleDef *m)
 {
     if (hl_js_check_module_declared(ctx, "hull/env", "hull:env") != 0) return -1;
@@ -37,6 +58,8 @@ static int js_env_module_init(JSContext *ctx, JSModuleDef *m)
     JSValue env = JS_NewObject(ctx);
     JS_SetPropertyStr(ctx, env, "get",
                       JS_NewCFunction(ctx, js_env_get, "get", 1));
+    JS_SetPropertyStr(ctx, env, "allowed",
+                      JS_NewCFunction(ctx, js_env_allowed, "allowed", 1));
     JS_SetModuleExport(ctx, m, "env", env);
     return 0;
 }

--- a/src/hull/runtime/lua/mod_env.c
+++ b/src/hull/runtime/lua/mod_env.c
@@ -28,8 +28,22 @@ static int lua_env_get(lua_State *L)
     return 1;
 }
 
+/* env.allowed(name) → boolean: is name in the manifest allowlist?
+ * (Membership only, never a value — lets callers tell "not declared" from
+ * "declared but unset", which env.get folds together. Used by hull/config.) */
+static int lua_env_allowed(lua_State *L)
+{
+    HlLua *lua = get_hl_lua(L);
+    const char *name = luaL_checkstring(L, 1);
+    int allowed = (lua && lua->base.env_cfg)
+        ? hl_cap_env_allowed(lua->base.env_cfg, name) : 0;
+    lua_pushboolean(L, allowed);
+    return 1;
+}
+
 static const luaL_Reg env_funcs[] = {
     {"get", lua_env_get},
+    {"allowed", lua_env_allowed},
     {NULL, NULL}
 };
 

--- a/stdlib/js/hull/config.js
+++ b/stdlib/js/hull/config.js
@@ -1,0 +1,141 @@
+/**
+ * @file hull:config
+ * @module hull:config
+ * @description Typed application configuration over the environment. Lua parity:
+ *   `hull.config`.
+ *
+ * A thin, fail-fast layer over the `env` capability: read a setting with a type,
+ * a default, and optional required-ness instead of hand-rolling
+ * `Number(env.get("PORT")) || 8080` at every call site. The env allowlist still
+ * applies - a name must be in `manifest.env` for `env.get` to return it (an
+ * un-allowlisted name reads as absent -> default, or throws if `required`).
+ *
+ * Errors follow the stdlib convention (docs/stdlib_style.md section 1): a
+ * missing required value or an uncoercible value THROWS; a present-and-valid or
+ * absent-with-default value is returned.
+ *
+ * @license AGPL-3.0-or-later
+ * @example
+ *   import { config } from "hull:config";
+ *   const port  = config.get("PORT", { type: "integer", default: 8080 });
+ *   const dsn   = config.require("DATABASE_URL");            // throws if unset
+ *   const debug = config.get("DEBUG", { type: "boolean", default: false });
+ */
+
+import { env } from "hull:env";
+import { fs } from "hull:fs";
+
+const config = {};
+
+// Values loaded from a .env file by config.loadDotenv. ONLY names in the
+// manifest env allowlist are ever stored (see loadDotenv), so this fallback
+// can never widen what config exposes beyond manifest.env.
+const _dotenv = {};
+
+const TRUTHY = { "1": true, "true": true, "yes": true, "on": true };
+const FALSY = { "0": true, "false": true, "no": true, "off": true, "": true };
+
+function coerce(name, raw, ty) {
+    if (ty === undefined || ty === "string") return raw;
+    if (ty === "boolean") {
+        const k = raw.toLowerCase();
+        if (TRUTHY[k]) return true;
+        if (FALSY[k]) return false;
+        throw new Error("config: " + name + " is not a boolean: '" + raw + "'");
+    }
+    if (ty === "number") {
+        const n = Number(raw);
+        if (!Number.isFinite(n)) throw new Error("config: " + name + " is not a number: '" + raw + "'");
+        return n;
+    }
+    if (ty === "integer") {
+        const n = Number(raw);
+        if (!Number.isFinite(n) || !Number.isInteger(n))
+            throw new Error("config: " + name + " is not an integer: '" + raw + "'");
+        return n;
+    }
+    throw new Error("config: unknown type '" + String(ty) + "' for " + name);
+}
+
+/**
+ * Read a configuration value.
+ * @param {string} name  Environment variable name (must be in manifest.env).
+ * @param {Object} [opts]
+ * @param {("string"|"number"|"integer"|"boolean")} [opts.type="string"]
+ * @param {*} [opts.default]  Returned when absent. NOT type-coerced.
+ * @param {boolean} [opts.required=false]  Throw if the value is absent.
+ * @returns {*} The typed value, or `default` when absent.
+ */
+config.get = function(name, opts) {
+    opts = opts || {};
+    // Precedence: the real process env (allowlisted env cap) wins; a .env value
+    // (also allowlist-gated at load time) backs a declared-but-unset name; then
+    // the default.
+    let raw = env.get(name);
+    if ((raw === null || raw === undefined || raw === "") &&
+        Object.prototype.hasOwnProperty.call(_dotenv, name)) {
+        raw = _dotenv[name];
+    }
+    if (raw === null || raw === undefined || raw === "") {
+        if (opts.required)
+            throw new Error("config: required setting " + String(name) + " is not set");
+        return opts.default;
+    }
+    return coerce(name, raw, opts.type);
+};
+
+function stripQuotes(v) {
+    if (v.length >= 2) {
+        const q = v[0];
+        if ((q === '"' || q === "'") && v[v.length - 1] === q) return v.slice(1, -1);
+    }
+    return v;
+}
+
+/**
+ * Load a `.env` file so its values back declared settings. Two gates, both
+ * enforced: (1) the file is read through the `fs` capability, so the path must
+ * be in `manifest.fs.read` (a denied/missing file is a silent no-op -> 0); (2) a
+ * `KEY=value` line is applied ONLY when `KEY` is in the manifest env allowlist
+ * (`env.allowed(KEY)`), so `.env` can never introduce a value for an
+ * undeclared name. The real process env always overrides a `.env` value. Call
+ * once at startup before the first config.get.
+ *
+ * @param {string} [path=".env"]  File path (must be in manifest.fs.read).
+ * @returns {number} Number of allowlisted keys applied.
+ */
+config.loadDotenv = function(path) {
+    path = path || ".env";
+    let ab;
+    try { ab = fs.read(path); } catch (e) { return 0; }   // denied / missing
+    const bytes = new Uint8Array(ab);
+    let content = "";
+    for (let i = 0; i < bytes.length; i++) content += String.fromCharCode(bytes[i]);
+    let n = 0;
+    const lines = content.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+        let s = lines[i].trim();
+        if (s === "" || s[0] === "#") continue;
+        s = s.replace(/^export\s+/, "");
+        const eq = s.indexOf("=");
+        if (eq < 0) continue;
+        const k = s.slice(0, eq).replace(/\s+$/, "");
+        const v = stripQuotes(s.slice(eq + 1).replace(/^\s+/, ""));
+        if (k !== "" && env.allowed(k)) { _dotenv[k] = v; n++; }
+    }
+    return n;
+};
+
+/**
+ * Read a required configuration value (throws if absent).
+ * @param {string} name
+ * @param {Object} [opts]  Accepts `type` (see config.get).
+ * @returns {*} The typed value.
+ */
+config.require = function(name, opts) {
+    opts = opts || {};
+    return config.get(name, { type: opts.type, required: true });
+};
+
+export { config };
+export default config;

--- a/stdlib/js/hull/uuid.js
+++ b/stdlib/js/hull/uuid.js
@@ -1,0 +1,65 @@
+/**
+ * @file hull:uuid
+ * @module hull:uuid
+ * @description RFC 9562 UUID generation (v4 random, v7 time-ordered).
+ *   Lua parity: `hull.uuid`.
+ *
+ * Both variants are 36-char canonical strings
+ * (`xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx`, `M` the version nibble, `N` the
+ * variant). Built on `crypto.random` (CSPRNG) + `time.nowMs`; no new authority.
+ * Prefer these over ad-hoc ids from `crypto.base64urlEncode(crypto.random(16))`:
+ * canonical, externally interoperable, and v7 is lexically sortable.
+ *
+ * @license AGPL-3.0-or-later
+ * @example
+ *   import { uuid } from "hull:uuid";
+ *   const id = uuid.v7();   // time-ordered; ideal for DB primary keys
+ *   const r  = uuid.v4();   // fully random
+ */
+
+import { crypto } from "hull:crypto";
+import { time } from "hull:time";
+
+// Byte -> 2-hex-char lookup, built once.
+const HEX = new Array(256);
+for (let i = 0; i < 256; i++) HEX[i] = (i + 0x100).toString(16).slice(1);
+
+function fmt(b) {
+    return HEX[b[0]] + HEX[b[1]] + HEX[b[2]] + HEX[b[3]] + "-" +
+           HEX[b[4]] + HEX[b[5]] + "-" + HEX[b[6]] + HEX[b[7]] + "-" +
+           HEX[b[8]] + HEX[b[9]] + "-" +
+           HEX[b[10]] + HEX[b[11]] + HEX[b[12]] + HEX[b[13]] + HEX[b[14]] + HEX[b[15]];
+}
+
+/**
+ * Random (version 4) UUID.
+ * @returns {string} 36-char canonical UUID.
+ */
+function v4() {
+    const b = new Uint8Array(crypto.random(16));
+    b[6] = (b[6] & 0x0f) | 0x40;   // version 4
+    b[8] = (b[8] & 0x3f) | 0x80;   // variant 10
+    return fmt(b);
+}
+
+/**
+ * Time-ordered (version 7) UUID: 48-bit big-endian Unix-ms timestamp followed
+ * by 74 random bits. Lexically sortable by creation time - good for database
+ * primary keys.
+ * @returns {string} 36-char canonical UUID.
+ */
+function v7() {
+    const b = new Uint8Array(16);
+    // 48-bit ms timestamp, big-endian. ms exceeds 2^32, so peel bytes by
+    // division (JS bitwise ops are 32-bit and would overflow).
+    let t = time.nowMs();
+    for (let i = 5; i >= 0; i--) { b[i] = t % 256; t = Math.floor(t / 256); }
+    const r = new Uint8Array(crypto.random(10));
+    for (let i = 0; i < 10; i++) b[6 + i] = r[i];
+    b[6] = (b[6] & 0x0f) | 0x70;   // version 7
+    b[8] = (b[8] & 0x3f) | 0x80;   // variant 10
+    return fmt(b);
+}
+
+export const uuid = { v4, v7 };
+export default uuid;

--- a/stdlib/lua/hull/config.lua
+++ b/stdlib/lua/hull/config.lua
@@ -1,0 +1,147 @@
+--- Typed application configuration over the environment.
+--
+-- A thin, fail-fast layer over the `env` capability: read a setting with a
+-- type, a default, and optional required-ness, instead of hand-rolling
+-- `tonumber(env.get("PORT")) or 8080` at every call site. The env allowlist
+-- still applies - a name must be in `manifest.env` for `env.get` to return it
+-- (an un-allowlisted name reads as absent, so it falls back to the default or,
+-- if `required`, throws).
+--
+-- Errors follow the stdlib convention (docs/stdlib_style.md section 1): a
+-- missing required value or an uncoercible value THROWS; a present-and-valid or
+-- absent-with-default value is returned.
+--
+-- @module hull.config
+-- @license AGPL-3.0-or-later
+-- @usage
+--   local config = require("hull.config")
+--   local port   = config.get("PORT", { type = "integer", default = 8080 })
+--   local dsn    = config.require("DATABASE_URL")          -- throws if unset
+--   local debug  = config.get("DEBUG", { type = "boolean", default = false })
+
+local env = require("hull.env")
+local fs = require("hull.fs")
+
+local config = {}
+
+-- Values loaded from a .env file by config.load_dotenv. ONLY names that are in
+-- the manifest env allowlist are ever stored here (see load_dotenv), so falling
+-- back to this map can never widen what config exposes beyond manifest.env.
+local _dotenv = {}
+
+-- "1"/"true"/"yes"/"on" -> true; "0"/"false"/"no"/"off"/"" -> false (case-
+-- insensitive). Anything else throws (an ambiguous boolean is a config error).
+local TRUTHY = { ["1"] = true, ["true"] = true, ["yes"] = true, ["on"] = true }
+local FALSY = { ["0"] = true, ["false"] = true, ["no"] = true, ["off"] = true, [""] = true }
+
+local function coerce(name, raw, ty)
+    if ty == nil or ty == "string" then
+        return raw
+    elseif ty == "boolean" then
+        local k = raw:lower()
+        if TRUTHY[k] then return true end
+        if FALSY[k] then return false end
+        error("config: " .. name .. " is not a boolean: '" .. raw .. "'")
+    elseif ty == "number" then
+        local n = tonumber(raw)
+        if n == nil then error("config: " .. name .. " is not a number: '" .. raw .. "'") end
+        return n
+    elseif ty == "integer" then
+        local n = tonumber(raw)
+        if n == nil or n ~= math.floor(n) then
+            error("config: " .. name .. " is not an integer: '" .. raw .. "'")
+        end
+        return math.floor(n)
+    end
+    error("config: unknown type '" .. tostring(ty) .. "' for " .. name)
+end
+
+--- Read a configuration value.
+--
+-- @tparam string name  Environment variable name (must be in `manifest.env`).
+-- @tparam[opt] table opts
+--   - `type`     `"string"` (default) / `"number"` / `"integer"` / `"boolean"`.
+--   - `default`  Returned when the value is absent. NOT type-coerced (pass a
+--                real `8080`, not `"8080"`).
+--   - `required` (boolean) Throw if the value is absent (default `false`).
+-- @return The typed value, or `default` when absent.
+function config.get(name, opts)
+    opts = opts or {}
+    -- Precedence: the real process env (via the allowlisted env cap) wins; a
+    -- .env value (also allowlist-gated at load time) is a fallback for a
+    -- declared-but-unset name; then the default.
+    local raw = env.get(name)
+    if (raw == nil or raw == "") and _dotenv[name] ~= nil then
+        raw = _dotenv[name]
+    end
+    if raw == nil or raw == "" then
+        if opts.required then
+            error("config: required setting " .. tostring(name) .. " is not set")
+        end
+        return opts.default
+    end
+    return coerce(name, raw, opts.type)
+end
+
+local function strip_quotes(v)
+    if #v >= 2 then
+        local q = v:sub(1, 1)
+        if (q == '"' or q == "'") and v:sub(-1) == q then
+            return v:sub(2, -2)
+        end
+    end
+    return v
+end
+
+--- Load a `.env` file so its values back declared settings.
+--
+-- TWO gates, both enforced:
+--   1. The file is read through the `fs` capability, so the app must declare
+--      the path in `manifest.fs.read` (a denied / missing file is a silent
+--      no-op returning 0 - `.env` is optional local-dev convenience).
+--   2. A `KEY=value` line is applied ONLY when `KEY` is in the manifest env
+--      allowlist (`env.allowed(KEY)`). Keys not in `manifest.env` are ignored,
+--      so `.env` can never introduce a value for a name the manifest doesn't
+--      already permit.
+--
+-- The real process environment always overrides a `.env` value (`.env` is
+-- defaults for local dev). Call once at startup, before the first
+-- `config.get`. Parses `KEY=value`, `#` comments, blank lines, an optional
+-- `export ` prefix, and surrounding single/double quotes.
+--
+-- @tparam[opt=".env"] string path  File path (must be in `manifest.fs.read`).
+-- @treturn integer  Number of allowlisted keys applied.
+function config.load_dotenv(path)
+    path = path or ".env"
+    local content = fs.read(path)   -- (nil, err) when denied / missing
+    if not content then return 0 end
+    local n = 0
+    for line in (content .. "\n"):gmatch("([^\n]*)\n") do
+        local s = line:gsub("^%s+", ""):gsub("%s+$", "")
+        if s ~= "" and s:sub(1, 1) ~= "#" then
+            s = s:gsub("^export%s+", "")
+            local eq = s:find("=", 1, true)
+            if eq then
+                local k = (s:sub(1, eq - 1)):gsub("%s+$", "")
+                local v = strip_quotes((s:sub(eq + 1)):gsub("^%s+", ""))
+                if k ~= "" and env.allowed(k) then
+                    _dotenv[k] = v
+                    n = n + 1
+                end
+            end
+        end
+    end
+    return n
+end
+
+--- Read a required configuration value (throws if absent). Shorthand for
+-- `config.get(name, { required = true, type = opts.type })`.
+-- @tparam string name
+-- @tparam[opt] table opts  Accepts `type` (see @{config.get}).
+-- @return The typed value.
+function config.require(name, opts)
+    opts = opts or {}
+    return config.get(name, { type = opts.type, required = true })
+end
+
+return config

--- a/stdlib/lua/hull/uuid.lua
+++ b/stdlib/lua/hull/uuid.lua
@@ -1,0 +1,50 @@
+--- RFC 9562 UUID generation (v4 random, v7 time-ordered).
+--
+-- Both variants are 36-char canonical strings
+-- (`xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx`, `M` the version nibble, `N` the
+-- variant). Built on `crypto.random` (CSPRNG) + `time.now_ms`; no new
+-- authority. Apps that previously minted ad-hoc ids from
+-- `crypto.base64url_encode(crypto.random(16))` should prefer these - they are
+-- canonical, interoperable with external systems, and v7 is lexically sortable.
+--
+-- @module hull.uuid
+-- @license AGPL-3.0-or-later
+-- @usage
+--   local uuid = require("hull.uuid")
+--   local id = uuid.v7()   -- time-ordered; ideal for DB primary keys
+--   local r  = uuid.v4()   -- fully random
+
+local crypto = require("hull.crypto")
+local time = require("hull.time")
+
+local uuid = {}
+
+local FMT = "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x"
+
+--- Random (version 4) UUID.
+-- @treturn string  36-char canonical UUID.
+function uuid.v4()
+    local b = { crypto.random(16):byte(1, 16) }
+    b[7] = (b[7] & 0x0f) | 0x40   -- version 4
+    b[9] = (b[9] & 0x3f) | 0x80   -- variant 10
+    return string.format(FMT, table.unpack(b))
+end
+
+--- Time-ordered (version 7) UUID: 48-bit big-endian Unix-ms timestamp followed
+-- by 74 random bits. Lexically sortable by creation time - good for database
+-- primary keys (better index locality than v4).
+-- @treturn string  36-char canonical UUID.
+function uuid.v7()
+    local ms = time.now_ms()
+    local r = { crypto.random(10):byte(1, 10) }
+    local b = {
+        (ms >> 40) & 0xff, (ms >> 32) & 0xff, (ms >> 24) & 0xff,
+        (ms >> 16) & 0xff, (ms >> 8) & 0xff, ms & 0xff,
+        r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9], r[10],
+    }
+    b[7] = (b[7] & 0x0f) | 0x70   -- version 7
+    b[9] = (b[9] & 0x3f) | 0x80   -- variant 10
+    return string.format(FMT, table.unpack(b))
+end
+
+return uuid

--- a/tests/e2e_config_parity.sh
+++ b/tests/e2e_config_parity.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+# e2e_config_parity.sh: Lua/JS parity for hull.config (typed env config + .env).
+#
+# Phase 1 (env-only): typed coercion, defaults, required-throws, and a coercion
+# failure through both runtimes with an identical environment; asserts the
+# result vector is byte-identical.
+#
+# Phase 2 (.env): config.load_dotenv must clear BOTH gates - fs.read for the
+# file AND the manifest env allowlist per key. Asserts: an allowlisted key
+# present only in .env is served; a key in .env but NOT in manifest.env is
+# ignored; the real process env overrides a .env value; the applied-count
+# reflects only allowlisted keys. Identical across runtimes.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+HULL="${HULL:-./build/hull}"
+case "$HULL" in /*) : ;; *) HULL="$(pwd)/$HULL" ;; esac
+[ -x "$HULL" ] || HULL="$(pwd)/build/hull"
+WD=$(mktemp -d)
+trap 'rm -rf "$WD"' EXIT
+
+# ── Phase 1: env-only ───────────────────────────────────────────────────────
+cat > "$WD/c.lua" <<'LUA'
+local config = require("hull.config")
+app.manifest({ modules = { "hull/config@1" }, env = { "T_PORT", "T_DEBUG", "T_MISSING" } })
+app.main(function(ctx)
+    local out = {}
+    out[#out + 1] = tostring(config.get("T_PORT", { type = "integer", default = 1 }))
+    out[#out + 1] = tostring(config.get("T_DEBUG", { type = "boolean", default = false }))
+    out[#out + 1] = tostring(config.get("T_MISSING", { default = 42 }))
+    out[#out + 1] = (pcall(config.require, "T_MISSING")) and "N" or "T"
+    out[#out + 1] = (pcall(config.get, "T_PORT", { type = "boolean" })) and "N" or "T"
+    ctx.stdout:write(table.concat(out, "|") .. "\n"); return 0
+end)
+LUA
+cat > "$WD/c.js" <<'JS'
+import { app } from "hull:app"; import { config } from "hull:config";
+app.manifest({ modules: ["hull/config@1"], env: ["T_PORT", "T_DEBUG", "T_MISSING"] });
+function threw(fn) { try { fn(); return "N"; } catch (e) { return "T"; } }
+app.main((ctx) => {
+    const out = [];
+    out.push(String(config.get("T_PORT", { type: "integer", default: 1 })));
+    out.push(String(config.get("T_DEBUG", { type: "boolean", default: false })));
+    out.push(String(config.get("T_MISSING", { default: 42 })));
+    out.push(threw(() => config.require("T_MISSING")));
+    out.push(threw(() => config.get("T_PORT", { type: "boolean" })));
+    ctx.stdout.write(out.join("|") + "\n"); return 0;
+});
+JS
+
+lua1="$(T_PORT=8080 T_DEBUG=yes "$HULL" "$WD/c.lua" 2>/dev/null | tail -1)"
+js1="$( T_PORT=8080 T_DEBUG=yes "$HULL" "$WD/c.js"  2>/dev/null | tail -1)"
+expect1="8080|true|42|T|T"
+
+# ── Phase 2: .env (two gates) ───────────────────────────────────────────────
+# T_DSN + T_PORT are allowlisted; T_SECRET + NOT_ALLOWED are NOT.
+cat > "$WD/.env" <<'ENV'
+# a comment
+T_DSN=postgres://localhost/db
+export T_SECRET="shhh"
+NOT_ALLOWED=leak
+T_PORT=1111
+ENV
+cat > "$WD/d.lua" <<'LUA'
+local config = require("hull.config")
+app.manifest({ modules = { "hull/config@1" },
+               env = { "T_DSN", "T_PORT" },
+               fs = { read = { ".env" } } })
+app.main(function(ctx)
+    local n = config.load_dotenv()
+    local out = {
+        tostring(n),
+        config.get("T_DSN") or "nil",            -- allowlisted, only in .env
+        config.get("T_SECRET") or "nil",         -- in .env, NOT allowlisted -> nil
+        tostring(config.get("T_PORT", { type = "integer" })),  -- real env wins
+    }
+    ctx.stdout:write(table.concat(out, "|") .. "\n"); return 0
+end)
+LUA
+cat > "$WD/d.js" <<'JS'
+import { app } from "hull:app"; import { config } from "hull:config";
+app.manifest({ modules: ["hull/config@1"],
+               env: ["T_DSN", "T_PORT"],
+               fs: { read: [".env"] } });
+app.main((ctx) => {
+    const n = config.loadDotenv();
+    const out = [
+        String(n),
+        config.get("T_DSN") || "nil",
+        config.get("T_SECRET") || "nil",
+        String(config.get("T_PORT", { type: "integer" })),
+    ];
+    ctx.stdout.write(out.join("|") + "\n"); return 0;
+});
+JS
+
+# 2 allowlisted keys applied (T_DSN, T_PORT); T_DSN from .env; T_SECRET ignored
+# (not allowlisted) -> nil; T_PORT real env 9090 overrides .env 1111.
+expect2="2|postgres://localhost/db|nil|9090"
+lua2="$(cd "$WD" && T_PORT=9090 "$HULL" ./d.lua 2>/dev/null | tail -1)"
+js2="$( cd "$WD" && T_PORT=9090 "$HULL" ./d.js  2>/dev/null | tail -1)"
+
+ok=1
+[ "$lua1" = "$expect1" ] && [ "$lua1" = "$js1" ] || { ok=0; echo "::error phase1: expect=$expect1 lua=$lua1 js=$js1"; }
+[ "$lua2" = "$expect2" ] && [ "$lua2" = "$js2" ] || { ok=0; echo "::error phase2(.env): expect=$expect2 lua=$lua2 js=$js2"; }
+
+if [ "$ok" -eq 1 ]; then
+    echo "PASS: hull.config (typed env + two-gate .env) is byte-identical across Lua and JS"
+else
+    exit 1
+fi

--- a/tests/e2e_uuid.sh
+++ b/tests/e2e_uuid.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# e2e_uuid.sh: hull.uuid produces spec-valid v4/v7 UUIDs in BOTH runtimes.
+#
+# UUIDs are random so they can't be byte-compared cross-runtime; instead this
+# asserts each runtime emits canonical RFC 9562 strings with the correct version
+# nibble (4 / 7) and variant (8-b), that two v4s differ (randomness), and that
+# v7's leading 48 bits are a plausible current-time-ms prefix (sortable).
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+HULL="${HULL:-./build/hull}"
+[ -x "$HULL" ] || HULL="build/hull"
+WD=$(mktemp -d)
+trap 'rm -rf "$WD"' EXIT
+
+cat > "$WD/u.lua" <<'LUA'
+local uuid = require("hull.uuid")
+app.manifest({ modules = { "hull/uuid@1" } })
+app.main(function(ctx)
+    ctx.stdout:write(uuid.v4() .. " " .. uuid.v7() .. " " .. uuid.v4() .. " " .. uuid.v7() .. "\n"); return 0
+end)
+LUA
+cat > "$WD/u.js" <<'JS'
+import { app } from "hull:app"; import { uuid } from "hull:uuid";
+app.manifest({ modules: ["hull/uuid@1"] });
+app.main((ctx) => { ctx.stdout.write(uuid.v4() + " " + uuid.v7() + " " + uuid.v4() + " " + uuid.v7() + "\n"); return 0; });
+JS
+
+V4RE='^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+V7RE='^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+
+fails=0
+check_rt() { # runtime label, output line
+    lbl="$1"; line="$2"
+    set -- $line
+    a="$1"; b="$2"; c="$3"; d="$4"
+    echo "$a" | grep -Eq "$V4RE" || { echo "  FAIL: $lbl v4 malformed: $a"; fails=$((fails+1)); }
+    echo "$c" | grep -Eq "$V4RE" || { echo "  FAIL: $lbl v4b malformed: $c"; fails=$((fails+1)); }
+    echo "$b" | grep -Eq "$V7RE" || { echo "  FAIL: $lbl v7 malformed: $b"; fails=$((fails+1)); }
+    echo "$d" | grep -Eq "$V7RE" || { echo "  FAIL: $lbl v7b malformed: $d"; fails=$((fails+1)); }
+    [ "$a" != "$c" ] || { echo "  FAIL: $lbl two v4s identical (not random): $a"; fails=$((fails+1)); }
+    # v7 is time-ordered: the 48-bit timestamp prefix (first 13 chars, incl. the
+    # dash) is non-decreasing. Within one millisecond it ties (the random tail is
+    # NOT ordered), across a millisecond it increases.
+    pb=$(printf %s "$b" | cut -c1-13); pd=$(printf %s "$d" | cut -c1-13)
+    [ "$pb" \< "$pd" ] || [ "$pb" = "$pd" ] || { echo "  FAIL: $lbl v7 ts prefix regressed: $pb > $pd"; fails=$((fails+1)); }
+}
+
+check_rt "lua" "$("$HULL" "$WD/u.lua" 2>/dev/null | tail -1)"
+check_rt "js"  "$("$HULL" "$WD/u.js"  2>/dev/null | tail -1)"
+
+if [ "$fails" -eq 0 ]; then
+    echo "PASS: hull.uuid emits spec-valid v4/v7 in both runtimes"
+else
+    echo "::error hull.uuid: $fails failing check(s)"; exit 1
+fi

--- a/tests/hull/cap/test_env.c
+++ b/tests/hull/cap/test_env.c
@@ -88,4 +88,25 @@ UTEST(hl_cap_env, multiple_allowed)
     unsetenv("HULL_B");
 }
 
+UTEST(hl_cap_env, allowed_membership)
+{
+    const char *allowed[] = { "HULL_ALLOWED", NULL };
+    HlEnvConfig cfg = { .allowed = allowed, .count = 1 };
+
+    /* Membership only - independent of whether the var is set. */
+    ASSERT_TRUE(hl_cap_env_allowed(&cfg, "HULL_ALLOWED"));   /* declared, unset */
+    ASSERT_FALSE(hl_cap_env_allowed(&cfg, "HULL_OTHER"));    /* not declared */
+}
+
+UTEST(hl_cap_env, allowed_null_safe)
+{
+    const char *allowed[] = { "PATH", NULL };
+    HlEnvConfig cfg = { .allowed = allowed, .count = 1 };
+
+    ASSERT_FALSE(hl_cap_env_allowed(NULL, "PATH"));
+    ASSERT_FALSE(hl_cap_env_allowed(&cfg, NULL));
+    HlEnvConfig empty = { .allowed = NULL, .count = 0 };
+    ASSERT_FALSE(hl_cap_env_allowed(&empty, "PATH"));
+}
+
 UTEST_MAIN();


### PR DESCRIPTION
## What

The first two "plumbing every app re-writes" gaps from the stdlib review, as
clean dual-runtime modules with cross-runtime parity tests.

### `hull/uuid`
RFC 9562 UUID **v4** (random) and **v7** (time-ordered — lexically sortable,
good for DB primary keys). Pure composition over `crypto.random` + `time`; no
new authority. Replaces the ad-hoc `crypto.base64url_encode(crypto.random(16))`
id-minting scattered across `jobs`/auth with canonical, externally
interoperable ids.

```lua
local uuid = require("hull.uuid")
local id = uuid.v7()   -- time-ordered
```

### `hull/config`
Typed, fail-fast configuration over the `env` capability — stop hand-rolling
`tonumber(env.get("PORT")) or 8080`:

```lua
local port  = config.get("PORT", { type = "integer", default = 8080 })
local dsn   = config.require("DATABASE_URL")          -- throws if unset
local debug = config.get("DEBUG", { type = "boolean", default = false })
```

Coercion (`string`/`number`/`integer`/`boolean`) and a missing-`required` value
**throw** per the stdlib error convention; the env allowlist still gates every
read.

### `.env` support — behind **both** gates (as requested)
`config.load_dotenv([path])` is opt-in and enforces two independent gates:
1. **fs gate** — the file is read through the `fs` capability, so the app must
   declare the path in `manifest.fs.read` (a denied/missing file is a silent
   no-op → `0`).
2. **env-allowlist gate** — a `KEY=value` line is applied **only when `KEY` is in
   `manifest.env`**, so `.env` can never introduce a value for a name the
   manifest doesn't already permit.

The real process env always overrides a `.env` value (`.env` = local-dev
defaults). Parses comments, blank lines, `export `, and quoted values.

## New cap: `env.allowed(name)`

Enforcing gate (2) requires telling "declared but unset" from "not declared",
which `env.get` deliberately folds together. So this adds a tiny read-only
`hl_cap_env_allowed(cfg, name)` → `env.allowed(name)` in both runtimes. It
reveals **allowlist membership only, never a value** — no new authority — and is
independently useful (probe whether an optional env is configured).

## Tests

- `e2e_uuid.sh` — spec-valid v4/v7 + correct version/variant + v7 timestamp-prefix
  monotonicity, both runtimes.
- `e2e_config_parity.sh` — typed coercion / defaults / required-throws, and the
  full two-gate `.env` matrix (allowlisted-only-in-file served;
  non-allowlisted-in-file ignored; real-env-overrides-file). Byte-identical
  across runtimes.
- Two `hl_cap_env` unit tests for `env.allowed`.

Both e2e wired as `make` targets + CI steps. Local: `make test` 62/62; both new
e2e green.

## Remaining plumbing (follow-ups)

`hull/retry` (HTTP backoff — also de-dups the copy-pasted backoff math in
`jobs`/`outbox`) and `log.with{fields}` (contextual logging — needs a decision on
extending the C `hull.log` module vs a wrapper).
