### PR TITLE
stdlib: share one logfmt formatter (hull.web._logfmt); fix logx escaping

### DIFF
--- a/stdlib/js/hull/logx.js
+++ b/stdlib/js/hull/logx.js
@@ -27,25 +27,23 @@
  */
 
 import { log } from "hull:log";
+import { _logfmt } from "hull:web:_logfmt";
 
 const logx = {};
 
 const LEVELS = ["info", "warn", "error", "debug"];
 
 // Format a fields object as a leading-space logfmt fragment " k=v k2=v2". Keys
-// sorted for deterministic, cross-runtime-identical output. A value containing
-// whitespace, a quote, or '=' is double-quoted with '"' escaped.
+// sorted for deterministic, cross-runtime-identical output. Value escaping +
+// quoting is the shared hull:web:_logfmt rule (escapes \ CR LF ", quotes when
+// needed) - the logger middleware uses the same one.
 function fmt(fields) {
     if (!fields) return "";
     const keys = Object.keys(fields).sort();
     if (keys.length === 0) return "";
     const parts = [];
     for (let i = 0; i < keys.length; i++) {
-        const k = keys[i];
-        const v = fields[k];
-        let s = (typeof v === "boolean") ? (v ? "true" : "false") : String(v);
-        if (/[\s"=]/.test(s)) s = '"' + s.replace(/"/g, '\\"') + '"';
-        parts.push(k + "=" + s);
+        parts.push(_logfmt.pair(keys[i], fields[keys[i]]));
     }
     return " " + parts.join(" ");
 }

--- a/stdlib/js/hull/web/_logfmt.js
+++ b/stdlib/js/hull/web/_logfmt.js
@@ -1,0 +1,45 @@
+/**
+ * @file hull:web:_logfmt
+ * @module hull:web:_logfmt
+ * @description Internal logfmt value formatting shared across the logging
+ *   stdlib. Lua parity: `hull.web._logfmt`.
+ *
+ * Contributor-only (the `_` prefix): imported by `hull:web:middleware:logger`
+ * and `hull:logx`, never declared by apps. One place for the escape + quote
+ * rules so the two logfmt producers can't drift. See docs/stdlib_style.md
+ * section 4.
+ *
+ * @license AGPL-3.0-or-later
+ */
+
+/**
+ * Escape a value for safe logfmt output (log-injection defense): a raw newline
+ * could otherwise forge a second log line. Escapes backslash, CR, LF, and
+ * double-quote.
+ * @param {*} v
+ * @returns {string}
+ */
+function sanitize(v) {
+    return String(v)
+        .replace(/\\/g, "\\\\")
+        .replace(/\n/g, "\\n")
+        .replace(/\r/g, "\\r")
+        .replace(/"/g, '\\"');
+}
+
+/**
+ * Format one key=value logfmt pair, quoting the value when the RAW value
+ * contains a space, `=`, `"`, or a CR/LF.
+ * @param {string} k
+ * @param {*} v
+ * @returns {string}
+ */
+function pair(k, v) {
+    const raw = String(v);
+    const s = sanitize(raw);
+    if (/[ ="\n\r]/.test(raw)) return k + '="' + s + '"';
+    return k + "=" + s;
+}
+
+export const _logfmt = { sanitize, pair };
+export default _logfmt;

--- a/stdlib/js/hull/web/middleware/logger.js
+++ b/stdlib/js/hull/web/middleware/logger.js
@@ -12,6 +12,7 @@
  */
 
 import { log } from "hull:log";
+import { _logfmt } from "hull:web:_logfmt";
 
 let counter = 0;
 
@@ -21,25 +22,13 @@ function generateId() {
     return counter.toString(16).padStart(8, "0");
 }
 
-function sanitizeValue(v) {
-    return v.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/"/g, '\\"');
-}
-
-function needsQuoting(v) {
-    return v.indexOf(" ") >= 0 || v.indexOf("=") >= 0 || v.indexOf('"') >= 0 || v.indexOf("\n") >= 0 || v.indexOf("\r") >= 0;
-}
-
+// Escaping + quoting is the shared hull:web:_logfmt rule (escapes \ CR LF ";
+// quotes values containing a space, =, ", or a CR/LF). The same rule backs
+// hull:logx, so the two logfmt producers can't drift.
 function formatLine(entries) {
     const parts = [];
     for (let i = 0; i < entries.length; i++) {
-        const k = entries[i][0];
-        const raw = String(entries[i][1]);
-        const v = sanitizeValue(raw);
-        if (needsQuoting(raw)) {
-            parts.push(k + '="' + v + '"');
-        } else {
-            parts.push(k + "=" + v);
-        }
+        parts.push(_logfmt.pair(entries[i][0], entries[i][1]));
     }
     return parts.join(" ");
 }

--- a/stdlib/lua/hull/logx.lua
+++ b/stdlib/lua/hull/logx.lua
@@ -26,13 +26,16 @@
 
 local log = require("hull.log")
 
+local _logfmt = require("hull.web._logfmt")
+
 local logx = {}
 
 local LEVELS = { "info", "warn", "error", "debug" }
 
 -- Format a fields table as a leading-space logfmt fragment: " k=v k2=v2".
--- Keys are sorted for deterministic, cross-runtime-identical output. A value
--- containing whitespace, a quote, or '=' is double-quoted with '"' escaped.
+-- Keys are sorted for deterministic, cross-runtime-identical output. Value
+-- escaping + quoting is the shared hull.web._logfmt rule (escapes \ CR LF ",
+-- quotes when needed) - the logger middleware uses the same one.
 local function fmt(fields)
     if not fields then return "" end
     local keys = {}
@@ -41,17 +44,7 @@ local function fmt(fields)
     if #keys == 0 then return "" end
     local parts = {}
     for _, k in ipairs(keys) do
-        local v = fields[k]
-        local s
-        if type(v) == "boolean" then
-            s = v and "true" or "false"
-        else
-            s = tostring(v)
-        end
-        if s:find('[%s"=]') then
-            s = '"' .. s:gsub('"', '\\"') .. '"'
-        end
-        parts[#parts + 1] = k .. "=" .. s
+        parts[#parts + 1] = _logfmt.pair(k, fields[k])
     end
     return " " .. table.concat(parts, " ")
 end

--- a/stdlib/lua/hull/web/_logfmt.lua
+++ b/stdlib/lua/hull/web/_logfmt.lua
@@ -1,0 +1,44 @@
+--- Internal logfmt value formatting shared across the logging stdlib.
+--
+-- @module hull.web._logfmt
+-- @license AGPL-3.0-or-later
+--
+-- Contributor-only (the `_` prefix): required by `hull.web.middleware.logger`
+-- and `hull.logx`, never declared by apps. One place for the escape + quote
+-- rules so the two logfmt producers can't drift (they had: logx escaped only
+-- `"`, the logger middleware escaped `\ \r \n "`). See docs/stdlib_style.md
+-- section 4.
+
+local M = {}
+
+--- Escape a value for safe logfmt output (log-injection defense): a raw
+-- newline could otherwise forge a second log line. Escapes backslash, CR, LF,
+-- and double-quote.
+-- @tparam any v
+-- @treturn string
+function M.sanitize(v)
+    local s = tostring(v)
+    s = s:gsub("\\", "\\\\")
+    s = s:gsub("\n", "\\n")
+    s = s:gsub("\r", "\\r")
+    s = s:gsub('"', '\\"')
+    return s
+end
+
+--- Format one `key=value` logfmt pair, quoting the value when the RAW value
+-- contains a space, `=`, `"`, or a CR/LF (matches the format any logfmt reader
+-- expects). The quote test is on the raw value so an escaped newline still
+-- triggers quoting.
+-- @tparam string k
+-- @tparam any v
+-- @treturn string  e.g. `k=v` or `k="v with spaces"`.
+function M.pair(k, v)
+    local raw = tostring(v)
+    local s = M.sanitize(raw)
+    if raw:find('[ =\n\r"]') then
+        return k .. '="' .. s .. '"'
+    end
+    return k .. "=" .. s
+end
+
+return M

--- a/stdlib/lua/hull/web/middleware/logger.lua
+++ b/stdlib/lua/hull/web/middleware/logger.lua
@@ -1,4 +1,5 @@
 local log = require("hull.log")
+local _logfmt = require("hull.web._logfmt")
 
 --- Request logging middleware (logfmt output).
 --
@@ -28,32 +29,18 @@ function logger.generate_id()
     return string.format("%08x", _counter)
 end
 
---- Sanitize a value for safe logfmt output (prevent log injection).
-local function sanitize_value(v)
-    v = v:gsub("\\", "\\\\")
-    v = v:gsub("\n", "\\n")
-    v = v:gsub("\r", "\\r")
-    v = v:gsub('"', '\\"')
-    return v
-end
-
 --- Format `{key, value}` pairs into a logfmt line.
 --
--- Quotes values that contain spaces, `=`, `"`, or newlines. Sanitises
--- control characters.
+-- Escaping + quoting is the shared `hull.web._logfmt` rule (escapes
+-- `\ CR LF "`; quotes values containing a space, `=`, `"`, or a CR/LF). The
+-- same rule backs `hull.logx`, so the two logfmt producers can't drift.
 --
 -- @tparam {{string,any},...} entries  List of pairs.
 -- @treturn string  Single-line logfmt-encoded.
 function logger.format_line(entries)
     local parts = {}
     for _, entry in ipairs(entries) do
-        local k = entry[1]
-        local v = sanitize_value(tostring(entry[2]))
-        if v:find("[ =\"\n\r]") then
-            parts[#parts + 1] = k .. '="' .. v .. '"'
-        else
-            parts[#parts + 1] = k .. "=" .. v
-        end
+        parts[#parts + 1] = _logfmt.pair(entry[1], entry[2])
     end
     return table.concat(parts, " ")
 end

--- a/tests/e2e_logx_parity.sh
+++ b/tests/e2e_logx_parity.sh
@@ -21,6 +21,9 @@ app.manifest({ modules = { "hull/logx@1", "hull/log@1" } })
 app.main(function(ctx)
     logx.with({ b = "x y", a = 1, z = true }).info("AAAA")
     logx.with({ a = 1 }).with({ c = "d" }).warn("BBBB")
+    -- Escaping: backslash (escaped, unquoted), a quote (escaped + quoted),
+    -- an '=' (quoted). sorted keys bs, eq, qt.
+    logx.with({ bs = "a\\b", qt = 'x"y', eq = "k=v" }).info("CCCC")
     return 0
 end)
 LUA
@@ -30,6 +33,7 @@ app.manifest({ modules: ["hull/logx@1", "hull/log@1"] });
 app.main((ctx) => {
     logx.with({ b: "x y", a: 1, z: true }).info("AAAA");
     logx.with({ a: 1 }).with({ c: "d" }).warn("BBBB");
+    logx.with({ bs: "a\\b", qt: 'x"y', eq: "k=v" }).info("CCCC");
     return 0;
 });
 JS
@@ -38,7 +42,7 @@ JS
 extract() {
     "$HULL" "$1" 2>&1 \
         | sed 's/\x1b\[[0-9;]*m//g' \
-        | grep -oE '(AAAA|BBBB).*' \
+        | grep -oE '(AAAA|BBBB|CCCC).*' \
         | sed 's/[[:space:]]*$//' \
         | tr '\n' '~'
 }
@@ -46,8 +50,10 @@ extract() {
 lua_out="$(extract "$WD/l.lua")"
 js_out="$(extract "$WD/l.js")"
 
-# sorted keys (a,b,z); "x y" quoted; boolean true; child merge a+c
-expect='AAAA a=1 b="x y" z=true~BBBB a=1 c=d~'
+# AAAA: sorted keys (a,b,z); "x y" quoted; boolean true.
+# BBBB: child merge a+c.
+# CCCC: backslash doubled + unquoted; quote escaped + quoted; '=' quoted.
+expect='AAAA a=1 b="x y" z=true~BBBB a=1 c=d~CCCC bs=a\\b eq="k=v" qt="x\"y"~'
 
 if [ "$lua_out" = "$expect" ] && [ "$lua_out" = "$js_out" ]; then
     echo "PASS: hull.logx logfmt formatting is byte-identical across Lua and JS"


### PR DESCRIPTION
## What

The third-review delta audit caught a real (Medium) issue in `hull/logx` — which
I added last session: its logfmt formatter escaped only `"`, weaker than the
`logger` middleware's existing one (`\ CR LF "`). Since `logx` exists to fold
**untrusted per-request context** (request_id, user, route) into log lines, that
was a log-injection / readability gap (a value with a newline could forge a
second log line). It was also a **4th parallel logfmt implementation** with
different rules.

**Fix:** one shared internal helper `hull.web._logfmt` (Lua + JS, `_`-prefixed
contributor-only, like `_hex`/`_request`):
- `sanitize(v)` — escape `\ CR LF "`.
- `pair(k, v)` — format one `k=v`, quoting when the **raw** value has a
  space / `=` / `"` / CR / LF.

Both `hull/logx` and `hull/web/middleware/logger` now use it, so the two logfmt
producers can't drift.

## Bonus: fixed a pre-existing logger drift

Migrating `logger` surfaced a Lua/JS parity bug already in it: the **Lua** side
quoted on the *sanitized* value, so an already-escaped newline never triggered
quoting (`n=x\ny`), while **JS** quoted on the *raw* value (`n="x\ny"`). Both now
quote raw space/=/"/CR/LF identically — verified directly:

```
lua logger: m=GET p="/a b" n="x\ny" q="a\"b" bs=c\\d
js  logger: m=GET p="/a b" n="x\ny" q="a\"b" bs=c\\d
```

## Test

`tests/e2e_logx_parity.sh` extended with backslash / quote / `=` fields, asserting
byte-identical output across runtimes (`bs=a\\b eq="k=v" qt="x\"y"`). No registry
or Makefile change (`_logfmt` auto-embeds; the parity test was already wired in
CI). `make test` 62/62.
