### PR TITLE
wasm: classify WAMR "instruction limit exceeded" as gas exhaustion (#314)

### DIFF
--- a/src/hull/cap/wasm.c
+++ b/src/hull/cap/wasm.c
@@ -70,6 +70,19 @@ static const char *wasm_arch_suffix(void)
 #endif
 }
 
+/* Classify a WAMR call exception as gas exhaustion. WAMR surfaces the
+ * instruction-metering trap as an exception string, and the wording has drifted
+ * across versions: the vendored WAMR (2.4.1) emits "instruction limit exceeded",
+ * older builds used "instruction count". Match either token so a gas trap maps
+ * to HL_WASM_ERR_GAS regardless of wording (WAMR exposes no gas-specific error
+ * enum to key off instead). Both call paths route through here so the two stay
+ * in lockstep. */
+static int wasm_is_gas_exception(const char *exc)
+{
+    return exc && (strstr(exc, "instruction limit") ||
+                   strstr(exc, "instruction count"));
+}
+
 /* ── Thread-local callback context for host_call ───────────────────── */
 
 typedef struct {
@@ -909,7 +922,7 @@ int hl_cap_wasm_call_buf(HlWasmCache *cache, const char *name,
 
     if (!wasm_runtime_call_wasm(exec_env, process_fn, (uint32_t)argc, argv)) {
         const char *exception = wasm_runtime_get_exception(inst);
-        if (exception && strstr(exception, "instruction count")) {
+        if (wasm_is_gas_exception(exception)) {
             log_warn("[wasm] gas exhausted for '%s'", name);
             if (err_msg) *err_msg = err_gas;
             ret = HL_WASM_ERR_GAS;
@@ -1234,7 +1247,7 @@ int hl_cap_wasm_instance_call_buf(HlWasmInstance *pi,
 
     if (!wasm_runtime_call_wasm(exec_env, process_fn, (uint32_t)argc_call, argv)) {
         const char *exception = wasm_runtime_get_exception(inst);
-        if (exception && strstr(exception, "instruction count")) {
+        if (wasm_is_gas_exception(exception)) {
             if (err_msg) *err_msg = err_gas;
             ret = HL_WASM_ERR_GAS;
         } else {

--- a/tests/hull/cap/test_wasm.c
+++ b/tests/hull/cap/test_wasm.c
@@ -398,8 +398,13 @@ UTEST(hl_cap_wasm, gas_exhaustion)
                                &output, &output_len,
                                &opts, NULL, NULL,
                                &vfs, NULL, NULL, &err);
-    /* Gas exhaustion should cause a call failure */
-    ASSERT_NE(rc, 0);
+    /* Gas exhaustion must classify as HL_WASM_ERR_GAS + "gas_exhausted", not a
+     * generic call failure. Regression for #314: WAMR 2.4.1 emits "instruction
+     * limit exceeded" (older builds said "instruction count"); the classifier
+     * must match either. */
+    ASSERT_EQ(rc, HL_WASM_ERR_GAS);
+    ASSERT_TRUE(err != NULL);
+    ASSERT_STREQ(err, "gas_exhausted");
 
     free(output);
     hl_cap_wasm_destroy(&cache);
@@ -1376,7 +1381,10 @@ UTEST(hl_cap_wasm, instance_gas_recovery)
     int rc = hl_cap_wasm_instance_call(pi, "x", 1,
                                         &output, &output_len,
                                         &low_gas, NULL, NULL, NULL, &err);
-    ASSERT_NE(rc, HL_WASM_OK);
+    /* Instance path must classify gas exhaustion the same way (#314). */
+    ASSERT_EQ(rc, HL_WASM_ERR_GAS);
+    ASSERT_TRUE(err != NULL);
+    ASSERT_STREQ(err, "gas_exhausted");
 
     /* Now with normal gas — should succeed (instance reusable) */
     HlWasmCallOpts normal_gas = {0};


### PR DESCRIPTION
Fixes #314.

Both WASM call paths (`hl_cap_wasm_call_buf`, `hl_cap_wasm_instance_call_buf`)
classified a gas-metering trap by matching only the WAMR exception substring
`"instruction count"`. The vendored WAMR (2.4.1) actually emits **`"instruction
limit exceeded"`**, so a gas trap was misclassified as `call_failed`
(`HL_WASM_ERR_INTERNAL`, -5) instead of `gas_exhausted` (`HL_WASM_ERR_GAS`, -2).
Callers branching on the gas code/string never saw it. Cleanup/unwind was
unaffected — purely classification.

### Fix
Route both sites through a shared `wasm_is_gas_exception()` that matches **either**
`"instruction limit"` or `"instruction count"`, so classification is
wording-tolerant and the two paths stay in lockstep. WAMR exposes no gas-specific
error enum to key off instead; the single helper keeps a future wording change to
one edit.

### Tests
The two existing gas tests were deliberately loose (`rc != OK`) *because of this
bug*; tightened to the exact contract:
- `gas_exhaustion` (pooled): `rc == HL_WASM_ERR_GAS` **and** `err == "gas_exhausted"`
- `instance_gas_recovery` (persistent): same on the low-gas call, instance still recovers

`test_wasm` 58/58; `e2e-compute` 20/20; `e2e-compute-async-trap` 9/9 (the compute
async trap now surfaces as `gas_exhausted`, still a clean 500 / `pcall`/`try`-catchable).

### Scope
Small, self-contained; independent of #313 and #321. Does not touch Lua db/gpu
async (that hang is #321).
