### PR TITLE
stdlib: hull/kv + hull/cache.open - portable KV/cache subsystem (milestone 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,10 @@ jobs:
         timeout-minutes: 2
         run: make e2e-cache-module
 
+      - name: KV + cache backends (memory/sqlite) conformance E2E test
+        timeout-minutes: 2
+        run: make e2e-kv
+
       - name: Ratelimit (hull.cache-backed) Lua/JS parity E2E test
         timeout-minutes: 2
         run: make e2e-ratelimit-parity

--- a/docs/kv_cache.md
+++ b/docs/kv_cache.md
@@ -1,0 +1,165 @@
+# KV / cache subsystem (`hull.kv` + `hull.cache`)
+
+Two small, portable abstractions over local, SQL-backed, and (future)
+distributed key/value engines. The design goal is a clean semantic seam, **not**
+a Redis clone: define the minimal portable operation set + a capability model,
+and let mature storage engines do the storage.
+
+## `cache` is NOT a durable KV store
+
+This distinction is load-bearing. The two modules exist because the guarantees
+differ, and code that confuses them will lose data or leak memory.
+
+| | **`hull.cache`** (CACHE) | **`hull.kv`** (KV STORE) |
+|---|---|---|
+| Lifetime | ephemeral | externally meaningful |
+| Eviction | **expected** (LRU on cap) | **never**, unless you ask (`cleanup`) |
+| Values | recomputable | authoritative |
+| Bounded | yes (`max_bytes` / `max_items`) | unbounded by default |
+| TTL | common | optional |
+| Persistence | no (SQL cache is still evicting) | where the backend provides it |
+| Optimized for | fast local reuse | correctness + durability |
+
+If losing an entry is a correctness bug, it is KV state, not a cache.
+
+## Keys and values are bytes
+
+Keys and values are arbitrary bytes: Lua strings (natively binary-safe) and, in
+JS, **byte strings** (each char a code unit 0-255 - Hull's JS byte convention,
+the same one `crypto/_hex` and `jwt` use). `.length` / `#v` is the byte count;
+there is no UTF-8 assumption. Text values are stored as their bytes; for large
+binary blobs prefer `hull/blob`.
+
+- `get` on a **miss returns `nil` / `null`** (absence is a value, per the stdlib
+  error convention). A backend/transport error **throws** a coded error.
+- Coded errors carry a stable `.code`: `invalid_argument`, `unsupported`,
+  `capacity_exceeded`, `conflict`.
+- Max key size is 1024 bytes; values are bounded only by the backend (and, for a
+  memory cache, the byte budget).
+
+## API
+
+```lua
+local kv = require("hull.kv").open{ backend = "sqlite", database = db,
+                                    namespace = "agent-state" }
+kv:set("run:123", payload)          -- bytes -> bytes
+local v = kv:get("run:123")         -- bytes | nil
+kv:set(k, v, { ttl = 3600 })        -- TTL in seconds (capability-gated)
+kv:delete(k); kv:exists(k)
+kv:incr("hits", 1)                  -- atomic increment (capability-gated)
+kv:cas(k, expected, new)            -- compare-and-swap; expected=nil => set-if-absent
+kv:scan("run:")                     -- prefix iteration -> { keys } (capability-gated)
+kv:clear()                          -- namespace-scoped wipe
+kv:cleanup()                        -- delete expired rows (SQL); returns count
+kv.caps                             -- { ttl, atomic_increment, compare_exchange,
+                                    --   scan, persistent, shared, eviction, transactions }
+
+local cache = require("hull.cache").open{ backend = "memory", namespace = "query-ir",
+    max_bytes = 512*1024*1024, max_items = 100000, default_ttl = 600 }
+cache:set(k, bytes); cache:get(k)
+cache:fetch(k, 60, function() return render() end)   -- get-or-compute (bytes)
+cache:stats()                       -- { hits, misses, evictions, items, bytes }
+```
+
+JS mirror (sync; `import { kv } from "hull:kv"`, `import { cache } from "hull:cache"`)
+with camelCase options (`maxBytes`, `defaultTtl`, `maxItems`) and `store.get(k)`
+returning `null` on a miss.
+
+`hull.cache.open{}` is **additive**: the shipped top-level `cache.get/set/fetch/new`
+(a lightweight in-process memoizer for arbitrary values) is unchanged. Reach for
+`cache.new()` for a quick value memoizer, `cache.open{}` when you need byte
+accounting, a backend, or explicit namespaces.
+
+## Capability model
+
+Backends do not pretend to uniform guarantees. Each advertises a `caps` set;
+an optional op on a backend that lacks the cap **throws `unsupported`** rather
+than silently no-opping. Verified against the implementation:
+
+| capability | memory | sqlite | postgres | valkey/redis¹ | cachelib¹ |
+|---|:---:|:---:|:---:|:---:|:---:|
+| local / in-process | ✅ | ✅ | ❌ | ❌ | ✅ |
+| persistent | ❌ | ✅ | ✅ | ✅ | limited (SSD) |
+| shared (cross-process) | ❌ | ❌² | ✅ | ✅ | ❌ |
+| TTL | ✅ | ✅ | ✅ | ✅ | ✅ |
+| eviction (cache policy) | ✅ LRU | ✅ SQL | ✅ SQL | ✅ native | ✅ |
+| atomic increment | ✅ | ✅ | ✅ | ✅ | ❌ |
+| compare-and-swap | ✅ | ✅ | ✅ | ✅ | ❌ |
+| scan / prefix | ✅ | ✅ | ✅ | ✅ | limited |
+| transactions | ❌ | ✅ | ✅ | backend | ❌ |
+
+¹ planned backend (see extension points). ² a SQLite file can be opened by
+multiple processes but is a local file, not a shared service; `caps.shared` is
+`false`. TTL is app-managed (a lazily-filtered `expires_at`) on every SQL
+backend - the same capability regardless of how it is implemented.
+
+## SQL-backed KV
+
+The SQL backend reuses Hull's backend-agnostic `db` capability - **no second
+connection stack**. You pass an existing connection (`database = db`); every
+write goes through the same parameterized `query`/`exec`/`ON CONFLICT` the rest
+of the stdlib uses, so SQLite and PostgreSQL are served by one implementation.
+
+One table, backend-portable (all `TEXT`/`BIGINT`, protected by the `_hull_`
+prefix so app code cannot touch it):
+
+```sql
+CREATE TABLE _hull_kv (
+    ns TEXT NOT NULL, k TEXT NOT NULL, v TEXT NOT NULL,
+    expires_at BIGINT NOT NULL, version BIGINT NOT NULL DEFAULT 1,
+    created_at BIGINT NOT NULL, updated_at BIGINT NOT NULL,
+    PRIMARY KEY (ns, k)
+);
+```
+
+- Keys are **hex-encoded** (prefix-preserving, so `scan` is a `LIKE` range) and
+  values **base64-encoded**, both into portable `TEXT` - Postgres `TEXT` rejects
+  embedded NULs, so raw binary cannot be stored directly. This makes durable KV
+  byte-safe **and cross-runtime** (a value written by Lua reads back identically
+  under JS).
+- `put` is a native `INSERT ... ON CONFLICT (ns,k) DO UPDATE` (SQLite +
+  Postgres); `cas` is a single conditional `UPDATE ... WHERE v = ?` (or an
+  `INSERT ... ON CONFLICT DO NOTHING` for set-if-absent) - genuinely atomic, not
+  a read-then-write. `incr` is an optimistic version-guarded retry loop.
+- Cache-over-SQL eviction (`max_items`) is expressed as SQL
+  (`DELETE ... ORDER BY updated_at LIMIT`), never in C.
+- TTL is a lazily-filtered `expires_at` (`WHERE expires_at > now`); `cleanup()`
+  deletes expired rows.
+
+## Security
+
+The KV layer opens **no hidden fs or network access**. A SQLite-backed store
+runs through the `db` capability, so the file honors the fs sandbox exactly like
+`fs.read`/`db.open`; a network backend (Postgres today, Valkey/Redis later)
+honors the host allowlist and the `network_outbound` sandbox grant. Namespaces
+are first-class and isolate keyspaces; a `kv` and a `cache` that share a
+namespace name never collide (physical namespaces are prefixed `kv:` / `cache:`).
+
+## Backend extension points
+
+The subsystem is deliberately narrow; new engines slot in without touching the
+semantic layer.
+
+- **Native C cache store** (fast-follow): a small `cap/` module (hashmap +
+  intrusive LRU + byte accounting) implementing the same store interface the
+  Lua/JS memory backend presents, for high-throughput local caches. The stdlib
+  memory backend already byte-accounts, so this is a performance drop-in, not a
+  correctness prerequisite.
+- **Valkey / Redis** (preferred distributed backend): a `--with=valkey` /
+  `--with=redis` composable feature filling the existing weak
+  `hl_db_feature_backends` hook - reached by a `valkey://` / `redis://` DSN, the
+  same pattern as the Postgres/MySQL wire backends. The portable KV subset only;
+  streams / pub-sub / sorted-sets / vectors are out of scope and belong in
+  separate future capabilities.
+- **CacheLib**: an optional `--with=cachelib` high-performance local cache
+  behind a narrow C/C++ boundary; never a default dependency.
+- **DuckDB**: usable as a KV backend where its semantics fit; the code does not
+  force transactional guarantees DuckDB does not naturally provide.
+
+## Tests
+
+`tests/e2e_kv.sh` (`make e2e-kv`): a conformance vector run against **both** the
+memory and sqlite backends in one process (the app asserts they match), then
+compared across Lua and JS; durability across a process restart; and
+`cache.open` LRU + byte-budget eviction. `tests/e2e_cache_module.sh` continues
+to cover the legacy `cache.new` value memoizer.

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -696,6 +696,10 @@ e2e-uuid: $(BUILDDIR)/hull
 e2e-cache-module: $(BUILDDIR)/hull
 	sh tests/e2e_cache_module.sh
 
+.PHONY: e2e-kv
+e2e-kv: $(BUILDDIR)/hull
+	sh tests/e2e_kv.sh
+
 .PHONY: e2e-ratelimit-parity
 e2e-ratelimit-parity: $(BUILDDIR)/hull
 	sh tests/e2e_ratelimit_parity.sh

--- a/src/hull/module_registry.c
+++ b/src/hull/module_registry.c
@@ -231,6 +231,18 @@ static const HlModuleSpec REGISTRY[] = {
         /* HMAC needs crypto; payload encoding needs json; exp/iat checks need time. */
         .deps = {"hull/crypto", "hull/json", "hull/time", 0},
     },
+    {
+        /* Portable key/value STORE. Distinct from hull/cache (ephemeral +
+         * evicting): hull/kv is externally-meaningful state with no eviction
+         * unless explicitly requested. Backends: memory (in-process), sqlite /
+         * postgres (durable, over an EXISTING hull/db connection passed by the
+         * app). Pure Lua/JS over hull/time; it carries no new authority of its
+         * own - a SQL backend's fs/network access is the db capability's,
+         * already gated, so hull/db is the app's declaration, not a dep here. */
+        .name = "hull/kv",
+        .api_major = 1, .intrinsic = 0, .pure = 0,
+        .required_caps = 0, .deps = {"hull/time", 0},
+    },
 
     /* ── Logger ───────────────────────────────────────────────────── */
     {

--- a/stdlib/js/hull/cache.js
+++ b/stdlib/js/hull/cache.js
@@ -26,6 +26,10 @@
  */
 
 import { time } from "hull:time";
+import kvUtil from "hull:kv:_util";
+import kvHandle from "hull:kv:_handle";
+import kvMemstore from "hull:kv:_memstore";
+import kvSql from "hull:kv:_sql";
 
 const DEFAULT_MAX = 1000;
 
@@ -157,6 +161,66 @@ const cache = {
     delete: _default.delete,
     clear: _default.clear,
     size: _default.size,
+};
+
+// ---------------------------------------------------------------------------
+// cache.open({}) - the byte-oriented, backend-selectable CACHE handle.
+//
+// Distinct from cache.new() above: cache.new is a lightweight in-process
+// memoizer for arbitrary VALUES (item-count bound). cache.open deals in BYTE
+// STRINGS and adds byte accounting, pluggable backends (memory / sqlite), and
+// namespaces - sharing the same store cores as hull:kv but with CACHE policy
+// (eviction ON). Use cache.open for max_bytes / a durable SQL cache / explicit
+// namespaces; cache.new for a quick local value memoizer.
+//
+//   const c = cache.open({ backend: "memory", namespace: "query-ir",
+//                          maxBytes: 512*1024*1024, defaultTtl: 600 });
+//   c.set(k, bytes); const v = c.get(k);           // bytes | null
+//   c.fetch(k, 60, () => render());                // get-or-compute (bytes)
+//   c.stats();   // { hits, misses, evictions, items, bytes }
+// ---------------------------------------------------------------------------
+cache.open = function (opts) {
+    if (typeof opts !== "object" || opts === null)
+        kvUtil.error("invalid_argument", "cache.open: options object required");
+    const backend = opts.backend || "memory";
+    const namespace = opts.namespace || "default";
+    const storeNs = "cache:" + namespace; // isolated from hull:kv's "kv:" namespaces
+
+    let store, bname;
+    if (backend === "memory") {
+        store = kvMemstore.get(storeNs, {
+            evict: true, defaultTtl: opts.defaultTtl,
+            maxBytes: opts.maxBytes, maxItems: opts.maxItems,
+        });
+        bname = "memory";
+    } else if (backend === "sqlite") {
+        const conn = opts.database;
+        if (!conn || typeof conn.exec !== "function")
+            kvUtil.error("invalid_argument", "cache.open: sqlite backend needs database: <db connection>");
+        store = kvSql.new(conn, storeNs, {
+            evict: true, defaultTtl: opts.defaultTtl, maxItems: opts.maxItems,
+        });
+        bname = conn.backendName || "sqlite";
+    } else {
+        kvUtil.error("invalid_argument", "cache.open: unknown backend '" + backend + "'");
+    }
+
+    const h = kvHandle.build(store, { namespace, backend: bname });
+
+    // Get key, or compute + cache it. fetch(key, ttl, fn) or fetch(key, fn).
+    // fn must return bytes (a string); it is synchronous.
+    h.fetch = function (key, ttl, fn) {
+        if (fn === undefined && typeof ttl === "function") { fn = ttl; ttl = undefined; }
+        kvUtil.checkKey(key);
+        const v = h._store.get(key);
+        if (v !== null) return v;
+        const produced = fn();
+        kvUtil.checkValue(produced);
+        h._store.put(key, produced, ttl);
+        return produced;
+    };
+
+    return h;
 };
 
 export { cache };

--- a/stdlib/js/hull/kv.js
+++ b/stdlib/js/hull/kv.js
@@ -1,0 +1,68 @@
+/*
+ * hull:kv - portable key/value STORE (JS mirror of hull.kv).
+ *
+ * KV STORE semantics (distinct from hull:cache): externally meaningful state,
+ * no eviction unless requested, persistence where the backend provides it,
+ * potentially shared across processes. Keys and values are byte strings (each
+ * char a code unit 0-255 - Hull's JS byte convention).
+ *
+ * Backends (milestone 1): "memory" (in-process, process-shared by namespace),
+ * "sqlite" / "postgres" (durable, over an EXISTING db connection passed as
+ * `database` - no second connection stack). Each backend advertises a
+ * capability set (handle.caps); an optional op a backend lacks throws
+ * `unsupported`.
+ *
+ *   import { kv } from "hull:kv";
+ *   import { db as dbModule } from "hull:db";
+ *   const store = kv.open({ backend: "sqlite", database: dbModule.default(),
+ *                           namespace: "agent-state" });
+ *   store.set("run:123", payload);       // bytes -> bytes
+ *   const v = store.get("run:123");      // bytes | null (miss)
+ *   store.set(k, v, { ttl: 3600 });      // optional TTL (seconds)
+ *   store.cas(k, expected, next);        // atomic compare-and-swap
+ *   store.incr("hits", 1);               // atomic increment
+ *   store.scan("run:");                  // prefix iteration -> [keys]
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import util from "hull:kv:_util";
+import handle from "hull:kv:_handle";
+import memstore from "hull:kv:_memstore";
+import sqlstore from "hull:kv:_sql";
+
+function open(opts) {
+    if (typeof opts !== "object" || opts === null)
+        util.error("invalid_argument", "kv.open: options object required");
+    const backend = opts.backend || "memory";
+    const namespace = opts.namespace || "default";
+    // Prefix the physical namespace so a kv and a cache sharing a namespace
+    // name never collide in the same store / _hull_kv rows.
+    const storeNs = "kv:" + namespace;
+
+    let store, bname;
+    if (backend === "memory") {
+        store = memstore.get(storeNs, {
+            evict: false, defaultTtl: opts.defaultTtl,
+            maxBytes: opts.maxBytes, maxItems: opts.maxItems,
+        });
+        bname = "memory";
+    } else if (backend === "sqlite" || backend === "postgres") {
+        const conn = opts.database;
+        if (!conn || typeof conn.exec !== "function")
+            util.error("invalid_argument",
+                "kv.open: sql backend needs database: <db connection> "
+                + "(e.g. dbModule.default())");
+        store = sqlstore.new(conn, storeNs, { evict: false, defaultTtl: opts.defaultTtl });
+        bname = conn.backendName || "sql";
+    } else {
+        util.error("invalid_argument", "kv.open: unknown backend '" + backend + "'");
+    }
+
+    return handle.build(store, { namespace, backend: bname });
+}
+
+const kv = { open, _VERSION: "1" };
+
+export { kv };
+export default kv;

--- a/stdlib/js/hull/kv/_handle.js
+++ b/stdlib/js/hull/kv/_handle.js
@@ -1,0 +1,67 @@
+/*
+ * hull:kv:_handle - the semantic surface over a backend store (JS mirror of
+ * hull.kv._handle). Key/value validation + capability enforcement (an optional
+ * op on a backend that lacks the cap throws `unsupported`). Shared by hull.kv
+ * and hull.cache; hull.cache layers fetch() on top.
+ *
+ * Internal module. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import util from "hull:kv:_util";
+
+function build(store, meta) {
+    const need = (cap) => {
+        if (!store.caps[cap])
+            util.error("unsupported",
+                "kv: backend '" + meta.backend + "' does not support " + cap);
+    };
+    return {
+        namespace: meta.namespace,
+        backend: meta.backend,
+        caps: store.caps,
+
+        get(k) { util.checkKey(k); return store.get(k); },
+
+        set(k, v, opts) {
+            util.checkKey(k); util.checkValue(v);
+            store.put(k, v, opts && opts.ttl);
+            return true;
+        },
+
+        delete(k) { util.checkKey(k); return store.del(k); },
+
+        exists(k) { util.checkKey(k); return store.has(k); },
+
+        incr(k, by, opts) {
+            need("atomic_increment"); util.checkKey(k);
+            if (by === undefined) by = 1;
+            if (typeof by !== "number" || !Number.isInteger(by))
+                util.error("invalid_argument", "kv: incr amount must be an integer");
+            return store.incr(k, by, opts && opts.ttl);
+        },
+
+        cas(k, expected, newVal, opts) {
+            need("compare_exchange"); util.checkKey(k); util.checkValue(newVal);
+            if (expected !== undefined && expected !== null) util.checkValue(expected);
+            return store.cas(k, expected, newVal, opts && opts.ttl);
+        },
+
+        clear() { store.clear(); return true; },
+
+        scan(prefix, opts) {
+            need("scan");
+            if (prefix !== undefined && prefix !== null && typeof prefix !== "string")
+                util.error("invalid_argument", "kv: scan prefix must be a string (bytes)");
+            return store.scan(prefix, opts && opts.limit);
+        },
+
+        cleanup() { return store.cleanup(); },
+
+        stats() { return store.stats(); },
+
+        // Exposed for hull.cache.open's fetch() (byte-cache get-or-compute).
+        _store: store,
+    };
+}
+
+export default { build };

--- a/stdlib/js/hull/kv/_memstore.js
+++ b/stdlib/js/hull/kv/_memstore.js
@@ -1,0 +1,180 @@
+/*
+ * hull:kv:_memstore - native in-process byte store (JS mirror of
+ * hull.kv._memstore). One physical store, two policies: hull.kv memory
+ * (eviction off) and hull.cache memory (LRU eviction on). Byte-string keys and
+ * values; lazy TTL expiry; byte + item accounting; LRU by access sequence.
+ * Single-threaded (event-loop affinity); no locking. Stores are keyed by
+ * namespace at module level, so same-namespace opens share state.
+ *
+ * Internal module. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import util from "hull:kv:_util";
+
+const REGISTRY = new Map(); // namespace -> Store
+const ENTRY_OVERHEAD = 48;
+
+class Store {
+    constructor(policy) {
+        this.data = new Map(); // key -> { v, exp(ms|null), bytes, seq }
+        this.seq = 0;
+        this.items = 0;
+        this.bytes = 0;
+        this.maxBytes = policy.maxBytes || 0;
+        this.maxItems = policy.maxItems || 0;
+        this.defaultTtl = policy.defaultTtl;
+        this.evict = !!policy.evict;
+        this.st = { hits: 0, misses: 0, evictions: 0, expirations: 0 };
+        this.caps = {
+            ttl: true, atomic_increment: true, compare_exchange: true,
+            scan: true, persistent: false, shared: false,
+            eviction: !!policy.evict, transactions: false,
+        };
+    }
+
+    _drop(k, e) { this.data.delete(k); this.items -= 1; this.bytes -= e.bytes; }
+
+    _live(k) {
+        const e = this.data.get(k);
+        if (!e) return null;
+        if (e.exp !== null && util.nowMs() >= e.exp) {
+            this._drop(k, e);
+            this.st.expirations += 1;
+            return null;
+        }
+        return e;
+    }
+
+    _makeRoom(addBytes, addingItem) {
+        const over = () =>
+            (this.maxItems > 0 && this.items + (addingItem ? 1 : 0) > this.maxItems) ||
+            (this.maxBytes > 0 && this.bytes + addBytes > this.maxBytes);
+        if (!over()) return;
+        if (!this.evict)
+            util.error("capacity_exceeded", "kv: in-memory store is full (eviction disabled)");
+        while (over() && this.items > 0) {
+            let lruK, lruSeq;
+            for (const k of this.data.keys()) {
+                const e = this.data.get(k);
+                if (lruSeq === undefined || e.seq < lruSeq) { lruK = k; lruSeq = e.seq; }
+            }
+            if (lruK === undefined) break;
+            this._drop(lruK, this.data.get(lruK));
+            this.st.evictions += 1;
+        }
+        if (over())
+            util.error("capacity_exceeded", "kv: value larger than the cache byte budget");
+    }
+
+    get(k) {
+        const e = this._live(k);
+        if (!e) { this.st.misses += 1; return null; }
+        this.seq += 1; e.seq = this.seq;
+        this.st.hits += 1;
+        return e.v;
+    }
+
+    has(k) { return this._live(k) !== null; }
+
+    put(k, v, ttl) {
+        const exp = util.expiryMs(ttl, this.defaultTtl);
+        const nb = k.length + v.length + ENTRY_OVERHEAD;
+        const old = this.data.get(k);
+        if (old) {
+            // Bump to MRU first so make_room never evicts the key being updated.
+            this.seq += 1; old.seq = this.seq;
+            const delta = nb - old.bytes;
+            if (delta > 0) this._makeRoom(delta, false);
+            this.bytes = this.bytes - old.bytes + nb;
+            old.v = v; old.exp = exp; old.bytes = nb;
+            return v;
+        }
+        this._makeRoom(nb, true);
+        this.seq += 1;
+        this.data.set(k, { v, exp, bytes: nb, seq: this.seq });
+        this.items += 1; this.bytes += nb;
+        return v;
+    }
+
+    del(k) {
+        const e = this.data.get(k);
+        if (!e) return false;
+        this._drop(k, e);
+        return true;
+    }
+
+    incr(k, by, ttl) {
+        const e = this._live(k);
+        if (e) {
+            // Preserve the existing expiry (matches the SQL backend and Redis
+            // INCR); only the value changes.
+            const newv = String(util.toInt(e.v) + by);
+            const nb = k.length + newv.length + ENTRY_OVERHEAD;
+            const delta = nb - e.bytes;
+            this.seq += 1; e.seq = this.seq;
+            if (delta > 0) this._makeRoom(delta, false);
+            this.bytes = this.bytes - e.bytes + nb;
+            e.v = newv; e.bytes = nb;
+            return util.toInt(newv);
+        }
+        this.put(k, String(by), ttl); // fresh key: apply ttl
+        return by;
+    }
+
+
+    // compare-and-swap; expected undefined/null = set only if absent.
+    cas(k, expected, newVal, ttl) {
+        const e = this._live(k);
+        const cur = e ? e.v : null;
+        const exp = (expected === undefined || expected === null) ? null : expected;
+        if (cur !== exp) return false;
+        this.put(k, newVal, ttl);
+        return true;
+    }
+
+    clear() { this.data = new Map(); this.items = 0; this.bytes = 0; }
+
+    scan(prefix, limit) {
+        prefix = prefix || "";
+        const out = [];
+        for (const k of this.data.keys()) {
+            const e = this.data.get(k);
+            if ((e.exp === null || util.nowMs() < e.exp) && k.startsWith(prefix)) {
+                out.push(k);
+                if (limit && out.length >= limit) break;
+            }
+        }
+        return out;
+    }
+
+    cleanup() {
+        const now = util.nowMs();
+        let removed = 0;
+        for (const k of this.data.keys()) {
+            const e = this.data.get(k);
+            if (e.exp !== null && now >= e.exp) { this._drop(k, e); removed += 1; }
+        }
+        this.st.expirations += removed;
+        return removed;
+    }
+
+    stats() {
+        return {
+            hits: this.st.hits, misses: this.st.misses,
+            evictions: this.st.evictions, expirations: this.st.expirations,
+            items: this.items, bytes: this.bytes,
+        };
+    }
+}
+
+function get(namespace, policy) {
+    let s = REGISTRY.get(namespace);
+    if (s) return s;
+    s = new Store(policy || {});
+    REGISTRY.set(namespace, s);
+    return s;
+}
+
+function _forget(namespace) { REGISTRY.delete(namespace); }
+
+export default { get, _forget };

--- a/stdlib/js/hull/kv/_sql.js
+++ b/stdlib/js/hull/kv/_sql.js
@@ -1,0 +1,175 @@
+/*
+ * hull:kv:_sql - SQL-backed byte store over an existing Hull db connection (JS
+ * mirror of hull.kv._sql). Reuses the backend-agnostic db capability (no second
+ * connection stack); SQLite + PostgreSQL served by one implementation. Keys are
+ * hex-encoded (prefix-preserving for scan), values base64-encoded, both into
+ * portable TEXT columns (Postgres TEXT rejects embedded NULs). One `_hull_kv`
+ * table serves hull.kv (durable) and hull.cache (SQL max_items eviction).
+ *
+ * Internal module. SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import util from "hull:kv:_util";
+
+const SUPPORTED = { sqlite: true, postgres: true };
+
+const DDL =
+    "CREATE TABLE IF NOT EXISTS _hull_kv (" +
+    "ns TEXT NOT NULL, k TEXT NOT NULL, v TEXT NOT NULL, " +
+    "expires_at BIGINT NOT NULL, version BIGINT NOT NULL DEFAULT 1, " +
+    "created_at BIGINT NOT NULL, updated_at BIGINT NOT NULL, " +
+    "PRIMARY KEY (ns, k))";
+
+const created = new WeakMap();
+function ensureTable(conn) {
+    if (created.get(conn)) return;
+    conn.exec(DDL);
+    created.set(conn, true);
+}
+
+class SqlStore {
+    constructor(conn, namespace, policy) {
+        if (!conn || typeof conn.exec !== "function")
+            util.error("invalid_argument", "kv: sql backend needs a db connection (database: ...)");
+        const backend = conn.backendName || "?";
+        if (!SUPPORTED[backend])
+            util.error("unsupported",
+                "kv: sql backend does not support '" + backend + "' yet (sqlite/postgres)");
+        ensureTable(conn);
+        this.conn = conn;
+        this.ns = namespace;
+        this.defaultTtl = policy.defaultTtl;
+        this.evict = !!policy.evict;
+        this.maxItems = policy.maxItems || 0;
+        this.caps = {
+            ttl: true, atomic_increment: true, compare_exchange: true,
+            scan: true, persistent: true, shared: (backend === "postgres"),
+            eviction: !!policy.evict, transactions: true,
+        };
+    }
+
+    get(k) {
+        const rows = this.conn.query(
+            "SELECT v FROM _hull_kv WHERE ns = ? AND k = ? AND expires_at > ?",
+            [this.ns, util.hexencode(k), util.nowMs()]);
+        if (!rows || rows.length === 0) return null;
+        return util.b64decode(rows[0].v);
+    }
+
+    has(k) { return this.get(k) !== null; }
+
+    _evictItems() {
+        if (!this.evict || this.maxItems <= 0) return;
+        const rows = this.conn.query(
+            "SELECT COUNT(*) AS n FROM _hull_kv WHERE ns = ?", [this.ns]);
+        const n = rows && rows[0] ? Number(rows[0].n) : 0;
+        if (n <= this.maxItems) return;
+        const over = n - this.maxItems;
+        this.conn.exec(
+            "DELETE FROM _hull_kv WHERE ns = ? AND k IN (" +
+            "SELECT k FROM _hull_kv WHERE ns = ? ORDER BY updated_at ASC LIMIT " +
+            String(over) + ")",
+            [this.ns, this.ns]);
+    }
+
+    put(k, v, ttl) {
+        const now = util.nowMs();
+        const exp = util.expiryMs(ttl, this.defaultTtl);
+        const expVal = exp === null ? util.NO_EXPIRY : exp;
+        this.conn.exec(
+            "INSERT INTO _hull_kv (ns, k, v, expires_at, version, created_at, updated_at) " +
+            "VALUES (?, ?, ?, ?, 1, ?, ?) " +
+            "ON CONFLICT (ns, k) DO UPDATE SET " +
+            "v = excluded.v, expires_at = excluded.expires_at, " +
+            "version = _hull_kv.version + 1, updated_at = excluded.updated_at",
+            [this.ns, util.hexencode(k), util.b64encode(v), expVal, now, now]);
+        this._evictItems();
+        return v;
+    }
+
+    del(k) {
+        const n = this.conn.exec(
+            "DELETE FROM _hull_kv WHERE ns = ? AND k = ?", [this.ns, util.hexencode(k)]);
+        return (n || 0) > 0;
+    }
+
+    cas(k, expected, newVal, ttl) {
+        const now = util.nowMs();
+        const exp = util.expiryMs(ttl, this.defaultTtl);
+        const expVal = exp === null ? util.NO_EXPIRY : exp;
+        if (expected === undefined || expected === null) {
+            const n = this.conn.exec(
+                "INSERT INTO _hull_kv (ns, k, v, expires_at, version, created_at, updated_at) " +
+                "VALUES (?, ?, ?, ?, 1, ?, ?) ON CONFLICT (ns, k) DO NOTHING",
+                [this.ns, util.hexencode(k), util.b64encode(newVal), expVal, now, now]);
+            return (n || 0) === 1;
+        }
+        const n = this.conn.exec(
+            "UPDATE _hull_kv SET v = ?, version = version + 1, updated_at = ?, expires_at = ? " +
+            "WHERE ns = ? AND k = ? AND v = ? AND expires_at > ?",
+            [util.b64encode(newVal), now, expVal, this.ns, util.hexencode(k),
+             util.b64encode(expected), now]);
+        return (n || 0) === 1;
+    }
+
+    incr(k, by, ttl) {
+        const khex = util.hexencode(k);
+        for (let attempt = 0; attempt < 16; attempt++) {
+            const now = util.nowMs();
+            const rows = this.conn.query(
+                "SELECT v, version FROM _hull_kv WHERE ns = ? AND k = ? AND expires_at > ?",
+                [this.ns, khex, now]);
+            if (!rows || rows.length === 0) {
+                const exp = util.expiryMs(ttl, this.defaultTtl);
+                const expVal = exp === null ? util.NO_EXPIRY : exp;
+                const n = this.conn.exec(
+                    "INSERT INTO _hull_kv (ns, k, v, expires_at, version, created_at, updated_at) " +
+                    "VALUES (?, ?, ?, ?, 1, ?, ?) ON CONFLICT (ns, k) DO NOTHING",
+                    [this.ns, khex, util.b64encode(String(by)), expVal, now, now]);
+                if ((n || 0) === 1) return by;
+            } else {
+                const cur = util.toInt(util.b64decode(rows[0].v));
+                const ver = Number(rows[0].version);
+                const nv = cur + by;
+                const n = this.conn.exec(
+                    "UPDATE _hull_kv SET v = ?, version = version + 1, updated_at = ? " +
+                    "WHERE ns = ? AND k = ? AND version = ?",
+                    [util.b64encode(String(nv)), now, this.ns, khex, ver]);
+                if ((n || 0) === 1) return nv;
+            }
+            // lost the race; retry
+        }
+        util.error("conflict", "kv: incr contended past retry budget");
+    }
+
+    clear() { this.conn.exec("DELETE FROM _hull_kv WHERE ns = ?", [this.ns]); }
+
+    scan(prefix, limit) {
+        prefix = prefix || "";
+        let sql = "SELECT k FROM _hull_kv WHERE ns = ? AND k LIKE ? AND expires_at > ?";
+        if (limit && limit > 0) sql += " LIMIT " + String(Math.floor(limit));
+        const rows = this.conn.query(sql, [this.ns, util.hexencode(prefix) + "%", util.nowMs()]);
+        const out = [];
+        for (let i = 0; i < (rows ? rows.length : 0); i++) out.push(util.hexdecode(rows[i].k));
+        return out;
+    }
+
+    cleanup() {
+        return this.conn.exec(
+            "DELETE FROM _hull_kv WHERE ns = ? AND expires_at <= ?",
+            [this.ns, util.nowMs()]) || 0;
+    }
+
+    stats() {
+        const rows = this.conn.query(
+            "SELECT COUNT(*) AS n FROM _hull_kv WHERE ns = ? AND expires_at > ?",
+            [this.ns, util.nowMs()]);
+        return { items: rows && rows[0] ? Number(rows[0].n) : 0 };
+    }
+}
+
+function newStore(conn, namespace, policy) {
+    return new SqlStore(conn, namespace, policy || {});
+}
+
+export default { new: newStore };

--- a/stdlib/js/hull/kv/_util.js
+++ b/stdlib/js/hull/kv/_util.js
@@ -1,0 +1,119 @@
+/*
+ * hull:kv:_util - shared internals for the KV/cache subsystem (JS mirror of
+ * hull.kv._util). Coded errors, key/value validation, binary-safe base64 + hex
+ * codecs, capability vocabulary. Values are BYTE STRINGS (each char a code unit
+ * 0-255, one char per byte - Hull's JS byte convention, same as crypto/_hex),
+ * so `.length` is the byte count and there is no UTF-8 step.
+ *
+ * Internal (underscore-prefixed). SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { time } from "hull:time";
+
+const MAX_KEY = 1024;
+// Far-future "no expiry" sentinel for the SQL backend (keeps expires_at NOT
+// NULL and off the mid-array-nil binding path). Fits a 64-bit BIGINT.
+const NO_EXPIRY = Number.MAX_SAFE_INTEGER;
+
+function codedError(code, message) {
+    const e = new Error(message);
+    e.code = code;
+    throw e;
+}
+
+function checkKey(k) {
+    if (typeof k !== "string")
+        codedError("invalid_argument", "kv: key must be a string (bytes), got " + typeof k);
+    if (k.length === 0)
+        codedError("invalid_argument", "kv: key must be non-empty");
+    if (k.length > MAX_KEY)
+        codedError("invalid_argument", "kv: key exceeds " + MAX_KEY + " bytes");
+    return k;
+}
+
+function checkValue(v) {
+    if (typeof v !== "string")
+        codedError("invalid_argument", "kv: value must be a string (bytes), got " + typeof v);
+    return v;
+}
+
+// ttl (seconds) -> absolute expiry ms, or null for no expiry. undefined/null =
+// use default; false = no expiry overriding a default; number = seconds.
+function expiryMs(ttl, defaultTtl) {
+    if (ttl === undefined || ttl === null) ttl = defaultTtl;
+    if (ttl === undefined || ttl === null || ttl === false) return null;
+    if (typeof ttl !== "number")
+        codedError("invalid_argument", "kv: ttl must be a number of seconds");
+    return time.nowMs() + Math.floor(ttl * 1000);
+}
+
+function nowMs() { return time.nowMs(); }
+
+function toInt(bytes) {
+    const n = Number(bytes);
+    if (!Number.isInteger(n))
+        codedError("invalid_argument", "kv: value is not an integer for incr()");
+    return n;
+}
+
+// ---- binary-safe base64 (standard alphabet, padded) over byte strings ----
+const B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+const DEC = {};
+for (let i = 0; i < B64.length; i++) DEC[B64[i]] = i;
+
+function b64encode(s) {
+    const out = [];
+    const n = s.length;
+    for (let i = 0; i < n; i += 3) {
+        const b1 = s.charCodeAt(i) & 0xff;
+        const has2 = i + 1 < n, has3 = i + 2 < n;
+        const b2 = has2 ? s.charCodeAt(i + 1) & 0xff : 0;
+        const b3 = has3 ? s.charCodeAt(i + 2) & 0xff : 0;
+        out.push(B64[b1 >> 2]);
+        out.push(B64[((b1 & 0x3) << 4) | (b2 >> 4)]);
+        out.push(has2 ? B64[((b2 & 0xf) << 2) | (b3 >> 6)] : "=");
+        out.push(has3 ? B64[b3 & 0x3f] : "=");
+    }
+    return out.join("");
+}
+
+function b64decode(str) {
+    const out = [];
+    let buf = 0, bits = 0;
+    for (let i = 0; i < str.length; i++) {
+        const c = str[i];
+        if (c === "=") continue;
+        const d = DEC[c];
+        if (d === undefined) codedError("invalid_argument", "kv: corrupt base64 in store");
+        buf = (buf << 6) | d;
+        bits += 6;
+        if (bits >= 8) { bits -= 8; out.push(String.fromCharCode((buf >> bits) & 0xff)); }
+    }
+    return out.join("");
+}
+
+// ---- hex (prefix-preserving; lets the SQL backend scan keys with LIKE) ----
+function hexencode(s) {
+    let out = "";
+    for (let i = 0; i < s.length; i++)
+        out += (s.charCodeAt(i) & 0xff).toString(16).padStart(2, "0");
+    return out;
+}
+
+function hexdecode(hex) {
+    if (hex.length % 2 !== 0) codedError("invalid_argument", "kv: corrupt hex in store");
+    const out = [];
+    for (let i = 0; i < hex.length; i += 2) {
+        const n = parseInt(hex.substr(i, 2), 16);
+        if (Number.isNaN(n)) codedError("invalid_argument", "kv: corrupt hex in store");
+        out.push(String.fromCharCode(n));
+    }
+    return out.join("");
+}
+
+const util = {
+    MAX_KEY, NO_EXPIRY, error: codedError, checkKey, checkValue, expiryMs,
+    nowMs, toInt, b64encode, b64decode, hexencode, hexdecode,
+};
+
+export default util;

--- a/stdlib/lua/hull/cache.lua
+++ b/stdlib/lua/hull/cache.lua
@@ -151,6 +151,74 @@ function cache.new(opts)
     return self
 end
 
+-- ---------------------------------------------------------------------------
+-- cache.open{} - the byte-oriented, backend-selectable CACHE handle.
+--
+-- Distinct from cache.new() above: cache.new is a lightweight in-process
+-- memoizer for arbitrary Lua VALUES (item-count bound). cache.open deals in
+-- BYTES (keys/values are strings) and adds byte accounting, pluggable backends
+-- (memory / sqlite), and namespaces - sharing the same store cores as
+-- hull.kv but with CACHE policy (eviction ON). Use cache.open when you need
+-- max_bytes, a durable/SQL cache, or explicit namespaces; cache.new for a
+-- quick local value memoizer.
+--
+--   local c = require("hull.cache").open{ backend = "memory",
+--       namespace = "query-ir", max_bytes = 512*1024*1024, default_ttl = 600 }
+--   c:set(k, bytes); local v = c:get(k)   -- bytes | nil
+--   c:fetch(k, 60, function() return render() end)   -- get-or-compute (bytes)
+--   c.stats()   -- { hits, misses, evictions, items, bytes }
+-- ---------------------------------------------------------------------------
+function cache.open(opts)
+    local u      = require("hull.kv._util")
+    local handle = require("hull.kv._handle")
+    if type(opts) ~= "table" then
+        u.error("invalid_argument", "cache.open: options table required")
+    end
+    local backend = opts.backend or "memory"
+    local ns = opts.namespace or "default"
+    local store_ns = "cache:" .. ns   -- isolated from hull.kv's "kv:" namespaces
+
+    local store, bname
+    if backend == "memory" then
+        store = require("hull.kv._memstore").get(store_ns, {
+            evict       = true,                 -- CACHE: LRU eviction ON
+            default_ttl = opts.default_ttl,
+            max_bytes   = opts.max_bytes,
+            max_items   = opts.max_items,
+        })
+        bname = "memory"
+    elseif backend == "sqlite" then
+        local conn = opts.database
+        if type(conn) ~= "table" or type(conn.exec) ~= "function" then
+            u.error("invalid_argument",
+                "cache.open: sqlite backend needs database = <db connection>")
+        end
+        store = require("hull.kv._sql").new(conn, store_ns, {
+            evict = true, default_ttl = opts.default_ttl, max_items = opts.max_items,
+        })
+        bname = conn.backend_name or "sqlite"
+    else
+        u.error("invalid_argument", "cache.open: unknown backend '" .. tostring(backend) .. "'")
+    end
+
+    local h = handle.build(store, { namespace = ns, backend = bname })
+
+    --- Get `key`, or compute + cache it. `fetch(key, ttl, fn)` or
+    -- `fetch(key, fn)`. `fn` must return bytes (a string); it is synchronous.
+    function h:fetch(key, ttl, fn)
+        if fn == nil and type(ttl) == "function" then fn = ttl; ttl = nil end
+        u.check_key(key)
+        local v = self._s:get(key)
+        if v ~= nil then return v end
+        v = fn()
+        u.check_value(v)
+        self._s:put(key, v, ttl)
+        return v
+    end
+
+    return h
+end
+
 -- Default instance backs the top-level cache.* convenience API. A cache is
 -- intentionally cross-request shared state (like ratelimit's buckets), so a
 -- module-level default is correct here, not the request-scoped-global footgun.

--- a/stdlib/lua/hull/kv.lua
+++ b/stdlib/lua/hull/kv.lua
@@ -1,0 +1,89 @@
+--[[
+  hull.kv - portable key/value STORE.
+
+  KV STORE semantics (distinct from hull.cache): externally meaningful state,
+  no eviction unless explicitly requested, persistence where the backend
+  provides it, potentially shared across processes. Keys and values are
+  arbitrary bytes (Lua strings); we do not assume UTF-8.
+
+  Backends (milestone 1): "memory" (in-process, ephemeral, process-shared by
+  namespace), "sqlite" and "postgres" (durable, over an existing Hull db
+  connection). Each backend advertises a capability set (handle.caps); an
+  optional op on a backend that lacks the cap throws `unsupported`.
+
+    local kv = require("hull.kv").open{ backend = "sqlite", database = db,
+                                        namespace = "agent-state" }
+    kv:set("run:123", payload)          -- bytes -> bytes
+    local v = kv:get("run:123")         -- bytes | nil (miss)
+    kv:set(k, v, { ttl = 3600 })        -- optional TTL (seconds)
+    kv:cas(k, expected, new)            -- atomic compare-and-swap
+    kv:incr("hits", 1)                  -- atomic increment
+    kv:scan("run:")                     -- prefix iteration -> { keys }
+    kv:delete(k); kv:exists(k); kv:clear()
+
+  Security: SQL backends run through the db capability, so a SQLite file
+  honors the fs sandbox and a network DB honors the host allowlist +
+  network_outbound grant - the KV layer opens no hidden fs/network access.
+
+  SPDX-License-Identifier: AGPL-3.0-or-later
+]]
+
+local u      = require("hull.kv._util")
+local handle = require("hull.kv._handle")
+
+local M = { _VERSION = "1" }
+
+local function memory_backend(opts, store_ns)
+    -- KV memory: eviction OFF. A max_bytes/max_items cap (if given) makes a
+    -- full store raise on write rather than silently drop externally-meaningful
+    -- state. Unbounded by default.
+    local store = require("hull.kv._memstore").get(store_ns, {
+        evict       = false,
+        default_ttl = opts.default_ttl,
+        max_bytes   = opts.max_bytes,
+        max_items   = opts.max_items,
+    })
+    return store, "memory"
+end
+
+local function sql_backend(opts, store_ns)
+    -- Reuse the app's existing db connection - no second connection stack.
+    local conn = opts.database
+    if type(conn) ~= "table" or type(conn.exec) ~= "function" then
+        u.error("invalid_argument",
+            "kv.open: sql backend needs database = <db connection> "
+            .. "(e.g. require('hull.db').default())")
+    end
+    local store = require("hull.kv._sql").new(conn, store_ns, {
+        evict = false, default_ttl = opts.default_ttl,
+    })
+    return store, conn.backend_name or "sql"
+end
+
+--- Open a KV handle.
+-- @param opts { backend = "memory"|"sqlite"|"postgres", namespace = "default",
+--              database = <db conn> (sql), dsn|path = <dsn> (sql convenience),
+--              default_ttl = <seconds>, max_bytes, max_items (memory) }
+function M.open(opts)
+    if type(opts) ~= "table" then
+        u.error("invalid_argument", "kv.open: options table required")
+    end
+    local backend = opts.backend or "memory"
+    opts.namespace = opts.namespace or "default"
+    -- Prefix the physical store namespace so a kv and a cache that happen to
+    -- share a namespace name never collide in the same memory table / _hull_kv.
+    local store_ns = "kv:" .. opts.namespace
+
+    local store, bname
+    if backend == "memory" then
+        store, bname = memory_backend(opts, store_ns)
+    elseif backend == "sqlite" or backend == "postgres" then
+        store, bname = sql_backend(opts, store_ns)
+    else
+        u.error("invalid_argument", "kv.open: unknown backend '" .. tostring(backend) .. "'")
+    end
+
+    return handle.build(store, { namespace = opts.namespace, backend = bname })
+end
+
+return M

--- a/stdlib/lua/hull/kv/_handle.lua
+++ b/stdlib/lua/hull/kv/_handle.lua
@@ -1,0 +1,74 @@
+--[[
+  hull.kv._handle - the semantic surface over a backend store.
+
+  Wraps a memory/sql store with key/value validation and capability
+  enforcement (an optional op on a backend that lacks the cap throws
+  `unsupported`, never silently no-ops). Shared by hull.kv and hull.cache so
+  the two present the same core methods with the same guarantees; hull.cache
+  layers fetch() on top. Handles are used method-style (`h:get(k)`).
+
+  Internal module. SPDX-License-Identifier: AGPL-3.0-or-later
+]]
+
+local u = require("hull.kv._util")
+
+local M = {}
+local H = {}
+H.__index = H
+
+function M.build(store, meta)
+    return setmetatable({
+        _s = store, caps = store.caps,
+        namespace = meta.namespace, backend = meta.backend,
+    }, H)
+end
+
+local function need(self, cap)
+    if not self.caps[cap] then
+        u.error("unsupported",
+            "kv: backend '" .. self.backend .. "' does not support " .. cap)
+    end
+end
+
+function H:get(k) u.check_key(k); return self._s:get(k) end
+
+function H:set(k, v, opts)
+    u.check_key(k); u.check_value(v)
+    self._s:put(k, v, opts and opts.ttl)
+    return true
+end
+
+function H:delete(k) u.check_key(k); return self._s:del(k) end
+
+function H:exists(k) u.check_key(k); return self._s:has(k) end
+
+function H:incr(k, by, opts)
+    need(self, "atomic_increment"); u.check_key(k)
+    by = by or 1
+    if type(by) ~= "number" or by ~= math.floor(by) then
+        u.error("invalid_argument", "kv: incr amount must be an integer")
+    end
+    return self._s:incr(k, by, opts and opts.ttl)
+end
+
+function H:cas(k, expected, new, opts)
+    need(self, "compare_exchange"); u.check_key(k); u.check_value(new)
+    if expected ~= nil then u.check_value(expected) end
+    return self._s:cas(k, expected, new, opts and opts.ttl)
+end
+
+function H:clear() self._s:clear(); return true end
+
+function H:scan(prefix, opts)
+    need(self, "scan")
+    if prefix ~= nil and type(prefix) ~= "string" then
+        u.error("invalid_argument", "kv: scan prefix must be a string (bytes)")
+    end
+    return self._s:scan(prefix, opts and opts.limit)
+end
+
+function H:cleanup() return self._s:cleanup() end
+
+function H:stats() return self._s:stats() end
+
+return M

--- a/stdlib/lua/hull/kv/_memstore.lua
+++ b/stdlib/lua/hull/kv/_memstore.lua
@@ -1,0 +1,203 @@
+--[[
+  hull.kv._memstore - native in-process byte store.
+
+  One physical store backs two policies: hull.kv memory (eviction OFF, KV
+  semantics) and hull.cache memory (LRU eviction ON, cache semantics). Keys
+  and values are arbitrary bytes (Lua strings, binary-safe as table keys).
+  Lazy TTL expiry on access, byte + item accounting, LRU by access sequence.
+  Single-threaded (event-loop affinity); no locking.
+
+  Stores are keyed by namespace at MODULE level, so two opens of the same
+  namespace in one process share state (in-process "shared"); policy is fixed
+  by the first open of a namespace.
+
+  Internal module. SPDX-License-Identifier: AGPL-3.0-or-later
+]]
+
+local u = require("hull.kv._util")
+
+local M = {}
+local Store = {}
+Store.__index = Store
+
+-- namespace -> Store (process-wide, so same-namespace opens share)
+local REGISTRY = {}
+
+local ENTRY_OVERHEAD = 48 -- rough per-entry bookkeeping charged to byte accounting
+
+-- policy: { max_bytes=0, max_items=0, default_ttl=nil, evict=false }
+function M.get(namespace, policy)
+    local s = REGISTRY[namespace]
+    if s then return s end
+    policy = policy or {}
+    s = setmetatable({
+        data        = {},   -- key -> { v, exp(ms|nil), bytes, seq }
+        seq         = 0,
+        items       = 0,
+        bytes       = 0,
+        max_bytes   = policy.max_bytes or 0,
+        max_items   = policy.max_items or 0,
+        default_ttl = policy.default_ttl,
+        evict       = policy.evict and true or false,
+        st          = { hits = 0, misses = 0, evictions = 0, expirations = 0 },
+        caps        = {
+            ttl = true, atomic_increment = true, compare_exchange = true,
+            scan = true, persistent = false, shared = false,
+            eviction = policy.evict and true or false, transactions = false,
+        },
+    }, Store)
+    REGISTRY[namespace] = s
+    return s
+end
+
+local function drop(self, k, e)
+    self.data[k] = nil
+    self.items = self.items - 1
+    self.bytes = self.bytes - e.bytes
+end
+
+-- Return the entry if live; lazily drop + return nil if expired.
+local function live(self, k)
+    local e = self.data[k]
+    if not e then return nil end
+    if e.exp and u.now_ms() >= e.exp then
+        drop(self, k, e)
+        self.st.expirations = self.st.expirations + 1
+        return nil
+    end
+    return e
+end
+
+-- Evict least-recently-used live entries until the incoming entry fits, or
+-- (eviction disabled) raise once a cap would be exceeded.
+local function make_room(self, add_bytes, adding_item)
+    local function over()
+        return (self.max_items > 0 and self.items + (adding_item and 1 or 0) > self.max_items)
+            or (self.max_bytes > 0 and self.bytes + add_bytes > self.max_bytes)
+    end
+    if not over() then return end
+    if not self.evict then
+        u.error("capacity_exceeded", "kv: in-memory store is full (eviction disabled)")
+    end
+    -- Evict lowest-seq (LRU) entries until within caps or empty.
+    while over() and self.items > 0 do
+        local lru_k, lru_seq
+        for k, e in pairs(self.data) do
+            if not lru_seq or e.seq < lru_seq then lru_k, lru_seq = k, e.seq end
+        end
+        if not lru_k then break end
+        drop(self, lru_k, self.data[lru_k])
+        self.st.evictions = self.st.evictions + 1
+    end
+    if over() then
+        -- A single value larger than the whole budget.
+        u.error("capacity_exceeded", "kv: value larger than the cache byte budget")
+    end
+end
+
+function Store:get(k)
+    local e = live(self, k)
+    if not e then self.st.misses = self.st.misses + 1; return nil end
+    self.seq = self.seq + 1; e.seq = self.seq
+    self.st.hits = self.st.hits + 1
+    return e.v
+end
+
+function Store:has(k) return live(self, k) ~= nil end
+
+function Store:put(k, v, ttl)
+    local exp = u.expiry_ms(ttl, self.default_ttl)
+    local nb = #k + #v + ENTRY_OVERHEAD
+    local old = self.data[k]
+    if old then
+        -- Overwrite: bump to MRU first so make_room never evicts the key we are
+        -- updating, then account only the byte delta.
+        self.seq = self.seq + 1
+        old.seq = self.seq
+        local delta = nb - old.bytes
+        if delta > 0 then make_room(self, delta, false) end
+        self.bytes = self.bytes - old.bytes + nb
+        old.v, old.exp, old.bytes = v, exp, nb
+        return v
+    end
+    make_room(self, nb, true)
+    self.seq = self.seq + 1
+    self.data[k] = { v = v, exp = exp, bytes = nb, seq = self.seq }
+    self.items = self.items + 1
+    self.bytes = self.bytes + nb
+    return v
+end
+
+function Store:del(k)
+    local e = self.data[k]
+    if not e then return false end
+    drop(self, k, e)
+    return true
+end
+
+function Store:incr(k, by, ttl)
+    local e = live(self, k)
+    if e then
+        -- Preserve the existing expiry (matches the SQL backend and Redis
+        -- INCR); only the value changes.
+        local newv = tostring(u.to_int(e.v) + by)
+        local nb = #k + #newv + ENTRY_OVERHEAD
+        local delta = nb - e.bytes
+        self.seq = self.seq + 1
+        e.seq = self.seq
+        if delta > 0 then make_room(self, delta, false) end
+        self.bytes = self.bytes - e.bytes + nb
+        e.v, e.bytes = newv, nb
+        return u.to_int(newv)
+    end
+    self:put(k, tostring(by), ttl)   -- fresh key: apply ttl
+    return by
+end
+
+-- compare-and-swap: expected may be nil (set only if absent). Returns bool.
+function Store:cas(k, expected, new, ttl)
+    local e = live(self, k)
+    local cur = e and e.v or nil
+    if cur ~= expected then return false end
+    self:put(k, new, ttl)
+    return true
+end
+
+function Store:clear()
+    self.data, self.items, self.bytes = {}, 0, 0
+end
+
+function Store:scan(prefix, limit)
+    prefix = prefix or ""
+    local out = {}
+    for k, e in pairs(self.data) do
+        if (not e.exp or u.now_ms() < e.exp) and k:sub(1, #prefix) == prefix then
+            out[#out + 1] = k
+            if limit and #out >= limit then break end
+        end
+    end
+    return out
+end
+
+-- Sweep expired entries eagerly (optional hygiene; access already lazy-expires).
+function Store:cleanup()
+    local now, removed = u.now_ms(), 0
+    for k, e in pairs(self.data) do
+        if e.exp and now >= e.exp then drop(self, k, e); removed = removed + 1 end
+    end
+    self.st.expirations = self.st.expirations + removed
+    return removed
+end
+
+function Store:stats()
+    return {
+        hits = self.st.hits, misses = self.st.misses,
+        evictions = self.st.evictions, expirations = self.st.expirations,
+        items = self.items, bytes = self.bytes,
+    }
+end
+
+-- Test/lifecycle helper: forget a namespace's store entirely.
+function M._forget(namespace) REGISTRY[namespace] = nil end
+
+return M

--- a/stdlib/lua/hull/kv/_sql.lua
+++ b/stdlib/lua/hull/kv/_sql.lua
@@ -1,0 +1,202 @@
+--[[
+  hull.kv._sql - SQL-backed byte store over an existing Hull db connection.
+
+  Reuses the backend-agnostic db capability (no second connection stack): all
+  writes go through the same parameterized query/exec the rest of the stdlib
+  uses, so SQLite and PostgreSQL are served by one implementation. Keys are
+  hex-encoded (prefix-preserving, so scan() is a LIKE range) and values are
+  base64-encoded, both into portable TEXT columns - Postgres TEXT rejects
+  embedded NULs, so raw binary can't be stored directly.
+
+  One physical table `_hull_kv` (namespace + key primary key) serves both
+  hull.kv (durable, no eviction) and hull.cache (SQL-expressed max_items
+  eviction) via policy. Protected from app code by the `_hull_` prefix
+  (stdlib callers bypass the namespace guard).
+
+  Internal module. SPDX-License-Identifier: AGPL-3.0-or-later
+]]
+
+local u = require("hull.kv._util")
+
+local M = {}
+local Store = {}
+Store.__index = Store
+
+-- ON CONFLICT is SQLite + PostgreSQL (+ DuckDB) syntax; MySQL differs and is a
+-- later milestone. Gate explicitly so the failure is a clear message, not a
+-- syntax error at first write.
+local SUPPORTED = { sqlite = true, postgres = true }
+
+local DDL = [[
+CREATE TABLE IF NOT EXISTS _hull_kv (
+    ns TEXT NOT NULL,
+    k TEXT NOT NULL,
+    v TEXT NOT NULL,
+    expires_at BIGINT NOT NULL,
+    version BIGINT NOT NULL DEFAULT 1,
+    created_at BIGINT NOT NULL,
+    updated_at BIGINT NOT NULL,
+    PRIMARY KEY (ns, k)
+)]]
+
+-- Create the table once per connection (idempotent, but skip the round-trip).
+local created = setmetatable({}, { __mode = "k" })
+local function ensure_table(conn)
+    if created[conn] then return end
+    conn.exec(DDL)
+    created[conn] = true
+end
+
+-- policy: { default_ttl, evict(bool), max_items }
+function M.new(conn, namespace, policy)
+    if type(conn) ~= "table" or type(conn.exec) ~= "function" then
+        u.error("invalid_argument", "kv: sql backend needs a db connection (database = ...)")
+    end
+    local backend = conn.backend_name or "?"
+    if not SUPPORTED[backend] then
+        u.error("unsupported",
+            "kv: sql backend does not support '" .. backend .. "' yet (sqlite/postgres)")
+    end
+    ensure_table(conn)
+    policy = policy or {}
+    return setmetatable({
+        conn = conn, ns = namespace,
+        default_ttl = policy.default_ttl,
+        evict = policy.evict and true or false,
+        max_items = policy.max_items or 0,
+        caps = {
+            ttl = true, atomic_increment = true, compare_exchange = true,
+            scan = true, persistent = true, shared = (backend == "postgres"),
+            eviction = policy.evict and true or false, transactions = true,
+        },
+    }, Store)
+end
+
+local function kenc(k) return u.hexencode(k) end
+local function venc(v) return u.b64encode(v) end
+local function vdec(s) return u.b64decode(s) end
+
+function Store:get(k)
+    local rows = self.conn.query(
+        "SELECT v FROM _hull_kv WHERE ns = ? AND k = ? AND expires_at > ?",
+        { self.ns, kenc(k), u.now_ms() })
+    if not rows or #rows == 0 then return nil end
+    return vdec(rows[1].v)
+end
+
+function Store:has(k) return self:get(k) ~= nil end
+
+-- Enforce max_items for a cache-over-SQL store by deleting the oldest rows.
+local function evict_items(self)
+    if not self.evict or self.max_items <= 0 then return end
+    local rows = self.conn.query(
+        "SELECT COUNT(*) AS n FROM _hull_kv WHERE ns = ?", { self.ns })
+    local n = rows and rows[1] and tonumber(rows[1].n) or 0
+    if n <= self.max_items then return end
+    local over = n - self.max_items
+    -- Delete the `over` least-recently-updated keys in this namespace.
+    self.conn.exec(
+        "DELETE FROM _hull_kv WHERE ns = ? AND k IN ("
+        .. "SELECT k FROM _hull_kv WHERE ns = ? ORDER BY updated_at ASC LIMIT "
+        .. string.format("%d", over) .. ")",
+        { self.ns, self.ns })
+end
+
+function Store:put(k, v, ttl)
+    local now = u.now_ms()
+    local exp = u.expiry_ms(ttl, self.default_ttl) or u.NO_EXPIRY
+    self.conn.exec(
+        "INSERT INTO _hull_kv (ns, k, v, expires_at, version, created_at, updated_at) "
+        .. "VALUES (?, ?, ?, ?, 1, ?, ?) "
+        .. "ON CONFLICT (ns, k) DO UPDATE SET "
+        .. "v = excluded.v, expires_at = excluded.expires_at, "
+        .. "version = _hull_kv.version + 1, updated_at = excluded.updated_at",
+        { self.ns, kenc(k), venc(v), exp, now, now })
+    evict_items(self)
+    return v
+end
+
+function Store:del(k)
+    local n = self.conn.exec(
+        "DELETE FROM _hull_kv WHERE ns = ? AND k = ?", { self.ns, kenc(k) })
+    return (n or 0) > 0
+end
+
+-- Atomic compare-and-swap. expected == nil means "set only if absent".
+function Store:cas(k, expected, new, ttl)
+    local now = u.now_ms()
+    local exp = u.expiry_ms(ttl, self.default_ttl) or u.NO_EXPIRY
+    if expected == nil then
+        local n = self.conn.exec(
+            "INSERT INTO _hull_kv (ns, k, v, expires_at, version, created_at, updated_at) "
+            .. "VALUES (?, ?, ?, ?, 1, ?, ?) ON CONFLICT (ns, k) DO NOTHING",
+            { self.ns, kenc(k), venc(new), exp, now, now })
+        return (n or 0) == 1
+    end
+    local n = self.conn.exec(
+        "UPDATE _hull_kv SET v = ?, version = version + 1, updated_at = ?, expires_at = ? "
+        .. "WHERE ns = ? AND k = ? AND v = ? AND expires_at > ?",
+        { venc(new), now, exp, self.ns, kenc(k), venc(expected), now })
+    return (n or 0) == 1
+end
+
+-- Atomic increment via an optimistic version-guarded retry loop (portable;
+-- needs no row locks). A fresh key starts at 0.
+function Store:incr(k, by, ttl)
+    local khex = kenc(k)
+    for _ = 1, 16 do
+        local now = u.now_ms()
+        local rows = self.conn.query(
+            "SELECT v, version FROM _hull_kv WHERE ns = ? AND k = ? AND expires_at > ?",
+            { self.ns, khex, now })
+        if not rows or #rows == 0 then
+            local exp = u.expiry_ms(ttl, self.default_ttl) or u.NO_EXPIRY
+            local n = self.conn.exec(
+                "INSERT INTO _hull_kv (ns, k, v, expires_at, version, created_at, updated_at) "
+                .. "VALUES (?, ?, ?, ?, 1, ?, ?) ON CONFLICT (ns, k) DO NOTHING",
+                { self.ns, khex, venc(tostring(by)), exp, now, now })
+            if (n or 0) == 1 then return by end
+        else
+            local cur = u.to_int(vdec(rows[1].v))
+            local ver = tonumber(rows[1].version)
+            local nv = cur + by
+            local n = self.conn.exec(
+                "UPDATE _hull_kv SET v = ?, version = version + 1, updated_at = ? "
+                .. "WHERE ns = ? AND k = ? AND version = ?",
+                { venc(tostring(nv)), now, self.ns, khex, ver })
+            if (n or 0) == 1 then return nv end
+        end
+        -- lost the race; re-read and retry
+    end
+    u.error("conflict", "kv: incr contended past retry budget")
+end
+
+function Store:clear()
+    self.conn.exec("DELETE FROM _hull_kv WHERE ns = ?", { self.ns })
+end
+
+function Store:scan(prefix, limit)
+    prefix = prefix or ""
+    local sql = "SELECT k FROM _hull_kv WHERE ns = ? AND k LIKE ? AND expires_at > ?"
+    if limit and limit > 0 then sql = sql .. " LIMIT " .. string.format("%d", limit) end
+    local rows = self.conn.query(sql, { self.ns, u.hexencode(prefix) .. "%", u.now_ms() })
+    local out = {}
+    for _, r in ipairs(rows or {}) do out[#out + 1] = u.hexdecode(r.k) end
+    return out
+end
+
+-- Delete expired rows in this namespace; returns the count removed.
+function Store:cleanup()
+    return self.conn.exec(
+        "DELETE FROM _hull_kv WHERE ns = ? AND expires_at <= ?",
+        { self.ns, u.now_ms() }) or 0
+end
+
+function Store:stats()
+    local rows = self.conn.query(
+        "SELECT COUNT(*) AS n FROM _hull_kv WHERE ns = ? AND expires_at > ?",
+        { self.ns, u.now_ms() })
+    return { items = rows and rows[1] and tonumber(rows[1].n) or 0 }
+end
+
+return M

--- a/stdlib/lua/hull/kv/_util.lua
+++ b/stdlib/lua/hull/kv/_util.lua
@@ -1,0 +1,138 @@
+--[[
+  hull.kv._util - shared internals for the KV/cache subsystem.
+
+  Coded errors (docs/stdlib_style.md section 1), key/value validation, a
+  binary-safe base64 codec (so the SQL backend can store arbitrary bytes in
+  portable TEXT columns - Postgres TEXT rejects embedded NULs), and the
+  capability-name vocabulary. Consumed by hull.kv, hull.cache, and the
+  hull.kv._memstore / hull.kv._sql backends. Internal (underscore-prefixed);
+  not a user-facing module.
+
+  SPDX-License-Identifier: AGPL-3.0-or-later
+]]
+
+local time = require("hull.time")
+
+local M = {}
+
+-- Coded error: err.code is the stable, branch-on identity. Level 0 so the
+-- Lua source position is not prepended to the message.
+local _err_mt = { __tostring = function(e) return e.message end }
+function M.error(code, message)
+    error(setmetatable({ code = code, message = message }, _err_mt), 0)
+end
+
+M.MAX_KEY = 1024   -- bytes; bounds the SQL primary key and memory table keys
+
+-- Far-future sentinel for "no expiry" in the SQL backend, so expires_at stays
+-- NOT NULL and never appears mid-array as a nil (which would truncate a Lua
+-- params table). Fits a 64-bit BIGINT; any real ms-epoch is far below it.
+M.NO_EXPIRY = math.maxinteger
+
+-- A key is arbitrary NON-EMPTY bytes (a Lua string). Values are arbitrary
+-- bytes including empty. We do not assume UTF-8.
+function M.check_key(k)
+    if type(k) ~= "string" then
+        M.error("invalid_argument", "kv: key must be a string (bytes), got " .. type(k))
+    end
+    if #k == 0 then
+        M.error("invalid_argument", "kv: key must be non-empty")
+    end
+    if #k > M.MAX_KEY then
+        M.error("invalid_argument", "kv: key exceeds " .. M.MAX_KEY .. " bytes")
+    end
+    return k
+end
+
+function M.check_value(v)
+    if type(v) ~= "string" then
+        M.error("invalid_argument", "kv: value must be a string (bytes), got " .. type(v))
+    end
+    return v
+end
+
+-- ttl (seconds) -> absolute expiry in epoch ms, or nil for no expiry.
+--   nil      -> use the store default (may itself be nil = no expiry)
+--   number>0 -> that many seconds from now
+--   0        -> expire immediately (an explicit "already stale" write)
+--   false    -> no expiry, overriding any default
+function M.expiry_ms(ttl, default_ttl)
+    if ttl == nil then ttl = default_ttl end
+    if ttl == nil or ttl == false then return nil end
+    if type(ttl) ~= "number" then
+        M.error("invalid_argument", "kv: ttl must be a number of seconds")
+    end
+    return time.now_ms() + math.floor(ttl * 1000)
+end
+
+function M.now_ms() return time.now_ms() end
+
+-- Parse a stored value as a base-10 integer for incr(); a fresh key is 0.
+function M.to_int(bytes)
+    local n = tonumber(bytes)
+    if not n or n ~= math.floor(n) then
+        M.error("invalid_argument", "kv: value is not an integer for incr()")
+    end
+    return math.floor(n)
+end
+
+-- ---- binary-safe base64 (standard alphabet, padded) ----
+local B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+local DEC = {}
+for i = 1, #B64 do DEC[B64:sub(i, i)] = i - 1 end
+
+function M.b64encode(bytes)
+    local out, n = {}, #bytes
+    local i = 1
+    while i <= n do
+        local b1 = bytes:byte(i)
+        local b2 = i + 1 <= n and bytes:byte(i + 1) or nil
+        local b3 = i + 2 <= n and bytes:byte(i + 2) or nil
+        local n1 = b1 >> 2
+        local n2 = ((b1 & 0x3) << 4) | ((b2 or 0) >> 4)
+        local n3 = b2 and (((b2 & 0xf) << 2) | ((b3 or 0) >> 6)) or nil
+        local n4 = b3 and (b3 & 0x3f) or nil
+        out[#out + 1] = B64:sub(n1 + 1, n1 + 1)
+        out[#out + 1] = B64:sub(n2 + 1, n2 + 1)
+        out[#out + 1] = n3 and B64:sub(n3 + 1, n3 + 1) or "="
+        out[#out + 1] = n4 and B64:sub(n4 + 1, n4 + 1) or "="
+        i = i + 3
+    end
+    return table.concat(out)
+end
+
+function M.b64decode(str)
+    local out = {}
+    local buf, bits = 0, 0
+    for i = 1, #str do
+        local c = str:sub(i, i)
+        if c ~= "=" then
+            local d = DEC[c]
+            if not d then M.error("invalid_argument", "kv: corrupt base64 in store") end
+            buf = (buf << 6) | d
+            bits = bits + 6
+            if bits >= 8 then
+                bits = bits - 8
+                out[#out + 1] = string.char((buf >> bits) & 0xff)
+            end
+        end
+    end
+    return table.concat(out)
+end
+
+-- ---- hex (prefix-preserving: hex(prefix) is a prefix of hex(key), so the SQL
+-- backend can range-scan keys with a plain LIKE) ----
+function M.hexencode(bytes)
+    return (bytes:gsub(".", function(c) return string.format("%02x", c:byte()) end))
+end
+
+function M.hexdecode(hex)
+    if #hex % 2 ~= 0 then M.error("invalid_argument", "kv: corrupt hex in store") end
+    return (hex:gsub("..", function(cc)
+        local n = tonumber(cc, 16)
+        if not n then M.error("invalid_argument", "kv: corrupt hex in store") end
+        return string.char(n)
+    end))
+end
+
+return M

--- a/tests/e2e_kv.sh
+++ b/tests/e2e_kv.sh
@@ -1,0 +1,200 @@
+#!/bin/sh
+# e2e_kv.sh: hull.kv + hull.cache.open behavior, cross-BACKEND conformance
+# (memory vs sqlite behave identically) and cross-RUNTIME parity (Lua == JS).
+#
+# Part A - a deterministic conformance vector run against BOTH the memory and
+#          the sqlite backend inside one process; the app asserts they match,
+#          then prints the vector. The script asserts Lua's vector == JS's.
+# Part B - durability: a writer process stores durable sqlite KV; a fresh reader
+#          process reads it back (text, binary, a counter) - both runtimes.
+# Part C - hull.cache.open eviction: LRU at max_items + a max_bytes budget.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+HULL="${HULL:-./build/hull}"
+[ -x "$HULL" ] || HULL="build/hull"
+WD=$(mktemp -d)
+trap 'rm -rf "$WD"' EXIT
+
+# ---------------------------------------------------------------------------
+# Part A - conformance vector (identical across memory + sqlite, Lua + JS)
+# ---------------------------------------------------------------------------
+cat > "$WD/conf.lua" <<'LUA'
+local kv = require("hull.kv")
+app.manifest({ modules = { "hull/kv@1", "hull/db@1" } })
+
+local function run(s)
+    s:clear()
+    local o = {}
+    o[#o+1] = s:get("miss") == nil and "miss_nil" or "F_miss"
+    s:set("k", "v")
+    o[#o+1] = s:get("k") == "v" and "set_get" or "F_set"
+    s:set("bv", "\0\1\2\255")
+    o[#o+1] = s:get("bv") == "\0\1\2\255" and "binval" or "F_binval"
+    s:set("\0bk\255", "x")
+    o[#o+1] = s:get("\0bk\255") == "x" and "binkey" or "F_binkey"
+    s:set("ow", "1"); s:set("ow", "2")
+    o[#o+1] = s:get("ow") == "2" and "overwrite" or "F_ow"
+    s:set("d", "x")
+    o[#o+1] = (s:delete("d") == true and s:delete("d") == false and s:get("d") == nil)
+              and "delete" or "F_del"
+    o[#o+1] = (s:exists("k") and not s:exists("nope")) and "exists" or "F_exists"
+    o[#o+1] = (s:incr("n", 5) == 5 and s:incr("n", 3) == 8) and "incr" or "F_incr"
+    o[#o+1] = (s:cas("c", nil, "a") and not s:cas("c", "x", "b")
+               and s:cas("c", "a", "b") and s:get("c") == "b") and "cas" or "F_cas"
+    s:set("p:1", "x"); s:set("p:2", "y"); s:set("q:1", "z")
+    o[#o+1] = #s:scan("p:") == 2 and "scan2" or "F_scan"
+    s:set("e", "v", { ttl = 0 })
+    o[#o+1] = s:get("e") == nil and "ttl0" or "F_ttl0"
+    return table.concat(o, ",")
+end
+
+app.main(function(ctx)
+    local db = require("hull.db").default()
+    local mem = run(kv.open{ backend = "memory", namespace = "cm" })
+    local sql = run(kv.open{ backend = "sqlite", database = db, namespace = "cs" })
+    assert(mem == sql, "cross-backend drift:\n mem=" .. mem .. "\n sql=" .. sql)
+    -- namespace isolation: distinct namespaces never see each other
+    local a = kv.open{ backend = "memory", namespace = "ns_a" }
+    local b = kv.open{ backend = "memory", namespace = "ns_b" }
+    a:set("z", "A"); b:set("z", "B")
+    local iso = (a:get("z") == "A" and b:get("z") == "B") and "nsiso" or "F_nsiso"
+    ctx.stdout:write(mem .. "|" .. iso .. "\n")
+    return 0
+end)
+LUA
+
+cat > "$WD/conf.js" <<'JS'
+import { app } from "hull:app";
+import { kv } from "hull:kv";
+import { db as dbModule } from "hull:db";
+app.manifest({ modules: ["hull/kv@1", "hull/db@1"] });
+
+function run(s) {
+    s.clear();
+    const o = [];
+    o.push(s.get("miss") === null ? "miss_nil" : "F_miss");
+    s.set("k", "v");
+    o.push(s.get("k") === "v" ? "set_get" : "F_set");
+    s.set("bv", "\x00\x01\x02\xff");
+    o.push(s.get("bv") === "\x00\x01\x02\xff" ? "binval" : "F_binval");
+    s.set("\x00bk\xff", "x");
+    o.push(s.get("\x00bk\xff") === "x" ? "binkey" : "F_binkey");
+    s.set("ow", "1"); s.set("ow", "2");
+    o.push(s.get("ow") === "2" ? "overwrite" : "F_ow");
+    s.set("d", "x");
+    o.push((s.delete("d") === true && s.delete("d") === false && s.get("d") === null)
+           ? "delete" : "F_del");
+    o.push((s.exists("k") && !s.exists("nope")) ? "exists" : "F_exists");
+    o.push((s.incr("n", 5) === 5 && s.incr("n", 3) === 8) ? "incr" : "F_incr");
+    o.push((s.cas("c", null, "a") && !s.cas("c", "x", "b")
+            && s.cas("c", "a", "b") && s.get("c") === "b") ? "cas" : "F_cas");
+    s.set("p:1", "x"); s.set("p:2", "y"); s.set("q:1", "z");
+    o.push(s.scan("p:").length === 2 ? "scan2" : "F_scan");
+    s.set("e", "v", { ttl: 0 });
+    o.push(s.get("e") === null ? "ttl0" : "F_ttl0");
+    return o.join(",");
+}
+
+app.main((ctx) => {
+    const db = dbModule.default();
+    const mem = run(kv.open({ backend: "memory", namespace: "cm" }));
+    const sql = run(kv.open({ backend: "sqlite", database: db, namespace: "cs" }));
+    if (mem !== sql) throw new Error("cross-backend drift:\n mem=" + mem + "\n sql=" + sql);
+    const a = kv.open({ backend: "memory", namespace: "ns_a" });
+    const b = kv.open({ backend: "memory", namespace: "ns_b" });
+    a.set("z", "A"); b.set("z", "B");
+    const iso = (a.get("z") === "A" && b.get("z") === "B") ? "nsiso" : "F_nsiso";
+    ctx.stdout.write(mem + "|" + iso + "\n");
+    return 0;
+});
+JS
+
+expect="miss_nil,set_get,binval,binkey,overwrite,delete,exists,incr,cas,scan2,ttl0|nsiso"
+lua_out="$("$HULL" "$WD/conf.lua" -d "$WD/conf_lua.db" 2>/dev/null | tail -1)"
+js_out="$( "$HULL" "$WD/conf.js"  -d "$WD/conf_js.db"  2>/dev/null | tail -1)"
+
+if [ "$lua_out" = "$expect" ] && [ "$lua_out" = "$js_out" ]; then
+    echo "PASS A: kv conformance identical across memory+sqlite and Lua+JS"
+else
+    echo "::error kv conformance DRIFT"
+    echo "  expect=$expect"
+    echo "  lua   =$lua_out"
+    echo "  js    =$js_out"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Part B - durability across a process restart (write then reopen + read)
+# ---------------------------------------------------------------------------
+cat > "$WD/write.lua" <<'LUA'
+local kv = require("hull.kv")
+app.manifest({ modules = { "hull/kv@1", "hull/db@1" } })
+app.main(function()
+    local s = kv.open{ backend = "sqlite", database = require("hull.db").default(), namespace = "dur" }
+    s:set("greeting", "hello"); s:set("bytes", "\0\255\0"); s:incr("counter", 42)
+    return 0
+end)
+LUA
+cat > "$WD/read.lua" <<'LUA'
+local kv = require("hull.kv")
+app.manifest({ modules = { "hull/kv@1", "hull/db@1" } })
+app.main(function(ctx)
+    local s = kv.open{ backend = "sqlite", database = require("hull.db").default(), namespace = "dur" }
+    local ok = s:get("greeting") == "hello" and s:get("bytes") == "\0\255\0" and s:get("counter") == "42"
+    ctx.stdout:write(ok and "durable_ok\n" or "durable_FAIL\n"); return 0
+end)
+LUA
+DB="$WD/dur.db"
+"$HULL" "$WD/write.lua" -d "$DB" >/dev/null 2>&1
+dur_out="$("$HULL" "$WD/read.lua" -d "$DB" 2>/dev/null | tail -1)"
+if [ "$dur_out" = "durable_ok" ]; then
+    echo "PASS B: sqlite KV persists across process restart (reopen)"
+else
+    echo "::error kv durability FAIL: $dur_out"; exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Part C - cache.open eviction (LRU at max_items + max_bytes budget)
+# ---------------------------------------------------------------------------
+cat > "$WD/cache.lua" <<'LUA'
+local cache = require("hull.cache")
+app.manifest({ modules = { "hull/cache@1" } })
+app.main(function(ctx)
+    local o = {}
+    local c = cache.open{ backend = "memory", namespace = "lru", max_items = 2 }
+    c:set("a", "1"); c:set("b", "2"); c:get("a"); c:set("c", "3")   -- b is LRU
+    o[#o+1] = (c:get("b") == nil and c:get("a") == "1" and c:get("c") == "3"
+               and c:stats().evictions >= 1) and "lru" or "F_lru"
+    local cb = cache.open{ backend = "memory", namespace = "bud", max_bytes = 200 }
+    for i = 1, 20 do cb:set("k" .. i, string.rep("x", 30)) end
+    o[#o+1] = cb:stats().bytes <= 200 and "budget" or "F_budget"
+    ctx.stdout:write(table.concat(o, ",") .. "\n"); return 0
+end)
+LUA
+cat > "$WD/cache.js" <<'JS'
+import { app } from "hull:app"; import { cache } from "hull:cache";
+app.manifest({ modules: ["hull/cache@1"] });
+app.main((ctx) => {
+    const o = [];
+    const c = cache.open({ backend: "memory", namespace: "lru", maxItems: 2 });
+    c.set("a", "1"); c.set("b", "2"); c.get("a"); c.set("c", "3");
+    o.push((c.get("b") === null && c.get("a") === "1" && c.get("c") === "3"
+            && c.stats().evictions >= 1) ? "lru" : "F_lru");
+    const cb = cache.open({ backend: "memory", namespace: "bud", maxBytes: 200 });
+    for (let i = 1; i <= 20; i++) cb.set("k" + i, "x".repeat(30));
+    o.push(cb.stats().bytes <= 200 ? "budget" : "F_budget");
+    ctx.stdout.write(o.join(",") + "\n");
+});
+JS
+cexp="lru,budget"
+cl="$("$HULL" "$WD/cache.lua" 2>/dev/null | tail -1)"
+cj="$("$HULL" "$WD/cache.js"  2>/dev/null | tail -1)"
+if [ "$cl" = "$cexp" ] && [ "$cl" = "$cj" ]; then
+    echo "PASS C: cache.open eviction (LRU + byte budget) identical Lua+JS"
+else
+    echo "::error cache.open eviction DRIFT: lua=$cl js=$cj expect=$cexp"; exit 1
+fi
+
+echo "e2e_kv: ALL PASS"


### PR DESCRIPTION
A small, portable semantic seam over local, SQL-backed, and (future) distributed
key/value engines - **not a Redis clone**. Two abstractions with deliberately
distinct guarantees, per the spec:

| | `hull.cache` (CACHE) | `hull.kv` (KV STORE) |
|---|---|---|
| Lifetime | ephemeral | externally meaningful |
| Eviction | expected (LRU on cap) | never, unless asked |
| Values | recomputable | authoritative |
| Persistence | no | where the backend provides it |

## Milestone 1 scope (all stdlib, zero new C)
- **`hull/kv`** — `open{}` → handle with `get/set/delete/exists/incr/cas/scan/clear/cleanup/stats/caps`.
- **`cache.open{}`** — byte-oriented, backend-selectable, byte-accounted CACHE handle + `fetch`. **Additive**: the shipped `cache.new`/top-level value memoizer is byte-for-byte unchanged (ratelimit et al. keep working — verified).
- **Backends**: `memory` (in-process, process-shared by namespace) and `sqlite`/`postgres` (durable, over an **existing** `hull/db` connection — no second connection stack).
- **Lua + JS** at full parity (sync both runtimes; byte-string values).

## Key design decisions
- **SQL KV reuses the backend-agnostic `db` capability.** One portable `_hull_kv` table (all `TEXT`/`BIGINT`, `_hull_`-protected). Keys **hex**-encoded (prefix-preserving → `scan` is a `LIKE` range), values **base64**-encoded, both into `TEXT` (Postgres `TEXT` rejects embedded NULs) — durable KV is byte-safe **and cross-runtime** (Lua-written values read back identically under JS, verified).
- **`cas` is a single conditional `UPDATE ... WHERE v = ?`** (genuinely atomic), not read-then-write; **`incr`** is an optimistic version-guarded retry loop; cache eviction is expressed as SQL, never in C.
- **Capability model**: each backend advertises `caps`; an optional op a backend lacks throws `unsupported`. TTL is one uniform capability across SQL backends (lazily-filtered `expires_at`).
- **Byte accounting needs no C** (values are byte-slices), so the native hashmap+LRU store is a documented **performance drop-in**, not a correctness prerequisite. Valkey/Redis → future `--with=` features via the existing `HlDbBackend` weak hook; CacheLib → optional `--with`.
- **Security**: no hidden fs/network access — a SQLite file honors the fs sandbox, a network backend the host allowlist + `network_outbound` grant. `kv` and `cache` sharing a namespace name never collide (prefixed `kv:`/`cache:`).

Folded in the three review corrections: `HL_KV_CAP_SHARED` naming, CAS-as-conditional-UPDATE, and TTL as ordinary app-managed expiry (no "lazy vs native" cap distinction). Also fixed a memory-vs-SQL divergence found in self-review: `incr` now preserves an existing key's TTL on both backends (Redis semantics).

## Tests
`tests/e2e_kv.sh` (`make e2e-kv`, wired into CI) asserts:
- a conformance vector **identical across memory + sqlite** (in-process cross-backend assert) **and Lua + JS**,
- **durability** across a process restart (write → reopen → read),
- `cache.open` **LRU + byte-budget** eviction.

Full unit suite (62/62) + existing `e2e_cache_module` / `e2e_ratelimit_parity` green locally under ASan.

## Follow-ups (documented extension points, out of scope here)
Native C cache store; `--with=valkey`/`--with=redis`; `--with=cachelib`; DuckDB KV. See `docs/kv_cache.md`.
