### PR TITLE
stdlib: plumbing modules hull/retry + hull/logx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,14 @@ jobs:
         timeout-minutes: 2
         run: make e2e-config-parity
 
+      - name: Retry (generic backoff) Lua/JS parity E2E test
+        timeout-minutes: 2
+        run: make e2e-retry
+
+      - name: Logx (contextual logging) Lua/JS parity E2E test
+        timeout-minutes: 2
+        run: make e2e-logx-parity
+
       - name: Validate Lua/JS parity E2E test
         timeout-minutes: 2
         run: make e2e-validate-parity

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -696,6 +696,14 @@ e2e-uuid: $(BUILDDIR)/hull
 e2e-config-parity: $(BUILDDIR)/hull
 	sh tests/e2e_config_parity.sh
 
+.PHONY: e2e-retry
+e2e-retry: $(BUILDDIR)/hull
+	sh tests/e2e_retry.sh
+
+.PHONY: e2e-logx-parity
+e2e-logx-parity: $(BUILDDIR)/hull
+	sh tests/e2e_logx_parity.sh
+
 .PHONY: e2e-validate-parity
 e2e-validate-parity: $(BUILDDIR)/hull
 	sh tests/e2e_validate_parity.sh

--- a/src/hull/module_registry.c
+++ b/src/hull/module_registry.c
@@ -235,6 +235,13 @@ static const HlModuleSpec REGISTRY[] = {
         .required_caps = 0, .deps = {0},
     },
     {
+        /* Contextual logging: logx.with{fields} binds logfmt fields onto a
+         * child logger over hull/log. Pure Lua/JS, no new authority. */
+        .name = "hull/logx",
+        .api_major = 1, .intrinsic = 0, .pure = 0,
+        .required_caps = 0, .deps = {"hull/log", 0},
+    },
+    {
         /* Content-MIME sniffer. Thin binding around hl_cap_mime_sniff:
          * mime.sniff(bytes) returns the sniffed MIME string or nil.
          * Pure — no fs/network/db access — usable in CLI tools as
@@ -254,6 +261,14 @@ static const HlModuleSpec REGISTRY[] = {
         .name = "hull/qrcode",
         .api_major = 1, .intrinsic = 0, .pure = 1,
         .required_caps = 0, .deps = {0},
+    },
+    {
+        /* Generic retry-with-backoff for any fallible op (http/compute/gpu/db).
+         * retry.run(fn, opts) + retry.backoff. Sleeps via the hull.sleep
+         * intrinsic; crypto is used only for optional jitter. */
+        .name = "hull/retry",
+        .api_major = 1, .intrinsic = 0, .pure = 0,
+        .required_caps = 0, .deps = {"hull/crypto", 0},
     },
     {
         .name = "hull/search",

--- a/stdlib/js/hull/logx.js
+++ b/stdlib/js/hull/logx.js
@@ -1,0 +1,86 @@
+/**
+ * @file hull:logx
+ * @module hull:logx
+ * @description Contextual logging: bind a set of fields once, log them on every
+ *   line. Lua parity: `hull.logx`.
+ *
+ * A thin, pure layer over the built-in `hull:log`. `logx.with({...})` returns a
+ * child logger whose info/warn/error/debug append the bound fields to the
+ * message in logfmt form (`key=value`, quoted when needed), so per-request
+ * context rides every line without threading it through every call.
+ *
+ *     import { logx } from "hull:logx";
+ *     const rl = logx.with({ requestId: id, user: uid });
+ *     rl.info("handled");    // -> "handled requestId=... user=..."
+ *     rl.with({ step: 2 }).warn("slow");  // children compose
+ *
+ * CAVEAT (source tag): hull:log tags each line by the CALLER's source, and the
+ * two runtimes resolve that differently for a wrapped call. In JS a wrapper line
+ * tags [hull:js] (QuickJS reports the immediate module, hull:logx); in Lua it
+ * stays [app]. Message + fields are identical either way - only the JS source
+ * tag shifts. When you need a guaranteed [app] tag in BOTH runtimes, use the
+ * escape hatch: log.info("handled" + logx.fields({...})) - the app calls log
+ * directly, so the tag stays [app]. (A future C-level log.with would make the
+ * bound logger tag [app] in JS too.)
+ *
+ * @license AGPL-3.0-or-later
+ */
+
+import { log } from "hull:log";
+
+const logx = {};
+
+const LEVELS = ["info", "warn", "error", "debug"];
+
+// Format a fields object as a leading-space logfmt fragment " k=v k2=v2". Keys
+// sorted for deterministic, cross-runtime-identical output. A value containing
+// whitespace, a quote, or '=' is double-quoted with '"' escaped.
+function fmt(fields) {
+    if (!fields) return "";
+    const keys = Object.keys(fields).sort();
+    if (keys.length === 0) return "";
+    const parts = [];
+    for (let i = 0; i < keys.length; i++) {
+        const k = keys[i];
+        const v = fields[k];
+        let s = (typeof v === "boolean") ? (v ? "true" : "false") : String(v);
+        if (/[\s"=]/.test(s)) s = '"' + s.replace(/"/g, '\\"') + '"';
+        parts.push(k + "=" + s);
+    }
+    return " " + parts.join(" ");
+}
+
+/**
+ * Format a fields object into a leading-space logfmt fragment. Escape hatch for
+ * keeping the [app] source tag: log.info("msg" + logx.fields({...})).
+ * @param {Object} [fields]
+ * @returns {string} e.g. " requestId=abc user=42" ("" for no fields).
+ */
+logx.fields = function(fields) {
+    return fmt(fields);
+};
+
+function make(fields) {
+    const self = {};
+    for (let i = 0; i < LEVELS.length; i++) {
+        const lvl = LEVELS[i];
+        self[lvl] = (msg) => log[lvl](String(msg == null ? "" : msg) + fmt(fields));
+    }
+    self.with = (more) => make(Object.assign({}, fields, more || {}));
+    return self;
+}
+
+/**
+ * Create a bound logger carrying `fields`.
+ * @param {Object} [fields]
+ * @returns {Object} A logger with info/warn/error/debug and with().
+ */
+logx.with = function(fields) {
+    return make(fields || {});
+};
+
+// Bare pass-throughs (no bound fields), so logx can stand in for log.
+for (let i = 0; i < LEVELS.length; i++) logx[LEVELS[i]] = log[LEVELS[i]];
+
+export { logx };
+export default logx;

--- a/stdlib/js/hull/retry.js
+++ b/stdlib/js/hull/retry.js
@@ -1,0 +1,95 @@
+/**
+ * @file hull:retry
+ * @module hull:retry
+ * @description Generic retry-with-backoff for any fallible operation. Lua
+ *   parity: `hull.retry`.
+ *
+ * `retry.run(fn, opts)` calls `fn` and retries it on failure with exponential
+ * backoff. `fn` is ARBITRARY - it may return a Promise (`http.fetch`,
+ * `compute.async.call`, `gpu.async.dispatch`, `db.async.*`) or a plain value.
+ * No HTTP coupling: wrap a fetch (`retry.run(() => http.fetch(url), {...})`); the
+ * same shape retries a WASM/GPU dispatch or a DB query. `run` is async and
+ * `await`s `fn`; it sleeps between attempts via `hull.sleep`, so it must run on
+ * the event-loop thread (a handler, `app.main`, a timer).
+ *
+ * Failure = `fn` throwing/rejecting, OR (when `opts.retryOn` is given) `fn`
+ * resolving to a value the predicate flags as retryable.
+ *
+ * @license AGPL-3.0-or-later
+ * @example
+ *   import { retry } from "hull:retry";
+ *   const res = await retry.run(() => http.fetch(url), {
+ *       maxAttempts: 4,
+ *       retryOn: (r) => r.status >= 500 || r.status === 429,
+ *   });
+ *   const out = await retry.run(() => gpu.async.dispatch("scan", opts));
+ */
+
+import { crypto } from "hull:crypto";
+
+const retry = {};
+
+const DEFAULTS = { maxAttempts: 3, baseMs: 100, factor: 2, capMs: 30000 };
+
+/**
+ * Backoff delay (ms) for a 1-based attempt: `base * factor^(n-1)`, clamped to
+ * `cap`, with optional full jitter (uniform in `[0, delay)`).
+ * @param {number} attempt  1-based attempt number.
+ * @param {Object} [opts]  `baseMs` (100), `factor` (2), `capMs` (30000),
+ *   `jitter` (boolean, default false).
+ * @returns {number} Delay in milliseconds.
+ */
+retry.backoff = function(attempt, opts) {
+    opts = opts || {};
+    const base = opts.baseMs || DEFAULTS.baseMs;
+    const factor = opts.factor || DEFAULTS.factor;
+    const cap = opts.capMs || DEFAULTS.capMs;
+    let d = base * Math.pow(factor, attempt - 1);
+    if (d > cap) d = cap;
+    if (opts.jitter) {
+        const b = new Uint8Array(crypto.random(4));
+        const u = ((b[0] * 256 + b[1]) * 256 + b[2]) * 256 + b[3];
+        d = d * (u / 4294967296);   // uniform in [0, d)
+    }
+    return Math.floor(d);
+};
+
+/**
+ * Run `fn` with retries.
+ * @param {Function} fn  The operation (may return a Promise). Its resolved value
+ *   is passed through on success; a throw/reject or a `retryOn`-flagged result
+ *   triggers a retry.
+ * @param {Object} [opts]
+ *   - `maxAttempts` (default 3) total attempts incl. the first.
+ *   - `baseMs` / `factor` / `capMs` / `jitter` - see backoff.
+ *   - `retryOn(result) -> boolean` - retry on a "bad" success value.
+ *   - `retryOnError(err) -> boolean` - return false to re-throw immediately (no retry).
+ *   - `onRetry(attempt, ok, value)` - called before each backoff sleep.
+ * @returns {Promise<*>} The successful (or last) result; re-throws the last
+ *   error if all attempts threw.
+ */
+retry.run = async function(fn, opts) {
+    opts = opts || {};
+    const max = opts.maxAttempts || DEFAULTS.maxAttempts;
+    let lastOk = false, lastVal;
+    for (let attempt = 1; attempt <= max; attempt++) {
+        let ok, val;
+        try { val = await fn(); ok = true; }
+        catch (e) { ok = false; val = e; }
+        lastOk = ok; lastVal = val;
+        if (ok) {
+            if (!(opts.retryOn && opts.retryOn(val))) return val;
+        } else {
+            if (opts.retryOnError && !opts.retryOnError(val)) throw val;
+        }
+        if (attempt < max) {
+            if (opts.onRetry) opts.onRetry(attempt, ok, val);
+            await hull.sleep(retry.backoff(attempt, opts));
+        }
+    }
+    if (lastOk) return lastVal;
+    throw lastVal;
+};
+
+export { retry };
+export default retry;

--- a/stdlib/lua/hull/logx.lua
+++ b/stdlib/lua/hull/logx.lua
@@ -1,0 +1,94 @@
+--- Contextual logging: bind a set of fields once, log them on every line.
+--
+-- A thin, pure layer over the built-in `hull.log`. `logx.with{...}` returns a
+-- child logger whose `info`/`warn`/`error`/`debug` append the bound fields to
+-- the message in logfmt form (`key=value`, quoted when needed), so per-request
+-- context (request_id, user, route) rides every log line without threading it
+-- through every call.
+--
+--     local logx = require("hull.logx")
+--     local rl = logx.with({ request_id = id, user = uid })
+--     rl.info("handled")     -- -> "handled request_id=... user=..."
+--     rl.with({ step = 2 }).warn("slow")  -- children compose
+--
+-- CAVEAT (source tag): `hull.log` tags each line by the CALLER's source, and
+-- the two runtimes resolve that differently for a wrapped call. In Lua a wrapper
+-- line still tags `[app]`; in JS it tags `[hull:js]` (QuickJS reports the
+-- immediate module, `hull:logx`). The message + fields are identical either way
+-- - only the JS source tag shifts. When you need a guaranteed `[app]` tag in
+-- BOTH runtimes, use the escape hatch: `log.info("handled" .. logx.fields({...}))`
+-- - the app calls `log` directly, so the tag stays `[app]`, and `logx.fields`
+-- just formats. (A future C-level `log.with` would make the bound logger tag
+-- `[app]` in JS too.)
+--
+-- @module hull.logx
+-- @license AGPL-3.0-or-later
+
+local log = require("hull.log")
+
+local logx = {}
+
+local LEVELS = { "info", "warn", "error", "debug" }
+
+-- Format a fields table as a leading-space logfmt fragment: " k=v k2=v2".
+-- Keys are sorted for deterministic, cross-runtime-identical output. A value
+-- containing whitespace, a quote, or '=' is double-quoted with '"' escaped.
+local function fmt(fields)
+    if not fields then return "" end
+    local keys = {}
+    for k in pairs(fields) do keys[#keys + 1] = tostring(k) end
+    table.sort(keys)
+    if #keys == 0 then return "" end
+    local parts = {}
+    for _, k in ipairs(keys) do
+        local v = fields[k]
+        local s
+        if type(v) == "boolean" then
+            s = v and "true" or "false"
+        else
+            s = tostring(v)
+        end
+        if s:find('[%s"=]') then
+            s = '"' .. s:gsub('"', '\\"') .. '"'
+        end
+        parts[#parts + 1] = k .. "=" .. s
+    end
+    return " " .. table.concat(parts, " ")
+end
+
+--- Format a fields table into a leading-space logfmt fragment. Escape hatch for
+-- keeping the `[app]` source tag: `log.info("msg" .. logx.fields({...}))`.
+-- @tparam[opt] table fields
+-- @treturn string  e.g. ` request_id=abc user=42` (empty string for no fields).
+function logx.fields(fields)
+    return fmt(fields)
+end
+
+local function make(fields)
+    local self = {}
+    for _, lvl in ipairs(LEVELS) do
+        self[lvl] = function(msg)
+            log[lvl](tostring(msg == nil and "" or msg) .. fmt(fields))
+        end
+    end
+    --- Return a new child logger with `more` merged over the current fields.
+    function self.with(more)
+        local merged = {}
+        for k, v in pairs(fields) do merged[k] = v end
+        if more then for k, v in pairs(more) do merged[k] = v end end
+        return make(merged)
+    end
+    return self
+end
+
+--- Create a bound logger carrying `fields`.
+-- @tparam[opt] table fields
+-- @treturn table  A logger with `info`/`warn`/`error`/`debug` and `with`.
+function logx.with(fields)
+    return make(fields or {})
+end
+
+-- Bare pass-throughs (no bound fields), so `logx` can stand in for `log`.
+for _, lvl in ipairs(LEVELS) do logx[lvl] = log[lvl] end
+
+return logx

--- a/stdlib/lua/hull/retry.lua
+++ b/stdlib/lua/hull/retry.lua
@@ -1,0 +1,100 @@
+--- Generic retry-with-backoff for any fallible operation.
+--
+-- `retry.run(fn, opts)` calls `fn` and retries it on failure with exponential
+-- backoff. `fn` is ARBITRARY - a plain function, an async op that yields
+-- (`http.fetch`, `compute.async.call`, `gpu.async.dispatch`, `db.async.*`), or a
+-- blocking compute call. There is no HTTP coupling: to retry a fetch, wrap it
+-- (`retry.run(function() return http.fetch(url) end, {...})`); the same shape
+-- retries a WASM/GPU dispatch or a DB query. Sleeps between attempts via
+-- `hull.sleep`, so it must run on the event-loop thread (a handler, `app.main`,
+-- a timer).
+--
+-- Failure = `fn` raising an error, OR (when `opts.retry_on` is given) `fn`
+-- returning a value the predicate flags as retryable (e.g. an HTTP 503, a
+-- compute result that didn't converge).
+--
+-- @module hull.retry
+-- @license AGPL-3.0-or-later
+-- @usage
+--   local retry = require("hull.retry")
+--   -- retry an HTTP call on 5xx / network error:
+--   local res = retry.run(function() return http.fetch(url) end, {
+--       max_attempts = 4,
+--       retry_on = function(r) return r.status >= 500 or r.status == 429 end,
+--   })
+--   -- retry a GPU dispatch that can transiently fail:
+--   local out = retry.run(function() return gpu.async.dispatch("scan", opts) end)
+
+local crypto = require("hull.crypto")
+
+local retry = {}
+
+local DEFAULTS = { max_attempts = 3, base_ms = 100, factor = 2, cap_ms = 30000 }
+
+--- Backoff delay (ms) for a 1-based attempt number: `base * factor^(n-1)`,
+-- clamped to `cap`, with optional full jitter (uniform in `[0, delay]`).
+-- Exposed so schedulers can share one backoff curve.
+-- @tparam integer attempt  1-based attempt number.
+-- @tparam[opt] table opts  `base_ms` (100), `factor` (2), `cap_ms` (30000),
+--   `jitter` (boolean, default false).
+-- @treturn integer  Delay in milliseconds.
+function retry.backoff(attempt, opts)
+    opts = opts or {}
+    local base = opts.base_ms or DEFAULTS.base_ms
+    local factor = opts.factor or DEFAULTS.factor
+    local cap = opts.cap_ms or DEFAULTS.cap_ms
+    local d = base * (factor ^ (attempt - 1))
+    if d > cap then d = cap end
+    if opts.jitter then
+        local b = { crypto.random(4):byte(1, 4) }
+        local u = ((b[1] * 256 + b[2]) * 256 + b[3]) * 256 + b[4]
+        d = d * (u / 4294967296.0)   -- uniform in [0, d)
+    end
+    return math.floor(d)
+end
+
+--- Run `fn` with retries.
+--
+-- @tparam function fn  The operation. Its return value is passed through on
+--   success; a raised error or a `retry_on`-flagged result triggers a retry.
+-- @tparam[opt] table opts
+--   - `max_attempts`   (integer, default 3) total attempts, including the first.
+--   - `base_ms` / `factor` / `cap_ms` / `jitter` - see @{retry.backoff}.
+--   - `retry_on`       `function(result) -> boolean` - retry on a "bad" success
+--                      value (e.g. an HTTP 5xx). Absent: only a raised error
+--                      retries.
+--   - `retry_on_error` `function(err) -> boolean` - return false to treat an
+--                      error as PERMANENT and re-raise immediately (no retry).
+--                      Absent: every error retries.
+--   - `on_retry`       `function(attempt, ok, value)` - called before each
+--                      backoff sleep (for logging / metrics).
+-- @return The successful (or last) result of `fn`. Re-raises the last error if
+--   all attempts errored.
+function retry.run(fn, opts)
+    opts = opts or {}
+    local max = opts.max_attempts or DEFAULTS.max_attempts
+    local last_ok, last_val = false, nil
+    for attempt = 1, max do
+        local ok, val = pcall(fn)
+        last_ok, last_val = ok, val
+        if ok then
+            if not (opts.retry_on and opts.retry_on(val)) then
+                return val
+            end
+        else
+            if opts.retry_on_error and not opts.retry_on_error(val) then
+                error(val)
+            end
+        end
+        if attempt < max then
+            if opts.on_retry then opts.on_retry(attempt, ok, val) end
+            hull.sleep(retry.backoff(attempt, opts))
+        end
+    end
+    -- Exhausted. A trailing error re-raises; a retry_on-flagged success returns
+    -- the last value (the caller's predicate can inspect it).
+    if last_ok then return last_val end
+    error(last_val)
+end
+
+return retry

--- a/tests/e2e_logx_parity.sh
+++ b/tests/e2e_logx_parity.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# e2e_logx_parity.sh: hull.logx contextual-logging formatting, Lua/JS parity.
+#
+# logx.with(fields).info(msg) must append the SAME logfmt fragment in both
+# runtimes: sorted keys, quoting of values with spaces/quotes/'=', boolean
+# rendering, and child-logger field merging. Captures the log line (stderr),
+# strips any ANSI, extracts the message onward, and asserts byte-identical
+# output across runtimes.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+HULL="${HULL:-./build/hull}"
+[ -x "$HULL" ] || HULL="build/hull"
+WD=$(mktemp -d)
+trap 'rm -rf "$WD"' EXIT
+
+cat > "$WD/l.lua" <<'LUA'
+local logx = require("hull.logx")
+app.manifest({ modules = { "hull/logx@1", "hull/log@1" } })
+app.main(function(ctx)
+    logx.with({ b = "x y", a = 1, z = true }).info("AAAA")
+    logx.with({ a = 1 }).with({ c = "d" }).warn("BBBB")
+    return 0
+end)
+LUA
+cat > "$WD/l.js" <<'JS'
+import { app } from "hull:app"; import { logx } from "hull:logx";
+app.manifest({ modules: ["hull/logx@1", "hull/log@1"] });
+app.main((ctx) => {
+    logx.with({ b: "x y", a: 1, z: true }).info("AAAA");
+    logx.with({ a: 1 }).with({ c: "d" }).warn("BBBB");
+    return 0;
+});
+JS
+
+# Strip ANSI, keep only the marker-onward text of each marked line, join.
+extract() {
+    "$HULL" "$1" 2>&1 \
+        | sed 's/\x1b\[[0-9;]*m//g' \
+        | grep -oE '(AAAA|BBBB).*' \
+        | sed 's/[[:space:]]*$//' \
+        | tr '\n' '~'
+}
+
+lua_out="$(extract "$WD/l.lua")"
+js_out="$(extract "$WD/l.js")"
+
+# sorted keys (a,b,z); "x y" quoted; boolean true; child merge a+c
+expect='AAAA a=1 b="x y" z=true~BBBB a=1 c=d~'
+
+if [ "$lua_out" = "$expect" ] && [ "$lua_out" = "$js_out" ]; then
+    echo "PASS: hull.logx logfmt formatting is byte-identical across Lua and JS"
+else
+    echo "::error hull.logx DRIFT:"
+    echo "  expect=[$expect]"
+    echo "  lua   =[$lua_out]"
+    echo "  js    =[$js_out]"
+    exit 1
+fi

--- a/tests/e2e_retry.sh
+++ b/tests/e2e_retry.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# e2e_retry.sh: hull.retry generic retry-with-backoff, Lua/JS parity.
+#
+# Drives retry.run through: a fn that errors N times then succeeds (retry on
+# error), a fn that always errors (exhaustion re-raises), a fn retried on a
+# value predicate (retry_on), and the deterministic backoff curve. Uses
+# base_ms=1 so the real hull.sleep between attempts is negligible. Asserts the
+# result vector is byte-identical across runtimes.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+HULL="${HULL:-./build/hull}"
+[ -x "$HULL" ] || HULL="build/hull"
+WD=$(mktemp -d)
+trap 'rm -rf "$WD"' EXIT
+
+cat > "$WD/r.lua" <<'LUA'
+local retry = require("hull.retry")
+app.manifest({ modules = { "hull/retry@1" } })
+app.main(function(ctx)
+    local calls = 0
+    local res = retry.run(function()
+        calls = calls + 1
+        if calls < 3 then error("boom") end
+        return "ok:" .. calls
+    end, { max_attempts = 5, base_ms = 1 })
+
+    local ex = 0
+    local ok = pcall(retry.run, function() ex = ex + 1; error("always") end,
+                     { max_attempts = 3, base_ms = 1 })
+
+    local vc = 0
+    local vres = retry.run(function() vc = vc + 1; return vc end,
+                           { max_attempts = 4, base_ms = 1,
+                             retry_on = function(v) return v < 3 end })
+
+    local b1 = retry.backoff(1, { base_ms = 100, cap_ms = 100000 })
+    local b3 = retry.backoff(3, { base_ms = 100, cap_ms = 100000 })
+    local bc = retry.backoff(9, { base_ms = 100, cap_ms = 500 })
+
+    ctx.stdout:write(table.concat({ res, calls, ok and "N" or "T", ex, vres, vc, b1, b3, bc }, "|") .. "\n")
+    return 0
+end)
+LUA
+cat > "$WD/r.js" <<'JS'
+import { app } from "hull:app"; import { retry } from "hull:retry";
+app.manifest({ modules: ["hull/retry@1"] });
+app.main(async (ctx) => {
+    let calls = 0;
+    const res = await retry.run(async () => {
+        calls++;
+        if (calls < 3) throw new Error("boom");
+        return "ok:" + calls;
+    }, { maxAttempts: 5, baseMs: 1 });
+
+    let ex = 0, ok = "N";
+    try { await retry.run(async () => { ex++; throw new Error("always"); },
+                          { maxAttempts: 3, baseMs: 1 }); }
+    catch (e) { ok = "T"; }
+
+    let vc = 0;
+    const vres = await retry.run(async () => { vc++; return vc; },
+                                 { maxAttempts: 4, baseMs: 1, retryOn: (v) => v < 3 });
+
+    const b1 = retry.backoff(1, { baseMs: 100, capMs: 100000 });
+    const b3 = retry.backoff(3, { baseMs: 100, capMs: 100000 });
+    const bc = retry.backoff(9, { baseMs: 100, capMs: 500 });
+
+    ctx.stdout.write([res, calls, ok === "T" ? "T" : "N", ex, vres, vc, b1, b3, bc].join("|") + "\n");
+    return 0;
+});
+JS
+
+# success-after-2-errors / 3 calls / exhaustion re-raises / 3 err calls /
+# retry_on stops at 3 / 3 val calls / backoff 100 / 400 / capped 500
+expect="ok:3|3|T|3|3|3|100|400|500"
+lua_out="$("$HULL" "$WD/r.lua" 2>/dev/null | tail -1)"
+js_out="$( "$HULL" "$WD/r.js"  2>/dev/null | tail -1)"
+
+if [ "$lua_out" = "$expect" ] && [ "$lua_out" = "$js_out" ]; then
+    echo "PASS: hull.retry is byte-identical across Lua and JS"
+else
+    echo "::error hull.retry DRIFT:"
+    echo "  expect=$expect"
+    echo "  lua   =$lua_out"
+    echo "  js    =$js_out"
+    exit 1
+fi


### PR DESCRIPTION
## What

The last two "plumbing every app re-writes" gaps from the stdlib review, as pure
dual-runtime modules with parity tests.

### `hull/retry` — generic retry-with-backoff
`retry.run(fn, opts)` retries **any** fallible operation, not just HTTP (per your
note — it must cover async I/O *and* WASM/GPU compute). `fn` may be a plain
function, an async op that yields / returns a Promise (`http.fetch`,
`compute.async.call`, `gpu.async.dispatch`, `db.async.*`), or a blocking compute
call. No HTTP coupling — wrap a fetch, and the same shape retries a WASM/GPU
dispatch or a DB query:

```lua
-- HTTP, retry on 5xx/429:
local res = retry.run(function() return http.fetch(url) end,
    { max_attempts = 4, retry_on = function(r) return r.status >= 500 end })
-- GPU dispatch, retry on transient failure:
local out = retry.run(function() return gpu.async.dispatch("scan", opts) end)
```

Retries on a raised error, or (via `retry_on`) on a "bad" success value. Sleeps
between attempts via the `hull.sleep` intrinsic. `retry.backoff(attempt, opts)`
(`base * factor^(n-1)`, capped, optional full jitter) is exposed so schedulers
share one curve — the same formula `jobs`/`outbox` hand-roll.

### `hull/logx` — contextual logging
`logx.with({fields})` returns a child logger whose `info`/`warn`/`error`/`debug`
append the bound fields in logfmt (`key=value`, sorted, quoted when needed), so
per-request context rides every line; children compose via `.with()`.
`logx.fields(t)` exposes just the formatter.

```lua
local rl = logx.with({ request_id = id, user = uid })
rl.info("handled")   -- -> "handled request_id=... user=..."
```

## Honest caveat on `logx` (documented in-module)

`hull/log` tags each line by the **caller's source**, and the two runtimes
resolve a *wrapped* call differently: a `logx` line tags **`[app]` in Lua** but
**`[hull:js]` in JS** (QuickJS reports the immediate `hull:logx` module). The
message + fields are **byte-identical** (the parity test asserts exactly that);
only the JS source tag shifts. The escape hatch `log.info("m" .. logx.fields({...}))`
keeps `[app]` in both runtimes. The seamless fix is a C-level `log.with` (the
option declined earlier) — noted as a follow-up. I surfaced this rather than
bury it since it's a real (if cosmetic) cross-runtime difference.

## Tests

- `e2e_retry.sh` — error-retry / exhaustion-reraise / value-`retry_on` /
  deterministic backoff curve, both runtimes, byte-identical.
- `e2e_logx_parity.sh` — sorted keys, quoting, boolean rendering, child merge;
  message byte-identical across runtimes.

Wired as `make` targets + CI steps. Local `make test` 62/62; both e2e green.

## Plumbing status

This completes the four plumbing gaps from the review: **uuid**, **config** (+
two-gate `.env`), **retry**, **logx**. Remaining review items are larger/optional
(caching module, cursor pagination, metrics) or naming reconciliations.
