### PR TITLE
chore(source): lua-audit follow-ups (dead method, contract notes, idempotent attach)

### DIFF
--- a/stdlib/cli/lua/hull/source/annotations.lua
+++ b/stdlib/cli/lua/hull/source/annotations.lua
@@ -44,11 +44,13 @@ local DECLARATION_KINDS = {
 }
 
 -- Parse one comment into an annotation record, or nil when it is not a `---@`
--- annotation. Only LINE comments qualify, and only with THREE-or-more leading
--- hyphens then `@` (Lua's `--@x` two-hyphen form is an ordinary comment, matching
--- the LuaCATS convention).
+-- annotation. Line comments qualify (only with THREE-or-more leading hyphens then
+-- `@` -- Lua's `--@x` two-hyphen form is an ordinary comment, matching the LuaCATS
+-- convention); a comment already retagged kind "annotation" by a prior attach()
+-- also qualifies, so re-parsing / re-attaching is idempotent. Long comments never.
 function M.parse_comment(comment)
-    if type(comment) ~= "table" or comment.kind ~= "line" then return nil end
+    if type(comment) ~= "table" then return nil end
+    if comment.kind ~= "line" and comment.kind ~= "annotation" then return nil end
     local body = comment.text:match("^%-%-%-+%s*@%s*(.+)$")
     if not body then return nil end
     local name = body:match("^([%a_][%w_]*)")
@@ -68,9 +70,10 @@ function M.parse_comment(comment)
     return { name = name, args = args, text = text, raw = comment.text, range = comment.range }
 end
 
--- Attach annotation runs to declaration nodes on unit.ast. Idempotent-ish: it
--- overwrites annotation_list / annotations on the nodes it touches. Returns the
--- unit. Best-effort: a malformed unit (no ast / comments) is a silent no-op.
+-- Attach annotation runs to declaration nodes on unit.ast. Idempotent: attachment
+-- is deterministic and parse_comment re-recognizes already-retagged comments, so a
+-- second call reproduces the same annotation_list / annotations. Returns the unit.
+-- Best-effort: a malformed unit (no ast / comments) is a silent no-op.
 function M.attach(unit)
     if type(unit) ~= "table" then return unit end
     local ast, comments, src = unit.ast, unit.comments, unit.source

--- a/stdlib/cli/lua/hull/source/parser.lua
+++ b/stdlib/cli/lua/hull/source/parser.lua
@@ -73,9 +73,9 @@ function P:err(message, tok)
     return { kind = "error", range = { start = tok.range.start, stop = tok.range.stop } }
 end
 
-function P:unsupported(message, s, e)
-    self:emit(diag.error("lua.unsupported", message, self.path, { start = s, stop = e }))
-end
+-- Note: `lua.unsupported` stays a reserved code in the diagnostic vocabulary (for a
+-- future "valid syntax not yet represented" notice), but nothing emits it today --
+-- the whole statement grammar parses, so there is no P:unsupported helper.
 
 -- Consume `text` op/kw or emit a diagnostic; returns the token or nil.
 function P:expect_op(text)
@@ -563,8 +563,10 @@ function P:exprstat()
 end
 
 -- ── public: parse a single expression from source (slice-2 surface) ───
--- Returns (node, diagnostics). The lexer must be run by the caller (lua.lua) or
--- via M.parse_expression which does both.
+-- Returns (node, diagnostics). CONTRACT: `tokens` must be a lexer token stream
+-- terminated by an `eof` token (as hull.source.lexer always produces); the parser
+-- relies on that sentinel and does not defend against an empty / eof-less array.
+-- lua.parse() is the production caller and additionally wraps this in pcall.
 function M.parse_expression(tokens, source, opts)
     opts = opts or {}
     local st = new_state(tokens, source, opts)
@@ -577,6 +579,8 @@ end
 
 -- ── public: parse a whole chunk (the full source AST) ────────────────
 -- chunk := block. Returns (ast, diagnostics). This is what lua.parse() drives.
+-- CONTRACT: same as parse_expression -- `tokens` must be an eof-terminated lexer
+-- stream.
 function M.parse_chunk(tokens, source, opts)
     opts = opts or {}
     local st = new_state(tokens, source, opts)

--- a/stdlib/cli/lua/hull/source/tests/test_annotations.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_annotations.lua
@@ -229,6 +229,19 @@ do
     ok(hit, "internal: attach failure -> lua.internal diagnostic (never silently swallowed)")
 end
 
+-- ── I2: attach is idempotent (re-running reproduces the same annotations) ─
+do
+    local u = lua.parse("---@compute\n---@pure\nlocal function f() end\n", { path = "t.lua" })
+    local f = u.ast.body[1]
+    eq(#f.annotation_list, 2, "idempotent: first attach set 2 annotations")
+    -- comments are now retagged kind "annotation"; a second attach must not drop them
+    annotations.attach(u)
+    eq(#f.annotation_list, 2, "idempotent: second attach preserves annotation_list")
+    eq(lua.annotation(f, "compute").name, "compute", "idempotent: annotations[name] stable")
+    ok(annotations.parse_comment(u.comments[1]) ~= nil,
+        "idempotent: parse_comment re-recognizes a retagged annotation comment")
+end
+
 -- ── boundary: attachment never raises on nasty / annotation-only input ─
 do
     local nasty = {


### PR DESCRIPTION
Follow-ups from a `/lua-audit` of the `hull.source.lua` layer. The audit found **no Critical/High/Medium** issues — the layer is sandbox-clean (zero `load`/`loadstring`/`dofile`), never-raises against untrusted source (every `advance()` is eof-guarded; `lua.parse` also `pcall`-wraps), resource-bounded (byte/token/comment/depth/diagnostic caps with terminal-bypass), and ReDoS-free (linear patterns). These are the three actionable notes:

- **L1 (dead code)** — remove the unused `P:unsupported` method. After slice 3 the whole statement grammar parses, so nothing emits `lua.unsupported`; the code stays **reserved** in the diagnostic vocabulary for a future "valid syntax not yet represented" notice, only the orphaned helper is deleted (luacheck can't flag a table method).
- **I1 (contract note)** — document that `parse_chunk`/`parse_expression` require an eof-terminated lexer token stream (`lua.parse()` is the production caller, always supplies `eof`, wraps in `pcall`).
- **I2 (idempotency)** — `annotations.attach` is now idempotent: `parse_comment` also recognizes a comment already retagged `kind = "annotation"`, so a second `attach` reproduces the same `annotation_list`/`annotations` rather than dropping them.

Tests: +4 idempotency assertions. **lexer 110 + parser 133 + statements 130 + annotations 77**; luacheck clean; full `hull` build OK.
