### PR TITLE
wasm/js: async resume rejects on a thrown push_result instead of swallowing (#319)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,7 @@ jobs:
         timeout-minutes: 2
         run: make e2e-compute
 
-      - name: Compute async-trap surfacing E2E (Lua, #317)
+      - name: Async-trap surfacing E2E (Lua #317 + JS #319, cross-consumer)
         timeout-minutes: 2
         run: make e2e-compute-async-trap
 

--- a/src/hull/runtime/js/async.c
+++ b/src/hull/runtime/js/async.c
@@ -83,11 +83,31 @@ static void hl_js_async_resume(HlAsyncCont *self, void *driver)
      * (e.g., another http.async.get) can find the active connection */
     js->active_conn = conn;
 
-    /* Resolve the inner promise with the driver result */
+    /* Settle the inner promise with the driver result.
+     *
+     * A push_result may signal a driver-side error two ways:
+     *   1. by THROWING — returning JS_EXCEPTION with a pending exception on ctx
+     *      (compute / db / gpu async: `return JS_ThrowInternalError(...)`), or
+     *   2. by RETURNING an ordinary value that encodes the error
+     *      (worker async resolves with `{ error: msg }`; http/tui resolve with
+     *      undefined/null on their own terms).
+     * Case 2 is the callback's own contract and must reach `resolve` unchanged.
+     * Case 1 must reach `reject`: routing a JS_EXCEPTION through `resolve` FULFILLS
+     * the promise with undefined and silently swallows the error (#319). Detect
+     * the thrown case by the returned value and reject with the real exception so
+     * `await` throws — catchable by the handler, else its promise rejects and the
+     * REJECTED branch below writes a 500. Exactly one of resolve/reject fires. */
     if (driver && jc->push_result) {
         JSValue result = jc->push_result(ctx, driver);
-        JSValue ret = JS_Call(ctx, jc->resolve, JS_UNDEFINED, 1, &result);
-        JS_FreeValue(ctx, ret);
+        if (JS_IsException(result)) {
+            JSValue exc = JS_GetException(ctx); /* retrieve + clear pending */
+            JSValue ret = JS_Call(ctx, jc->reject, JS_UNDEFINED, 1, &exc);
+            JS_FreeValue(ctx, ret);
+            JS_FreeValue(ctx, exc);
+        } else {
+            JSValue ret = JS_Call(ctx, jc->resolve, JS_UNDEFINED, 1, &result);
+            JS_FreeValue(ctx, ret);
+        }
         JS_FreeValue(ctx, result);
     } else {
         JSValue ret = JS_Call(ctx, jc->resolve, JS_UNDEFINED, 0, NULL);

--- a/tests/e2e_compute_async_trap.sh
+++ b/tests/e2e_compute_async_trap.sh
@@ -1,19 +1,23 @@
 #!/bin/sh
-# tests/e2e_compute_async_trap.sh — a Lua compute.async.call whose worker call
-# traps (gas exhaustion / WASM trap / internal error) must SURFACE the error to
-# the yielded handler, not hang the request (issue #317). Before the fix, the
-# error path raised via luaL_error from push_result — which runs BEFORE
-# lua_resume, so the longjmp escaped the resume and stranded the suspended
-# connection (observed HTTP 000). The fix defers the raise to a lua_yieldk
-# continuation that runs INSIDE lua_resume:
-#   - uncaught  -> a clean 500 (not a 000 hang)
-#   - pcall'd   -> the handler recovers and responds 200
+# tests/e2e_compute_async_trap.sh — an async compute call whose worker call traps
+# (gas exhaustion / WASM trap / internal error) must SURFACE the error to the
+# awaiting/yielded handler, not hang it or swallow it. Covers BOTH runtimes:
 #
-# LUA-ONLY on purpose. The JS sibling (`compute.async.call` and other JS async
-# ops) has a SEPARATE bug: the shared JS resume never calls reject, so a worker
-# error is silently swallowed (the promise fulfills with undefined). That is
-# tracked in #319 and will get its own JS coverage when fixed; asserting today's
-# swallow here would bake in wrong behavior.
+#   Lua (#317): push_result raised via luaL_error, which runs BEFORE lua_resume,
+#     so the longjmp escaped the resume and stranded the suspended connection
+#     (HTTP 000). The fix defers the raise to a lua_yieldk continuation that runs
+#     INSIDE lua_resume.
+#   JS (#319): the shared JS resume only ever called `resolve`, so a push_result
+#     that threw (compute/db/gpu return JS_ThrowInternalError) fulfilled the
+#     promise with undefined and silently swallowed the error. The fix detects a
+#     thrown push_result result and routes it to `reject`.
+#
+# Symmetric expectation, both runtimes:
+#   - uncaught -> a clean 500 (not a 000 hang, not a swallowed 200)
+#   - pcall / try-catch -> the handler recovers and responds 200
+#
+# Also asserts the SHARED js/async.c fix generalises beyond compute: a db.async
+# error (a throwing consumer, like compute/gpu) now rejects too (cross-consumer).
 #
 # Persistent-instance async additionally depends on the busy-owner fix (#316,
 # landing via #313). On a base without #316 the first persistent async call is
@@ -35,70 +39,121 @@ cp tests/fixtures/compute/echo.wasm "$TMP/compute/echo.wasm"
 
 cat > "$TMP/app.lua" << 'EOF'
 local compute = require("hull.compute")
-app.manifest({ modules = { "hull/compute@1", "hull/http-server@1", "hull/json@1" } })
+local dbmod   = require("hull.db")
+app.manifest({ modules = { "hull/compute@1", "hull/db@1", "hull/http-server@1", "hull/json@1" } })
 local inst = compute.instance("echo")
--- pooled async, success (baseline)
 app.get("/ok", function(req, res)
     local r = compute.async.call("echo", req.query.t or "x", {})
     res:json({ r = r or "NIL" })
 end)
--- pooled async, uncaught trap -> must be a clean 500, not a 000 hang
 app.get("/trap", function(req, res)
     local r = compute.async.call("echo", "hi", { gas = 1 })
     res:json({ r = r or "NIL" })  -- unreached
 end)
--- pooled async, trap wrapped in pcall -> handler recovers, 200
 app.get("/caught", function(req, res)
     local ok, err = pcall(function()
         return compute.async.call("echo", "hi", { gas = 1 })
     end)
     res:json({ ok = ok, err = ok and "none" or tostring(err) })
 end)
--- persistent async trap -> must not hang (status asserted non-000 only; #316)
 app.get("/pinst", function(req, res)
     local r = inst.async.call("hi", { gas = 1 })
     res:json({ r = r or "NIL" })  -- unreached
 end)
+app.get("/dberr", function(req, res)
+    local ok = pcall(function()
+        return dbmod.default().async.query("SELECT * FROM no_such_table")
+    end)
+    res:json({ ok = ok })
+end)
+EOF
+
+cat > "$TMP/app.js" << 'EOF'
+import { app } from "hull:app";
+import { compute } from "hull:compute";
+import { db as dbmod } from "hull:db";
+app.manifest({ modules: ["hull/compute@1", "hull/db@1", "hull/http-server@1", "hull/json@1"] });
+const dec = (b) => { const u = new Uint8Array(b); let s = ""; for (let i = 0; i < u.length; i++) s += String.fromCharCode(u[i]); return s; };
+const inst = compute.instance("echo");
+app.get("/ok", async (req, res) => {
+    const r = await compute.async.call("echo", req.query.t || "x", {});
+    res.json({ r: r ? dec(r) : "NIL" });
+});
+app.get("/trap", async (req, res) => {
+    const r = await compute.async.call("echo", "hi", { gas: 1 });
+    res.json({ r: "reached" });  // unreached — must reject, not resolve
+});
+app.get("/caught", async (req, res) => {
+    let ok = true, err = "none";
+    try { await compute.async.call("echo", "hi", { gas: 1 }); }
+    catch (e) { ok = false; err = String(e); }
+    res.json({ ok: ok, err: err });
+});
+app.get("/pinst", async (req, res) => {
+    const r = await inst.async.call("hi", { gas: 1 });
+    res.json({ r: "reached" });  // unreached
+});
+app.get("/dberr", async (req, res) => {
+    let ok = true;
+    try { await dbmod.default().async.query("SELECT * FROM no_such_table"); }
+    catch (e) { ok = false; }
+    res.json({ ok: ok });
+});
 EOF
 
 code() { curl -s -o /dev/null --max-time 8 -w "%{http_code}" "$1" 2>/dev/null || echo 000; }
 body() { curl -s --max-time 8 "$1" 2>/dev/null || echo FAIL; }
 
-echo "--- compute.async trap surfacing (lua) ---"
-PORT=$((19820 + $$ % 400))
-"$HULL" -p "$PORT" --no-sandbox "$TMP/app.lua" >"$TMP/srv.log" 2>&1 &
-PID=$!
-sleep 2
-if ! kill -0 $PID 2>/dev/null; then
-    fail "lua server failed to start"; cat "$TMP/srv.log"
-else
+run_rt() {
+    runtime="$1"; ext="$2"
+    echo "--- async trap surfacing (${runtime}) ---"
+    PORT=$((19820 + $$ % 400))
+    "$HULL" -p "$PORT" --no-sandbox -d "$TMP/t_${runtime}.db" "$TMP/app.${ext}" >"$TMP/srv_${runtime}.log" 2>&1 &
+    PID=$!
+    sleep 2
+    if ! kill -0 $PID 2>/dev/null; then fail "${runtime} server failed to start"; cat "$TMP/srv_${runtime}.log"; return; fi
+
     ok=$(body "http://127.0.0.1:$PORT/ok?t=alive")
     trap_code=$(code "http://127.0.0.1:$PORT/trap")
     caught=$(body "http://127.0.0.1:$PORT/caught")
     pinst_code=$(code "http://127.0.0.1:$PORT/pinst")
+    dberr=$(body "http://127.0.0.1:$PORT/dberr")
     kill $PID 2>/dev/null; wait $PID 2>/dev/null
 
     case "$ok" in
-        *'"r":"alive"'*) pass "pooled async success still works" ;;
-        *) fail "pooled async success (got: $ok)" ;;
+        *'"r":"alive"'*) pass "${runtime} pooled async success still works" ;;
+        *) fail "${runtime} pooled async success (got: $ok)" ;;
     esac
-    # The core regression: the trap must NOT hang (000). It surfaces as 500.
+    # The core regression: the trap must NOT hang (000) and NOT resolve (200). 500.
     if [ "$trap_code" = "500" ]; then
-        pass "pooled async uncaught trap -> 500 (no hang)"
+        pass "${runtime} pooled async uncaught trap -> 500 (no hang, not swallowed)"
     else
-        fail "pooled async uncaught trap (want 500, got: $trap_code)"
+        fail "${runtime} pooled async uncaught trap (want 500, got: $trap_code)"
     fi
     case "$caught" in
-        *'"ok":false'*) pass "pooled async trap catchable (pcall -> 200, recovered)" ;;
-        *) fail "pooled async trap catchable (got: $caught)" ;;
+        *'"ok":false'*) pass "${runtime} pooled async trap catchable (pcall/try -> 200, recovered)" ;;
+        *) fail "${runtime} pooled async trap catchable (got: $caught)" ;;
     esac
-    # Persistent path: only assert it does not hang (000). Error text depends on #316.
     if [ "$pinst_code" != "000" ]; then
-        pass "persistent async trap does not hang (code $pinst_code)"
+        pass "${runtime} persistent async trap does not hang (code $pinst_code)"
     else
-        fail "persistent async trap hung (000)"
+        fail "${runtime} persistent async trap hung (000)"
     fi
-fi
+    # Cross-consumer proof for the SHARED js/async.c reject fix: db.async (another
+    # throwing consumer) error is catchable too. JS-only: the JS fix is shared
+    # across all consumers, so one fix covers compute+db+gpu. The Lua side is
+    # per-module (the #317 continuation only landed for compute); Lua db.async /
+    # gpu.async still hang on error -- tracked as #321, not #319.
+    if [ "$runtime" = "js" ]; then
+        case "$dberr" in
+            *'"ok":false'*) pass "${runtime} db.async error is catchable (cross-consumer)" ;;
+            *) fail "${runtime} db.async error catchable (got: $dberr)" ;;
+        esac
+    fi
+}
+
+run_rt "lua" "lua"
+run_rt "js"  "js"
 
 echo ""
 echo "compute-async-trap: ${PASS} passed, ${FAIL} failed"


### PR DESCRIPTION
Fixes #319.

The shared JS async resume (`hl_js_async_resume`) only ever called `jc->resolve`
— `jc->reject` was stored but never invoked. When a driver's `push_result`
signalled an error by **throwing** (returning `JS_EXCEPTION` with a pending
exception, as compute/db/gpu async do via `JS_ThrowInternalError`), the resume
routed that `JS_EXCEPTION` through `resolve`, **fulfilling** the awaited promise
with `undefined` and silently swallowing the error: `await` returned success,
`try/catch` never fired, and an uncaught failure produced a wrong 200.

### Fix
One change, shared across every JS async consumer: after `push_result`, detect a
thrown result with `JS_IsException` and **reject** with the real exception
(`JS_GetException` retrieves + clears the pending one) instead of resolving.
Success and the return-value error conventions are untouched. Exactly one of
resolve/reject fires; the existing REJECTED handler-promise branch already writes
a 500 for an uncaught rejection.

### Consumer audit (all reached through this resume)
| Consumer | error signal | effect of fix |
|---|---|---|
| compute / db / gpu | throw (`JS_ThrowInternalError`) | **now rejects** |
| worker | resolves `{ error: msg }` | unchanged (own contract) |
| http / tui | resolve `undefined`/`null` | unchanged |
| `hull.sleep` | no driver / push_result | unchanged |

### Before / after (JS)
```js
app.get("/trap", async (req, res) => {
  const r = await compute.async.call("echo", "hi", { gas: 1 });  // traps
  res.json({ reached: true });   // before: REACHED (200). after: rejects -> 500
});
```
`try/catch` now catches with the real message
(`InternalError: compute.async.call: call_failed`); db.async likewise
(`db.async: query: no such table: ...`).

### Coverage
`tests/e2e_compute_async_trap.sh` now runs **both runtimes** symmetrically — the
JS legs mirror the Lua #317 cases (uncaught → 500, try/catch → 200 recovered,
success unchanged, persistent no-hang) — plus a JS `db.async` **cross-consumer**
case proving the shared fix generalises beyond compute. Verified under ASan/UBSan
(`test_js` 154/154, e2e 9/9) and TSan worker-pool (`test_wasm`,
`test_async_backend`, `test_async_backend_poll` — 0 races).

### Exactly-once / cleanup
- success → `resolve` once; worker error → `reject` once (resolve not called);
  cancel → neither, both freed (unchanged path); detached → same resume function,
  fix applies. Both `resolve`/`reject` freed after settling; the retrieved
  exception is freed.

### Scope notes
- **JS-only.** The Lua counterpart for `db.async` / `gpu.async` still hangs on
  error — the #317 continuation fix was compute-only; each Lua module needs its
  own continuation. Tracked as **#321** (the Lua `db.async` e2e leg here is
  therefore not asserted). This PR does not touch Lua.
