### PR TITLE
fix: MSan/UBSan clean on main (cache for-of destructuring + obj_emit 0-byte memcpy)

### DIFF
--- a/src/hull/obj_emit.c
+++ b/src/hull/obj_emit.c
@@ -56,10 +56,14 @@ static void buf_reserve(Buf *b, size_t extra) {
     b->p = np; b->cap = ncap;
 }
 static void buf_put(Buf *b, const void *src, size_t n) {
+    if (n == 0) return;  /* memcpy(b->p + b->len, src, 0) is UB when b->p is
+                          * still NULL (empty buf) or src is NULL - copying 0
+                          * bytes is a no-op anyway. */
     buf_reserve(b, n); if (b->oom) return;
     memcpy(b->p + b->len, src, n); b->len += n;
 }
 static void buf_zero(Buf *b, size_t n) {
+    if (n == 0) return;  /* same: memset(NULL, 0, 0) is UB; no-op regardless. */
     buf_reserve(b, n); if (b->oom) return;
     memset(b->p + b->len, 0, n); b->len += n;
 }

--- a/src/hull/obj_emit.c
+++ b/src/hull/obj_emit.c
@@ -77,8 +77,13 @@ static void buf_fixed(Buf *b, const char *str, size_t field) {
     size_t n = strlen(str); if (n > field) n = field;
     buf_put(b, str, n); buf_zero(b, field - n);
 }
-/* Overwrite an already-appended u64 at absolute offset off (little-endian). */
+/* Overwrite an already-appended u64 at absolute offset off (little-endian).
+ * Only ever called after the u64 was appended, so b->p is non-NULL and
+ * off+8 <= b->len; the guard makes that invariant explicit (and keeps the
+ * static analyzer from tracing a NULL b->p through the empty-buffer path the
+ * n==0 short-circuits in buf_put/buf_zero opened up). */
 static void buf_patch64(Buf *b, size_t off, uint64_t v) {
+    if (b->oom || !b->p) return;
     for (int i = 0; i < 8; i++) b->p[off + i] = (unsigned char)(v >> (8*i));
 }
 static uint32_t strtab_add(Buf *b, const char *s) {

--- a/stdlib/js/hull/cache.js
+++ b/stdlib/js/hull/cache.js
@@ -61,7 +61,12 @@ function newCache(opts) {
     const evictOne = () => {
         const now = time.nowMs();
         let lruKey, lruSeq;
-        for (const [k, e] of store) {
+        // Iterate keys + store.get, NOT `for (const [k, e] of store)`: QuickJS's
+        // parser trips a known MSan use-of-uninit false-positive on array
+        // destructuring in a for-of (same issue jwt.js avoids by index access).
+        // Deleting the current key mid-iteration then returning is spec-safe.
+        for (const k of store.keys()) {
+            const e = store.get(k);
             if (e.expires != null && now >= e.expires) {
                 store.delete(k);
                 count -= 1;


### PR DESCRIPTION
CI's **MSan+UBSan** job went red at #288 (ratelimit-on-cache) — caught while
prepping the v0.13.0 release (a tag on red CI = a broken release).

## Root cause
#288 wired `import { cache } from "hull:cache"` into `ratelimit`, so `cache.js`
began being **parsed under MSan for the first time** — and `cache.js:64` used
`for (const [k, e] of store)` (array destructuring in a for-of). QuickJS's
**parser** trips a known MSan use-of-uninit false-positive on array
destructuring — the exact one `jwt.js` already avoids by index access
(`jwt.js:236`: "QuickJS's parser trips an MSan use-of-uninit warning on
`const [a,b,c] = parts`"). The MSan stack is entirely inside `quickjs.c`
(`js_parse_destructuring_element` → `js_parse_for_in_of`), not Hull code.

**Fix:** iterate `store.keys()` + `store.get(k)` instead of destructuring
(deleting the current key mid-iteration then returning is spec-safe). LRU
eviction behavior is unchanged.

## Bonus (pre-existing UB in the same job)
`obj_emit.c` `buf_put`/`buf_zero` did `memcpy`/`memset(b->p + b->len, src, n)`
with `n == 0` on a fresh buffer where `b->p` is still `NULL` — passing `NULL` to
`memcpy`/`memset` is UB even for 0 bytes. This was UBSan-**recoverable** (so not
the CI-red cause) but real; guarded with `if (n == 0) return;`.

## Validation
Can't run MSan on macOS. Verified `make test` 62/62 and `e2e_cache_module` +
`e2e_ratelimit_parity` still byte-identical across runtimes; relying on CI's
MSan+UBSan job to confirm green. History: MSan was green through #287, red
#288–#289; this restores it.
