### PR TITLE
stdlib: session honors a per-call ttl = 0 (Lua/JS parity)

### DIFF
--- a/stdlib/lua/hull/web/middleware/session.lua
+++ b/stdlib/lua/hull/web/middleware/session.lua
@@ -196,7 +196,10 @@ end
 function session.create(data, opts)
     local id = generate_id()
     local now = time.now()
-    local ttl = (opts and opts.ttl) or _ttl
+    -- Explicit nil check (not `or`): a caller-supplied ttl = 0 is legal and
+    -- must not be silently replaced by the default. Matches session.init and
+    -- the JS sibling. (In Lua 0 is truthy, so `x and 0 or d` keeps the 0.)
+    local ttl = (opts and opts.ttl ~= nil) and opts.ttl or _ttl
     local encoded = json.encode(data or {})
 
     -- Capture device columns for hull/web/middleware/audit-log
@@ -287,7 +290,10 @@ function session.load(session_id, opts)
     end
 
     -- Update last_accessed and extend expiry
-    local ttl = (opts and opts.ttl) or _ttl
+    -- Explicit nil check (not `or`): a caller-supplied ttl = 0 is legal and
+    -- must not be silently replaced by the default. Matches session.init and
+    -- the JS sibling. (In Lua 0 is truthy, so `x and 0 or d` keeps the 0.)
+    local ttl = (opts and opts.ttl ~= nil) and opts.ttl or _ttl
     db.exec(
         "UPDATE _hull_sessions SET last_accessed = ?, expires_at = ? WHERE id = ?",
         { now, now + ttl, session_id }
@@ -315,7 +321,10 @@ function session.update(session_id, data, opts)
     end
 
     local now = time.now()
-    local ttl = (opts and opts.ttl) or _ttl
+    -- Explicit nil check (not `or`): a caller-supplied ttl = 0 is legal and
+    -- must not be silently replaced by the default. Matches session.init and
+    -- the JS sibling. (In Lua 0 is truthy, so `x and 0 or d` keeps the 0.)
+    local ttl = (opts and opts.ttl ~= nil) and opts.ttl or _ttl
     local encoded = json.encode(data or {})
 
     -- AND expires_at > ? prevents reviving a session that the user


### PR DESCRIPTION
The `/lua-audit` of this session's changes caught a real Lua/JS divergence.

`session.create` / `load` / `update` used `local ttl = (opts and opts.ttl) or _ttl`,
which silently substitutes the 24h default when a caller passes `ttl = 0` (an
immediate-expiry session). `session.init` was already fixed to an explicit
`~= nil` check, and the JS sibling honors `opts.ttl === 0`
(`(opts && opts.ttl !== undefined) ? opts.ttl : sessionTtl`) — so Lua was the
outlier, exactly the truthiness footgun `docs/stdlib_style.md` §3 warns about (in
Lua `0` is truthy, so the trap is the `or` folding, not `0` itself; the fix is
the explicit nil check).

All three sites now use `(opts and opts.ttl ~= nil) and opts.ttl or _ttl`.

Verified: `session.create({...}, { ttl = 0 })` → `session.load` returns `nil`
(expired) in Lua now, matching JS; the default (no-ttl) path is unchanged.
`make test` 62/62; `e2e_sign_in_events` 40/0.
