### PR TITLE
feat(source): hull.source.lua design + slice 1 (lexer, ranges, line map)

### DIFF
--- a/docs/lua_source_analysis_design.md
+++ b/docs/lua_source_analysis_design.md
@@ -1,0 +1,251 @@
+# `hull.source.lua` — Lua source-analysis layer (design / decision record)
+
+**Status:** DESIGN, locked for implementation. Establishes the reusable,
+Hull-owned Lua source-analysis foundation (AST + comments + annotations + exact
+source ranges + structured diagnostics) that later powers `hull analyze`, generic
+build plugins, `hull.query`, `hull.compute`, derive/codegen, schema generation,
+and editor/agent tooling. **None of those consumers are built here.** This layer
+only parses/analyzes source structure (no type-checking, no bytecode/WASM, no IR,
+no source mutation, no module loading — §14).
+
+## 0. Decision: a Hull-owned pure-Lua parser, not vendored LuaLS
+
+The preferred starting point was LuaLS. Investigation (against LuaLS's actual
+architecture) trips the spec's stop conditions:
+
+- LuaLS's tokenizer depends on **LPegLabel**, a **native C library** — violates
+  "no native dependencies" and "no C parser" (keep parsing out of the trusted
+  core). The tool VM ships no extra native libs.
+- The syntactic parse is **coupled** to `parser/guide` + `parser/compile` (the
+  semantic phase this layer explicitly excludes); a syntax-only extraction is a
+  large, surgical subset.
+- LuaLS node positions are an internal encoding, not raw byte offsets; and its
+  `luadoc` uses a fixed tag grammar (poor fit for arbitrary Hull annotations).
+
+**Chosen:** a compact **pure-Lua recursive-descent Lua 5.4 parser** (~0.8–1.4k
+LOC), same pattern Hull already uses (`stdlib/lua/hull/template.lua`). Zero native
+deps, exact byte ranges by construction, arbitrary annotations trivial, no
+vendoring/provenance burden. **LuaLS is used only as a grammar/AST reference.**
+The parser is the single replaceable implementation detail behind the
+`hull.source.lua` contract — so it can be swapped later without touching any
+consumer.
+
+```
+        pure-Lua RD parser (implementation detail, replaceable)
+                              │
+   ┌──────────────────────────┴──────────────────────────┐
+   │ stdlib/cli/lua/hull/source/                          │
+   │   range.lua        SourceRange + line map (neutral)  │
+   │   diagnostic.lua   Diagnostic            (neutral)   │
+   │   annotations.lua  ---@ scanner + attach (neutral)   │
+   │   lexer.lua        Lua 5.4 lexer (byte ranges)       │
+   │   parser.lua       Lua 5.4 RD parser → Hull AST      │
+   │   ast.lua          node kinds + walk/is helpers      │
+   │   lua.lua          parse() → SourceUnit  ◄─ CONTRACT │
+   └──────┬───────────────┬───────────────┬──────────────┘
+       analyze          query           compute   (future — NOT here)
+```
+
+Placement is the **CLI/tool tree** (`stdlib/cli/lua/hull/source/`): this is
+build-time metaprogramming, never the runtime request path. Reached via
+`require("hull.source.lua")` in the tool VM.
+
+## 1. Public surface (§39 — keep it this small)
+
+```lua
+local lua = require("hull.source.lua")
+
+local unit, err = lua.parse(source, { path = "src/example.lua" })
+
+lua.walk(unit.ast, function(node) ... end)   -- deterministic depth-first
+if lua.is(node, "call") then ... end
+local a = lua.annotation(node, "query")       -- annotation table or nil
+local text = unit:text(node_or_range)         -- original bytes for a node/range
+local line, col = unit:position(byte_offset)  -- line/col on demand
+```
+
+Everything else is plain-data tables (nodes, ranges, comments, diagnostics,
+annotations). No OO hierarchy. Fewer functions if fewer suffice.
+
+## 2. `parse()` contract (PRECISE — tightening #2)
+
+`lua.parse(source, opts) -> unit, err`
+
+- **`source` must be a string.** `opts` optional: `{ path = string?, limits =
+  {...}? }` (§7 limits).
+- **Ordinary syntax failure → `unit` is returned with `err == nil`**; the
+  problems appear in `unit.diagnostics` (severity `"error"`). A caller that wants
+  "did it parse cleanly?" checks `#unit.diagnostics == 0`, not `err`.
+- **`err ~= nil` (and `unit == nil`) is reserved for:** invalid API arguments
+  (e.g. `source` not a string) and internal parser failure / limit-guard trips
+  that make continuing unsafe. `err` is a `Diagnostic`-shaped table (or a string
+  for pure API misuse) — never a raw Lua `error()` across the boundary; the
+  parser catches its own internal faults and reports them as `err`.
+- The layer **never prints** (§36). Diagnostics are data.
+
+## 3. `SourceRange` (language-neutral, §6 — tightening #5)
+
+- `range = { start = <int>, stop = <int> }`, **half-open `[start, stop)`**,
+  **1-based byte offsets** (Lua string convention). `stop` is one-past-end.
+- Original text of a range: `source:sub(range.start, range.stop - 1)` — provided
+  by `unit:text(x)`; consumers never do byte math themselves (§20).
+- **Nodes carry byte offsets only.** Line/column is **resolved on demand** via a
+  per-unit **line-start index** (built once, binary-searched): `unit:position(off)
+  -> line, col` and `unit:line_col(range) -> sl, sc, el, ec`. Nodes are NOT
+  eagerly annotated with line/col (avoids duplicating expensive data on every
+  node, §6). The line map is generic (reused verbatim for JS later, §21/§33).
+- Empty/zero-width ranges use `start == stop`.
+
+## 4. `SourceUnit` (§5)
+
+```lua
+{ path = "src/example.lua", language = "lua", source = "<original bytes>",
+  ast = <chunk node>, comments = { <comment>, ... }, diagnostics = { <diag>, ... } }
+```
+Methods: `unit:text(node_or_range)`, `unit:position(off)`, `unit:line_col(range)`,
+`unit:annotations_for(node)`. Annotations attach **onto AST nodes**
+(`node.annotations`, a name→annotation map; ordered list in
+`node.annotation_list`) — the KISS choice; consumers use `lua.annotation(node,
+name)`.
+
+## 5. Hull AST vocabulary (§7/§8 — stable, small, source-faithful)
+
+`{ kind = <string>, range = {start,stop}, ... }` tables. Source order preserved;
+no IR, no semantic scopes. Node kinds (final set fixed in slice 3):
+
+- **Statements:** `chunk`, `local_declaration` (`names[]` each `{name, attrib?}`
+  where attrib ∈ `const|close`, `values[]`), `assignment` (`targets[]`,
+  `values[]`), `call_statement`, `do`, `while`, `repeat`, `if`
+  (`clauses[]`=`{cond?, body}`), `numeric_for`, `generic_for`,
+  `function_declaration` (`name` path, `is_local`, `is_method`, `params[]`,
+  `is_vararg`, `body`), `return` (`values[]`), `break`, `goto` (`label`),
+  `label`.
+- **Expressions:** `name`, `index` (`obj`, `key`), `field` (`obj`, `name`),
+  `call` (`callee`, `args[]`), `method_call` (`obj`, `method`, `args[]`),
+  `function_expr` (`params[]`, `is_vararg`, `body`), `table` (`fields[]` =
+  positional / `name=` / `[expr]=`), `binary` (`op`, `lhs`, `rhs`), `unary`
+  (`op`, `operand`), `vararg`, `paren`, `literal` (`subtype` ∈
+  `string|number|boolean|nil`, `value`, plus `string_kind` ∈ `quoted|long`,
+  `number_kind` ∈ `int|float|hex|hexfloat`).
+
+Preserves local-vs-global, function-vs-local-function, method syntax, params,
+literal sub-forms. Consumers recognize e.g. `local q = query{...}`
+(`local_declaration` whose `values[1]` is a `call` with a single `table` arg) and
+`function score(x,y) ... end` structurally.
+
+## 6. Full Lua 5.4 syntax is REQUIRED (tightening #1)
+
+The parser must accept **all** valid Lua 5.4: long strings/comments
+(`[==[ ... ]==]`, level-matched), every numeral form (decimal int/float, hex
+`0xff`, **hex float** `0x1.8p3`), all string escapes (`\n \t \\ \" \' \a \b \f \r
+\v \xFF \ddd \u{XXXX} \z` and `\<newline>`), labels/`goto`, attributes
+(`<const>` / `<close>`), method calls (`:`), varargs (`...`), and the **complete**
+operator precedence + associativity table (incl. right-assoc `^` and `..`, unary
+binding, `and`/`or` short-circuit precedence).
+
+**Hard rule:** any **valid** Lua 5.4 syntax the parser cannot yet represent must
+emit an **explicit diagnostic** (`code = "lua.unsupported"`) and stop that
+construct — **never** silently produce a malformed/partial AST that lies. A
+missing feature is a loud diagnostic, not a wrong tree.
+
+## 7. Resource limits (tightening #3 — adversarial build inputs)
+
+`opts.limits` with safe defaults (documented, overridable): `max_bytes`
+(source length), `max_tokens`, `max_depth` (nesting), `max_diagnostics`.
+Exceeding any cap emits a terminal diagnostic (`code = "lua.limit.<which>"`,
+severity error), stops parsing, and returns the partial `unit` with `err == nil`
+(it's an input problem, not API misuse). Guarantees bounded work + memory so a
+hostile source in a build plugin cannot exhaust the tool VM. Recursion-depth is
+tracked explicitly (no unbounded native Lua recursion).
+
+## 8. Comments (§11) + annotations (§9/§10/§25 — Hull-owned, arbitrary)
+
+- **Comments** preserved as `{ text, range, kind }`, `kind ∈ line | long |
+  annotation`, in `unit.comments` (source order).
+- **Annotations are Hull's own scanner over comment text — no known-tag
+  whitelist.** Any `---@name`, optional `(args)`, optional trailing text becomes
+  `{ name, args = <string?>, raw = <full comment>, range }`. Arbitrary
+  `---@query`, `---@compute`, `---@derive(json)`, `---@some_future_plugin(a,b)`
+  all survive generically. Known LuaDoc tags (`@param/@return/@field/@class`)
+  MAY additionally expose parsed fields, but the generic form is always present.
+- **Attachment rule (deterministic, documented):** a **contiguous run** of
+  comment lines (`--` line comments and `--[[ ]]` blocks) immediately preceding a
+  statement, with **no blank line** between the run and the statement, attaches to
+  that statement's node (`node.annotations` / `node.annotation_list`). A blank
+  line, code, or a different statement breaks the run. Trailing/inline comments do
+  not attach. `unit:annotations_for(node)` and `lua.annotation(node, name)` read
+  them. Comments that attach to nothing remain in `unit.comments` only.
+
+## 9. Diagnostics (§12/§13) + recovery
+
+`{ severity = "error"|"warning", code = "lua.syntax"|"lua.unsupported"|"lua.limit.*",
+   message, path, range, related? }`. Returned in `unit.diagnostics`, never
+printed. This is THE shared diagnostic shape (JS reuses it later, §33).
+
+**Recovery:** best-effort, statement-level only. On a syntax error the parser
+emits the diagnostic, resynchronizes to the next statement boundary, and
+continues — yielding a **partial** AST for the well-formed statements. Documented
+as "partial, not editor-grade recovery." Correctness over speculative recovery.
+
+## 10. Isolation boundary (§16/§27)
+
+No consumer touches parser/lexer internals — only the Hull AST + `SourceUnit`.
+Enforced by tests asserting solely on the public AST/API (no lexer-private
+fields). Because the parser is Hull-owned there is no third-party field leakage to
+guard, but the adapter boundary (`lua.lua`) remains the sole contract so the
+parser stays swappable.
+
+## 11. Tests + Lua 5.4 differential conformance (§22–27 — tightening #4)
+
+- **Unit tests** for every node kind (§22), exact byte ranges (§23: incl.
+  UTF-8-before-node, multiline, long strings/comments, CRLF), annotation
+  name/raw/range/attachment (§24), arbitrary-annotation survival (§25), malformed
+  → diagnostics (§26), and adapter-stability (§27).
+- **Differential conformance corpus** against Lua 5.4's own parser (Hull already
+  embeds Lua 5.4): for each valid sample, `load()` succeeds **and** our parser
+  emits no diagnostics; for each invalid sample, both reject. **Excluded** are the
+  cases where `load()` is stricter than pure syntax (compile-time *semantic*
+  checks our syntactic layer intentionally does not enforce): `break`/`goto`
+  outside a valid target, `...` in a non-vararg function, assignment to a
+  `<const>`, jump-into-scope, and the various "too many locals/upvalues/constants"
+  limits. Those are listed explicitly and asserted as "parser accepts, `load`
+  rejects (semantic)" so the boundary is documented, not accidental.
+- Tests assert on Hull's public representation only.
+
+## 12. Debug (§28) + performance/memory (§31/§32)
+
+`unit`→JSON dump via `hull.json` for tests/dev (deterministic; no new CLI).
+Build-time code, not the request path — correctness first, no premature
+optimization; a single-pass lexer + RD parser with the line map built once. Do
+not retain duplicate source/AST copies beyond the `SourceUnit`.
+
+## 13. Implementation slices (locked order)
+
+1. **Lexer + ranges** — full Lua 5.4 tokens with exact half-open byte ranges;
+   the line-start index; comment capture. Tests: token/range correctness incl.
+   long strings/comments, numerals, escapes, CRLF, UTF-8.
+2. **Expression grammar** — complete precedence/associativity; literals,
+   tables, calls/index/method, function expr, varargs, parens, unary/binary.
+3. **Statements/declarations** — all statement kinds incl. attributes,
+   labels/goto, for-forms, function declarations; the final node vocabulary.
+4. **Comments/annotations** — the generic `---@` scanner + the attachment rule.
+5. **Recovery + conformance** — statement-level resync, resource limits, the
+   differential corpus.
+
+**Consumers wait until the adapter-level (slice 3–4) AST tests are stable.**
+
+## 14. Out of scope (§37 — do not build here)
+
+Type system, symbol/scope solver beyond parsing needs, bytecode/WASM, Query IR,
+Compute IR, source transformation engine, macros, LSP/editor server, incremental
+parser, JS parser, build plugins, package manager. One parser, one annotation
+model, one range representation, one diagnostic representation (§38).
+
+## 15. Deliverables / report template (§40)
+
+On completion, report: vendored LOC/files (**0** — none vendored); Hull adapter
+LOC (parser + 5 modules); dependencies introduced (**none**); Lua versions tested
+(**5.4**); known parser limitations; annotation limitations (generic-only
+semantics; attachment is contiguous-leading-run only); error-recovery behavior
+(statement-level partial). License/provenance: N/A (Hull-owned; standard
+`AGPL-3.0-or-later` SPDX headers).

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -161,6 +161,14 @@ $(BUILDDIR)/test_%: $(TESTDIR)/hull/cap/test_%.c $(TUI_CAP_TEST_OBJS) $(TEST_COM
 $(BUILDDIR)/test_%: $(TESTDIR)/hull/cap/test_%.c $(TEST_COMMON_DEPS) | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(TEST_COMMON_LIBS) $(LDFLAGS)
 
+# hull.source.lua (pure-Lua source-analysis layer): a vanilla lua_State harness
+# linking ONLY the vendored Lua 5.4 objects (no Hull sandbox / cap layer). The
+# test .c lives under tests/hull/source/, so it is not matched by the cap/ pattern
+# rule above -- explicit recipe. It runs the co-located Lua test scripts from the
+# repo-root source tree via package.path.
+$(BUILDDIR)/test_lua_source: $(TESTDIR)/hull/source/test_lua_source.c $(LUA_OBJS) | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -Ivendor/lua -o $@ $< $(LUA_OBJS) -lm $(LDFLAGS)
+
 # Read-only shared-heap C-API test: build-time AOT fixture. Generate an .aot from
 # the embedded .wasm via the Hull-built wamrc when present (arch + OS correct);
 # otherwise a zero-length stub so the test compiles and SKIPS the AOT case

--- a/stdlib/cli/lua/hull/source/diagnostic.lua
+++ b/stdlib/cli/lua/hull/source/diagnostic.lua
@@ -1,0 +1,40 @@
+--
+-- hull.source.diagnostic — language-neutral structured diagnostic.
+--
+-- THE shared diagnostic shape for the whole source-analysis layer (Lua now, JS
+-- later, and eventually `hull analyze`). Never printed — diagnostics are data,
+-- returned in unit.diagnostics. A parse() API-misuse / internal-failure error is
+-- also diagnostic-shaped (returned as the second value with unit == nil).
+--
+--   { severity = "error" | "warning",
+--     code     = "lua.syntax" | "lua.unsupported" | "lua.limit.<which>" | "lua.internal",
+--     message  = string,
+--     path     = string | nil,
+--     range    = { start, stop } | nil,      -- half-open byte range (see range.lua)
+--     related  = { { message, path?, range? }, ... } | nil }
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local M = {}
+
+function M.new(severity, code, message, path, range, related)
+    return {
+        severity = severity,
+        code = code,
+        message = message,
+        path = path,
+        range = range,
+        related = related,
+    }
+end
+
+function M.error(code, message, path, range)
+    return M.new("error", code, message, path, range)
+end
+
+function M.warning(code, message, path, range)
+    return M.new("warning", code, message, path, range)
+end
+
+return M

--- a/stdlib/cli/lua/hull/source/lexer.lua
+++ b/stdlib/cli/lua/hull/source/lexer.lua
@@ -25,10 +25,15 @@ local diag = require("hull.source.diagnostic")
 
 local M = {}
 
+-- Defaults bound work AND memory on adversarial build input. Every lexical item
+-- (token or comment) is a small Lua table with a range subtable; millions of them
+-- exhaust the tool VM even within the byte limit, so token/comment counts are
+-- capped well below the byte limit's theoretical maximum.
 M.DEFAULT_LIMITS = {
     max_bytes = 4 * 1024 * 1024,   -- 4 MiB of source
-    max_tokens = 2000000,
-    max_diagnostics = 200,
+    max_tokens = 500000,           -- ~a 500k-token file is already pathological at build time
+    max_comments = 200000,         -- comments have their own table, bounded separately
+    max_diagnostics = 200,         -- caps NORMAL diagnostics; terminal limit diags always emit
     max_depth = 400,               -- parser-side; carried through for the full contract
 }
 
@@ -64,9 +69,17 @@ function M.tokenize(source, opts)
             diag.error(code, message, path, { start = s, stop = e })
     end
 
+    -- Terminal (limit) diagnostics ALWAYS record, bypassing max_diagnostics, so a
+    -- full diagnostic list or max_diagnostics == 0 can never silently suppress the
+    -- reason lexing stopped.
+    local function emit_terminal(code, message, s, e)
+        diagnostics[#diagnostics + 1] =
+            diag.error(code, message, path, { start = s, stop = e })
+    end
+
     -- Source-size guard: refuse an oversized source up front (bounded work).
     if n > limits.max_bytes then
-        emit_diag("lua.limit.max_bytes",
+        emit_terminal("lua.limit.max_bytes",
             "source exceeds max_bytes (" .. n .. " > " .. limits.max_bytes .. ")", 1, 1)
         tokens[#tokens + 1] = { kind = "eof", range = { start = 1, stop = 1 }, text = "" }
         return { tokens = tokens, comments = comments, diagnostics = diagnostics }
@@ -112,7 +125,13 @@ function M.tokenize(source, opts)
     local function scan_escape(p)
         local e = at(p + 1)
         if e == "" then emit_diag("lua.syntax", "unfinished escape sequence", p, p + 1); return p + 1 end
-        if e:match("[abfnrtv\\\"'\n\r]") then return p + 2 end       -- simple + \<newline>
+        if e == "\n" or e == "\r" then                              -- \<newline>: LF, CR, CRLF, or LFCR = ONE sequence
+            local q = p + 2
+            local nxt = at(q)
+            if (e == "\r" and nxt == "\n") or (e == "\n" and nxt == "\r") then q = q + 1 end
+            return q
+        end
+        if e:match("[abfnrtv\\\"']") then return p + 2 end          -- simple escapes
         if e == "z" then                                            -- \z: skip following whitespace
             local q = p + 2
             while q <= n and is_space(at(q)) do q = q + 1 end
@@ -262,8 +281,13 @@ function M.tokenize(source, opts)
         end
 
         if #tokens > limits.max_tokens then
-            emit_diag("lua.limit.max_tokens",
+            emit_terminal("lua.limit.max_tokens",
                 "token count exceeds max_tokens (" .. limits.max_tokens .. ")", pos, pos)
+            break
+        end
+        if #comments > limits.max_comments then
+            emit_terminal("lua.limit.max_comments",
+                "comment count exceeds max_comments (" .. limits.max_comments .. ")", pos, pos)
             break
         end
     end

--- a/stdlib/cli/lua/hull/source/lexer.lua
+++ b/stdlib/cli/lua/hull/source/lexer.lua
@@ -1,0 +1,275 @@
+--
+-- hull.source.lexer — Lua 5.4 lexer (slice 1 of hull.source.lua).
+--
+-- Pure Lua, no native deps, no dynamic compilation (never calls load()). Produces
+-- tokens and comments with EXACT half-open byte ranges { start, stop } (see
+-- range.lua), plus structured diagnostics for malformed input. It NEVER raises:
+-- every malformed form becomes a diagnostic and lexing continues (advancing at
+-- least one byte so it always terminates). Numeral validity is checked with
+-- tonumber() (a pure value conversion, not load()).
+--
+-- Result: { tokens = { <token>, ... }, comments = { <comment>, ... },
+--           diagnostics = { <diagnostic>, ... } }
+--   token   = { kind = "name"|"keyword"|"number"|"string"|"op"|"eof",
+--               range = {start,stop}, text = <lexeme>, malformed = true? }
+--   comment = { kind = "line"|"long"|"shebang", range = {start,stop}, text = <lexeme> }
+--
+-- Resource limits (opts.limits, defaults below) bound work on adversarial input:
+-- max_bytes (source length), max_tokens, max_diagnostics. max_depth is a PARSER
+-- limit (nesting) and is not applicable to the flat token stream.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local diag = require("hull.source.diagnostic")
+
+local M = {}
+
+M.DEFAULT_LIMITS = {
+    max_bytes = 4 * 1024 * 1024,   -- 4 MiB of source
+    max_tokens = 2000000,
+    max_diagnostics = 200,
+    max_depth = 400,               -- parser-side; carried through for the full contract
+}
+
+local KEYWORDS = {
+    ["and"]=true, ["break"]=true, ["do"]=true, ["else"]=true, ["elseif"]=true,
+    ["end"]=true, ["false"]=true, ["for"]=true, ["function"]=true, ["goto"]=true,
+    ["if"]=true, ["in"]=true, ["local"]=true, ["nil"]=true, ["not"]=true,
+    ["or"]=true, ["repeat"]=true, ["return"]=true, ["then"]=true, ["true"]=true,
+    ["until"]=true, ["while"]=true,
+}
+
+-- Multi-char operators, longest first (maximal munch).
+local OPS3 = { ["..."]=true }
+local OPS2 = { [".."]=true, ["::"]=true, ["=="]=true, ["~="]=true, ["<="]=true,
+               [">="]=true, ["<<"]=true, [">>"]=true, ["//"]=true }
+local OPS1 = "+-*/%^#&~|<>=(){}[];:,."
+
+-- Lexer state is a small closure-captured table; helpers read/advance `pos`.
+function M.tokenize(source, opts)
+    opts = opts or {}
+    local limits = {}
+    for k, v in pairs(M.DEFAULT_LIMITS) do limits[k] = v end
+    if opts.limits then for k, v in pairs(opts.limits) do limits[k] = v end end
+    local path = opts.path
+
+    local tokens, comments, diagnostics = {}, {}, {}
+    local n = #source
+    local pos = 1
+
+    local function emit_diag(code, message, s, e)
+        if #diagnostics >= limits.max_diagnostics then return end
+        diagnostics[#diagnostics + 1] =
+            diag.error(code, message, path, { start = s, stop = e })
+    end
+
+    -- Source-size guard: refuse an oversized source up front (bounded work).
+    if n > limits.max_bytes then
+        emit_diag("lua.limit.max_bytes",
+            "source exceeds max_bytes (" .. n .. " > " .. limits.max_bytes .. ")", 1, 1)
+        tokens[#tokens + 1] = { kind = "eof", range = { start = 1, stop = 1 }, text = "" }
+        return { tokens = tokens, comments = comments, diagnostics = diagnostics }
+    end
+
+    local sub = string.sub
+    local function at(p) return sub(source, p, p) end               -- 1-char string ("" past EOF)
+
+    -- Opening long bracket at p: "[" ("="*) "[" -> level (# of '='), else nil.
+    local function open_long(p)
+        if at(p) ~= "[" then return nil end
+        local q = p + 1
+        while at(q) == "=" do q = q + 1 end
+        if at(q) == "[" then return q - (p + 1), q + 1 end          -- level, content-start
+        return nil
+    end
+
+    -- Consume a long-bracket body of `level` starting at content offset `cstart`.
+    -- Returns the offset just past the closing "]"..."]" (or n+1 if unterminated).
+    local function scan_long(cstart, level)
+        local close = "]" .. string.rep("=", level) .. "]"
+        local idx = source:find(close, cstart, true)
+        if idx then return idx + #close, true end
+        return n + 1, false
+    end
+
+    -- ── whitespace / newline ──────────────────────────────────────────
+    local function is_space(c) return c == " " or c == "\t" or c == "\r"
+        or c == "\n" or c == "\v" or c == "\f" end
+
+    -- ── shebang: a leading '#' line (Lua's loader skips it) ───────────
+    if at(1) == "#" then
+        local e = source:find("\n", 1, true)
+        local stop = e and (e + 1) or (n + 1)   -- include the newline if present
+        comments[#comments + 1] =
+            { kind = "shebang", range = { start = 1, stop = stop }, text = sub(source, 1, stop - 1) }
+        pos = stop
+    end
+
+    -- ── string-escape validation (short strings) ──────────────────────
+    -- p points at '\'; returns the offset just past the escape, emitting a
+    -- diagnostic for a malformed one (but always consuming >= 2 bytes).
+    local function scan_escape(p)
+        local e = at(p + 1)
+        if e == "" then emit_diag("lua.syntax", "unfinished escape sequence", p, p + 1); return p + 1 end
+        if e:match("[abfnrtv\\\"'\n\r]") then return p + 2 end       -- simple + \<newline>
+        if e == "z" then                                            -- \z: skip following whitespace
+            local q = p + 2
+            while q <= n and is_space(at(q)) do q = q + 1 end
+            return q
+        end
+        if e == "x" then
+            if at(p + 2):match("%x") and at(p + 3):match("%x") then return p + 4 end
+            emit_diag("lua.syntax", "\\x must be followed by two hex digits", p, math.min(p + 4, n + 1))
+            return p + 2
+        end
+        if e:match("%d") then                                       -- \ddd (1-3 decimal, <=255)
+            local q = p + 1
+            local d = ""
+            while #d < 3 and at(q):match("%d") do d = d .. at(q); q = q + 1 end
+            if tonumber(d) > 255 then
+                emit_diag("lua.syntax", "decimal escape too large (>255)", p, q)
+            end
+            return q
+        end
+        if e == "u" then                                            -- \u{XXXX}
+            if at(p + 2) ~= "{" then
+                emit_diag("lua.syntax", "missing '{' in \\u{xxxx}", p, p + 2); return p + 2
+            end
+            local q = p + 3
+            local hexn = 0
+            while at(q):match("%x") do q = q + 1; hexn = hexn + 1 end
+            if hexn == 0 or at(q) ~= "}" then
+                emit_diag("lua.syntax", "malformed \\u{xxxx} escape", p, math.min(q + 1, n + 1))
+                return (at(q) == "}") and (q + 1) or q
+            end
+            return q + 1
+        end
+        emit_diag("lua.syntax", "invalid escape sequence '\\" .. e .. "'", p, p + 2)
+        return p + 2
+    end
+
+    -- ── short string ("..." / '...') ──────────────────────────────────
+    local function scan_short_string(start, quote)
+        local p = start + 1
+        while p <= n do
+            local c = at(p)
+            if c == quote then
+                return { kind = "string", range = { start = start, stop = p + 1 },
+                         text = sub(source, start, p) }
+            elseif c == "\n" or c == "\r" then
+                emit_diag("lua.syntax", "unfinished string (newline in short string)", start, p)
+                return { kind = "string", range = { start = start, stop = p }, text = sub(source, start, p - 1), malformed = true }
+            elseif c == "\\" then
+                p = scan_escape(p)
+            else
+                p = p + 1
+            end
+        end
+        emit_diag("lua.syntax", "unfinished string (reached end of source)", start, n + 1)
+        return { kind = "string", range = { start = start, stop = n + 1 }, text = sub(source, start, n), malformed = true }
+    end
+
+    -- ── number (maximal munch, validated with tonumber) ──────────────
+    local function scan_number(start)
+        local p = start
+        while true do
+            local c = at(p)
+            if c:match("[%w.]") then
+                p = p + 1
+            elseif (c == "+" or c == "-") and at(p - 1):match("[eEpP]") then
+                p = p + 1                                            -- exponent sign
+            else
+                break
+            end
+        end
+        local text = sub(source, start, p - 1)
+        local malformed = tonumber(text) == nil
+        if malformed then
+            emit_diag("lua.syntax", "malformed number near '" .. text .. "'", start, p)
+        end
+        return { kind = "number", range = { start = start, stop = p }, text = text, malformed = malformed or nil }
+    end
+
+    -- ── main loop ─────────────────────────────────────────────────────
+    while pos <= n do
+        local c = at(pos)
+
+        if is_space(c) then
+            pos = pos + 1
+
+        elseif c == "-" and at(pos + 1) == "-" then                 -- comment
+            local start = pos
+            local level, cstart = open_long(pos + 2)
+            if level ~= nil then
+                local stop, ok = scan_long(cstart, level)
+                if not ok then emit_diag("lua.syntax", "unfinished long comment", start, n + 1) end
+                comments[#comments + 1] =
+                    { kind = "long", range = { start = start, stop = stop }, text = sub(source, start, stop - 1) }
+                pos = stop
+            else
+                local e = source:find("\n", pos, true)
+                local stop = e or (n + 1)                           -- line comment excludes the newline
+                comments[#comments + 1] =
+                    { kind = "line", range = { start = start, stop = stop }, text = sub(source, start, stop - 1) }
+                pos = stop
+            end
+
+        elseif c:match("[%a_]") then                                -- name or keyword
+            local start = pos
+            local p = pos + 1
+            while at(p):match("[%w_]") do p = p + 1 end
+            local text = sub(source, start, p - 1)
+            tokens[#tokens + 1] = {
+                kind = KEYWORDS[text] and "keyword" or "name",
+                range = { start = start, stop = p }, text = text,
+            }
+            pos = p
+
+        elseif c:match("%d") or (c == "." and at(pos + 1):match("%d")) then
+            tokens[#tokens + 1] = scan_number(pos)
+            pos = tokens[#tokens].range.stop
+
+        elseif c == '"' or c == "'" then
+            tokens[#tokens + 1] = scan_short_string(pos, c)
+            pos = tokens[#tokens].range.stop
+
+        elseif c == "[" and open_long(pos) ~= nil then              -- long string
+            local start = pos
+            local level, cstart = open_long(pos)
+            local stop, ok = scan_long(cstart, level)
+            if not ok then emit_diag("lua.syntax", "unfinished long string", start, n + 1) end
+            tokens[#tokens + 1] = { kind = "string", range = { start = start, stop = stop },
+                                    text = sub(source, start, stop - 1), malformed = (not ok) or nil }
+            pos = stop
+
+        else                                                        -- operator / unknown
+            local three = sub(source, pos, pos + 2)
+            local two = sub(source, pos, pos + 1)
+            if OPS3[three] then
+                tokens[#tokens + 1] = { kind = "op", range = { start = pos, stop = pos + 3 }, text = three }
+                pos = pos + 3
+            elseif OPS2[two] then
+                tokens[#tokens + 1] = { kind = "op", range = { start = pos, stop = pos + 2 }, text = two }
+                pos = pos + 2
+            elseif OPS1:find(c, 1, true) then
+                tokens[#tokens + 1] = { kind = "op", range = { start = pos, stop = pos + 1 }, text = c }
+                pos = pos + 1
+            else
+                emit_diag("lua.syntax", "unexpected symbol near '" .. c .. "'", pos, pos + 1)
+                pos = pos + 1                                        -- always advance -> terminates
+            end
+        end
+
+        if #tokens > limits.max_tokens then
+            emit_diag("lua.limit.max_tokens",
+                "token count exceeds max_tokens (" .. limits.max_tokens .. ")", pos, pos)
+            break
+        end
+    end
+
+    tokens[#tokens + 1] = { kind = "eof", range = { start = n + 1, stop = n + 1 }, text = "" }
+    return { tokens = tokens, comments = comments, diagnostics = diagnostics }
+end
+
+return M

--- a/stdlib/cli/lua/hull/source/lua.lua
+++ b/stdlib/cli/lua/hull/source/lua.lua
@@ -37,24 +37,54 @@ function Unit:text(x)
 end
 
 -- 1-based (line, col) for a byte offset; col is a byte column within the line.
+-- Offsets outside [1, #source + 1] are CLAMPED to that valid range (a byte past
+-- end-of-source resolves to #source+1, the position after the last byte) so a
+-- caller passing a stray offset gets a meaningful boundary position, never a
+-- meaningless column.
 function Unit:position(off)
+    local maxoff = #self.source + 1
+    if type(off) ~= "number" then off = 1 end
+    if off < 1 then off = 1 elseif off > maxoff then off = maxoff end
     return range.position(self._linestarts, off)
 end
 
 -- (start_line, start_col, end_line, end_col) for a range. end_col is resolved at
--- the exclusive `stop` (one past the last byte).
+-- the exclusive `stop` (one past the last byte). Routes through :position so the
+-- same clamping applies.
 function Unit:line_col(r)
     r = r.range or r
-    local sl, sc = range.position(self._linestarts, r.start)
-    local el, ec = range.position(self._linestarts, r.stop)
+    local sl, sc = self:position(r.start)
+    local el, ec = self:position(r.stop)
     return sl, sc, el, ec
 end
+
+-- Limit keys validated at the boundary (each, if present, must be a non-negative
+-- integer). Invalid opts/limits are API MISUSE -> a clear (nil, err) BEFORE the
+-- lexer runs, not a lua.internal failure surfacing through the pcall.
+local LIMIT_KEYS = { "max_bytes", "max_tokens", "max_comments", "max_diagnostics", "max_depth" }
 
 function M.parse(source, opts)
     if type(source) ~= "string" then
         return nil, "hull.source.lua: source must be a string, got " .. type(source)
     end
+    if opts ~= nil and type(opts) ~= "table" then
+        return nil, "hull.source.lua: opts must be a table or nil, got " .. type(opts)
+    end
     opts = opts or {}
+    if opts.path ~= nil and type(opts.path) ~= "string" then
+        return nil, "hull.source.lua: opts.path must be a string or nil, got " .. type(opts.path)
+    end
+    if opts.limits ~= nil then
+        if type(opts.limits) ~= "table" then
+            return nil, "hull.source.lua: opts.limits must be a table or nil, got " .. type(opts.limits)
+        end
+        for _, k in ipairs(LIMIT_KEYS) do
+            local v = opts.limits[k]
+            if v ~= nil and (type(v) ~= "number" or math.type(v) ~= "integer" or v < 0) then
+                return nil, "hull.source.lua: opts.limits." .. k .. " must be a non-negative integer"
+            end
+        end
+    end
 
     -- Defense in depth: the lexer is written not to raise, but a bug must still
     -- surface as `err`, never as a raw error crossing parse().

--- a/stdlib/cli/lua/hull/source/lua.lua
+++ b/stdlib/cli/lua/hull/source/lua.lua
@@ -1,0 +1,81 @@
+--
+-- hull.source.lua — the PUBLIC Lua source-analysis contract.
+--
+--   local lua = require("hull.source.lua")
+--   local unit, err = lua.parse(source, { path = "src/example.lua" })
+--
+-- parse() contract (locked, docs/lua_source_analysis_design.md):
+--   * `source` must be a string. `opts` optional: { path?, limits? }.
+--   * Ordinary syntax problems => a SourceUnit is returned with err == nil; the
+--     problems are in unit.diagnostics (severity "error"). "Did it parse cleanly?"
+--     is `#unit.diagnostics == 0`, NOT `err`.
+--   * err ~= nil (and unit == nil) is reserved for invalid API arguments and
+--     internal parser failure. err is a Diagnostic-shaped table (or a string for
+--     pure API misuse). No raw Lua error() ever crosses this boundary.
+--   * Never prints. Diagnostics are data.
+--
+-- SLICE 1 (this file): lexer + ranges + line map. `unit.ast` is nil until the
+-- statement slice lands; `unit.tokens`/`unit.comments`/`unit.diagnostics` and the
+-- unit:text/position/line_col helpers are live now.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local lexer = require("hull.source.lexer")
+local range = require("hull.source.range")
+local diag = require("hull.source.diagnostic")
+
+local M = {}
+
+local Unit = {}
+Unit.__index = Unit
+
+-- Exact original text for a node/range (anything carrying a `.range`, or a range).
+function Unit:text(x)
+    local r = x.range or x
+    return self.source:sub(r.start, r.stop - 1)
+end
+
+-- 1-based (line, col) for a byte offset; col is a byte column within the line.
+function Unit:position(off)
+    return range.position(self._linestarts, off)
+end
+
+-- (start_line, start_col, end_line, end_col) for a range. end_col is resolved at
+-- the exclusive `stop` (one past the last byte).
+function Unit:line_col(r)
+    r = r.range or r
+    local sl, sc = range.position(self._linestarts, r.start)
+    local el, ec = range.position(self._linestarts, r.stop)
+    return sl, sc, el, ec
+end
+
+function M.parse(source, opts)
+    if type(source) ~= "string" then
+        return nil, "hull.source.lua: source must be a string, got " .. type(source)
+    end
+    opts = opts or {}
+
+    -- Defense in depth: the lexer is written not to raise, but a bug must still
+    -- surface as `err`, never as a raw error crossing parse().
+    local ok, res = pcall(lexer.tokenize, source, opts)
+    if not ok then
+        return nil, diag.error("lua.internal",
+            "internal lexer failure: " .. tostring(res), opts.path, nil)
+    end
+
+    local unit = setmetatable({
+        path = opts.path,
+        language = "lua",
+        source = source,
+        ast = nil,                       -- slice 3
+        tokens = res.tokens,             -- slice-1 surface; the parser consumes these
+        comments = res.comments,
+        diagnostics = res.diagnostics,
+        _linestarts = range.linemap(source),
+    }, Unit)
+
+    return unit, nil
+end
+
+return M

--- a/stdlib/cli/lua/hull/source/range.lua
+++ b/stdlib/cli/lua/hull/source/range.lua
@@ -1,0 +1,62 @@
+--
+-- hull.source.range — language-neutral SourceRange + line map.
+--
+-- A range is a half-open byte interval { start = <int>, stop = <int> } over the
+-- 1-based bytes of the source (Lua string convention). `stop` is one-past-end,
+-- so the exact text is source:sub(range.start, range.stop - 1). An empty range
+-- has start == stop.
+--
+-- Line/column are resolved ON DEMAND from a per-source line-start index (built
+-- once, binary-searched) rather than duplicated onto every AST node. Columns are
+-- 1-based BYTE columns within the line (a UTF-8 codepoint column mode can be added
+-- later without changing byte ranges). This module is Lua-agnostic and is reused
+-- verbatim for the future JS source layer.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local M = {}
+
+-- Construct a half-open range. No validation here (callers pass lexer positions).
+function M.new(start, stop)
+    return { start = start, stop = stop }
+end
+
+-- Exact original text for a range over `source`.
+function M.slice(source, r)
+    return source:sub(r.start, r.stop - 1)
+end
+
+-- Build the line-start index: byte offset (1-based) of the first byte of each
+-- line. Line 1 starts at offset 1; every byte immediately after a '\n' starts a
+-- new line. CRLF ends its line at the '\n' (the '\r' is the line's trailing byte);
+-- a final line without a trailing newline has no extra entry. Lone '\r' (classic
+-- Mac) is NOT treated as a line terminator.
+function M.linemap(source)
+    local starts = { 1 }
+    local i = 1
+    local n = #source
+    while i <= n do
+        local nl = source:find("\n", i, true)
+        if not nl then break end
+        starts[#starts + 1] = nl + 1
+        i = nl + 1
+    end
+    return starts
+end
+
+-- Resolve a 1-based byte offset to (line, col), both 1-based; col is the byte
+-- column within the line. An offset one past end-of-source resolves to the last
+-- line at the column after its last byte. Binary search for the largest
+-- line-start <= off.
+function M.position(starts, off)
+    if off < 1 then off = 1 end
+    local lo, hi = 1, #starts
+    while lo < hi do
+        local mid = (lo + hi + 1) // 2
+        if starts[mid] <= off then lo = mid else hi = mid - 1 end
+    end
+    return lo, off - starts[lo] + 1
+end
+
+return M

--- a/stdlib/cli/lua/hull/source/tests/test_lexer.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_lexer.lua
@@ -189,5 +189,64 @@ do
     ok(okc2 and u2 == nil and e2 ~= nil, "boundary: nil source -> (nil, err)")
 end
 
+-- ── 9. escaped newline (LF / CR / CRLF / LFCR) is ONE escape sequence ─
+do
+    local cases = { { "\n", "LF" }, { "\r", "CR" }, { "\r\n", "CRLF" }, { "\n\r", "LFCR" } }
+    for _, c in ipairs(cases) do
+        local src = 'local s = "a\\' .. c[1] .. 'b"'   -- string with a backslash-escaped newline
+        local u = assert(lua.parse(src))
+        eq(#u.diagnostics, 0, "esc-nl " .. c[2] .. ": no diagnostic")
+        local st
+        for _, k in ipairs(u.tokens) do if k.kind == "string" then st = k end end
+        ok(st ~= nil and not st.malformed, "esc-nl " .. c[2] .. ": one clean string token")
+        eq(u:text(st), '"a\\' .. c[1] .. 'b"', "esc-nl " .. c[2] .. ": lossless range")
+    end
+end
+
+-- ── 10. comments are bounded (max_comments) ───────────────────────────
+do
+    local many = string.rep("--c\n", 50)
+    local u = assert(lua.parse(many, { limits = { max_comments = 5 } }))
+    local hit = false
+    for _, d in ipairs(u.diagnostics) do if d.code == "lua.limit.max_comments" then hit = true end end
+    ok(hit, "limit: max_comments trips")
+end
+
+-- ── 11. terminal limit diagnostic always emits (even max_diagnostics=0) ─
+do
+    local u = assert(lua.parse("a b c d e", { limits = { max_tokens = 2, max_diagnostics = 0 } }))
+    local hit = false
+    for _, d in ipairs(u.diagnostics) do if d.code == "lua.limit.max_tokens" then hit = true end end
+    ok(hit, "limit: terminal diagnostic survives max_diagnostics=0")
+    local u2 = assert(lua.parse("@ @ @", { limits = { max_diagnostics = 0 } }))
+    eq(#u2.diagnostics, 0, "limit: max_diagnostics=0 suppresses NORMAL diagnostics")
+end
+
+-- ── 12. opts / limits validated at the boundary (API misuse -> err) ───
+do
+    local function misuse(fn, name)
+        local u, e = fn()
+        ok(u == nil and type(e) == "string", "opts-validate: " .. name)
+    end
+    misuse(function() return lua.parse("x", "notatable") end, "opts non-table")
+    misuse(function() return lua.parse("x", { limits = "notatable" }) end, "limits non-table")
+    misuse(function() return lua.parse("x", { limits = { max_bytes = -1 } }) end, "limit negative")
+    misuse(function() return lua.parse("x", { limits = { max_tokens = 1.5 } }) end, "limit non-integer")
+    misuse(function() return lua.parse("x", { path = 123 }) end, "path non-string")
+    local u = assert(lua.parse("x", { path = "f.lua", limits = { max_tokens = 10 } }))
+    ok(u ~= nil, "opts-validate: valid opts accepted")
+end
+
+-- ── 13. unit:position clamps offsets outside [1, #source+1] ────────────
+do
+    local u = assert(lua.parse("ab\ncd"))                 -- #source = 5, last line = 2
+    eq(select(1, u:position(1)), 1, "pos: byte 1 -> line 1")
+    eq(select(2, u:position(1)), 1, "pos: byte 1 -> col 1")
+    eq(select(1, u:position(0)), 1, "pos: off<1 clamps to line 1")
+    eq(select(1, u:position(9999)), 2, "pos: huge off clamps to last line")
+    eq(select(1, u:position(6)), 2, "pos: #source+1 is valid")
+    eq(select(1, u:position("x")), 1, "pos: non-number off is safe")
+end
+
 print(string.format("test_lexer: %d passed, %d failed", pass, fail))
 return { pass = pass, fail = fail, failures = failures }

--- a/stdlib/cli/lua/hull/source/tests/test_lexer.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_lexer.lua
@@ -1,0 +1,193 @@
+--
+-- test_lexer.lua — slice-1 tests for hull.source.lua (lexer + ranges + line map).
+--
+-- Pure Lua; run by tests/hull/source/test_lua_source.c (a vanilla lua_State with
+-- package.path pointed at stdlib/cli/lua). Returns { pass, fail, failures } and
+-- prints FAIL lines. The Lua load() differential corpus lives in the HARNESS, not
+-- here (this module never calls dynamic compilation).
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local lua = require("hull.source.lua")
+
+local pass, fail, failures = 0, 0, {}
+local function ok(cond, name)
+    if cond then pass = pass + 1
+    else fail = fail + 1; failures[#failures + 1] = name; print("FAIL: " .. name) end
+end
+local function eq(a, b, name)
+    ok(a == b, name .. " (expected " .. tostring(b) .. ", got " .. tostring(a) .. ")")
+end
+
+-- helpers over a parsed unit
+local function toks(unit)  -- non-eof tokens
+    local t = {}
+    for _, k in ipairs(unit.tokens) do if k.kind ~= "eof" then t[#t + 1] = k end end
+    return t
+end
+local function find(unit, text)
+    for _, k in ipairs(unit.tokens) do if k.text == text then return k end end
+    return nil
+end
+
+-- ── 1. exact half-open byte ranges ────────────────────────────────────
+do
+    local u = assert(lua.parse("local x = 42"))
+    local t = toks(u)
+    eq(#t, 4, "ranges: token count")
+    eq(t[1].kind, "keyword", "ranges: 'local' is keyword")
+    eq(t[1].range.start, 1, "ranges: local.start"); eq(t[1].range.stop, 6, "ranges: local.stop [half-open)")
+    eq(t[2].text, "x", "ranges: name x"); eq(t[2].range.start, 7, "ranges: x.start"); eq(t[2].range.stop, 8, "ranges: x.stop")
+    eq(find(u, "42").range.start, 11, "ranges: 42.start"); eq(find(u, "42").range.stop, 13, "ranges: 42.stop")
+    -- eof is a zero-width range one past the last byte
+    local eof = u.tokens[#u.tokens]
+    eq(eof.kind, "eof", "ranges: last token eof"); eq(eof.range.start, 13, "ranges: eof at n+1"); eq(eof.range.stop, 13, "ranges: eof zero-width")
+end
+
+-- ── 1b. UTF-8 before a token: byte ranges must account for multibyte ──
+do
+    -- "-- café\n" = 2 + 1 + 3 + 2(é) + 1(\n) = 9 bytes; 'local' starts at byte 10
+    local src = "-- caf\xC3\xA9\nlocal x = 1"
+    local u = assert(lua.parse(src))
+    eq(find(u, "local").range.start, 10, "utf8: local starts after multibyte comment")
+    eq(u:text(find(u, "local")), "local", "utf8: slice round-trips")
+    local sl, sc = u:position(find(u, "local").range.start)
+    eq(sl, 2, "utf8: local on line 2"); eq(sc, 1, "utf8: local at col 1")
+end
+
+-- ── 2. CRLF / LF / final line without newline / shebang ───────────────
+do
+    local u = assert(lua.parse("local x=1\r\nlocal y=2"))   -- CRLF
+    local yl = select(1, u:position(find(u, "y").range.start))
+    eq(yl, 2, "crlf: y is on line 2")
+    eq(u:text(find(u, "y")), "y", "crlf: slice round-trips")
+
+    local u2 = assert(lua.parse("local x=1"))               -- no trailing newline
+    eq(#u2.diagnostics, 0, "no-newline: clean")
+    eq(u2.tokens[#u2.tokens].range.start, 10, "no-newline: eof at n+1")
+
+    local u3 = assert(lua.parse("#!/usr/bin/env hull\nlocal x=1"))  -- shebang
+    eq(#u3.comments, 1, "shebang: one comment"); eq(u3.comments[1].kind, "shebang", "shebang: kind")
+    eq(u3.comments[1].range.start, 1, "shebang: from byte 1")
+    eq(u3:text(u3.comments[1]), "#!/usr/bin/env hull\n", "shebang: lossless incl newline")
+    eq(toks(u3)[1].text, "local", "shebang: first token is local")
+end
+
+-- ── 3. long-bracket strings/comments at multiple = levels ─────────────
+do
+    local u = assert(lua.parse("local s = [==[ hi ]] there ]==]"))
+    local s = find(u, "[==[ hi ]] there ]==]")
+    ok(s ~= nil and s.kind == "string", "long: level-2 string, inner ]] ignored")
+    eq(u:text(s), "[==[ hi ]] there ]==]", "long: lossless")
+    eq(#u.diagnostics, 0, "long: no diagnostics")
+
+    local u2 = assert(lua.parse("[[x]]"))
+    eq(toks(u2)[1].text, "[[x]]", "long: level-0 string")
+
+    local u3 = assert(lua.parse("--[=[ long comment ]=]\nlocal a=1"))
+    eq(u3.comments[1].kind, "long", "long: comment kind")
+    eq(u3:text(u3.comments[1]), "--[=[ long comment ]=]", "long: comment lossless")
+
+    local u4 = assert(lua.parse("local s = [[ unterminated"))       -- unterminated long string
+    ok(#u4.diagnostics >= 1, "long: unterminated -> diagnostic")
+    eq(u4.diagnostics[1].code, "lua.syntax", "long: unterminated code")
+end
+
+-- ── 4. numerals + escapes (valid + malformed) ─────────────────────────
+do
+    for _, good in ipairs({ "42", "0xFF", "3.14", ".5", "3.", "1e10", "0x1p4", "0x1.8p3", "0xA" }) do
+        local u = assert(lua.parse("local n = " .. good))
+        local t = find(u, good)
+        ok(t ~= nil and t.kind == "number" and not t.malformed, "number ok: " .. good)
+        eq(#u.diagnostics, 0, "number ok clean: " .. good)
+    end
+    for _, bad in ipairs({ "0x", "1e", "1..2", "3abc" }) do
+        local u = assert(lua.parse("local n = " .. bad))
+        ok(#u.diagnostics >= 1, "number malformed -> diagnostic: " .. bad)
+    end
+    -- escapes: all valid forms, no diagnostics
+    local u = assert(lua.parse([[local s = "\n\t\\\"\x41\65\u{1F600}\z   x"]]))
+    eq(#u.diagnostics, 0, "escapes: valid forms clean")
+    -- malformed escapes
+    for _, src in ipairs({ [[local s = "\x1"]], [[local s = "\999"]], [[local s = "\q"]], [[local s = "abc]] }) do
+        local u2 = assert(lua.parse(src))
+        ok(#u2.diagnostics >= 1, "escape/string malformed -> diagnostic: " .. src)
+    end
+end
+
+-- ── 5. keyword vs identifier boundaries ───────────────────────────────
+do
+    local u = assert(lua.parse("and andx _end end function1 local2 nil nily"))
+    local want = {
+        { "and", "keyword" }, { "andx", "name" }, { "_end", "name" }, { "end", "keyword" },
+        { "function1", "name" }, { "local2", "name" }, { "nil", "keyword" }, { "nily", "name" },
+    }
+    local t = toks(u)
+    for i, w in ipairs(want) do
+        eq(t[i] and t[i].text, w[1], "kw/id text " .. w[1])
+        eq(t[i] and t[i].kind, w[2], "kw/id kind " .. w[1])
+    end
+end
+
+-- ── 6. resource limits (bounded behavior) ─────────────────────────────
+do
+    local big = string.rep("x ", 100)                      -- 200 bytes
+    local u = assert(lua.parse(big, { limits = { max_bytes = 10 } }))
+    eq(u.diagnostics[1] and u.diagnostics[1].code, "lua.limit.max_bytes", "limit: max_bytes")
+
+    local u2 = assert(lua.parse("a b c d e f", { limits = { max_tokens = 3 } }))
+    local hit = false
+    for _, d in ipairs(u2.diagnostics) do if d.code == "lua.limit.max_tokens" then hit = true end end
+    ok(hit, "limit: max_tokens")
+
+    local u3 = assert(lua.parse("@ @ @ @ @ @", { limits = { max_diagnostics = 2 } }))
+    ok(#u3.diagnostics <= 2, "limit: max_diagnostics caps count (" .. #u3.diagnostics .. ")")
+end
+
+-- ── 7. lossless comment/token slicing through unit:text() ─────────────
+do
+    local src = table.concat({
+        "#!/usr/bin/env hull",
+        "-- a line comment",
+        "--[[ a long comment ]]",
+        'local s = "esc \\n \\x41 done"',
+        "local n = 0x1.8p3",
+        "local t = [==[ raw ]] block ]==]",
+        "function f(a, b) return a .. b end",
+    }, "\n")
+    local u = assert(lua.parse(src))
+    local lossless = true
+    for _, k in ipairs(u.tokens) do
+        if k.kind ~= "eof" and u:text(k) ~= k.text then lossless = false; print("  token slice mismatch: " .. tostring(k.text)) end
+    end
+    for _, cm in ipairs(u.comments) do
+        if u:text(cm) ~= cm.text then lossless = false; print("  comment slice mismatch: " .. tostring(cm.text)) end
+    end
+    ok(lossless, "lossless: every token/comment slices back to its text")
+end
+
+-- ── 8. no raw exceptions cross parse() ────────────────────────────────
+do
+    local nasty = {
+        "", "'", '"', "[[", "--[[", "\\", "0x", "\255\0\1", "local x = ", string.rep("(", 500),
+        "[==[", "\"\\u{", "1..2..3", "::::", "...",
+    }
+    local all_safe = true
+    for _, s in ipairs(nasty) do
+        local okc, a, b = pcall(lua.parse, s)
+        if not okc then all_safe = false; print("  parse RAISED on: " .. tostring(s)) end
+        -- must return (unit, nil) or (nil, err): never (nil, nil)
+        if okc and a == nil and b == nil then all_safe = false; print("  parse returned (nil,nil) on: " .. tostring(s)) end
+    end
+    ok(all_safe, "boundary: parse never raises, never returns (nil,nil)")
+
+    -- API misuse -> (nil, err), not a raised error
+    local okc, u, e = pcall(lua.parse, 123)
+    ok(okc and u == nil and e ~= nil, "boundary: non-string source -> (nil, err)")
+    local okc2, u2, e2 = pcall(lua.parse, nil)
+    ok(okc2 and u2 == nil and e2 ~= nil, "boundary: nil source -> (nil, err)")
+end
+
+print(string.format("test_lexer: %d passed, %d failed", pass, fail))
+return { pass = pass, fail = fail, failures = failures }

--- a/tests/hull/source/test_lua_source.c
+++ b/tests/hull/source/test_lua_source.c
@@ -1,0 +1,73 @@
+/*
+ * test_lua_source.c — harness for the pure-Lua hull.source.lua layer.
+ *
+ * The source-analysis layer is pure Lua with NO Hull C dependencies, so it is
+ * tested in a VANILLA lua_State (vendored Lua 5.4, no Hull sandbox / module
+ * resolver): we point package.path at stdlib/cli/lua and run the co-located Lua
+ * test scripts, which self-assert and return { pass, fail }. This keeps the
+ * source layer's own tests in Lua (where the data lives) while surfacing pass/
+ * fail to the C test runner + CI. Tests run from the repo root (see mk/tests.mk).
+ *
+ * The Lua 5.4 load() differential conformance corpus (later slice) belongs HERE,
+ * in the harness, not in the source-analysis module — the module never calls
+ * dynamic compilation.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#include "utest.h"
+
+#include "lua.h"
+#include "lauxlib.h"
+#include "lualib.h"
+
+/* Run a co-located Lua test script in a vanilla state. Returns 0 when the script
+ * ran and returned a { pass, fail } table (values via out-params); -1 on any
+ * harness-level failure (state alloc, package.path, dofile raise, bad return).
+ * Uses NO utest macros -- those are only valid inside a UTEST body. */
+static int run_lua_test(const char *script_path, long long *pass_out, long long *fail_out)
+{
+    *pass_out = 0;
+    *fail_out = -1;
+
+    lua_State *L = luaL_newstate();
+    if (!L) return -1;
+    luaL_openlibs(L);
+
+    /* Resolve require("hull.source.X") from the source tree (repo-root relative). */
+    if (luaL_dostring(L,
+            "package.path = 'stdlib/cli/lua/?.lua;stdlib/cli/lua/?/init.lua;' .. package.path")
+        != LUA_OK) {
+        fprintf(stderr, "package.path setup failed: %s\n", lua_tostring(L, -1));
+        lua_close(L);
+        return -1;
+    }
+
+    if (luaL_dofile(L, script_path) != LUA_OK) {
+        fprintf(stderr, "\n%s: %s\n", script_path, lua_tostring(L, -1));
+        lua_close(L);
+        return -1;   /* the Lua script raised (a bug in the layer or the test) */
+    }
+
+    if (!lua_istable(L, -1)) { lua_close(L); return -1; }
+    lua_getfield(L, -1, "fail");
+    *fail_out = (long long)lua_tointeger(L, -1);
+    lua_pop(L, 1);
+    lua_getfield(L, -1, "pass");
+    *pass_out = (long long)lua_tointeger(L, -1);
+    lua_pop(L, 1);
+
+    fprintf(stderr, "  %s: %lld passed, %lld failed\n", script_path, *pass_out, *fail_out);
+    lua_close(L);
+    return 0;
+}
+
+UTEST(lua_source, lexer_slice1)
+{
+    long long pass = 0, fail = -1;
+    int rc = run_lua_test("stdlib/cli/lua/hull/source/tests/test_lexer.lua", &pass, &fail);
+    ASSERT_EQ(rc, 0);              /* harness ran the script to a { pass, fail } return */
+    EXPECT_EQ(fail, 0LL);          /* every Lua assertion passed */
+    EXPECT_GT(pass, 0LL);          /* and the script actually ran cases */
+}
+
+UTEST_MAIN()


### PR DESCRIPTION
Foundation for Hull's future build-plugin/metaprogramming system: a small, reusable, **Hull-owned** Lua source-analysis API (AST + comments + annotations + exact source ranges + syntax diagnostics). No consumer (`hull analyze` / `hull.query` / `hull.compute` / codegen) is built here.

## Design decision (committed record: `docs/lua_source_analysis_design.md`)
LuaLS was the preferred starting point but **rejected**: its tokenizer needs LPegLabel (a native C lib — violates the no-native-dep / no-C-parser rules) and its parse is coupled to the semantic `guide`/`compile` layer, tripping the spec's stop conditions. Chosen: a **compact pure-Lua recursive-descent Lua 5.4 parser** (same pattern as `template.lua`), a replaceable detail behind the `hull.source.lua` contract. All five reviewer contract tightenings are locked in the design (full Lua 5.4 required; `parse()` returns `(unit, err)` with syntax→diagnostics/`err==nil`; resource limits; byte-based half-open ranges with on-demand line/col; Lua 5.4 differential conformance corpus in the harness).

## Slice 1 (this PR): lexer + ranges + line map
- `source/range.lua` — neutral `SourceRange` (`[start, stop)`, 1-based bytes) + line-start index, on-demand `(line, col)` (JS-reusable).
- `source/diagnostic.lua` — the shared structured Diagnostic.
- `source/lexer.lua` — complete Lua 5.4 lexer with exact half-open byte ranges; long brackets at any `=` level, every numeral (validated via `tonumber`, not `load()`) + escape form, shebang, CRLF/LF/no-final-newline. **Never raises** — malformed → diagnostic, always advances. Resource limits bound adversarial input.
- `source/lua.lua` — the public `parse()` contract (no raw error crosses; `unit:text/:position/:line_col`; `unit.ast` arrives in slice 3).

## Tests
`test_lexer.lua` (**83 cases**) via a vanilla `lua_State` harness (`tests/hull/source/test_lua_source.c`, links only vendored Lua 5.4, auto-discovered by `make test`): exact byte ranges incl. UTF-8-before-token, CRLF/LF/no-newline/shebang, long brackets at multiple levels, valid+malformed numerals/escapes, keyword-vs-identifier boundaries, every resource limit, lossless slicing via `unit:text()`, and no-raw-exception-crossing-`parse()`. luacheck clean. The `load()` differential corpus stays in the harness (later slice), never the module.

Next slices: expression grammar → statements/declarations → comments/annotations → recovery/conformance. Consumers wait until the slice 3–4 AST tests are stable.