### PR TITLE
wasm/spans: windowed HlMappedBuffer ownership foundation (mapped-spans cut 1, checkpoint 1)

### DIFF
--- a/include/hull/cap/fs.h
+++ b/include/hull/cap/fs.h
@@ -133,13 +133,101 @@ int hl_cap_fs_delete(const HlFsConfig *cfg, const char *path,
  * "HlBufferView").
  */
 typedef struct HlMappedBuffer {
-    void         *addr;   /**< mmap'd region. Read-only on the kernel side. */
-    size_t        len;    /**< Mapping length in bytes. */
+    void         *addr;   /**< Start of the caller-visible window. For a whole-file
+                               mmap this equals @ref map_base; for a windowed mmap
+                               it is @ref map_base plus the intra-page slop. */
+    size_t        len;    /**< Caller-visible window length in bytes. */
     int           closed; /**< `1` iff already munmap'd; further `_munmap` is a no-op. */
     HlAllocator  *alloc;  /**< Tracked allocator (NULL = raw malloc). */
     int           borrow_count;  /**< Live zero-copy borrowers (e.g. images). */
     int           pending_free;  /**< close()/gc was deferred while borrowed. */
+    /* Windowing (mapped-spans cut 1). For a whole-file mmap, @ref map_base ==
+     * @ref addr, @ref map_len == @ref len, and @ref foffset == 0. For a windowed
+     * mmap the mmap is page-aligned: @ref map_base / @ref map_len are the actual
+     * `mmap`/`munmap` region (page-aligned base + page-rounded length), while
+     * @ref addr / @ref len are the caller's requested sub-window inside it.
+     * @ref munmap MUST use @ref map_base / @ref map_len, never @ref addr / @ref len. */
+    void         *map_base;  /**< Page-aligned mmap base (the `munmap` address). */
+    size_t        map_len;   /**< Page-rounded mmap length (the `munmap` length). */
+    uint64_t      foffset;   /**< 64-bit logical file offset of the window's first byte. */
 } HlMappedBuffer;
+
+/**
+ * @brief Upper bound on a single windowed mapping's LOGICAL length, in bytes
+ *        (1 GiB).
+ *
+ * `hl_cap_fs_mmap_window` rejects a requested `length` above this. The cap is on
+ * the caller's LOGICAL window length (the `length` argument), NOT on the
+ * page-aligned mapped size: the actual `mmap` region (`map_len`) may exceed this
+ * by up to the intra-page slop plus one page of rounding (`< 2 * page_size`).
+ * Per the mapped-spans design (docs/wasm_mapped_spans_design.md §3.6) the SAME
+ * conservative cap applies on wasm32 and Memory64; the per-invocation TOTAL
+ * across multiple spans is a separate (not-yet-implemented) accounting layer.
+ */
+#define HL_FS_MMAP_MAX_WINDOW_BYTES ((uint64_t)1 << 30)
+
+/**
+ * @brief Pure, filesystem-free geometry for a page-aligned windowed mmap.
+ *
+ * Computes, with fully overflow-safe arithmetic, the `mmap` parameters for a
+ * caller window `[offset, offset+length)` over a file of `file_size` bytes with
+ * the given `page_size` (a power of two). The window is clamped to end-of-file
+ * (a short final window is normal when scanning a large file in fixed windows).
+ * No filesystem access, so overflow / boundary cases near `UINT64_MAX` are
+ * directly unit-testable.
+ *
+ * @param offset        Caller's logical file offset of the window's first byte.
+ * @param length        Caller's requested window length (bytes). Must be > 0.
+ * @param file_size     Total file size in bytes.
+ * @param page_size     System page size (power of two, > 0).
+ * @param out_map_off   Out: page-aligned file offset to pass to `mmap`.
+ * @param out_map_len   Out: page-rounded length to pass to `mmap` / `munmap`.
+ * @param out_slop      Out: `offset - *out_map_off` (0 <= slop < page_size);
+ *                      the caller window begins this many bytes into the mmap.
+ * @param out_eff_len   Out: effective (EOF-clamped) caller window length.
+ * @param err           Out: static reason string on failure; may be NULL.
+ *
+ * @return 0 on success; -1 on any out-of-range / overflow (with `*err` set):
+ *         "bad_page_size", "empty_window", "window_too_large",
+ *         "offset_past_eof", or "align_overflow".
+ */
+int hl_cap_fs_mmap_window_geometry(uint64_t offset, uint64_t length,
+                                   uint64_t file_size, uint64_t page_size,
+                                   uint64_t *out_map_off, uint64_t *out_map_len,
+                                   uint64_t *out_slop, uint64_t *out_eff_len,
+                                   const char **err);
+
+/**
+ * @brief Memory-map a fixed, page-aligned WINDOW of a file for read-only access.
+ *
+ * Like @ref hl_cap_fs_mmap but maps only `[offset, offset+length)` (clamped to
+ * end-of-file). The alignment/overflow math is @ref hl_cap_fs_mmap_window_geometry;
+ * the returned buffer's `addr`/`len` are the caller's window while `map_base`/
+ * `map_len` hold the page-aligned mapping that teardown unmaps. `foffset` carries
+ * the 64-bit logical position so a windowing caller knows where the window sits.
+ *
+ * @param cfg      Filesystem config.
+ * @param path     Relative path; validated.
+ * @param offset   Logical file offset of the window's first byte.
+ * @param length   Requested window length in bytes (> 0, <= @ref
+ *                 HL_FS_MMAP_MAX_WINDOW_BYTES); the effective length is clamped
+ *                 to end-of-file.
+ * @param alloc    Allocator for the wrapper struct. NULL = raw malloc.
+ * @param err_msg  Out-parameter for error description; may be NULL.
+ *
+ * @return Heap-allocated @ref HlMappedBuffer (free via @ref hl_cap_fs_munmap),
+ *         or NULL on failure.
+ *
+ * @note Truncation-after-map is the standard `mmap` limitation, NOT made safe
+ *       here: if the underlying file is truncated (or otherwise shrunk) AFTER the
+ *       window is mapped, touching a mapped page that is now wholly beyond the
+ *       new end-of-file raises `SIGBUS` on access. This is identical to
+ *       @ref hl_cap_fs_mmap and to POSIX `mmap` in general; the EOF clamp only
+ *       bounds the window at map time, it cannot track later size changes.
+ */
+HlMappedBuffer *hl_cap_fs_mmap_window(const HlFsConfig *cfg, const char *path,
+                                      uint64_t offset, uint64_t length,
+                                      HlAllocator *alloc, const char **err_msg);
 
 /**
  * @brief Memory-map a file for read-only access.

--- a/src/hull/cap/fs.c
+++ b/src/hull/cap/fs.c
@@ -345,11 +345,173 @@ HlMappedBuffer *hl_cap_fs_mmap(const HlFsConfig *cfg, const char *path,
     buf->alloc = alloc;
     buf->borrow_count = 0;
     buf->pending_free = 0;
+    /* Whole-file mmap: the window IS the whole mapping. */
+    buf->map_base = addr;
+    buf->map_len = (size_t)st.st_size;
+    buf->foffset = 0;
 
 audit:
     {
         ShJsonWriter w = hl_audit_begin("fs.mmap");
         sh_json_write_kv_string(&w, "path", path);
+        sh_json_write_kv_int(&w, "size", buf ? (int64_t)buf->len : -1);
+        hl_audit_end(&w);
+    }
+    return buf;
+}
+
+int hl_cap_fs_mmap_window_geometry(uint64_t offset, uint64_t length,
+                                   uint64_t file_size, uint64_t page_size,
+                                   uint64_t *out_map_off, uint64_t *out_map_len,
+                                   uint64_t *out_slop, uint64_t *out_eff_len,
+                                   const char **err)
+{
+    /* page_size need only be > 0. The modulo/division arithmetic below makes NO
+     * power-of-two assumption (POSIX page sizes are powers of two, but we do not
+     * rely on it -- so an exotic page size neither misbehaves nor is rejected). */
+    if (page_size == 0) {
+        if (err) *err = "bad_page_size";
+        return -1;
+    }
+    if (length == 0) {
+        if (err) *err = "empty_window";
+        return -1;
+    }
+    /* The cap is on the LOGICAL requested window length; see the header note. */
+    if (length > HL_FS_MMAP_MAX_WINDOW_BYTES) {
+        if (err) *err = "window_too_large";
+        return -1;
+    }
+    /* offset must be strictly inside the file; offset == file_size maps nothing. */
+    if (offset >= file_size) {
+        if (err) *err = "offset_past_eof";
+        return -1;
+    }
+
+    /* Clamp the window to end-of-file (a short final window is normal when
+     * scanning a large file in fixed windows). offset < file_size, so avail >= 1
+     * and eff_len >= 1: the EOF clamp can NEVER produce a zero-length mapping. */
+    uint64_t avail = file_size - offset;
+    uint64_t eff_len = length < avail ? length : avail;
+
+    uint64_t slop = offset % page_size;   /* 0 <= slop < page_size */
+    uint64_t map_off = offset - slop;     /* page-aligned; no underflow (slop<=offset) */
+
+    /* need = slop + eff_len, then round UP to a whole number of pages, with fully
+     * overflow-safe arithmetic (never `a + b <= LIMIT`, never an a*b that wraps). */
+    if (slop > UINT64_MAX - eff_len) {
+        if (err) *err = "align_overflow";
+        return -1;
+    }
+    uint64_t need = slop + eff_len;
+    uint64_t pages = need / page_size;
+    if (need % page_size != 0) {
+        if (pages == UINT64_MAX) { if (err) *err = "align_overflow"; return -1; }
+        pages += 1;
+    }
+    if (pages > UINT64_MAX / page_size) {
+        if (err) *err = "align_overflow";
+        return -1;
+    }
+    uint64_t map_len = pages * page_size;
+
+    /* The mmap region must not wrap the address space and its LENGTH must fit
+     * size_t (the mmap/munmap length type) on this host. map_off's off_t
+     * representability is enforced by the caller (see hl_cap_fs_mmap_window). */
+    if (map_off > UINT64_MAX - map_len || map_len > (uint64_t)SIZE_MAX) {
+        if (err) *err = "align_overflow";
+        return -1;
+    }
+
+    if (out_map_off) *out_map_off = map_off;
+    if (out_map_len) *out_map_len = map_len;
+    if (out_slop) *out_slop = slop;
+    if (out_eff_len) *out_eff_len = eff_len;
+    return 0;
+}
+
+HlMappedBuffer *hl_cap_fs_mmap_window(const HlFsConfig *cfg, const char *path,
+                                      uint64_t offset, uint64_t length,
+                                      HlAllocator *alloc, const char **err_msg)
+{
+    HlMappedBuffer *buf = NULL;
+    uint64_t map_off = 0, map_len = 0, slop = 0, eff_len = 0;
+
+    char full[PATH_MAX];
+    if (build_path(cfg, path, full, sizeof(full), err_msg) != 0)
+        goto audit;
+
+    int fd = open(full, O_RDONLY);
+    if (fd < 0) {
+        if (err_msg) *err_msg = "open_failed";
+        goto audit;
+    }
+
+    struct stat st;
+    if (fstat(fd, &st) != 0) {
+        close(fd);
+        if (err_msg) *err_msg = "mmap_failed";
+        goto audit;
+    }
+    if (st.st_size <= 0) {
+        close(fd);
+        if (err_msg) *err_msg = st.st_size == 0 ? "empty_file" : "mmap_failed";
+        goto audit;
+    }
+
+    long pg = sysconf(_SC_PAGESIZE);
+    if (pg <= 0) pg = 4096;
+
+    if (hl_cap_fs_mmap_window_geometry(offset, length, (uint64_t)st.st_size,
+                                       (uint64_t)pg, &map_off, &map_len, &slop,
+                                       &eff_len, err_msg) != 0) {
+        close(fd);
+        goto audit;
+    }
+
+    /* Reject before the narrowing (off_t)map_off cast. map_off <= offset <
+     * file_size == st.st_size, itself a valid non-negative off_t, so this cannot
+     * fire on a file-derived size; the explicit guard documents the invariant and
+     * fails closed should a future change ever break it. (map_len's size_t fit is
+     * enforced inside the geometry helper.) */
+    off_t off_t_max =
+        (off_t)((((uintmax_t)1) << (sizeof(off_t) * CHAR_BIT - 1)) - 1);
+    if (map_off > (uint64_t)off_t_max) {
+        close(fd);
+        if (err_msg) *err_msg = "window_too_large";
+        goto audit;
+    }
+
+    void *base = mmap(NULL, (size_t)map_len, PROT_READ, MAP_PRIVATE, fd,
+                      (off_t)map_off);
+    close(fd); /* mapping survives close */
+    if (base == MAP_FAILED) {
+        if (err_msg) *err_msg = "mmap_failed";
+        goto audit;
+    }
+
+    buf = hl_alloc_malloc(alloc, sizeof(HlMappedBuffer));
+    if (!buf) {
+        munmap(base, (size_t)map_len);
+        if (err_msg) *err_msg = "mmap_failed";
+        goto audit;
+    }
+
+    buf->map_base = base;
+    buf->map_len = (size_t)map_len;
+    buf->addr = (char *)base + slop;
+    buf->len = (size_t)eff_len;
+    buf->foffset = offset;
+    buf->closed = 0;
+    buf->alloc = alloc;
+    buf->borrow_count = 0;
+    buf->pending_free = 0;
+
+audit:
+    {
+        ShJsonWriter w = hl_audit_begin("fs.mmap_window");
+        sh_json_write_kv_string(&w, "path", path);
+        sh_json_write_kv_int(&w, "offset", (int64_t)offset);
         sh_json_write_kv_int(&w, "size", buf ? (int64_t)buf->len : -1);
         hl_audit_end(&w);
     }
@@ -367,8 +529,10 @@ void hl_cap_fs_munmap(HlMappedBuffer *buf)
         buf->pending_free = 1;
         return;
     }
-    if (!buf->closed && buf->addr) {
-        munmap(buf->addr, buf->len);
+    /* Unmap the PAGE-ALIGNED mapping (map_base/map_len), never the caller window
+     * (addr/len) -- for a windowed buffer addr is offset into map_base. */
+    if (!buf->closed && buf->map_base) {
+        munmap(buf->map_base, buf->map_len);
         buf->closed = 1;
     }
     hl_alloc_free(buf->alloc, buf, sizeof(HlMappedBuffer));
@@ -385,8 +549,9 @@ void hl_cap_fs_mmap_release(void *p)
     if (!buf) return;
     if (buf->borrow_count > 0) buf->borrow_count--;
     if (buf->borrow_count == 0 && buf->pending_free) {
-        if (!buf->closed && buf->addr) {
-            munmap(buf->addr, buf->len);
+        /* Unmap the page-aligned mapping, not the caller window (see munmap). */
+        if (!buf->closed && buf->map_base) {
+            munmap(buf->map_base, buf->map_len);
             buf->closed = 1;
         }
         hl_alloc_free(buf->alloc, buf, sizeof(HlMappedBuffer));

--- a/tests/hull/cap/test_fs.c
+++ b/tests/hull/cap/test_fs.c
@@ -321,4 +321,270 @@ UTEST(hl_cap_fs, mmap_null_safe)
     hl_cap_fs_munmap(NULL); /* should not crash */
 }
 
+/* ── Windowed mmap: pure geometry (mapped-spans cut 1) ──────────────────
+ * hl_cap_fs_mmap_window_geometry is filesystem-free, so overflow / boundary
+ * cases near UINT64_MAX are tested directly without giant files. */
+
+UTEST(hl_cap_fs, mmap_geometry_offset_zero)
+{
+    uint64_t off, len, slop, eff; const char *err = NULL;
+    ASSERT_EQ(hl_cap_fs_mmap_window_geometry(0, 100, 1000, 4096,
+                                             &off, &len, &slop, &eff, &err), 0);
+    ASSERT_EQ((int)off, 0);
+    ASSERT_EQ((int)slop, 0);
+    ASSERT_EQ((int)len, 4096);   /* round_up(0 + 100) */
+    ASSERT_EQ((int)eff, 100);
+}
+
+UTEST(hl_cap_fs, mmap_geometry_cross_page_slop)
+{
+    uint64_t off, len, slop, eff; const char *err = NULL;
+    /* offset 5000 with a 4096 page: base page 4096, slop 904, map spans two
+     * pages to cover [5000,5100). */
+    ASSERT_EQ(hl_cap_fs_mmap_window_geometry(5000, 100, 10000, 4096,
+                                             &off, &len, &slop, &eff, &err), 0);
+    ASSERT_EQ((int)off, 4096);
+    ASSERT_EQ((int)slop, 904);
+    ASSERT_EQ((int)eff, 100);
+    ASSERT_EQ((int)len, 4096);   /* round_up(904 + 100 = 1004) */
+}
+
+UTEST(hl_cap_fs, mmap_geometry_page_multiple_offset)
+{
+    uint64_t off, len, slop, eff; const char *err = NULL;
+    ASSERT_EQ(hl_cap_fs_mmap_window_geometry(8192, 5000, 20000, 4096,
+                                             &off, &len, &slop, &eff, &err), 0);
+    ASSERT_EQ((int)off, 8192);   /* already page-aligned */
+    ASSERT_EQ((int)slop, 0);
+    ASSERT_EQ((int)eff, 5000);
+    ASSERT_EQ((int)len, 8192);   /* round_up(5000) = 2 pages */
+}
+
+UTEST(hl_cap_fs, mmap_geometry_eof_clamp)
+{
+    uint64_t off, len, slop, eff; const char *err = NULL;
+    /* window runs past EOF: eff_len clamps to file_size - offset. */
+    ASSERT_EQ(hl_cap_fs_mmap_window_geometry(900, 500, 1000, 4096,
+                                             &off, &len, &slop, &eff, &err), 0);
+    ASSERT_EQ((int)eff, 100);    /* 1000 - 900 */
+    ASSERT_EQ((int)off, 0);
+    ASSERT_EQ((int)slop, 900);
+    ASSERT_EQ((int)len, 4096);   /* round_up(900 + 100 = 1000) */
+}
+
+UTEST(hl_cap_fs, mmap_geometry_rejections)
+{
+    uint64_t off, len, slop, eff; const char *err;
+    /* empty window */
+    err = NULL;
+    ASSERT_EQ(hl_cap_fs_mmap_window_geometry(0, 0, 1000, 4096,
+                                             &off, &len, &slop, &eff, &err), -1);
+    ASSERT_STREQ(err, "empty_window");
+    /* over the per-window cap */
+    err = NULL;
+    ASSERT_EQ(hl_cap_fs_mmap_window_geometry(0, HL_FS_MMAP_MAX_WINDOW_BYTES + 1,
+                                             (uint64_t)1 << 40, 4096,
+                                             &off, &len, &slop, &eff, &err), -1);
+    ASSERT_STREQ(err, "window_too_large");
+    /* offset at/after EOF maps nothing */
+    err = NULL;
+    ASSERT_EQ(hl_cap_fs_mmap_window_geometry(1000, 10, 1000, 4096,
+                                             &off, &len, &slop, &eff, &err), -1);
+    ASSERT_STREQ(err, "offset_past_eof");
+    /* zero page size */
+    err = NULL;
+    ASSERT_EQ(hl_cap_fs_mmap_window_geometry(0, 10, 1000, 0,
+                                             &off, &len, &slop, &eff, &err), -1);
+    ASSERT_STREQ(err, "bad_page_size");
+}
+
+/* The geometry makes no power-of-two assumption: an exotic page size computes
+ * correctly via modulo/division rather than being rejected. */
+UTEST(hl_cap_fs, mmap_geometry_non_power_of_two_page)
+{
+    uint64_t off, len, slop, eff; const char *err = NULL;
+    /* page 1000: offset 2500 -> base 2000, slop 500, need 500+100=600 -> 1 page. */
+    ASSERT_EQ(hl_cap_fs_mmap_window_geometry(2500, 100, 10000, 1000,
+                                             &off, &len, &slop, &eff, &err), 0);
+    ASSERT_EQ((int)off, 2000);
+    ASSERT_EQ((int)slop, 500);
+    ASSERT_EQ((int)eff, 100);
+    ASSERT_EQ((int)len, 1000);
+    /* a window that spans two 1000-byte pages rounds up to 2000. */
+    ASSERT_EQ(hl_cap_fs_mmap_window_geometry(2500, 700, 10000, 1000,
+                                             &off, &len, &slop, &eff, &err), 0);
+    ASSERT_EQ((int)len, 2000);   /* round_up(500 + 700 = 1200) */
+}
+
+/* The EOF clamp bottoms out at 1 byte, never 0: a request at the last byte with
+ * a huge length still maps a non-empty (one-page) region. */
+UTEST(hl_cap_fs, mmap_geometry_eof_min_one_byte)
+{
+    uint64_t off, len, slop, eff; const char *err = NULL;
+    ASSERT_EQ(hl_cap_fs_mmap_window_geometry(4999, 1000000, 5000, 4096,
+                                             &off, &len, &slop, &eff, &err), 0);
+    ASSERT_EQ((int)eff, 1);       /* 5000 - 4999, clamped */
+    ASSERT_TRUE(len >= 4096);     /* non-zero mapping */
+    ASSERT_TRUE(eff >= 1);
+}
+
+UTEST(hl_cap_fs, mmap_geometry_overflow_near_uint64_max)
+{
+    uint64_t off, len, slop, eff; const char *err = NULL;
+    /* offset just below UINT64_MAX with a maximal file_size: eff_len clamps to
+     * the few remaining bytes, but the page-rounded mapping's base+len wraps the
+     * 64-bit address space -> must fail closed, not silently overflow. */
+    uint64_t huge = UINT64_MAX;
+    ASSERT_EQ(hl_cap_fs_mmap_window_geometry(huge - 10, 1000, huge, 4096,
+                                             &off, &len, &slop, &eff, &err), -1);
+    ASSERT_STREQ(err, "align_overflow");
+}
+
+/* ── Windowed mmap: real files (mapped-spans cut 1) ─────────────────────── */
+
+/* Write `n` bytes where byte i == (i & 0xff), so a window at `off` is verifiable
+ * against the deterministic pattern. */
+static int write_pattern(const char *name, size_t n)
+{
+    unsigned char *p = (unsigned char *)malloc(n);
+    if (!p) return -1;
+    for (size_t i = 0; i < n; i++) p[i] = (unsigned char)(i & 0xff);
+    int rc = hl_cap_fs_write(&test_cfg, name, (const char *)p, n, NULL);
+    free(p);
+    return rc;
+}
+
+static void assert_window_invariants(int *utest_result, HlMappedBuffer *buf,
+                                     uint64_t offset, size_t eff_len)
+{
+    long pg = sysconf(_SC_PAGESIZE);
+    if (pg <= 0) pg = 4096;
+    uint64_t pagemask = (uint64_t)pg - 1;
+
+    ASSERT_NE(buf, NULL);
+    ASSERT_EQ(buf->foffset, offset);
+    ASSERT_EQ(buf->len, eff_len);
+    ASSERT_EQ(buf->closed, 0);
+    /* the mmap base is page-aligned; the window sits `slop` bytes into it */
+    ASSERT_EQ((uint64_t)(uintptr_t)buf->map_base & pagemask, (uint64_t)0);
+    uint64_t slop = offset - (offset & ~pagemask);
+    ASSERT_EQ((size_t)((char *)buf->addr - (char *)buf->map_base), (size_t)slop);
+    /* the window lies wholly inside the page-aligned mapping */
+    ASSERT_TRUE((char *)buf->addr >= (char *)buf->map_base);
+    ASSERT_TRUE((char *)buf->addr + buf->len
+                <= (char *)buf->map_base + buf->map_len);
+    /* the bytes are exactly the file's window (pattern: byte k == k & 0xff) */
+    const unsigned char *w = (const unsigned char *)buf->addr;
+    for (size_t j = 0; j < eff_len; j++)
+        ASSERT_EQ((int)w[j], (int)((offset + j) & 0xff));
+}
+
+UTEST(hl_cap_fs, mmap_window_cross_page)
+{
+    setup_fs();
+    ASSERT_EQ(write_pattern("win_cross.bin", 40000), 0);
+    /* offset 20000 forces a non-zero page-aligned base on both 4K and 16K
+     * pages (20000 & ~4095 == 20000 & ~16383 == 16384). */
+    HlMappedBuffer *buf =
+        hl_cap_fs_mmap_window(&test_cfg, "win_cross.bin", 20000, 100, NULL, NULL);
+    assert_window_invariants(utest_result, buf, 20000, 100);
+    hl_cap_fs_munmap(buf);
+    teardown_fs();
+}
+
+UTEST(hl_cap_fs, mmap_window_offset_zero)
+{
+    setup_fs();
+    ASSERT_EQ(write_pattern("win_zero.bin", 8192), 0);
+    HlMappedBuffer *buf =
+        hl_cap_fs_mmap_window(&test_cfg, "win_zero.bin", 0, 256, NULL, NULL);
+    assert_window_invariants(utest_result, buf, 0, 256);
+    hl_cap_fs_munmap(buf);
+    teardown_fs();
+}
+
+UTEST(hl_cap_fs, mmap_window_eof_clamp)
+{
+    setup_fs();
+    ASSERT_EQ(write_pattern("win_eof.bin", 5000), 0);
+    /* ask for 4000 bytes starting at 4000; only 1000 remain -> clamp to 1000,
+     * and reading the whole (clamped) window must not SIGBUS. */
+    HlMappedBuffer *buf =
+        hl_cap_fs_mmap_window(&test_cfg, "win_eof.bin", 4000, 4000, NULL, NULL);
+    assert_window_invariants(utest_result, buf, 4000, 1000);
+    hl_cap_fs_munmap(buf);
+    teardown_fs();
+}
+
+UTEST(hl_cap_fs, mmap_window_borrow_defers_close)
+{
+    setup_fs();
+    ASSERT_EQ(write_pattern("win_borrow.bin", 40000), 0);
+    HlMappedBuffer *buf =
+        hl_cap_fs_mmap_window(&test_cfg, "win_borrow.bin", 20000, 100, NULL, NULL);
+    ASSERT_NE(buf, NULL);
+    void *map_base = buf->map_base; /* teardown must unmap THIS, not addr */
+
+    hl_cap_fs_mmap_borrow(buf);
+    ASSERT_EQ(buf->borrow_count, 1);
+    hl_cap_fs_munmap(buf);            /* deferred while borrowed */
+    ASSERT_EQ(buf->pending_free, 1);
+    ASSERT_EQ(buf->closed, 0);
+    ASSERT_EQ((int)((const unsigned char *)buf->addr)[0], (int)(20000 & 0xff));
+    ASSERT_EQ(buf->map_base, map_base);
+
+    hl_cap_fs_mmap_release(buf);      /* last release -> real munmap(map_base) + free */
+    teardown_fs();
+}
+
+UTEST(hl_cap_fs, mmap_window_rejections)
+{
+    setup_fs();
+    ASSERT_EQ(write_pattern("win_rej.bin", 4096), 0);
+    const char *err;
+    /* offset past EOF */
+    err = NULL;
+    ASSERT_EQ(hl_cap_fs_mmap_window(&test_cfg, "win_rej.bin", 4096, 10, NULL, &err),
+              NULL);
+    ASSERT_STREQ(err, "offset_past_eof");
+    /* empty window */
+    err = NULL;
+    ASSERT_EQ(hl_cap_fs_mmap_window(&test_cfg, "win_rej.bin", 0, 0, NULL, &err),
+              NULL);
+    ASSERT_STREQ(err, "empty_window");
+    /* over the per-window cap */
+    err = NULL;
+    ASSERT_EQ(hl_cap_fs_mmap_window(&test_cfg, "win_rej.bin", 0,
+                                    HL_FS_MMAP_MAX_WINDOW_BYTES + 1, NULL, &err),
+              NULL);
+    ASSERT_STREQ(err, "window_too_large");
+    teardown_fs();
+}
+
+UTEST(hl_cap_fs, mmap_window_path_traversal)
+{
+    setup_fs();
+    ASSERT_EQ(hl_cap_fs_mmap_window(&test_cfg, "../etc/passwd", 0, 10, NULL, NULL),
+              NULL);
+    ASSERT_EQ(hl_cap_fs_mmap_window(&test_cfg, "/etc/passwd", 0, 10, NULL, NULL),
+              NULL);
+    teardown_fs();
+}
+
+/* Whole-file mmap must keep the window fields self-consistent so the shared
+ * munmap/borrow path is uniform: map_base==addr, map_len==len, foffset==0. */
+UTEST(hl_cap_fs, mmap_whole_file_window_fields)
+{
+    setup_fs();
+    const char *data = "whole file window fields";
+    ASSERT_EQ(hl_cap_fs_write(&test_cfg, "whole.txt", data, strlen(data), NULL), 0);
+    HlMappedBuffer *buf = hl_cap_fs_mmap(&test_cfg, "whole.txt", NULL, NULL);
+    ASSERT_NE(buf, NULL);
+    ASSERT_EQ(buf->map_base, buf->addr);
+    ASSERT_EQ(buf->map_len, buf->len);
+    ASSERT_EQ(buf->foffset, (uint64_t)0);
+    hl_cap_fs_munmap(buf);
+    teardown_fs();
+}
+
 UTEST_MAIN();


### PR DESCRIPTION
## Mapped-spans cut 1 — checkpoint 1: windowed `HlMappedBuffer` (ownership foundation)

First implementation checkpoint of the zero-copy mapped-spans design
([docs/wasm_mapped_spans_design.md](docs/wasm_mapped_spans_design.md), #304).
**Scope is deliberately limited to the ownership foundation for review** — no
public span API, no `HullSpan`/SDK header, no WAMR attachment wiring, no
`fs.mmap` window binding yet. Those follow once this foundation is reviewed.
(The WAMR read-only-store trap patch already landed in Phase 0, #305.)

### What this adds
- **`HlMappedBuffer` gains `map_base` / `map_len` / `foffset`.** `addr`/`len`
  stay the caller-visible window; `map_base`/`map_len` are the actual
  page-aligned `mmap`/`munmap` region; `foffset` is the 64-bit logical file
  offset of the window's first byte. Whole-file mmap keeps `map_base==addr`,
  `map_len==len`, `foffset==0`, so **every existing consumer is unchanged**.
- **`hl_cap_fs_mmap_window(path, offset, length)`** — maps only
  `[offset, offset+length)` read-only, page-aligned internally (caller stays
  alignment-agnostic), clamped to end-of-file (a short final window is normal
  when scanning a large file in fixed windows). Teardown + the borrow-deferred
  release path now unmap `map_base`/`map_len`, never the offset window.
- **`hl_cap_fs_mmap_window_geometry()`** — the page-align + clamp + cap math as
  a **pure, filesystem-free** function with fully overflow-safe arithmetic
  (checked add / round-up, never `a + b <= LIMIT`), so overflow/boundary cases
  near `UINT64_MAX` are unit-testable without giant files. Fails closed on empty
  windows, over-cap length (`HL_FS_MMAP_MAX_WINDOW_BYTES` = 1 GiB, design §3.6),
  offset at/after EOF, non-power-of-two page size, and any alignment overflow.

### Tests (`tests/hull/cap/test_fs.c`, +13 to 34 total)
Geometry: offset-zero, cross-page slop, page-multiple offset, EOF clamp, the
rejection set, near-`UINT64_MAX` overflow. Real-file windows: cross-page
addressing, offset zero, EOF clamp, path traversal, rejections. Lifecycle:
borrow-pin on a windowed buffer (close-while-borrowed defers; last release
unmaps `map_base`). Regression: whole-file field consistency. **Green under
ASan/UBSan; full `make test` 69/69.**

### Not started (awaiting review of this foundation)
Span attach/detach lifecycle, the versioned metadata query, the SDK accessor
header, per-invocation total accounting, and any WAMR attachment wiring.
