### PR TITLE
feat(source): hull.source.lua slice 2 — expression grammar

### DIFF
--- a/stdlib/cli/lua/hull/source/lexer.lua
+++ b/stdlib/cli/lua/hull/source/lexer.lua
@@ -110,8 +110,10 @@ function M.tokenize(source, opts)
     local function is_space(c) return c == " " or c == "\t" or c == "\r"
         or c == "\n" or c == "\v" or c == "\f" end
 
-    -- ── shebang: a leading '#' line (Lua's loader skips it) ───────────
-    if at(1) == "#" then
+    -- ── shebang: a leading '#!' line (Lua's file loader skips it). Only "#!",
+    -- NOT a bare '#', so a chunk/expression beginning with the length operator
+    -- (e.g. `#t`) lexes '#' as an operator rather than eating the line. ─────
+    if at(1) == "#" and at(2) == "!" then
         local e = source:find("\n", 1, true)
         local stop = e and (e + 1) or (n + 1)   -- include the newline if present
         comments[#comments + 1] =

--- a/stdlib/cli/lua/hull/source/parser.lua
+++ b/stdlib/cli/lua/hull/source/parser.lua
@@ -1,0 +1,339 @@
+--
+-- hull.source.parser — recursive-descent Lua 5.4 parser (slice 2: expressions).
+--
+-- Consumes the lexer token stream and builds Hull AST expression nodes with EXACT
+-- half-open byte ranges (see range.lua). Statements/declarations land in slice 3;
+-- a function EXPRESSION's body is a statement block, so in slice 2 the body is
+-- skipped (balanced to its `end`) and a `lua.unsupported` diagnostic is emitted
+-- (a non-empty body is valid syntax this slice does not yet represent -- an
+-- explicit diagnostic, never a silently malformed AST). Slice 3 replaces the skip
+-- with the real block parser.
+--
+-- The parser NEVER raises: a parse error emits a diagnostic and returns an
+-- { kind = "error" } node (best-effort). Node vocabulary (expressions) matches
+-- docs/lua_source_analysis_design.md §5.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local diag = require("hull.source.diagnostic")
+
+local M = {}
+
+-- Lua 5.4 binary operator priorities {left, right} (lparser.c). Right-assoc ops
+-- (`..`, `^`) have right < left. `and`/`or` are keywords; the rest are ops. `~`
+-- is binary xor here (unary bitwise-not is handled in prefix position).
+local BINPRI = {
+    ["or"] = { 1, 1 }, ["and"] = { 2, 2 },
+    ["<"] = { 3, 3 }, [">"] = { 3, 3 }, ["<="] = { 3, 3 }, [">="] = { 3, 3 },
+    ["~="] = { 3, 3 }, ["=="] = { 3, 3 },
+    ["|"] = { 4, 4 }, ["~"] = { 5, 5 }, ["&"] = { 6, 6 },
+    ["<<"] = { 7, 7 }, [">>"] = { 7, 7 },
+    [".."] = { 9, 8 },
+    ["+"] = { 10, 10 }, ["-"] = { 10, 10 },
+    ["*"] = { 11, 11 }, ["/"] = { 11, 11 }, ["//"] = { 11, 11 }, ["%"] = { 11, 11 },
+    ["^"] = { 14, 13 },
+}
+local UNARY_PRIORITY = 12
+local UNARY = { ["not"] = true, ["-"] = true, ["#"] = true, ["~"] = true }
+
+-- ── parser state ──────────────────────────────────────────────────────
+local P = {}
+P.__index = P
+
+local function new_state(tokens, source, opts)
+    return setmetatable({
+        tokens = tokens, source = source, path = opts.path,
+        diagnostics = {}, pos = 1,
+        prev = nil,                         -- last consumed token (for node end offsets)
+        depth = 0, max_depth = (opts.limits and opts.limits.max_depth) or 400,
+        aborted = false,
+    }, P)
+end
+
+function P:cur() return self.tokens[self.pos] end
+function P:advance() local t = self.tokens[self.pos]; self.prev = t; self.pos = self.pos + 1; return t end
+function P:at_eof() return self:cur().kind == "eof" end
+
+function P:is_op(text) local t = self:cur(); return t.kind == "op" and t.text == text end
+function P:is_kw(text) local t = self:cur(); return t.kind == "keyword" and t.text == text end
+
+function P:err(message, tok)
+    tok = tok or self:cur()
+    if #self.diagnostics < 200 then
+        self.diagnostics[#self.diagnostics + 1] =
+            diag.error("lua.syntax", message, self.path, tok.range)
+    end
+    return { kind = "error", range = { start = tok.range.start, stop = tok.range.stop } }
+end
+
+function P:unsupported(message, s, e)
+    self.diagnostics[#self.diagnostics + 1] =
+        diag.error("lua.unsupported", message, self.path, { start = s, stop = e })
+end
+
+-- Consume `text` op/kw or emit a diagnostic; returns the token or nil.
+function P:expect_op(text)
+    if self:is_op(text) then return self:advance() end
+    self:err("'" .. text .. "' expected"); return nil
+end
+function P:expect_kw(text)
+    if self:is_kw(text) then return self:advance() end
+    self:err("'" .. text .. "' expected"); return nil
+end
+
+-- node spanning [start_off, self.prev.stop)
+function P:finish(node, start_off)
+    node.range = { start = start_off, stop = (self.prev and self.prev.range.stop) or start_off }
+    return node
+end
+
+-- ── the binary operator, if the current token is one ──────────────────
+function P:binop()
+    local t = self:cur()
+    if t.kind == "op" and BINPRI[t.text] then return t.text end
+    if t.kind == "keyword" and (t.text == "and" or t.text == "or") then return t.text end
+    return nil
+end
+
+-- ── expression: precedence climbing (Lua's algorithm) ─────────────────
+function P:subexpr(limit)
+    self.depth = self.depth + 1
+    if self.depth > self.max_depth then
+        if not self.aborted then
+            self.aborted = true
+            self.diagnostics[#self.diagnostics + 1] =
+                diag.error("lua.limit.max_depth", "expression nesting exceeds max_depth (" ..
+                    self.max_depth .. ")", self.path, self:cur().range)
+        end
+        self.depth = self.depth - 1
+        return { kind = "error", range = self:cur().range }
+    end
+
+    local e
+    local t = self:cur()
+    if (t.kind == "op" and UNARY[t.text]) or (t.kind == "keyword" and t.text == "not") then
+        local op = t.text
+        local start = t.range.start
+        self:advance()
+        local operand = self:subexpr(UNARY_PRIORITY)
+        e = self:finish({ kind = "unary", op = op, operand = operand }, start)
+    else
+        e = self:simple()
+    end
+
+    while not self.aborted do
+        local op = self:binop()
+        if not op or BINPRI[op][1] <= limit then break end
+        self:advance()
+        local rhs = self:subexpr(BINPRI[op][2])
+        e = self:finish({ kind = "binary", op = op, lhs = e, rhs = rhs }, e.range.start)
+    end
+
+    self.depth = self.depth - 1
+    return e
+end
+
+function M.parse_expression_state(st)
+    return st:subexpr(0)
+end
+
+-- ── simple expressions ────────────────────────────────────────────────
+function P:simple()
+    local t = self:cur()
+    local start = t.range.start
+
+    if t.kind == "number" then
+        self:advance()
+        return self:finish({ kind = "literal", subtype = "number", text = t.text, malformed = t.malformed }, start)
+    elseif t.kind == "string" then
+        self:advance()
+        return self:finish({ kind = "literal", subtype = "string", text = t.text, malformed = t.malformed }, start)
+    elseif t.kind == "keyword" and (t.text == "nil" or t.text == "true" or t.text == "false") then
+        self:advance()
+        local subtype = (t.text == "nil") and "nil" or "boolean"
+        return self:finish({ kind = "literal", subtype = subtype, value = t.text }, start)
+    elseif self:is_op("...") then
+        self:advance()
+        return self:finish({ kind = "vararg" }, start)
+    elseif self:is_op("{") then
+        return self:table_constructor()
+    elseif t.kind == "keyword" and t.text == "function" then
+        return self:function_expr()
+    else
+        return self:suffixed()
+    end
+end
+
+-- ── prefix / suffixed expressions (var, call, index, method) ──────────
+function P:primary()
+    local t = self:cur()
+    local start = t.range.start
+    if self:is_op("(") then
+        self:advance()
+        local inner = self:subexpr(0)
+        self:expect_op(")")
+        return self:finish({ kind = "paren", expr = inner }, start)
+    elseif t.kind == "name" then
+        self:advance()
+        return self:finish({ kind = "name", name = t.text }, start)
+    else
+        return self:err("unexpected symbol")
+    end
+end
+
+function P:suffixed()
+    local e = self:primary()
+    local start = e.range.start
+    while true do
+        if self:is_op(".") then
+            self:advance()
+            local name = self:cur()
+            if name.kind ~= "name" then self:err("<name> expected after '.'"); break end
+            self:advance()
+            e = self:finish({ kind = "field", obj = e, name = name.text }, start)
+        elseif self:is_op("[") then
+            self:advance()
+            local key = self:subexpr(0)
+            self:expect_op("]")
+            e = self:finish({ kind = "index", obj = e, key = key }, start)
+        elseif self:is_op(":") then
+            self:advance()
+            local method = self:cur()
+            if method.kind ~= "name" then self:err("<name> expected after ':'"); break end
+            self:advance()
+            local args = self:call_args()
+            e = self:finish({ kind = "method_call", obj = e, method = method.text, args = args }, start)
+        elseif self:is_op("(") or self:is_op("{") or self:cur().kind == "string" then
+            local args = self:call_args()
+            e = self:finish({ kind = "call", callee = e, args = args }, start)
+        else
+            break
+        end
+    end
+    return e
+end
+
+-- args := '(' [explist] ')' | tableconstructor | String
+function P:call_args()
+    if self:cur().kind == "string" then
+        local t = self:advance()
+        return { self:finish({ kind = "literal", subtype = "string", text = t.text, malformed = t.malformed }, t.range.start) }
+    elseif self:is_op("{") then
+        return { self:table_constructor() }
+    elseif self:is_op("(") then
+        self:advance()
+        local args = {}
+        if not self:is_op(")") then
+            args[#args + 1] = self:subexpr(0)
+            while self:is_op(",") do self:advance(); args[#args + 1] = self:subexpr(0) end
+        end
+        self:expect_op(")")
+        return args
+    else
+        self:err("function arguments expected")
+        return {}
+    end
+end
+
+-- ── table constructor ─────────────────────────────────────────────────
+-- field := '[' exp ']' '=' exp | Name '=' exp | exp ; sep := ',' | ';'
+function P:table_constructor()
+    local start = self:cur().range.start
+    self:expect_op("{")
+    local fields = {}
+    while not self:is_op("}") and not self:at_eof() do
+        local fstart = self:cur().range.start
+        if self:is_op("[") then
+            self:advance()
+            local key = self:subexpr(0)
+            self:expect_op("]")
+            self:expect_op("=")
+            local val = self:subexpr(0)
+            fields[#fields + 1] = self:finish({ kind = "field_expr", key = key, value = val }, fstart)
+        elseif self:cur().kind == "name" and self.tokens[self.pos + 1]
+               and self.tokens[self.pos + 1].kind == "op" and self.tokens[self.pos + 1].text == "=" then
+            local nametok = self:advance()
+            self:advance()                          -- '='
+            local val = self:subexpr(0)
+            fields[#fields + 1] = self:finish({ kind = "field_name", name = nametok.text, value = val }, fstart)
+        else
+            local val = self:subexpr(0)
+            fields[#fields + 1] = self:finish({ kind = "field_item", value = val }, fstart)
+        end
+        if self:is_op(",") or self:is_op(";") then self:advance() else break end
+    end
+    self:expect_op("}")
+    return self:finish({ kind = "table", fields = fields }, start)
+end
+
+-- ── function expression (params now; body skipped until slice 3) ──────
+-- Balanced skip to the matching `end` (nested block openers counted). repeat/until
+-- is a distinct pair and does not consume an `end`.
+function P:skip_block_to_end()
+    local open = 1
+    while not self:at_eof() do
+        local t = self:cur()
+        if t.kind == "keyword" then
+            if t.text == "function" or t.text == "if" or t.text == "do" or t.text == "for" or t.text == "while" then
+                open = open + 1
+            elseif t.text == "end" then
+                open = open - 1
+                if open == 0 then return self:advance() end
+            end
+        end
+        self:advance()
+    end
+    self:err("'end' expected (unterminated function)")
+    return nil
+end
+
+function P:function_expr()
+    local start = self:cur().range.start
+    self:advance()                              -- 'function'
+    self:expect_op("(")
+    local params, is_vararg = {}, false
+    if not self:is_op(")") then
+        while true do
+            if self:is_op("...") then
+                local v = self:advance(); is_vararg = true
+                params[#params + 1] = { kind = "vararg", range = v.range }
+                break
+            elseif self:cur().kind == "name" then
+                local nm = self:advance()
+                params[#params + 1] = { kind = "param", name = nm.text, range = nm.range }
+                if self:is_op(",") then self:advance() else break end
+            else
+                self:err("<name> or '...' expected in parameter list"); break
+            end
+        end
+    end
+    self:expect_op(")")
+    -- body: slice 3. Empty body (immediate `end`) is fine; a non-empty one is
+    -- valid syntax not yet represented -> explicit diagnostic + balanced skip.
+    local body_start = self:cur().range.start
+    if not self:is_kw("end") then
+        self:skip_block_to_end()
+        self:unsupported("function body is parsed in a later slice", body_start,
+            (self.prev and self.prev.range.stop) or body_start)
+    else
+        self:advance()                          -- 'end'
+    end
+    return self:finish({ kind = "function_expr", params = params, is_vararg = is_vararg, body = nil }, start)
+end
+
+-- ── public: parse a single expression from source (slice-2 surface) ───
+-- Returns (node, diagnostics). The lexer must be run by the caller (lua.lua) or
+-- via M.parse_expression which does both.
+function M.parse_expression(tokens, source, opts)
+    opts = opts or {}
+    local st = new_state(tokens, source, opts)
+    local node = st:subexpr(0)
+    if not st:at_eof() then
+        st:err("unexpected trailing tokens after expression")
+    end
+    return node, st.diagnostics
+end
+
+M.new_state = new_state
+return M

--- a/stdlib/cli/lua/hull/source/parser.lua
+++ b/stdlib/cli/lua/hull/source/parser.lua
@@ -42,14 +42,22 @@ local P = {}
 P.__index = P
 
 local function new_state(tokens, source, opts)
+    local limits = opts.limits or {}
     return setmetatable({
         tokens = tokens, source = source, path = opts.path,
         diagnostics = {}, pos = 1,
         prev = nil,                         -- last consumed token (for node end offsets)
-        depth = 0, max_depth = (opts.limits and opts.limits.max_depth) or 400,
+        depth = 0, max_depth = limits.max_depth or 400,
+        max_diagnostics = limits.max_diagnostics or 200,
         aborted = false,
     }, P)
 end
+
+-- Normal diagnostics respect max_diagnostics; terminal (limit) diagnostics always
+-- record, mirroring the lexer's policy so the reason parsing stopped is never
+-- suppressed.
+function P:emit(d) if #self.diagnostics < self.max_diagnostics then self.diagnostics[#self.diagnostics + 1] = d end end
+function P:emit_terminal(d) self.diagnostics[#self.diagnostics + 1] = d end
 
 function P:cur() return self.tokens[self.pos] end
 function P:advance() local t = self.tokens[self.pos]; self.prev = t; self.pos = self.pos + 1; return t end
@@ -60,16 +68,12 @@ function P:is_kw(text) local t = self:cur(); return t.kind == "keyword" and t.te
 
 function P:err(message, tok)
     tok = tok or self:cur()
-    if #self.diagnostics < 200 then
-        self.diagnostics[#self.diagnostics + 1] =
-            diag.error("lua.syntax", message, self.path, tok.range)
-    end
+    self:emit(diag.error("lua.syntax", message, self.path, tok.range))
     return { kind = "error", range = { start = tok.range.start, stop = tok.range.stop } }
 end
 
 function P:unsupported(message, s, e)
-    self.diagnostics[#self.diagnostics + 1] =
-        diag.error("lua.unsupported", message, self.path, { start = s, stop = e })
+    self:emit(diag.error("lua.unsupported", message, self.path, { start = s, stop = e }))
 end
 
 -- Consume `text` op/kw or emit a diagnostic; returns the token or nil.
@@ -102,9 +106,9 @@ function P:subexpr(limit)
     if self.depth > self.max_depth then
         if not self.aborted then
             self.aborted = true
-            self.diagnostics[#self.diagnostics + 1] =
-                diag.error("lua.limit.max_depth", "expression nesting exceeds max_depth (" ..
-                    self.max_depth .. ")", self.path, self:cur().range)
+            self:emit_terminal(diag.error("lua.limit.max_depth",
+                "expression nesting exceeds max_depth (" .. self.max_depth .. ")",
+                self.path, self:cur().range))
         end
         self.depth = self.depth - 1
         return { kind = "error", range = self:cur().range }
@@ -151,8 +155,13 @@ function P:simple()
         return self:finish({ kind = "literal", subtype = "string", text = t.text, malformed = t.malformed }, start)
     elseif t.kind == "keyword" and (t.text == "nil" or t.text == "true" or t.text == "false") then
         self:advance()
-        local subtype = (t.text == "nil") and "nil" or "boolean"
-        return self:finish({ kind = "literal", subtype = subtype, value = t.text }, start)
+        -- CONVENTION: every literal carries `text` = its exact lexeme. Booleans
+        -- ADDITIONALLY expose the actual boolean `value`; nil carries no `value`.
+        if t.text == "nil" then
+            return self:finish({ kind = "literal", subtype = "nil", text = t.text }, start)
+        end
+        return self:finish({ kind = "literal", subtype = "boolean", text = t.text,
+                             value = (t.text == "true") }, start)
     elseif self:is_op("...") then
         self:advance()
         return self:finish({ kind = "vararg" }, start)
@@ -178,7 +187,9 @@ function P:primary()
         self:advance()
         return self:finish({ kind = "name", name = t.text }, start)
     else
-        return self:err("unexpected symbol")
+        local e = self:err("unexpected symbol")
+        if not self:at_eof() then self:advance() end   -- consume to progress (avoid stalls)
+        return e
     end
 end
 
@@ -268,19 +279,31 @@ function P:table_constructor()
 end
 
 -- ── function expression (params now; body skipped until slice 3) ──────
--- Balanced skip to the matching `end` (nested block openers counted). repeat/until
--- is a distinct pair and does not consume an `end`.
+-- Balanced skip to the matching `end`. The `end`-terminated openers are
+-- `function`, `if`, `for`, `while`, and a STANDALONE `do`. A `for`/`while` opens
+-- ONE block whose `do` is a syntactic marker, not a second `end`-taker -- so its
+-- `do` is absorbed (tracked by `pending_do`, a count, which stays correct even
+-- when a nested function literal appears inside a loop header). `repeat ... until`
+-- is NOT `end`-terminated and is ignored for the `end` count. Replaced by the real
+-- block parser in slice 3.
 function P:skip_block_to_end()
-    local open = 1
+    local open = 1              -- the function's own `end`
+    local pending_do = 0        -- for/while opened but awaiting their `do`
     while not self:at_eof() do
         local t = self:cur()
         if t.kind == "keyword" then
-            if t.text == "function" or t.text == "if" or t.text == "do" or t.text == "for" or t.text == "while" then
+            local k = t.text
+            if k == "function" or k == "if" then
                 open = open + 1
-            elseif t.text == "end" then
+            elseif k == "for" or k == "while" then
+                open = open + 1; pending_do = pending_do + 1
+            elseif k == "do" then
+                if pending_do > 0 then pending_do = pending_do - 1 else open = open + 1 end
+            elseif k == "end" then
                 open = open - 1
                 if open == 0 then return self:advance() end
             end
+            -- repeat / until are not end-terminated: ignored for `open`.
         end
         self:advance()
     end

--- a/stdlib/cli/lua/hull/source/tests/test_parser.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_parser.lua
@@ -49,6 +49,40 @@ do
     end
     local v = parse_expr("...")
     eq(v.kind, "vararg", "vararg kind")
+
+    -- LOCKED literal shapes: every literal has `text`; booleans add boolean
+    -- `value`; nil carries NO value.
+    local num = parse_expr("42");   eq(num.text, "42", "num.text"); ok(num.value == nil, "num: no value field")
+    local str = parse_expr('"hi"'); eq(str.text, '"hi"', "str.text")
+    local nl = parse_expr("nil");   eq(nl.subtype, "nil", "nil.subtype"); eq(nl.text, "nil", "nil.text"); ok(nl.value == nil, "nil: no value")
+    local tr = parse_expr("true");  eq(tr.subtype, "boolean", "true.subtype"); eq(tr.text, "true", "true.text"); eq(tr.value, true, "true.value")
+    local fa = parse_expr("false"); eq(fa.text, "false", "false.text"); eq(fa.value, false, "false.value")
+end
+
+-- ── function-body balanced skip: nested constructs, one `end` each ────
+do
+    local bodies = {
+        "function() for i = 1, 3 do f(i) end end",             -- for + its do = one end
+        "function() if x then a() else b() end end",           -- if/elseif/else = one end
+        "function() while c do g() end end",                   -- while + its do = one end
+        "function() do local x = 1 end end",                   -- STANDALONE do
+        "function() repeat h() until done end",                -- repeat/until (no end)
+        "function() local f = function() return 1 end; return f end", -- nested function
+        "function() for a in pairs(t) do if a then break end end end", -- nested if in for
+    }
+    for _, src in ipairs(bodies) do
+        local node, all = parse_expr(src)
+        eq(node.kind, "function_expr", "skip: function_expr for " .. src)
+        eq(n_diag(all, "lua.syntax"), 0, "skip: no spurious 'unterminated' for " .. src)
+        eq(n_diag(all, "lua.unsupported"), 1, "skip: one deferred-body notice for " .. src)
+        eq(slice(src, node), src, "skip: full range for " .. src)
+    end
+end
+
+-- ── parser diagnostics respect the configured max_diagnostics ─────────
+do
+    local _, all = parse_expr("f(+, +, +, +, +)", { limits = { max_diagnostics = 2 } })
+    ok(#all <= 2, "parser: max_diagnostics caps normal diagnostics (" .. #all .. ")")
 end
 
 -- ── names / field / index / call / method / call-forms ────────────────

--- a/stdlib/cli/lua/hull/source/tests/test_parser.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_parser.lua
@@ -1,0 +1,167 @@
+--
+-- test_parser.lua — slice-2 tests for hull.source.parser (expression grammar).
+--
+-- Lexes then parses a single expression; asserts AST structure, exact half-open
+-- byte ranges, and Lua 5.4 precedence/associativity. Pure Lua; run by
+-- tests/hull/source/test_lua_source.c. Returns { pass, fail }.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local lexer = require("hull.source.lexer")
+local parser = require("hull.source.parser")
+
+local pass, fail, failures = 0, 0, {}
+local function ok(cond, name)
+    if cond then pass = pass + 1
+    else fail = fail + 1; failures[#failures + 1] = name; print("FAIL: " .. name) end
+end
+local function eq(a, b, name)
+    ok(a == b, name .. " (expected " .. tostring(b) .. ", got " .. tostring(a) .. ")")
+end
+
+local function parse_expr(src, opts)
+    local lx = lexer.tokenize(src, opts)
+    local node, pdiags = parser.parse_expression(lx.tokens, src, opts)
+    local all = {}
+    for _, d in ipairs(lx.diagnostics) do all[#all + 1] = d end
+    for _, d in ipairs(pdiags) do all[#all + 1] = d end
+    return node, all
+end
+local function slice(src, node) return src:sub(node.range.start, node.range.stop - 1) end
+local function n_diag(all, code)
+    local c = 0
+    for _, d in ipairs(all) do if d.code == code then c = c + 1 end end
+    return c
+end
+
+-- ── literals + vararg ─────────────────────────────────────────────────
+do
+    for _, c in ipairs({
+        { "42", "number" }, { '"hi"', "string" }, { "nil", "nil" },
+        { "true", "boolean" }, { "false", "boolean" }, { "0x1.8p3", "number" },
+    }) do
+        local node, all = parse_expr(c[1])
+        eq(node.kind, "literal", "literal kind: " .. c[1])
+        eq(node.subtype, c[2], "literal subtype: " .. c[1])
+        eq(slice(c[1], node), c[1], "literal range: " .. c[1])
+        eq(#all, 0, "literal clean: " .. c[1])
+    end
+    local v = parse_expr("...")
+    eq(v.kind, "vararg", "vararg kind")
+end
+
+-- ── names / field / index / call / method / call-forms ────────────────
+do
+    local node, all = parse_expr("foo(1, 2)")
+    eq(node.kind, "call", "call kind")
+    eq(node.callee.kind, "name", "call callee name")
+    eq(node.callee.name, "foo", "call callee text")
+    eq(#node.args, 2, "call arg count")
+    eq(slice("foo(1, 2)", node), "foo(1, 2)", "call range covers whole")
+    eq(node.callee.range.start, 1, "callee.start"); eq(node.callee.range.stop, 4, "callee.stop [half-open)")
+    eq(node.args[1].range.start, 5, "arg1.start"); eq(node.args[2].range.start, 8, "arg2.start")
+    eq(#all, 0, "call clean")
+
+    eq(parse_expr("a.b").kind, "field", "field kind")
+    eq(parse_expr("a.b").name, "b", "field name")
+    eq(parse_expr("a[b]").kind, "index", "index kind")
+    local m = parse_expr("obj:m(x)")
+    eq(m.kind, "method_call", "method_call kind"); eq(m.method, "m", "method name")
+    eq(parse_expr('f"x"').kind, "call", "call with string arg")
+    eq(parse_expr("f{}").kind, "call", "call with table arg")
+
+    -- chained suffixes: a.b.c(1)[2]:m()
+    local ch = parse_expr("a.b.c(1)[2]:m()")
+    eq(ch.kind, "method_call", "chain: outermost is method_call")
+    eq(slice("a.b.c(1)[2]:m()", ch), "a.b.c(1)[2]:m()", "chain: full range")
+end
+
+-- ── table constructors ────────────────────────────────────────────────
+do
+    eq(#parse_expr("{}").fields, 0, "table: empty")
+    local t = parse_expr("{ 1, 2, 3 }")
+    eq(t.kind, "table", "table kind"); eq(#t.fields, 3, "table: 3 items")
+    eq(t.fields[1].kind, "field_item", "table: positional")
+    local t2 = parse_expr('{ a = 1, ["b"] = 2, 3; 4 }')
+    eq(#t2.fields, 4, "table: mixed field count")
+    eq(t2.fields[1].kind, "field_name", "table: name field")
+    eq(t2.fields[1].name, "a", "table: name field key")
+    eq(t2.fields[2].kind, "field_expr", "table: [expr] field")
+    eq(t2.fields[3].kind, "field_item", "table: item after ,")
+    eq(t2.fields[4].kind, "field_item", "table: item after ;")
+end
+
+-- ── unary ─────────────────────────────────────────────────────────────
+do
+    for _, c in ipairs({ { "-x", "-" }, { "not y", "not" }, { "#t", "#" }, { "~n", "~" } }) do
+        local u = parse_expr(c[1])
+        eq(u.kind, "unary", "unary kind: " .. c[1]); eq(u.op, c[2], "unary op: " .. c[1])
+    end
+end
+
+-- ── precedence / associativity (assert TREE shape, not just no-crash) ─
+do
+    local a = parse_expr("1 + 2 * 3")           -- +(1, *(2,3))
+    eq(a.kind, "binary", "prec: root"); eq(a.op, "+", "prec: root +")
+    eq(a.rhs.kind, "binary", "prec: rhs is *"); eq(a.rhs.op, "*", "prec: * under +")
+
+    local b = parse_expr("2 ^ 2 ^ 3")           -- right assoc: ^(2, ^(2,3))
+    eq(b.op, "^", "assoc: ^ root"); eq(b.rhs.op, "^", "assoc: ^ nests right")
+
+    local c = parse_expr("a .. b .. c")         -- right assoc: ..(a, ..(b,c))
+    eq(c.op, "..", "assoc: .. root"); eq(c.rhs.op, "..", "assoc: .. nests right")
+
+    local d = parse_expr("1 - 2 - 3")           -- left assoc: -(-(1,2),3)
+    eq(d.op, "-", "assoc: - root"); eq(d.lhs.kind, "binary", "assoc: - nests left")
+
+    local e = parse_expr("-2 ^ 2")              -- unary looser than ^: -(^(2,2))
+    eq(e.kind, "unary", "prec: unary root"); eq(e.operand.op, "^", "prec: ^ under unary -")
+
+    local f = parse_expr("(a + b) * c")         -- paren groups
+    eq(f.op, "*", "paren: * root"); eq(f.lhs.kind, "paren", "paren: lhs parenthesized")
+end
+
+-- ── function expression (params now; body deferred to slice 3) ────────
+do
+    local empty, all = parse_expr("function() end")
+    eq(empty.kind, "function_expr", "func: kind"); eq(#empty.params, 0, "func: no params")
+    eq(empty.is_vararg, false, "func: not vararg"); eq(#all, 0, "func: empty body clean")
+
+    local va = parse_expr("function(...) end")
+    eq(va.is_vararg, true, "func: vararg")
+
+    local body, ball = parse_expr("function(x, y) return x end")
+    eq(body.kind, "function_expr", "func: with params kind")
+    eq(#body.params, 2, "func: 2 params"); eq(body.params[1].name, "x", "func: param name")
+    eq(n_diag(ball, "lua.unsupported"), 1, "func: non-empty body -> lua.unsupported (slice 3)")
+    eq(slice("function(x, y) return x end", body), "function(x, y) return x end", "func: full range incl skipped body")
+end
+
+-- ── errors: diagnostics, never a raise; no partial garbage ────────────
+do
+    local _, a1 = parse_expr("1 +")            -- trailing operator
+    ok(n_diag(a1, "lua.syntax") >= 1, "error: trailing operator -> diagnostic")
+    local _, a2 = parse_expr("(1")             -- unterminated paren
+    ok(n_diag(a2, "lua.syntax") >= 1, "error: unterminated paren -> diagnostic")
+    local _, a3 = parse_expr("1 2")            -- trailing tokens
+    ok(n_diag(a3, "lua.syntax") >= 1, "error: trailing tokens -> diagnostic")
+    -- never raises on nasty input
+    local nasty = { "", "(", ")", "{", "}", "[", ".", ":", "..", "a.", "a:", "f(", "{,}", "1+*2" }
+    local safe = true
+    for _, s in ipairs(nasty) do
+        local okc = pcall(parse_expr, s)
+        if not okc then safe = false; print("  parser RAISED on: " .. tostring(s)) end
+    end
+    ok(safe, "error: parser never raises on malformed expressions")
+end
+
+-- ── max_depth bounds nesting (no stack overflow) ──────────────────────
+do
+    local deep = string.rep("(", 100) .. "1" .. string.rep(")", 100)
+    local _, all = parse_expr(deep, { limits = { max_depth = 20 } })
+    ok(n_diag(all, "lua.limit.max_depth") >= 1, "depth: max_depth trips")
+end
+
+print(string.format("test_parser: %d passed, %d failed", pass, fail))
+return { pass = pass, fail = fail, failures = failures }

--- a/tests/hull/source/test_lua_source.c
+++ b/tests/hull/source/test_lua_source.c
@@ -70,4 +70,13 @@ UTEST(lua_source, lexer_slice1)
     EXPECT_GT(pass, 0LL);          /* and the script actually ran cases */
 }
 
+UTEST(lua_source, parser_slice2)
+{
+    long long pass = 0, fail = -1;
+    int rc = run_lua_test("stdlib/cli/lua/hull/source/tests/test_parser.lua", &pass, &fail);
+    ASSERT_EQ(rc, 0);
+    EXPECT_EQ(fail, 0LL);
+    EXPECT_GT(pass, 0LL);
+}
+
 UTEST_MAIN()


### PR DESCRIPTION
Slice 2 of the Hull-owned Lua source-analysis layer (design: `docs/lua_source_analysis_design.md`; slice 1 in #343). Builds the recursive-descent **expression** parser on the slice-1 token stream.

## What lands
- `source/parser.lua` — Lua 5.4 expression grammar with **exact half-open byte ranges** on every node and the complete precedence/associativity table (lparser.c priorities: right-assoc `..`/`^`, unary priority 12, `and`/`or`/`not` as keyword operators). Nodes: `literal` (number/string/nil/boolean), `vararg`, `name`, `field`, `index`, `call`, `method_call`, `table` (`field_item`/`field_name`/`field_expr`), `unary`, `binary`, `paren`, `function_expr`.
- **Never raises** — a parse error emits a `lua.syntax` diagnostic + an `{kind="error"}` node; nesting bounded by `max_depth` (no stack overflow). A `function` expression's body is a statement block (slice 3), so it's balanced-skipped to `end` with a `lua.unsupported` diagnostic for a non-empty body (valid syntax not yet represented → explicit, never a silent malform); `function() end` parses cleanly.
- Lexer fix surfaced by `#t`: a shebang is only `#!`, not a bare leading `#`, so the length operator lexes correctly.

## Tests
`test_parser.lua` (**91 cases**) via the existing vanilla-`lua_State` harness: literals, all suffix/call forms, chained suffixes, table constructors (every field kind + `,`/`;`), unary, and **precedence/associativity asserted on tree shape** (`1+2*3`, `2^2^3` right-assoc, `a..b..c` right-assoc, `1-2-3` left-assoc, `-2^2`, parens), `function_expr` params + deferred-body diagnostic, error diagnostics with no raises, `max_depth`. Lexer suite still **110/110**. luacheck clean.

Next: slice 3 (statements/declarations — completes `function_expr` bodies and the full `parse()` AST). Consumers still wait until slices 3–4 stabilize.