### PR TITLE
feat(source): hull.source.lua slice 4 — the ---@ annotation layer

### DIFF
--- a/docs/lua_source_analysis_design.md
+++ b/docs/lua_source_analysis_design.md
@@ -164,17 +164,26 @@ tracked explicitly (no unbounded native Lua recursion).
   annotation`, in `unit.comments` (source order).
 - **Annotations are Hull's own scanner over comment text — no known-tag
   whitelist.** Any `---@name`, optional `(args)`, optional trailing text becomes
-  `{ name, args = <string?>, raw = <full comment>, range }`. Arbitrary
-  `---@query`, `---@compute`, `---@derive(json)`, `---@some_future_plugin(a,b)`
-  all survive generically. Known LuaDoc tags (`@param/@return/@field/@class`)
-  MAY additionally expose parsed fields, but the generic form is always present.
+  `{ name, args = <string?>, text = <string?>, raw = <full comment>, range }`.
+  Arbitrary `---@query`, `---@compute`, `---@derive(json)`,
+  `---@some_future_plugin(a,b)` all survive generically. Known LuaDoc tags
+  (`@param/@return/@field/@class`) MAY additionally expose parsed fields, but the
+  generic form is always present.
 - **Attachment rule (deterministic, documented):** a **contiguous run** of
-  comment lines (`--` line comments and `--[[ ]]` blocks) immediately preceding a
-  statement, with **no blank line** between the run and the statement, attaches to
-  that statement's node (`node.annotations` / `node.annotation_list`). A blank
-  line, code, or a different statement breaks the run. Trailing/inline comments do
-  not attach. `unit:annotations_for(node)` and `lua.annotation(node, name)` read
-  them. Comments that attach to nothing remain in `unit.comments` only.
+  comment lines (`--` line comments and `--[[ ]]` blocks — plain comments
+  participate in the run, contributing no annotation) immediately preceding a
+  **declaration**, with **no blank line** between the run and the declaration,
+  attaches to that declaration's node (`node.annotations` /
+  `node.annotation_list`). Attachment is **declaration-scoped** (the smaller, safer
+  surface): only `local_declaration` and `function_declaration` (both `local` and
+  global `function name() ... end`) carry annotations. A `---@` run above any other
+  statement (assignment, call, loop, conditional, return, break/goto/label)
+  attaches to the **nearest following declaration** instead, or to nothing. A blank
+  line, intervening code, or a different declaration breaks the run.
+  Trailing/inline comments do not attach. `unit:annotations_for(node)` and
+  `lua.annotation(node, name)` read them. Every `---@` comment is retagged
+  `kind = "annotation"` in `unit.comments` whether or not it attaches; comments
+  that attach to nothing remain in `unit.comments` only.
 
 ## 9. Diagnostics (§12/§13) + recovery
 

--- a/stdlib/cli/lua/hull/source/annotations.lua
+++ b/stdlib/cli/lua/hull/source/annotations.lua
@@ -31,14 +31,16 @@
 
 local M = {}
 
--- Statement / declaration kinds that can carry leading annotations. A
--- function_EXPR is not a statement (it appears as a value); the enclosing
--- local_declaration / assignment / function_declaration is the attach target.
-local STATEMENT_KINDS = {
-    local_declaration = true, assignment = true, call_statement = true,
-    ["do"] = true, ["while"] = true, ["repeat"] = true, ["if"] = true,
-    numeric_for = true, generic_for = true, function_declaration = true,
-    ["return"] = true, ["break"] = true, ["goto"] = true, label = true,
+-- DECLARATION kinds that can carry leading annotations. The contract (docs §8)
+-- attaches annotations to DECLARATIONS only: `local x = ...` / `local function` and
+-- global `function name() ... end`. Every other statement (assignments, calls,
+-- loops, conditionals, returns, break/goto/labels) does NOT carry annotations, so a
+-- `---@` run above one attaches to the nearest following declaration instead, or to
+-- nothing. A function_EXPR is a value, not a statement; the enclosing
+-- local_declaration / function_declaration is the attach target.
+local DECLARATION_KINDS = {
+    local_declaration = true,
+    function_declaration = true,
 }
 
 -- Parse one comment into an annotation record, or nil when it is not a `---@`
@@ -98,12 +100,12 @@ function M.attach(unit)
         end
     end
 
-    -- Collect every declaration/statement node (any nesting), in source order.
-    local stmts = {}
+    -- Collect every DECLARATION node (any nesting), in source order.
+    local decls = {}
     local function collect(node)
         if type(node) ~= "table" then return end
-        if node.kind and STATEMENT_KINDS[node.kind] and node.range then
-            stmts[#stmts + 1] = node
+        if node.kind and DECLARATION_KINDS[node.kind] and node.range then
+            decls[#decls + 1] = node
         end
         for k, v in pairs(node) do
             if k ~= "range" and type(v) == "table" then collect(v) end
@@ -111,7 +113,7 @@ function M.attach(unit)
     end
     collect(ast)
 
-    for _, stmt in ipairs(stmts) do
+    for _, stmt in ipairs(decls) do
         local sl = unit:position(stmt.range.start)
         -- Walk contiguous leading comment lines upward from the line above.
         local run = {}

--- a/stdlib/cli/lua/hull/source/annotations.lua
+++ b/stdlib/cli/lua/hull/source/annotations.lua
@@ -1,0 +1,149 @@
+--
+-- hull.source.annotations — the generic `---@` scanner + declaration attachment.
+--
+-- Turns any `---@name`, `---@name(args)`, or `---@name rest` LINE comment into a
+-- structured annotation record and attaches contiguous runs of such comments to
+-- the declaration they lead. Deliberately WHITELIST-FREE: `name` is whatever
+-- follows `@`, so an app's own `---@derive`, `---@route`, `---@query` annotations
+-- are captured with the same fidelity as any LuaCATS tag. Consumers give meaning
+-- to names; this layer only records them, with exact byte ranges.
+--
+-- Annotation record (docs/lua_source_analysis_design.md §6):
+--   { name = "param",            -- the identifier after `@`
+--     args = "a, b" | nil,       -- raw text inside a trailing (...) group, or nil
+--     text = "x f64" | nil,      -- trailing text after the name / (...), trimmed
+--     raw  = "---@param x f64",  -- the full original comment text
+--     range = <SourceRange> }    -- the comment's half-open byte range
+--
+-- Attachment rule: a declaration's annotations are the annotation comments in the
+-- UNBROKEN run of LEADING comment lines directly above it (no blank line, no code
+-- between the run and the declaration; trailing comments on a code line do NOT
+-- attach). A blank line breaks the run. On the target node:
+--   node.annotation_list  -- ordered array of every annotation in the run (top->down)
+--   node.annotations      -- name -> FIRST annotation of that name (repeat tags like
+--                            @param keep all copies in annotation_list)
+--
+-- Pure Lua, no Hull C dependency. NEVER raises: M.attach is best-effort and the
+-- public parse() wraps it defensively.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local M = {}
+
+-- Statement / declaration kinds that can carry leading annotations. A
+-- function_EXPR is not a statement (it appears as a value); the enclosing
+-- local_declaration / assignment / function_declaration is the attach target.
+local STATEMENT_KINDS = {
+    local_declaration = true, assignment = true, call_statement = true,
+    ["do"] = true, ["while"] = true, ["repeat"] = true, ["if"] = true,
+    numeric_for = true, generic_for = true, function_declaration = true,
+    ["return"] = true, ["break"] = true, ["goto"] = true, label = true,
+}
+
+-- Parse one comment into an annotation record, or nil when it is not a `---@`
+-- annotation. Only LINE comments qualify, and only with THREE-or-more leading
+-- hyphens then `@` (Lua's `--@x` two-hyphen form is an ordinary comment, matching
+-- the LuaCATS convention).
+function M.parse_comment(comment)
+    if type(comment) ~= "table" or comment.kind ~= "line" then return nil end
+    local body = comment.text:match("^%-%-%-+%s*@%s*(.+)$")
+    if not body then return nil end
+    local name = body:match("^([%a_][%w_]*)")
+    if not name then return nil end                       -- `@` with no identifier
+
+    local after = body:sub(#name + 1):match("^%s*(.*)$")  -- left-trim the remainder
+    local args, text
+    local group = after:match("^(%b())")                  -- a balanced (...) right after the name
+    if group then
+        args = group:sub(2, -2)                           -- strip the outer parens
+        text = after:sub(#group + 1):match("^%s*(.-)%s*$")
+    else
+        text = after:match("^(.-)%s*$")                   -- right-trim
+    end
+    if text == "" then text = nil end
+
+    return { name = name, args = args, text = text, raw = comment.text, range = comment.range }
+end
+
+-- Attach annotation runs to declaration nodes on unit.ast. Idempotent-ish: it
+-- overwrites annotation_list / annotations on the nodes it touches. Returns the
+-- unit. Best-effort: a malformed unit (no ast / comments) is a silent no-op.
+function M.attach(unit)
+    if type(unit) ~= "table" then return unit end
+    local ast, comments, src = unit.ast, unit.comments, unit.source
+    if type(ast) ~= "table" or type(comments) ~= "table" or type(src) ~= "string" then
+        return unit
+    end
+    local starts = unit._linestarts
+
+    -- One pass over every comment: (1) tag annotation comments as kind
+    -- "annotation" and hang the parsed record off the comment (so unit.comments
+    -- reflects kind in {line, long, annotation} per the contract, leading or not);
+    -- (2) index the LEADING comments (nothing but whitespace before them on their
+    -- own line) by end-line for attachment. A trailing comment on a code line
+    -- (`x = 1  -- note`) is still tagged but never attaches downward.
+    local by_end = {}                                     -- end_line -> comment info
+    for _, c in ipairs(comments) do
+        if type(c) == "table" and c.range then
+            local rec = M.parse_comment(c)                -- parse BEFORE re-tagging kind
+            if rec then c.kind = "annotation"; c.annotation = rec end
+            local sl = unit:position(c.range.start)
+            local el = unit:position(c.range.stop - 1)
+            local line_start = starts[sl] or 1
+            local before = src:sub(line_start, c.range.start - 1)
+            if before:match("^%s*$") then
+                by_end[el] = { comment = c, start_line = sl, ann = rec }
+            end
+        end
+    end
+
+    -- Collect every declaration/statement node (any nesting), in source order.
+    local stmts = {}
+    local function collect(node)
+        if type(node) ~= "table" then return end
+        if node.kind and STATEMENT_KINDS[node.kind] and node.range then
+            stmts[#stmts + 1] = node
+        end
+        for k, v in pairs(node) do
+            if k ~= "range" and type(v) == "table" then collect(v) end
+        end
+    end
+    collect(ast)
+
+    for _, stmt in ipairs(stmts) do
+        local sl = unit:position(stmt.range.start)
+        -- Walk contiguous leading comment lines upward from the line above.
+        local run = {}
+        local target = sl - 1
+        while by_end[target] do
+            local info = by_end[target]
+            run[#run + 1] = info
+            target = info.start_line - 1
+        end
+        if #run > 0 then
+            local list, byname = {}, {}
+            for j = #run, 1, -1 do                        -- reverse: top -> down
+                local a = run[j].ann
+                if a then
+                    list[#list + 1] = a
+                    if byname[a.name] == nil then byname[a.name] = a end
+                end
+            end
+            if #list > 0 then
+                stmt.annotation_list = list
+                stmt.annotations = byname
+            end
+        end
+    end
+
+    return unit
+end
+
+-- node.annotations[name] (the first annotation of that name), or nil.
+function M.get(node, name)
+    if type(node) ~= "table" or type(node.annotations) ~= "table" then return nil end
+    return node.annotations[name]
+end
+
+return M

--- a/stdlib/cli/lua/hull/source/lua.lua
+++ b/stdlib/cli/lua/hull/source/lua.lua
@@ -14,9 +14,9 @@
 --     pure API misuse). No raw Lua error() ever crosses this boundary.
 --   * Never prints. Diagnostics are data.
 --
--- SLICE 1 (this file): lexer + ranges + line map. `unit.ast` is nil until the
--- statement slice lands; `unit.tokens`/`unit.comments`/`unit.diagnostics` and the
--- unit:text/position/line_col helpers are live now.
+-- Live surface: unit.tokens / unit.comments / unit.diagnostics, unit.ast (the
+-- chunk node), the unit:text/position/line_col helpers, M.walk / M.is, and the
+-- `---@` annotation layer (attached to declaration nodes; M.annotation reads it).
 --
 -- SPDX-License-Identifier: AGPL-3.0-or-later
 --
@@ -25,6 +25,7 @@ local lexer = require("hull.source.lexer")
 local parser = require("hull.source.parser")
 local range = require("hull.source.range")
 local diag = require("hull.source.diagnostic")
+local annotations = require("hull.source.annotations")
 
 local M = {}
 
@@ -57,6 +58,11 @@ function Unit:line_col(r)
     local sl, sc = self:position(r.start)
     local el, ec = self:position(r.stop)
     return sl, sc, el, ec
+end
+
+-- Ordered list of `---@` annotations attached to `node` (empty when none).
+function Unit:annotations_for(node)
+    return (type(node) == "table" and node.annotation_list) or {}
 end
 
 -- Limit keys validated at the boundary (each, if present, must be a non-negative
@@ -129,7 +135,17 @@ function M.parse(source, opts)
         _linestarts = range.linemap(source),
     }, Unit)
 
+    -- Attach `---@` annotation runs to declaration nodes (slice 4). Best-effort:
+    -- a bug here must degrade to "no annotations", never fail a clean parse.
+    pcall(annotations.attach, unit)
+
     return unit, nil
+end
+
+-- The FIRST `---@<name>` annotation attached to `node` (see hull.source.annotations),
+-- or nil. Repeat tags (e.g. @param) keep every copy in node.annotation_list.
+function M.annotation(node, name)
+    return annotations.get(node, name)
 end
 
 -- ── AST traversal (§18) + kind test (§19) ─────────────────────────────

--- a/stdlib/cli/lua/hull/source/lua.lua
+++ b/stdlib/cli/lua/hull/source/lua.lua
@@ -135,9 +135,17 @@ function M.parse(source, opts)
         _linestarts = range.linemap(source),
     }, Unit)
 
-    -- Attach `---@` annotation runs to declaration nodes (slice 4). Best-effort:
-    -- a bug here must degrade to "no annotations", never fail a clean parse.
-    pcall(annotations.attach, unit)
+    -- Attach `---@` annotation runs to declaration nodes (slice 4). Attachment is
+    -- part of the parse contract, so a failure is NOT silently swallowed: attach is
+    -- written not to raise, but if it ever does, an explicit lua.internal diagnostic
+    -- is appended so `#unit.diagnostics == 0` reflects the degraded state (a clean
+    -- unit with annotations silently missing would be the worst outcome for
+    -- query/codegen consumers). The valid AST is still returned.
+    local aok, aerr = pcall(annotations.attach, unit)
+    if not aok then
+        unit.diagnostics[#unit.diagnostics + 1] = diag.error("lua.internal",
+            "annotation attachment failed: " .. tostring(aerr), opts.path, nil)
+    end
 
     return unit, nil
 end

--- a/stdlib/cli/lua/hull/source/tests/test_annotations.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_annotations.lua
@@ -1,0 +1,195 @@
+--
+-- test_annotations.lua — slice-4 tests for the `---@` annotation layer.
+--
+-- Covers hull.source.annotations.parse_comment (the generic scanner) and the
+-- declaration-attachment run via the PUBLIC lua.parse() -> node.annotation_list /
+-- node.annotations + lua.annotation() + unit:annotations_for(). Pure Lua; run by
+-- tests/hull/source/test_lua_source.c.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local lua = require("hull.source.lua")
+local annotations = require("hull.source.annotations")
+
+local pass, fail, failures = 0, 0, {}
+local function ok(cond, name)
+    if cond then pass = pass + 1
+    else fail = fail + 1; failures[#failures + 1] = name; print("FAIL: " .. name) end
+end
+local function eq(a, b, name)
+    ok(a == b, name .. " (expected " .. tostring(b) .. ", got " .. tostring(a) .. ")")
+end
+
+-- A synthetic line-comment token for parse_comment unit tests.
+local function line_comment(text) return { kind = "line", text = text, range = { start = 1, stop = #text + 1 } } end
+local function pc(text) return annotations.parse_comment(line_comment(text)) end
+
+-- ── scanner: the generic `---@name(args) text` shapes ─────────────────
+do
+    local a = pc("---@compute")
+    ok(a ~= nil, "scan: name-only recognized")
+    eq(a.name, "compute", "scan: name-only name"); ok(a.args == nil, "scan: name-only no args")
+    ok(a.text == nil, "scan: name-only no text"); eq(a.raw, "---@compute", "scan: raw preserved")
+
+    local p = pc("---@param x f64")
+    eq(p.name, "param", "scan: param name"); ok(p.args == nil, "scan: param no parens")
+    eq(p.text, "x f64", "scan: param trailing text")
+
+    local d = pc("---@derive(json)")
+    eq(d.name, "derive", "scan: derive name"); eq(d.args, "json", "scan: paren args")
+    ok(d.text == nil, "scan: derive no trailing text")
+
+    local r = pc('---@route(GET, "/x")  register')
+    eq(r.name, "route", "scan: route name")
+    eq(r.args, 'GET, "/x"', "scan: multi-arg paren content verbatim")
+    eq(r.text, "register", "scan: text after paren, trimmed")
+
+    -- whitelist-free: an arbitrary vendor tag is captured like any other
+    local v = pc("---@acme_widget_v2 hello")
+    eq(v.name, "acme_widget_v2", "scan: arbitrary tag name captured")
+    eq(v.text, "hello", "scan: arbitrary tag text")
+
+    -- extra hyphens + spacing tolerated
+    eq(pc("----@ note here").name, "note", "scan: 4 hyphens + space before @")
+    eq(pc("---@spaced   trailing").text, "trailing", "scan: inner whitespace collapsed at edges")
+end
+
+-- ── scanner: non-annotations return nil ───────────────────────────────
+do
+    ok(pc("-- ordinary comment") == nil, "scan: 2-hyphen comment is not an annotation")
+    ok(pc("--@twohyphen") == nil, "scan: --@ (two hyphens) is not an annotation")
+    ok(pc("--- doc without tag") == nil, "scan: --- doc with no @ is not an annotation")
+    ok(pc("---@") == nil, "scan: bare ---@ (no name) is nil")
+    ok(pc("---@123 bad") == nil, "scan: @ + digit-led name is nil")
+    ok(annotations.parse_comment({ kind = "long", text = "--[[ ---@x ]]", range = { start = 1, stop = 2 } }) == nil,
+        "scan: a long comment is never an annotation")
+end
+
+-- ── attachment: contiguous leading run over a declaration ─────────────
+do
+    local u = lua.parse("---@compute\n---@pure\nlocal function f() end\n", { path = "t.lua" })
+    eq(#u.diagnostics, 0, "attach: annotated source parses clean")
+    local f = u.ast.body[1]
+    ok(f.annotation_list ~= nil, "attach: node got annotation_list")
+    eq(#f.annotation_list, 2, "attach: both leading annotations attached")
+    eq(f.annotation_list[1].name, "compute", "attach: order top->down (compute first)")
+    eq(f.annotation_list[2].name, "pure", "attach: order top->down (pure second)")
+    eq(lua.annotation(f, "compute").name, "compute", "attach: lua.annotation lookup")
+    ok(lua.annotation(f, "nope") == nil, "attach: lua.annotation miss -> nil")
+    eq(#u:annotations_for(f), 2, "attach: unit:annotations_for returns the list")
+end
+
+-- ── attachment: repeat tags kept in list; annotations[name] = first ────
+do
+    local u = lua.parse("---@param x f64\n---@param y f64\n---@return f64\nlocal function g(x, y) return x end\n",
+        { path = "t.lua" })
+    local g = u.ast.body[1]
+    eq(#g.annotation_list, 3, "repeat: all three annotations in the list")
+    eq(g.annotations.param.text, "x f64", "repeat: annotations[name] is the FIRST @param")
+    eq(g.annotations["return"].name, "return", "repeat: @return also reachable by name")
+    -- annotation_list keeps BOTH @param copies
+    local nparam = 0
+    for _, a in ipairs(g.annotation_list) do if a.name == "param" then nparam = nparam + 1 end end
+    eq(nparam, 2, "repeat: annotation_list retains both @param copies")
+end
+
+-- ── attachment: a blank line breaks the run ───────────────────────────
+do
+    local u = lua.parse("---@compute\n\nlocal x = 1\n", { path = "t.lua" })
+    local x = u.ast.body[1]
+    ok(x.annotation_list == nil, "blank: blank line between comment and decl -> no attach")
+end
+
+-- ── attachment: a trailing comment on a code line does not attach down ─
+do
+    local u = lua.parse("local a = 1  ---@nope\nlocal b = 2\n", { path = "t.lua" })
+    local b = u.ast.body[2]
+    ok(b.annotation_list == nil, "trailing: comment on the prior code line does not lead the next decl")
+end
+
+-- ── attachment: nested statement inside a function body ───────────────
+do
+    local u = lua.parse("local function outer()\n  ---@inner\n  local y = 2\nend\n", { path = "t.lua" })
+    local inner
+    lua.walk(u.ast, function(n)
+        if lua.is(n, "local_declaration") then
+            for _, nm in ipairs(n.names) do if nm.name == "y" then inner = n end end
+        end
+    end)
+    ok(inner ~= nil, "nested: found the inner local")
+    ok(inner.annotation_list ~= nil and inner.annotation_list[1].name == "inner",
+        "nested: leading annotation attaches to the nested declaration")
+    -- and NOT to the enclosing function_declaration
+    ok(u.ast.body[1].annotation_list == nil, "nested: enclosing function has no annotation")
+end
+
+-- ── attachment: a plain block comment above a decl is harmless ────────
+do
+    local u = lua.parse("--[[ a block comment ]]\nlocal z = 1\n", { path = "t.lua" })
+    eq(#u.diagnostics, 0, "block: parses clean")
+    ok(u.ast.body[1].annotation_list == nil, "block: non-annotation leading comment yields no annotations")
+end
+
+-- ── ranges: annotation.range slices back to the exact comment text ────
+do
+    local src = "---@derive(json)\nlocal rec = {}\n"
+    local u = lua.parse(src, { path = "t.lua" })
+    local a = u.ast.body[1].annotation_list[1]
+    eq(u:text(a), "---@derive(json)", "range: annotation range recovers the comment verbatim")
+    eq(a.args, "json", "range: derive args")
+end
+
+-- ── unit.comments kind is retagged to "annotation" (leading or trailing) ─
+do
+    local u = lua.parse("---@compute\nlocal a = 1  ---@trailing\n-- plain\n--[[ block ]]\n", { path = "t.lua" })
+    local kinds = {}
+    for _, c in ipairs(u.comments) do kinds[#kinds + 1] = c.kind end
+    -- ---@compute (annotation), ---@trailing (annotation), -- plain (line), block (long)
+    eq(kinds[1], "annotation", "kind: leading ---@ tagged annotation")
+    eq(kinds[2], "annotation", "kind: trailing ---@ also tagged annotation")
+    eq(kinds[3], "line", "kind: plain comment stays line")
+    eq(kinds[4], "long", "kind: block comment stays long")
+    ok(u.comments[1].annotation ~= nil and u.comments[1].annotation.name == "compute",
+        "kind: parsed record hung off the annotation comment")
+end
+
+-- ── §41 acceptance example: full attachment through the public API ────
+do
+    local src = "---@compute\n" ..
+        "---@param x f64\n---@param y f64\n---@return f64\n" ..
+        "local function score(x, y)\n    return x * x + y * y\nend\n\n" ..
+        "---@query\nlocal active = query {\n    from = \"trips\"\n}\n"
+    local u = lua.parse(src, { path = "t.lua" })
+    eq(#u.diagnostics, 0, "acceptance: parses clean")
+
+    local score = u.ast.body[1]
+    eq(score.name.name, "score", "acceptance: first decl is score")
+    eq(#score.annotation_list, 4, "acceptance: score has 4 leading annotations")
+    eq(lua.annotation(score, "compute").name, "compute", "acceptance: @compute on score")
+    eq(#(function() local t = {} for _, a in ipairs(score.annotation_list) do if a.name == "param" then t[#t+1]=a end end return t end)(),
+        2, "acceptance: two @param annotations on score")
+
+    local active = u.ast.body[2]
+    eq(active.names[1].name, "active", "acceptance: second decl is active")
+    eq(#active.annotation_list, 1, "acceptance: active has 1 annotation")
+    eq(active.annotation_list[1].name, "query", "acceptance: @query on active")
+end
+
+-- ── boundary: attachment never raises on nasty / annotation-only input ─
+do
+    local nasty = {
+        "---@compute", "---@compute\n", "---@x\n---@y", "\n\n---@a\nlocal q=1",
+        "---@only annotations and no code following at all",
+        string.rep("---@a\n", 50) .. "local w = 1",
+    }
+    local safe = true
+    for _, s in ipairs(nasty) do
+        local okc, u = pcall(lua.parse, s, { path = "t.lua" })
+        if not okc or u == nil then safe = false; print("  RAISED/nil: " .. s:sub(1, 24)) end
+    end
+    ok(safe, "boundary: annotation attachment never raises")
+end
+
+print(string.format("test_annotations: %d passed, %d failed", pass, fail))
+return { pass = pass, fail = fail, failures = failures }

--- a/stdlib/cli/lua/hull/source/tests/test_annotations.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_annotations.lua
@@ -176,6 +176,59 @@ do
     eq(active.annotation_list[1].name, "query", "acceptance: @query on active")
 end
 
+-- ── scope: annotations attach to DECLARATIONS only (docs §8) ──────────
+do
+    -- above a non-declaration statement the run does not attach to that statement.
+    local u = lua.parse("local function f()\n  ---@note\n  return 1\nend\n", { path = "t.lua" })
+    local ret
+    lua.walk(u.ast, function(n) if lua.is(n, "return") then ret = n end end)
+    ok(ret ~= nil, "scope: found the return")
+    ok(ret.annotation_list == nil, "scope: annotation does NOT attach to a return")
+
+    local u2 = lua.parse("---@note\ng()\n", { path = "t.lua" })
+    ok(u2.ast.body[1].annotation_list == nil, "scope: annotation does NOT attach to a call statement")
+
+    local u3 = lua.parse("---@note\nx = 1\n", { path = "t.lua" })
+    eq(u3.ast.body[1].kind, "assignment", "scope: bare x=1 is an assignment (not a declaration)")
+    ok(u3.ast.body[1].annotation_list == nil, "scope: annotation does NOT attach to an assignment")
+    -- retag still happens even when the annotation attaches to nothing
+    eq(u3.comments[1].kind, "annotation", "scope: unattached annotation comment is still retagged")
+end
+
+-- ── contiguous block: plain comments participate; code/blank/trailing break ─
+do
+    -- a plain `--` line ABOVE the annotation stays in the contiguous block
+    local a = lua.parse("-- header\n---@compute\nlocal function f() end\n", { path = "t.lua" })
+    ok(lua.annotation(a.ast.body[1], "compute") ~= nil, "block: plain comment above the annotation -> still attaches")
+    -- a plain `--` line BELOW the annotation (still contiguous) stays in the block
+    local b = lua.parse("---@compute\n-- interstitial note\nlocal function g() end\n", { path = "t.lua" })
+    ok(lua.annotation(b.ast.body[1], "compute") ~= nil, "block: plain comment below the annotation -> still attaches")
+    -- a --[[ ]] block line likewise participates, contributing no annotation
+    local c = lua.parse("---@compute\n--[[ note ]]\nlocal function h() end\n", { path = "t.lua" })
+    ok(lua.annotation(c.ast.body[1], "compute") ~= nil, "block: long comment participates in the run")
+
+    -- intervening CODE breaks the run: @compute leads the NEAREST following decl
+    local d = lua.parse("---@compute\nlocal q = 1\nlocal function f() end\n", { path = "t.lua" })
+    ok(lua.annotation(d.ast.body[1], "compute") ~= nil, "block: code-between -> attaches to the nearer decl (q)")
+    ok(d.ast.body[2].annotation_list == nil, "block: intervening code breaks attachment to the later decl (f)")
+
+    -- a blank line breaks even a plain+annotation block
+    local e = lua.parse("-- header\n---@compute\n\nlocal function f() end\n", { path = "t.lua" })
+    ok(e.ast.body[1].annotation_list == nil, "block: blank line breaks the whole leading block")
+end
+
+-- ── fix 1: an attachment failure surfaces as a lua.internal diagnostic ─
+do
+    local orig = annotations.attach
+    annotations.attach = function() error("boom") end   -- same module table lua.lua holds
+    local u = lua.parse("local x = 1", { path = "t.lua" })
+    annotations.attach = orig
+    ok(u ~= nil, "internal: unit still returned on attach failure")
+    local hit = false
+    for _, d in ipairs(u.diagnostics) do if d.code == "lua.internal" then hit = true end end
+    ok(hit, "internal: attach failure -> lua.internal diagnostic (never silently swallowed)")
+end
+
 -- ── boundary: attachment never raises on nasty / annotation-only input ─
 do
     local nasty = {

--- a/tests/hull/source/test_lua_source.c
+++ b/tests/hull/source/test_lua_source.c
@@ -88,4 +88,13 @@ UTEST(lua_source, statements_slice3)
     EXPECT_GT(pass, 0LL);
 }
 
+UTEST(lua_source, annotations_slice4)
+{
+    long long pass = 0, fail = -1;
+    int rc = run_lua_test("stdlib/cli/lua/hull/source/tests/test_annotations.lua", &pass, &fail);
+    ASSERT_EQ(rc, 0);
+    EXPECT_EQ(fail, 0LL);
+    EXPECT_GT(pass, 0LL);
+}
+
 UTEST_MAIN()


### PR DESCRIPTION
Slice 4 of `hull.source.lua`: the generic `---@` annotation layer, attaching to the stable, range-bearing declaration nodes from slice 3 without touching statement shapes or diagnostic budgeting.

## New module: `hull.source.annotations`
- **Scanner** `parse_comment` — a LINE comment `---@name`, `---@name(args)`, or `---@name text` → `{ name, args?, text?, raw, range }`. Whitelist-free: any name is captured (`---@derive`, `---@route`, `---@query`) with the same fidelity as LuaDoc tags. `--@` (two hyphens) and long comments are never annotations.
- **Attachment** `attach` — the annotation comments in the unbroken run of **leading** comment lines directly above a declaration attach to it. Blank line / code / trailing-comment-on-a-code-line breaks or is excluded. Nested declarations get their own runs. Node carries `annotation_list` (ordered, repeat tags like `@param` all kept) + `annotations` (name → first). Annotation comments in `unit.comments` are retagged `kind = "annotation"` per the contract, with the parsed record hung off the comment.

## Public surface (`lua.lua`)
- `lua.annotation(node, name)` and `unit:annotations_for(node)`.
- `attach` runs `pcall`-guarded after unit construction — an attachment bug degrades to "no annotations", never fails a clean parse.

## Tests
`test_annotations.lua` (59 cases): scanner shapes, non-annotations, contiguous / blank-broken / trailing / nested attachment, repeat-tag retention, comment retagging, range fidelity, the §41 acceptance example, and a never-raises boundary.

Suites: **lexer 110 + parser 133 + statements 130 + annotations 59** via the vanilla `lua_State` harness. luacheck clean; full `hull` build OK (module embeds into the binary). No `load()` / dynamic compilation.
