### PR TITLE
stdlib: csrf JS/Lua parity + cookie dep; position htmx widgets (docs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,10 @@ jobs:
         timeout-minutes: 2
         run: make e2e-naming-aliases
 
+      - name: CSRF session-id cookie-fallback Lua/JS parity E2E test
+        timeout-minutes: 2
+        run: make e2e-csrf-cookie-fallback
+
       - name: Validate Lua/JS parity E2E test
         timeout-minutes: 2
         run: make e2e-validate-parity

--- a/docs/htmx.md
+++ b/docs/htmx.md
@@ -8,6 +8,13 @@
 > [HTMX widgets guide](htmx_widgets.md). The page below covers the
 > broader profile — scaffolding, Pico, CSP nonces, htmx core
 > helpers — that the widgets sit on top of.
+>
+> **Positioning:** the base `hull/web/htmx` module (htmx request
+> detection + `HX-*` response headers) is frontend-agnostic core, a peer
+> of `csv`/`jwt`/`validate`. The 8 **widgets** are an *optional,
+> opinionated component pack* (they emit HTML/CSS/JS and are inert
+> without htmx on the page) — opt into them only if you're building
+> htmx-first. See the widgets guide's "Positioning" section.
 
 Hypermedia means HTML is the application protocol. Browsers fetch HTML, render it, follow links, submit forms. HTMX (`htmx.org`, v2.x in Hull's profile) extends the HTML vocabulary so any element can issue any HTTP verb and swap the response into the page. The server's job is unchanged: return HTML. There is no JSON state machine, no client-side router, no build step.
 

--- a/docs/htmx_widgets.md
+++ b/docs/htmx_widgets.md
@@ -14,6 +14,34 @@ destructive action, toast on completion, surface validation errors
 with the right a11y wiring. Zero client framework. ~395 LOC of plain
 JS total across all 8 widgets, all loaded once per page.
 
+## Positioning: an optional component pack, not frontend-agnostic core
+
+Draw a firm line between two things that both live under `hull/web/htmx*`:
+
+- **`hull/web/htmx` (the base module) is frontend-agnostic core.** It emits
+  *no HTML* — only the server-side htmx *protocol dialect*: detect an htmx
+  request (`HX-Request`) and set the response headers htmx interprets
+  (`HX-Redirect`, `HX-Retarget`, `HX-Reswap`, `HX-Trigger`, …). It is the
+  legitimate peer of `csv` / `jwt` / `validate` — a wire-format helper that
+  doesn't care what your frontend is.
+
+- **The 8 widgets (`hull/web/htmx/{toast,confirm,form,search,inline-edit,sort,pagination,table}`)
+  are an opinionated, optional component pack.** They emit real HTML with
+  hardcoded class names (`hull-table`, `hull-pagination`, …), a prescribed DOM
+  structure, URL conventions (`?sort=col:asc`), and a paired client JS/CSS
+  runtime — all **inert without htmx on the page**. That makes them a
+  single-frontend-library UI kit, categorically different from the
+  frontend-agnostic modules above. They are well-built (centralized escaping,
+  real a11y, SQL-injection-conscious sort allowlisting) and honestly gated
+  (namespaced, explicit `manifest.modules` declaration, `csp = "htmx"`), but
+  they are **not** core stdlib on equal footing with `jwt`/`validate`.
+
+**What this means for you:** reach for the widgets only if you are deliberately
+building htmx-first. Nothing else in the stdlib depends on them; an app on any
+other frontend (or a JSON API) never touches them and pays nothing for them.
+Treat this page as the docs for an optional pack you opt into, not a description
+of baseline framework surface.
+
 ## At a glance
 
 | Widget | Server helpers | Client JS | Client CSS |

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -708,6 +708,10 @@ e2e-logx-parity: $(BUILDDIR)/hull
 e2e-naming-aliases: $(BUILDDIR)/hull
 	sh tests/e2e_naming_aliases.sh
 
+.PHONY: e2e-csrf-cookie-fallback
+e2e-csrf-cookie-fallback: $(BUILDDIR)/hull
+	sh tests/e2e_csrf_cookie_fallback.sh
+
 .PHONY: e2e-validate-parity
 e2e-validate-parity: $(BUILDDIR)/hull
 	sh tests/e2e_validate_parity.sh

--- a/src/hull/module_registry.c
+++ b/src/hull/module_registry.c
@@ -600,8 +600,12 @@ static const HlModuleSpec REGISTRY[] = {
         .name = "hull/web/middleware/csrf",
         .api_major = 1, .intrinsic = 0, .pure = 0,
         .required_caps = HL_MOD_CAP_HTTP_SERVER,
-        /* HMAC token + max-age check; needs crypto + time. */
-        .deps = {"hull/http-server", "hull/crypto", "hull/time", 0},
+        /* HMAC token (crypto + time). hull/web/cookie for the session-id
+         * cookie fallback: both runtimes parse it now (previously only JS,
+         * which broke a JS app that declared only csrf - the cookie import
+         * wasn't auto-admitted). */
+        .deps = {"hull/http-server", "hull/crypto", "hull/time",
+                 "hull/web/cookie", 0},
     },
     {
         .name = "hull/web/middleware/etag",

--- a/stdlib/js/hull/web/middleware/csrf.js
+++ b/stdlib/js/hull/web/middleware/csrf.js
@@ -129,6 +129,10 @@ function parseCookieSessionId(req, cookieName) {
  * @param {string[]} [opts.safeMethods=["GET","HEAD","OPTIONS"]]
  * @param {string}  [opts.headerName="x-csrf-token"]
  * @param {string}  [opts.fieldName="_csrf"]
+ * @param {string}  [opts.name="hull_session"]  Session cookie name for the
+ *   session-id fallback. Alias: `cookieName`.
+ * @param {boolean} [opts.requireSession=false]  Reject unsafe requests with no
+ *   resolvable session (403) instead of passing them through.
  * @returns {(req, res) => number}
  * @throws {Error} If `opts.secret` is missing.
  */
@@ -140,7 +144,8 @@ function middleware(opts) {
     // Fallback session-cookie name when upstream session middleware hasn't
     // populated req.ctx[sessionKey]. Matches the session/auth middleware
     // default ("hull_session") so the fallback actually finds the cookie.
-    const cookieName = o.cookieName || "hull_session";
+    // Canonical `name`; back-compat alias `cookieName`.
+    const cookieName = o.name || o.cookieName || "hull_session";
     const sessionKey = o.sessionKey || "session_id";
     const headerName = o.headerName || "X-CSRF-Token";
     const fieldName = o.fieldName || "_csrf";

--- a/stdlib/lua/hull/web/middleware/csrf.lua
+++ b/stdlib/lua/hull/web/middleware/csrf.lua
@@ -19,6 +19,7 @@
 local crypto = require("hull.crypto")
 local _hex = require("hull.crypto._hex")
 local time = require("hull.time")
+local cookie = require("hull.web.cookie")
 
 local csrf = {}
 
@@ -138,6 +139,10 @@ end
 --   - `safe_methods` (`{string,...}`, default `{"GET","HEAD","OPTIONS"}`).
 --   - `header_name`  (string, default `"x-csrf-token"`).
 --   - `field_name`   (string, default `"_csrf"`).
+--   - `name`         (string, default `"hull_session"`): session cookie name
+--                    for the session-id fallback (alias: `cookie_name`).
+--   - `require_session` (boolean, default `false`): reject unsafe requests
+--                    that have no resolvable session (403) instead of passing.
 --
 -- @treturn function  Middleware `(req, res) -> integer`.
 -- @raise If `opts.secret` is missing.
@@ -156,6 +161,24 @@ function csrf.middleware(opts)
     if ttl == nil then ttl = 3600 end
     local header_name = opts.header_name or "x-csrf-token"
     local field_name = opts.field_name or "_csrf"
+    -- Fallback session-cookie name when upstream session middleware hasn't
+    -- populated req.ctx[session_key]. Matches the session/auth default so the
+    -- fallback actually finds the cookie.
+    local cookie_name = opts.name or opts.cookie_name or "hull_session"
+    local require_session = opts.require_session or false
+
+    -- Resolve the session id: prefer req.ctx[session_key] (set by upstream
+    -- session middleware on the SAME request), else parse it out of the
+    -- session cookie. Parity with the JS sibling.
+    local function resolve_session_id(req)
+        local sid = req.ctx and req.ctx[session_key]
+        if sid then return sid end
+        local ck = req.headers and req.headers["cookie"]
+        if not ck then return nil end
+        local v = cookie.parse(ck)[cookie_name]
+        if v == nil or v == "" then return nil end
+        return v
+    end
 
     -- Build safe methods lookup
     local safe_list = opts.safe_methods or { "GET", "HEAD", "OPTIONS" }
@@ -173,17 +196,22 @@ function csrf.middleware(opts)
             -- inspects req.ctx. HMAC-SHA256 here is sub-millisecond
             -- and the audit's "wasted" qualification was a perf
             -- observation, not a correctness issue.
-            local sid = req.ctx[session_key]
+            local sid = resolve_session_id(req)
             if sid then
+                if not req.ctx then req.ctx = {} end
                 req.ctx.csrf_token = csrf.generate(sid, secret)
             end
             return 0
         end
 
-        -- CSRF only applies to authenticated sessions. Unauthenticated POST
-        -- requests pass through — handlers must independently verify authentication.
-        local sid = req.ctx[session_key]
+        -- CSRF only applies to authenticated sessions by default.
+        -- require_session = true rejects unauthenticated unsafe requests.
+        local sid = resolve_session_id(req)
         if not sid then
+            if require_session then
+                res:status(403):json({ error = "csrf: session required for unsafe methods" })
+                return 1
+            end
             return 0
         end
 
@@ -223,6 +251,11 @@ function csrf.middleware(opts)
                 end
                 ::continue::
             end
+        end
+
+        if not token then
+            res:status(403):json({ error = "csrf: token missing" })
+            return 1
         end
 
         if not csrf.verify(token, sid, secret, ttl) then

--- a/tests/e2e_csrf_cookie_fallback.sh
+++ b/tests/e2e_csrf_cookie_fallback.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# e2e_csrf_cookie_fallback.sh: csrf middleware session-id resolution parity.
+#
+# The JS csrf resolved the session id as req.ctx[sessionKey] ELSE parse the
+# session cookie, and had cookieName + requireSession opts; the Lua csrf did
+# only req.ctx[session_key] (no cookie fallback, no opts) - a behavioral
+# divergence (Lua under-applied CSRF when the session id lived only in the
+# cookie) AND a module-resolution wrinkle (csrf.js statically imports
+# hull:web:cookie, so a JS app declaring only csrf failed to resolve until
+# hull/web/cookie was added to csrf's registry deps). Both fixed. This drives
+# the middleware with stub req/res through the shared branches and asserts an
+# identical result vector across runtimes.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+HULL="${HULL:-./build/hull}"
+[ -x "$HULL" ] || HULL="build/hull"
+WD=$(mktemp -d)
+trap 'rm -rf "$WD"' EXIT
+
+cat > "$WD/c.lua" <<'LUA'
+local csrf = require("hull.web.middleware.csrf")
+app.manifest({ modules = { "hull/web/middleware/csrf@1" } })   -- NOTE: cookie NOT declared; auto-admitted via csrf deps
+local SEC = "test-secret-key"
+local function res() return setmetatable({}, { __index = {
+    status = function(self) return self end, json = function() end } }) end
+app.main(function(ctx)
+    local mw  = csrf.middleware({ secret = SEC })
+    local mwr = csrf.middleware({ secret = SEC, require_session = true })
+    local out = {}
+    -- 1. GET, session only in the cookie -> token generated from the cookie sid
+    local g = { method = "GET", ctx = {}, headers = { cookie = "hull_session=abc" } }
+    mw(g, res()); out[#out+1] = g.ctx.csrf_token and "gen" or "nogen"
+    local tok = csrf.generate("abc", SEC)
+    -- 2. POST, cookie-only session + valid token -> accept (0)
+    out[#out+1] = tostring(mw({ method = "POST", ctx = {},
+        headers = { cookie = "hull_session=abc", ["x-csrf-token"] = tok } }, res()))
+    -- 3. POST, cookie-only session + bad token -> reject (1)
+    out[#out+1] = tostring(mw({ method = "POST", ctx = {},
+        headers = { cookie = "hull_session=abc", ["x-csrf-token"] = "bad.tok" } }, res()))
+    -- 4. POST, no session, require_session off -> pass (0)
+    out[#out+1] = tostring(mw({ method = "POST", ctx = {}, headers = {} }, res()))
+    -- 5. POST, no session, require_session on -> reject (1)
+    out[#out+1] = tostring(mwr({ method = "POST", ctx = {}, headers = {} }, res()))
+    ctx.stdout:write(table.concat(out, "|") .. "\n"); return 0
+end)
+LUA
+cat > "$WD/c.js" <<'JS'
+import { app } from "hull:app"; import { csrf } from "hull:web:middleware:csrf";
+app.manifest({ modules: ["hull/web/middleware/csrf@1"] });
+const SEC = "test-secret-key";
+const res = () => ({ status() { return this; }, json() {} });
+// req.header(name) is case-insensitive over a lowercase map.
+const mkReq = (method, map) => ({ method, ctx: {}, header(n) { return map[n.toLowerCase()] || null; } });
+app.main((ctx) => {
+    const mw  = csrf.middleware({ secret: SEC });
+    const mwr = csrf.middleware({ secret: SEC, requireSession: true });
+    const out = [];
+    const g = mkReq("GET", { cookie: "hull_session=abc" });
+    mw(g, res()); out.push(g.ctx.csrf_token ? "gen" : "nogen");
+    const tok = csrf.generate("abc", SEC);
+    out.push(String(mw(mkReq("POST", { cookie: "hull_session=abc", "x-csrf-token": tok }), res())));
+    out.push(String(mw(mkReq("POST", { cookie: "hull_session=abc", "x-csrf-token": "bad.tok" }), res())));
+    out.push(String(mw(mkReq("POST", {}), res())));
+    out.push(String(mwr(mkReq("POST", {}), res())));
+    ctx.stdout.write(out.join("|") + "\n"); return 0;
+});
+JS
+
+# token-from-cookie / accept valid / reject bad / pass no-session / reject (require)
+expect="gen|0|1|0|1"
+lua_out="$("$HULL" "$WD/c.lua" 2>/dev/null | tail -1)"
+js_out="$( "$HULL" "$WD/c.js"  2>/dev/null | tail -1)"
+
+if [ "$lua_out" = "$expect" ] && [ "$lua_out" = "$js_out" ]; then
+    echo "PASS: csrf session-id resolution (cookie fallback + require_session) is identical across Lua and JS"
+else
+    echo "::error csrf cookie-fallback DRIFT:"
+    echo "  expect=$expect"
+    echo "  lua   =$lua_out"
+    echo "  js    =$js_out"
+    exit 1
+fi


### PR DESCRIPTION
Two review follow-ups you asked for.

## 1. csrf session-id parity + module-resolution fix

The #281 note — "a JS app declaring only `hull/web/middleware/csrf` fails because
`csrf.js` imports `hull:web:cookie` while Lua doesn't" — turned out to be a
**deeper behavioral divergence**, not just a missing dep declaration:

- `csrf.js` resolved the session id as `req.ctx[sessionKey]` **else parse the
  session cookie**, and had `cookieName` + `requireSession` opts.
- `csrf.lua` did **only** `req.ctx[session_key]` — no cookie fallback, no opts.

So Lua **under-applied CSRF** when the session id lived only in the cookie (a
session-cookie POST that Lua passed through unchecked). The JS comment even
claimed "the same precedence as the Lua sibling" — which was false.

**Fix:** ported the fallback to Lua (`resolve_session_id`: ctx → parse the
session cookie) plus the `name` (alias `cookie_name`) and `require_session` opts,
and an explicit "token missing" 403 for message parity. Both runtimes now behave
identically. Declared `hull/web/cookie` as a dep of `hull/web/middleware/csrf`,
so a JS app declaring only csrf resolves (the cookie import is auto-admitted) —
the original wrinkle. `csrf.js` `cookieName` also accepts the canonical `name`.

**Test:** `tests/e2e_csrf_cookie_fallback.sh` drives the middleware with stub
req/res through the shared branches (token generated from a cookie-only session;
valid/invalid token accept/reject; `require_session` on/off) and asserts an
identical result vector across runtimes. The app declares **only** csrf,
exercising the auto-admitted cookie dep. `make` target + CI step.

## 2. htmx widgets positioning (docs only)

Drew a firm line in `docs/htmx_widgets.md` (+ a pointer in `docs/htmx.md`):

- the base `hull/web/htmx` module (htmx request detection + `HX-*` response
  headers) is **frontend-agnostic core**, a peer of `csv`/`jwt`/`validate`;
- the 8 **widgets** are an **optional, opinionated component pack** (they emit
  HTML/CSS/JS and are inert without htmx on the page) — opt into them only when
  building htmx-first.

No code change — a positioning call, as the review framed it.

## Validation

`make test` 62/62; `e2e_csrf_cookie_fallback` + `e2e_naming_aliases` parity tests
green. Existing `ctx.session_id` flows are unchanged (the fallback only fires
when ctx has no session id), so `e2e_htmx`/auth flows are unaffected.
