### PR TITLE
stdlib: reconcile option-name clashes (name / secret / ttl) with aliases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,10 @@ jobs:
         timeout-minutes: 2
         run: make e2e-logx-parity
 
+      - name: Naming-reconciliation alias E2E test (canonical + alias both work)
+        timeout-minutes: 2
+        run: make e2e-naming-aliases
+
       - name: Validate Lua/JS parity E2E test
         timeout-minutes: 2
         run: make e2e-validate-parity

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -704,6 +704,10 @@ e2e-retry: $(BUILDDIR)/hull
 e2e-logx-parity: $(BUILDDIR)/hull
 	sh tests/e2e_logx_parity.sh
 
+.PHONY: e2e-naming-aliases
+e2e-naming-aliases: $(BUILDDIR)/hull
+	sh tests/e2e_naming_aliases.sh
+
 .PHONY: e2e-validate-parity
 e2e-validate-parity: $(BUILDDIR)/hull
 	sh tests/e2e_validate_parity.sh

--- a/stdlib/js/hull/web/auth-flows.js
+++ b/stdlib/js/hull/web/auth-flows.js
@@ -1115,8 +1115,10 @@ function standardUsers(opts) {
 
 function init(opts) {
     opts = opts || {};
-    if (typeof opts.stateSecret !== "string" || opts.stateSecret.length < 32) {
-        throw new Error("auth-flows.init: stateSecret must be a string >= 32 bytes");
+    // Canonical `secret`; back-compat alias `stateSecret` (same HMAC key).
+    const secret = opts.secret || opts.stateSecret;
+    if (typeof secret !== "string" || secret.length < 32) {
+        throw new Error("auth-flows.init: secret must be a string >= 32 bytes");
     }
     if (typeof opts.emailSend !== "function") {
         throw new Error("auth-flows.init: emailSend(to, subject, html, text) required");
@@ -1220,7 +1222,7 @@ function init(opts) {
         }
     }
 
-    _state.stateSecretHex = bytesToHex(opts.stateSecret);
+    _state.stateSecretHex = bytesToHex(secret);
     _state.emailSend      = opts.emailSend;
     _state.publicOrigin   = opts.publicOrigin || null;
     _state.trustedHosts   = opts.trustedHosts || null;

--- a/stdlib/js/hull/web/middleware/auth.js
+++ b/stdlib/js/hull/web/middleware/auth.js
@@ -41,7 +41,8 @@ function parseCookieHeader(req) {
  *   - returns 0 if `opts.optional`.
  *
  * @param {Object} [opts]
- * @param {string} [opts.cookieName="hull_session"]
+ * @param {string} [opts.name="hull_session"]  Session cookie name (matches
+ *   hull:web:middleware:session's `name`). Back-compat alias: `cookieName`.
  * @param {string} [opts.loginPath]    Redirect target on failure.
  * @param {boolean} [opts.optional=false]
  * @param {string[]} [opts.excludePaths]   Paths skipped entirely.
@@ -49,7 +50,7 @@ function parseCookieHeader(req) {
  */
 function sessionMiddleware(opts) {
     const o = opts || {};
-    const cookieName = o.cookieName || "hull_session";
+    const cookieName = o.name || o.cookieName || "hull_session";
     const loginPath = o.loginPath || null;
     const optional = o.optional === true;
     const excludePaths = o.excludePaths || [];
@@ -201,13 +202,14 @@ function copyCookieOpts(src) {
  * @param {Object} res            Response — `Set-Cookie` is added here.
  * @param {Object} userData       Session payload, e.g. `{ user_id: 1 }`.
  * @param {Object} [opts]
- * @param {string} [opts.cookieName="hull_session"]
+ * @param {string} [opts.name="hull_session"]  Session cookie name (matches
+ *   hull:web:middleware:session's `name`). Back-compat alias: `cookieName`.
  * @param {Object} [opts.cookieOpts]   Forwarded to {@link module:hull:web:cookie.serialize}.
  * @returns {string}              Session id (hex).
  */
 function login(req, res, userData, opts) {
     const o = opts || {};
-    const cookieName = o.cookieName || "hull_session";
+    const cookieName = o.name || o.cookieName || "hull_session";
     const cookieOpts = copyCookieOpts(o.cookieOpts);
 
     // Set Max-Age from session TTL if not explicitly provided
@@ -228,12 +230,13 @@ function login(req, res, userData, opts) {
  * @param {Object} req            Reads the session cookie.
  * @param {Object} res            Emits a `Set-Cookie` that clears it.
  * @param {Object} [opts]
- * @param {string} [opts.cookieName="hull_session"]
+ * @param {string} [opts.name="hull_session"]  Session cookie name (matches
+ *   hull:web:middleware:session's `name`). Back-compat alias: `cookieName`.
  * @param {Object} [opts.cookieOpts]   Forwarded to {@link module:hull:web:cookie.clear}.
  */
 function logout(req, res, opts) {
     const o = opts || {};
-    const cookieName = o.cookieName || "hull_session";
+    const cookieName = o.name || o.cookieName || "hull_session";
     const cookieOpts = o.cookieOpts || {};
 
     const cookies = parseCookieHeader(req);

--- a/stdlib/js/hull/web/middleware/csrf.js
+++ b/stdlib/js/hull/web/middleware/csrf.js
@@ -64,10 +64,10 @@ function generate(sessionId, secret) {
  * @param {string} token
  * @param {string} sessionId
  * @param {string} secret
- * @param {number} [maxAge=3600]
+ * @param {number} [ttl=3600]  Max token age in seconds.
  * @returns {boolean}
  */
-function verify(token, sessionId, secret, maxAge) {
+function verify(token, sessionId, secret, ttl) {
     if (!token || typeof token !== "string")
         return false;
     if (!sessionId || typeof sessionId !== "string")
@@ -95,7 +95,7 @@ function verify(token, sessionId, secret, maxAge) {
     if (isNaN(ts))
         return false;
 
-    const age = maxAge !== undefined ? maxAge : 3600;
+    const age = ttl !== undefined ? ttl : 3600;
     const now = time.now();
     if (now - ts > age)
         return false;
@@ -125,7 +125,7 @@ function parseCookieSessionId(req, cookieName) {
  * @param {Object}  opts
  * @param {string}  opts.secret              **Required.** HMAC secret.
  * @param {string}  [opts.sessionKey="session_id"]
- * @param {number}  [opts.maxAge=3600]
+ * @param {number}  [opts.ttl=3600]  Max token age in seconds. Alias: `maxAge`.
  * @param {string[]} [opts.safeMethods=["GET","HEAD","OPTIONS"]]
  * @param {string}  [opts.headerName="x-csrf-token"]
  * @param {string}  [opts.fieldName="_csrf"]
@@ -135,7 +135,8 @@ function parseCookieSessionId(req, cookieName) {
 function middleware(opts) {
     const o = opts || {};
     const secret = o.secret;
-    const maxAge = o.maxAge !== undefined ? o.maxAge : 3600;
+    // Canonical `ttl`; back-compat alias `maxAge`.
+    const ttl = o.ttl !== undefined ? o.ttl : (o.maxAge !== undefined ? o.maxAge : 3600);
     // Fallback session-cookie name when upstream session middleware hasn't
     // populated req.ctx[sessionKey]. Matches the session/auth middleware
     // default ("hull_session") so the fallback actually finds the cookie.
@@ -243,7 +244,7 @@ function middleware(opts) {
             return 1;
         }
 
-        if (!verify(token, sessionId, secret, maxAge)) {
+        if (!verify(token, sessionId, secret, ttl)) {
             res.status(403);
             res.json({ error: "CSRF token invalid" });
             return 1;

--- a/stdlib/js/hull/web/middleware/oauth.js
+++ b/stdlib/js/hull/web/middleware/oauth.js
@@ -54,7 +54,7 @@
  * @example
  *   import { oauth } from "hull:web:middleware:oauth";
  *   oauth.init({
- *       stateSecret: env.get("OAUTH_STATE_SECRET"),
+ *       secret: env.get("OAUTH_STATE_SECRET"),   // alias: stateSecret
  *       providers: {
  *           entra: {
  *               preset: "microsoft",
@@ -541,11 +541,13 @@ function init(opts) {
     if (!opts || typeof opts !== "object") {
         throw new Error("oauth.init: opts object required");
     }
-    if (typeof opts.stateSecret !== "string" || opts.stateSecret.length < 32) {
-        throw new Error("oauth.init: stateSecret must be a string >= 32 bytes "
+    // Canonical `secret`; back-compat alias `stateSecret` (same HMAC key).
+    const secret = opts.secret || opts.stateSecret;
+    if (typeof secret !== "string" || secret.length < 32) {
+        throw new Error("oauth.init: secret must be a string >= 32 bytes "
             + "(same HMAC primitive as hull/web/auth-flows; pick one floor)");
     }
-    _state.stateSecretHex = bytesToHex(opts.stateSecret);
+    _state.stateSecretHex = bytesToHex(secret);
     _state.stateCookie = opts.stateCookie || _state.stateCookie;
     _state.stateCookiePath =
         opts.stateCookiePath || _state.stateCookiePath;

--- a/stdlib/lua/hull/web/auth-flows.lua
+++ b/stdlib/lua/hull/web/auth-flows.lua
@@ -75,7 +75,7 @@
 --
 --     local authflows = require("hull.web.auth-flows")
 --     authflows.init({
---         state_secret  = env.get("AUTH_FLOWS_SECRET"),
+--         secret        = env.get("AUTH_FLOWS_SECRET"),  -- alias: state_secret
 --         email_send    = function(to, subject, html, text) ... end,
 --         templates     = {
 --             welcome        = function(ctx) ... end,
@@ -1517,8 +1517,10 @@ end
 
 function M.init(opts)
     opts = opts or {}
-    if type(opts.state_secret) ~= "string" or #opts.state_secret < 32 then
-        error("auth-flows.init: state_secret must be a string >= 32 bytes")
+    -- Canonical `secret`; back-compat alias `state_secret` (same HMAC key).
+    local secret = opts.secret or opts.state_secret
+    if type(secret) ~= "string" or #secret < 32 then
+        error("auth-flows.init: secret must be a string >= 32 bytes")
     end
     if type(opts.email_send) ~= "function" then
         error("auth-flows.init: email_send(to, subject, html, text) required")
@@ -1635,7 +1637,7 @@ function M.init(opts)
     -- with a non-ASCII byte would derive different HMAC keys per runtime and
     -- break the cross-runtime wire-format guarantee. _hex is byte-identical in
     -- both runtimes.
-    _state.state_secret_hex = _hex.to_hex(opts.state_secret)
+    _state.state_secret_hex = _hex.to_hex(secret)
     _state.email_send       = opts.email_send
     _state.public_origin    = opts.public_origin
     _state.trusted_hosts    = opts.trusted_hosts

--- a/stdlib/lua/hull/web/middleware/auth.lua
+++ b/stdlib/lua/hull/web/middleware/auth.lua
@@ -30,7 +30,9 @@ local auth = {}
 --
 -- @tparam[opt] table opts  Options:
 --
---   - `cookie_name`   (string, default `"hull_session"`)
+--   - `name`          (string, default `"hull_session"`): session cookie name.
+--                     Matches `hull.web.middleware.session`'s `name` option.
+--                     Back-compat alias: `cookie_name`.
 --   - `cookie_opts`   (table): forwarded to @{hull.web.cookie.clear} on
 --                     stale-cookie cleanup.
 --   - `optional`      (boolean, default `false`)
@@ -44,7 +46,7 @@ local auth = {}
 -- app.use("*", "/app/*", auth.session_middleware({ login_path = "/login" }))
 function auth.session_middleware(opts)
     opts = opts or {}
-    local cookie_name = opts.cookie_name or "hull_session"
+    local cookie_name = opts.name or opts.cookie_name or "hull_session"
     local cookie_opts = opts.cookie_opts
     local optional = opts.optional or false
     local login_path = opts.login_path
@@ -185,7 +187,7 @@ end
 -- @tparam table user_data    Data to persist in the session, e.g. `{ user_id = 1 }`.
 -- @tparam[opt] table opts    Options:
 --
---   - `cookie_name` (string, default `"hull_session"`)
+--   - `name` (string, default `"hull_session"`; alias: `cookie_name`)
 --   - `cookie_opts` (table): forwarded to @{hull.web.cookie.serialize}.
 --   - `ttl`         (integer, seconds): convenience that auto-fills
 --                   `cookie_opts.max_age` when the caller didn't.
@@ -207,7 +209,7 @@ end
 -- end)
 function auth.login(_req, res, user_data, opts)
     opts = opts or {}
-    local cookie_name = opts.cookie_name or "hull_session"
+    local cookie_name = opts.name or opts.cookie_name or "hull_session"
     local cookie_opts = opts.cookie_opts or {}
     if cookie_opts.max_age == nil and opts.ttl then
         -- Copy on write so we don't mutate the caller's table.
@@ -232,12 +234,12 @@ end
 -- @tparam table res           Response — emits a `Set-Cookie` that clears it.
 -- @tparam[opt] table opts     Options:
 --
---   - `cookie_name` (string, default `"hull_session"`)
+--   - `name` (string, default `"hull_session"`; alias: `cookie_name`)
 --   - `cookie_opts` (table): forwarded to @{hull.web.cookie.clear} so `path`
 --     / `domain` match the original cookie.
 function auth.logout(req, res, opts)
     opts = opts or {}
-    local cookie_name = opts.cookie_name or "hull_session"
+    local cookie_name = opts.name or opts.cookie_name or "hull_session"
     local cookie_opts = opts.cookie_opts or {}
 
     -- Get session ID from cookie

--- a/stdlib/lua/hull/web/middleware/csrf.lua
+++ b/stdlib/lua/hull/web/middleware/csrf.lua
@@ -61,15 +61,15 @@ end
 --- Verify a CSRF token.
 --
 -- Constant-time HMAC comparison + age check. Tokens older than
--- `max_age` are rejected even if the HMAC matches.
+-- `ttl` are rejected even if the HMAC matches.
 --
 -- @tparam string token
 -- @tparam string session_id
 -- @tparam string secret
--- @tparam[opt] integer max_age  Max token age in seconds (default `3600`).
+-- @tparam[opt] integer ttl  Max token age in seconds (default `3600`).
 -- @treturn boolean  `true` if valid.
-function csrf.verify(token, session_id, secret, max_age)
-    max_age = max_age or 3600
+function csrf.verify(token, session_id, secret, ttl)
+    ttl = ttl or 3600
 
     if not token or not session_id or not secret then
         return false
@@ -99,7 +99,7 @@ function csrf.verify(token, session_id, secret, max_age)
     -- Check expiry (and reject clearly-future timestamps to bound
     -- replay windows; mirrors the JS sibling's ts > now + 60 check).
     local now = time.now()
-    if now - ts > max_age then
+    if now - ts > ttl then
         return false
     end
     if ts > now + 60 then
@@ -133,7 +133,8 @@ end
 --
 --   - `secret`       (string, **required**): HMAC secret.
 --   - `session_key`  (string, default `"session_id"`): key in `req.ctx`.
---   - `max_age`      (integer, default `3600`).
+--   - `ttl`          (integer, default `3600`): max token age in seconds.
+--                    Back-compat alias: `max_age`.
 --   - `safe_methods` (`{string,...}`, default `{"GET","HEAD","OPTIONS"}`).
 --   - `header_name`  (string, default `"x-csrf-token"`).
 --   - `field_name`   (string, default `"_csrf"`).
@@ -149,7 +150,10 @@ function csrf.middleware(opts)
 
     local secret = opts.secret
     local session_key = opts.session_key or "session_id"
-    local max_age = opts.max_age or 3600
+    -- Canonical `ttl`; back-compat alias `max_age`.
+    local ttl = opts.ttl
+    if ttl == nil then ttl = opts.max_age end
+    if ttl == nil then ttl = 3600 end
     local header_name = opts.header_name or "x-csrf-token"
     local field_name = opts.field_name or "_csrf"
 
@@ -221,7 +225,7 @@ function csrf.middleware(opts)
             end
         end
 
-        if not csrf.verify(token, sid, secret, max_age) then
+        if not csrf.verify(token, sid, secret, ttl) then
             res:status(403):json({ error = "csrf: invalid token" })
             return 1
         end

--- a/stdlib/lua/hull/web/middleware/oauth.lua
+++ b/stdlib/lua/hull/web/middleware/oauth.lua
@@ -77,7 +77,7 @@
 --
 --     local oauth = require("hull.web.middleware.oauth")
 --     oauth.init({
---         state_secret = env.get("OAUTH_STATE_SECRET"),
+--         secret = env.get("OAUTH_STATE_SECRET"),  -- alias: state_secret
 --         providers = {
 --             entra = {
 --                 preset      = "microsoft",
@@ -582,12 +582,14 @@ function oauth.init(opts)
     if type(opts) ~= "table" then
         error("oauth.init: opts table required")
     end
-    if type(opts.state_secret) ~= "string" or #opts.state_secret < 32 then
-        error("oauth.init: state_secret must be a string >= 32 bytes "
+    -- Canonical `secret`; back-compat alias `state_secret` (same HMAC key).
+    local secret = opts.secret or opts.state_secret
+    if type(secret) ~= "string" or #secret < 32 then
+        error("oauth.init: secret must be a string >= 32 bytes "
               .. "(same HMAC primitive as hull/web/auth-flows; pick "
               .. "one floor)")
     end
-    _state.state_secret_hex = bytes_to_hex(opts.state_secret)
+    _state.state_secret_hex = bytes_to_hex(secret)
     -- redirect_uri origin (see compute_redirect_uri): explicit base_url wins,
     -- else trust_proxy gates the spoofable X-Forwarded-Proto/Host headers.
     if opts.base_url ~= nil then

--- a/tests/e2e_naming_aliases.sh
+++ b/tests/e2e_naming_aliases.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+# e2e_naming_aliases.sh: the stdlib naming reconciliation keeps both the
+# canonical option name AND its back-compat alias working, in both runtimes.
+#
+# Reconciled (canonical <- alias):
+#   auth.session_middleware/login/logout  name          <- cookie_name
+#   oauth.init / auth-flows.init           secret        <- state_secret
+#   csrf.middleware / csrf.verify          ttl           <- max_age
+#
+# For the init-based secrets, `secret` is validated FIRST, so a valid value
+# shifts the thrown error away from the ">= 32 bytes" message - that shift is
+# the proof the alias was accepted (no DB / callbacks needed).
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+HULL="${HULL:-./build/hull}"
+[ -x "$HULL" ] || HULL="build/hull"
+WD=$(mktemp -d)
+trap 'rm -rf "$WD"' EXIT
+
+MODS_LUA='"hull/web/middleware/csrf@1", "hull/web/middleware/auth@1", "hull/web/middleware/oauth@1", "hull/web/auth-flows@1"'
+MODS_JS='"hull/web/middleware/csrf@1", "hull/web/middleware/auth@1", "hull/web/middleware/oauth@1", "hull/web/auth-flows@1"'
+
+cat > "$WD/n.lua" <<LUA
+local csrf = require("hull.web.middleware.csrf")
+local auth = require("hull.web.middleware.auth")
+local oauth = require("hull.web.middleware.oauth")
+local authflows = require("hull.web.auth-flows")
+app.manifest({ modules = { $MODS_LUA } })
+local S = string.rep("x", 32)
+-- secret accepted iff the throw is NOT the ">= 32 bytes" floor error.
+local function sec_ok(fn, key)
+    local ok, err = pcall(fn, { [key] = S })
+    if ok then return true end
+    return not tostring(err):find(">= 32", 1, true)
+end
+app.main(function(ctx)
+    local o = {}
+    local t = csrf.generate("sid", "sec")
+    o[#o+1] = csrf.verify(t, "sid", "sec", 3600) and "csrf_rt" or "F1"
+    o[#o+1] = type(csrf.middleware({ secret = "s", ttl = 60 })) == "function" and "csrf_ttl" or "F2"
+    o[#o+1] = type(csrf.middleware({ secret = "s", max_age = 60 })) == "function" and "csrf_maxage" or "F3"
+    o[#o+1] = type(auth.session_middleware({ name = "c" })) == "function" and "auth_name" or "F4"
+    o[#o+1] = type(auth.session_middleware({ cookie_name = "c" })) == "function" and "auth_cookiename" or "F5"
+    o[#o+1] = sec_ok(oauth.init, "secret") and "oauth_secret" or "F6"
+    o[#o+1] = sec_ok(oauth.init, "state_secret") and "oauth_statesecret" or "F7"
+    o[#o+1] = sec_ok(authflows.init, "secret") and "af_secret" or "F8"
+    o[#o+1] = sec_ok(authflows.init, "state_secret") and "af_statesecret" or "F9"
+    local ok_s, err_s = pcall(oauth.init, { secret = "short" })
+    o[#o+1] = (not ok_s and tostring(err_s):find(">= 32", 1, true)) and "short_rejected" or "F10"
+    ctx.stdout:write(table.concat(o, "|") .. "\n"); return 0
+end)
+LUA
+cat > "$WD/n.js" <<JS
+import { app } from "hull:app";
+import { csrf } from "hull:web:middleware:csrf";
+import { auth } from "hull:web:middleware:auth";
+import { oauth } from "hull:web:middleware:oauth";
+import { authFlows } from "hull:web:auth-flows";
+app.manifest({ modules: [ $MODS_JS ] });
+const S = "x".repeat(32);
+function secOk(fn, key) {
+    try { fn({ [key]: S }); return true; }
+    catch (e) { return String(e).indexOf(">= 32") === -1; }
+}
+app.main((ctx) => {
+    const o = [];
+    const t = csrf.generate("sid", "sec");
+    o.push(csrf.verify(t, "sid", "sec", 3600) ? "csrf_rt" : "F1");
+    o.push(typeof csrf.middleware({ secret: "s", ttl: 60 }) === "function" ? "csrf_ttl" : "F2");
+    o.push(typeof csrf.middleware({ secret: "s", maxAge: 60 }) === "function" ? "csrf_maxage" : "F3");
+    o.push(typeof auth.sessionMiddleware({ name: "c" }) === "function" ? "auth_name" : "F4");
+    o.push(typeof auth.sessionMiddleware({ cookieName: "c" }) === "function" ? "auth_cookiename" : "F5");
+    o.push(secOk(oauth.init, "secret") ? "oauth_secret" : "F6");
+    o.push(secOk(oauth.init, "stateSecret") ? "oauth_statesecret" : "F7");
+    o.push(secOk(authFlows.init, "secret") ? "af_secret" : "F8");
+    o.push(secOk(authFlows.init, "stateSecret") ? "af_statesecret" : "F9");
+    let shortRejected = "F10";
+    try { oauth.init({ secret: "short" }); } catch (e) { if (String(e).indexOf(">= 32") !== -1) shortRejected = "short_rejected"; }
+    o.push(shortRejected);
+    ctx.stdout.write(o.join("|") + "\n"); return 0;
+});
+JS
+
+expect="csrf_rt|csrf_ttl|csrf_maxage|auth_name|auth_cookiename|oauth_secret|oauth_statesecret|af_secret|af_statesecret|short_rejected"
+lua_out="$("$HULL" "$WD/n.lua" 2>/dev/null | tail -1)"
+js_out="$( "$HULL" "$WD/n.js"  2>/dev/null | tail -1)"
+
+if [ "$lua_out" = "$expect" ] && [ "$lua_out" = "$js_out" ]; then
+    echo "PASS: canonical + alias option names both work across Lua and JS"
+else
+    echo "::error naming-alias DRIFT:"
+    echo "  expect=$expect"
+    echo "  lua   =$lua_out"
+    echo "  js    =$js_out"
+    exit 1
+fi


### PR DESCRIPTION
## What

The three same-concept-different-name clashes the stdlib review flagged —
between modules that are configured side by side — reconciled to one canonical
name each, with the old spelling kept as a **back-compat alias** (the style
guide's prescription: accept the old name, treat the canonical as primary). No
breakage — existing apps and all fixtures keep working.

| Concept | Was | Canonical | Where |
|---|---|---|---|
| session cookie name | `cookie_name` / `cookieName` | **`name`** | `auth.session_middleware` / `login` / `logout` (session already used `name`) |
| auth HMAC key | `state_secret` / `stateSecret` | **`secret`** | `oauth.init`, `auth-flows.init` (csrf / jwt / totp already used `secret`) |
| CSRF token lifetime | `max_age` / `maxAge` | **`ttl`** | `csrf.middleware` / `csrf.verify` (cookie/cors keep `max_age` — a real HTTP `Max-Age`) |

Each is a `canonical or alias` fallback in both runtimes; docstrings now lead
with the canonical name and note the alias. The oauth/auth-flows validation
message loses the `state_` prefix (`secret must be a string >= 32 bytes`).

## Verification

- **`tests/e2e_naming_aliases.sh`** (new, both runtimes) — asserts **both**
  spellings work for every reconciled option: csrf `ttl`/`max_age` (generate+verify
  roundtrip + middleware build), auth `name`/`cookie_name`, and oauth +
  auth-flows `secret`/`state_secret`. The secret aliases are proven by the
  `>= 32 bytes` error shifting away once a valid secret is accepted (so no
  DB/callbacks are needed), plus a short-secret rejection sanity check. `make`
  target + CI step.
- **Back-compat** (the old names) stays covered end-to-end by the existing
  `e2e_auth_flows` (48/0), `e2e_oauth` (44/0), and `e2e_sign_in_events` (40/0),
  whose fixtures still use the old spellings.
- `make test` 62/62 (includes auth-flows unit tests that use `state_secret`).

## Not changed

`cookie.max_age` and `cors.max_age` stay `max_age` — those map to the real HTTP
`Max-Age` attribute, which the guide explicitly allows naming after the wire
concept. `totp` / `jwt` / `csrf` already used `secret`, so no change there.
