### PR TITLE
fix(kv): KV/cache audit follow-ups — Lua/JS parity + robustness

### DIFF
--- a/stdlib/js/hull/kv/_util.js
+++ b/stdlib/js/hull/kv/_util.js
@@ -15,6 +15,14 @@ const MAX_KEY = 1024;
 // NULL and off the mid-array-nil binding path). Fits a 64-bit BIGINT.
 const NO_EXPIRY = Number.MAX_SAFE_INTEGER;
 
+// Any code unit > 255 means the caller passed a non-byte string (e.g. a UTF-16
+// string like "café" or "Ā"). The hex/base64/toBuf codecs mask `& 0xff`, which
+// would SILENTLY collapse distinct keys onto the same physical key ("Ā" U+0100
+// -> byte 0x00, colliding with "\x00") and corrupt values. Lua strings are
+// already bytes so the Lua side is immune; enforce the byte invariant here so
+// JS behaves identically and fails loudly instead of silently mangling.
+const NON_BYTE = /[^\u0000-\u00ff]/;
+
 function codedError(code, message) {
     const e = new Error(message);
     e.code = code;
@@ -28,12 +36,16 @@ function checkKey(k) {
         codedError("invalid_argument", "kv: key must be non-empty");
     if (k.length > MAX_KEY)
         codedError("invalid_argument", "kv: key exceeds " + MAX_KEY + " bytes");
+    if (NON_BYTE.test(k))
+        codedError("invalid_argument", "kv: key must be a byte string (code units 0-255)");
     return k;
 }
 
 function checkValue(v) {
     if (typeof v !== "string")
         codedError("invalid_argument", "kv: value must be a string (bytes), got " + typeof v);
+    if (NON_BYTE.test(v))
+        codedError("invalid_argument", "kv: value must be a byte string (code units 0-255)");
     return v;
 }
 
@@ -119,7 +131,7 @@ function hexdecode(hex) {
     if (hex.length % 2 !== 0) codedError("invalid_argument", "kv: corrupt hex in store");
     const out = [];
     for (let i = 0; i < hex.length; i += 2) {
-        const n = parseInt(hex.substr(i, 2), 16);
+        const n = parseInt(hex.slice(i, i + 2), 16);
         if (Number.isNaN(n)) codedError("invalid_argument", "kv: corrupt hex in store");
         out.push(String.fromCharCode(n));
     }

--- a/stdlib/js/hull/kv/_valkey.js
+++ b/stdlib/js/hull/kv/_valkey.js
@@ -62,8 +62,11 @@ function physPrefix(storeNs) {
 }
 
 function ttlMs(store, ttl) {
+    // Mirror util.expiryMs: undefined/null -> use the default; an explicit
+    // `false` (or a nil default) means NO expiry, matching the memory/SQL
+    // backends so `ttl: false` behaves the same on every backend.
     if (ttl === undefined || ttl === null) ttl = store.defaultTtl;
-    if (ttl === undefined || ttl === null) return undefined;
+    if (ttl === undefined || ttl === null || ttl === false) return undefined;
     if (typeof ttl !== "number" || ttl < 0)
         util.error("invalid_argument", "kv: ttl must be a non-negative number of seconds");
     return Math.floor(ttl * 1000);

--- a/stdlib/lua/hull/kv.lua
+++ b/stdlib/lua/hull/kv.lua
@@ -69,10 +69,10 @@ function M.open(opts)
         u.error("invalid_argument", "kv.open: options table required")
     end
     local backend = opts.backend or "memory"
-    opts.namespace = opts.namespace or "default"
+    local namespace = opts.namespace or "default"   -- do not mutate the caller's opts
     -- Prefix the physical store namespace so a kv and a cache that happen to
     -- share a namespace name never collide in the same memory table / _hull_kv.
-    local store_ns = "kv:" .. opts.namespace
+    local store_ns = "kv:" .. namespace
 
     local store, bname
     if backend == "memory" then
@@ -87,7 +87,7 @@ function M.open(opts)
         u.error("invalid_argument", "kv.open: unknown backend '" .. tostring(backend) .. "'")
     end
 
-    return handle.build(store, { namespace = opts.namespace, backend = bname })
+    return handle.build(store, { namespace = namespace, backend = bname })
 end
 
 return M

--- a/stdlib/lua/hull/kv/_sql.lua
+++ b/stdlib/lua/hull/kv/_sql.lua
@@ -123,6 +123,12 @@ function Store:del(k)
 end
 
 -- Atomic compare-and-swap. expected == nil means "set only if absent".
+-- CAS/incr correctness relies on `conn.exec` returning rows CHANGED (not rows
+-- matched): `ON CONFLICT ... DO NOTHING` on an existing row must report 0, and a
+-- real insert/update 1. Both shipped backends satisfy this (SQLite
+-- sqlite3_changes(); Postgres command tag). A backend reporting rows-matched
+-- would break set-if-absent (a DO-NOTHING on an existing key would falsely
+-- report success) -- keep that invariant in mind when adding a backend.
 function Store:cas(k, expected, new, ttl)
     local now = u.now_ms()
     local exp = u.expiry_ms(ttl, self.default_ttl) or u.NO_EXPIRY

--- a/stdlib/lua/hull/kv/_valkey.lua
+++ b/stdlib/lua/hull/kv/_valkey.lua
@@ -58,8 +58,11 @@ local Store = {}
 Store.__index = Store
 
 local function ttl_ms(self, ttl)
-    ttl = ttl or self.default_ttl
-    if ttl == nil then return nil end
+    -- Mirror u.expiry_ms's contract exactly: nil -> use the default; an explicit
+    -- `false` (or a nil default) means NO expiry. `ttl or self.default_ttl` would
+    -- wrongly turn `false` into the default, so branch on nil explicitly.
+    if ttl == nil then ttl = self.default_ttl end
+    if ttl == nil or ttl == false then return nil end
     if type(ttl) ~= "number" or ttl < 0 then
         u.error("invalid_argument", "kv: ttl must be a non-negative number of seconds")
     end


### PR DESCRIPTION
## Summary

Small quality follow-ups from the KV/cache subsystem audit "once more" sweep (C backend layer, Lua stdlib, JS stdlib). The C layer audited **clean** (borrow-copy guards, bounds-checked+fuzzed RESP parser, const dispatch tables, host allowlist all intact) — no C changes. These are the Low-severity Lua/JS robustness + parity items. No behavior change for valid byte-string inputs.

## Changes

- **JS `_util.js`:** `checkKey`/`checkValue` now reject code units above 255 (non-byte strings). Previously a JS app passing a UTF-16 key/value had it silently `& 0xff`-collapsed by the hex/base64/toBuf codecs, so **distinct keys could collide** (U+0100 → byte 0x00) and values corrupt. Lua strings are already bytes (immune), so this closes a JS-only footgun and a Lua/JS parity gap. Embedded NUL and 0x80–0xFF bytes stay valid.
- **`_valkey.lua` `ttl_ms` / `_valkey.js` `ttlMs`:** honor an explicit `ttl = false` as "no expiry", matching the memory + SQL backends. The Lua `ttl or self.default_ttl` idiom wrongly turned `false` into the default; both now branch on nil explicitly. **Cross-backend `ttl=false` is now uniform** (both auditors flagged this independently).
- **`kv.lua`:** `kv.open` no longer mutates the caller's `opts` table (reads `namespace` into a local).
- **`_sql.lua`:** documents the load-bearing "affected-rows == rows *changed*, not matched" contract that `cas`/`incr` set-if-absent relies on.
- **`_util.js`:** deprecated `String.prototype.substr` → `slice`.

## Verification

- Binary (NUL + high-byte) round-trip OK both runtimes.
- `ttl=false` no-expiry OK both runtimes.
- Non-byte key/value rejected with `invalid_argument` (JS); Lua immune by construction.
- `e2e_kv` ALL PASS (memory + sqlite, Lua==JS conformance) and `e2e_cache_module` PASS after rebuild.

The subsystem stays mature/closed; these are validation + parity polish, not backend work.