### PR TITLE
stdlib: back ratelimit's bucket store with hull/cache (LRU-bounded)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,10 @@ jobs:
         timeout-minutes: 2
         run: make e2e-cache-module
 
+      - name: Ratelimit (hull.cache-backed) Lua/JS parity E2E test
+        timeout-minutes: 2
+        run: make e2e-ratelimit-parity
+
       - name: Config (typed env + .env) Lua/JS parity E2E test
         timeout-minutes: 2
         run: make e2e-config-parity

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -696,6 +696,10 @@ e2e-uuid: $(BUILDDIR)/hull
 e2e-cache-module: $(BUILDDIR)/hull
 	sh tests/e2e_cache_module.sh
 
+.PHONY: e2e-ratelimit-parity
+e2e-ratelimit-parity: $(BUILDDIR)/hull
+	sh tests/e2e_ratelimit_parity.sh
+
 .PHONY: e2e-config-parity
 e2e-config-parity: $(BUILDDIR)/hull
 	sh tests/e2e_config_parity.sh

--- a/src/hull/module_registry.c
+++ b/src/hull/module_registry.c
@@ -686,7 +686,8 @@ static const HlModuleSpec REGISTRY[] = {
         .name = "hull/web/middleware/ratelimit",
         .api_major = 1, .intrinsic = 0, .pure = 0,
         .required_caps = HL_MOD_CAP_HTTP_SERVER,
-        .deps = {"hull/http-server", "hull/time", 0},
+        /* hull/cache backs the per-key bucket store (LRU-bounded). */
+        .deps = {"hull/http-server", "hull/time", "hull/cache", 0},
     },
     {
         .name = "hull/web/middleware/rbac",

--- a/stdlib/js/hull/web/middleware/ratelimit.js
+++ b/stdlib/js/hull/web/middleware/ratelimit.js
@@ -7,66 +7,42 @@
  * Sliding-window counter per key. **In-memory only — resets on restart.**
  * For multi-instance production rate limiting, layer a DB-backed limiter.
  *
+ * The per-key buckets live in a bounded `hull:cache` instance, so memory is
+ * capped and stale buckets are evicted automatically (LRU) - no hand-rolled
+ * sweep. (The cache's internal Map also treats a `__proto__` limit key as an
+ * ordinary key, so no prototype-pollution guard is needed here.) The window
+ * logic uses the caller-passed `now`, so `check` stays a pure, testable
+ * function of its inputs.
+ *
  * @license AGPL-3.0-or-later
  */
 
 import { time } from "hull:time";
+import { cache } from "hull:cache";
 
 const MAX_BUCKETS = 10000;
-const SWEEP_INTERVAL = 100;
 
-/* M-4: bucket counter is per-store, not module-global. Multiple
- * ratelimit.middleware() instances would otherwise share the same
- * MAX_BUCKETS budget and starve each other. The store object holds the
- * bucket map plus its own count. */
-function makeStore() {
-    // Null-prototype map: a request-derived rate-limit key of "__proto__"
-    // must be an ordinary key, not the Object.prototype setter.
-    return { buckets: Object.create(null), count: 0 };
-}
-
-function sweepExpired(store, window, now) {
-    const buckets = store.buckets;
-    for (const k in buckets) {
-        if ((now - buckets[k].windowStart) >= window) {
-            delete buckets[k];
-            store.count--;
-        }
-    }
-}
-
-function check(store, key, limit, window, now) {
-    /* Back-compat: the exported `ratelimit.check(buckets, key, ...)` API
-     * accepts either a bare object (legacy) or a Store. Wrap on demand.
-     *
-     * @deprecated The bare-bucket-map form is legacy. New callers should
-     * use ratelimit.middleware() which manages its own per-instance Store
-     * via makeStore(). The bare form is preserved only for existing
-     * direct callers of `ratelimit.check` in tests / app code; it recomputes
-     * Object.keys(b).length per call and the MAX_BUCKETS cap enforcement
-     * is effectively pass-through because the transient store's count is
-     * thrown away. */
-    if (!store || typeof store.count !== "number") {
-        // Treat as a bare bucket map; use a transient store with count
-        // derived from Object.keys length. Cap enforcement still applies.
-        const b = store || {};
-        const transient = { buckets: b, count: Object.keys(b).length };
-        return check(transient, key, limit, window, now);
-    }
-    const buckets = store.buckets;
-    let bucket = buckets[key];
+/**
+ * Check rate-limit state for a key. Pure over the passed clock `now`.
+ * @param {Object} buckets  Bucket store: a hull:cache instance (from cache.new)
+ *   mapping key -> { count, windowStart }.
+ * @param {string} key
+ * @param {number} limit
+ * @param {number} window  seconds
+ * @param {number} now     seconds
+ * @returns {{allowed: boolean, remaining: number, reset: number}}
+ */
+function check(buckets, key, limit, window, now) {
+    let bucket = buckets.get(key);
     if (!bucket || (now - bucket.windowStart) >= window) {
-        // Enforce max-entries cap before creating a new bucket
-        if (!bucket && store.count >= MAX_BUCKETS) {
-            sweepExpired(store, window, now);
-            if (store.count >= MAX_BUCKETS) {
-                return { allowed: false, remaining: 0, reset: now + window };
-            }
-        }
-        if (!bucket) store.count++;
-        buckets[key] = { count: 1, windowStart: now };
-        bucket = buckets[key];
+        // New window. cache.set bounds the store at maxEntries by evicting the
+        // least-recently-used bucket, so a flood of unique keys never rejects a
+        // legitimate new key (it drops an idle one instead).
+        bucket = { count: 1, windowStart: now };
+        buckets.set(key, bucket);
     } else {
+        // Live window: bump in place. buckets.get already refreshed this
+        // bucket's LRU rank, so an active key won't be the eviction victim.
         bucket.count++;
     }
 
@@ -86,10 +62,11 @@ function check(store, key, limit, window, now) {
  * allowed: sets `X-RateLimit-Limit` / `-Remaining` / `-Reset` headers
  * and returns `0`.
  *
- * Memory cap: 10_000 unique keys per limiter instance (Phase 6 fix: now
- * per-instance, not module-global).
+ * Memory cap: 10_000 unique keys per limiter instance. Beyond that, the
+ * least-recently-used bucket is evicted to admit the new key (a unique-key
+ * flood cannot deny service to genuine new clients).
  *
- * Concurrency: the bucket map is per-process and in-memory. Multi-
+ * Concurrency: the bucket store is per-process and in-memory. Multi-
  * process deployments (multiple Hull workers behind a load balancer,
  * horizontal scaling) will multiply the effective limit by the
  * worker count — each worker enforces independently. Apps that need
@@ -114,8 +91,7 @@ function middleware(opts) {
     const limit = o.limit !== undefined ? o.limit : 60;
     const window = o.window !== undefined ? o.window : 60;
     let keyFn = o.key;
-    const store = makeStore();
-    let checkCount = 0;
+    const buckets = cache.new({ maxEntries: MAX_BUCKETS });
 
     // Normalize key option into a function
     if (typeof keyFn !== "function") {
@@ -127,13 +103,7 @@ function middleware(opts) {
         const key = keyFn(req);
         const now = time.now();
 
-        // Periodic sweep of expired buckets to prevent unbounded growth
-        checkCount++;
-        if (checkCount % SWEEP_INTERVAL === 0) {
-            sweepExpired(store, window, now);
-        }
-
-        const result = check(store, key, limit, window, now);
+        const result = check(buckets, key, limit, window, now);
 
         res.header("X-RateLimit-Limit", String(limit));
         res.header("X-RateLimit-Remaining", String(result.remaining));

--- a/stdlib/js/hull/web/middleware/tests/test_ratelimit.js
+++ b/stdlib/js/hull/web/middleware/tests/test_ratelimit.js
@@ -3,6 +3,7 @@
 // Tests pure-function helpers (no runtime globals needed).
 
 import { ratelimit } from "hull:web:middleware:ratelimit";
+import { cache } from "hull:cache";  // bucket store is a cache instance now
 
 let pass = 0;
 let fail = 0;
@@ -25,14 +26,14 @@ function assertEq(a, b, msg) {
 // ── check ────────────────────────────────────────────────────────────
 
 test("check allows first request", () => {
-    const buckets = {};
+    const buckets = cache.new();
     const r = ratelimit.check(buckets, "ip1", 5, 60, 1000);
     assertEq(r.allowed, true);
     assertEq(r.remaining, 4);
 });
 
 test("check blocks after limit", () => {
-    const buckets = {};
+    const buckets = cache.new();
     for (let i = 0; i < 5; i++)
         ratelimit.check(buckets, "ip2", 5, 60, 1000);
     const r = ratelimit.check(buckets, "ip2", 5, 60, 1000);
@@ -41,7 +42,7 @@ test("check blocks after limit", () => {
 });
 
 test("check resets after window", () => {
-    const buckets = {};
+    const buckets = cache.new();
     for (let i = 0; i < 5; i++)
         ratelimit.check(buckets, "ip3", 5, 60, 1000);
     const r = ratelimit.check(buckets, "ip3", 5, 60, 1061);
@@ -50,7 +51,7 @@ test("check resets after window", () => {
 });
 
 test("check returns remaining count", () => {
-    const buckets = {};
+    const buckets = cache.new();
     ratelimit.check(buckets, "ip4", 10, 60, 1000);
     ratelimit.check(buckets, "ip4", 10, 60, 1000);
     const r = ratelimit.check(buckets, "ip4", 10, 60, 1000);
@@ -58,7 +59,7 @@ test("check returns remaining count", () => {
 });
 
 test("check returns reset timestamp", () => {
-    const buckets = {};
+    const buckets = cache.new();
     const r = ratelimit.check(buckets, "ip5", 5, 60, 1000);
     assertEq(r.reset, 1060);
 });

--- a/stdlib/lua/hull/web/middleware/ratelimit.lua
+++ b/stdlib/lua/hull/web/middleware/ratelimit.lua
@@ -6,55 +6,39 @@
 -- Sliding-window counter per key. **In-memory only — resets on restart.**
 -- For production-grade rate limiting across multiple instances, layer
 -- a DB-backed limiter on top.
+--
+-- The per-key buckets live in a bounded `hull.cache` instance, so memory is
+-- capped and stale buckets are evicted automatically (LRU) - no hand-rolled
+-- sweep. The window logic uses the caller-passed `now`, so `check` stays a
+-- pure, deterministically-testable function of its inputs.
 
 local time = require("hull.time")
+local cache = require("hull.cache")
 
 local ratelimit = {}
 
-local SWEEP_INTERVAL = 100  -- sweep every N checks
-local MAX_BUCKETS = 10000   -- max unique keys before forced eviction
+local MAX_BUCKETS = 10000   -- max unique keys per limiter (cache LRU cap)
 
---- Sweep expired buckets from the table.
--- Returns the number of remaining buckets after sweep.
-local function sweep_expired(buckets, window, now)
-    local remaining = 0
-    for k, v in pairs(buckets) do
-        if (now - v.window_start) >= window then
-            buckets[k] = nil
-        else
-            remaining = remaining + 1
-        end
-    end
-    return remaining
-end
-
---- Check rate-limit state for a key. Pure helper.
+--- Check rate-limit state for a key. Pure over the passed clock `now`.
 --
--- @tparam table buckets       `{ [key] = { count, window_start } }`.
--- @tparam string key          Limit key (e.g. user id, IP).
--- @tparam integer limit       Max hits per window.
--- @tparam integer window      Window length (seconds).
--- @tparam integer now         Current time (seconds).
--- @tparam[opt] integer bucket_count  Pre-tracked entry count for O(1) cap check.
--- @treturn table result       `{ allowed, remaining, reset }`.
--- @treturn integer new_bucket_count
-function ratelimit.check(buckets, key, limit, window, now, bucket_count)
-    bucket_count = bucket_count or 0
-    local bucket = buckets[key]
+-- @tparam table buckets  Bucket store: a `hull.cache` instance (from
+--   `cache.new`) mapping key -> `{ count, window_start }`.
+-- @tparam string key     Limit key (e.g. user id, IP).
+-- @tparam integer limit  Max hits per window.
+-- @tparam integer window Window length (seconds).
+-- @tparam integer now    Current time (seconds).
+-- @treturn table  `{ allowed, remaining, reset }`.
+function ratelimit.check(buckets, key, limit, window, now)
+    local bucket = buckets.get(key)
     if not bucket or (now - bucket.window_start) >= window then
-        -- Cap check: prevent unbounded memory growth from unique keys
-        if not bucket then
-            if bucket_count >= MAX_BUCKETS then
-                bucket_count = sweep_expired(buckets, window, now)
-                if bucket_count >= MAX_BUCKETS then
-                    return { allowed = false, remaining = 0, reset = now + window }, bucket_count
-                end
-            end
-            bucket_count = bucket_count + 1
-        end
-        buckets[key] = { count = 1, window_start = now }
-        bucket = buckets[key]
+        -- New window. cache.set bounds the store at max_entries by evicting
+        -- the least-recently-used bucket, so a flood of unique keys never
+        -- rejects a legitimate new key (it drops an idle one instead).
+        bucket = { count = 1, window_start = now }
+        buckets.set(key, bucket)
     else
+        -- Live window: bump in place. buckets.get already refreshed this
+        -- bucket's LRU rank, so an active key won't be the eviction victim.
         bucket.count = bucket.count + 1
     end
 
@@ -65,7 +49,7 @@ function ratelimit.check(buckets, key, limit, window, now, bucket_count)
         allowed = bucket.count <= limit,
         remaining = remaining,
         reset = bucket.window_start + window,
-    }, bucket_count
+    }
 end
 
 --- Build a rate-limit middleware.
@@ -74,10 +58,11 @@ end
 -- returns `1` (short-circuit). On allowed: sets `X-RateLimit-Limit` /
 -- `-Remaining` / `-Reset` headers and returns `0`.
 --
--- Memory cap: 10_000 unique keys per limiter instance. Beyond that,
--- expired entries are swept; if still full, new keys are rejected.
+-- Memory cap: 10_000 unique keys per limiter instance. Beyond that, the
+-- least-recently-used bucket is evicted to admit the new key (a unique-key
+-- flood cannot deny service to genuine new clients).
 --
--- Concurrency: the bucket map is per-process and in-memory. Multi-
+-- Concurrency: the bucket store is per-process and in-memory. Multi-
 -- process deployments (multiple Hull workers behind a load balancer,
 -- horizontal scaling) will multiply the effective limit by the
 -- worker count — each worker enforces independently. Apps that need
@@ -104,9 +89,7 @@ function ratelimit.middleware(opts)
     local limit = opts.limit or 60
     local window = opts.window or 60
     local key_fn = opts.key
-    local buckets = {}
-    local bucket_count = 0
-    local check_count = 0
+    local buckets = cache.new({ max_entries = MAX_BUCKETS })
 
     -- Normalize key option into a function
     if type(key_fn) ~= "function" then
@@ -118,14 +101,7 @@ function ratelimit.middleware(opts)
         local key = key_fn(req)
         local now = time.now()
 
-        -- Periodic sweep of expired buckets to prevent unbounded growth
-        check_count = check_count + 1
-        if check_count % SWEEP_INTERVAL == 0 then
-            bucket_count = sweep_expired(buckets, window, now)
-        end
-
-        local result
-        result, bucket_count = ratelimit.check(buckets, key, limit, window, now, bucket_count)
+        local result = ratelimit.check(buckets, key, limit, window, now)
 
         res:header("X-RateLimit-Limit", tostring(limit))
         res:header("X-RateLimit-Remaining", tostring(result.remaining))

--- a/stdlib/lua/hull/web/middleware/tests/test_ratelimit.lua
+++ b/stdlib/lua/hull/web/middleware/tests/test_ratelimit.lua
@@ -4,6 +4,7 @@
 -- Run via: the C test harness (test_lua_runtime.c) loads and executes this.
 
 local ratelimit = require('hull.web.middleware.ratelimit')
+local cache = require('hull.cache')  -- bucket store is a cache instance now
 
 local pass = 0
 local fail = 0
@@ -27,14 +28,14 @@ end
 -- ── check ────────────────────────────────────────────────────────────
 
 test("check allows first request", function()
-    local buckets = {}
+    local buckets = cache.new()
     local r = ratelimit.check(buckets, "ip1", 5, 60, 1000)
     assert_eq(r.allowed, true)
     assert_eq(r.remaining, 4)
 end)
 
 test("check blocks after limit", function()
-    local buckets = {}
+    local buckets = cache.new()
     for i = 1, 5 do
         ratelimit.check(buckets, "ip2", 5, 60, 1000)
     end
@@ -44,7 +45,7 @@ test("check blocks after limit", function()
 end)
 
 test("check resets after window", function()
-    local buckets = {}
+    local buckets = cache.new()
     for i = 1, 5 do
         ratelimit.check(buckets, "ip3", 5, 60, 1000)
     end
@@ -54,7 +55,7 @@ test("check resets after window", function()
 end)
 
 test("check returns remaining count", function()
-    local buckets = {}
+    local buckets = cache.new()
     ratelimit.check(buckets, "ip4", 10, 60, 1000)
     ratelimit.check(buckets, "ip4", 10, 60, 1000)
     local r = ratelimit.check(buckets, "ip4", 10, 60, 1000)
@@ -62,7 +63,7 @@ test("check returns remaining count", function()
 end)
 
 test("check returns reset timestamp", function()
-    local buckets = {}
+    local buckets = cache.new()
     local r = ratelimit.check(buckets, "ip5", 5, 60, 1000)
     assert_eq(r.reset, 1060)
 end)

--- a/tests/e2e_ratelimit_parity.sh
+++ b/tests/e2e_ratelimit_parity.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# e2e_ratelimit_parity.sh: ratelimit.check (now backed by hull.cache) behavior
+# + Lua/JS parity.
+#
+# Core rate-limiting is unchanged (count-per-window, block-when-over, window
+# reset, reset timestamp). The one behavior change from the hull.cache refactor
+# is the overflow policy: at the bucket cap, a NEW key is now ADMITTED by
+# evicting the least-recently-used bucket, instead of being rejected - so a
+# unique-key flood can't 429 a genuine new client. This asserts all of that,
+# byte-identical across runtimes. check takes the caller's `now`, so it's
+# deterministic (no wall-clock waits).
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+HULL="${HULL:-./build/hull}"
+[ -x "$HULL" ] || HULL="build/hull"
+WD=$(mktemp -d)
+trap 'rm -rf "$WD"' EXIT
+
+cat > "$WD/r.lua" <<'LUA'
+local rl = require("hull.web.middleware.ratelimit")
+local cache = require("hull.cache")
+app.manifest({ modules = { "hull/web/middleware/ratelimit@1", "hull/cache@1" } })
+app.main(function(ctx)
+    local o = {}
+    -- allow first + reset timestamp
+    local c1 = cache.new()
+    local r1 = rl.check(c1, "ip", 5, 60, 1000)
+    o[#o+1] = (r1.allowed == true and r1.remaining == 4 and r1.reset == 1060) and "allow4_ts" or "F1"
+    -- block after limit
+    local c2 = cache.new()
+    for _ = 1, 5 do rl.check(c2, "ip", 5, 60, 1000) end
+    local r2 = rl.check(c2, "ip", 5, 60, 1000)
+    o[#o+1] = (r2.allowed == false and r2.remaining == 0) and "block" or "F2"
+    -- reset after window
+    local c3 = cache.new()
+    for _ = 1, 5 do rl.check(c3, "ip", 5, 60, 1000) end
+    local r3 = rl.check(c3, "ip", 5, 60, 1061)
+    o[#o+1] = (r3.allowed == true and r3.remaining == 4) and "reset" or "F3"
+    -- LRU overflow: at cap, a NEW key is admitted (evict LRU), not rejected
+    local c4 = cache.new({ max_entries = 2 })
+    rl.check(c4, "a", 1, 60, 1000)
+    rl.check(c4, "b", 1, 60, 1000)
+    rl.check(c4, "a", 1, 60, 1000)                       -- touch a -> b is LRU
+    local rc = rl.check(c4, "c", 1, 60, 1000)            -- new key at cap
+    o[#o+1] = (rc.allowed == true and c4.size() == 2) and "lru_admit" or "F5"
+    ctx.stdout:write(table.concat(o, "|") .. "\n"); return 0
+end)
+LUA
+cat > "$WD/r.js" <<'JS'
+import { app } from "hull:app";
+import { ratelimit as rl } from "hull:web:middleware:ratelimit";
+import { cache } from "hull:cache";
+app.manifest({ modules: ["hull/web/middleware/ratelimit@1", "hull/cache@1"] });
+app.main((ctx) => {
+    const o = [];
+    const c1 = cache.new();
+    const r1 = rl.check(c1, "ip", 5, 60, 1000);
+    o.push((r1.allowed === true && r1.remaining === 4 && r1.reset === 1060) ? "allow4_ts" : "F1");
+    const c2 = cache.new();
+    for (let i = 0; i < 5; i++) rl.check(c2, "ip", 5, 60, 1000);
+    const r2 = rl.check(c2, "ip", 5, 60, 1000);
+    o.push((r2.allowed === false && r2.remaining === 0) ? "block" : "F2");
+    const c3 = cache.new();
+    for (let i = 0; i < 5; i++) rl.check(c3, "ip", 5, 60, 1000);
+    const r3 = rl.check(c3, "ip", 5, 60, 1061);
+    o.push((r3.allowed === true && r3.remaining === 4) ? "reset" : "F3");
+    const c4 = cache.new({ maxEntries: 2 });
+    rl.check(c4, "a", 1, 60, 1000);
+    rl.check(c4, "b", 1, 60, 1000);
+    rl.check(c4, "a", 1, 60, 1000);
+    const rc = rl.check(c4, "c", 1, 60, 1000);
+    o.push((rc.allowed === true && c4.size() === 2) ? "lru_admit" : "F5");
+    ctx.stdout.write(o.join("|") + "\n"); return 0;
+});
+JS
+
+expect="allow4_ts|block|reset|lru_admit"
+lua_out="$("$HULL" "$WD/r.lua" 2>/dev/null | tail -1)"
+js_out="$( "$HULL" "$WD/r.js"  2>/dev/null | tail -1)"
+
+if [ "$lua_out" = "$expect" ] && [ "$lua_out" = "$js_out" ]; then
+    echo "PASS: ratelimit.check (hull.cache-backed) is byte-identical across Lua and JS"
+else
+    echo "::error ratelimit DRIFT:"
+    echo "  expect=$expect"
+    echo "  lua   =$lua_out"
+    echo "  js    =$js_out"
+    exit 1
+fi


### PR DESCRIPTION
Refactors the rate-limit middleware's per-key bucket store onto a bounded
`hull.cache` instance — the integration you asked for after `hull/cache` landed.

## What changed

- `ratelimit.check(buckets, key, limit, window, now)` now takes a **cache
  instance** (drops the old `bucket_count` arg); the middleware creates one
  `cache.new({ max_entries = 10000 })`. The cache's LRU cap + lazy handling
  replace the hand-rolled `sweep_expired` + `SWEEP_INTERVAL` + `bucket_count`.
- `check` stays a **pure function of the caller-passed `now`** (the window logic
  never touches the cache's internal clock), so it remains deterministically
  testable.
- This also **unifies a Lua/JS drift**: JS had grown a `makeStore()` abstraction
  + a legacy back-compat wrapper in `check()`; Lua threaded an explicit
  `bucket_count`. Both now share the same cache-backed shape.

## Behavior

Core rate-limiting is **byte-identical**: count-per-window, block-when-over-limit,
window reset, `X-RateLimit-*` headers, `429`.

The **one intended change** (the direction you picked) is the overflow policy at
the `MAX_BUCKETS` cap: a new key is now **admitted by evicting the
least-recently-used idle bucket**, instead of being rejected. Strictly friendlier
— a unique-key flood can no longer `429` a genuine new client (the old
sweep-then-reject-when-full path could). A `"__proto__"` bucket key is handled
safely by the cache's internal `Map`/table, so the old JS `Object.create(null)`
guard is gone.

## Tests

- `tests/e2e_ratelimit_parity.sh` (new) — drives `check` through allow / block /
  window-reset / reset-timestamp / **LRU-admit-at-cap** deterministically (passed
  `now`, no wall-clock) and asserts a byte-identical vector across runtimes.
- The **real middleware `429` path** stays covered by `e2e_auth_flows_hardening`
  (42/0 — login-lockout rate limit), confirming the middleware behavior is
  preserved end-to-end.
- Updated the orphaned `stdlib/*/tests/test_ratelimit.*` to the cache-instance
  store. `make test` 62/62.
