### PR TITLE
wasm: internal per-invocation mapped-span attachment lifecycle (checkpoint 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,7 +388,25 @@ jobs:
             grep -qE "OK[^A-Za-z].*wasm_guarded\.$c" gsub.log \
               || { echo "::error::guarded AOT case $c did not run to OK"; exit 1; }
           done
-          echo "guarded-subrange AOT case (SW-bound) ran against a real wamrc .aot and passed."
+          echo " guarded-subrange AOT case (SW-bound) ran against a real wamrc .aot and passed."
+
+      - name: Build + run the mapped-span AOT lifecycle case (must NOT skip)
+        timeout-minutes: 6
+        run: |
+          # checkpoint 2: the span lifecycle + Design B window under a real AOT
+          # instance. FAIL if the AOT case takes the wamrc-unavailable skip path.
+          rm -f build/gen_ro_heap_span_aot.h
+          make build/test_wasm_spans
+          set -o pipefail
+          ./build/test_wasm_spans 2>&1 | tee spans.log
+          rc=${PIPESTATUS[0]}
+          [ "$rc" -eq 0 ] || { echo "::error::test_wasm_spans failed (rc=$rc)"; exit "$rc"; }
+          if grep -qE "SKIPPED.*wasm_spans\\.aot_span_lifecycle" spans.log; then
+            echo "::error::span AOT lifecycle case took the wamrc-unavailable skip path"; exit 1
+          fi
+          grep -qE "OK[^A-Za-z].*wasm_spans\\.aot_span_lifecycle" spans.log \
+            || { echo "::error::span AOT lifecycle case did not run to OK"; exit 1; }
+          echo "mapped-span AOT lifecycle case ran against a real wamrc .aot and passed."
 
   # patch 0004 arm64 AOT gate. The x86_64 job above proves the guarded-subrange
   # AOT path on x86_64; this runs the same non-skipped AOT matrix on arm64, where
@@ -436,6 +454,24 @@ jobs:
               || { echo "::error::guarded AOT case $c did not run to OK"; exit 1; }
           done
           echo "arm64 guarded-subrange AOT case (SW-bound) ran against a real wamrc .aot and passed."
+
+      - name: Build + run the mapped-span AOT lifecycle case (arm64, must NOT skip)
+        timeout-minutes: 6
+        run: |
+          # checkpoint 2: the span lifecycle + Design B window under a real AOT
+          # instance. FAIL if the AOT case takes the wamrc-unavailable skip path.
+          rm -f build/gen_ro_heap_span_aot.h
+          make build/test_wasm_spans
+          set -o pipefail
+          ./build/test_wasm_spans 2>&1 | tee spans.log
+          rc=${PIPESTATUS[0]}
+          [ "$rc" -eq 0 ] || { echo "::error::test_wasm_spans failed (rc=$rc)"; exit "$rc"; }
+          if grep -qE "SKIPPED.*wasm_spans\\.aot_span_lifecycle" spans.log; then
+            echo "::error::span AOT lifecycle case took the wamrc-unavailable skip path"; exit 1
+          fi
+          grep -qE "OK[^A-Za-z].*wasm_spans\\.aot_span_lifecycle" spans.log \
+            || { echo "::error::span AOT lifecycle case did not run to OK"; exit 1; }
+          echo "arm64 mapped-span AOT lifecycle case ran against a real wamrc .aot and passed."
 
   # Reproducibility gate. Three properties tested independently on
   # both Linux and macOS via matrix strategy:
@@ -781,15 +817,17 @@ jobs:
         timeout-minutes: 15
         run: make CC=clang tsan
 
-  # WAMR patch 0003 is race-sensitive (shared_heap_list + attached_count under
-  # shared_heap_list_lock). The worker-pool TSan job above leaves WAMR
+  # The WAMR shared-heap lifecycle is race-sensitive (shared_heap_list +
+  # attached_count under shared_heap_list_lock, patch 0003; the mapped-span
+  # attachment layer built on it). The worker-pool TSan job above leaves WAMR
   # uninstrumented, so this dedicated job builds the staged WAMR TUs WITH
-  # ThreadSanitizer (WAMR_TSAN=1) and runs the 8-case shared-heap-destroy matrix,
-  # so a race inside the destroy/attach/detach lifecycle is caught in CI, not
-  # only locally. Isolated from the worker-pool job so instrumenting WAMR does
-  # not perturb that signal.
+  # ThreadSanitizer (WAMR_TSAN=1) and runs BOTH the shared-heap-destroy matrix and
+  # the mapped-span attachment-lifecycle test, so a race inside destroy / attach /
+  # detach / chain / span-set teardown is caught in CI, not only locally.
+  # Isolated from the worker-pool job so instrumenting WAMR does not perturb that
+  # signal.
   tsan-shared-heap:
-    name: TSan (WAMR shared-heap destroy + guarded subrange)
+    name: TSan (WAMR shared-heap destroy + guarded subrange + spans)
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -801,7 +839,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang
 
-      - name: WAMR-instrumented TSan (destroy matrix + guarded-subrange matrix)
+      - name: WAMR-instrumented TSan (destroy + guarded-subrange + span lifecycle)
         timeout-minutes: 20
         run: make CC=clang tsan-shared-heap
 

--- a/include/hull/cap/wasm_spans.h
+++ b/include/hull/cap/wasm_spans.h
@@ -1,0 +1,143 @@
+/*
+ * cap/wasm_spans.h - internal per-invocation mapped-span attachment lifecycle.
+ *
+ * Mapped-spans cut 1, checkpoint 2. This is the C-level lifecycle that attaches
+ * a set of read-only mmap windows (HlMappedBuffer, checkpoint 1) to a WASM
+ * instance for ONE invocation, then reverse-order tears them down on every exit
+ * path. It is DELIBERATELY internal: there is NO public `spans={}` API, NO
+ * metadata host_call, NO SDK header, and NO Lua/JS binding here -- those are held
+ * until this lifecycle is reviewed. It is distinct from `compute.segment`
+ * (cap/wasm_data.c), which stays module-scoped/shared/persistent and unchanged.
+ *
+ * Ownership/reclamation: each span BORROWS its HlMappedBuffer (pinned via the
+ * checkpoint-1 borrow/release refcount for the set's lifetime, so a close()
+ * mid-flight defers munmap) and OWNS a read-only WAMR shared heap it creates over
+ * the buffer's page-aligned region. Teardown detaches, unchains, DESTROYS each
+ * heap (WAMR patch 0003, wasm_runtime_destroy_shared_heap -> the shared-heap list
+ * count returns to baseline every invocation), and releases each borrow -- in
+ * reverse order.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#ifndef HL_CAP_WASM_SPANS_H
+#define HL_CAP_WASM_SPANS_H
+
+#ifdef HL_ENABLE_WASM
+
+#include "hull/cap/fs.h" /* HlMappedBuffer */
+
+#include <pthread.h>
+#include <stdint.h>
+
+/* Max spans attached to one invocation. */
+#ifndef HL_WASM_MAX_SPANS
+#define HL_WASM_MAX_SPANS 16
+#endif
+
+/* Aggregate cap on the LOGICAL span bytes attached to ONE invocation (1 GiB),
+ * matching HL_FS_MMAP_MAX_WINDOW_BYTES / the design 3.6. This is the TOTAL across
+ * all spans of the set, accumulated overflow-safe. */
+#ifndef HL_WASM_MAX_SPAN_BYTES_TOTAL
+#define HL_WASM_MAX_SPAN_BYTES_TOTAL ((uint64_t)1 << 30)
+#endif
+
+/* One attached span: a borrowed read-only buffer + the shared heap over it.
+ * Design B (WAMR patch 0004): the shared heap is created over the whole
+ * page-aligned mapping [map_base, map_base+map_len) as the RESERVED region, and
+ * carries a valid sub-window (valid_offset = addr - map_base, valid_size = len)
+ * so the guest can reach only the caller's logical window [addr, addr+len). */
+typedef struct HlWasmSpan {
+    HlMappedBuffer *buf;         /**< Borrowed input; pinned while the set lives. */
+    void           *shared_heap; /**< wasm_shared_heap_t (read-only) over buf's
+                                      page-aligned [map_base, map_base+map_len). */
+    uint64_t        wasm_addr;   /**< Guest LOGICAL window base = the heap's
+                                      reserved WASM base + valid_offset (slop), so
+                                      it maps natively to buf->addr. Metadata for a
+                                      later cut. */
+} HlWasmSpan;
+
+/* An invocation-scoped set of spans. Zero-initialised by hl_wasm_span_set_init;
+ * all state lives here (no globals), so distinct invocations on distinct pooled
+ * instances are independent. */
+typedef struct HlWasmSpanSet {
+    HlWasmSpan spans[HL_WASM_MAX_SPANS];
+    int        count;          /**< Spans successfully added (heaps created + borrowed). */
+    uint64_t   total_logical;  /**< Sum of buf->len (logical); <= HL_WASM_MAX_SPAN_BYTES_TOTAL. */
+    uint64_t   total_reserved; /**< Sum of buf->map_len (page-aligned reserved);
+                                    tracked separately, kept under the address ceiling. */
+    void      *chain_head;      /**< wasm_shared_heap_t chain head, or NULL. */
+    void      *inst;            /**< Attached instance (wasm_module_inst_t), or NULL. */
+    int        is_memory64;    /**< Address-ceiling selection for the chain. */
+    pthread_t  owner;          /**< Thread that owns the set (add/attach/teardown). */
+    int        owner_set;      /**< 1 iff `owner` has been recorded. */
+} HlWasmSpanSet;
+
+/**
+ * @brief Begin an empty invocation-scoped span set on the calling thread.
+ *
+ * Records the calling thread as the owner; all subsequent add/attach/teardown
+ * MUST run on this thread (the instance is single-threaded per call). For async,
+ * the owning thread is the worker that runs the job and also tears the set down.
+ */
+void hl_wasm_span_set_init(HlWasmSpanSet *set, int is_memory64);
+
+/**
+ * @brief Add one read-only span backed by `buf` (a windowed HlMappedBuffer).
+ *
+ * Validates, then borrows the buffer and creates its read-only shared heap:
+ *  - count < HL_WASM_MAX_SPANS (else "too_many_spans");
+ *  - overflow-safe aggregate: total_logical + buf->len <= 1 GiB (else "span_cap");
+ *  - no duplicate backing: `buf` / buf->map_base not already in the set, and no
+ *    native byte-range overlap with an existing span (else "duplicate_span");
+ *  - buf->map_len page-aligned and <= UINT32_MAX (a windowed buffer; else the
+ *    heap create fails -> "heap_create").
+ *
+ * On success the buffer is pinned (borrow) and its RO heap is recorded.
+ * On failure NOTHING for this span is left behind (no borrow, no heap); prior
+ * spans remain -- the caller rolls the whole set back with
+ * hl_wasm_span_set_teardown. Owning-thread only.
+ *
+ * @return 0 on success; -1 with *err set on failure.
+ */
+int hl_wasm_span_set_add(HlWasmSpanSet *set, HlMappedBuffer *buf,
+                         const char **err);
+
+/**
+ * @brief Transactionally chain the added spans and attach them to `inst`.
+ *
+ * Chains the per-span heaps into one WAMR shared-heap chain at distinct,
+ * non-overlapping high WASM addresses (asserted strictly disjoint), then attaches
+ * the chain to `inst`. Must be called once, after all adds, before the WASM call.
+ * If chaining or attach fails, the set is left UN-attached and the caller tears it
+ * down (which unchains + destroys + releases). Rejects a set already attached
+ * (reentrancy) and a foreign owning thread. Owning-thread only.
+ *
+ * @return 0 on success; -1 with *err set on failure.
+ */
+int hl_wasm_span_set_attach(HlWasmSpanSet *set, void *inst, const char **err);
+
+/**
+ * @brief Reverse-order teardown on EVERY exit path (and partial-failure rollback).
+ *
+ * Runs on the owning thread after the WASM call has returned (success, WASM trap,
+ * gas exhaustion, host error, cancellation) or to unwind a partial build: detach
+ * (if attached) -> unchain -> destroy each heap (patch 0003) -> release each
+ * borrow, in REVERSE order of addition. Idempotent and safe on a partially-built
+ * set.
+ *
+ * @return 0 when the set is FULLY torn down: the shared-heap list count and every
+ *         borrow return to their pre-build baseline and the set is zeroed (a stale
+ *         handle then rejects access). -1 when one or more heaps could NOT be
+ *         destroyed (unexpected after detach + unchain): those spans are RETAINED
+ *         (heap handle + mmap borrow kept, so nothing WAMR still references is
+ *         freed) and COMPACTED to the front of the set, leaving it live and
+ *         reachable. The caller may retry (call teardown again once the block
+ *         clears -- an already-destroyed span is never re-destroyed and its
+ *         backing never re-released) or hand the still-populated set to an
+ *         explicit runtime-teardown cleanup path. Never silently discards a
+ *         retained pin.
+ */
+int hl_wasm_span_set_teardown(HlWasmSpanSet *set);
+
+#endif /* HL_ENABLE_WASM */
+#endif /* HL_CAP_WASM_SPANS_H */

--- a/mk/features/wasm.mk
+++ b/mk/features/wasm.mk
@@ -16,7 +16,8 @@
 # compute BINDING (mod_compute) moves into libhull_feature-wasm-<rt>.a. The base
 # keeps the wasm_weakstub.c weak defaults (Phase 0) so a compute-less app links.
 FEATURE_WASM_OBJS := $(BUILDDIR)/cap_wasm.o $(BUILDDIR)/cap_wasm_buffer.o \
-                     $(BUILDDIR)/cap_wasm_data.o $(BUILDDIR)/cap_wasm_stream.o
+                     $(BUILDDIR)/cap_wasm_data.o $(BUILDDIR)/cap_wasm_stream.o \
+                     $(BUILDDIR)/cap_wasm_spans.o
 
 # libhull_feature-wasm.a: the runtime-agnostic WASM CORE (docs/wasm_feature.md,
 # Phase 1). Bundles the wasm caps + worker_wasm + the vendored WAMR objects

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -203,6 +203,16 @@ $(BUILDDIR)/gen_gsub_aot_sw.h: $(TESTDIR)/hull/fixtures/gsub.wasm | $(BUILDDIR)
 $(BUILDDIR)/test_wasm_guarded_subrange: INCLUDES += -I$(BUILDDIR)
 $(BUILDDIR)/test_wasm_guarded_subrange: $(BUILDDIR)/gen_gsub_aot_sw.h
 
+# Mapped-span lifecycle (checkpoint 2). SW-bound AOT fixture of the same
+# store_i32/load_i32 module the test embeds, so the span lifecycle + Design B
+# guest-window checks run under AOT too (skipped when wamrc is absent; the
+# wasm-readonly-heap-aot CI job builds wamrc and asserts the AOT case is NOT
+# skipped).
+$(BUILDDIR)/gen_ro_heap_span_aot.h: $(TESTDIR)/hull/fixtures/ro_heap.wasm | $(BUILDDIR)
+	$(call GEN_GSUB_AOT,$@,--bounds-checks=1,ro_heap_span_aot)
+$(BUILDDIR)/test_wasm_spans: INCLUDES += -I$(BUILDDIR)
+$(BUILDDIR)/test_wasm_spans: $(BUILDDIR)/gen_ro_heap_span_aot.h
+
 # Top-level tests (tests/hull/)
 $(BUILDDIR)/test_parse_size: $(TESTDIR)/hull/test_parse_size.c $(TEST_COMMON_DEPS) | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(TEST_COMMON_LIBS)
@@ -563,7 +573,8 @@ tsan:
 tsan-shared-heap:
 	$(MAKE) clean
 	$(MAKE) TSAN=1 WAMR_TSAN=1 $(BUILDDIR)/test_wasm_shared_heap_destroy \
-		$(BUILDDIR)/test_wasm_guarded_subrange
+		$(BUILDDIR)/test_wasm_guarded_subrange \
+		$(BUILDDIR)/test_wasm_spans
 	@nm $(BUILDDIR)/wamr_core/iwasm/common/wasm_memory.o 2>/dev/null | grep -q '__tsan' \
 		|| { echo "FAIL: wasm_memory.o is NOT TSan-instrumented (WAMR_TSAN not applied)"; exit 1; }
 	@echo "── TSan (WAMR-instrumented): shared-heap destroy 8-case matrix ──"
@@ -572,6 +583,9 @@ tsan-shared-heap:
 	@echo "── TSan (WAMR-instrumented): guarded-subrange access matrix (patch 0004) ──"
 	TSAN_OPTIONS="halt_on_error=1 second_deadlock_stack=1" \
 		$(BUILDDIR)/test_wasm_guarded_subrange
+	@echo "── TSan (WAMR-instrumented): mapped-span attachment lifecycle ──"
+	TSAN_OPTIONS="halt_on_error=1 second_deadlock_stack=1" \
+		$(BUILDDIR)/test_wasm_spans
 
 # ── Fuzzing (libFuzzer + ASan/UBSan) ────────────────────────────────
 # Mirrors vendor/keel/fuzz. Requires clang with the libFuzzer runtime.

--- a/src/hull/cap/wasm_spans.c
+++ b/src/hull/cap/wasm_spans.c
@@ -1,0 +1,330 @@
+/*
+ * cap/wasm_spans.c - internal per-invocation mapped-span attachment lifecycle.
+ *
+ * See include/hull/cap/wasm_spans.h. Internal only: no public spans API, no
+ * metadata host_call, no SDK header, no bindings (held for review). Distinct from
+ * cap/wasm_data.c (compute.segment), which is unchanged.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#ifdef HL_ENABLE_WASM
+
+#include "hull/cap/wasm_spans.h"
+#include "hull/cap/fs.h"
+#include "log.h"
+#include "wasm_export.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+/* Overflow-safe native byte-range overlap: does [a, a+alen) meet [b, b+blen)?
+ * alen/blen are > 0 and bounded (<= 1 GiB), and real mmap addresses sit far below
+ * the top of the address space, so a+alen does not wrap. */
+static int
+ranges_overlap(const void *a, size_t alen, const void *b, size_t blen)
+{
+    uintptr_t a0 = (uintptr_t)a, a1 = a0 + alen;
+    uintptr_t b0 = (uintptr_t)b, b1 = b0 + blen;
+    return a0 < b1 && b0 < a1;
+}
+
+static int
+owner_ok(const HlWasmSpanSet *set)
+{
+    return set->owner_set && pthread_equal(set->owner, pthread_self());
+}
+
+void
+hl_wasm_span_set_init(HlWasmSpanSet *set, int is_memory64)
+{
+    if (!set)
+        return;
+    memset(set, 0, sizeof(*set));
+    set->is_memory64 = is_memory64 ? 1 : 0;
+    set->owner = pthread_self();
+    set->owner_set = 1;
+}
+
+int
+hl_wasm_span_set_add(HlWasmSpanSet *set, HlMappedBuffer *buf, const char **err)
+{
+    if (!set || !buf) {
+        if (err) *err = "internal_error";
+        return -1;
+    }
+    if (!owner_ok(set)) {
+        if (err) *err = "wrong_thread";
+        return -1;
+    }
+    if (set->inst) { /* the set is attached; no mutation until teardown */
+        if (err) *err = "already_attached";
+        return -1;
+    }
+    if (set->count >= HL_WASM_MAX_SPANS) {
+        if (err) *err = "too_many_spans";
+        return -1;
+    }
+
+    /* the buffer must be a live, page-aligned window usable as a shared heap.
+     * (A whole-file mmap whose map_len is not page-aligned is not a valid span;
+     * spans use the windowed constructor.) */
+    if (buf->closed || !buf->map_base || buf->map_len == 0) {
+        if (err) *err = "bad_buffer";
+        return -1;
+    }
+    long pg = sysconf(_SC_PAGESIZE);
+    if (pg <= 0)
+        pg = 4096;
+    if ((uint64_t)buf->map_len % (uint64_t)pg != 0
+        || (uint64_t)buf->map_len > (uint64_t)UINT32_MAX) {
+        if (err) *err = "bad_buffer";
+        return -1;
+    }
+
+    /* Design B validity: the logical window [addr, addr+len) must sit inside the
+     * page-aligned mapping. valid_offset = addr - map_base (the intra-page slop);
+     * valid_offset + len <= map_len always holds for a windowed buffer, but assert
+     * it (fail closed) so a malformed HlMappedBuffer can never widen the guest. */
+    uint64_t voff = (uint64_t)((uintptr_t)buf->addr - (uintptr_t)buf->map_base);
+    if ((uintptr_t)buf->addr < (uintptr_t)buf->map_base
+        || voff + (uint64_t)buf->len > (uint64_t)buf->map_len) {
+        if (err) *err = "bad_buffer";
+        return -1;
+    }
+
+    /* overflow-safe aggregate cap on LOGICAL bytes (the caller window, buf->len):
+     * total + len <= CAP, written to never wrap. */
+    if ((uint64_t)buf->len > HL_WASM_MAX_SPAN_BYTES_TOTAL
+        || set->total_logical > HL_WASM_MAX_SPAN_BYTES_TOTAL - (uint64_t)buf->len) {
+        if (err) *err = "span_cap";
+        return -1;
+    }
+
+    /* Account RESERVED (page-aligned map_len) bytes separately, and keep the sum
+     * under the WASM address-space ceiling: the shared-heap chain occupies the top
+     * of the address space, so sum(reserved) must fit below UINT32_MAX (wasm32) /
+     * UINT64_MAX (memory64). Overflow-safe: total + map_len <= ceil. */
+    uint64_t addr_ceil = set->is_memory64 ? UINT64_MAX : (uint64_t)UINT32_MAX;
+    if ((uint64_t)buf->map_len > addr_ceil
+        || set->total_reserved > addr_ceil - (uint64_t)buf->map_len) {
+        if (err) *err = "addr_space";
+        return -1;
+    }
+
+    /* reject duplicate backing (same buffer / same mapping) and any native
+     * byte-range overlap with an already-added span. */
+    for (int i = 0; i < set->count; i++) {
+        HlMappedBuffer *o = set->spans[i].buf;
+        if (o == buf || o->map_base == buf->map_base
+            || ranges_overlap(buf->map_base, buf->map_len, o->map_base,
+                              o->map_len)) {
+            if (err) *err = "duplicate_span";
+            return -1;
+        }
+    }
+
+    /* pin the buffer for the set's lifetime, then create its read-only heap over
+     * the whole page-aligned mapping (RESERVED) with the valid sub-window carved
+     * to [valid_offset, valid_offset+len) (Design B, WAMR patch 0004). */
+    hl_cap_fs_mmap_borrow(buf);
+
+    SharedHeapInitArgs args;
+    memset(&args, 0, sizeof(args));
+    args.pre_allocated_addr = buf->map_base;
+    args.size = (uint32_t)buf->map_len;
+    args.read_only = true;
+    args.valid_offset = voff;
+    args.valid_size = (uint64_t)buf->len;
+    wasm_shared_heap_t heap = wasm_runtime_create_shared_heap(&args);
+    if (!heap) {
+        hl_cap_fs_mmap_release(buf); /* undo the borrow: nothing left behind */
+        if (err) *err = "heap_create";
+        return -1;
+    }
+
+    set->spans[set->count].buf = buf;
+    set->spans[set->count].shared_heap = heap;
+    set->spans[set->count].wasm_addr = 0; /* computed on attach */
+    set->count++;
+    set->total_logical += (uint64_t)buf->len;
+    set->total_reserved += (uint64_t)buf->map_len;
+    return 0;
+}
+
+int
+hl_wasm_span_set_attach(HlWasmSpanSet *set, void *inst, const char **err)
+{
+    if (!set || !inst) {
+        if (err) *err = "internal_error";
+        return -1;
+    }
+    if (!owner_ok(set)) {
+        if (err) *err = "wrong_thread";
+        return -1;
+    }
+    if (set->inst) {
+        if (err) *err = "already_attached";
+        return -1;
+    }
+    if (set->count == 0) {
+        if (err) *err = "no_spans";
+        return -1;
+    }
+
+    uint64_t addr_ceil =
+        set->is_memory64 ? UINT64_MAX : (uint64_t)UINT32_MAX;
+
+    /* Chain right-to-left (last span highest). On a partial-chain failure, the
+     * spans already chained live in `chain`; record it so teardown unchains them. */
+    wasm_shared_heap_t chain =
+        (wasm_shared_heap_t)set->spans[set->count - 1].shared_heap;
+    for (int i = set->count - 2; i >= 0; i--) {
+        wasm_shared_heap_t next = wasm_runtime_chain_shared_heaps(
+            (wasm_shared_heap_t)set->spans[i].shared_heap, chain);
+        if (!next) {
+            set->chain_head = chain; /* partial chain (spans i+1..end) */
+            if (err) *err = "chain_failed";
+            return -1;
+        }
+        chain = next;
+    }
+    set->chain_head = chain;
+
+    /* Compute the RESERVED WASM slots from the ceiling downward (map_len each,
+     * mirroring how WAMR's create + chain place them), and record each span's
+     * guest LOGICAL base = reserved_base + valid_offset (slop). That logical base
+     * maps natively to buf->addr; the guest can reach only [wasm_addr, +len). */
+    uint64_t next_start = addr_ceil;
+    uint64_t reserved_base[HL_WASM_MAX_SPANS];
+    for (int i = set->count - 1; i >= 0; i--) {
+        uint64_t alloc = (uint64_t)set->spans[i].buf->map_len;
+        reserved_base[i] = next_start - alloc + 1;
+        uint64_t voff = (uint64_t)((uintptr_t)set->spans[i].buf->addr
+                                   - (uintptr_t)set->spans[i].buf->map_base);
+        set->spans[i].wasm_addr = reserved_base[i] + voff;
+        if (i > 0)
+            next_start = reserved_base[i] - 1;
+    }
+
+    /* Fail-closed: assert the RESERVED WASM slots are STRICTLY DISJOINT (the chain
+     * places them non-overlapping; this catches any math regression). The logical
+     * windows are sub-ranges of disjoint reserved slots, so they are disjoint too.
+     * Inclusive ends avoid the wrap at addr_ceil + 1. */
+    for (int i = 0; i < set->count; i++) {
+        uint64_t ai0 = reserved_base[i];
+        uint64_t ai1 = ai0 + (uint64_t)set->spans[i].buf->map_len - 1;
+        for (int j = i + 1; j < set->count; j++) {
+            uint64_t aj0 = reserved_base[j];
+            uint64_t aj1 = aj0 + (uint64_t)set->spans[j].buf->map_len - 1;
+            if (ai0 <= aj1 && aj0 <= ai1) {
+                if (err) *err = "wasm_overlap";
+                return -1;
+            }
+        }
+    }
+
+    if (!wasm_runtime_attach_shared_heap((wasm_module_inst_t)inst,
+                                         (wasm_shared_heap_t)set->chain_head)) {
+        /* leave un-attached; the caller tears down (unchain + destroy + release). */
+        if (err) *err = "attach_failed";
+        return -1;
+    }
+    set->inst = inst;
+    return 0;
+}
+
+int
+hl_wasm_span_set_teardown(HlWasmSpanSet *set)
+{
+    if (!set)
+        return 0;
+
+    /* Reverse order on every exit path (success / trap / error / cancel) and
+     * partial-failure rollback: detach -> unchain -> destroy -> release.
+     * Returns 0 when the set is fully torn down (list + borrows back to
+     * baseline, set zeroed), or -1 when one or more heaps could NOT be destroyed:
+     * those spans are RETAINED, live, and COMPACTED to the front of the set so
+     * the caller can retry (call teardown again once the block clears) or hand
+     * the still-populated set to a runtime-teardown cleanup path. Idempotent:
+     * detach/unchain no-op on a retry (inst/chain already cleared). */
+
+    /* 1. detach the chain from the instance (clears the interp/AOT caches and
+     *    drops attached_count to 0). */
+    if (set->inst) {
+        wasm_runtime_detach_shared_heap((wasm_module_inst_t)set->inst);
+        set->inst = NULL;
+    }
+
+    /* 2. unchain (requires attached_count == 0, just satisfied). Only when a
+     *    chain was actually formed (count > 1); a lone heap is already standalone. */
+    if (set->chain_head && set->count > 1) {
+        wasm_runtime_unchain_shared_heaps((wasm_shared_heap_t)set->chain_head,
+                                          true);
+    }
+    set->chain_head = NULL;
+
+    /* 3+4. destroy each heap (patch 0003) then release each borrow, in REVERSE
+     *      order of addition. Destroy frees only WAMR's descriptor; release drops
+     *      the borrow pin so the mmap can finally go.
+     *
+     *      On destroy FAILURE (unexpected after detach + unchain): WAMR may still
+     *      reference this heap's backing memory, so RETAIN BOTH the heap handle
+     *      and the mmap borrow -- releasing the borrow could munmap memory WAMR
+     *      still points at (use-after-free). The retained span stays in the set
+     *      (see compaction below) so it is reachable for a retry or an explicit
+     *      cleanup path, NOT silently discarded into a permanent pin. Only a
+     *      SUCCESSFUL destroy releases the borrow and NULLs the span; an
+     *      already-destroyed span (buf/heap NULL) is skipped, so a retry never
+     *      re-destroys a heap or re-releases backing. */
+    for (int i = set->count - 1; i >= 0; i--) {
+        if (!set->spans[i].shared_heap)
+            continue; /* already destroyed on a prior pass; do not touch */
+        if (wasm_runtime_destroy_shared_heap(
+                (wasm_shared_heap_t)set->spans[i].shared_heap)) {
+            set->spans[i].shared_heap = NULL;
+            if (set->spans[i].buf) {
+                hl_cap_fs_mmap_release(set->spans[i].buf);
+                set->spans[i].buf = NULL;
+            }
+        }
+        else {
+            log_error("[wasm] span shared-heap destroy failed; "
+                      "retaining heap handle + mmap borrow (retry-able)");
+        }
+    }
+
+    /* Compact any RETAINED spans (destroy failed -> heap still set) to the front,
+     * recompute count + logical/reserved totals from what survives, and clear the
+     * rest. If nothing survives, zero the whole set so a stale handle is rejected.
+     * The retained set stays valid for a subsequent teardown retry. */
+    int w = 0;
+    uint64_t logical = 0, reserved = 0;
+    for (int i = 0; i < set->count; i++) {
+        if (!set->spans[i].shared_heap)
+            continue;
+        if (w != i)
+            set->spans[w] = set->spans[i];
+        if (set->spans[w].buf) {
+            logical += (uint64_t)set->spans[w].buf->len;
+            reserved += (uint64_t)set->spans[w].buf->map_len;
+        }
+        w++;
+    }
+    for (int i = w; i < set->count; i++)
+        memset(&set->spans[i], 0, sizeof(set->spans[i]));
+
+    if (w == 0) {
+        int is_mem64 = set->is_memory64;
+        memset(set, 0, sizeof(*set));
+        set->is_memory64 = is_mem64;
+        return 0;
+    }
+    set->count = w;
+    set->total_logical = logical;
+    set->total_reserved = reserved;
+    return -1;
+}
+
+#endif /* HL_ENABLE_WASM */

--- a/tests/hull/cap/test_wasm_spans.c
+++ b/tests/hull/cap/test_wasm_spans.c
@@ -465,6 +465,116 @@ UTEST(wasm_spans, cross_instance_isolation)
     teardown_dir();
 }
 
+/* ── cross-instance isolation, PROVEN BY EXECUTION: instance i1 cannot LOAD from
+ *    an address that is a valid span only in i0. i0 gets two spans (so its lower
+ *    slot sits below i1's single top slot); i1 has only the top slot. A guest load
+ *    in i1 at i0's lower-span address is out of every range i1 has attached and
+ *    TRAPS, while i1's own span and i0's own load of the same address both succeed
+ *    -- so the trap is isolation, not a bogus address. ─────────────────────────── */
+UTEST(wasm_spans, cross_instance_execution_isolation)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    ASSERT_EQ(write_file("a.bin", 40000), 0);
+    wasm_module_t m0, m1; uint8_t *bb0, *bb1;
+    wasm_module_inst_t i0 = make_instance(&m0, &bb0);
+    wasm_module_inst_t i1 = make_instance(&m1, &bb1);
+    ASSERT_TRUE(i0 && i1);
+    wasm_exec_env_t e0 = wasm_runtime_create_exec_env(i0, 16 * 1024);
+    wasm_exec_env_t e1 = wasm_runtime_create_exec_env(i1, 16 * 1024);
+    ASSERT_TRUE(e0 && e1);
+
+    /* i0 owns TWO page-aligned windows -> two chained slots (top + one below). */
+    HlMappedBuffer *s0a = hl_cap_fs_mmap_window(&cfg, "a.bin", 0, 4096, NULL, NULL);
+    HlMappedBuffer *s0b = hl_cap_fs_mmap_window(&cfg, "a.bin", 8192, 4096, NULL, NULL);
+    /* i1 owns ONE window -> a single slot at the top of the address space. */
+    HlMappedBuffer *s1 = hl_cap_fs_mmap_window(&cfg, "a.bin", 16384, 4096, NULL, NULL);
+    ASSERT_TRUE(s0a && s0b && s1);
+
+    HlWasmSpanSet set0, set1; const char *err = NULL;
+    hl_wasm_span_set_init(&set0, 0);
+    hl_wasm_span_set_init(&set1, 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set0, s0a, &err), 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set0, s0b, &err), 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set1, s1, &err), 0);
+    ASSERT_EQ(hl_wasm_span_set_attach(&set0, i0, &err), 0);
+    ASSERT_EQ(hl_wasm_span_set_attach(&set1, i1, &err), 0);
+
+    /* s0a is i0's LOWER slot; with only a single (top) slot attached, that address
+     * is not in any range i1 can reach. Confirm it is a real, reachable address in
+     * i0 first, then that the SAME address traps in i1 -- pure isolation. */
+    uint64_t s0a_addr = set0.spans[0].wasm_addr;
+    uint32_t v = 0;
+    ASSERT_TRUE(guest_load(i0, e0, s0a_addr, &v));            /* i0 owns it */
+    ASSERT_FALSE(guest_load(i1, e1, s0a_addr, &v));           /* i1 cannot reach it */
+    ASSERT_TRUE(guest_load(i1, e1, set1.spans[0].wasm_addr, &v)); /* i1's own span ok */
+
+    hl_wasm_span_set_teardown(&set0);
+    hl_wasm_span_set_teardown(&set1);
+    wasm_runtime_destroy_exec_env(e0);
+    wasm_runtime_destroy_exec_env(e1);
+    hl_cap_fs_munmap(s0a); hl_cap_fs_munmap(s0b); hl_cap_fs_munmap(s1);
+    free_instance(i0, m0, bb0);
+    free_instance(i1, m1, bb1);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── distinct-buffer native-backing rejection: two DIFFERENT HlMappedBuffers that
+ *    alias the same native mapping (or whose native ranges overlap) are rejected,
+ *    exercising the map_base-equality and ranges_overlap arms of the duplicate
+ *    check that the same-pointer case (duplicate_rejected) does not reach. The
+ *    real windowed constructor never produces aliasing mappings (independent mmaps
+ *    are disjoint), so a synthetic alias drives these defense-in-depth arms. The
+ *    alias is rejected BEFORE any borrow/heap-create, so it is never pinned and
+ *    needs no teardown. ──────────────────────────────────────────────────────── */
+UTEST(wasm_spans, distinct_buffer_overlap_rejected)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    uint32_t base = wasm_runtime_shared_heap_count();
+    ASSERT_EQ(write_file("a.bin", 40000), 0);
+    HlMappedBuffer *b0 = hl_cap_fs_mmap_window(&cfg, "a.bin", 0, 4096, NULL, NULL);
+    ASSERT_TRUE(b0 != NULL);
+
+    HlWasmSpanSet set; const char *err = NULL;
+    hl_wasm_span_set_init(&set, 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, b0, &err), 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 1);
+
+    /* (a) distinct buffer, SAME native base -> map_base-equality arm. */
+    HlMappedBuffer alias; memset(&alias, 0, sizeof(alias));
+    alias.map_base = b0->map_base;
+    alias.map_len = b0->map_len;
+    alias.addr = b0->map_base;   /* voff = 0 */
+    alias.len = 256;
+    ASSERT_TRUE(&alias != b0);
+    err = NULL;
+    ASSERT_EQ(hl_wasm_span_set_add(&set, &alias, &err), -1);
+    ASSERT_STREQ(err, "duplicate_span");
+
+    /* (b) distinct buffer, DISTINCT base but OVERLAPPING native range -> the
+     * ranges_overlap arm. Base is offset into b0's mapping so the ranges meet. */
+    HlMappedBuffer overlap; memset(&overlap, 0, sizeof(overlap));
+    overlap.map_base = (char *)b0->map_base + 2048; /* != b0->map_base, overlaps */
+    overlap.map_len = b0->map_len;
+    overlap.addr = overlap.map_base;
+    overlap.len = 256;
+    err = NULL;
+    ASSERT_EQ(hl_wasm_span_set_add(&set, &overlap, &err), -1);
+    ASSERT_STREQ(err, "duplicate_span");
+
+    /* neither synthetic alias was pinned or created a heap. */
+    ASSERT_EQ(set.count, 1);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 1);
+
+    hl_wasm_span_set_teardown(&set);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);
+    hl_cap_fs_munmap(b0);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
 /* ── concurrent invocations: N threads each drive their OWN instance + span-set
  *    build/attach/teardown, racing on the shared heap list. Validated under the
  *    WAMR-instrumented TSan (make tsan-spans). Final count returns to baseline. ─ */

--- a/tests/hull/cap/test_wasm_spans.c
+++ b/tests/hull/cap/test_wasm_spans.c
@@ -1,0 +1,927 @@
+/*
+ * Hull-tree C-level test for the internal per-invocation mapped-span attachment
+ * lifecycle (mapped-spans cut 1, checkpoint 2 -- cap/wasm_spans.c). Exercised
+ * through Hull's own WAMR build. NO public spans API / metadata / SDK / bindings
+ * are involved (held for review); this drives the internal HlWasmSpanSet directly.
+ *
+ * Covers: pin+account (logical + reserved bytes), duplicate/overlap/cap
+ * rejection, transactional create+attach+chain, partial-attach + chain-failure
+ * rollback, reverse-order teardown on every exit path, owning-thread enforcement,
+ * close-while-borrowed, cross-instance isolation, zero-span, maximum span count,
+ * and -- the load-bearing property -- the shared-heap list count returning to
+ * baseline after repeated invocations (via WAMR patch 0003).
+ *
+ * Design B (WAMR patch 0004): each heap is created over the whole page-aligned
+ * mapping with a valid sub-window (valid_offset = addr - map_base, valid_size =
+ * len), so the guest reaches only the caller's logical window. Verified from the
+ * WASM side: an unaligned window's logical base maps to addr, and a guest read in
+ * the slop prefix or the page-rounding suffix (incl. the EOF-tail past-EOF page)
+ * traps.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#if defined(__linux__) && !defined(_XOPEN_SOURCE)
+# define _XOPEN_SOURCE 700
+#endif
+
+#include "utest.h"
+
+#include "hull/cap/wasm.h"
+#include "hull/cap/wasm_spans.h"
+#include "hull/cap/fs.h"
+#include "wasm_export.h"
+
+#include "gen_ro_heap_span_aot.h" /* build-generated: ro_heap_span_aot[] + _len (or empty) */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+UTEST_MAIN();
+
+static char test_dir[256];
+static HlFsConfig cfg;
+
+static void setup(void)
+{
+    snprintf(test_dir, sizeof(test_dir), "/tmp/hull_spans_%d", getpid());
+    mkdir(test_dir, 0755);
+    cfg.base_dir = test_dir;
+    cfg.base_len = strlen(test_dir);
+}
+static void teardown_dir(void)
+{
+    /* best-effort: unlink the files we create + rmdir. */
+    char p[512];
+    const char *names[] = { "a.bin", "b.bin", "c.bin", "big.bin", "big2.bin" };
+    for (size_t i = 0; i < sizeof(names) / sizeof(names[0]); i++) {
+        snprintf(p, sizeof(p), "%s/%s", test_dir, names[i]);
+        unlink(p);
+    }
+    rmdir(test_dir);
+}
+
+/* Write `n` bytes (pattern byte i == i&0xff) so a window is content-verifiable. */
+static int write_file(const char *name, size_t n)
+{
+    unsigned char *b = (unsigned char *)malloc(n);
+    if (!b) return -1;
+    for (size_t i = 0; i < n; i++) b[i] = (unsigned char)(i & 0xff);
+    int rc = hl_cap_fs_write(&cfg, name, (const char *)b, n, NULL);
+    free(b);
+    return rc;
+}
+
+/* Create a SPARSE file of `n` bytes (ftruncate; no disk for the holes). */
+static int make_sparse(const char *name, off_t n)
+{
+    char full[512];
+    snprintf(full, sizeof(full), "%s/%s", test_dir, name);
+    int fd = open(full, O_RDWR | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) return -1;
+    int rc = ftruncate(fd, n);
+    close(fd);
+    return rc;
+}
+
+/* store_i32/load_i32 module with (memory 1) -- gives instances a linear memory. */
+static const unsigned char ro_heap_wasm[] = {
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0a, 0x02, 0x60,
+    0x01, 0x7f, 0x00, 0x60, 0x01, 0x7f, 0x01, 0x7f, 0x03, 0x03, 0x02, 0x00,
+    0x01, 0x05, 0x03, 0x01, 0x00, 0x01, 0x07, 0x21, 0x03, 0x06, 0x6d, 0x65,
+    0x6d, 0x6f, 0x72, 0x79, 0x02, 0x00, 0x09, 0x73, 0x74, 0x6f, 0x72, 0x65,
+    0x5f, 0x69, 0x33, 0x32, 0x00, 0x00, 0x08, 0x6c, 0x6f, 0x61, 0x64, 0x5f,
+    0x69, 0x33, 0x32, 0x00, 0x01, 0x0a, 0x17, 0x02, 0x0d, 0x00, 0x20, 0x00,
+    0x41, 0xc4, 0xe6, 0x88, 0x89, 0x01, 0x36, 0x02, 0x00, 0x0b, 0x07, 0x00,
+    0x20, 0x00, 0x28, 0x02, 0x00, 0x0b
+};
+static const unsigned int ro_heap_wasm_len = 90;
+
+/* Instantiate a fresh instance (owns its mutable module buffer). */
+static wasm_module_inst_t make_instance(wasm_module_t *out_mod, uint8_t **out_buf)
+{
+    uint8_t *mbuf = (uint8_t *)malloc(ro_heap_wasm_len);
+    if (!mbuf) return NULL;
+    memcpy(mbuf, ro_heap_wasm, ro_heap_wasm_len);
+    char err[128] = { 0 };
+    wasm_module_t mod = wasm_runtime_load(mbuf, ro_heap_wasm_len, err, sizeof(err));
+    if (!mod) { free(mbuf); return NULL; }
+    wasm_module_inst_t inst =
+        wasm_runtime_instantiate(mod, 16 * 1024, 64 * 1024, err, sizeof(err));
+    if (!inst) { wasm_runtime_unload(mod); free(mbuf); return NULL; }
+    *out_mod = mod; *out_buf = mbuf;
+    return inst;
+}
+static void free_instance(wasm_module_inst_t inst, wasm_module_t mod, uint8_t *buf)
+{
+    if (inst) wasm_runtime_deinstantiate(inst);
+    if (mod) wasm_runtime_unload(mod);
+    free(buf);
+}
+
+/* Instantiate from arbitrary module bytes (interp .wasm or wamrc .aot); WAMR
+ * picks the loader from the magic. Owns a mutable copy of the image. */
+static wasm_module_inst_t inst_from(const unsigned char *img, unsigned int len,
+                                    wasm_module_t *out_mod, uint8_t **out_buf)
+{
+    uint8_t *mbuf = (uint8_t *)malloc(len);
+    if (!mbuf) return NULL;
+    memcpy(mbuf, img, len);
+    char err[128] = { 0 };
+    wasm_module_t mod = wasm_runtime_load(mbuf, len, err, sizeof(err));
+    if (!mod) { free(mbuf); return NULL; }
+    wasm_module_inst_t inst =
+        wasm_runtime_instantiate(mod, 16 * 1024, 64 * 1024, err, sizeof(err));
+    if (!inst) { wasm_runtime_unload(mod); free(mbuf); return NULL; }
+    *out_mod = mod; *out_buf = mbuf;
+    return inst;
+}
+
+/* guest load_i32(app_addr): out set to the read value; returns 1 on success, 0 if
+ * the guest trapped (bounds violation). Verifies the Design B window from the
+ * WASM side. */
+static int guest_load(wasm_module_inst_t inst, wasm_exec_env_t env,
+                      uint64_t app_addr, uint32_t *out)
+{
+    wasm_function_inst_t f = wasm_runtime_lookup_function(inst, "load_i32");
+    uint32_t argv[2] = { (uint32_t)app_addr, 0 };
+    wasm_runtime_set_exception(inst, NULL);
+    if (!wasm_runtime_call_wasm(env, f, 1, argv))
+        return 0;
+    if (out) *out = argv[0];
+    return 1;
+}
+
+/* ── basic lifecycle: add one span, attach, teardown, count -> baseline ─────── */
+UTEST(wasm_spans, lifecycle_basic)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    uint32_t base = wasm_runtime_shared_heap_count();
+    ASSERT_EQ(write_file("a.bin", 40000), 0);
+
+    wasm_module_t mod; uint8_t *mb;
+    wasm_module_inst_t inst = make_instance(&mod, &mb);
+    ASSERT_TRUE(inst != NULL);
+
+    HlMappedBuffer *buf = hl_cap_fs_mmap_window(&cfg, "a.bin", 8192, 4096, NULL, NULL);
+    ASSERT_TRUE(buf != NULL);
+
+    HlWasmSpanSet set; const char *err = NULL;
+    hl_wasm_span_set_init(&set, 0 /* wasm32 */);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, buf, &err), 0);
+    ASSERT_EQ(set.count, 1);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 1);   /* heap created */
+    ASSERT_EQ(hl_wasm_span_set_attach(&set, inst, &err), 0);
+    ASSERT_TRUE(set.spans[0].wasm_addr != 0);                /* address computed */
+
+    hl_wasm_span_set_teardown(&set);
+    ASSERT_EQ(set.count, 0);
+    ASSERT_EQ(set.inst, NULL);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);       /* reclaimed */
+
+    hl_cap_fs_munmap(buf);
+    free_instance(inst, mod, mb);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── multiple spans: chained, non-overlapping WASM addresses ────────────────── */
+UTEST(wasm_spans, multiple_spans)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    uint32_t base = wasm_runtime_shared_heap_count();
+    ASSERT_EQ(write_file("a.bin", 40000), 0);
+
+    wasm_module_t mod; uint8_t *mb;
+    wasm_module_inst_t inst = make_instance(&mod, &mb);
+    ASSERT_TRUE(inst != NULL);
+
+    /* three DISTINCT windows (distinct mmaps -> distinct map_base). */
+    HlMappedBuffer *b0 = hl_cap_fs_mmap_window(&cfg, "a.bin", 0, 4096, NULL, NULL);
+    HlMappedBuffer *b1 = hl_cap_fs_mmap_window(&cfg, "a.bin", 8192, 4096, NULL, NULL);
+    HlMappedBuffer *b2 = hl_cap_fs_mmap_window(&cfg, "a.bin", 16384, 4096, NULL, NULL);
+    ASSERT_TRUE(b0 && b1 && b2);
+
+    HlWasmSpanSet set; const char *err = NULL;
+    hl_wasm_span_set_init(&set, 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, b0, &err), 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, b1, &err), 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, b2, &err), 0);
+    ASSERT_EQ(set.count, 3);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 3);
+    ASSERT_EQ(hl_wasm_span_set_attach(&set, inst, &err), 0);
+
+    /* Design B: wasm_addr is the guest LOGICAL base; the accessible windows
+     * [wasm_addr, wasm_addr+len) are non-zero and strictly disjoint. */
+    for (int i = 0; i < 3; i++) ASSERT_TRUE(set.spans[i].wasm_addr != 0);
+    for (int i = 0; i < 3; i++) {
+        uint64_t ai0 = set.spans[i].wasm_addr;
+        uint64_t ai1 = ai0 + set.spans[i].buf->len - 1;
+        for (int j = i + 1; j < 3; j++) {
+            uint64_t aj0 = set.spans[j].wasm_addr;
+            uint64_t aj1 = aj0 + set.spans[j].buf->len - 1;
+            ASSERT_FALSE(ai0 <= aj1 && aj0 <= ai1);
+        }
+    }
+
+    hl_wasm_span_set_teardown(&set);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);
+    hl_cap_fs_munmap(b0); hl_cap_fs_munmap(b1); hl_cap_fs_munmap(b2);
+    free_instance(inst, mod, mb);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── duplicate backing rejected; teardown rolls back cleanly ────────────────── */
+UTEST(wasm_spans, duplicate_rejected)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    uint32_t base = wasm_runtime_shared_heap_count();
+    ASSERT_EQ(write_file("a.bin", 40000), 0);
+    HlMappedBuffer *buf = hl_cap_fs_mmap_window(&cfg, "a.bin", 0, 4096, NULL, NULL);
+    ASSERT_TRUE(buf != NULL);
+
+    HlWasmSpanSet set; const char *err = NULL;
+    hl_wasm_span_set_init(&set, 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, buf, &err), 0);
+    /* same buffer again -> duplicate backing, no second heap, no second borrow. */
+    err = NULL;
+    ASSERT_EQ(hl_wasm_span_set_add(&set, buf, &err), -1);
+    ASSERT_STREQ(err, "duplicate_span");
+    ASSERT_EQ(set.count, 1);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 1);   /* only one heap */
+
+    hl_wasm_span_set_teardown(&set);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);
+    hl_cap_fs_munmap(buf);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── 1 GiB aggregate cap enforced (overflow-safe) ───────────────────────────── */
+UTEST(wasm_spans, cap_enforced)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    uint32_t base = wasm_runtime_shared_heap_count();
+
+    /* a 1 GiB sparse file + a small one. */
+    ASSERT_EQ(make_sparse("big.bin", (off_t)1 << 30), 0);
+    ASSERT_EQ(write_file("b.bin", 8192), 0);
+
+    /* one 1 GiB window fills the cap exactly (== APP_HEAP_SIZE_MAX). */
+    HlMappedBuffer *big =
+        hl_cap_fs_mmap_window(&cfg, "big.bin", 0, (uint64_t)1 << 30, NULL, NULL);
+    ASSERT_TRUE(big != NULL);
+    HlMappedBuffer *small = hl_cap_fs_mmap_window(&cfg, "b.bin", 0, 4096, NULL, NULL);
+    ASSERT_TRUE(small != NULL);
+
+    HlWasmSpanSet set; const char *err = NULL;
+    hl_wasm_span_set_init(&set, 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, big, &err), 0);   /* total == 1 GiB */
+    err = NULL;
+    ASSERT_EQ(hl_wasm_span_set_add(&set, small, &err), -1); /* would exceed cap */
+    ASSERT_STREQ(err, "span_cap");
+    ASSERT_EQ(set.count, 1);
+
+    hl_wasm_span_set_teardown(&set);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);
+    hl_cap_fs_munmap(big); hl_cap_fs_munmap(small);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── close-while-borrowed: the borrow pin defers munmap until teardown ──────── */
+UTEST(wasm_spans, close_while_borrowed)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    ASSERT_EQ(write_file("a.bin", 40000), 0);
+    HlMappedBuffer *buf = hl_cap_fs_mmap_window(&cfg, "a.bin", 8192, 256, NULL, NULL);
+    ASSERT_TRUE(buf != NULL);
+
+    HlWasmSpanSet set; const char *err = NULL;
+    hl_wasm_span_set_init(&set, 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, buf, &err), 0);   /* pins buf */
+    ASSERT_EQ(buf->borrow_count, 1);
+
+    /* close the buffer while the span borrows it: munmap is deferred. */
+    hl_cap_fs_munmap(buf);
+    ASSERT_EQ(buf->pending_free, 1);
+    ASSERT_EQ(buf->closed, 0);
+    ASSERT_EQ((int)((const unsigned char *)buf->addr)[0], (int)(8192 & 0xff));
+
+    /* teardown releases the last borrow -> the deferred munmap + free run now. */
+    hl_wasm_span_set_teardown(&set);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── partial attach failure: second set on an already-attached instance fails;
+ *    teardown rolls back its heaps + borrows ─────────────────────────────────── */
+UTEST(wasm_spans, partial_attach_failure)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    uint32_t base = wasm_runtime_shared_heap_count();
+    ASSERT_EQ(write_file("a.bin", 40000), 0);
+    wasm_module_t mod; uint8_t *mb;
+    wasm_module_inst_t inst = make_instance(&mod, &mb);
+    ASSERT_TRUE(inst != NULL);
+
+    HlMappedBuffer *b0 = hl_cap_fs_mmap_window(&cfg, "a.bin", 0, 4096, NULL, NULL);
+    HlMappedBuffer *b1 = hl_cap_fs_mmap_window(&cfg, "a.bin", 8192, 4096, NULL, NULL);
+    ASSERT_TRUE(b0 && b1);
+
+    HlWasmSpanSet a, b; const char *err = NULL;
+    hl_wasm_span_set_init(&a, 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&a, b0, &err), 0);
+    ASSERT_EQ(hl_wasm_span_set_attach(&a, inst, &err), 0);   /* inst now has a heap */
+
+    /* set B built (heap created, borrowed), attach FAILS (inst already attached). */
+    hl_wasm_span_set_init(&b, 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&b, b1, &err), 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 2);
+    err = NULL;
+    ASSERT_EQ(hl_wasm_span_set_attach(&b, inst, &err), -1);
+    ASSERT_STREQ(err, "attach_failed");
+    ASSERT_EQ(b.inst, NULL);
+    /* teardown B: rolls back its heap + borrow (unchained, un-attached). */
+    hl_wasm_span_set_teardown(&b);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 1);   /* only A's heap left */
+
+    hl_wasm_span_set_teardown(&a);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);
+    hl_cap_fs_munmap(b0); hl_cap_fs_munmap(b1);
+    free_instance(inst, mod, mb);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── owning-thread rule: add/attach from another thread is rejected ─────────── */
+struct wt_arg { HlWasmSpanSet *set; HlMappedBuffer *buf; int add_rc; };
+static void *wt_worker(void *p)
+{
+    struct wt_arg *a = (struct wt_arg *)p;
+    const char *err = NULL;
+    a->add_rc = hl_wasm_span_set_add(a->set, a->buf, &err); /* wrong thread */
+    return NULL;
+}
+UTEST(wasm_spans, owning_thread_enforced)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    ASSERT_EQ(write_file("a.bin", 40000), 0);
+    HlMappedBuffer *buf = hl_cap_fs_mmap_window(&cfg, "a.bin", 0, 4096, NULL, NULL);
+    ASSERT_TRUE(buf != NULL);
+
+    HlWasmSpanSet set;
+    hl_wasm_span_set_init(&set, 0);   /* owner = this thread */
+    struct wt_arg a = { &set, buf, 99 };
+    pthread_t t; ASSERT_EQ(pthread_create(&t, NULL, wt_worker, &a), 0);
+    pthread_join(t, NULL);
+    ASSERT_EQ(a.add_rc, -1);          /* rejected on the wrong thread */
+    ASSERT_EQ(set.count, 0);
+
+    hl_wasm_span_set_teardown(&set);
+    hl_cap_fs_munmap(buf);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── repeated invocations: list count returns to baseline every time (0003) ─── */
+UTEST(wasm_spans, repeated_invocations_baseline)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    uint32_t base = wasm_runtime_shared_heap_count();
+    ASSERT_EQ(write_file("a.bin", 40000), 0);
+    wasm_module_t mod; uint8_t *mb;
+    wasm_module_inst_t inst = make_instance(&mod, &mb);
+    ASSERT_TRUE(inst != NULL);
+
+    for (int r = 0; r < 2000; r++) {
+        HlMappedBuffer *b0 = hl_cap_fs_mmap_window(&cfg, "a.bin", 0, 4096, NULL, NULL);
+        HlMappedBuffer *b1 = hl_cap_fs_mmap_window(&cfg, "a.bin", 8192, 4096, NULL, NULL);
+        ASSERT_TRUE(b0 && b1);
+        HlWasmSpanSet set; const char *err = NULL;
+        hl_wasm_span_set_init(&set, 0);
+        ASSERT_EQ(hl_wasm_span_set_add(&set, b0, &err), 0);
+        ASSERT_EQ(hl_wasm_span_set_add(&set, b1, &err), 0);
+        ASSERT_EQ(hl_wasm_span_set_attach(&set, inst, &err), 0);
+        hl_wasm_span_set_teardown(&set);
+        hl_cap_fs_munmap(b0); hl_cap_fs_munmap(b1);
+        /* the load-bearing invariant: no shared-heap growth per invocation. */
+        ASSERT_EQ(wasm_runtime_shared_heap_count(), base);
+    }
+    free_instance(inst, mod, mb);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── cross-instance isolation: two sets on two instances, independent ───────── */
+UTEST(wasm_spans, cross_instance_isolation)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    uint32_t base = wasm_runtime_shared_heap_count();
+    ASSERT_EQ(write_file("a.bin", 40000), 0);
+    wasm_module_t m0, m1; uint8_t *bb0, *bb1;
+    wasm_module_inst_t i0 = make_instance(&m0, &bb0);
+    wasm_module_inst_t i1 = make_instance(&m1, &bb1);
+    ASSERT_TRUE(i0 && i1);
+
+    HlMappedBuffer *s0 = hl_cap_fs_mmap_window(&cfg, "a.bin", 0, 4096, NULL, NULL);
+    HlMappedBuffer *s1 = hl_cap_fs_mmap_window(&cfg, "a.bin", 8192, 4096, NULL, NULL);
+    ASSERT_TRUE(s0 && s1);
+
+    HlWasmSpanSet set0, set1; const char *err = NULL;
+    hl_wasm_span_set_init(&set0, 0);
+    hl_wasm_span_set_init(&set1, 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set0, s0, &err), 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set1, s1, &err), 0);
+    ASSERT_EQ(hl_wasm_span_set_attach(&set0, i0, &err), 0);
+    ASSERT_EQ(hl_wasm_span_set_attach(&set1, i1, &err), 0);   /* independent */
+
+    /* tear down set0 first; set1 stays valid, then tear it down. */
+    hl_wasm_span_set_teardown(&set0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 1);    /* set1's heap remains */
+    hl_wasm_span_set_teardown(&set1);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);
+
+    hl_cap_fs_munmap(s0); hl_cap_fs_munmap(s1);
+    free_instance(i0, m0, bb0);
+    free_instance(i1, m1, bb1);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── concurrent invocations: N threads each drive their OWN instance + span-set
+ *    build/attach/teardown, racing on the shared heap list. Validated under the
+ *    WAMR-instrumented TSan (make tsan-spans). Final count returns to baseline. ─ */
+#define SPAN_NTHREAD 4
+#define SPAN_NITER   400
+/* Each worker drives its OWN pre-made instance (WAMR's module loader is not
+ * thread-safe -- a global handle_table -- so modules/instances are created on the
+ * main thread; only the span-set lifecycle, which touches the shared_heap_list
+ * under 0003's lock, runs concurrently). */
+struct ci_arg { HlFsConfig *cfg; wasm_module_inst_t inst; int ok; };
+static void *ci_worker(void *p)
+{
+    struct ci_arg *a = (struct ci_arg *)p;
+    a->ok = 1;
+    for (int r = 0; r < SPAN_NITER; r++) {
+        HlMappedBuffer *b0 = hl_cap_fs_mmap_window(a->cfg, "a.bin", 0, 4096, NULL, NULL);
+        HlMappedBuffer *b1 = hl_cap_fs_mmap_window(a->cfg, "a.bin", 8192, 4096, NULL, NULL);
+        if (!b0 || !b1) { a->ok = 0; if (b0) hl_cap_fs_munmap(b0); if (b1) hl_cap_fs_munmap(b1); break; }
+        HlWasmSpanSet set; const char *err = NULL;
+        hl_wasm_span_set_init(&set, 0);
+        if (hl_wasm_span_set_add(&set, b0, &err) != 0
+            || hl_wasm_span_set_add(&set, b1, &err) != 0
+            || hl_wasm_span_set_attach(&set, a->inst, &err) != 0)
+            a->ok = 0;
+        hl_wasm_span_set_teardown(&set);
+        hl_cap_fs_munmap(b0); hl_cap_fs_munmap(b1);
+    }
+    return NULL;
+}
+UTEST(wasm_spans, concurrent_invocations)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    uint32_t base = wasm_runtime_shared_heap_count();
+    ASSERT_EQ(write_file("a.bin", 40000), 0);
+
+    /* pre-create one instance per worker on THIS thread (loader/instantiate are
+     * not thread-safe); each worker then owns exactly one instance. */
+    wasm_module_t mod[SPAN_NTHREAD]; uint8_t *mb[SPAN_NTHREAD];
+    struct ci_arg args[SPAN_NTHREAD];
+    pthread_t th[SPAN_NTHREAD];
+    for (int i = 0; i < SPAN_NTHREAD; i++) {
+        args[i].inst = make_instance(&mod[i], &mb[i]);
+        ASSERT_TRUE(args[i].inst != NULL);
+        args[i].cfg = &cfg; args[i].ok = -1;
+    }
+    for (int i = 0; i < SPAN_NTHREAD; i++)
+        ASSERT_EQ(pthread_create(&th[i], NULL, ci_worker, &args[i]), 0);
+    for (int i = 0; i < SPAN_NTHREAD; i++) pthread_join(th[i], NULL);
+    for (int i = 0; i < SPAN_NTHREAD; i++) ASSERT_EQ(args[i].ok, 1);
+
+    /* every span set was torn down on its own thread -> list back to baseline. */
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);
+    for (int i = 0; i < SPAN_NTHREAD; i++) free_instance(args[i].inst, mod[i], mb[i]);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── zero-span: attach on an empty set is rejected; teardown is a clean no-op ── */
+UTEST(wasm_spans, zero_span)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    uint32_t base = wasm_runtime_shared_heap_count();
+    wasm_module_t mod; uint8_t *mb;
+    wasm_module_inst_t inst = make_instance(&mod, &mb);
+    ASSERT_TRUE(inst != NULL);
+
+    HlWasmSpanSet set; const char *err = NULL;
+    hl_wasm_span_set_init(&set, 0);
+    ASSERT_EQ(hl_wasm_span_set_attach(&set, inst, &err), -1);
+    ASSERT_STREQ(err, "no_spans");
+    hl_wasm_span_set_teardown(&set);          /* empty set: no-op */
+    ASSERT_EQ(set.count, 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);
+
+    free_instance(inst, mod, mb);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── maximum span count (HL_WASM_MAX_SPANS): the (max+1)-th add is rejected ──── */
+UTEST(wasm_spans, max_spans)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    uint32_t base = wasm_runtime_shared_heap_count();
+    long pg = sysconf(_SC_PAGESIZE); if (pg <= 0) pg = 4096;
+    /* one sparse file, MAX+2 page-aligned windows so each has a distinct slot. */
+    ASSERT_EQ(make_sparse("big.bin", (off_t)pg * (HL_WASM_MAX_SPANS + 2)), 0);
+
+    HlMappedBuffer *bufs[HL_WASM_MAX_SPANS + 1];
+    for (int i = 0; i < HL_WASM_MAX_SPANS + 1; i++) {
+        bufs[i] = hl_cap_fs_mmap_window(&cfg, "big.bin", (uint64_t)pg * i, 256,
+                                        NULL, NULL);
+        ASSERT_TRUE(bufs[i] != NULL);
+    }
+
+    HlWasmSpanSet set; const char *err = NULL;
+    hl_wasm_span_set_init(&set, 0);
+    for (int i = 0; i < HL_WASM_MAX_SPANS; i++)
+        ASSERT_EQ(hl_wasm_span_set_add(&set, bufs[i], &err), 0);
+    ASSERT_EQ(set.count, HL_WASM_MAX_SPANS);
+    /* the (max+1)-th add is rejected; no heap/borrow leaks. */
+    err = NULL;
+    ASSERT_EQ(hl_wasm_span_set_add(&set, bufs[HL_WASM_MAX_SPANS], &err), -1);
+    ASSERT_STREQ(err, "too_many_spans");
+    ASSERT_EQ(set.count, HL_WASM_MAX_SPANS);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + HL_WASM_MAX_SPANS);
+
+    ASSERT_EQ(hl_wasm_span_set_teardown(&set), 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);   /* list back to baseline */
+    for (int i = 0; i < HL_WASM_MAX_SPANS; i++)
+        ASSERT_EQ(bufs[i]->borrow_count, 0);             /* borrows back to baseline */
+    ASSERT_EQ(bufs[HL_WASM_MAX_SPANS]->borrow_count, 0); /* the rejected add never borrowed */
+    for (int i = 0; i < HL_WASM_MAX_SPANS + 1; i++) hl_cap_fs_munmap(bufs[i]);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── chain-failure rollback: a chain that fails mid-attach is torn down cleanly.
+ *    Force the failure by attaching one of the set's heaps to a helper instance
+ *    first, so its attached_count != 0 makes wasm_runtime_chain_shared_heaps fail. */
+UTEST(wasm_spans, chain_failure_rollback)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    uint32_t base = wasm_runtime_shared_heap_count();
+    ASSERT_EQ(write_file("a.bin", 40000), 0);
+    wasm_module_t mod, hmod; uint8_t *mb, *hmb;
+    wasm_module_inst_t inst = make_instance(&mod, &mb);
+    wasm_module_inst_t helper = make_instance(&hmod, &hmb);
+    ASSERT_TRUE(inst && helper);
+
+    HlMappedBuffer *b0 = hl_cap_fs_mmap_window(&cfg, "a.bin", 0, 4096, NULL, NULL);
+    HlMappedBuffer *b1 = hl_cap_fs_mmap_window(&cfg, "a.bin", 8192, 4096, NULL, NULL);
+    ASSERT_TRUE(b0 && b1);
+
+    HlWasmSpanSet set; const char *err = NULL;
+    hl_wasm_span_set_init(&set, 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, b0, &err), 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, b1, &err), 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 2);
+
+    /* pin span0's heap onto the helper so the internal chain(span0, span1) fails. */
+    ASSERT_TRUE(wasm_runtime_attach_shared_heap(
+        helper, (wasm_shared_heap_t)set.spans[0].shared_heap));
+    err = NULL;
+    ASSERT_EQ(hl_wasm_span_set_attach(&set, inst, &err), -1);
+    ASSERT_STREQ(err, "chain_failed");
+    ASSERT_EQ(set.inst, NULL);
+
+    /* release span0 from the helper, then teardown rolls the set back to baseline. */
+    wasm_runtime_detach_shared_heap(helper);
+    ASSERT_EQ(hl_wasm_span_set_teardown(&set), 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);   /* list back to baseline */
+    ASSERT_EQ(b0->borrow_count, 0);                       /* borrows back to baseline */
+    ASSERT_EQ(b1->borrow_count, 0);
+
+    hl_cap_fs_munmap(b0); hl_cap_fs_munmap(b1);
+    free_instance(inst, mod, mb);
+    free_instance(helper, hmod, hmb);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── unaligned window: a non-page-aligned file offset (slop > 0). The guest's
+ *    logical base maps to buf->addr and reads the right file bytes. ──────────── */
+UTEST(wasm_spans, unaligned_window)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    ASSERT_EQ(write_file("a.bin", 40000), 0);
+    wasm_module_t mod; uint8_t *mb;
+    wasm_module_inst_t inst = make_instance(&mod, &mb);
+    ASSERT_TRUE(inst != NULL);
+    wasm_exec_env_t env = wasm_runtime_create_exec_env(inst, 16 * 1024);
+    ASSERT_TRUE(env != NULL);
+
+    const uint64_t off = 100; /* deliberately not page-aligned -> slop = 100 */
+    HlMappedBuffer *buf = hl_cap_fs_mmap_window(&cfg, "a.bin", off, 64, NULL, NULL);
+    ASSERT_TRUE(buf != NULL);
+    /* the window really is unaligned: addr = map_base + slop, slop != 0. */
+    ASSERT_TRUE((uintptr_t)buf->addr > (uintptr_t)buf->map_base);
+
+    HlWasmSpanSet set; const char *err = NULL;
+    hl_wasm_span_set_init(&set, 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, buf, &err), 0);
+    ASSERT_EQ(hl_wasm_span_set_attach(&set, inst, &err), 0);
+
+    /* logical base reads file bytes [off..off+4) (pattern byte i == i&0xff). */
+    uint32_t v = 0;
+    ASSERT_TRUE(guest_load(inst, env, set.spans[0].wasm_addr, &v));
+    uint32_t exp = (uint32_t)((off) & 0xff) | (uint32_t)((off + 1) & 0xff) << 8
+                 | (uint32_t)((off + 2) & 0xff) << 16
+                 | (uint32_t)((off + 3) & 0xff) << 24;
+    ASSERT_EQ(v, exp);
+
+    hl_wasm_span_set_teardown(&set);
+    wasm_runtime_destroy_exec_env(env);
+    hl_cap_fs_munmap(buf);
+    free_instance(inst, mod, mb);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── explicit prefix/suffix guest-read rejection: the guest can read the window
+ *    but a read in the slop prefix or the page-rounding suffix traps. ────────── */
+UTEST(wasm_spans, guest_prefix_suffix_reject)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    ASSERT_EQ(write_file("a.bin", 40000), 0);
+    wasm_module_t mod; uint8_t *mb;
+    wasm_module_inst_t inst = make_instance(&mod, &mb);
+    ASSERT_TRUE(inst != NULL);
+    wasm_exec_env_t env = wasm_runtime_create_exec_env(inst, 16 * 1024);
+    ASSERT_TRUE(env != NULL);
+
+    const uint64_t off = 200, len = 64; /* slop = 200, window < reserved slot */
+    HlMappedBuffer *buf = hl_cap_fs_mmap_window(&cfg, "a.bin", off, len, NULL, NULL);
+    ASSERT_TRUE(buf != NULL);
+
+    HlWasmSpanSet set; const char *err = NULL;
+    hl_wasm_span_set_init(&set, 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, buf, &err), 0);
+    ASSERT_EQ(hl_wasm_span_set_attach(&set, inst, &err), 0);
+    uint64_t win = set.spans[0].wasm_addr;   /* guest logical base */
+    uint32_t v = 0;
+
+    /* in-window: last valid i32 reads. */
+    ASSERT_TRUE(guest_load(inst, env, win + len - 4, &v));
+    /* prefix (slop, just below the window) traps. */
+    ASSERT_FALSE(guest_load(inst, env, win - 4, &v));
+    /* suffix (page-rounding padding, just past the window) traps. */
+    ASSERT_FALSE(guest_load(inst, env, win + len, &v));
+
+    hl_wasm_span_set_teardown(&set);
+    wasm_runtime_destroy_exec_env(env);
+    hl_cap_fs_munmap(buf);
+    free_instance(inst, mod, mb);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── EOF-tail: a window that ends mid-page at end of file. Reads within the
+ *    window succeed with no SIGBUS; the suffix (past-EOF page tail) traps. ────── */
+UTEST(wasm_spans, eof_tail)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    const size_t fsize = 100; /* whole file is one partial page */
+    ASSERT_EQ(write_file("a.bin", fsize), 0);
+    wasm_module_t mod; uint8_t *mb;
+    wasm_module_inst_t inst = make_instance(&mod, &mb);
+    ASSERT_TRUE(inst != NULL);
+    wasm_exec_env_t env = wasm_runtime_create_exec_env(inst, 16 * 1024);
+    ASSERT_TRUE(env != NULL);
+
+    HlMappedBuffer *buf = hl_cap_fs_mmap_window(&cfg, "a.bin", 0, fsize, NULL, NULL);
+    ASSERT_TRUE(buf != NULL);
+
+    HlWasmSpanSet set; const char *err = NULL;
+    hl_wasm_span_set_init(&set, 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, buf, &err), 0);
+    ASSERT_EQ(hl_wasm_span_set_attach(&set, inst, &err), 0);
+    uint64_t win = set.spans[0].wasm_addr;
+    uint32_t v = 0;
+
+    /* last valid i32 in the window reads with no SIGBUS. */
+    ASSERT_TRUE(guest_load(inst, env, win + fsize - 4, &v));
+    /* the suffix (rest of the page, past EOF) traps -- the guard blocks it. */
+    ASSERT_FALSE(guest_load(inst, env, win + fsize, &v));
+
+    hl_wasm_span_set_teardown(&set);
+    wasm_runtime_destroy_exec_env(env);
+    hl_cap_fs_munmap(buf);
+    free_instance(inst, mod, mb);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── teardown return status + retry under an INJECTED destroy failure. Pin a
+ *    span's heap onto a helper so wasm_runtime_destroy_shared_heap fails; teardown
+ *    returns -1 and RETAINS the span (heap handle + borrow reachable, not a
+ *    permanent pin). Releasing the helper then lets a retry finish cleanly, with
+ *    both the list count AND the borrow count back to baseline. ──────────────── */
+UTEST(wasm_spans, destroy_failure_retry)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    uint32_t base = wasm_runtime_shared_heap_count();
+    ASSERT_EQ(write_file("a.bin", 40000), 0);
+    wasm_module_t hmod; uint8_t *hmb;
+    wasm_module_inst_t helper = make_instance(&hmod, &hmb);
+    ASSERT_TRUE(helper != NULL);
+
+    HlMappedBuffer *buf = hl_cap_fs_mmap_window(&cfg, "a.bin", 0, 4096, NULL, NULL);
+    ASSERT_TRUE(buf != NULL);
+
+    HlWasmSpanSet set; const char *err = NULL;
+    hl_wasm_span_set_init(&set, 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, buf, &err), 0);
+    ASSERT_EQ(buf->borrow_count, 1);            /* pinned by add */
+
+    /* pin the span's heap onto the helper -> its attached_count != 0 makes destroy
+     * fail-closed (patch 0003). */
+    ASSERT_TRUE(wasm_runtime_attach_shared_heap(
+        helper, (wasm_shared_heap_t)set.spans[0].shared_heap));
+
+    /* teardown cannot destroy the still-attached heap: returns -1, RETAINS it. */
+    ASSERT_EQ(hl_wasm_span_set_teardown(&set), -1);
+    ASSERT_EQ(set.count, 1);                    /* span retained, reachable */
+    ASSERT_TRUE(set.spans[0].shared_heap != NULL);
+    ASSERT_TRUE(set.spans[0].buf == buf);
+    ASSERT_EQ(buf->borrow_count, 1);            /* borrow RETAINED, not released */
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 1); /* heap still on the list */
+
+    /* clear the block, then retry: now destroy succeeds -> full teardown. */
+    wasm_runtime_detach_shared_heap(helper);
+    ASSERT_EQ(hl_wasm_span_set_teardown(&set), 0);
+    ASSERT_EQ(set.count, 0);
+    ASSERT_EQ(buf->borrow_count, 0);            /* borrow back to baseline */
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);
+
+    hl_cap_fs_munmap(buf);
+    free_instance(helper, hmod, hmb);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── wasm32 address accounting: reserved total = sum(map_len), and the reserved
+ *    slots sit at the TOP of the 32-bit space (below UINT32_MAX). ─────────────── */
+UTEST(wasm_spans, addr_accounting_wasm32)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    ASSERT_EQ(write_file("a.bin", 40000), 0);
+    wasm_module_t mod; uint8_t *mb;
+    wasm_module_inst_t inst = make_instance(&mod, &mb);
+    ASSERT_TRUE(inst != NULL);
+    HlMappedBuffer *b0 = hl_cap_fs_mmap_window(&cfg, "a.bin", 0, 4096, NULL, NULL);
+    HlMappedBuffer *b1 = hl_cap_fs_mmap_window(&cfg, "a.bin", 8192, 4096, NULL, NULL);
+    ASSERT_TRUE(b0 && b1);
+
+    HlWasmSpanSet set; const char *err = NULL;
+    hl_wasm_span_set_init(&set, 0 /* wasm32 */);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, b0, &err), 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, b1, &err), 0);
+    ASSERT_EQ(set.total_reserved,
+              (uint64_t)b0->map_len + (uint64_t)b1->map_len);
+    ASSERT_TRUE(set.total_logical < set.total_reserved
+                || set.total_logical == set.total_reserved);
+    ASSERT_EQ(hl_wasm_span_set_attach(&set, inst, &err), 0);
+    /* logical bases are in the top of the 32-bit space and never exceed it. */
+    for (int i = 0; i < 2; i++) {
+        ASSERT_TRUE(set.spans[i].wasm_addr
+                    > (uint64_t)UINT32_MAX - set.total_reserved);
+        ASSERT_TRUE(set.spans[i].wasm_addr + set.spans[i].buf->len - 1
+                    <= (uint64_t)UINT32_MAX);
+    }
+
+    ASSERT_EQ(hl_wasm_span_set_teardown(&set), 0);
+    ASSERT_EQ(b0->borrow_count, 0); ASSERT_EQ(b1->borrow_count, 0);
+    hl_cap_fs_munmap(b0); hl_cap_fs_munmap(b1);
+    free_instance(inst, mod, mb);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── memory64 address accounting: same reserved total, but the address ceiling is
+ *    UINT64_MAX, so the logical bases sit at the TOP of the 64-bit space. The heap
+ *    descriptors are width-agnostic, so the accounting is validated independently
+ *    of guest execution (a mem64 guest needs an AOT mem64 module, out of scope for
+ *    the lifecycle accounting). ──────────────────────────────────────────────── */
+UTEST(wasm_spans, addr_accounting_memory64)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    ASSERT_EQ(write_file("a.bin", 40000), 0);
+    wasm_module_t mod; uint8_t *mb;
+    wasm_module_inst_t inst = make_instance(&mod, &mb);
+    ASSERT_TRUE(inst != NULL);
+    HlMappedBuffer *b0 = hl_cap_fs_mmap_window(&cfg, "a.bin", 0, 4096, NULL, NULL);
+    HlMappedBuffer *b1 = hl_cap_fs_mmap_window(&cfg, "a.bin", 8192, 4096, NULL, NULL);
+    ASSERT_TRUE(b0 && b1);
+
+    HlWasmSpanSet set; const char *err = NULL;
+    hl_wasm_span_set_init(&set, 1 /* memory64 */);
+    ASSERT_EQ(set.is_memory64, 1);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, b0, &err), 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, b1, &err), 0);
+    /* reserved accounting is width-independent. */
+    ASSERT_EQ(set.total_reserved,
+              (uint64_t)b0->map_len + (uint64_t)b1->map_len);
+    ASSERT_EQ(hl_wasm_span_set_attach(&set, inst, &err), 0);
+    /* logical bases are in the top of the 64-bit space (ceiling = UINT64_MAX),
+     * confirming the memory64 ceiling selection independent of wasm32. */
+    for (int i = 0; i < 2; i++) {
+        ASSERT_TRUE(set.spans[i].wasm_addr
+                    > UINT64_MAX - set.total_reserved);
+    }
+
+    ASSERT_EQ(hl_wasm_span_set_teardown(&set), 0);
+    ASSERT_EQ(b0->borrow_count, 0); ASSERT_EQ(b1->borrow_count, 0);
+    hl_cap_fs_munmap(b0); hl_cap_fs_munmap(b1);
+    free_instance(inst, mod, mb);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── AOT span lifecycle: the full add/attach/guest-read/teardown path against a
+ *    wamrc-built AOT instance of the same module, so the span lifecycle + the
+ *    Design B window are exercised under AOT, not only the interpreter. Skips when
+ *    no wamrc-built fixture is present; the wasm-readonly-heap-aot CI job builds
+ *    wamrc and asserts this case is NOT skipped. ──────────────────────────────── */
+UTEST(wasm_spans, aot_span_lifecycle)
+{
+    if (ro_heap_span_aot_len == 0)
+        UTEST_SKIP("no wamrc-built .aot fixture in this build leg");
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    uint32_t hbase = wasm_runtime_shared_heap_count();
+    ASSERT_EQ(write_file("a.bin", 40000), 0);
+
+    wasm_module_t mod; uint8_t *mb;
+    wasm_module_inst_t inst = inst_from(ro_heap_span_aot, ro_heap_span_aot_len, &mod, &mb);
+    ASSERT_TRUE(inst != NULL);
+    wasm_exec_env_t env = wasm_runtime_create_exec_env(inst, 16 * 1024);
+    ASSERT_TRUE(env != NULL);
+
+    const uint64_t off = 100, len = 64; /* unaligned window (slop = 100) */
+    HlMappedBuffer *buf = hl_cap_fs_mmap_window(&cfg, "a.bin", off, len, NULL, NULL);
+    ASSERT_TRUE(buf != NULL);
+
+    HlWasmSpanSet set; const char *err = NULL;
+    hl_wasm_span_set_init(&set, 0);
+    ASSERT_EQ(hl_wasm_span_set_add(&set, buf, &err), 0);
+    ASSERT_EQ(hl_wasm_span_set_attach(&set, inst, &err), 0);
+    uint64_t win = set.spans[0].wasm_addr;
+    uint32_t v = 0;
+
+    /* under AOT: logical base reads the file bytes; prefix + suffix trap. */
+    ASSERT_TRUE(guest_load(inst, env, win, &v));
+    uint32_t exp = (uint32_t)((off) & 0xff) | (uint32_t)((off + 1) & 0xff) << 8
+                 | (uint32_t)((off + 2) & 0xff) << 16
+                 | (uint32_t)((off + 3) & 0xff) << 24;
+    ASSERT_EQ(v, exp);
+    ASSERT_FALSE(guest_load(inst, env, win - 4, &v));       /* slop prefix traps */
+    ASSERT_FALSE(guest_load(inst, env, win + len, &v));     /* suffix traps */
+
+    ASSERT_EQ(hl_wasm_span_set_teardown(&set), 0);
+    ASSERT_EQ(buf->borrow_count, 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), hbase);
+    wasm_runtime_destroy_exec_env(env);
+    hl_cap_fs_munmap(buf);
+    free_instance(inst, mod, mb);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}


### PR DESCRIPTION
## Checkpoint 2 of the mapped-spans feature (#304) — Design B, rebased onto patch 0004

The internal C-level per-invocation attachment lifecycle, now on **Design B** (WAMR patch 0004, merged in #311). **No public surface**: no `spans={}` API, no metadata `host_call`, no SDK header, no Lua/JS bindings — held until this lifecycle passes review. Distinct from `compute.segment` (unchanged, stays full-heap).

### What it does (Design B)
`HlWasmSpanSet` (cap/wasm_spans.{h,c}) attaches a set of read-only mmap windows (`HlMappedBuffer`, checkpoint 1) to a WASM instance for ONE invocation. Each span's shared heap is created over the **whole page-aligned mapping** as the reserved region, with a valid sub-window carved via `valid_offset = addr - map_base` and `valid_size = len` — so the guest reaches **only** `[addr, addr+len)`; the slop prefix and page-rounding suffix trap. Because `reserved = map_len`, the reserved range always sits inside the mmap (a missed guard is an in-mapping over-read, never SIGBUS). Arbitrary file offsets preserved.

- **`add`** validates (count < 16; logical window inside the mapping; overflow-safe 1 GiB logical cap; **reserved bytes tracked separately** and kept under the wasm32/memory64 address ceiling; no duplicate/overlap), pins the buffer, creates the RO heap with `valid_offset`/`valid_size`.
- **`attach`** chains the reserved slots at distinct non-overlapping WASM addresses, records each span's **guest logical base = reserved base + valid_offset** (maps natively to `addr`), asserts reserved slots strictly disjoint, attaches transactionally; partial chain recorded for rollback.
- **`teardown`** on every exit path + partial-build unwind: detach → unchain → destroy (patch 0003) → release, reverse order. **On destroy failure it retains both the heap handle and the mmap borrow** (releasing could munmap memory WAMR still references); only a successful destroy releases the borrow. Zeroes the set; list count returns to baseline.

### Tests (16 cases) + validation
basic lifecycle; multiple disjoint **logical** windows; duplicate/overlap + cap rejection; close-while-pinned deferred munmap; partial-attach **and chain-failure** rollback; owning-thread enforcement; cross-instance isolation; **zero-span**; **maximum span count** (16 + reject 17th); 2000-iteration list-count baseline; concurrent invocations; and the **Design B guest-side checks** through a real WASM instance — **unaligned window** logical base maps to `addr`, and a guest read in the **slop prefix / page-rounding suffix / EOF-tail past-EOF page** traps.

| Gate | Result |
|---|---|
| `make test` | 72/72 suites (incl. compute.segment regression) |
| ASan + UBSan | spans 16/16 |
| WAMR-instrumented TSan | destroy 8/8 + guarded 6/6 + spans 16/16, **0 reports** |
| MSan | Linux-clang CI gate |

Public `spans={}` API, metadata query, SDK header, and runtime bindings remain **blocked** until this lifecycle passes review. Auto-merge not enabled.