### PR TITLE
stdlib: add hull/cache — in-memory TTL cache + memoization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,10 @@ jobs:
         timeout-minutes: 2
         run: make e2e-uuid
 
+      - name: Cache module (TTL/LRU) Lua/JS parity E2E test
+        timeout-minutes: 2
+        run: make e2e-cache-module
+
       - name: Config (typed env + .env) Lua/JS parity E2E test
         timeout-minutes: 2
         run: make e2e-config-parity

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -692,6 +692,10 @@ e2e-email: $(BUILDDIR)/hull
 e2e-uuid: $(BUILDDIR)/hull
 	sh tests/e2e_uuid.sh
 
+.PHONY: e2e-cache-module
+e2e-cache-module: $(BUILDDIR)/hull
+	sh tests/e2e_cache_module.sh
+
 .PHONY: e2e-config-parity
 e2e-config-parity: $(BUILDDIR)/hull
 	sh tests/e2e_config_parity.sh

--- a/src/hull/module_registry.c
+++ b/src/hull/module_registry.c
@@ -81,6 +81,14 @@ static const HlModuleSpec REGISTRY[] = {
         .required_caps = HL_MOD_CAP_FS, .deps = {0},
     },
     {
+        /* In-memory key/value cache with TTL + get-or-compute memoization.
+         * Bounded (LRU on cap), lazily-expiring, process-local. Pure Lua/JS
+         * over time; no persistence, no new authority. */
+        .name = "hull/cache",
+        .api_major = 1, .intrinsic = 0, .pure = 0,
+        .required_caps = 0, .deps = {"hull/time", 0},
+    },
+    {
         .name = "hull/compute",
         .api_major = 1, .intrinsic = 0, .pure = 0,
         .required_caps = HL_MOD_CAP_WASM, .deps = {0},

--- a/stdlib/js/hull/cache.js
+++ b/stdlib/js/hull/cache.js
@@ -1,0 +1,158 @@
+/**
+ * @file hull:cache
+ * @module hull:cache
+ * @description In-memory key/value cache with TTL and get-or-compute
+ *   memoization. Lua parity: `hull.cache`.
+ *
+ * A bounded, lazily-expiring cache for the common "compute once, reuse for a
+ * while" pattern - derived values, parsed config, a hot DB row, an API response.
+ * In-memory and process-local (no persistence, no cross-node sharing); values
+ * are stored as-is (any value, no serialization). One small dep (time).
+ *
+ * The default instance backs the top-level `cache.*` calls; `cache.new(opts)`
+ * gives an isolated instance (own keyspace + cap) for a library or subsystem.
+ *
+ * @license AGPL-3.0-or-later
+ * @example
+ *   import { cache } from "hull:cache";
+ *   const u = cache.fetch("user:" + id, 300, () => loadUser(id));  // memoize
+ *   cache.set("k", value, 60);   // ttl seconds; null = no expiry; 0 = expire now
+ *   const v = cache.get("k");    // value or null
+ *
+ *   // async producers (http.fetch / compute.async): compose get + set so the
+ *   // app controls the await:
+ *   let v = cache.get(k);
+ *   if (v === null) { v = await fetchRemote(); cache.set(k, v, 60); }
+ */
+
+import { time } from "hull:time";
+
+const DEFAULT_MAX = 1000;
+
+/**
+ * Create an isolated cache instance.
+ * @param {Object} [opts]  `maxEntries` (default 1000), `defaultTtl` (seconds;
+ *   used by set/fetch when no ttl is passed; default no expiry).
+ * @returns {Object} Instance with get/set/fetch/has/delete/clear/size.
+ */
+function newCache(opts) {
+    opts = opts || {};
+    let store = new Map();     // key -> { value, expires (ms|null), seq }
+    let count = 0;
+    let seq = 0;
+    const max = opts.maxEntries || DEFAULT_MAX;
+    const defaultTtl = opts.defaultTtl;
+
+    const nextSeq = () => ++seq;
+
+    // Return the entry if live; drop + return null if it has expired.
+    const live = (key) => {
+        const e = store.get(key);
+        if (!e) return null;
+        if (e.expires != null && time.nowMs() >= e.expires) {
+            store.delete(key);
+            count -= 1;
+            return null;
+        }
+        return e;
+    };
+
+    // Make room: drop an expired entry if any, else the least-recently-used.
+    const evictOne = () => {
+        const now = time.nowMs();
+        let lruKey, lruSeq;
+        for (const [k, e] of store) {
+            if (e.expires != null && now >= e.expires) {
+                store.delete(k);
+                count -= 1;
+                return;
+            }
+            if (lruSeq === undefined || e.seq < lruSeq) {
+                lruKey = k;
+                lruSeq = e.seq;
+            }
+        }
+        if (lruKey !== undefined) {
+            store.delete(lruKey);
+            count -= 1;
+        }
+    };
+
+    const get = (key) => {
+        const e = live(key);
+        if (!e) return null;
+        e.seq = nextSeq();
+        return e.value;
+    };
+
+    const has = (key) => live(key) !== null;
+
+    const set = (key, value, ttl) => {
+        if (ttl === undefined) ttl = defaultTtl;
+        let expires = null;
+        if (ttl != null) expires = time.nowMs() + ttl * 1000;
+        const e = store.get(key);
+        if (e === undefined) {
+            if (count >= max) evictOne();
+            store.set(key, { value, expires, seq: nextSeq() });
+            count += 1;
+        } else {
+            e.value = value;
+            e.expires = expires;
+            e.seq = nextSeq();
+        }
+        return value;
+    };
+
+    const fetch = (key, ttl, fn) => {
+        if (fn === undefined && typeof ttl === "function") {
+            fn = ttl;
+            ttl = undefined;
+        }
+        const e = live(key);
+        if (e) {
+            e.seq = nextSeq();
+            return e.value;
+        }
+        const v = fn();
+        set(key, v, ttl);
+        return v;
+    };
+
+    const del = (key) => {
+        if (store.has(key)) {
+            store.delete(key);
+            count -= 1;
+            return true;
+        }
+        return false;
+    };
+
+    const clear = () => {
+        store = new Map();
+        count = 0;
+    };
+
+    const size = () => count;
+
+    return { get, has, set, fetch, delete: del, clear, size };
+}
+
+// Default instance backs the top-level cache.* convenience API. A cache is
+// intentionally cross-request shared state (like ratelimit's buckets), so a
+// module-level default is correct here, not the request-scoped-global footgun.
+const _default = newCache();
+
+const cache = {
+    new: newCache,
+    get: _default.get,
+    set: _default.set,
+    fetch: _default.fetch,
+    has: _default.has,
+    delete: _default.delete,
+    clear: _default.clear,
+    size: _default.size,
+};
+
+export { cache };
+export default cache;

--- a/stdlib/lua/hull/cache.lua
+++ b/stdlib/lua/hull/cache.lua
@@ -1,0 +1,166 @@
+--- In-memory key/value cache with TTL and get-or-compute memoization.
+--
+-- A bounded, lazily-expiring cache for the common "compute once, reuse for a
+-- while" pattern - derived values, parsed config, a hot DB row, an API response.
+-- In-memory and process-local (no persistence, no cross-node sharing); values
+-- are stored as-is (any Lua value, no serialization). One small dep (time).
+--
+-- The default instance backs the top-level `cache.*` calls; `cache.new(opts)`
+-- gives an isolated instance (own keyspace + cap) for a library or subsystem.
+--
+-- @module hull.cache
+-- @license AGPL-3.0-or-later
+-- @usage
+--   local cache = require("hull.cache")
+--   -- memoize: hit returns cached; miss runs fn(), stores it, returns it
+--   local u = cache.fetch("user:" .. id, 300, function() return load_user(id) end)
+--   cache.set("k", value, 60)   -- ttl seconds; nil = no expiry; 0 = expire now
+--   local v = cache.get("k")    -- value or nil
+--
+--   -- async producers (http.fetch / compute.async): compose get + set so the
+--   -- app controls the await:
+--   local v = cache.get(k)
+--   if v == nil then v = fetch_remote(); cache.set(k, v, 60) end
+
+local time = require("hull.time")
+
+local cache = {}
+
+local DEFAULT_MAX = 1000
+
+--- Create an isolated cache instance.
+-- @tparam[opt] table opts  `max_entries` (default 1000), `default_ttl`
+--   (seconds; used by set/fetch when no ttl is passed; default no expiry).
+-- @treturn table  Instance with get/set/fetch/has/delete/clear/size.
+function cache.new(opts)
+    opts = opts or {}
+    local store = {}          -- key -> { value, expires (ms|nil), seq }
+    local count = 0
+    local seq = 0
+    local max = opts.max_entries or DEFAULT_MAX
+    local default_ttl = opts.default_ttl
+
+    local function next_seq() seq = seq + 1; return seq end
+
+    -- Return the entry if live; drop + return nil if it has expired.
+    local function live(key)
+        local e = store[key]
+        if not e then return nil end
+        if e.expires ~= nil and time.now_ms() >= e.expires then
+            store[key] = nil
+            count = count - 1
+            return nil
+        end
+        return e
+    end
+
+    -- Make room: drop an expired entry if any, else the least-recently-used.
+    local function evict_one()
+        local now = time.now_ms()
+        local lru_key, lru_seq
+        for k, e in pairs(store) do
+            if e.expires ~= nil and now >= e.expires then
+                store[k] = nil
+                count = count - 1
+                return
+            end
+            if lru_seq == nil or e.seq < lru_seq then
+                lru_key, lru_seq = k, e.seq
+            end
+        end
+        if lru_key ~= nil then
+            store[lru_key] = nil
+            count = count - 1
+        end
+    end
+
+    local self = {}
+
+    --- Return the value for `key`, or nil on miss / expiry.
+    function self.get(key)
+        local e = live(key)
+        if not e then return nil end
+        e.seq = next_seq()
+        return e.value
+    end
+
+    --- Whether `key` is present and unexpired.
+    function self.has(key)
+        return live(key) ~= nil
+    end
+
+    --- Store `value` under `key`. `ttl` is seconds (fractional ok); nil uses
+    -- the instance `default_ttl` (no expiry if unset); 0 expires immediately.
+    -- @return value
+    function self.set(key, value, ttl)
+        if ttl == nil then ttl = default_ttl end
+        local expires = nil
+        if ttl ~= nil then expires = time.now_ms() + ttl * 1000 end
+        local e = store[key]
+        if e == nil then
+            if count >= max then evict_one() end
+            store[key] = { value = value, expires = expires, seq = next_seq() }
+            count = count + 1
+        else
+            e.value = value
+            e.expires = expires
+            e.seq = next_seq()
+        end
+        return value
+    end
+
+    --- Get `key`, or compute it: on miss run `fn()`, store the result under
+    -- `ttl`, and return it. Call as `fetch(key, ttl, fn)` or `fetch(key, fn)`.
+    -- `fn` is synchronous; for async producers compose get + set.
+    function self.fetch(key, ttl, fn)
+        if fn == nil and type(ttl) == "function" then
+            fn = ttl
+            ttl = nil
+        end
+        local e = live(key)
+        if e then
+            e.seq = next_seq()
+            return e.value
+        end
+        local v = fn()
+        self.set(key, v, ttl)
+        return v
+    end
+
+    --- Remove `key`. Returns true if it was present.
+    function self.delete(key)
+        if store[key] ~= nil then
+            store[key] = nil
+            count = count - 1
+            return true
+        end
+        return false
+    end
+
+    --- Remove every entry.
+    function self.clear()
+        store = {}
+        count = 0
+    end
+
+    --- Current entry count (may include not-yet-swept expired entries).
+    function self.size()
+        return count
+    end
+
+    return self
+end
+
+-- Default instance backs the top-level cache.* convenience API. A cache is
+-- intentionally cross-request shared state (like ratelimit's buckets), so a
+-- module-level default is correct here, not the request-scoped-global footgun.
+local _default = cache.new()
+cache.get = _default.get
+cache.set = _default.set
+cache.fetch = _default.fetch
+cache.has = _default.has
+cache.delete = _default.delete
+cache.clear = _default.clear
+cache.size = _default.size
+
+return cache

--- a/tests/e2e_cache_module.sh
+++ b/tests/e2e_cache_module.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# e2e_cache_module.sh: hull.cache (the app-facing key/value cache) behavior +
+# Lua/JS parity. (Distinct from e2e_cache.sh, which tests the `hull cache` CLI.)
+#
+# Exercises the full surface deterministically (no wall-clock waits): miss,
+# set/get, has, fetch memoization (fn runs once), ttl=0 immediate expiry,
+# delete idempotence, and LRU eviction at a max_entries cap. Asserts an
+# identical result vector across runtimes.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+HULL="${HULL:-./build/hull}"
+[ -x "$HULL" ] || HULL="build/hull"
+WD=$(mktemp -d)
+trap 'rm -rf "$WD"' EXIT
+
+cat > "$WD/c.lua" <<'LUA'
+local cache = require("hull.cache")
+app.manifest({ modules = { "hull/cache@1" } })
+app.main(function(ctx)
+    local o = {}
+    cache.clear()
+    o[#o+1] = cache.get("miss") == nil and "miss_nil" or "F1"
+    cache.set("k", "v")
+    o[#o+1] = cache.get("k") == "v" and "set_get" or "F2"
+    o[#o+1] = (cache.has("k") and cache.has("nope") == false) and "has" or "F3"
+    local calls = 0
+    local a = cache.fetch("f", 60, function() calls = calls + 1; return "c" end)
+    local b = cache.fetch("f", 60, function() calls = calls + 1; return "c" end)
+    o[#o+1] = (a == "c" and b == "c" and calls == 1) and "fetch_memo" or "F4"
+    cache.set("z", "v", 0)
+    o[#o+1] = cache.get("z") == nil and "ttl0_expired" or "F5"
+    cache.set("d", "x")
+    local d1 = cache.delete("d")
+    local d2 = cache.delete("d")
+    o[#o+1] = (d1 == true and d2 == false and cache.get("d") == nil) and "delete" or "F6"
+    local c2 = cache.new({ max_entries = 2 })
+    c2.set("a", 1); c2.set("b", 2); c2.get("a"); c2.set("c", 3)  -- b is LRU -> evicted
+    o[#o+1] = (c2.has("a") and not c2.has("b") and c2.has("c") and c2.size() == 2) and "lru" or "F7"
+    ctx.stdout:write(table.concat(o, "|") .. "\n"); return 0
+end)
+LUA
+cat > "$WD/c.js" <<'JS'
+import { app } from "hull:app"; import { cache } from "hull:cache";
+app.manifest({ modules: ["hull/cache@1"] });
+app.main((ctx) => {
+    const o = [];
+    cache.clear();
+    o.push(cache.get("miss") === null ? "miss_nil" : "F1");
+    cache.set("k", "v");
+    o.push(cache.get("k") === "v" ? "set_get" : "F2");
+    o.push((cache.has("k") && cache.has("nope") === false) ? "has" : "F3");
+    let calls = 0;
+    const a = cache.fetch("f", 60, () => { calls++; return "c"; });
+    const b = cache.fetch("f", 60, () => { calls++; return "c"; });
+    o.push((a === "c" && b === "c" && calls === 1) ? "fetch_memo" : "F4");
+    cache.set("z", "v", 0);
+    o.push(cache.get("z") === null ? "ttl0_expired" : "F5");
+    cache.set("d", "x");
+    const d1 = cache.delete("d"); const d2 = cache.delete("d");
+    o.push((d1 === true && d2 === false && cache.get("d") === null) ? "delete" : "F6");
+    const c2 = cache.new({ maxEntries: 2 });
+    c2.set("a", 1); c2.set("b", 2); c2.get("a"); c2.set("c", 3);
+    o.push((c2.has("a") && !c2.has("b") && c2.has("c") && c2.size() === 2) ? "lru" : "F7");
+    ctx.stdout.write(o.join("|") + "\n"); return 0;
+});
+JS
+
+expect="miss_nil|set_get|has|fetch_memo|ttl0_expired|delete|lru"
+lua_out="$("$HULL" "$WD/c.lua" 2>/dev/null | tail -1)"
+js_out="$( "$HULL" "$WD/c.js"  2>/dev/null | tail -1)"
+
+if [ "$lua_out" = "$expect" ] && [ "$lua_out" = "$js_out" ]; then
+    echo "PASS: hull.cache behavior is byte-identical across Lua and JS"
+else
+    echo "::error hull.cache DRIFT:"
+    echo "  expect=$expect"
+    echo "  lua   =$lua_out"
+    echo "  js    =$js_out"
+    exit 1
+fi


### PR DESCRIPTION
The highest-frequency remaining gap from the stdlib review: apps had no
key/value cache, so every "compute once, reuse for a while" (derived values,
parsed config, a hot DB row, an API response) was hand-rolled or recomputed.

## API

```lua
local cache = require("hull.cache")
-- memoize: hit returns cached; miss runs fn(), stores it, returns it
local u = cache.fetch("user:" .. id, 300, function() return load_user(id) end)
cache.set("k", value, 60)   -- ttl seconds; nil = no expiry; 0 = expire now
local v = cache.get("k")    -- value or nil
cache.has(k); cache.delete(k); cache.clear(); cache.size()
local c = cache.new({ max_entries = 500, default_ttl = 60 })  -- isolated instance
```

## Design (as reviewed before implementing)

- **In-memory only (v1):** highest value, zero persistence deps, works on
  compute-only builds, trivial Lua/JS parity, stores any value.
- **Lazy expiry** on read (never serves stale data). **Bounded memory:**
  `max_entries` cap (default 1000) with **LRU eviction** on overflow (prefers an
  already-expired entry, else the least-recently-used) — generalizes the sweep
  pattern already trapped in `ratelimit`/`session`.
- **`fetch` is synchronous** in both runtimes (keeps parity clean, no forced
  `await`); async producers (`http.fetch`/`compute.async`) compose `get` + `set`
  so the app owns the await.
- The module-level default backs `cache.*` — a cache is *intentionally*
  cross-request shared state (like `ratelimit`'s buckets), not the
  request-scoped-global footgun.

**Explicit v1 non-goals (follow-ups):** a DB-backed/shared store (persistence +
multi-node — pairs naturally with the shared-rate-limit-backend gap), async
`fetch`, single-flight stampede protection.

## Test

`tests/e2e_cache_module.sh` drives miss / set+get / has / fetch-runs-once /
`ttl=0` immediate-expiry / delete-idempotence / **LRU eviction** deterministically
(no wall-clock waits — `ttl=0` and a `max_entries=2` cap give exact assertions)
and asserts a byte-identical result vector across runtimes. `make` target + CI
step. `make test` 62/62.

Named `e2e_cache_module.sh` to avoid clashing with the existing `e2e_cache.sh`
(which tests the `hull cache` CLI).
