### PR TITLE
feat(source): hull.source.lua slice 3 — statements, declarations, full AST

### DIFF
--- a/stdlib/cli/lua/hull/source/lua.lua
+++ b/stdlib/cli/lua/hull/source/lua.lua
@@ -22,6 +22,7 @@
 --
 
 local lexer = require("hull.source.lexer")
+local parser = require("hull.source.parser")
 local range = require("hull.source.range")
 local diag = require("hull.source.diagnostic")
 
@@ -86,26 +87,65 @@ function M.parse(source, opts)
         end
     end
 
-    -- Defense in depth: the lexer is written not to raise, but a bug must still
-    -- surface as `err`, never as a raw error crossing parse().
-    local ok, res = pcall(lexer.tokenize, source, opts)
+    -- Defense in depth: the lexer/parser are written not to raise, but a bug must
+    -- still surface as `err`, never as a raw error crossing parse().
+    local ok, res = pcall(function()
+        local lx = lexer.tokenize(source, opts)
+        local ast, pdiags = parser.parse_chunk(lx.tokens, source, opts)
+        return { lx = lx, ast = ast, pdiags = pdiags }
+    end)
     if not ok then
         return nil, diag.error("lua.internal",
-            "internal lexer failure: " .. tostring(res), opts.path, nil)
+            "internal parse failure: " .. tostring(res), opts.path, nil)
     end
+
+    -- Combine lexer + parser diagnostics (each phase is independently capped by
+    -- max_diagnostics; the union is bounded by 2x that).
+    local diagnostics = {}
+    for _, d in ipairs(res.lx.diagnostics) do diagnostics[#diagnostics + 1] = d end
+    for _, d in ipairs(res.pdiags) do diagnostics[#diagnostics + 1] = d end
 
     local unit = setmetatable({
         path = opts.path,
         language = "lua",
         source = source,
-        ast = nil,                       -- slice 3
-        tokens = res.tokens,             -- slice-1 surface; the parser consumes these
-        comments = res.comments,
-        diagnostics = res.diagnostics,
+        ast = res.ast,                   -- the chunk node (slice 3)
+        tokens = res.lx.tokens,          -- convenience; not part of the SourceUnit contract
+        comments = res.lx.comments,
+        diagnostics = diagnostics,
         _linestarts = range.linemap(source),
     }, Unit)
 
     return unit, nil
+end
+
+-- ── AST traversal (§18) + kind test (§19) ─────────────────────────────
+-- Collect the immediate child NODES of `v` (descending through structural
+-- wrappers like if-clauses / name lists, stopping at each kind-bearing node).
+local function collect(v, out)
+    if type(v) ~= "table" then return end
+    if v.kind then out[#out + 1] = v; return end
+    for k, e in pairs(v) do if k ~= "range" then collect(e, out) end end
+end
+
+-- Deterministic depth-first (pre-order) walk in SOURCE order: fn is called on
+-- `node` then on each descendant, children visited by ascending range.
+function M.walk(node, fn)
+    if type(node) ~= "table" or not node.kind then return end
+    fn(node)
+    local children = {}
+    for k, v in pairs(node) do
+        if k ~= "range" and k ~= "kind" then collect(v, children) end
+    end
+    table.sort(children, function(a, b)
+        if a.range.start ~= b.range.start then return a.range.start < b.range.start end
+        return a.range.stop < b.range.stop
+    end)
+    for _, c in ipairs(children) do M.walk(c, fn) end
+end
+
+function M.is(node, kind)
+    return type(node) == "table" and node.kind == kind
 end
 
 return M

--- a/stdlib/cli/lua/hull/source/lua.lua
+++ b/stdlib/cli/lua/hull/source/lua.lua
@@ -99,11 +99,24 @@ function M.parse(source, opts)
             "internal parse failure: " .. tostring(res), opts.path, nil)
     end
 
-    -- Combine lexer + parser diagnostics (each phase is independently capped by
-    -- max_diagnostics; the union is bounded by 2x that).
+    -- Combine lexer + parser diagnostics with the SourceUnit-level max_diagnostics
+    -- as the AUTHORITATIVE bound: keep EVERY terminal limit diagnostic (lua.limit.*)
+    -- but cap the ORDINARY diagnostics across both phases at max_diagnostics total,
+    -- in source order (lexer then parser).
+    local max_d = (opts.limits and opts.limits.max_diagnostics) or 200
     local diagnostics = {}
-    for _, d in ipairs(res.lx.diagnostics) do diagnostics[#diagnostics + 1] = d end
-    for _, d in ipairs(res.pdiags) do diagnostics[#diagnostics + 1] = d end
+    local ordinary = 0
+    local function absorb(list)
+        for _, d in ipairs(list) do
+            if d.code and d.code:match("^lua%.limit%.") then
+                diagnostics[#diagnostics + 1] = d           -- terminal: always kept
+            elseif ordinary < max_d then
+                diagnostics[#diagnostics + 1] = d; ordinary = ordinary + 1
+            end
+        end
+    end
+    absorb(res.lx.diagnostics)
+    absorb(res.pdiags)
 
     local unit = setmetatable({
         path = opts.path,

--- a/stdlib/cli/lua/hull/source/parser.lua
+++ b/stdlib/cli/lua/hull/source/parser.lua
@@ -1,17 +1,18 @@
 --
--- hull.source.parser — recursive-descent Lua 5.4 parser (slice 2: expressions).
+-- hull.source.parser — recursive-descent Lua 5.4 parser (expressions + statements).
 --
--- Consumes the lexer token stream and builds Hull AST expression nodes with EXACT
--- half-open byte ranges (see range.lua). Statements/declarations land in slice 3;
--- a function EXPRESSION's body is a statement block, so in slice 2 the body is
--- skipped (balanced to its `end`) and a `lua.unsupported` diagnostic is emitted
--- (a non-empty body is valid syntax this slice does not yet represent -- an
--- explicit diagnostic, never a silently malformed AST). Slice 3 replaces the skip
--- with the real block parser.
---
--- The parser NEVER raises: a parse error emits a diagnostic and returns an
--- { kind = "error" } node (best-effort). Node vocabulary (expressions) matches
+-- Consumes the lexer token stream and builds the Hull AST (expressions AND
+-- statements) with EXACT half-open byte ranges (see range.lua). M.parse_chunk()
+-- returns the whole-source { kind="chunk", body, range }; M.parse_expression()
+-- parses a single expression. Node vocabulary matches
 -- docs/lua_source_analysis_design.md §5.
+--
+-- The parser NEVER raises: a parse error emits a lua.syntax diagnostic and returns
+-- an { kind = "error" } node (best-effort recovery -- a stall guard in block() and
+-- a token-consuming primary() keep the chunk parsing past a bad construct).
+-- Expression and block nesting share one max_depth budget (a terminal
+-- lua.limit.max_depth diagnostic, no stack overflow); ordinary diagnostics respect
+-- max_diagnostics while terminal ones always record.
 --
 -- SPDX-License-Identifier: AGPL-3.0-or-later
 --
@@ -446,7 +447,8 @@ function P:for_stat()
         local step = nil
         if self:is_op(",") then self:advance(); step = self:subexpr(0) end
         self:expect_kw("do"); local body = self:block(); self:expect_kw("end")
-        return self:finish({ kind = "numeric_for", var = nm.text, from = from, to = to, step = step, body = body }, start)
+        return self:finish({ kind = "numeric_for", var = { name = nm.text, range = nm.range },
+            from = from, to = to, step = step, body = body }, start)
     else                                                -- generic for
         local names = {}
         while true do
@@ -512,10 +514,17 @@ function P:local_stat()
         if nm.kind ~= "name" then self:err("<name> expected in local declaration"); break end
         self:advance()
         local attrib = nil
-        if self:is_op("<") then                         -- <const> / <close>
+        if self:is_op("<") then                         -- <const> / <close> only
             self:advance()
             local a = self:cur()
-            if a.kind == "name" then self:advance(); attrib = a.text else self:err("<name> expected in attribute") end
+            if a.kind == "name" then
+                self:advance(); attrib = a.text         -- preserve the text for source fidelity
+                if attrib ~= "const" and attrib ~= "close" then
+                    self:err("unknown attribute '" .. attrib .. "' (expected 'const' or 'close')", a)
+                end
+            else
+                self:err("<name> expected in attribute")
+            end
             self:expect_op(">")
         end
         names[#names + 1] = { name = nm.text, attrib = attrib, range = nm.range }
@@ -533,6 +542,15 @@ function P:exprstat()
     if self:is_op("=") or self:is_op(",") then
         local targets = { e }
         while self:is_op(",") do self:advance(); targets[#targets + 1] = self:suffixed() end
+        -- Each target must END as a name / field / index lvalue. A call inside a
+        -- target is fine (f().x = 1); a call/literal/paren/etc. AS the target is
+        -- not. Diagnose each invalid target but keep the node for recovery.
+        for _, tg in ipairs(targets) do
+            if tg.kind ~= "name" and tg.kind ~= "field" and tg.kind ~= "index" then
+                self:err("cannot assign to this expression (target must be a name, field, or index)",
+                    { range = tg.range })
+            end
+        end
         self:expect_op("=")
         local values = self:explist()
         return self:finish({ kind = "assignment", targets = targets, values = values }, start)

--- a/stdlib/cli/lua/hull/source/parser.lua
+++ b/stdlib/cli/lua/hull/source/parser.lua
@@ -138,9 +138,6 @@ function P:subexpr(limit)
     return e
 end
 
-function M.parse_expression_state(st)
-    return st:subexpr(0)
-end
 
 -- ── simple expressions ────────────────────────────────────────────────
 function P:simple()
@@ -278,42 +275,9 @@ function P:table_constructor()
     return self:finish({ kind = "table", fields = fields }, start)
 end
 
--- ── function expression (params now; body skipped until slice 3) ──────
--- Balanced skip to the matching `end`. The `end`-terminated openers are
--- `function`, `if`, `for`, `while`, and a STANDALONE `do`. A `for`/`while` opens
--- ONE block whose `do` is a syntactic marker, not a second `end`-taker -- so its
--- `do` is absorbed (tracked by `pending_do`, a count, which stays correct even
--- when a nested function literal appears inside a loop header). `repeat ... until`
--- is NOT `end`-terminated and is ignored for the `end` count. Replaced by the real
--- block parser in slice 3.
-function P:skip_block_to_end()
-    local open = 1              -- the function's own `end`
-    local pending_do = 0        -- for/while opened but awaiting their `do`
-    while not self:at_eof() do
-        local t = self:cur()
-        if t.kind == "keyword" then
-            local k = t.text
-            if k == "function" or k == "if" then
-                open = open + 1
-            elseif k == "for" or k == "while" then
-                open = open + 1; pending_do = pending_do + 1
-            elseif k == "do" then
-                if pending_do > 0 then pending_do = pending_do - 1 else open = open + 1 end
-            elseif k == "end" then
-                open = open - 1
-                if open == 0 then return self:advance() end
-            end
-            -- repeat / until are not end-terminated: ignored for `open`.
-        end
-        self:advance()
-    end
-    self:err("'end' expected (unterminated function)")
-    return nil
-end
-
-function P:function_expr()
-    local start = self:cur().range.start
-    self:advance()                              -- 'function'
+-- ── function parameters / body (shared by function_expr, function decl) ─
+-- funcparams := '(' [ Name {',' Name} [',' '...'] | '...' ] ')'
+function P:funcparams()
     self:expect_op("(")
     local params, is_vararg = {}, false
     if not self:is_op(")") then
@@ -332,17 +296,252 @@ function P:function_expr()
         end
     end
     self:expect_op(")")
-    -- body: slice 3. Empty body (immediate `end`) is fine; a non-empty one is
-    -- valid syntax not yet represented -> explicit diagnostic + balanced skip.
-    local body_start = self:cur().range.start
-    if not self:is_kw("end") then
-        self:skip_block_to_end()
-        self:unsupported("function body is parsed in a later slice", body_start,
-            (self.prev and self.prev.range.stop) or body_start)
-    else
-        self:advance()                          -- 'end'
+    return params, is_vararg
+end
+
+-- funcbody := '(' params ')' block 'end'   (the real block parser -- slice 3)
+function P:funcbody()
+    local params, is_vararg = self:funcparams()
+    local body = self:block()
+    self:expect_kw("end")
+    return params, is_vararg, body
+end
+
+function P:function_expr()
+    local start = self:cur().range.start
+    self:advance()                              -- 'function'
+    local params, is_vararg, body = self:funcbody()
+    return self:finish({ kind = "function_expr", params = params, is_vararg = is_vararg, body = body }, start)
+end
+
+-- ── statements ────────────────────────────────────────────────────────
+local BLOCK_FOLLOW = { ["end"] = true, ["else"] = true, ["elseif"] = true, ["until"] = true }
+
+function P:block_follow()
+    local t = self:cur()
+    return t.kind == "eof" or (t.kind == "keyword" and BLOCK_FOLLOW[t.text] == true)
+end
+
+-- block := {stat} [retstat]
+function P:block()
+    self.depth = self.depth + 1                         -- bound statement nesting too (shared budget)
+    if self.depth > self.max_depth then
+        if not self.aborted then
+            self.aborted = true
+            self:emit_terminal(diag.error("lua.limit.max_depth",
+                "block nesting exceeds max_depth (" .. self.max_depth .. ")", self.path, self:cur().range))
+        end
+        self.depth = self.depth - 1
+        return {}
     end
-    return self:finish({ kind = "function_expr", params = params, is_vararg = is_vararg, body = nil }, start)
+    local stmts = {}
+    while not self:block_follow() and not self.aborted do
+        if self:is_kw("return") then
+            stmts[#stmts + 1] = self:return_stat()
+            break                                       -- return is the block's last statement
+        end
+        local before = self.pos
+        local s = self:statement()
+        if s then stmts[#stmts + 1] = s end
+        if self.pos == before then self:advance() end   -- stall guard: always make progress
+    end
+    self.depth = self.depth - 1
+    return stmts
+end
+
+function P:explist()
+    local list = { self:subexpr(0) }
+    while self:is_op(",") do self:advance(); list[#list + 1] = self:subexpr(0) end
+    return list
+end
+
+function P:statement()
+    local start = self:cur().range.start
+    if self:is_op(";") then self:advance(); return nil
+    elseif self:is_kw("if") then return self:if_stat()
+    elseif self:is_kw("while") then return self:while_stat()
+    elseif self:is_kw("do") then
+        self:advance(); local body = self:block(); self:expect_kw("end")
+        return self:finish({ kind = "do", body = body }, start)
+    elseif self:is_kw("for") then return self:for_stat()
+    elseif self:is_kw("repeat") then return self:repeat_stat()
+    elseif self:is_kw("function") then return self:function_decl()
+    elseif self:is_kw("local") then return self:local_stat()
+    elseif self:is_kw("break") then self:advance(); return self:finish({ kind = "break" }, start)
+    elseif self:is_kw("goto") then
+        self:advance()
+        local nm = self:cur(); local label = nil
+        if nm.kind == "name" then self:advance(); label = nm.text else self:err("<name> expected after 'goto'") end
+        return self:finish({ kind = "goto", label = label }, start)
+    elseif self:is_op("::") then return self:label_stat()
+    else return self:exprstat()
+    end
+end
+
+function P:label_stat()
+    local start = self:cur().range.start
+    self:advance()                                      -- '::'
+    local nm = self:cur(); local name = nil
+    if nm.kind == "name" then self:advance(); name = nm.text else self:err("<name> expected in label") end
+    self:expect_op("::")
+    return self:finish({ kind = "label", name = name }, start)
+end
+
+function P:return_stat()
+    local start = self:cur().range.start
+    self:advance()                                      -- 'return'
+    local values = {}
+    if not self:block_follow() and not self:is_op(";") then values = self:explist() end
+    if self:is_op(";") then self:advance() end
+    return self:finish({ kind = "return", values = values }, start)
+end
+
+function P:if_stat()
+    local start = self:cur().range.start
+    self:advance()                                      -- 'if'
+    local clauses = {}
+    local cond = self:subexpr(0); self:expect_kw("then")
+    clauses[#clauses + 1] = { cond = cond, body = self:block() }
+    while self:is_kw("elseif") do
+        self:advance()
+        local c = self:subexpr(0); self:expect_kw("then")
+        clauses[#clauses + 1] = { cond = c, body = self:block() }
+    end
+    if self:is_kw("else") then
+        self:advance()
+        clauses[#clauses + 1] = { cond = nil, body = self:block() }   -- else clause: no cond
+    end
+    self:expect_kw("end")
+    return self:finish({ kind = "if", clauses = clauses }, start)
+end
+
+function P:while_stat()
+    local start = self:cur().range.start
+    self:advance()                                      -- 'while'
+    local cond = self:subexpr(0); self:expect_kw("do")
+    local body = self:block(); self:expect_kw("end")
+    return self:finish({ kind = "while", cond = cond, body = body }, start)
+end
+
+function P:repeat_stat()
+    local start = self:cur().range.start
+    self:advance()                                      -- 'repeat'
+    local body = self:block(); self:expect_kw("until")
+    local cond = self:subexpr(0)
+    return self:finish({ kind = "repeat", body = body, cond = cond }, start)
+end
+
+function P:for_stat()
+    local start = self:cur().range.start
+    self:advance()                                      -- 'for'
+    if self:cur().kind ~= "name" then
+        self:err("<name> expected after 'for'")
+        return self:finish({ kind = "error" }, start)
+    end
+    local n2 = self.tokens[self.pos + 1]
+    if n2 and n2.kind == "op" and n2.text == "=" then   -- numeric for
+        local nm = self:advance(); self:advance()       -- name, '='
+        local from = self:subexpr(0); self:expect_op(",")
+        local to = self:subexpr(0)
+        local step = nil
+        if self:is_op(",") then self:advance(); step = self:subexpr(0) end
+        self:expect_kw("do"); local body = self:block(); self:expect_kw("end")
+        return self:finish({ kind = "numeric_for", var = nm.text, from = from, to = to, step = step, body = body }, start)
+    else                                                -- generic for
+        local names = {}
+        while true do
+            local nm = self:cur()
+            if nm.kind == "name" then self:advance(); names[#names + 1] = { name = nm.text, range = nm.range }
+            else self:err("<name> expected in 'for'"); break end
+            if self:is_op(",") then self:advance() else break end
+        end
+        self:expect_kw("in"); local exprs = self:explist()
+        self:expect_kw("do"); local body = self:block(); self:expect_kw("end")
+        return self:finish({ kind = "generic_for", names = names, exprs = exprs, body = body }, start)
+    end
+end
+
+-- funcname := Name {'.' Name} [':' Name] -> (name-path node, is_method)
+function P:funcname()
+    local start = self:cur().range.start
+    local nm = self:cur()
+    if nm.kind ~= "name" then return self:err("<name> expected in function name"), false end
+    self:advance()
+    local node = self:finish({ kind = "name", name = nm.text }, start)
+    while self:is_op(".") do
+        self:advance()
+        local f = self:cur()
+        if f.kind ~= "name" then self:err("<name> expected after '.'"); break end
+        self:advance(); node = self:finish({ kind = "field", obj = node, name = f.text }, start)
+    end
+    local is_method = false
+    if self:is_op(":") then
+        self:advance()
+        local m = self:cur()
+        if m.kind == "name" then
+            self:advance(); node = self:finish({ kind = "field", obj = node, name = m.text }, start); is_method = true
+        else self:err("<name> expected after ':'") end
+    end
+    return node, is_method
+end
+
+function P:function_decl()
+    local start = self:cur().range.start
+    self:advance()                                      -- 'function'
+    local name, is_method = self:funcname()
+    local params, is_vararg, body = self:funcbody()
+    return self:finish({ kind = "function_declaration", name = name, is_local = false,
+        is_method = is_method, params = params, is_vararg = is_vararg, body = body }, start)
+end
+
+function P:local_stat()
+    local start = self:cur().range.start
+    self:advance()                                      -- 'local'
+    if self:is_kw("function") then
+        self:advance()                                  -- 'function'
+        local nm = self:cur(); local name = nil
+        if nm.kind == "name" then self:advance(); name = self:finish({ kind = "name", name = nm.text }, nm.range.start)
+        else self:err("<name> expected in 'local function'") end
+        local params, is_vararg, body = self:funcbody()
+        return self:finish({ kind = "function_declaration", name = name, is_local = true,
+            is_method = false, params = params, is_vararg = is_vararg, body = body }, start)
+    end
+    local names = {}
+    while true do
+        local nm = self:cur()
+        if nm.kind ~= "name" then self:err("<name> expected in local declaration"); break end
+        self:advance()
+        local attrib = nil
+        if self:is_op("<") then                         -- <const> / <close>
+            self:advance()
+            local a = self:cur()
+            if a.kind == "name" then self:advance(); attrib = a.text else self:err("<name> expected in attribute") end
+            self:expect_op(">")
+        end
+        names[#names + 1] = { name = nm.text, attrib = attrib, range = nm.range }
+        if self:is_op(",") then self:advance() else break end
+    end
+    local values = {}
+    if self:is_op("=") then self:advance(); values = self:explist() end
+    return self:finish({ kind = "local_declaration", names = names, values = values }, start)
+end
+
+-- exprstat := varlist '=' explist | functioncall
+function P:exprstat()
+    local start = self:cur().range.start
+    local e = self:suffixed()
+    if self:is_op("=") or self:is_op(",") then
+        local targets = { e }
+        while self:is_op(",") do self:advance(); targets[#targets + 1] = self:suffixed() end
+        self:expect_op("=")
+        local values = self:explist()
+        return self:finish({ kind = "assignment", targets = targets, values = values }, start)
+    elseif e.kind == "call" or e.kind == "method_call" then
+        return self:finish({ kind = "call_statement", call = e }, start)
+    else
+        self:err("syntax error (expected assignment or function call)")
+        return self:finish({ kind = "error", expr = e }, start)
+    end
 end
 
 -- ── public: parse a single expression from source (slice-2 surface) ───
@@ -356,6 +555,20 @@ function M.parse_expression(tokens, source, opts)
         st:err("unexpected trailing tokens after expression")
     end
     return node, st.diagnostics
+end
+
+-- ── public: parse a whole chunk (the full source AST) ────────────────
+-- chunk := block. Returns (ast, diagnostics). This is what lua.parse() drives.
+function M.parse_chunk(tokens, source, opts)
+    opts = opts or {}
+    local st = new_state(tokens, source, opts)
+    local body = st:block()
+    if not st:at_eof() then
+        st:err("'<eof>' expected (unexpected token '" .. (st:cur().text or "") .. "')")
+    end
+    local ast = { kind = "chunk", body = body,
+        range = { start = 1, stop = (source and (#source + 1)) or 1 } }
+    return ast, st.diagnostics
 end
 
 M.new_state = new_state

--- a/stdlib/cli/lua/hull/source/tests/test_parser.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_parser.lua
@@ -72,10 +72,10 @@ do
     }
     for _, src in ipairs(bodies) do
         local node, all = parse_expr(src)
-        eq(node.kind, "function_expr", "skip: function_expr for " .. src)
-        eq(n_diag(all, "lua.syntax"), 0, "skip: no spurious 'unterminated' for " .. src)
-        eq(n_diag(all, "lua.unsupported"), 1, "skip: one deferred-body notice for " .. src)
-        eq(slice(src, node), src, "skip: full range for " .. src)
+        eq(node.kind, "function_expr", "body: function_expr for " .. src)
+        eq(n_diag(all, "lua.syntax"), 0, "body: no spurious 'unterminated' for " .. src)
+        eq(n_diag(all, "lua.unsupported"), 0, "body: parses (no deferred notice) for " .. src)
+        eq(slice(src, node), src, "body: full range for " .. src)
     end
 end
 
@@ -168,8 +168,10 @@ do
     local body, ball = parse_expr("function(x, y) return x end")
     eq(body.kind, "function_expr", "func: with params kind")
     eq(#body.params, 2, "func: 2 params"); eq(body.params[1].name, "x", "func: param name")
-    eq(n_diag(ball, "lua.unsupported"), 1, "func: non-empty body -> lua.unsupported (slice 3)")
-    eq(slice("function(x, y) return x end", body), "function(x, y) return x end", "func: full range incl skipped body")
+    eq(n_diag(ball, "lua.unsupported"), 0, "func: non-empty body parses (slice 3)")
+    eq(n_diag(ball, "lua.syntax"), 0, "func: body clean")
+    ok(type(body.body) == "table" and body.body[1].kind == "return", "func: parsed body has return")
+    eq(slice("function(x, y) return x end", body), "function(x, y) return x end", "func: full range")
 end
 
 -- ── errors: diagnostics, never a raise; no partial garbage ────────────

--- a/stdlib/cli/lua/hull/source/tests/test_statements.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_statements.lua
@@ -79,7 +79,9 @@ do
     eq(r.kind, "repeat", "repeat: kind"); ok(r.cond ~= nil, "repeat: cond")
 
     local nf = first("for i = 1, 10, 2 do f(i) end")
-    eq(nf.kind, "numeric_for", "numfor: kind"); eq(nf.var, "i", "numfor: var")
+    eq(nf.kind, "numeric_for", "numfor: kind")
+    eq(nf.var.name, "i", "numfor: var.name (range-bearing record)")
+    ok(nf.var.range ~= nil and nf.var.range.start ~= nil, "numfor: var.range present")
     ok(nf.from and nf.to and nf.step, "numfor: from/to/step")
     local gf = first("for k, v in pairs(t) do end")
     eq(gf.kind, "generic_for", "genfor: kind"); eq(#gf.names, 2, "genfor: 2 names")
@@ -169,6 +171,47 @@ do
     -- deep statement nesting is bounded (no stack overflow)
     local u = parse(string.rep("do ", 100) .. "return" .. string.rep(" end", 100))
     ok(u ~= nil, "boundary: deep nesting parses within default max_depth")
+end
+
+-- ── assignment target validation ──────────────────────────────────────
+do
+    for _, s in ipairs({ "x = 1", "a.b = 1", "a[b] = 1", "f().x = 1", "a().b[c] = 1" }) do
+        eq(#parse(s).diagnostics, 0, "target valid (name/field/index): " .. s)
+    end
+    for _, s in ipairs({ "f() = 1", "a, g() = 1, 2", "1 = 2", "(x) = 1" }) do
+        local u = lua.parse(s, { path = "t.lua" })
+        local hit = false
+        for _, d in ipairs(u.diagnostics) do if d.code == "lua.syntax" then hit = true end end
+        ok(hit, "target invalid -> lua.syntax: " .. s)
+        local has_assign = false
+        lua.walk(u.ast, function(n) if lua.is(n, "assignment") then has_assign = true end end)
+        ok(has_assign, "target invalid: assignment node retained for recovery: " .. s)
+    end
+end
+
+-- ── local attribute must be const/close (text preserved either way) ────
+do
+    eq(first("local x <const> = 1").names[1].attrib, "const", "attr: const")
+    eq(first("local x <close> = f()").names[1].attrib, "close", "attr: close")
+    eq(#parse("local x <const> = 1").diagnostics, 0, "attr: valid -> no diagnostic")
+    local u = lua.parse("local x <other> = 1", { path = "t.lua" })
+    eq(u.ast.body[1].names[1].attrib, "other", "attr: text preserved for invalid")
+    local hit = false
+    for _, d in ipairs(u.diagnostics) do if d.code == "lua.syntax" then hit = true end end
+    ok(hit, "attr: invalid attribute -> lua.syntax")
+end
+
+-- ── max_diagnostics is an AUTHORITATIVE total bound (ordinary) ─────────
+do
+    local u = lua.parse("@ @ @ @ @\nf() = 1\ng() = 2\nh() = 3", { path = "t.lua", limits = { max_diagnostics = 3 } })
+    local ordinary = 0
+    for _, d in ipairs(u.diagnostics) do if not d.code:match("^lua%.limit%.") then ordinary = ordinary + 1 end end
+    ok(ordinary <= 3, "budget: total ordinary diagnostics <= max_diagnostics (" .. ordinary .. ")")
+    -- terminal limit diagnostics always survive, even at max_diagnostics = 0
+    local u2 = lua.parse("a b c d e", { path = "t.lua", limits = { max_tokens = 2, max_diagnostics = 0 } })
+    local has_terminal = false
+    for _, d in ipairs(u2.diagnostics) do if d.code:match("^lua%.limit%.") then has_terminal = true end end
+    ok(has_terminal, "budget: terminal limit diagnostic kept at max_diagnostics=0")
 end
 
 print(string.format("test_statements: %d passed, %d failed", pass, fail))

--- a/stdlib/cli/lua/hull/source/tests/test_statements.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_statements.lua
@@ -1,0 +1,175 @@
+--
+-- test_statements.lua — slice-3 tests for hull.source.lua (statements + full AST).
+--
+-- Drives the PUBLIC lua.parse() (which now produces unit.ast = a chunk) plus
+-- lua.walk / lua.is. Pure Lua; run by tests/hull/source/test_lua_source.c.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local lua = require("hull.source.lua")
+
+local pass, fail, failures = 0, 0, {}
+local function ok(cond, name)
+    if cond then pass = pass + 1
+    else fail = fail + 1; failures[#failures + 1] = name; print("FAIL: " .. name) end
+end
+local function eq(a, b, name)
+    ok(a == b, name .. " (expected " .. tostring(b) .. ", got " .. tostring(a) .. ")")
+end
+
+local function parse(src)
+    local u, e = lua.parse(src, { path = "t.lua" })
+    ok(u ~= nil and e == nil, "parse returns (unit,nil): " .. (src:gsub("%s+", " "):sub(1, 36)))
+    return u
+end
+local function body(src) return parse(src).ast.body end
+local function first(src) return body(src)[1] end
+
+-- ── local declarations (+ attributes) ────────────────────────────────
+do
+    local s = first("local x = 1")
+    eq(s.kind, "local_declaration", "local: kind")
+    eq(s.names[1].name, "x", "local: name"); eq(#s.values, 1, "local: 1 value")
+    eq(s.values[1].kind, "literal", "local: value literal")
+    eq(#first("local a, b = 1, 2").names, 2, "local: two names")
+    eq(first("local x <const> = 1").names[1].attrib, "const", "local: <const>")
+    eq(first("local h <close> = f()").names[1].attrib, "close", "local: <close>")
+    eq(#first("local y").values, 0, "local: no initializer")
+end
+
+-- ── assignment / call statement ───────────────────────────────────────
+do
+    local a = first("x = 1")
+    eq(a.kind, "assignment", "assign: kind"); eq(a.targets[1].kind, "name", "assign: name target")
+    local a2 = first("a.b, c[d] = 1, 2")
+    eq(#a2.targets, 2, "assign: 2 targets")
+    eq(a2.targets[1].kind, "field", "assign: field target"); eq(a2.targets[2].kind, "index", "assign: index target")
+    eq(first("f(x)").kind, "call_statement", "callstat: kind")
+    eq(first("f(x)").call.kind, "call", "callstat: call node")
+    eq(first("obj:m()").call.kind, "method_call", "callstat: method call")
+end
+
+-- ── function declarations (global / dotted / method / local) ──────────
+do
+    local f = first("function foo() end")
+    eq(f.kind, "function_declaration", "func: kind"); eq(f.is_local, false, "func: not local")
+    eq(f.name.name, "foo", "func: name")
+    eq(first("function a.b.c() end").name.kind, "field", "func: dotted name -> field chain")
+    eq(first("function a:m() end").is_method, true, "func: method")
+    eq(first("local function g() end").is_local, true, "func: local function")
+    eq(first("local function v(...) end").is_vararg, true, "func: vararg")
+
+    local u = parse("function sq(x) return x * x end")           -- real body now parses
+    eq(#u.diagnostics, 0, "func: body parses clean (no lua.unsupported)")
+    local sq = u.ast.body[1]
+    eq(#sq.params, 1, "func: 1 param"); eq(sq.params[1].name, "x", "func: param name")
+    eq(sq.body[1].kind, "return", "func: body has return")
+end
+
+-- ── control flow ──────────────────────────────────────────────────────
+do
+    local i = first("if a then x() elseif b then y() else z() end")
+    eq(i.kind, "if", "if: kind"); eq(#i.clauses, 3, "if: 3 clauses")
+    ok(i.clauses[1].cond ~= nil, "if: clause1 has cond"); ok(i.clauses[3].cond == nil, "if: else has no cond")
+
+    local w = first("while c do g() end")
+    eq(w.kind, "while", "while: kind"); ok(w.cond ~= nil, "while: cond"); eq(#w.body, 1, "while: body")
+    local r = first("repeat h() until done")
+    eq(r.kind, "repeat", "repeat: kind"); ok(r.cond ~= nil, "repeat: cond")
+
+    local nf = first("for i = 1, 10, 2 do f(i) end")
+    eq(nf.kind, "numeric_for", "numfor: kind"); eq(nf.var, "i", "numfor: var")
+    ok(nf.from and nf.to and nf.step, "numfor: from/to/step")
+    local gf = first("for k, v in pairs(t) do end")
+    eq(gf.kind, "generic_for", "genfor: kind"); eq(#gf.names, 2, "genfor: 2 names")
+    eq(gf.names[1].name, "k", "genfor: name k"); eq(#gf.exprs, 1, "genfor: exprs")
+    eq(first("do local x = 1 end").kind, "do", "do: kind")
+end
+
+-- ── break / goto / label / return ─────────────────────────────────────
+do
+    eq(body("while true do break end")[1].body[1].kind, "break", "break: kind")
+    local g = first("goto done"); eq(g.kind, "goto", "goto: kind"); eq(g.label, "done", "goto: label")
+    local l = first("::done::"); eq(l.kind, "label", "label: kind"); eq(l.name, "done", "label: name")
+    local ret = body("return 1, 2")[1]; eq(ret.kind, "return", "return: kind"); eq(#ret.values, 2, "return: 2 values")
+    eq(#body("return")[1].values, 0, "return: bare")
+end
+
+-- ── walk / is (§18/§19) ───────────────────────────────────────────────
+do
+    local u = parse("local x = f(1) + g(2)")
+    local seq = {}
+    lua.walk(u.ast, function(n) seq[#seq + 1] = n.kind end)
+    eq(seq[1], "chunk", "walk: root (chunk) visited first (pre-order)")
+    local ncall = 0
+    lua.walk(u.ast, function(n) if lua.is(n, "call") then ncall = ncall + 1 end end)
+    eq(ncall, 2, "walk: visits both calls")
+    -- deterministic: two walks -> identical kind sequence
+    local a, b = {}, {}
+    lua.walk(u.ast, function(n) a[#a + 1] = n.kind end)
+    lua.walk(u.ast, function(n) b[#b + 1] = n.kind end)
+    eq(table.concat(a, ","), table.concat(b, ","), "walk: deterministic")
+    ok(not lua.is(nil, "call") and not lua.is(42, "call"), "is: safe on non-nodes")
+end
+
+-- ── §41 acceptance example (structure via the Hull-owned API only) ─────
+do
+    local src = "---@compute\n" ..
+        "---@param x f64\n---@param y f64\n---@return f64\n" ..
+        "local function score(x, y)\n    return x * x + y * y\nend\n\n" ..
+        "---@query\nlocal active = query {\n    from = \"trips\"\n}\n"
+    local u = parse(src)
+    eq(#u.diagnostics, 0, "acceptance: parses clean")
+
+    local score
+    lua.walk(u.ast, function(n)
+        if lua.is(n, "function_declaration") and n.name and n.name.name == "score" then score = n end
+    end)
+    ok(score ~= nil, "acceptance: found `local function score`")
+    eq(score.is_local, true, "acceptance: score is local")
+    eq(#score.params, 2, "acceptance: score has 2 params")
+    eq(score.body[1].kind, "return", "acceptance: score returns")
+    ok(u:text(score):find("^local function score") ~= nil, "acceptance: score range starts at declaration")
+
+    local active = u.ast.body[2]
+    eq(active.kind, "local_declaration", "acceptance: active local_declaration")
+    eq(active.names[1].name, "active", "acceptance: active name")
+    eq(active.values[1].kind, "call", "acceptance: query call")
+    eq(active.values[1].args[1].kind, "table", "acceptance: query table arg")
+end
+
+-- ── best-effort recovery: a bad statement does not abort the chunk ─────
+do
+    local u = parse("local x = ; local y = 2")   -- ';' where a value is expected
+    ok(#u.diagnostics >= 1, "recovery: bad statement -> diagnostic")
+    local found_y = false
+    lua.walk(u.ast, function(n)
+        if lua.is(n, "local_declaration") then
+            for _, nm in ipairs(n.names) do if nm.name == "y" then found_y = true end end
+        end
+    end)
+    ok(found_y, "recovery: parsing continued to `local y`")
+end
+
+-- ── boundary: parse never raises / returns (nil,nil) on nasty sources ─
+do
+    local nasty = {
+        "", "end", "do", "if", "function", "local", "for", "return return",
+        "local x =", "function f(", "::", "goto", "a.b.", "1 = 2",
+        string.rep("do ", 300), string.rep("(", 300),
+    }
+    local safe = true
+    for _, s in ipairs(nasty) do
+        local okc, uu, e = pcall(lua.parse, s)
+        if not okc then safe = false; print("  RAISED: " .. s:sub(1, 20)) end
+        if okc and uu == nil and e == nil then safe = false; print("  (nil,nil): " .. s:sub(1, 20)) end
+    end
+    ok(safe, "boundary: parse never raises / (nil,nil)")
+    -- deep statement nesting is bounded (no stack overflow)
+    local u = parse(string.rep("do ", 100) .. "return" .. string.rep(" end", 100))
+    ok(u ~= nil, "boundary: deep nesting parses within default max_depth")
+end
+
+print(string.format("test_statements: %d passed, %d failed", pass, fail))
+return { pass = pass, fail = fail, failures = failures }

--- a/tests/hull/source/test_lua_source.c
+++ b/tests/hull/source/test_lua_source.c
@@ -79,4 +79,13 @@ UTEST(lua_source, parser_slice2)
     EXPECT_GT(pass, 0LL);
 }
 
+UTEST(lua_source, statements_slice3)
+{
+    long long pass = 0, fail = -1;
+    int rc = run_lua_test("stdlib/cli/lua/hull/source/tests/test_statements.lua", &pass, &fail);
+    ASSERT_EQ(rc, 0);
+    EXPECT_EQ(fail, 0LL);
+    EXPECT_GT(pass, 0LL);
+}
+
 UTEST_MAIN()


### PR DESCRIPTION
Slice 3 completes the Lua 5.4 parser: the statement layer, real function bodies (the slice-2 balanced-skip stub is gone), the full chunk AST from the public `parse()`, and the `walk`/`is` traversal helpers. Design: `docs/lua_source_analysis_design.md` (slice 1 #343, slice 2 #344).

## What lands
- **Statements**: `local_declaration` (with `<const>`/`<close>`), `assignment` (multi-target), `call_statement`, `do`, `while`, `repeat`, `if`/`elseif`/`else`, `numeric_for`, `generic_for`, `function_declaration` (global / dotted / method / `local function`, with `is_local`+`is_method`), `return`, `break`, `goto`, `label`. `exprstat` disambiguates assignment vs call the standard way.
- **Real function bodies** — `funcbody` parses the body block, so function expressions *and* declarations carry a statement `body`.
- **`parse()` produces `unit.ast`** = `{kind="chunk", body, range}`; lexer+parser diagnostics combined (each phase capped by `max_diagnostics`).
- **Bounded block nesting** (shared `depth` budget) → a terminal `lua.limit.max_depth` instead of a Lua stack overflow on deeply nested `do`/`if`.
- **Best-effort recovery** — stall guard in `block()` + token-consuming `primary()` keep the chunk parsing past a bad statement.
- **`lua.walk(ast, fn)`** (deterministic pre-order DFS in source order) and **`lua.is(node, kind)`**.

## Tests
`test_statements.lua` (**101 cases**): every statement kind, function bodies, control flow, break/goto/label/return, `walk`/`is` determinism, the **§41 acceptance example** (score function + query declaration discovered *structurally through the Hull API*), best-effort recovery, and a no-raise / bounded-nesting boundary. Slice-2 body assertions updated (a non-empty body now parses cleanly instead of emitting `lua.unsupported`). Totals: lexer 110, parser 133, statements 101. luacheck clean.

Next: slice 4 (comments/annotations — the generic `---@` scanner + declaration attachment, completing `lua.annotation`), then slice 5 (recovery + the Lua 5.4 differential conformance corpus).