### PR TITLE
test(source): Lua source-analysis conformance harness (+ first lexer conformance fix)

### DIFF
--- a/docs/lua_source_conformance_design.md
+++ b/docs/lua_source_conformance_design.md
@@ -1,0 +1,241 @@
+# Lua source-analysis conformance harness (design)
+
+Status: DESIGN (pre-implementation). Companion to
+[lua_source_analysis_design.md](lua_source_analysis_design.md). This is step **A**
+of the post-build-plan roadmap: validate `hull.source.lua` against real Lua 5.4 as
+ground truth, systematically, before any consumer (`hull analyze`, `hull.query`,
+`hull.compute`, codegen) is built on the AST.
+
+## 1. Goal
+
+Turn "the tests I hand-wrote pass" into "the parser agrees with real Lua 5.4 across
+thousands of files, and its byte ranges are internally consistent." Concretely, catch:
+
+1. **False rejects** — the parser emits a syntax diagnostic on input real Lua
+   accepts. This is the highest-value bug class: real code the layer would choke on.
+2. **False accepts** — the parser reports clean on input real Lua rejects for a
+   *syntactic* reason (a missed syntax error).
+3. **Range-integrity bugs** — a node whose half-open range is out of bounds, empty
+   for a non-empty construct, or not nested within its parent.
+4. **Never-raise breaches** — any input that makes `lua.parse` raise instead of
+   returning `(unit, err)`.
+
+## 2. Why `load()` is the oracle (and a good one)
+
+The test harness (`tests/hull/source/test_lua_source.c`) runs co-located Lua scripts
+in a **vanilla `lua_State`** built from the **same vendored Lua 5.4** (`LUA_OBJS`)
+that Hull ships. That state's `load()` therefore drives the *exact* lexer/parser
+Hull targets — not "some Lua," the same one. Properties that make it ideal:
+
+- **Same version, in-process.** No subprocess, no version skew, no external Lua.
+- **Compile-only.** `load(src, name, "t")` compiles and returns the function
+  **without executing it** (mode `"t"` = text only, so a binary-chunk payload can
+  never be loaded, and nothing runs). Pure accept/reject with zero side effects.
+- **The module still never calls `load()`.** The locked contract
+  ([design §…]) keeps dynamic compilation out of `hull.source.*`; the *test* calls
+  `load()`. The corpus and the oracle live in the harness, exactly as reserved.
+
+`load()` returns `(chunk, nil)` on accept, `(nil, errmsg)` on reject.
+
+## 3. The core invariant — and its one-directional exception
+
+`hull.source.lua` is a **syntactic recognizer**. Real Lua's `load()` is syntactic
+**plus a thin layer of static-semantic checks** that a pure parser deliberately does
+not perform. So the invariant is directional:
+
+- **If the parser rejects (≥1 `lua.syntax`), `load()` MUST reject.** A parser reject
+  on load-accepted input is a **false-reject bug** (fail). This is the direction we
+  most want to nail down, because real code lives here.
+- **If the parser accepts (0 syntax diagnostics), `load()` USUALLY accepts** — but
+  may reject for a **semantic** reason the parser intentionally ignores. Those are
+  *expected divergences*, not bugs. A load-reject with a genuinely *syntactic*
+  message on parser-accepted input is a **false-accept bug** (fail).
+
+### 3.1 The semantic-exception set (expected `accept` / `load`-reject)
+
+These constructs are syntactically valid (parser accepts) but statically rejected by
+`load()`. They are pinned as EXPECTED divergences, matched by a stable substring of
+Lua 5.4's error message:
+
+| Construct | Example | Lua 5.4 message fragment |
+|---|---|---|
+| `break` outside a loop | `break` | `outside a loop` |
+| `goto` to an undefined / out-of-scope label | `goto x` | `no visible label`, `jumps into the scope` |
+| `...` outside a vararg function | `function f() return ... end` | `cannot use '...' outside a vararg` |
+| assign to a `<const>` / `<close>` | `local x <const> = 1; x = 2` | `attempt to assign to const` |
+| bad attribute name | `local x <bad> = 1` | `unknown attribute` |
+| compiler limits | deeply nested / huge | `too many `, `constant overflow`, `control structure too long` |
+
+The classifier is a small, documented allowlist of fragments (`SEMANTIC_REJECTS`)
+anchored to the vendored Lua 5.4 error text. If `load()` rejects with a message
+matching one, the divergence is expected. Lua 5.4's static-check messages are stable
+within the version Hull vendors, and the set is closed (Lua adds these checks
+rarely).
+
+**Guardrails (the classifier must not become a catch-all):**
+- It applies in **exactly one situation**: Hull parses **cleanly** (0 syntax /
+  unsupported diagnostics) **and** `load()` rejects. It is consulted nowhere else.
+- It **never** excuses: (a) a Hull diagnostic on `load()`-**accepted** input (that is
+  a false-reject, always a failure); (b) a curated syntactic-negative mismatch (§5);
+  (c) a `lua.internal` or `lua.limit.*` diagnostic (those are excluded from the
+  accept/reject signal entirely — a limit/internal marker is never a "clean parse").
+- Every allowed divergence is **reported by category and count** in the suite output,
+  so an over-broad fragment surfaces as an anomalous tally instead of hiding.
+- **Direct classifier tests** accompany the allowlist: for each fragment, a snippet
+  that provably triggers its intended semantic error (asserting `load` rejects and
+  `classify()` returns that category) **and** a nearby *syntax* error snippet that the
+  classifier must **not** match (asserting `classify()` returns nil). This pins that
+  each fragment recognizes only its semantic case and does not bleed onto adjacent
+  syntax errors.
+
+Note the `<bad>` attribute case: the parser ALSO emits its own `lua.syntax`
+("unknown attribute…") there — so both reject and it is not even a divergence. It is
+listed only because a mutation could produce the attribute form without the parser's
+own guard firing; the classifier keeps that from reading as a false-accept.
+
+## 4. Input normalization (exactly one)
+
+**Shebang.** Lua's *file* loader (`luaL_loadfilex`) skips a leading `#!…\n`; Lua's
+*string* `load()` does not (`#` is the length operator, so `load("#!/x\n…")` is a
+syntax error). `hull.source.lexer` follows *file* semantics (a leading `#!` line is a
+shebang comment). To compare fairly, the harness strips a leading `#!…\n` (through
+the first newline) from the source before handing it to `load()`, mirroring what the
+parser does. This is the only normalization; everything else is byte-identical.
+
+Empty input, trailing garbage, and every other case need no special handling: `load`
+and the parser already agree (empty → accept; trailing tokens → both reject).
+
+## 5. What the harness checks (three parts)
+
+### Part 1 — Corpus, classified by the oracle (not assumed positive)
+Do NOT assume every `.lua` file is valid — `tests/fixtures` and examples may hold
+intentionally-broken inputs. The **oracle classifies each file** (after
+shebang-normalization for `load()`), and the directional rules from §3 apply
+uniformly:
+- **`load()`-accepted files** (the bulk of committed code) enforce the anti-
+  false-reject gate: `lua.parse` must yield **zero** `lua.syntax` / `lua.unsupported`
+  diagnostics. This is the single most valuable check — real, shipping Hull code.
+- **`load()`-rejected files** follow the same directional / semantic-divergence rules
+  as any other reject: Hull must also reject (≥1 syntax diagnostic), OR the divergence
+  is a pinned §3.1 semantic case (Hull clean + a matching fragment). These are
+  **counted and reported separately** from the accepted-file tally, so a rejected
+  fixture is surfaced, never silently passed.
+
+### Part 2 — Range round-trip integrity
+For every accepted corpus file, walk the AST (`lua.walk`) and assert, for every node:
+- `1 <= range.start <= range.stop <= #src + 1` (in-bounds, non-inverted),
+- `unit:text(node)` is a byte-exact slice (`src:sub(start, stop-1)`), non-empty for
+  any node that spans a real construct,
+- each **AST child node**'s range is **nested within** its parent's `[start, stop)`
+  (structural sanity).
+
+**Nesting covers AST child nodes ONLY.** Attached annotations
+(`node.annotation_list` / `node.annotations`) are *not* AST children and their ranges
+intentionally **precede** the declaration they annotate (a `---@` comment sits
+*above* the decl), so they are **excluded** from the nesting check — gathering
+children skips the `annotation_list` / `annotations` fields (and only kind-bearing
+tables are children, which annotation records are not, so `lua.walk` never visits
+them anyway). Independent of accept/reject — catches range / `finish()` bugs directly.
+
+### Part 3 — Curated negatives + seeded mutation fuzz
+- **Curated syntactic negatives**: a table of *syntactically* invalid snippets
+  (`"1 +"`, `"function f("`, `"a.b."`, `"{,}"`, `"if then end"`, `"local = 1"`, `"::"`,
+  `"return return"`, …). Assert BOTH `load()` rejects AND the parser emits ≥1
+  `lua.syntax`. Anti-false-accept for known shapes.
+- **Pinned semantic divergences**: the §3.1 constructs, asserted as *parser accepts +
+  `load()` rejects with a semantic fragment* — so if either side's behavior shifts
+  we notice.
+- **Seeded mutation fuzz** (deterministic): with a FIXED `math.randomseed`, take each
+  accepted corpus file, apply N small mutations (delete / insert / duplicate one byte
+  or token), and for each mutant run both oracles and assert the directional
+  invariant from §3: never-raise; no false-reject; no false-accept (a parser-accept
+  with a *syntactic* load-reject). Budget is bounded (≈N=20 per seed file, capped
+  total) so it stays sub-second inside `make test`. Continuous/unbounded fuzzing is
+  the follow-up in §8.
+
+## 6. Corpus enumeration (C-side, hermetic, deterministic)
+
+Enumeration AND file reading happen in **C** (the vanilla `lua_State` has no portable
+directory walk in pure Lua, and we will NOT shell out — `io.popen('find')` is
+non-hermetic and shaky under the cosmo runner). A `dirent` walk over a fixed set of
+repo-relative roots (`stdlib/lua`, `stdlib/cli/lua`, `examples`, `tests/fixtures`).
+
+**C exposes `{path, source}` records, not paths.** C reads each file's bytes and
+builds `HULL_LUA_CORPUS = { { path = <rel>, source = <bytes> }, … }`. Rationale
+(a correction over the first draft): the Lua side does **no** `io` and does **no**
+second filesystem pass, and — critically — the **oracle (`load()`) and the Hull
+parser receive the identical bytes** C read (a re-open could race or resolve
+differently). The script is pure compute over an injected table.
+
+**Determinism (required for CI reproducibility):**
+- **Regular files only.** Include an entry iff `lstat` reports `S_ISREG` and the name
+  ends in `.lua`. No directories, devices, FIFOs.
+- **Symlinks: explicit, never followed.** Use `lstat` (not `stat`); a symlink entry —
+  file OR directory — is **skipped entirely**. This both fixes symlink handling and
+  **avoids traversal loops** (no symlinked directory is ever descended), with a
+  defensive recursion-depth cap as a backstop.
+- **Sorted.** Collect normalized repo-relative paths and `qsort` them (byte-wise
+  `strcmp`) before anything downstream selects from them, so ordering is stable
+  across platforms and filesystem iteration order.
+- **Deterministic seed scheduling.** When the corpus exceeds the mutation cap (§7),
+  seeds are selected by a fixed stride over the sorted list (not by which files the
+  FS yielded first), so the fuzzed subset is identical run to run.
+
+The corpus is Hull's own committed Lua — always in sync, never embedded / stale.
+
+## 7. Resource limits, determinism, CI
+
+- Run the corpus with **generous limits** (raise `max_bytes` / `max_tokens` /
+  `max_depth`) so `lua.limit.*` never trips on legitimate files; `lua.limit.*` and
+  `lua.internal` are **excluded** from the accept/reject signal in every part (they
+  are Hull-side bounds / internal-error markers, not syntax verdicts).
+- **Deterministic**: one fixed seed, index-derived mutation choices, bounded budget —
+  a CI failure reproduces exactly.
+- Runs inside `make test` as a new UTEST leg (fast: low-thousands of parses,
+  sub-second). No new external dependency.
+
+## 8. Deliverables + follow-up
+
+**This harness (one PR):**
+- `docs/lua_source_conformance_design.md` (this file).
+- C, in the existing `tests/hull/source/test_lua_source.c` (one vanilla Lua-state
+  harness, one source-analysis target): a `dirent` corpus walk building `{path,
+  source}` records + a runner that injects `HULL_LUA_CORPUS`, plus a **separate**
+  `UTEST(lua_source, conformance)` leg driving its **own** Lua script — so a
+  conformance failure stays isolated and readable, distinct from the lexer/parser/
+  statements/annotations legs.
+- Lua: `stdlib/cli/lua/hull/source/tests/test_conformance.lua` — the three-part
+  differential (oracle-classified corpus, range round-trip over AST children only,
+  curated negatives + pinned semantic divergences + seeded mutation fuzz) plus the
+  direct classifier tests (§3.1); returns `{ pass, fail }` like the other suites.
+
+**Follow-up (separate, later):** a continuous **libFuzzer never-raise harness**
+`tests/fuzz_lua_source.c` (spin a `lua_State`, set `package.path`, feed
+`LLVMFuzzerTestOneInput` bytes to `lua.parse`, assert it returns without raising) —
+parallels Hull's existing pgwire / mysqlwire fuzzers and runs 60s in CI. The
+differential-vs-`load` fuzz stays the seeded, bounded Lua-side loop in Part 3 (a
+`load`-comparison inside libFuzzer is heavier and less reproducible).
+
+## 9. Non-goals
+
+- **Not** proving AST *equivalence* to Lua's internal parse tree (not exposed, and
+  not needed — we prove accept/reject agreement + range integrity).
+- **Not** semantic analysis (scopes, binding, const-checking) — that is a possible
+  future slice for consumers that rewrite references, tracked separately.
+- **Not** a second Lua implementation — `load()` is the oracle; the harness only
+  compares.
+
+## 10. Decisions (ratified)
+
+1. **Semantic-exception classifier** — KEPT, with the §3.1 guardrails: anchored to
+   vendored Lua 5.4 text, consulted only when Hull is clean and `load()` rejects,
+   never excusing Hull-diagnostics-on-accepted / curated-negative mismatch /
+   internal / limit diagnostics, every divergence reported by category + count, and
+   direct classifier tests proving each fragment matches its case and not adjacent
+   syntax errors.
+2. **Harness placement** — extend `tests/hull/source/test_lua_source.c` (one vanilla
+   Lua-state harness, one target), with conformance logic in its **own** Lua script
+   under its **own** `UTEST` leg for isolated, readable failures.
+3. **Mutation budget** — N=20 mutations per selected seed, ~4000-mutant ceiling,
+   fixed seed; corpus enumeration deterministic per §6 (regular `.lua` only, symlinks
+   skipped / no loops, sorted paths, fixed-stride seed scheduling above the cap).

--- a/docs/lua_source_conformance_design.md
+++ b/docs/lua_source_conformance_design.md
@@ -1,6 +1,7 @@
-# Lua source-analysis conformance harness (design)
+# Lua source-analysis conformance harness
 
-Status: DESIGN (pre-implementation). Companion to
+Status: IMPLEMENTED (`tests/hull/source/test_lua_source.c` +
+`stdlib/cli/lua/hull/source/tests/test_conformance.lua`). Companion to
 [lua_source_analysis_design.md](lua_source_analysis_design.md). This is step **A**
 of the post-build-plan roadmap: validate `hull.source.lua` against real Lua 5.4 as
 ground truth, systematically, before any consumer (`hull analyze`, `hull.query`,
@@ -41,44 +42,68 @@ Hull targets — not "some Lua," the same one. Properties that make it ideal:
 
 `hull.source.lua` is a **syntactic recognizer**. Real Lua's `load()` is syntactic
 **plus a thin layer of static-semantic checks** that a pure parser deliberately does
-not perform. So the invariant is directional:
+not perform.
 
-- **If the parser rejects (≥1 `lua.syntax`), `load()` MUST reject.** A parser reject
-  on load-accepted input is a **false-reject bug** (fail). This is the direction we
-  most want to nail down, because real code lives here.
-- **If the parser accepts (0 syntax diagnostics), `load()` USUALLY accepts** — but
-  may reject for a **semantic** reason the parser intentionally ignores. Those are
-  *expected divergences*, not bugs. A load-reject with a genuinely *syntactic*
-  message on parser-accepted input is a **false-accept bug** (fail).
+**Hull's result is THREE-STATE, not two.** `hull_state(unit)` returns:
+- **`reject`** — ≥1 `lua.syntax` / `lua.unsupported` diagnostic.
+- **`clean`** — zero syntax diagnostics AND zero `lua.internal` / `lua.limit.*`.
+- **`indeterminate`** — any `lua.internal` or `lua.limit.*` marker.
+
+An internal/limit marker is **never** a clean parse and **never** enters semantic
+classification (the locked guardrail). In this *required* gate an `indeterminate`
+result **fails with a harness diagnostic** (raise the limits, or fix the never-raise
+/ internal bug) — it is not silently read as acceptance. So the directional invariant
+is over `reject` vs `clean` only:
+
+- **`reject` ⟹ `load()` MUST reject.** A `reject` on load-accepted input is a
+  **false-reject bug** (fail). This is the direction we most want to nail down.
+- **`clean` USUALLY means `load()` accepts** — but `load()` may reject for a
+  **semantic** reason the parser intentionally ignores. Those are *expected
+  divergences*. A `load()` reject with a genuinely *syntactic* message on a `clean`
+  parse is a **false-accept bug** (fail).
 
 ### 3.1 The semantic-exception set (expected `accept` / `load`-reject)
 
-These constructs are syntactically valid (parser accepts) but statically rejected by
-`load()`. They are pinned as EXPECTED divergences, matched by a stable substring of
-Lua 5.4's error message:
+These constructs are syntactically valid (parser is `clean`) but statically rejected
+by `load()`. They are pinned as EXPECTED divergences, each matched by a **precise**
+Lua 5.4 message fragment (`SEMANTIC_REJECTS`):
 
 | Construct | Example | Lua 5.4 message fragment |
 |---|---|---|
-| `break` outside a loop | `break` | `outside a loop` |
-| `goto` to an undefined / out-of-scope label | `goto x` | `no visible label`, `jumps into the scope` |
+| `break` outside a loop | `break` | `break outside loop` |
+| `goto` to an undefined label | `goto x` | `no visible label` |
+| `goto` into a local's scope | `goto s; local x=1; ::s:: return x` | `jumps into the scope` |
 | `...` outside a vararg function | `function f() return ... end` | `cannot use '...' outside a vararg` |
-| assign to a `<const>` / `<close>` | `local x <const> = 1; x = 2` | `attempt to assign to const` |
-| bad attribute name | `local x <bad> = 1` | `unknown attribute` |
-| compiler limits | deeply nested / huge | `too many `, `constant overflow`, `control structure too long` |
+| assign to a `<const>` / `<close>` | `local x <const> = 1; x = 2` | `attempt to assign to const variable` |
+| too many locals (compiler limit) | 260 `local`s | `too many local variables` |
 
-The classifier is a small, documented allowlist of fragments (`SEMANTIC_REJECTS`)
-anchored to the vendored Lua 5.4 error text. If `load()` rejects with a message
-matching one, the divergence is expected. Lua 5.4's static-check messages are stable
-within the version Hull vendors, and the set is closed (Lua adds these checks
-rarely).
+**Matching is honest SUBSTRING matching against the NORMALIZED message body** — the
+`chunkname:line: ` prefix is stripped first (`normalize`) so a fragment matches the
+semantic body, not an accidental chunkname/path — not full anchoring. Each fragment
+is a precise vendored-Lua string and is pinned by a direct test (§5).
+
+**Deliberately NOT in the allowlist:**
+- **unknown attribute** (`local x <bad> = 1`). Hull validates attribute names itself
+  (emits `lua.syntax` for anything but `const`/`close`), so an unknown attribute is a
+  Hull **`reject`** that must AGREE with `load()`'s reject. If Hull ever parsed one
+  `clean`, that is a **false-accept** and must fail — never be classified away. A
+  direct test pins this (Hull `reject` + not classified).
+- **broad `too many` / `constant overflow` / `control structure too long`.** The bare
+  `too many` fragment could mask unrelated failures; only the precise, directly-
+  testable `too many local variables` is kept. Upvalue/constant/control-structure
+  limits need pathological inputs a mutation of a small file cannot reach, so they are
+  omitted (a real occurrence would surface as a false-accept, correctly).
+
+The set is small, closed, and each entry has a direct test.
 
 **Guardrails (the classifier must not become a catch-all):**
 - It applies in **exactly one situation**: Hull parses **cleanly** (0 syntax /
   unsupported diagnostics) **and** `load()` rejects. It is consulted nowhere else.
-- It **never** excuses: (a) a Hull diagnostic on `load()`-**accepted** input (that is
-  a false-reject, always a failure); (b) a curated syntactic-negative mismatch (§5);
-  (c) a `lua.internal` or `lua.limit.*` diagnostic (those are excluded from the
-  accept/reject signal entirely — a limit/internal marker is never a "clean parse").
+- It **never** excuses: (a) a Hull `reject` on `load()`-**accepted** input (that is a
+  false-reject, always a failure); (b) a curated syntactic-negative mismatch (§5);
+  (c) an `indeterminate` result — a `lua.internal` or `lua.limit.*` marker is not a
+  `clean` parse, so the classifier is never even reached; an `indeterminate` in this
+  gate is its own failure.
 - Every allowed divergence is **reported by category and count** in the suite output,
   so an over-broad fragment surfaces as an anomalous tally instead of hiding.
 - **Direct classifier tests** accompany the allowlist: for each fragment, a snippet
@@ -88,10 +113,11 @@ rarely).
   each fragment recognizes only its semantic case and does not bleed onto adjacent
   syntax errors.
 
-Note the `<bad>` attribute case: the parser ALSO emits its own `lua.syntax`
-("unknown attribute…") there — so both reject and it is not even a divergence. It is
-listed only because a mutation could produce the attribute form without the parser's
-own guard firing; the classifier keeps that from reading as a false-accept.
+The `<bad>` attribute case is NOT a divergence: Hull emits its own `lua.syntax`
+("unknown attribute…"), so it is a Hull `reject` that agrees with `load()`'s reject.
+It is deliberately absent from the allowlist, and a direct test asserts Hull rejects
+it (and that `classify()` does not match it) — a `clean` parse of an unknown attribute
+would be a false-accept and must fail.
 
 ## 4. Input normalization (exactly one)
 
@@ -122,12 +148,14 @@ uniformly:
   fixture is surfaced, never silently passed.
 
 ### Part 2 — Range round-trip integrity
-For every accepted corpus file, walk the AST (`lua.walk`) and assert, for every node:
+For every `clean` + load-accepted corpus file, walk the AST and assert, for every node:
 - `1 <= range.start <= range.stop <= #src + 1` (in-bounds, non-inverted),
-- `unit:text(node)` is a byte-exact slice (`src:sub(start, stop-1)`), non-empty for
-  any node that spans a real construct,
-- each **AST child node**'s range is **nested within** its parent's `[start, stop)`
-  (structural sanity).
+- **exact slice**: `unit:text(node) == src:sub(range.start, range.stop - 1)` (the
+  round-trip actually holds, not just by construction),
+- **non-empty for real constructs**: `range.stop > range.start` for every node
+  EXCEPT the empty-source **chunk** root (an empty file's chunk is legitimately
+  `[1, 1)`); a zero-width node of any other kind is a bug,
+- each **AST child node**'s range is **nested within** its parent's `[start, stop)`.
 
 **Nesting covers AST child nodes ONLY.** Attached annotations
 (`node.annotation_list` / `node.annotations`) are *not* AST children and their ranges
@@ -137,21 +165,23 @@ children skips the `annotation_list` / `annotations` fields (and only kind-beari
 tables are children, which annotation records are not, so `lua.walk` never visits
 them anyway). Independent of accept/reject — catches range / `finish()` bugs directly.
 
-### Part 3 — Curated negatives + seeded mutation fuzz
-- **Curated syntactic negatives**: a table of *syntactically* invalid snippets
-  (`"1 +"`, `"function f("`, `"a.b."`, `"{,}"`, `"if then end"`, `"local = 1"`, `"::"`,
-  `"return return"`, …). Assert BOTH `load()` rejects AND the parser emits ≥1
-  `lua.syntax`. Anti-false-accept for known shapes.
-- **Pinned semantic divergences**: the §3.1 constructs, asserted as *parser accepts +
-  `load()` rejects with a semantic fragment* — so if either side's behavior shifts
-  we notice.
-- **Seeded mutation fuzz** (deterministic): with a FIXED `math.randomseed`, take each
-  accepted corpus file, apply N small mutations (delete / insert / duplicate one byte
-  or token), and for each mutant run both oracles and assert the directional
-  invariant from §3: never-raise; no false-reject; no false-accept (a parser-accept
-  with a *syntactic* load-reject). Budget is bounded (≈N=20 per seed file, capped
-  total) so it stays sub-second inside `make test`. Continuous/unbounded fuzzing is
-  the follow-up in §8.
+### Part 3 — Curated negatives + classifier tests + seeded mutation fuzz
+- **Curated syntactic negatives**: syntactically invalid snippets (`"1 +"`,
+  `"function f("`, `"a.b."`, `"{,}"`, `"::"`, `"return return"`, …). Assert `load()`
+  rejects AND Hull's verdict is `reject`.
+- **Pinned semantic divergences**: the §3.1 constructs, asserted as `load()` rejects +
+  Hull `clean` + `classify()` returns the expected category — so a behavior shift on
+  either side is noticed.
+- **Unknown-attribute guardrail**: `local x <bad> = 1` asserted as `load()` rejects +
+  Hull `reject` + `classify()` returns nil (it must NOT be classified away).
+- **Direct classifier tests** (§3.1 guardrail): each fragment's own good/bad pair.
+- **Seeded mutation fuzz** (deterministic): FIXED `math.randomseed`, N small byte
+  mutations (delete / duplicate / insert) per selected seed, each mutant run through
+  both oracles asserting the §3 directional invariant with the three-state verdict:
+  never-raise; `indeterminate` fails; no false-reject (`reject` + load-accept); no
+  false-accept (`clean` + a *non-semantic* load-reject). Bounded (N=20/seed, 4000
+  cap) so it stays sub-second in `make test`. Continuous/unbounded fuzzing is the §8
+  follow-up.
 
 ## 6. Corpus enumeration (C-side, hermetic, deterministic)
 
@@ -166,6 +196,18 @@ builds `HULL_LUA_CORPUS = { { path = <rel>, source = <bytes> }, … }`. Rational
 second filesystem pass, and — critically — the **oracle (`load()`) and the Hull
 parser receive the identical bytes** C read (a re-open could race or resolve
 differently). The script is pure compute over an injected table.
+
+**Fail-closed (a gate must not silently degrade):**
+- **Allocation failures propagate.** `sl_push` latches an `oom` flag on any
+  `realloc`/`strdup` failure and **never inserts a NULL** (which would crash the
+  sort); the runner aborts the whole leg (`return -1`) rather than test a truncated
+  corpus.
+- **`strdup` is validated** (a NULL result latches `oom`).
+- **Full reads required.** `read_all` returns NULL on open/seek/alloc failure OR a
+  short read (`fread` count ≠ file size); an enumerated file that fails to read
+  **aborts the leg** — it is not skipped.
+- **Counts reported.** The runner prints `enumerated N, read N`; because every
+  enumerated file must read fully, `read == enumerated` always holds at success.
 
 **Determinism (required for CI reproducibility):**
 - **Regular files only.** Include an entry iff `lstat` reports `S_ISREG` and the name
@@ -185,10 +227,12 @@ The corpus is Hull's own committed Lua — always in sync, never embedded / stal
 
 ## 7. Resource limits, determinism, CI
 
-- Run the corpus with **generous limits** (raise `max_bytes` / `max_tokens` /
-  `max_depth`) so `lua.limit.*` never trips on legitimate files; `lua.limit.*` and
-  `lua.internal` are **excluded** from the accept/reject signal in every part (they
-  are Hull-side bounds / internal-error markers, not syntax verdicts).
+- Run the corpus with **generous limits** (raised `max_bytes` / `max_tokens` /
+  `max_depth`) so `lua.limit.*` never trips on legitimate files. A `lua.limit.*` /
+  `lua.internal` marker yields the `indeterminate` verdict (§3), which **fails the
+  gate with a harness diagnostic** — it is never read as `clean`. A tripped limit on
+  a legit file means "raise the limit"; a `lua.internal` means "fix a never-raise
+  breach."
 - **Deterministic**: one fixed seed, index-derived mutation choices, bounded budget —
   a CI failure reproduces exactly.
 - Runs inside `make test` as a new UTEST leg (fast: low-thousands of parses,

--- a/stdlib/cli/lua/hull/source/lexer.lua
+++ b/stdlib/cli/lua/hull/source/lexer.lua
@@ -229,7 +229,10 @@ function M.tokenize(source, opts)
                     { kind = "long", range = { start = start, stop = stop }, text = sub(source, start, stop - 1) }
                 pos = stop
             else
-                local e = source:find("\n", pos, true)
+                -- Lua ends a short comment at '\n' OR '\r' (llex.c currIsNewline), not
+                -- just '\n' -- a lone '\r' terminates the comment and exposes the rest
+                -- of the line as code. Stop at whichever newline byte comes first.
+                local e = source:find("[\r\n]", pos)
                 local stop = e or (n + 1)                           -- line comment excludes the newline
                 comments[#comments + 1] =
                     { kind = "line", range = { start = start, stop = stop }, text = sub(source, start, stop - 1) }

--- a/stdlib/cli/lua/hull/source/range.lua
+++ b/stdlib/cli/lua/hull/source/range.lua
@@ -28,19 +28,23 @@ function M.slice(source, r)
 end
 
 -- Build the line-start index: byte offset (1-based) of the first byte of each
--- line. Line 1 starts at offset 1; every byte immediately after a '\n' starts a
--- new line. CRLF ends its line at the '\n' (the '\r' is the line's trailing byte);
--- a final line without a trailing newline has no extra entry. Lone '\r' (classic
--- Mac) is NOT treated as a line terminator.
+-- line. Line 1 starts at offset 1. A newline is '\n' OR '\r', and a '\r\n' / '\n\r'
+-- pair counts as ONE break -- matching Lua's own lexer (llex.c inclinenumber), so
+-- reported line numbers agree with real Lua on every line-ending style (LF, CRLF,
+-- lone CR, LFCR). A final line without a trailing newline has no extra entry.
 function M.linemap(source)
     local starts = { 1 }
-    local i = 1
     local n = #source
+    local i = 1
     while i <= n do
-        local nl = source:find("\n", i, true)
+        local nl = source:find("[\r\n]", i)
         if not nl then break end
-        starts[#starts + 1] = nl + 1
-        i = nl + 1
+        local c = source:sub(nl, nl)
+        local j = nl + 1
+        local d = source:sub(j, j)
+        if (c == "\r" and d == "\n") or (c == "\n" and d == "\r") then j = j + 1 end
+        starts[#starts + 1] = j
+        i = j
     end
     return starts
 end

--- a/stdlib/cli/lua/hull/source/tests/test_conformance.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_conformance.lua
@@ -1,0 +1,269 @@
+--
+-- test_conformance.lua — differential conformance of hull.source.lua vs real Lua 5.4.
+--
+-- Oracle: the harness's vanilla lua_State runs the SAME vendored Lua 5.4 Hull ships,
+-- so its load(src, name, "t") is the exact parser Hull targets (compile-only, no
+-- execution). The C harness injects HULL_LUA_CORPUS = { {path, source}, ... } (the
+-- repo's own .lua files, read in C so both oracle and parser see identical bytes).
+--
+-- Directional invariant (design: docs/lua_source_conformance_design.md):
+--   * Hull is a SYNTACTIC recognizer; load() is syntactic + a thin static-semantic
+--     layer. So a Hull reject MUST imply a load reject (a false-reject is the key
+--     bug); a Hull accept may diverge from a load reject only for a pinned SEMANTIC
+--     case (classified by an anchored allowlist of Lua 5.4 error fragments).
+--   * lua.limit.* / lua.internal are Hull-side markers, EXCLUDED from accept/reject.
+--
+-- Parts: (1) oracle-classified corpus, (2) range round-trip over AST children only,
+-- (3) curated syntactic negatives + pinned semantic divergences + seeded mutation
+-- fuzz, plus direct classifier tests. Returns { pass, fail }.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+-- luacheck: read globals HULL_LUA_CORPUS (injected by the C harness)
+local lua = require("hull.source.lua")
+
+local corpus = HULL_LUA_CORPUS or {}
+
+local pass, fail, failures = 0, 0, {}
+local function ok(cond, name)
+    if cond then pass = pass + 1
+    else fail = fail + 1; failures[#failures + 1] = name; print("FAIL: " .. name) end
+end
+
+-- Generous limits so lua.limit.* never trips on legitimate corpus files (we test the
+-- parser's ACCEPT/REJECT behavior here, not its resource bounds).
+local LIMITS = { max_bytes = 64 * 1024 * 1024, max_tokens = 5000000,
+                 max_comments = 5000000, max_depth = 2000 }
+
+-- load() (string form) does NOT skip a shebang; the lexer (file semantics) does. Strip
+-- a leading '#!...\n' for the oracle so both see the same post-shebang content.
+local function oracle_src(src)
+    if src:sub(1, 2) == "#!" then
+        local nl = src:find("\n", 1, true)
+        return nl and src:sub(nl + 1) or ""
+    end
+    return src
+end
+
+-- Count only SYNTAX rejections; limit/internal markers are not syntax verdicts.
+local function hull_syntax_diags(unit)
+    local c, first = 0, nil
+    for _, d in ipairs(unit.diagnostics) do
+        local code = d.code or ""
+        if code == "lua.syntax" or code == "lua.unsupported" then
+            c = c + 1; first = first or d
+        end
+    end
+    return c, first
+end
+
+-- ── semantic-reject classifier: anchored fragments of vendored Lua 5.4 text ──
+-- Consulted ONLY where Hull is clean AND load() rejects (see call sites). Small and
+-- closed; each fragment is pinned by a direct test below (matches its case, and a
+-- nearby SYNTAX error does NOT match it).
+local SEMANTIC_REJECTS = {
+    { category = "break_outside_loop", fragment = "break outside loop" },
+    { category = "goto_no_label",      fragment = "no visible label" },
+    { category = "goto_into_scope",    fragment = "jumps into the scope" },
+    { category = "vararg_outside",     fragment = "cannot use '...' outside a vararg" },
+    { category = "assign_const",       fragment = "attempt to assign to const variable" },
+    { category = "unknown_attribute",  fragment = "unknown attribute" },
+    { category = "too_many",           fragment = "too many" },
+}
+local function classify(err)
+    err = err or ""
+    for _, s in ipairs(SEMANTIC_REJECTS) do
+        if err:find(s.fragment, 1, true) then return s.category end
+    end
+    return nil
+end
+
+-- ── Part 2: range round-trip (AST child nodes ONLY; annotations excluded) ──
+-- Gather immediate kind-bearing child nodes, skipping range/kind and the annotation
+-- fields (attached annotation ranges intentionally PRECEDE their declaration and are
+-- not AST children).
+local function child_nodes(node)
+    local out = {}
+    local function collect(v)
+        if type(v) ~= "table" then return end
+        if v.kind then out[#out + 1] = v; return end
+        for k, e in pairs(v) do if k ~= "range" then collect(e) end end
+    end
+    for k, v in pairs(node) do
+        if k ~= "range" and k ~= "kind" and k ~= "annotation_list" and k ~= "annotations" then
+            collect(v)
+        end
+    end
+    return out
+end
+
+local function check_ranges(unit, src, path)
+    local maxoff = #src + 1
+    local bad = nil
+    local function visit(n)
+        if bad then return end
+        local r = n.range
+        if type(r) ~= "table" or type(r.start) ~= "number" or type(r.stop) ~= "number"
+           or r.start < 1 or r.stop < r.start or r.stop > maxoff then
+            bad = "range out of bounds kind=" .. tostring(n.kind)
+            return
+        end
+        for _, c in ipairs(child_nodes(n)) do
+            if type(c.range) ~= "table" or c.range.start < r.start or c.range.stop > r.stop then
+                bad = "child (" .. tostring(c.range and c.range.start) .. "," ..
+                      tostring(c.range and c.range.stop) .. ") not nested in " ..
+                      tostring(n.kind) .. " (" .. r.start .. "," .. r.stop .. ") child=" .. tostring(c.kind)
+                return
+            end
+            visit(c)
+        end
+    end
+    visit(unit.ast)
+    ok(bad == nil, "ranges consistent: " .. path .. (bad and (" :: " .. bad) or ""))
+end
+
+-- ── Part 1: oracle-classified corpus ──
+ok(#corpus > 0, "corpus enumerated (non-empty)")
+local accepted, rejected = 0, 0
+local semantic_counts = {}
+local seeds = {}                              -- load-accepted sources feed the fuzz
+for _, rec in ipairs(corpus) do
+    local src = rec.source
+    local chunk, lerr = load(oracle_src(src), "@" .. rec.path, "t")
+    local unit = lua.parse(src, { path = rec.path, limits = LIMITS })
+    if unit == nil then
+        ok(false, "parse returned nil: " .. rec.path)
+    elseif chunk ~= nil then
+        accepted = accepted + 1
+        seeds[#seeds + 1] = src
+        local hs, first = hull_syntax_diags(unit)
+        ok(hs == 0, "no false-reject (load accepts): " .. rec.path ..
+            (hs ~= 0 and (" :: " .. (first and first.message or "?")) or ""))
+        check_ranges(unit, src, rec.path)
+    else
+        rejected = rejected + 1
+        local hs = hull_syntax_diags(unit)
+        if hs > 0 then
+            ok(true, "both reject: " .. rec.path)
+        else
+            local cat = classify(lerr)
+            if cat then
+                semantic_counts[cat] = (semantic_counts[cat] or 0) + 1
+                ok(true, "semantic divergence [" .. cat .. "]: " .. rec.path)
+            else
+                ok(false, "FALSE ACCEPT (load rejects non-semantically, hull clean): " ..
+                    rec.path .. " :: load: " .. tostring(lerr))
+            end
+        end
+    end
+end
+
+-- ── Part 3a: curated syntactic negatives (BOTH must reject) ──
+local CURATED_SYNTAX_BAD = {
+    "1 +", "function f(", "a.b.", "{,}", "if then end", "local = 1", "::",
+    "return return", "1 2", "(1", "a =", "function 3() end", "local x, = 1",
+    "{ [ ] = 1 }", "while do end", "for", "do", "end", "repeat until",
+}
+for _, s in ipairs(CURATED_SYNTAX_BAD) do
+    local chunk = load(s, "@bad", "t")
+    local unit = lua.parse(s, { path = "bad", limits = LIMITS })
+    ok(chunk == nil, "curated: load rejects [" .. s .. "]")
+    ok(unit ~= nil and hull_syntax_diags(unit) > 0, "curated: hull rejects [" .. s .. "]")
+end
+
+-- ── Part 3b: pinned semantic divergences (hull accepts, load rejects semantically) ──
+local SEMANTIC_CASES = {
+    { src = "break",                              cat = "break_outside_loop" },
+    { src = "goto nowhere",                       cat = "goto_no_label" },
+    { src = "goto s\nlocal x = 1\n::s::\nreturn x", cat = "goto_into_scope" },
+    { src = "function f() return ... end",        cat = "vararg_outside" },
+    { src = "local x <const> = 1\nx = 2",         cat = "assign_const" },
+}
+for _, tc in ipairs(SEMANTIC_CASES) do
+    local label = tc.src:gsub("\n", " ")
+    local chunk, lerr = load(oracle_src(tc.src), "@sem", "t")
+    local unit = lua.parse(tc.src, { path = "sem", limits = LIMITS })
+    ok(chunk == nil, "semantic: load rejects [" .. label .. "]")
+    ok(unit ~= nil and hull_syntax_diags(unit) == 0, "semantic: hull accepts syntactically [" .. label .. "]")
+    ok(classify(lerr) == tc.cat, "semantic: classify -> " .. tc.cat ..
+        " (got " .. tostring(classify(lerr)) .. ") :: load: " .. tostring(lerr))
+end
+
+-- ── Part 3c: direct classifier tests (each fragment matches its case, not syntax) ──
+local function gen_many_locals(k)
+    local t = {}
+    for i = 1, k do t[#t + 1] = "local v" .. i .. " = 1" end
+    return table.concat(t, "\n")
+end
+local CLASSIFY_TESTS = {
+    { cat = "break_outside_loop", good = "break",                        bad = "1 +" },
+    { cat = "goto_no_label",      good = "goto nowhere",                 bad = "goto" },
+    { cat = "goto_into_scope",    good = "goto s\nlocal x=1\n::s::\nreturn x", bad = "a.b." },
+    { cat = "vararg_outside",     good = "function f() return ... end",  bad = "function f(" },
+    { cat = "assign_const",       good = "local x <const> = 1\nx = 2",   bad = "local x <const> 1" },
+    { cat = "unknown_attribute",  good = "local x <weird> = 1",          bad = "local x < = 1" },
+    { cat = "too_many",           good = gen_many_locals(260),           bad = "local a,,b = 1" },
+}
+for _, t in ipairs(CLASSIFY_TESTS) do
+    local _, gerr = load(oracle_src(t.good), "@g", "t")
+    ok(classify(gerr) == t.cat, "classify[good " .. t.cat .. "] -> " ..
+        tostring(classify(gerr)) .. " :: load: " .. tostring(gerr))
+    local _, berr = load(t.bad, "@b", "t")
+    ok(classify(berr) == nil, "classify[bad syntax " .. t.cat .. "] -> " ..
+        tostring(classify(berr)) .. " (must be nil) :: load: " .. tostring(berr))
+end
+
+-- ── Part 3d: seeded, bounded mutation fuzz over load-accepted corpus seeds ──
+math.randomseed(0x5EED)
+local N_PER_SEED, TOTAL_CAP = 20, 4000
+local function mutate(src)
+    if #src == 0 then return "x" end
+    local op = math.random(3)
+    local i = math.random(#src)
+    if op == 1 then                                   -- delete one byte
+        return src:sub(1, i - 1) .. src:sub(i + 1)
+    elseif op == 2 then                               -- duplicate one byte
+        return src:sub(1, i) .. src:sub(i, i) .. src:sub(i + 1)
+    else                                              -- insert one random byte
+        return src:sub(1, i - 1) .. string.char(math.random(0, 255)) .. src:sub(i)
+    end
+end
+local max_seeds = math.max(1, math.floor(TOTAL_CAP / N_PER_SEED))
+local stride = math.max(1, math.floor(#seeds / max_seeds))
+local mutants, fuzz_fail = 0, 0
+for i = 1, #seeds, stride do
+    if mutants >= TOTAL_CAP then break end
+    local base = seeds[i]
+    for _ = 1, N_PER_SEED do
+        if mutants >= TOTAL_CAP then break end
+        mutants = mutants + 1
+        local m = mutate(base)
+        local okc, unit = pcall(lua.parse, m, { path = "fuzz", limits = LIMITS })
+        if not okc or type(unit) ~= "table" then
+            fuzz_fail = fuzz_fail + 1
+            print("FUZZ raise/nil on mutant of seed " .. i)
+        else
+            local chunk, lerr = load(oracle_src(m), "@fuzz", "t")
+            local hs = hull_syntax_diags(unit)
+            if chunk ~= nil and hs > 0 then
+                fuzz_fail = fuzz_fail + 1
+                print("FUZZ false-reject: " .. string.format("%q", m:sub(1, 72)))
+            elseif chunk == nil and hs == 0 and not classify(lerr) then
+                fuzz_fail = fuzz_fail + 1
+                print("FUZZ false-accept: " .. string.format("%q", m:sub(1, 72)) .. " :: " .. tostring(lerr))
+            end
+        end
+    end
+end
+ok(fuzz_fail == 0, "mutation fuzz: " .. mutants .. " mutants, " .. fuzz_fail .. " divergences")
+
+-- ── report (by category + count, so the allowlist cannot silently over-match) ──
+print(string.format("conformance corpus: %d files (%d load-accepted, %d load-rejected)",
+    #corpus, accepted, rejected))
+local cats = {}
+for k, v in pairs(semantic_counts) do cats[#cats + 1] = k .. "=" .. v end
+table.sort(cats)
+print("semantic divergences: " .. (#cats > 0 and table.concat(cats, ", ") or "none"))
+print(string.format("test_conformance: %d passed, %d failed", pass, fail))
+return { pass = pass, fail = fail, failures = failures }

--- a/stdlib/cli/lua/hull/source/tests/test_conformance.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_conformance.lua
@@ -4,18 +4,19 @@
 -- Oracle: the harness's vanilla lua_State runs the SAME vendored Lua 5.4 Hull ships,
 -- so its load(src, name, "t") is the exact parser Hull targets (compile-only, no
 -- execution). The C harness injects HULL_LUA_CORPUS = { {path, source}, ... } (the
--- repo's own .lua files, read in C so both oracle and parser see identical bytes).
+-- repo's own .lua files, read in C -- fail-closed -- so both oracle and parser see
+-- identical bytes).
 --
 -- Directional invariant (design: docs/lua_source_conformance_design.md):
 --   * Hull is a SYNTACTIC recognizer; load() is syntactic + a thin static-semantic
 --     layer. So a Hull reject MUST imply a load reject (a false-reject is the key
 --     bug); a Hull accept may diverge from a load reject only for a pinned SEMANTIC
---     case (classified by an anchored allowlist of Lua 5.4 error fragments).
---   * lua.limit.* / lua.internal are Hull-side markers, EXCLUDED from accept/reject.
---
--- Parts: (1) oracle-classified corpus, (2) range round-trip over AST children only,
--- (3) curated syntactic negatives + pinned semantic divergences + seeded mutation
--- fuzz, plus direct classifier tests. Returns { pass, fail }.
+--     case (see SEMANTIC_REJECTS).
+--   * Hull's result is THREE-STATE: "reject" (>=1 lua.syntax/unsupported), "clean"
+--     (no syntax AND no internal/limit), or "indeterminate" (any lua.internal or
+--     lua.limit.*). An internal/limit result is NEVER a clean parse and NEVER enters
+--     semantic classification -- in this required gate it FAILS with a harness
+--     diagnostic (raise the limits or fix the bug).
 --
 -- SPDX-License-Identifier: AGPL-3.0-or-later
 --
@@ -32,7 +33,8 @@ local function ok(cond, name)
 end
 
 -- Generous limits so lua.limit.* never trips on legitimate corpus files (we test the
--- parser's ACCEPT/REJECT behavior here, not its resource bounds).
+-- parser's ACCEPT/REJECT behavior here, not its resource bounds). A trip becomes an
+-- "indeterminate" verdict, which this gate treats as a failure, not a clean parse.
 local LIMITS = { max_bytes = 64 * 1024 * 1024, max_tokens = 5000000,
                  max_comments = 5000000, max_depth = 2000 }
 
@@ -46,43 +48,55 @@ local function oracle_src(src)
     return src
 end
 
--- Count only SYNTAX rejections; limit/internal markers are not syntax verdicts.
-local function hull_syntax_diags(unit)
-    local c, first = 0, nil
+-- Three-state verdict for a Hull parse. Internal/limit markers are DISTINCT from a
+-- clean parse (never excused): they yield "indeterminate".
+local function hull_state(unit)
+    if type(unit) ~= "table" or type(unit.diagnostics) ~= "table" then
+        return "indeterminate", "no unit"
+    end
+    local syntax, indet, detail = 0, 0, nil
     for _, d in ipairs(unit.diagnostics) do
         local code = d.code or ""
         if code == "lua.syntax" or code == "lua.unsupported" then
-            c = c + 1; first = first or d
+            syntax = syntax + 1; detail = detail or (d.message or code)
+        elseif code == "lua.internal" or code:find("^lua%.limit%.") then
+            indet = indet + 1; detail = detail or (code .. ": " .. (d.message or ""))
         end
     end
-    return c, first
+    if indet > 0 then return "indeterminate", detail end
+    if syntax > 0 then return "reject", detail end
+    return "clean", nil
 end
 
--- ── semantic-reject classifier: anchored fragments of vendored Lua 5.4 text ──
--- Consulted ONLY where Hull is clean AND load() rejects (see call sites). Small and
--- closed; each fragment is pinned by a direct test below (matches its case, and a
--- nearby SYNTAX error does NOT match it).
+-- ── semantic-reject classifier: SUBSTRING match against the NORMALIZED Lua 5.4
+-- error body (the "chunkname:line: " prefix stripped) ──
+-- Consulted ONLY where Hull is "clean" AND load() rejects. Small and closed; each
+-- fragment is a precise vendored-Lua message and is pinned by a direct test below
+-- (matches its case, and a nearby SYNTAX error does NOT match it). NOTE: this is
+-- honest substring matching on the normalized body, not full anchoring.
 local SEMANTIC_REJECTS = {
     { category = "break_outside_loop", fragment = "break outside loop" },
     { category = "goto_no_label",      fragment = "no visible label" },
     { category = "goto_into_scope",    fragment = "jumps into the scope" },
     { category = "vararg_outside",     fragment = "cannot use '...' outside a vararg" },
     { category = "assign_const",       fragment = "attempt to assign to const variable" },
-    { category = "unknown_attribute",  fragment = "unknown attribute" },
-    { category = "too_many",           fragment = "too many" },
+    { category = "too_many_locals",    fragment = "too many local variables" },
 }
+-- Deliberately NOT here: unknown-attribute. Hull validates attribute names itself
+-- (emits lua.syntax for anything but const/close), so an unknown attribute is a Hull
+-- REJECT and must agree with load's reject -- never a divergence classified away.
+local function normalize(err)
+    return (tostring(err or "")):gsub("^[^:]*:%d+:%s*", "")   -- drop "chunkname:line: "
+end
 local function classify(err)
-    err = err or ""
+    local body = normalize(err)
     for _, s in ipairs(SEMANTIC_REJECTS) do
-        if err:find(s.fragment, 1, true) then return s.category end
+        if body:find(s.fragment, 1, true) then return s.category end
     end
     return nil
 end
 
--- ── Part 2: range round-trip (AST child nodes ONLY; annotations excluded) ──
--- Gather immediate kind-bearing child nodes, skipping range/kind and the annotation
--- fields (attached annotation ranges intentionally PRECEDE their declaration and are
--- not AST children).
+-- ── Part 2 helpers: range round-trip (AST child nodes ONLY; annotations excluded) ──
 local function child_nodes(node)
     local out = {}
     local function collect(v)
@@ -106,8 +120,15 @@ local function check_ranges(unit, src, path)
         local r = n.range
         if type(r) ~= "table" or type(r.start) ~= "number" or type(r.stop) ~= "number"
            or r.start < 1 or r.stop < r.start or r.stop > maxoff then
-            bad = "range out of bounds kind=" .. tostring(n.kind)
-            return
+            bad = "range out of bounds kind=" .. tostring(n.kind); return
+        end
+        -- exact-slice round-trip: unit:text(node) is the precise source slice
+        if unit:text(n) ~= src:sub(r.start, r.stop - 1) then
+            bad = "unit:text ~= slice kind=" .. tostring(n.kind); return
+        end
+        -- non-empty for real constructs; only the empty-source chunk root may be empty
+        if r.stop == r.start and n.kind ~= "chunk" then
+            bad = "empty range for real construct kind=" .. tostring(n.kind); return
         end
         for _, c in ipairs(child_nodes(n)) do
             if type(c.range) ~= "table" or c.range.start < r.start or c.range.stop > r.stop then
@@ -123,37 +144,42 @@ local function check_ranges(unit, src, path)
     ok(bad == nil, "ranges consistent: " .. path .. (bad and (" :: " .. bad) or ""))
 end
 
--- ── Part 1: oracle-classified corpus ──
+-- ── Part 1: oracle-classified corpus (three-state) ──
 ok(#corpus > 0, "corpus enumerated (non-empty)")
 local accepted, rejected = 0, 0
 local semantic_counts = {}
-local seeds = {}                              -- load-accepted sources feed the fuzz
+local seeds = {}                              -- clean + load-accepted sources feed the fuzz
 for _, rec in ipairs(corpus) do
     local src = rec.source
     local chunk, lerr = load(oracle_src(src), "@" .. rec.path, "t")
-    local unit = lua.parse(src, { path = rec.path, limits = LIMITS })
-    if unit == nil then
-        ok(false, "parse returned nil: " .. rec.path)
-    elseif chunk ~= nil then
-        accepted = accepted + 1
-        seeds[#seeds + 1] = src
-        local hs, first = hull_syntax_diags(unit)
-        ok(hs == 0, "no false-reject (load accepts): " .. rec.path ..
-            (hs ~= 0 and (" :: " .. (first and first.message or "?")) or ""))
-        check_ranges(unit, src, rec.path)
+    local okp, unit = pcall(lua.parse, src, { path = rec.path, limits = LIMITS })
+    if not okp or type(unit) ~= "table" then
+        ok(false, "parse raised / returned non-unit: " .. rec.path)
     else
-        rejected = rejected + 1
-        local hs = hull_syntax_diags(unit)
-        if hs > 0 then
-            ok(true, "both reject: " .. rec.path)
+        local st, detail = hull_state(unit)
+        if st == "indeterminate" then
+            ok(false, "INDETERMINATE (internal/limit) on corpus file: " .. rec.path .. " :: " .. tostring(detail))
+        elseif chunk ~= nil then
+            accepted = accepted + 1
+            ok(st == "clean", "no false-reject (load accepts): " .. rec.path ..
+                (st ~= "clean" and (" :: " .. tostring(detail)) or ""))
+            if st == "clean" then
+                seeds[#seeds + 1] = src
+                check_ranges(unit, src, rec.path)
+            end
         else
-            local cat = classify(lerr)
-            if cat then
-                semantic_counts[cat] = (semantic_counts[cat] or 0) + 1
-                ok(true, "semantic divergence [" .. cat .. "]: " .. rec.path)
-            else
-                ok(false, "FALSE ACCEPT (load rejects non-semantically, hull clean): " ..
-                    rec.path .. " :: load: " .. tostring(lerr))
+            rejected = rejected + 1
+            if st == "reject" then
+                ok(true, "both reject: " .. rec.path)
+            else                                          -- st == "clean"
+                local cat = classify(lerr)
+                if cat then
+                    semantic_counts[cat] = (semantic_counts[cat] or 0) + 1
+                    ok(true, "semantic divergence [" .. cat .. "]: " .. rec.path)
+                else
+                    ok(false, "FALSE ACCEPT (load rejects non-semantically, hull clean): " ..
+                        rec.path .. " :: load: " .. tostring(lerr))
+                end
             end
         end
     end
@@ -167,27 +193,37 @@ local CURATED_SYNTAX_BAD = {
 }
 for _, s in ipairs(CURATED_SYNTAX_BAD) do
     local chunk = load(s, "@bad", "t")
-    local unit = lua.parse(s, { path = "bad", limits = LIMITS })
+    local st = hull_state(lua.parse(s, { path = "bad", limits = LIMITS }))
     ok(chunk == nil, "curated: load rejects [" .. s .. "]")
-    ok(unit ~= nil and hull_syntax_diags(unit) > 0, "curated: hull rejects [" .. s .. "]")
+    ok(st == "reject", "curated: hull rejects [" .. s .. "] (got " .. st .. ")")
 end
 
--- ── Part 3b: pinned semantic divergences (hull accepts, load rejects semantically) ──
+-- ── Part 3b: pinned semantic divergences (hull clean, load rejects semantically) ──
 local SEMANTIC_CASES = {
-    { src = "break",                              cat = "break_outside_loop" },
-    { src = "goto nowhere",                       cat = "goto_no_label" },
+    { src = "break",                                cat = "break_outside_loop" },
+    { src = "goto nowhere",                         cat = "goto_no_label" },
     { src = "goto s\nlocal x = 1\n::s::\nreturn x", cat = "goto_into_scope" },
-    { src = "function f() return ... end",        cat = "vararg_outside" },
-    { src = "local x <const> = 1\nx = 2",         cat = "assign_const" },
+    { src = "function f() return ... end",          cat = "vararg_outside" },
+    { src = "local x <const> = 1\nx = 2",           cat = "assign_const" },
 }
 for _, tc in ipairs(SEMANTIC_CASES) do
     local label = tc.src:gsub("\n", " ")
     local chunk, lerr = load(oracle_src(tc.src), "@sem", "t")
-    local unit = lua.parse(tc.src, { path = "sem", limits = LIMITS })
+    local st = hull_state(lua.parse(tc.src, { path = "sem", limits = LIMITS }))
     ok(chunk == nil, "semantic: load rejects [" .. label .. "]")
-    ok(unit ~= nil and hull_syntax_diags(unit) == 0, "semantic: hull accepts syntactically [" .. label .. "]")
+    ok(st == "clean", "semantic: hull clean (syntactically valid) [" .. label .. "] (got " .. st .. ")")
     ok(classify(lerr) == tc.cat, "semantic: classify -> " .. tc.cat ..
         " (got " .. tostring(classify(lerr)) .. ") :: load: " .. tostring(lerr))
+end
+
+-- Guardrail: an unknown attribute is a Hull REJECT (both reject), NOT classified away.
+do
+    local src = "local x <weird> = 1"
+    local chunk, lerr = load(src, "@a", "t")
+    local st = hull_state(lua.parse(src, { path = "a", limits = LIMITS }))
+    ok(chunk == nil, "attr: load rejects unknown attribute")
+    ok(st == "reject", "attr: hull REJECTS unknown attribute (not classified) (got " .. st .. ")")
+    ok(classify(lerr) == nil, "attr: unknown attribute is NOT in the semantic allowlist")
 end
 
 -- ── Part 3c: direct classifier tests (each fragment matches its case, not syntax) ──
@@ -197,13 +233,12 @@ local function gen_many_locals(k)
     return table.concat(t, "\n")
 end
 local CLASSIFY_TESTS = {
-    { cat = "break_outside_loop", good = "break",                        bad = "1 +" },
-    { cat = "goto_no_label",      good = "goto nowhere",                 bad = "goto" },
+    { cat = "break_outside_loop", good = "break",                             bad = "1 +" },
+    { cat = "goto_no_label",      good = "goto nowhere",                      bad = "goto" },
     { cat = "goto_into_scope",    good = "goto s\nlocal x=1\n::s::\nreturn x", bad = "a.b." },
-    { cat = "vararg_outside",     good = "function f() return ... end",  bad = "function f(" },
-    { cat = "assign_const",       good = "local x <const> = 1\nx = 2",   bad = "local x <const> 1" },
-    { cat = "unknown_attribute",  good = "local x <weird> = 1",          bad = "local x < = 1" },
-    { cat = "too_many",           good = gen_many_locals(260),           bad = "local a,,b = 1" },
+    { cat = "vararg_outside",     good = "function f() return ... end",       bad = "function f(" },
+    { cat = "assign_const",       good = "local x <const> = 1\nx = 2",        bad = "local x <const> 1" },
+    { cat = "too_many_locals",    good = gen_many_locals(260),                bad = "local a,,b = 1" },
 }
 for _, t in ipairs(CLASSIFY_TESTS) do
     local _, gerr = load(oracle_src(t.good), "@g", "t")
@@ -214,7 +249,7 @@ for _, t in ipairs(CLASSIFY_TESTS) do
         tostring(classify(berr)) .. " (must be nil) :: load: " .. tostring(berr))
 end
 
--- ── Part 3d: seeded, bounded mutation fuzz over load-accepted corpus seeds ──
+-- ── Part 3d: seeded, bounded mutation fuzz over clean + load-accepted seeds ──
 math.randomseed(0x5EED)
 local N_PER_SEED, TOTAL_CAP = 20, 4000
 local function mutate(src)
@@ -239,17 +274,20 @@ for i = 1, #seeds, stride do
         if mutants >= TOTAL_CAP then break end
         mutants = mutants + 1
         local m = mutate(base)
-        local okc, unit = pcall(lua.parse, m, { path = "fuzz", limits = LIMITS })
-        if not okc or type(unit) ~= "table" then
+        local okp, unit = pcall(lua.parse, m, { path = "fuzz", limits = LIMITS })
+        if not okp or type(unit) ~= "table" then
             fuzz_fail = fuzz_fail + 1
-            print("FUZZ raise/nil on mutant of seed " .. i)
+            print("FUZZ raise/non-unit on mutant of seed " .. i)
         else
+            local st = hull_state(unit)
             local chunk, lerr = load(oracle_src(m), "@fuzz", "t")
-            local hs = hull_syntax_diags(unit)
-            if chunk ~= nil and hs > 0 then
+            if st == "indeterminate" then
+                fuzz_fail = fuzz_fail + 1
+                print("FUZZ INDETERMINATE (internal/limit): " .. string.format("%q", m:sub(1, 72)))
+            elseif chunk ~= nil and st == "reject" then
                 fuzz_fail = fuzz_fail + 1
                 print("FUZZ false-reject: " .. string.format("%q", m:sub(1, 72)))
-            elseif chunk == nil and hs == 0 and not classify(lerr) then
+            elseif chunk == nil and st == "clean" and not classify(lerr) then
                 fuzz_fail = fuzz_fail + 1
                 print("FUZZ false-accept: " .. string.format("%q", m:sub(1, 72)) .. " :: " .. tostring(lerr))
             end

--- a/stdlib/cli/lua/hull/source/tests/test_lexer.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_lexer.lua
@@ -74,6 +74,23 @@ do
     eq(toks(u3)[1].text, "local", "shebang: first token is local")
 end
 
+-- ── 2b. lone '\r' terminates a short comment (Lua llex currIsNewline) ─
+do
+    -- code after a lone CR is CODE, not comment (matches real Lua 5.4)
+    local u = assert(lua.parse("-- c\rx = 1"))
+    eq(#u.diagnostics, 0, "cr-comment: clean")
+    eq(u:text(find(u, "x")), "x", "cr-comment: 'x' after CR is a real token")
+    eq(select(1, u:position(find(u, "x").range.start)), 2, "cr-comment: 'x' on line 2")
+    -- a stray symbol after the CR is a syntax error (the comment did not swallow it)
+    local u2 = assert(lua.parse("-- c\r@"))
+    local ns = 0
+    for _, d in ipairs(u2.diagnostics) do if d.code == "lua.syntax" then ns = ns + 1 end end
+    ok(ns >= 1, "cr-comment: stray '@' after CR is a syntax error")
+    -- CRLF still ends the comment as ONE break (no phantom empty line)
+    local u3 = assert(lua.parse("-- c\r\ny = 2"))
+    eq(select(1, u3:position(find(u3, "y").range.start)), 2, "crlf-comment: 'y' on line 2")
+end
+
 -- ── 3. long-bracket strings/comments at multiple = levels ─────────────
 do
     local u = assert(lua.parse("local s = [==[ hi ]] there ]==]"))

--- a/tests/hull/source/test_lua_source.c
+++ b/tests/hull/source/test_lua_source.c
@@ -14,7 +14,16 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE   /* lstat / S_ISLNK / dirent under -std=c11 -Wpedantic */
+#endif
+
 #include "utest.h"
+
+#include <dirent.h>
+#include <sys/stat.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "lua.h"
 #include "lauxlib.h"
@@ -61,6 +70,141 @@ static int run_lua_test(const char *script_path, long long *pass_out, long long 
     return 0;
 }
 
+/* ── conformance corpus: enumerate real .lua files in C (hermetic + deterministic) ──
+ * The conformance suite (test_conformance.lua) needs the repo's actual Lua sources.
+ * We enumerate + READ them in C and inject { path, source } records as a Lua global
+ * HULL_LUA_CORPUS, so the Lua side needs no io, makes no second filesystem pass, and
+ * the oracle (load()) and the Hull parser see the identical bytes. Deterministic:
+ * regular .lua files only, symlinks skipped (no traversal loops), paths sorted. */
+
+typedef struct { char **items; size_t count, cap; } StrList;
+
+static void sl_push(StrList *l, const char *s)
+{
+    if (l->count == l->cap) {
+        size_t nc = l->cap ? l->cap * 2 : 64;
+        char **ni = realloc(l->items, nc * sizeof(char *));
+        if (!ni) return;                 /* best-effort; a short corpus still tests */
+        l->items = ni; l->cap = nc;
+    }
+    l->items[l->count++] = strdup(s);
+}
+
+static void sl_free(StrList *l)
+{
+    for (size_t i = 0; i < l->count; i++) free(l->items[i]);
+    free(l->items);
+    l->items = NULL; l->count = l->cap = 0;
+}
+
+static int cmp_cstr(const void *a, const void *b)
+{
+    return strcmp(*(const char *const *)a, *(const char *const *)b);
+}
+
+/* Recursive walk. lstat (never stat) so a symlink -- file OR dir -- is skipped
+ * outright, which fixes symlink handling AND makes traversal loops impossible; a
+ * depth cap is a defensive backstop. Regular *.lua files only. */
+static void walk_lua(const char *root, StrList *out, int depth)
+{
+    if (depth > 32) return;
+    DIR *d = opendir(root);
+    if (!d) return;
+    struct dirent *e;
+    while ((e = readdir(d)) != NULL) {
+        if (strcmp(e->d_name, ".") == 0 || strcmp(e->d_name, "..") == 0) continue;
+        char path[4096];
+        int w = snprintf(path, sizeof path, "%s/%s", root, e->d_name);
+        if (w < 0 || (size_t)w >= sizeof path) continue;
+        struct stat st;
+        if (lstat(path, &st) != 0) continue;
+        if (S_ISLNK(st.st_mode)) continue;                 /* never follow symlinks */
+        if (S_ISDIR(st.st_mode)) {
+            walk_lua(path, out, depth + 1);
+        } else if (S_ISREG(st.st_mode)) {
+            size_t nl = strlen(e->d_name);
+            if (nl > 4 && strcmp(e->d_name + nl - 4, ".lua") == 0) sl_push(out, path);
+        }
+    }
+    closedir(d);
+}
+
+static char *read_all(const char *path, size_t *out_len)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) return NULL;
+    if (fseek(f, 0, SEEK_END) != 0) { fclose(f); return NULL; }
+    long sz = ftell(f);
+    if (sz < 0) { fclose(f); return NULL; }
+    rewind(f);
+    char *buf = malloc((size_t)sz + 1);
+    if (!buf) { fclose(f); return NULL; }
+    size_t rd = fread(buf, 1, (size_t)sz, f);
+    fclose(f);
+    buf[rd] = '\0';
+    *out_len = rd;
+    return buf;
+}
+
+/* Run the conformance script with HULL_LUA_CORPUS injected. Same contract as
+ * run_lua_test (returns 0 + { pass, fail } via out-params, -1 on harness failure). */
+static int run_lua_conformance(const char *script_path, long long *pass_out, long long *fail_out)
+{
+    *pass_out = 0;
+    *fail_out = -1;
+
+    lua_State *L = luaL_newstate();
+    if (!L) return -1;
+    luaL_openlibs(L);
+    if (luaL_dostring(L,
+            "package.path = 'stdlib/cli/lua/?.lua;stdlib/cli/lua/?/init.lua;' .. package.path")
+        != LUA_OK) {
+        fprintf(stderr, "package.path setup failed: %s\n", lua_tostring(L, -1));
+        lua_close(L);
+        return -1;
+    }
+
+    static const char *const roots[] = {
+        "stdlib/lua", "stdlib/cli/lua", "examples", "tests/fixtures",
+    };
+    StrList files = { NULL, 0, 0 };
+    for (size_t i = 0; i < sizeof roots / sizeof roots[0]; i++)
+        walk_lua(roots[i], &files, 0);
+    qsort(files.items, files.count, sizeof(char *), cmp_cstr);
+
+    lua_createtable(L, (int)files.count, 0);
+    int n = 0;
+    for (size_t i = 0; i < files.count; i++) {
+        size_t len = 0;
+        char *src = read_all(files.items[i], &len);
+        if (!src) continue;
+        lua_createtable(L, 0, 2);
+        lua_pushstring(L, files.items[i]); lua_setfield(L, -2, "path");
+        lua_pushlstring(L, src, len);      lua_setfield(L, -2, "source");
+        free(src);
+        lua_rawseti(L, -2, ++n);
+    }
+    lua_setglobal(L, "HULL_LUA_CORPUS");
+    sl_free(&files);
+
+    if (luaL_dofile(L, script_path) != LUA_OK) {
+        fprintf(stderr, "\n%s: %s\n", script_path, lua_tostring(L, -1));
+        lua_close(L);
+        return -1;
+    }
+    if (!lua_istable(L, -1)) { lua_close(L); return -1; }
+    lua_getfield(L, -1, "fail");
+    *fail_out = (long long)lua_tointeger(L, -1);
+    lua_pop(L, 1);
+    lua_getfield(L, -1, "pass");
+    *pass_out = (long long)lua_tointeger(L, -1);
+    lua_pop(L, 1);
+
+    fprintf(stderr, "  %s: %lld passed, %lld failed\n", script_path, *pass_out, *fail_out);
+    lua_close(L);
+    return 0;
+}
+
 UTEST(lua_source, lexer_slice1)
 {
     long long pass = 0, fail = -1;
@@ -92,6 +236,18 @@ UTEST(lua_source, annotations_slice4)
 {
     long long pass = 0, fail = -1;
     int rc = run_lua_test("stdlib/cli/lua/hull/source/tests/test_annotations.lua", &pass, &fail);
+    ASSERT_EQ(rc, 0);
+    EXPECT_EQ(fail, 0LL);
+    EXPECT_GT(pass, 0LL);
+}
+
+/* Differential conformance vs real Lua 5.4 (load()) over the repo's own .lua corpus,
+ * plus range round-trip, curated negatives, pinned semantic divergences, seeded
+ * mutation fuzz, and the classifier's own tests. Its own leg for isolated failures. */
+UTEST(lua_source, conformance)
+{
+    long long pass = 0, fail = -1;
+    int rc = run_lua_conformance("stdlib/cli/lua/hull/source/tests/test_conformance.lua", &pass, &fail);
     ASSERT_EQ(rc, 0);
     EXPECT_EQ(fail, 0LL);
     EXPECT_GT(pass, 0LL);

--- a/tests/hull/source/test_lua_source.c
+++ b/tests/hull/source/test_lua_source.c
@@ -77,17 +77,22 @@ static int run_lua_test(const char *script_path, long long *pass_out, long long 
  * the oracle (load()) and the Hull parser see the identical bytes. Deterministic:
  * regular .lua files only, symlinks skipped (no traversal loops), paths sorted. */
 
-typedef struct { char **items; size_t count, cap; } StrList;
+/* Fail-closed: any allocation failure latches `oom`; the runner then aborts the
+ * whole conformance leg rather than testing a silently-truncated corpus. */
+typedef struct { char **items; size_t count, cap; int oom; } StrList;
 
 static void sl_push(StrList *l, const char *s)
 {
+    if (l->oom) return;
     if (l->count == l->cap) {
         size_t nc = l->cap ? l->cap * 2 : 64;
         char **ni = realloc(l->items, nc * sizeof(char *));
-        if (!ni) return;                 /* best-effort; a short corpus still tests */
+        if (!ni) { l->oom = 1; return; }
         l->items = ni; l->cap = nc;
     }
-    l->items[l->count++] = strdup(s);
+    char *dup = strdup(s);
+    if (!dup) { l->oom = 1; return; }    /* never insert NULL (would crash qsort) */
+    l->items[l->count++] = dup;
 }
 
 static void sl_free(StrList *l)
@@ -129,6 +134,8 @@ static void walk_lua(const char *root, StrList *out, int depth)
     closedir(d);
 }
 
+/* Read the whole file, or NULL on ANY failure (open, seek, alloc, OR a short read).
+ * A short read of a regular file is an error here, not a truncated-but-ok corpus. */
 static char *read_all(const char *path, size_t *out_len)
 {
     FILE *f = fopen(path, "rb");
@@ -141,6 +148,7 @@ static char *read_all(const char *path, size_t *out_len)
     if (!buf) { fclose(f); return NULL; }
     size_t rd = fread(buf, 1, (size_t)sz, f);
     fclose(f);
+    if (rd != (size_t)sz) { free(buf); return NULL; }    /* short read -> fail closed */
     buf[rd] = '\0';
     *out_len = rd;
     return buf;
@@ -167,24 +175,33 @@ static int run_lua_conformance(const char *script_path, long long *pass_out, lon
     static const char *const roots[] = {
         "stdlib/lua", "stdlib/cli/lua", "examples", "tests/fixtures",
     };
-    StrList files = { NULL, 0, 0 };
+    StrList files = { NULL, 0, 0, 0 };
     for (size_t i = 0; i < sizeof roots / sizeof roots[0]; i++)
         walk_lua(roots[i], &files, 0);
+    if (files.oom) {                       /* fail closed: never test a truncated corpus */
+        fprintf(stderr, "conformance: corpus enumeration ran out of memory\n");
+        sl_free(&files); lua_close(L); return -1;
+    }
     qsort(files.items, files.count, sizeof(char *), cmp_cstr);
 
     lua_createtable(L, (int)files.count, 0);
-    int n = 0;
+    size_t read_ok = 0;
     for (size_t i = 0; i < files.count; i++) {
         size_t len = 0;
         char *src = read_all(files.items[i], &len);
-        if (!src) continue;
+        if (!src) {                        /* an enumerated file MUST read fully */
+            fprintf(stderr, "conformance: failed to read corpus file '%s'\n", files.items[i]);
+            sl_free(&files); lua_close(L); return -1;
+        }
         lua_createtable(L, 0, 2);
         lua_pushstring(L, files.items[i]); lua_setfield(L, -2, "path");
         lua_pushlstring(L, src, len);      lua_setfield(L, -2, "source");
         free(src);
-        lua_rawseti(L, -2, ++n);
+        lua_rawseti(L, -2, (int)(++read_ok));
     }
     lua_setglobal(L, "HULL_LUA_CORPUS");
+    fprintf(stderr, "  conformance: enumerated %zu, read %zu .lua files\n",
+            files.count, read_ok);
     sl_free(&files);
 
     if (luaL_dofile(L, script_path) != LUA_OK) {


### PR DESCRIPTION
Step **A** of the post-build-plan roadmap: a differential conformance harness validating `hull.source.lua` against **real Lua 5.4** (the same vendored `load()` the test harness links — in-process, compile-only), plus the first real bug it caught.

## Design
`docs/lua_source_conformance_design.md` (committed here). Directional invariant: Hull is a *syntactic* recognizer, `load()` is syntactic + a thin static-semantic layer, so a Hull reject must imply a `load` reject (false-reject is the key bug class), while a Hull accept may diverge from a `load` reject only for a **pinned semantic case** (break/goto/vararg/const/attribute/limits), classified by an anchored, guarded allowlist of Lua-5.4 error fragments.

## Harness (`UTEST(lua_source, conformance)`)
- **Corpus in C**: `dirent` walk over `stdlib/lua`, `stdlib/cli/lua`, `examples`, `tests/fixtures` — regular `.lua` only, symlinks skipped (no traversal loops), sorted; exposes `{path, source}` records so oracle and parser get **identical bytes** (no `io`, no second FS pass).
- **`test_conformance.lua`** (its own leg for isolated failures): oracle-classified corpus (load-accepted ⇒ Hull clean; load-rejected ⇒ directional/semantic rules, reported separately), range round-trip over **AST child nodes only** (annotations excluded), curated syntactic negatives, pinned semantic divergences, **direct classifier tests** (each fragment matches its case and *not* nearby syntax errors), and a **fixed-seed mutation fuzz** (N=20/seed, 4000-mutant cap). `lua.limit.*`/`lua.internal` excluded from accept/reject; divergences reported by category + count.

Result over **224 corpus files**: 0 false-rejects, 0 range violations, **0 fuzz divergences**; 517 conformance assertions.

## First catch: a real lexer conformance bug
The fuzz found that Hull terminated a short comment **only at `\n`**, but real Lua 5.4 ends it at `\n` **or** `\r` (`llex.c` `currIsNewline`). A lone `\r` in a comment made Hull swallow post-CR code as comment and *accept* input Lua rejects — a fidelity bug for lone-CR / mixed-ending files. Fixed the short-comment scan and `range.linemap` (lone `\r` and `\r\n`/`\n\r`-as-one-break) to match Lua exactly; the shebang finder is correctly left `\n`-only (matches `luaL_loadfilex`). +5 regression tests (lexer 110 → 115).

Follow-up (documented, not in this PR): a continuous libFuzzer never-raise harness.

Suites: **lexer 115 + parser 133 + statements 130 + annotations 77 + conformance 517**; luacheck clean; full `hull` build OK.
