### PR TITLE
wasm: destroy segment shared-heap descriptors on teardown (#315)

### DIFF
--- a/docs/wasm_mapped_spans_checkpoint3.md
+++ b/docs/wasm_mapped_spans_checkpoint3.md
@@ -1,14 +1,20 @@
 # Mapped spans — checkpoint 3 plan (public API, metadata delivery, SDK header)
 
-**Status:** PLAN. Turns the reviewed internal lifecycle (checkpoint 2 —
-`cap/wasm_spans.c` `HlWasmSpanSet` + WAMR patch 0004 guarded-subrange RO shared
-heaps, PR #309) into a usable feature: `compute.call(..., {spans={...}})` lets a
-WASM plugin read host-mapped file windows at native speed, learning each window's
-address via a versioned host-call query, with a safe SDK header.
+**Status:** DONE (cut 1). This document was the plan; both cuts have shipped.
+3a (windowed `fs.mmap`, named spans, `spans={}` bindings, invocation lifecycle
+integration, the `SPAN_INFO` host-call — the D1/D2 locks below) merged via #313 /
+#324 / #325 / #327 / #330 / #332 and the shared-heap AOT enablement (#326/#329);
+3b (the `hull/wasm/span.h` SDK header shipped as `templates/hull_span.h`, the
+`spanreader` example, header install/refresh, the interp+AOT e2e legs, and the
+native-vs-WASM differential) merged via #324 and the follow-ups. The AOT span
+lifecycle + differential are CI must-not-skip gates. Deferred, tracked, non-goals:
+spans+segments composition in one call (D0.1 below), Memory64 span-metadata
+dispatch (blocked on #318), and the orthogonal segment shared-heap descriptor leak
+(#315, fixed separately). The turns-the-lifecycle-into-a-feature framing below is
+retained as the design record.
 
-**Blocked on:** PR #309 (checkpoint 2) green + merged. No checkpoint-3 code lands
-before that. This document locks the two design decisions (§0) so 3a can start the
-instant #309 merges.
+**Was blocked on (resolved):** PR #309 (checkpoint 2) green + merged. This document
+locked the two design decisions (§0) so 3a could start the instant #309 merged.
 
 Reference: `docs/wasm_mapped_spans_design.md` (the WHAT — §§3.3, 3.5, 3.7),
 `docs/wamr_shared_heap_guarded_subrange_design.md` (Design B / patch 0004),

--- a/include/hull/cap/wasm_data.h
+++ b/include/hull/cap/wasm_data.h
@@ -20,11 +20,17 @@
  * Must be called under mod->mutex. Drains pool first. */
 int hl_wasm_rebuild_chain(HlWasmModule *mod);
 
-/* Free a single segment's resources (heap + backing if owned). */
-void hl_wasm_free_segment(HlWasmDataSegment *seg);
+/* Free a single segment's resources: destroy the shared-heap descriptor, then
+ * (only on success) release Hull-owned backing and clear the slot. Returns 0 when
+ * fully reclaimed, or -1 when descriptor destruction failed -- in which case the
+ * descriptor, backing, and metadata are all RETAINED (never a dangling descriptor)
+ * and the caller must keep the slot + any MappedBuffer pin. */
+int hl_wasm_free_segment(HlWasmDataSegment *seg);
 
-/* Free all shared data for a module. Caller holds mod->mutex. */
-void hl_wasm_free_shared_data(HlWasmModule *mod);
+/* Free all shared data for a module. Caller holds mod->mutex. Returns 0 when every
+ * segment was reclaimed (shared_data freed), or -1 when one or more descriptors
+ * could not be destroyed and were retained (shared_data kept alive). */
+int hl_wasm_free_shared_data(HlWasmModule *mod);
 
 /* Attach shared data chain to a WASM instance.
  * chain_head must be snapshotted under mod->mutex. */

--- a/src/hull/cap/wasm.c
+++ b/src/hull/cap/wasm.c
@@ -329,6 +329,17 @@ void hl_wasm_pool_drain(HlWasmPool *pool)
 {
     for (int i = 0; i < pool->count; i++) {
         HlWasmPoolEntry *e = &pool->entries[i];
+        /* Detach any attached shared heap (the module's segment chain) BEFORE
+         * deinstantiate. WAMR's deinstantiate does NOT auto-detach, so the
+         * chain-head heap's attached_count would otherwise stay inflated by every
+         * drained-but-attached instance -- and both wasm_runtime_unchain_shared_heaps
+         * and the patch-0003 wasm_runtime_destroy_shared_heap require
+         * attached_count == 0. Detaching here makes the count return to 0 whenever a
+         * segment mutation drains the pool, so the teardown in
+         * hl_wasm_free_segment / hl_wasm_free_shared_data can actually reclaim the
+         * descriptor. No-op for instances with nothing attached (fresh, or a
+         * span instance already detached by its per-call teardown). */
+        wasm_runtime_detach_shared_heap((wasm_module_inst_t)e->instance);
         wasm_runtime_destroy_exec_env((wasm_exec_env_t)e->exec_env);
         wasm_runtime_deinstantiate((wasm_module_inst_t)e->instance);
     }
@@ -1259,6 +1270,8 @@ HlWasmInstance *hl_cap_wasm_instance_create(HlWasmCache *cache,
     if (!pi) {
         if (err_msg) *err_msg = err_internal;
         wasm_runtime_destroy_exec_env(exec_env);
+        /* detach the chain attached just above before tearing the instance down */
+        wasm_runtime_detach_shared_heap(inst);
         wasm_runtime_deinstantiate(inst);
         return NULL;
     }
@@ -1635,8 +1648,17 @@ void hl_cap_wasm_instance_destroy(HlWasmInstance *pi)
 
     if (pi->exec_env)
         wasm_runtime_destroy_exec_env((wasm_exec_env_t)pi->exec_env);
-    if (pi->instance)
+    if (pi->instance) {
+        /* Detach any attached shared heap (the module's segment chain) BEFORE
+         * deinstantiate -- a persistent instance attaches the chain at creation
+         * and, like a pooled instance, is never auto-detached by deinstantiate.
+         * Leaving it attached keeps the chain head's attached_count > 0, which
+         * makes the later hl_wasm_free_shared_data destroy fail and RETAIN the
+         * whole HlWasmSharedData (a leak). Mirrors hl_wasm_pool_drain. No-op when
+         * nothing is attached. */
+        wasm_runtime_detach_shared_heap((wasm_module_inst_t)pi->instance);
         wasm_runtime_deinstantiate((wasm_module_inst_t)pi->instance);
+    }
 
     pi->exec_env   = NULL;
     pi->instance   = NULL;

--- a/src/hull/cap/wasm_data.c
+++ b/src/hull/cap/wasm_data.c
@@ -109,42 +109,85 @@ int hl_wasm_rebuild_chain(HlWasmModule *mod)
     return 0;
 }
 
-void hl_wasm_free_segment(HlWasmDataSegment *seg)
+int hl_wasm_free_segment(HlWasmDataSegment *seg)
 {
+    /* Reclaim WAMR's shared-heap descriptor (patch 0003,
+     * wasm_runtime_destroy_shared_heap) FIRST, then release the backing -- the
+     * ORDER matters. Its preconditions (detached, attached_count == 0, and
+     * unchained) are established by the callers: every segment teardown path
+     * drains the pool first (hl_wasm_pool_drain detaches) and unchains a
+     * multi-segment chain before calling this.
+     *
+     * On destroy FAILURE (unexpected after detach + unchain) RETAIN EVERYTHING and
+     * return -1: the descriptor stays on WAMR's list, and it still references the
+     * backing, so the backing MUST NOT be freed -- unmapping it (or, for is_mmap
+     * backing, letting the caller drop its MappedBuffer pin) would leave a live
+     * descriptor pointing at freed/unmapped memory (a UAF). This mirrors the span
+     * teardown's retain-on-destroy-failure rule (cap/wasm_spans.c): keep the heap
+     * handle AND the backing so cleanup can be retried, or deferred to
+     * wasm_runtime_destroy(). The caller propagates the -1 (keeps the slot + the
+     * MappedBuffer pin). Only a SUCCESSFUL destroy releases the backing. */
+    if (seg->shared_heap) {
+        if (!wasm_runtime_destroy_shared_heap(
+                (wasm_shared_heap_t)seg->shared_heap)) {
+            log_error("[wasm] segment shared-heap destroy failed; retaining "
+                      "descriptor + backing (deferred to runtime teardown)");
+            return -1; /* retain descriptor, backing, and metadata */
+        }
+        seg->shared_heap = NULL;
+    }
+
+    /* Descriptor reclaimed (or was never created) -> safe to release the backing.
+     * Only Hull-owned (copied) backing is unmapped here; zero-copy pre_alloc'd
+     * (is_mmap) backing is the caller's MappedBuffer, whose pin the binding drops
+     * once this returns 0. */
     if (!seg->is_mmap && seg->host_addr) {
         munmap(seg->host_addr, seg->alloc_size);
         seg->host_addr = NULL;
     }
-    /* WAMR has no public API to destroy individual shared heaps.
-     * The WASMSharedHeap struct (~64 bytes) is freed globally on
-     * wasm_runtime_destroy(). For pre-allocated heaps (our case),
-     * WAMR does not own the backing memory — we freed it above. */
-    seg->shared_heap = NULL;
     seg->size = 0;
     seg->wasm_addr = 0;
     seg->name[0] = '\0';
+    return 0;
 }
 
-void hl_wasm_free_shared_data(HlWasmModule *mod)
+int hl_wasm_free_shared_data(HlWasmModule *mod)
 {
     if (!mod->shared_data)
-        return;
+        return 0;
 
     HlWasmSharedData *sd = mod->shared_data;
 
-    /* Unchain all heaps first */
+    /* Unchain all heaps first (so every heap is standalone -> destroyable). */
     if (sd->chain_head && sd->count > 1) {
         wasm_runtime_unchain_shared_heaps(
             (wasm_shared_heap_t)sd->chain_head, true);
     }
-
-    for (int i = 0; i < sd->count; i++)
-        hl_wasm_free_segment(&sd->segments[i]);
-
-    sd->count = 0;
     sd->chain_head = NULL;
-    free(sd);
-    mod->shared_data = NULL;
+
+    /* Destroy each. RETAIN (compact to the front) any segment whose descriptor
+     * could not be destroyed, so its still-live descriptor keeps referencing
+     * backing that stays mapped/pinned -- never a dangling descriptor. */
+    int w = 0;
+    for (int i = 0; i < sd->count; i++) {
+        if (hl_wasm_free_segment(&sd->segments[i]) != 0) {
+            if (w != i)
+                sd->segments[w] = sd->segments[i];
+            w++;
+        }
+    }
+    for (int i = w; i < sd->count; i++)
+        memset(&sd->segments[i], 0, sizeof(sd->segments[i]));
+    sd->count = w;
+
+    if (w == 0) {
+        free(sd);
+        mod->shared_data = NULL;
+        return 0;
+    }
+    /* Some retained: keep shared_data alive (segments + their pins survive) so a
+     * later teardown can retry; wasm_runtime_destroy() reclaims the rest. */
+    return -1;
 }
 
 void hl_wasm_attach_shared_heap(void *inst, void *chain_head)
@@ -248,8 +291,15 @@ int hl_cap_wasm_data_load(HlWasmCache *cache, const char *module_name,
     /* Case 1: segment_name==NULL && data==NULL → remove all segments */
     if (!segment_name && !data) {
         hl_wasm_pool_drain(&mod->pool);
-        hl_wasm_free_shared_data(mod);
+        int frc = hl_wasm_free_shared_data(mod);
         pthread_mutex_unlock(&mod->mutex);
+        if (frc != 0) {
+            /* One or more descriptors could not be destroyed; retained (with their
+             * backing/pins) rather than left dangling. Report failure so a
+             * MappedBuffer-backed segment keeps its binding pin. */
+            if (err_msg) *err_msg = err_internal;
+            return -1;
+        }
         log_debug("[wasm] removed all shared data for '%s'", module_name);
         return 0;
     }
@@ -274,20 +324,29 @@ int hl_cap_wasm_data_load(HlWasmCache *cache, const char *module_name,
             HlWasmSharedData *sd = mod->shared_data;
             for (int i = 0; i < sd->count; i++) {
                 if (strcmp(sd->segments[i].name, segment_name) == 0) {
-                    /* Unchain before removing */
+                    /* Drain FIRST so the chain is detached (attached_count -> 0),
+                     * a precondition for both the unchain and the per-heap destroy
+                     * below. Then unchain (a multi-segment chain) so every heap is
+                     * standalone, then free (which destroys the removed heap). */
+                    hl_wasm_pool_drain(&mod->pool);
                     if (sd->chain_head && sd->count > 1) {
                         wasm_runtime_unchain_shared_heaps(
                             (wasm_shared_heap_t)sd->chain_head, true);
                         sd->chain_head = NULL;
                     }
-                    hl_wasm_free_segment(&sd->segments[i]);
-                    /* Compact: shift remaining segments */
-                    for (int j = i; j < sd->count - 1; j++)
-                        sd->segments[j] = sd->segments[j + 1];
-                    sd->count--;
-                    memset(&sd->segments[sd->count], 0, sizeof(HlWasmDataSegment));
-
-                    hl_wasm_pool_drain(&mod->pool);
+                    int frc = hl_wasm_free_segment(&sd->segments[i]);
+                    if (frc == 0) {
+                        /* Compact: shift remaining segments */
+                        for (int j = i; j < sd->count - 1; j++)
+                            sd->segments[j] = sd->segments[j + 1];
+                        sd->count--;
+                        memset(&sd->segments[sd->count], 0,
+                               sizeof(HlWasmDataSegment));
+                    }
+                    /* Rebuild the chain over whatever segments remain. On a retained
+                     * destroy failure the target stays LIVE in the array (its
+                     * descriptor + backing are intact), so it is re-chained too --
+                     * never dropped while its descriptor is on WAMR's list. */
                     if (sd->count > 0)
                         hl_wasm_rebuild_chain(mod);
                     else {
@@ -295,6 +354,12 @@ int hl_cap_wasm_data_load(HlWasmCache *cache, const char *module_name,
                         mod->shared_data = NULL;
                     }
                     pthread_mutex_unlock(&mod->mutex);
+                    if (frc != 0) {
+                        /* Descriptor retained (backing + MappedBuffer pin kept).
+                         * Report failure so the binding does not drop the pin. */
+                        if (err_msg) *err_msg = err_internal;
+                        return -1;
+                    }
                     log_debug("[wasm] removed segment '%s' from '%s'",
                               segment_name, module_name);
                     return 0;
@@ -355,6 +420,12 @@ int hl_cap_wasm_data_load(HlWasmCache *cache, const char *module_name,
         return -1;
     }
 
+    /* Drain the pool FIRST: it detaches the current chain (attached_count -> 0),
+     * a precondition for the unchain and for destroying the replaced slot's heap
+     * below. Held under mod->mutex, so the pool stays empty through the rebuild
+     * (no call can acquire), making the later re-drain unnecessary. */
+    hl_wasm_pool_drain(&mod->pool);
+
     /* Unchain existing chain before modifying */
     if (sd->chain_head && sd->count > 1) {
         wasm_runtime_unchain_shared_heaps(
@@ -362,9 +433,19 @@ int hl_cap_wasm_data_load(HlWasmCache *cache, const char *module_name,
         sd->chain_head = NULL;
     }
 
-    /* Free old segment at slot if replacing */
-    if (slot < sd->count && sd->segments[slot].shared_heap)
-        hl_wasm_free_segment(&sd->segments[slot]);
+    /* Free old segment at slot if replacing (destroys its heap; detached above).
+     * If the descriptor cannot be destroyed it is RETAINED live -- abort the
+     * replace rather than overwrite the slot, which would strand the old
+     * descriptor on WAMR's list pointing at soon-to-be-freed backing. Re-chain the
+     * retained segments and report failure so the binding keeps the old pin. */
+    if (slot < sd->count && sd->segments[slot].shared_heap) {
+        if (hl_wasm_free_segment(&sd->segments[slot]) != 0) {
+            hl_wasm_rebuild_chain(mod);
+            pthread_mutex_unlock(&mod->mutex);
+            if (err_msg) *err_msg = err_internal;
+            return -1;
+        }
+    }
 
     /* Create backing memory.
      * WAMR requires pre_allocated_addr regions to be page-aligned in size.
@@ -440,18 +521,21 @@ int hl_cap_wasm_data_load(HlWasmCache *cache, const char *module_name,
     if (slot == sd->count)
         sd->count++;
 
-    /* Rebuild chain and drain pool */
-    hl_wasm_pool_drain(&mod->pool);
+    /* Rebuild chain (pool already drained above, still empty under mod->mutex) */
     int chain_rc = hl_wasm_rebuild_chain(mod);
 
     if (chain_rc != 0) {
-        /* Rollback: remove the segment we just added */
-        hl_wasm_free_segment(seg);
-        if (slot == sd->count - 1)
-            sd->count--;
-        if (sd->count == 0) {
-            free(sd);
-            mod->shared_data = NULL;
+        /* Rollback: destroy the segment we just added. If its descriptor cannot be
+         * destroyed (retained -> non-zero), keep the slot so nothing frees the
+         * backing the live descriptor still references; only drop the slot on a
+         * clean destroy. */
+        if (hl_wasm_free_segment(seg) == 0) {
+            if (slot == sd->count - 1)
+                sd->count--;
+            if (sd->count == 0) {
+                free(sd);
+                mod->shared_data = NULL;
+            }
         }
         pthread_mutex_unlock(&mod->mutex);
         if (err_msg) *err_msg = err_internal;

--- a/tests/hull/cap/test_wasm_spans.c
+++ b/tests/hull/cap/test_wasm_spans.c
@@ -1066,13 +1066,203 @@ UTEST(wasm_spans, d2_segment_race_concurrency)
      * every span borrow was released -- so the D1 decision could not race the
      * segment mutation (mod->mutex serialises the read against the write), and no
      * span leaked under contention. TSan (make tsan-spans) covers the data-race
-     * dimension. (A final shared-heap-count baseline is intentionally NOT asserted
-     * here: the segment path leaks its heap descriptors until runtime teardown --
-     * hl_wasm_free_segment predates patch 0003's per-heap destroy -- so the
-     * mutator's churn inflates the count independently of spans. Span
-     * teardown-to-baseline is proven by d2_success / d2_pooled_reuse.) */
+     * dimension. The mutator loop ends on a "remove", and all worker threads are
+     * joined, so the runtime is quiescent with no segment installed and no span in
+     * flight: since #315 the segment path also destroys its heap descriptors
+     * (hl_wasm_free_segment via the drain-detach ordering), so the shared-heap
+     * count is back to baseline -- the churn no longer leaks. */
     for (int i = 0; i < D2R_NTHREAD; i++) ASSERT_EQ(args[i].ok, 1);
-    (void)base;
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);
+
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── #315: the compute.segment path destroys its shared-heap descriptors on every
+ *    teardown path, so the shared-heap-list count returns to baseline across
+ *    load / remove / replace / remove-all / unload -- including after a call has
+ *    attached the chain to a (now drained + detached) pooled instance. Purely
+ *    single-threaded + deterministic, unlike d2_segment_race_concurrency. ─────── */
+UTEST(wasm_spans, segment_lifecycle_baseline)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    HlVfs vfs; hl_vfs_init(&vfs, span_call_entries, NULL);
+    ASSERT_EQ(hl_cap_wasm_load(&cache, "echo", &vfs, NULL), 0);
+    uint32_t base = wasm_runtime_shared_heap_count();
+    static const unsigned char seg[16]  = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    static const unsigned char seg2[16] = { 9, 8, 7, 6, 5, 4, 3, 2 };
+    const char *derr = NULL;
+
+    /* A. load one segment, run a plain call (attaches the chain to a pooled
+     *    instance), then remove -> the drain detaches and free destroys. */
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "echo", "graph", seg, sizeof(seg),
+                                    NULL, &vfs, NULL, &derr), 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 1);
+    {
+        void *out = NULL; size_t out_len = 0; const char *err = NULL;
+        int rc = hl_cap_wasm_call(&cache, "echo", "x", 1, &out, &out_len,
+                                  NULL, NULL, NULL, &vfs, NULL, NULL, &err);
+        ASSERT_EQ(rc, HL_WASM_OK);
+        free(out);
+    }
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 1); /* call did not leak */
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "echo", "graph", NULL, 0,
+                                    NULL, &vfs, NULL, &derr), 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);     /* descriptor reclaimed */
+
+    /* B. load / remove churn: back to baseline every cycle (no monotonic growth). */
+    for (int i = 0; i < 10; i++) {
+        ASSERT_EQ(hl_cap_wasm_data_load(&cache, "echo", "g", seg, sizeof(seg),
+                                        NULL, &vfs, NULL, &derr), 0);
+        ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 1);
+        ASSERT_EQ(hl_cap_wasm_data_load(&cache, "echo", "g", NULL, 0,
+                                        NULL, &vfs, NULL, &derr), 0);
+        ASSERT_EQ(wasm_runtime_shared_heap_count(), base);
+    }
+
+    /* C. replace (same name, new data): the old heap is destroyed, one new heap
+     *    created -> net +1, never +2. */
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "echo", "graph", seg, sizeof(seg),
+                                    NULL, &vfs, NULL, &derr), 0);
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "echo", "graph", seg2, sizeof(seg2),
+                                    NULL, &vfs, NULL, &derr), 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 1); /* replaced, not doubled */
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "echo", "graph", NULL, 0,
+                                    NULL, &vfs, NULL, &derr), 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);
+
+    /* D. three segments (a chain), a call to attach the chain head, then
+     *    remove-all (segment_name==NULL && data==NULL) -> unchain + destroy all. */
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "echo", "a", seg, sizeof(seg),
+                                    NULL, &vfs, NULL, &derr), 0);
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "echo", "b", seg, sizeof(seg),
+                                    NULL, &vfs, NULL, &derr), 0);
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "echo", "c", seg, sizeof(seg),
+                                    NULL, &vfs, NULL, &derr), 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 3);
+    {
+        void *out = NULL; size_t out_len = 0; const char *err = NULL;
+        int rc = hl_cap_wasm_call(&cache, "echo", "x", 1, &out, &out_len,
+                                  NULL, NULL, NULL, &vfs, NULL, NULL, &err);
+        ASSERT_EQ(rc, HL_WASM_OK);
+        free(out);
+    }
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "echo", NULL, NULL, 0,
+                                    NULL, &vfs, NULL, &derr), 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);     /* whole chain reclaimed */
+
+    /* E. reload a chain, then unload the module's shared data (hl_cap_wasm_data_unload)
+     *    -> same drain + free_shared_data path -> baseline. */
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "echo", "a", seg, sizeof(seg),
+                                    NULL, &vfs, NULL, &derr), 0);
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "echo", "b", seg, sizeof(seg),
+                                    NULL, &vfs, NULL, &derr), 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 2);
+    hl_cap_wasm_data_unload(&cache, "echo");
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);
+
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── #315: the destroy-FAILURE branch of the segment teardown. Pin a segment's
+ *    heap onto a helper instance so wasm_runtime_destroy_shared_heap fails; the
+ *    remove then RETAINS the descriptor + backing (never munmaps behind a live
+ *    descriptor) and reports failure so the binding keeps its MappedBuffer pin.
+ *    Clearing the block lets a retry finish cleanly, back to baseline. This is the
+ *    path the normal/TSan/ASan matrix does not otherwise exercise. ────────────── */
+UTEST(wasm_spans, segment_destroy_failure_retain)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    HlVfs vfs; hl_vfs_init(&vfs, span_call_entries, NULL);
+    ASSERT_EQ(hl_cap_wasm_load(&cache, "echo", &vfs, NULL), 0);
+    uint32_t base = wasm_runtime_shared_heap_count();
+
+    wasm_module_t hmod; uint8_t *hmb;
+    wasm_module_inst_t helper = make_instance(&hmod, &hmb);
+    ASSERT_TRUE(helper != NULL);
+
+    static const unsigned char seg[16] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    const char *derr = NULL;
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "echo", "graph", seg, sizeof(seg),
+                                    NULL, &vfs, NULL, &derr), 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 1);
+
+    /* Reach the segment's heap and pin it onto the helper -> attached_count != 0
+     * makes the patch-0003 destroy fail-closed. */
+    HlWasmModule *m = hl_cap_wasm_module_lookup(&cache, "echo");
+    ASSERT_TRUE(m != NULL && m->shared_data != NULL && m->shared_data->count == 1);
+    wasm_shared_heap_t sh =
+        (wasm_shared_heap_t)m->shared_data->segments[0].shared_heap;
+    ASSERT_TRUE(sh != NULL);
+    ASSERT_TRUE(wasm_runtime_attach_shared_heap(helper, sh));
+
+    /* Remove cannot destroy the still-attached heap: reports failure and RETAINS
+     * the segment (descriptor still on the list, slot kept, backing not freed). */
+    derr = NULL;
+    int rc = hl_cap_wasm_data_load(&cache, "echo", "graph", NULL, 0,
+                                   NULL, &vfs, NULL, &derr);
+    ASSERT_NE(rc, 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 1);  /* retained, not leaked-dangling */
+    m = hl_cap_wasm_module_lookup(&cache, "echo");
+    ASSERT_TRUE(m->shared_data != NULL && m->shared_data->count == 1); /* slot kept */
+    ASSERT_TRUE(m->shared_data->segments[0].shared_heap == (void *)sh); /* same heap */
+
+    /* Clear the block and retry: destroy now succeeds -> clean removal, baseline. */
+    wasm_runtime_detach_shared_heap(helper);
+    derr = NULL;
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "echo", "graph", NULL, 0,
+                                    NULL, &vfs, NULL, &derr), 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);
+    m = hl_cap_wasm_module_lookup(&cache, "echo");
+    ASSERT_TRUE(m->shared_data == NULL);
+
+    free_instance(helper, hmod, hmb);
+    hl_cap_wasm_destroy(&cache);
+    teardown_dir();
+}
+
+/* ── #315: a PERSISTENT instance attaches the segment chain at creation and, like
+ *    a pooled instance, is not auto-detached by deinstantiate. Destroying it must
+ *    detach so the segment's descriptor can later be reclaimed. Without the detach
+ *    the heap stays attached, the subsequent remove's destroy fails, and both the
+ *    shared_heap_count AND the HlWasmSharedData leak -- the latter only visible to
+ *    LeakSanitizer (Linux), but the count assertion here catches it everywhere.
+ *    Guards the d3_d1_rejection regression this fix first tripped in CI. ───────── */
+UTEST(wasm_spans, segment_persistent_instance_baseline)
+{
+    setup();
+    HlWasmCache cache; ASSERT_EQ(hl_cap_wasm_init(&cache), 0);
+    HlVfs vfs; hl_vfs_init(&vfs, span_call_entries, NULL);
+    ASSERT_EQ(hl_cap_wasm_load(&cache, "echo", &vfs, NULL), 0);
+    uint32_t base = wasm_runtime_shared_heap_count();
+
+    static const unsigned char seg[16] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+    const char *derr = NULL;
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "echo", "graph", seg, sizeof(seg),
+                                    NULL, &vfs, NULL, &derr), 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base + 1);
+
+    /* Persistent instance attaches the chain at creation; a plain call exercises it. */
+    const char *err = NULL;
+    HlWasmInstance *pi = hl_cap_wasm_instance_create(&cache, "echo", NULL,
+                                                     &vfs, NULL, NULL, &err);
+    ASSERT_TRUE(pi != NULL);
+    void *out = NULL; size_t out_len = 0; err = NULL;
+    ASSERT_EQ(hl_cap_wasm_instance_call(pi, "x", 1, &out, &out_len,
+                                        NULL, NULL, NULL, NULL, &err), HL_WASM_OK);
+    free(out);
+
+    /* Destroy the instance (must detach), then remove the segment: the descriptor
+     * is now reclaimable, so the count returns to baseline and shared_data frees. */
+    hl_cap_wasm_instance_destroy(pi);
+    ASSERT_EQ(hl_cap_wasm_data_load(&cache, "echo", "graph", NULL, 0,
+                                    NULL, &vfs, NULL, &derr), 0);
+    ASSERT_EQ(wasm_runtime_shared_heap_count(), base);
+    HlWasmModule *m = hl_cap_wasm_module_lookup(&cache, "echo");
+    ASSERT_TRUE(m->shared_data == NULL);
 
     hl_cap_wasm_destroy(&cache);
     teardown_dir();


### PR DESCRIPTION
Fixes #315.

## Problem
`hl_wasm_free_segment` munmapped a `compute.segment`'s backing but never reclaimed WAMR's shared-heap **descriptor** (its comment claimed "WAMR has no public API to destroy individual shared heaps" — stale since patch 0003 added `wasm_runtime_destroy_shared_heap`, which the mapped-spans span teardown already uses). Every segment create leaked a descriptor onto WAMR's process-global `shared_heap_list`, reclaimed only at `wasm_runtime_destroy()`; `shared_heap_count()` grew monotonically with segment churn. The leak covered both Hull-owned and zero-copy (`is_mmap`) backing.

## Fix — mirrors the span teardown's detach → unchain → destroy discipline
- **`hl_wasm_pool_drain` detaches before deinstantiate.** WAMR's deinstantiate does not auto-detach, so a drained-but-attached segment instance left the chain head's `attached_count` inflated — and both `unchain` and `destroy` require `attached_count == 0`. Detaching in drain makes the count return to 0 on every segment mutation.
- **`hl_wasm_free_segment` destroys the descriptor FIRST, releases backing only on success.** On destroy failure it **retains** the descriptor, backing, and metadata and returns `-1`. Freeing the backing before a failed destroy would strand a live descriptor pointing at unmapped memory (a UAF) — this matches the span teardown's retain-the-borrow-on-failure rule.
- **`hl_wasm_free_shared_data` retains** (compacts) any segment whose descriptor could not be destroyed, keeping `shared_data` alive.
- **The mutation paths drain first and propagate the retained-on-failure result as an error.** The Lua/JS bindings drop a MappedBuffer's registry pin only on `rc == 0`, so propagating the failure keeps the pin — the `is_mmap` backing can't be GC'd out from under a retained descriptor.

Both free functions now return `int` (0 = reclaimed, -1 = retained); header contracts updated.

## Tests
- `segment_lifecycle_baseline` — load/call/remove, churn, replace (net +1 not +2), 3-segment chain + remove-all, and `data_unload` each return `shared_heap_count` to baseline, including after a call attached the chain to a pooled instance.
- `segment_destroy_failure_retain` — pins a segment's heap onto a helper instance so destroy fails; the remove reports failure and **retains** (count stays baseline+1, same heap, slot kept), then a retry after detaching succeeds and returns to baseline. Exercises the retain-on-failure branch the sanitizer matrix does not otherwise reach.
- `d2_segment_race_concurrency` now **asserts** baseline after the mutator loop (was documenting the leak).

## Validation
Normal (strict `-Werror`) + TSan (WAMR-instrumented, 0 warnings) + ASan/UBSan across `test_wasm` (58), `test_wasm_spans` (50), `test_wasm_shared_heap_destroy` (8). macOS has no LeakSanitizer, so the descriptor-leak proof is the `shared_heap_count` baseline assertions. The `compute.segment` AOT e2e (`e2e-compute-aot-shared-heap`) is covered by CI.

Also flips `docs/wasm_mapped_spans_checkpoint3.md` status `PLAN → DONE` (the doc still referenced the resolved #309 blocker).