### PR TITLE
feat(analyze): hull analyze — static Lua syntax analysis (first hull.source.lua consumer)

### DIFF
--- a/docs/hull_analyze_design.md
+++ b/docs/hull_analyze_design.md
@@ -1,6 +1,9 @@
-# `hull analyze` (design)
+# `hull analyze`
 
-Status: DESIGN (pre-implementation). The FIRST production consumer of the
+Status: IMPLEMENTED (`src/hull/commands/analyze.{c,h}`,
+`stdlib/cli/lua/hull/source/analyze.lua`, `tests/e2e_analyze.sh`; the
+`tool.path_kind` + `tool.stdout` bindings in `src/hull/runtime/lua/mod_tool.c`). The
+FIRST production consumer of the
 `hull.source.lua` analysis layer (see
 [lua_source_analysis_design.md](lua_source_analysis_design.md) and
 [lua_source_conformance_design.md](lua_source_conformance_design.md)). Step **C** of
@@ -187,6 +190,11 @@ forward-compat contract for agent/editor consumers.
   `analyze` is complementary — pure static syntax over the whole tree, no load, no
   tests. They can compose later (`check` could run `analyze` first), but v1 keeps them
   independent.
+- **`hull modules analyze`** (the existing `hull.analyze` module) statically compares
+  an app's `require`/`import` sites against its `manifest.modules` (undeclared / unused
+  modules). That is DECLARATION analysis; `hull analyze` is SOURCE SYNTAX analysis.
+  Different questions, different modules — the names are deliberately kept distinct
+  (this command's module is `hull.source.analyze`).
 - **`hull agent`** exposes JSON introspection for AI agents. `hull analyze --json`
   fits that world directly; a thin `hull agent analyze` alias is a possible later
   convenience, but v1 ships the `--json` flag on the top-level command.
@@ -197,33 +205,42 @@ A tool-mode command (the analyzer is Lua consuming a Lua module — the natural 
 same as `hull build` / `hull init` / `hull deploy`):
 
 - **C**: `src/hull/commands/analyze.{c,h}` — `hl_cmd_analyze` is ~15 lines:
-  `return hull_tool("hull.analyze", argc, argv, env->hull_exe);`. One row in the
-  `dispatch.c` table; grouped under "Develop & test" in `help.c`. **No build-flag
-  gate** — analyze needs no HTTP/DB/WASM, so it is present in every flavor (including
-  pure-compute); it runs in the tool VM, which is always built.
-- **Lua**: `stdlib/cli/lua/hull/analyze.lua` — reads the standard `arg` global,
+  `return hull_tool("hull.source.analyze", argc, argv, env->hull_exe);`. One row in the
+  `dispatch.c` table; grouped under "Diagnostics" in `help.c` (next to `check`). **No
+  build-flag gate** — analyze needs no HTTP/DB/WASM, so it is present in every flavor
+  (including pure-compute); it runs in the tool VM, which is always built.
+- **Module name**: `hull.source.analyze` (the source-analysis CLI, living with the
+  layer), NOT `hull.analyze` — that name already backs `hull modules analyze`
+  (import-vs-manifest declaration analysis, a distinct check; see §7). No collision.
+- **Lua**: `stdlib/cli/lua/hull/source/analyze.lua` — reads the standard `arg` global,
   `require("hull.source.lua")`, and uses `tool.find_files` / `tool.read_file` /
   `tool.path_kind` / `tool.stderr` / `tool.exit` / `hull.json`. The source layer is
   already embedded in the platform VFS (under `stdlib/cli/lua/hull/source/`), so the
   tool VM `require`s it with no new wiring. (Verify at implementation:
   `require("hull.source.lua")` resolves in the tool VM.)
-- **One new tool binding**: `tool.path_kind(path)` → `"dir" | "file" | "other" | nil`
-  (via `stat`, missing → nil). Needed for the positional rule (§3, "resolves to a
-  directory") and explicit-target regular-file validation (§4). `file_exists` is
-  `access(F_OK)` and cannot distinguish a directory; no stat binding exists today.
-  ~12 lines in `src/hull/runtime/lua/mod_tool.c`. Discovery still uses `find_files`
-  (which `lstat`s and excludes symlinks); `path_kind` `stat`s (follows) because an
-  explicitly-named root/target may legitimately be a symlink.
+- **Two new tool bindings** (both small, in `src/hull/runtime/lua/mod_tool.c`):
+  - `tool.path_kind(path)` → `"dir" | "file" | "other" | nil` (via `stat`, missing →
+    nil). Needed for the positional rule (§3) and explicit-target regular-file checks
+    (§4); `file_exists` is `access(F_OK)` and cannot distinguish a directory.
+    Discovery still uses `find_files` (which `lstat`s and excludes symlinks);
+    `path_kind` `stat`s (follows) because an explicitly-named root/target may
+    legitimately be a symlink.
+  - `tool.stdout(str)` → write verbatim to **stdout** (and flush). Hull routes `print`
+    to **stderr** in every Lua VM (`hl_lua_print`), so a command whose primary output
+    is DATA needs an explicit stdout channel to satisfy JSON purity (§6). `analyze`'s
+    real output (human diagnostics + JSON) goes through `tool.stdout`; `print` /
+    `tool.stderr` carry only operational messages.
 
-Net new C surface: the ~15-line dispatcher + one table row + one help line + the
-~12-line `tool.path_kind` binding. Everything else is Lua over the shipped layer.
+Net new C surface: the ~15-line dispatcher + one table row + one help line + the two
+small `tool.*` bindings. Everything else is Lua over the shipped layer.
 
 ## 9. Testing
 
 The parser is already conformance-tested; `analyze` is discovery + validation +
 formatting + exit codes, best covered end to end via **`tests/e2e_analyze.sh`**
-(+ `make e2e-analyze`) over tiny fixtures (`tests/fixtures/analyze_clean/`,
-`tests/fixtures/analyze_broken/`). Required cases:
+(+ `make e2e-analyze`). Fixtures are built in a **TMPDIR** at runtime (self-contained,
+and deliberately NOT committed — an intentionally-broken `.lua` under `tests/fixtures/`
+would otherwise enter the conformance corpus). Required cases:
 
 - **Clean app** → exit 0, "no issues".
 - **Syntax error in a NON-entry module** (`routes/*.lua`) → exit 1; the error's

--- a/docs/hull_analyze_design.md
+++ b/docs/hull_analyze_design.md
@@ -1,0 +1,277 @@
+# `hull analyze` (design)
+
+Status: DESIGN (pre-implementation). The FIRST production consumer of the
+`hull.source.lua` analysis layer (see
+[lua_source_analysis_design.md](lua_source_analysis_design.md) and
+[lua_source_conformance_design.md](lua_source_conformance_design.md)). Step **C** of
+the post-build-plan roadmap.
+
+## 1. Goal
+
+A static analyzer for Hull apps that **parses the app's Lua source and reports
+diagnostics without running the app or building it**. v1 is a **syntax checker**: it
+surfaces the layer's diagnostics (`lua.syntax` and friends) with exact `path:line:col`
+positions, a human format and a `--json` mode, and a meaningful exit code. It is the
+smallest consumer that proves `hull.source.lua` end to end in front of a user, and it
+gives an immediate, useful linter foundation that later grows AST/annotation lint
+rules.
+
+Why it matters: today a syntax error in a non-entry file (`routes/users.lua`) only
+surfaces when that module is first `require`d at run time. `hull analyze` catches it
+across the whole tree, statically, in one shot.
+
+## 2. Non-goals (v1)
+
+- **Not JS.** `hull.source.js` does not exist yet; `.js` files are reported as
+  "not analyzed (no JS analyzer yet)" and do not count as errors. When
+  `hull.source.js` lands, the same CLI surface picks it up (discovery already sees
+  `.js`).
+- **Not semantic analysis** (scopes / binding / types). Pure syntax + ranges.
+- **Not manifest / module validation** — that is `hull check` / `hull modules`
+  (§7). `analyze` is orthogonal: source diagnostics, no app load.
+- **Not auto-fix.** Diagnostics are reported, never rewritten.
+
+## 3. Command surface
+
+```
+hull analyze [app_dir] [files...] [--json] [--quiet]
+```
+
+**Positional resolution (locked, unambiguous).** The FIRST positional is `app_dir`
+ONLY when it resolves to a **directory** (`tool.path_kind(p) == "dir"`); then every
+remaining positional is an explicit file **relative to that app root**. Otherwise the
+app root is `.` and ALL positionals are explicit files relative to `.`. So:
+- **no positionals** → root `.`, **walk** mode.
+- **one positional, a directory** → root = it, **walk** mode.
+- **a directory then more positionals** → root = the dir, **explicit-files** mode
+  (the trailing positionals, resolved under the root).
+- **first positional not a directory** → root `.`, **explicit-files** mode (all
+  positionals).
+
+**Flags.**
+- `--json` → machine output (one JSON object on stdout, §6).
+- `--quiet` → human-mode only: suppress the per-file "ok" chatter, print diagnostics +
+  summary. In `--json` mode `--quiet` is a **no-op** (JSON overrides it; stdout stays
+  pure JSON) — documented, not an error.
+
+**Exit codes.**
+- `0` — analysis ran to completion on every input and found **zero** diagnostics.
+- `1` — analysis ran but is **not clean**: any source diagnostic (`lua.syntax` /
+  `lua.unsupported`), any **incomplete** (`lua.limit.*`) or **internal**
+  (`lua.internal` or a `parse()` `(nil, err)`) result, or any explicit-target error
+  (missing / unreadable / non-regular / non-Lua / outside-root).
+- `2` — the invocation could not proceed: unknown flag, or a discovery failure (the
+  app root is missing / not a directory / unreadable). **Fail closed** — never a
+  silently reduced scan.
+
+## Discovery (walk mode) — deterministic + bounded
+
+`tool.find_files(root, "*.lua")` already returns **sorted**, **regular-file-only**,
+**no-symlink-traversal** results (it `lstat`s each entry and never descends a
+symlinked dir) and skips dotdirs (`.git`, `.hull`), `node_modules`, and `vendor`.
+`analyze` adds a Lua post-filter dropping any path with a segment in the explicit
+exclusion set `{.git, .hull, build, vendor, node_modules}` — the `build` segment
+covers both top-level `build/` and `site/build/`. The result is a sorted, de-duplicated
+list of regular `.lua` files under the root. If the root itself is not a readable
+directory, that is a discovery failure (exit 2), not an empty scan.
+
+## 4. What it does (pipeline)
+
+1. **Resolve inputs** (positional rule, §3). Walk mode → filtered `tool.find_files`.
+   Explicit-files mode → validate each target (below). Sort + de-duplicate the final
+   path list for deterministic output.
+2. **Per file**: `src = tool.read_file(path)`; `unit, err = lua.parse(src, { path = rel })`.
+   Generous limits so `lua.limit.*` only trips on genuinely pathological input.
+3. **Positions**: for each diagnostic with a range, resolve `(line, col)` via
+   `unit:line_col(diag.range)` (1-based line, 1-based byte column); a range-less
+   diagnostic reports `line/col = null`.
+4. **Aggregate + report** (human or JSON), set the exit code.
+
+**Explicit-target validation (no silent skips).** For each explicit file, `analyze`
+resolves it under the app root and emits a per-target error diagnostic (not a skip)
+for any of: **outside the root** (`analyze.outside_root`), **missing**
+(`analyze.not_found`), **not a regular file** (`analyze.not_regular`, e.g. a directory
+or device via `tool.path_kind`), **unreadable** (`analyze.unreadable`), or **not
+`.lua`** (`analyze.not_lua`). Each marks that target's analysis state `internal` and
+drives exit 1. Duplicated paths (after normalization) are analyzed once.
+
+`lua.parse` never raises and returns diagnostics as data, so `analyze` is pure glue +
+formatting over the already-conformance-tested layer.
+
+## 5. Diagnostic handling — the full `parse()` boundary + per-file state
+
+`analyze` handles **every** outcome of the `parse()` contract, and each non-clean one
+drives exit 1. Each analyzed file carries an **analysis state** ∈
+`complete | incomplete | internal`:
+
+| `parse()` outcome | file state | shown as | drives exit 1 |
+|---|---|---|---|
+| unit, only `lua.syntax` / `lua.unsupported` (or none) | `complete` | `error` per diag (clean if none) | iff ≥1 diag |
+| unit with any `lua.limit.*` | `incomplete` | `error (incomplete)` — analysis truncated | yes |
+| unit with any `lua.internal` | `internal` | `error (internal)` | yes |
+| `(nil, err)` (API misuse / internal failure) | `internal` | `error (internal)` — `err.message` | yes |
+| explicit-target error (§4) | `internal` | `error` with an `analyze.*` code | yes |
+
+So a `complete` file may still carry syntax diagnostics (fully analyzed, found
+errors); `incomplete`/`internal` mean the file could not be fully/authoritatively
+analyzed and is never reported as clean — the same guardrail the conformance gate
+enforces. `analyze` runs with generous limits so a legitimate file never trips
+`incomplete`; if one does, the message says so (and points at future `--max-*` knobs,
+§10) rather than pretending the file is fine. A `clean` run requires every file
+`complete` with zero diagnostics and zero target errors.
+
+## 6. Output
+
+**Human** (default) — gcc/clang style, editor-clickable, sorted by (path, line, col):
+```
+routes/users.lua:12:5: error: '=' expected [lua.syntax]
+app.lua:3:1: error: unexpected symbol near '@' [lua.syntax]
+
+hull analyze: 2 errors in 2 files (14 files scanned)
+```
+Clean:
+```
+hull analyze: no issues (14 files scanned)
+```
+
+**JSON stdout purity.** In `--json` mode **stdout contains exactly one JSON object and
+nothing else**. All operational / usage failures (exit 2) print a plain message to
+**stderr** and emit no stdout. Human-mode chatter never appears in JSON mode.
+
+**Versioned JSON schema (LOCKED, `schema_version: 1`).** Deterministic: `files` sorted
+by path, `diagnostics` sorted by `(path, range.start, code)`.
+```json
+{
+  "schema_version": 1,
+  "root": "app",
+  "files_scanned": 14,
+  "files": [
+    { "path": "app.lua",          "state": "complete" },
+    { "path": "routes/users.lua", "state": "complete" }
+  ],
+  "diagnostics": [
+    { "path": "routes/users.lua",
+      "code": "lua.syntax",
+      "severity": "error",
+      "message": "'=' expected",
+      "range": { "start": 120, "stop": 121 },
+      "line": 12,
+      "col": 5,
+      "state": "complete" }
+  ],
+  "summary": {
+    "errors": 2,
+    "files_with_issues": 1,
+    "incomplete": 0,
+    "internal": 0,
+    "clean": false
+  }
+}
+```
+- **`root`** — the resolved app root (`.` normalized).
+- **`files`** — every analyzed file with its `state` (`complete|incomplete|internal`),
+  sorted by path.
+- **`diagnostics`** — deterministic, each with `path`, `code` (a `lua.*` or
+  `analyze.*` code), `severity`, `message`, `range` (`{start, stop}` half-open, or
+  `null` when the diagnostic has no range), `line` / `col` (1-based, or `null` when no
+  range), and the owning file's `state`.
+- **`summary.clean`** — `true` iff exit 0.
+
+Built with `hull.json` (the tool VM already uses it). The `schema_version` is the
+forward-compat contract for agent/editor consumers.
+
+## 7. Relationship to `hull check` / `hull agent`
+
+- **`hull check`** (C) composes `hull modules` (manifest/module validation) + `hull
+  test`. It loads/validates the app; it does not statically parse every source file.
+  `analyze` is complementary — pure static syntax over the whole tree, no load, no
+  tests. They can compose later (`check` could run `analyze` first), but v1 keeps them
+  independent.
+- **`hull agent`** exposes JSON introspection for AI agents. `hull analyze --json`
+  fits that world directly; a thin `hull agent analyze` alias is a possible later
+  convenience, but v1 ships the `--json` flag on the top-level command.
+
+## 8. Architecture
+
+A tool-mode command (the analyzer is Lua consuming a Lua module — the natural fit,
+same as `hull build` / `hull init` / `hull deploy`):
+
+- **C**: `src/hull/commands/analyze.{c,h}` — `hl_cmd_analyze` is ~15 lines:
+  `return hull_tool("hull.analyze", argc, argv, env->hull_exe);`. One row in the
+  `dispatch.c` table; grouped under "Develop & test" in `help.c`. **No build-flag
+  gate** — analyze needs no HTTP/DB/WASM, so it is present in every flavor (including
+  pure-compute); it runs in the tool VM, which is always built.
+- **Lua**: `stdlib/cli/lua/hull/analyze.lua` — reads the standard `arg` global,
+  `require("hull.source.lua")`, and uses `tool.find_files` / `tool.read_file` /
+  `tool.path_kind` / `tool.stderr` / `tool.exit` / `hull.json`. The source layer is
+  already embedded in the platform VFS (under `stdlib/cli/lua/hull/source/`), so the
+  tool VM `require`s it with no new wiring. (Verify at implementation:
+  `require("hull.source.lua")` resolves in the tool VM.)
+- **One new tool binding**: `tool.path_kind(path)` → `"dir" | "file" | "other" | nil`
+  (via `stat`, missing → nil). Needed for the positional rule (§3, "resolves to a
+  directory") and explicit-target regular-file validation (§4). `file_exists` is
+  `access(F_OK)` and cannot distinguish a directory; no stat binding exists today.
+  ~12 lines in `src/hull/runtime/lua/mod_tool.c`. Discovery still uses `find_files`
+  (which `lstat`s and excludes symlinks); `path_kind` `stat`s (follows) because an
+  explicitly-named root/target may legitimately be a symlink.
+
+Net new C surface: the ~15-line dispatcher + one table row + one help line + the
+~12-line `tool.path_kind` binding. Everything else is Lua over the shipped layer.
+
+## 9. Testing
+
+The parser is already conformance-tested; `analyze` is discovery + validation +
+formatting + exit codes, best covered end to end via **`tests/e2e_analyze.sh`**
+(+ `make e2e-analyze`) over tiny fixtures (`tests/fixtures/analyze_clean/`,
+`tests/fixtures/analyze_broken/`). Required cases:
+
+- **Clean app** → exit 0, "no issues".
+- **Syntax error in a NON-entry module** (`routes/*.lua`) → exit 1; the error's
+  path/line/col/code present in BOTH human and `--json` output (proves whole-tree
+  discovery, not just the entry).
+- **Deterministic ordering** → the diagnostics/files order is identical across two
+  runs and matches the documented sort.
+- **Explicit files**: a valid file (analyzed), a **missing** file, an **unreadable**
+  file, a **non-Lua** file, and a path **outside the root** → each yields its
+  `analyze.*` diagnostic (never a silent skip) and exit 1.
+- **Exclusions**: a `.lua` planted under `build/` (and `site/build/`, `vendor/`,
+  `.git/`) is NOT scanned; one outside the excluded dirs IS.
+- **JSON purity + schema**: `--json` stdout parses as one object, matches
+  `schema_version: 1` with all required keys, and carries NO non-JSON bytes; a usage
+  error (exit 2) writes to stderr with EMPTY stdout.
+- **Quiet**: `--quiet` suppresses human "ok" chatter but still prints diagnostics; with
+  `--json` it is a no-op (stdout stays pure JSON).
+- **All three exit codes** exercised (0 clean, 1 diagnostics/targets, 2 usage/discovery
+  failure such as a non-existent app root).
+
+The pure aggregation/format/sort helpers may additionally be factored into functions
+unit-tested via the vanilla-`lua_State` harness style if the e2e proves too coarse.
+
+## 10. Extension path (documented, NOT v1)
+
+- **AST / annotation lint rules**: undeclared-import detection (static, no run),
+  unused `require`s, shadowed locals, `---@deprecated` usage, TODO/FIXME extraction —
+  each a small rule over `lua.walk` + `unit.annotations`, behind a rule registry and
+  `--rules` / `--disable` flags.
+- **JS** via `hull.source.js` (the CLI surface is language-agnostic already).
+- **`--max-bytes` / `--max-depth`** knobs to raise limits for the rare huge file.
+- **`hull agent analyze`** alias; **`hull check` composition**.
+
+## 11. Decisions (ratified)
+
+1. **v1 scope** — syntax-only (lint rules are the §10 follow-up).
+2. **Surface** — directory discovery + explicit files + `--json`, with the locked
+   positional-resolution rule (§3).
+3. **`lua.limit.*` / `lua.internal` / `(nil, err)`** — all make analysis incomplete
+   and exit 1, with honest per-file `incomplete` / `internal` state (§5).
+4. **Placement** — top-level `hull analyze` (agents use `--json`).
+
+Contract tightenings folded in: unambiguous positional resolution; deterministic +
+bounded discovery (regular `.lua` only, sorted, no symlink traversal, exclusions
+`{.git, .hull, build, vendor, node_modules}` covering `site/build`); explicit files
+kept inside the root, de-duplicated, with `analyze.*` diagnostics for
+missing/unreadable/non-regular/non-Lua/outside-root (no silent skips); the full
+`parse()` boundary handled; a versioned JSON schema (`schema_version: 1`) with pure
+JSON stdout and stderr-only operational failures; `--quiet` as human-mode suppression,
+a no-op under `--json`; discovery failures fail closed (exit 2). One new binding,
+`tool.path_kind`.

--- a/include/hull/commands/analyze.h
+++ b/include/hull/commands/analyze.h
@@ -1,0 +1,16 @@
+/**
+ * @file commands/analyze.h
+ * @brief `hull analyze` — static source analysis (syntax diagnostics) for Hull apps.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef HL_COMMANDS_ANALYZE_H
+#define HL_COMMANDS_ANALYZE_H
+
+#include "hull/commands/dispatch.h"
+
+/** @brief Entry point — invoked by the command dispatcher. */
+int hl_cmd_analyze(int argc, char **argv, const HlCommandEnv *env);
+
+#endif /* HL_COMMANDS_ANALYZE_H */

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -891,6 +891,10 @@ e2e-cli: $(BUILDDIR)/hull
 e2e-migrate: $(BUILDDIR)/hull
 	sh tests/e2e_migrate.sh
 
+.PHONY: e2e-analyze
+e2e-analyze: $(BUILDDIR)/hull
+	sh tests/e2e_analyze.sh
+
 # PostgreSQL backend end-to-end (needs Docker; builds its own POSTGRES hull).
 e2e-postgres:
 	sh tests/e2e_postgres.sh

--- a/src/hull/commands/analyze.c
+++ b/src/hull/commands/analyze.c
@@ -1,0 +1,21 @@
+/*
+ * commands/analyze.c — hull analyze subcommand
+ *
+ * Thin wrapper: launches the Lua tool VM with the hull.source.analyze module, which
+ * parses the app's Lua source via hull.source.lua and reports diagnostics (see
+ * docs/hull_analyze_design.md). No HTTP/DB/WASM -- present in every build flavor.
+ *
+ * Note: the module is hull.source.analyze, NOT hull.analyze -- the latter already
+ * backs `hull modules analyze` (import-vs-manifest declaration analysis), a distinct
+ * check. This command is source SYNTAX analysis.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "hull/commands/analyze.h"
+#include "hull/tool.h"
+
+int hl_cmd_analyze(int argc, char **argv, const HlCommandEnv *env)
+{
+    return hull_tool("hull.source.analyze", argc, argv, env->hull_exe);
+}

--- a/src/hull/commands/dispatch.c
+++ b/src/hull/commands/dispatch.c
@@ -24,6 +24,7 @@
 #include "hull/commands/dev.h"
 #endif
 #include "hull/commands/eject.h"
+#include "hull/commands/analyze.h"
 #ifdef HL_ENABLE_DB
 #include "hull/commands/jobs.h"
 #include "hull/commands/migrate.h"
@@ -81,6 +82,7 @@ static const HlCommand commands[] = {
     { "mcp",           hl_cmd_mcp },
 #endif
     { "check",         hl_cmd_check },
+    { "analyze",       hl_cmd_analyze },
     { "compute",       hl_cmd_compute },
     { "deploy",        hl_cmd_deploy },
     { "version",       hl_cmd_version },

--- a/src/hull/commands/help.c
+++ b/src/hull/commands/help.c
@@ -76,6 +76,7 @@ int hl_cmd_help(int argc, char **argv, const HlCommandEnv *env)
     section(f, "Diagnostics");
     row(f, "doctor",        "check this hull binary's capabilities + host toolchain");
     row(f, "check",         "validate an app's manifest before running");
+    row(f, "analyze",       "static syntax analysis of an app's Lua source");
     row(f, "modules",       "list / explain the first-party module registry");
     row(f, "version",       "print version (also --version / -v)");
 

--- a/src/hull/runtime/lua/mod_tool.c
+++ b/src/hull/runtime/lua/mod_tool.c
@@ -427,6 +427,34 @@ static int l_tool_file_exists(lua_State *L)
     return 1;
 }
 
+/* ── tool.path_kind(path) → "dir"|"file"|"other"|nil ───────────────────
+ * stat() (follows symlinks): an explicitly-named root/target may legitimately be a
+ * symlink; directory discovery uses find_files (which lstat's + skips symlinks). Used
+ * by hull analyze for positional resolution + explicit-target regular-file checks;
+ * file_exists is access(F_OK) only and cannot distinguish a directory. */
+static int l_tool_path_kind(lua_State *L)
+{
+    const char *path = luaL_checkstring(L, 1);
+    HlToolUnveilCtx *ctx = get_unveil_ctx(L);
+
+    if (ctx && hl_tool_unveil_check(ctx, path, 'r') != 0) {
+        lua_pushnil(L);
+        return 1;
+    }
+
+    struct stat st;
+    if (stat(path, &st) != 0) {
+        lua_pushnil(L);
+    } else if (S_ISDIR(st.st_mode)) {
+        lua_pushstring(L, "dir");
+    } else if (S_ISREG(st.st_mode)) {
+        lua_pushstring(L, "file");
+    } else {
+        lua_pushstring(L, "other");
+    }
+    return 1;
+}
+
 /* ── tool.file_mtime(path) → number|nil ────────────────────────────── */
 
 static int l_tool_file_mtime(lua_State *L)
@@ -455,6 +483,18 @@ static int l_tool_stderr(lua_State *L)
 {
     const char *msg = luaL_checkstring(L, 1);
     fprintf(stderr, "%s", msg);
+    return 0;
+}
+
+/* tool.stdout(str): write verbatim to STDOUT (and flush). `print` in every Hull Lua
+ * VM is routed to stderr (hl_lua_print), so a command whose primary output is DATA
+ * (e.g. hull analyze --json, which must keep stdout pure JSON) writes it here. */
+static int l_tool_stdout(lua_State *L)
+{
+    size_t len = 0;
+    const char *msg = luaL_checklstring(L, 1, &len);
+    fwrite(msg, 1, len, stdout);
+    fflush(stdout);
     return 0;
 }
 
@@ -1489,8 +1529,10 @@ static const luaL_Reg tool_funcs[] = {
     { "read_file",              l_tool_read_file },
     { "write_file",             l_tool_write_file },
     { "file_exists",            l_tool_file_exists },
+    { "path_kind",              l_tool_path_kind },
     { "file_mtime",             l_tool_file_mtime },
     { "stderr",                 l_tool_stderr },
+    { "stdout",                 l_tool_stdout },
     { "loadfile",               l_tool_loadfile },
     { "extract_manifest_js",    l_tool_extract_manifest_js },
     { "extract_platform",       l_tool_extract_platform },

--- a/stdlib/cli/lua/hull/source/analyze.lua
+++ b/stdlib/cli/lua/hull/source/analyze.lua
@@ -1,0 +1,271 @@
+--
+-- hull.source.analyze — `hull analyze`: static SYNTAX analysis of an app's Lua source.
+--
+-- The first production consumer of hull.source.lua. Parses every .lua file in an app
+-- (or explicit files) WITHOUT running or building it, and reports diagnostics with
+-- exact path:line:col. Design + locked contract: docs/hull_analyze_design.md.
+--
+-- NOT to be confused with `hull modules analyze` (module hull.analyze), which compares
+-- require/import sites against manifest.modules. This is source syntax analysis.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local lua = require("hull.source.lua")
+local json = require("hull.json")
+
+-- Generous limits so lua.limit.* only trips on genuinely pathological input; a trip is
+-- reported as an "incomplete" analysis (never silently treated as clean).
+local LIMITS = { max_bytes = 64 * 1024 * 1024, max_tokens = 5000000,
+                 max_comments = 5000000, max_depth = 2000 }
+
+local EXCLUDE_SEGMENT = {   -- generated / dependency dirs (build covers site/build)
+    [".git"] = true, [".hull"] = true, build = true, vendor = true, node_modules = true,
+}
+
+-- ── small path helpers (pure Lua; no path-normalize binding in the tool VM) ──
+local function normalize(p)
+    local absolute = p:sub(1, 1) == "/"
+    local segs = {}
+    for seg in p:gmatch("[^/]+") do
+        if seg == ".." then
+            if #segs > 0 and segs[#segs] ~= ".." then table.remove(segs)
+            elseif not absolute then segs[#segs + 1] = ".." end   -- absolute: .. at root stays root
+        elseif seg ~= "." then                               -- "." is dropped
+            segs[#segs + 1] = seg
+        end
+    end
+    return (absolute and "/" or "") .. table.concat(segs, "/")
+end
+
+local function join(root, rel)
+    if rel:sub(1, 1) == "/" then return rel end              -- absolute stays absolute
+    if root == "" or root == "." then return rel end
+    return root .. "/" .. rel
+end
+
+-- Is `target_norm` inside `root_norm`? (root_norm "" means cwd.)
+local function inside_root(root_norm, target_norm)
+    if target_norm == ".." or target_norm:sub(1, 3) == "../" then return false end
+    if root_norm == "" then return target_norm:sub(1, 1) ~= "/" end
+    return target_norm == root_norm or target_norm:sub(1, #root_norm + 1) == root_norm .. "/"
+end
+
+local function excluded(path)
+    for seg in path:gmatch("[^/]+") do
+        if EXCLUDE_SEGMENT[seg] then return true end
+    end
+    return false
+end
+
+local function ends_lua(path) return path:sub(-4) == ".lua" end
+
+-- ── argument parsing (arg[0] = "analyze"; real args at arg[1..#arg]) ──
+local function usage_error(msg)
+    tool.stderr("hull analyze: " .. msg .. "\n")
+    tool.stderr("usage: hull analyze [app_dir] [files...] [--json] [--quiet]\n")
+    tool.exit(2)
+end
+
+local function parse_args()
+    local o = { json = false, quiet = false, positionals = {} }
+    for i = 1, #arg do
+        local a = arg[i]
+        if a == "--json" then o.json = true
+        elseif a == "--quiet" then o.quiet = true
+        elseif a == "-h" or a == "--help" then o.help = true
+        elseif a:sub(1, 1) == "-" and a ~= "-" then usage_error("unknown flag: " .. a)
+        else o.positionals[#o.positionals + 1] = a end
+    end
+    return o
+end
+
+-- ── resolve inputs into { root, mode, targets? } ──
+local function resolve_inputs(o)
+    local pos = o.positionals
+    if #pos == 0 then
+        return { root = ".", mode = "walk" }
+    end
+    if tool.path_kind(pos[1]) == "dir" then                  -- first positional is app_dir
+        local root = pos[1]
+        if #pos == 1 then return { root = root, mode = "walk" } end
+        local targets = {}
+        for i = 2, #pos do targets[#targets + 1] = pos[i] end
+        return { root = root, mode = "files", targets = targets }
+    end
+    return { root = ".", mode = "files", targets = pos }     -- all positionals are files under .
+end
+
+-- ── discovery (walk mode): sorted, regular .lua, no symlink, exclusions ──
+local function discover(root)
+    local out, seen = {}, {}
+    for _, p in ipairs(tool.find_files(root, "*.lua")) do    -- already sorted/regular/no-symlink
+        local n = normalize(p)
+        if not excluded(n) and not seen[n] then
+            seen[n] = true; out[#out + 1] = n
+        end
+    end
+    table.sort(out)
+    return out
+end
+
+-- ── analyze one readable Lua file: returns (state, diagnostics[]) ──
+local function analyze_source(path, src)
+    local unit, err = lua.parse(src, { path = path, limits = LIMITS })
+    if unit == nil then                                      -- (nil, err): API/internal failure
+        local msg = (type(err) == "table" and err.message) or tostring(err)
+        local code = (type(err) == "table" and err.code) or "lua.internal"
+        return "internal", { { code = code, message = msg } }
+    end
+    local diags, has_limit, has_internal = {}, false, false
+    for _, d in ipairs(unit.diagnostics) do
+        local code = d.code or ""
+        if code:find("^lua%.limit%.") then has_limit = true
+        elseif code == "lua.internal" then has_internal = true end
+        local line, col
+        if d.range then line, col = unit:line_col(d.range) end
+        diags[#diags + 1] = {
+            code = code, message = d.message or "",
+            range = d.range and { start = d.range.start, stop = d.range.stop } or nil,
+            line = line, col = col,
+        }
+    end
+    local state = has_internal and "internal" or (has_limit and "incomplete") or "complete"
+    return state, diags
+end
+
+-- ── build the result set: files[] + diagnostics[] + summary ──
+local function run()
+    local o = parse_args()
+    if o.help then
+        tool.stdout("usage: hull analyze [app_dir] [files...] [--json] [--quiet]\n" ..
+            "  static syntax analysis of an app's Lua source (parses, never runs).\n")
+        tool.exit(0)
+    end
+    local inp = resolve_inputs(o)
+    local root_norm = normalize(inp.root)
+
+    -- Collect { path, state, diags[] } records. A file with a target error carries an
+    -- analyze.* diagnostic and state "internal"; a readable Lua file is parsed.
+    local files, diagnostics = {}, {}
+
+    local function record(path, state, diags)
+        files[#files + 1] = { path = path, state = state }
+        for _, d in ipairs(diags) do
+            d.path = path; d.severity = "error"; d.state = state
+            diagnostics[#diagnostics + 1] = d
+        end
+    end
+    local function target_error(path, code, message)
+        record(path, "internal", { { code = code, message = message } })
+    end
+
+    if inp.mode == "walk" then
+        local paths = discover(inp.root)
+        for _, path in ipairs(paths) do
+            local src = tool.read_file(path)
+            if not src then                                  -- fail closed: never a silent skip
+                target_error(path, "analyze.unreadable", "cannot read file")
+            else
+                record(path, analyze_source(path, src))
+            end
+        end
+    else                                                     -- explicit files
+        local seen = {}
+        for _, raw in ipairs(inp.targets) do
+            local path = normalize(join(inp.root, raw))
+            if seen[path] then goto continue end
+            seen[path] = true
+            if not inside_root(root_norm, path) then
+                target_error(path, "analyze.outside_root", "path is outside the app root")
+            else
+                local kind = tool.path_kind(path)
+                if kind == nil then
+                    target_error(path, "analyze.not_found", "no such file")
+                elseif kind ~= "file" then
+                    target_error(path, "analyze.not_regular", "not a regular file (" .. kind .. ")")
+                elseif not ends_lua(path) then
+                    target_error(path, "analyze.not_lua", "not a Lua (.lua) file")
+                else
+                    local src = tool.read_file(path)
+                    if not src then
+                        target_error(path, "analyze.unreadable", "cannot read file")
+                    else
+                        record(path, analyze_source(path, src))
+                    end
+                end
+            end
+            ::continue::
+        end
+    end
+
+    -- deterministic ordering
+    table.sort(files, function(a, b) return a.path < b.path end)
+    table.sort(diagnostics, function(a, b)
+        if a.path ~= b.path then return a.path < b.path end
+        local as, bs = (a.range and a.range.start) or 0, (b.range and b.range.start) or 0
+        if as ~= bs then return as < bs end
+        return a.code < b.code
+    end)
+
+    -- summary
+    local errors, incomplete, internal, with_issues = 0, 0, 0, 0
+    local seen_issue = {}
+    for _, f in ipairs(files) do
+        if f.state == "incomplete" then incomplete = incomplete + 1 end
+        if f.state == "internal" then internal = internal + 1 end
+    end
+    for _, d in ipairs(diagnostics) do
+        errors = errors + 1
+        if not seen_issue[d.path] then seen_issue[d.path] = true; with_issues = with_issues + 1 end
+    end
+    local clean = (errors == 0 and incomplete == 0 and internal == 0)
+
+    return o, inp, root_norm, files, diagnostics, {
+        errors = errors, files_with_issues = with_issues,
+        incomplete = incomplete, internal = internal, clean = clean,
+    }
+end
+
+-- ── output (real output on STDOUT via tool.stdout; print is routed to stderr) ──
+local function emit_json(root_norm, files, diagnostics, summary)
+    tool.stdout(json.encode({
+        schema_version = 1,
+        root = (root_norm == "") and "." or root_norm,
+        files_scanned = #files,
+        files = files,
+        diagnostics = diagnostics,
+        summary = summary,
+    }) .. "\n")
+end
+
+local function emit_human(o, files, diagnostics, summary)
+    local out = {}
+    for _, d in ipairs(diagnostics) do
+        local pos = (d.line and d.col) and (d.line .. ":" .. d.col) or "?:?"
+        out[#out + 1] = string.format("%s:%s: %s: %s [%s]", d.path, pos, d.severity, d.message, d.code)
+    end
+    if not o.quiet then                                      -- --quiet drops the summary chatter
+        if summary.clean then
+            out[#out + 1] = string.format("hull analyze: no issues (%d files scanned)", #files)
+        else
+            local parts = { summary.errors .. " error" .. (summary.errors == 1 and "" or "s") ..
+                            " in " .. summary.files_with_issues .. " file" ..
+                            (summary.files_with_issues == 1 and "" or "s") }
+            if summary.incomplete > 0 then parts[#parts + 1] = summary.incomplete .. " incomplete" end
+            if summary.internal > 0 then parts[#parts + 1] = summary.internal .. " internal" end
+            if #diagnostics > 0 then out[#out + 1] = "" end
+            out[#out + 1] = string.format("hull analyze: %s (%d files scanned)",
+                table.concat(parts, ", "), #files)
+        end
+    end
+    if #out > 0 then tool.stdout(table.concat(out, "\n") .. "\n") end
+end
+
+local o, _, root_norm, files, diagnostics, summary = run()
+if o.json then
+    emit_json(root_norm, files, diagnostics, summary)        -- JSON overrides --quiet; stdout is pure JSON
+else
+    emit_human(o, files, diagnostics, summary)
+end
+tool.exit(summary.clean and 0 or 1)

--- a/tests/e2e_analyze.sh
+++ b/tests/e2e_analyze.sh
@@ -1,0 +1,130 @@
+#!/bin/sh
+# E2E tests — `hull analyze` (static Lua source syntax analysis)
+#
+# Usage: sh tests/e2e_analyze.sh
+# Requires: build/hull already built
+#
+# Fixtures are built in a TMPDIR (self-contained; keeps intentionally-broken .lua out
+# of the repo / the conformance corpus). Covers: deterministic ordering, syntax error
+# in a NON-entry module, explicit-file target errors, directory exclusions, JSON
+# purity + schema, --quiet, and all three exit codes.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -e
+
+HULL=./build/hull
+PASS=0
+FAIL=0
+
+if [ ! -x "$HULL" ]; then
+    echo "e2e-analyze: hull binary not found at $HULL — run 'make' first"
+    exit 1
+fi
+
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+echo ""
+echo "=== E2E: hull analyze ==="
+
+# ── a clean modular app ───────────────────────────────────────────────
+APP="$TMP/clean"
+mkdir -p "$APP/routes" "$APP/lib"
+printf 'app.manifest({ modules = {} })\napp.main(function() return 0 end)\n' > "$APP/app.lua"
+printf 'local M = {}\nfunction M.register(app) app.get("/u", function(req, res) res:json({ ok = true }) end) end\nreturn M\n' > "$APP/routes/users.lua"
+printf 'local M = {}\nfunction M.add(a, b) return a + b end\nreturn M\n' > "$APP/lib/util.lua"
+
+# ── a broken app: a syntax error in a NON-entry module ────────────────
+BROKEN="$TMP/broken"
+cp -r "$APP" "$BROKEN"
+printf 'local M = {}\nfunction M.oops() return { ok = ) end\nreturn M\n' > "$BROKEN/routes/bad.lua"
+
+# ── Test 1: clean app → exit 0, "no issues", stdout only ──────────────
+rc=0; out=$("$HULL" analyze "$APP" 2>/dev/null) || rc=$?
+if [ "$rc" = "0" ] && echo "$out" | grep -q "no issues"; then
+    pass "clean app → exit 0 + no issues"
+else
+    fail "clean app (rc=$rc, out=$out)"
+fi
+
+# ── Test 2: syntax error in non-entry module → exit 1 + located ───────
+rc=0; out=$("$HULL" analyze "$BROKEN" 2>/dev/null) || rc=$?
+if [ "$rc" = "1" ] && echo "$out" | grep -q "routes/bad.lua:2:" && echo "$out" | grep -q "lua.syntax"; then
+    pass "broken non-entry module → exit 1 + path:line + lua.syntax"
+else
+    fail "broken app (rc=$rc, out=$out)"
+fi
+
+# ── Test 3: deterministic ordering (two --json runs are byte-identical) ─
+# (a broken app exits 1; guard the substitutions so `set -e` does not abort)
+a=$("$HULL" analyze "$BROKEN" --json 2>/dev/null) || true
+b=$("$HULL" analyze "$BROKEN" --json 2>/dev/null) || true
+if [ "$a" = "$b" ] && [ -n "$a" ]; then pass "deterministic --json output"; else fail "non-deterministic --json"; fi
+
+# ── Test 4: JSON purity + schema ──────────────────────────────────────
+"$HULL" analyze "$BROKEN" --json 2>/dev/null > "$TMP/j.txt" || true
+lines=$(wc -l < "$TMP/j.txt" | tr -d ' ')
+first=$(head -c1 "$TMP/j.txt")
+last=$(tail -c2 "$TMP/j.txt" | head -c1)
+if [ "$lines" = "1" ] && [ "$first" = "{" ] && [ "$last" = "}" ] \
+   && grep -q '"schema_version":1' "$TMP/j.txt" \
+   && grep -q '"root":' "$TMP/j.txt" \
+   && grep -q '"code":"lua.syntax"' "$TMP/j.txt" \
+   && grep -q '"files_scanned":' "$TMP/j.txt" \
+   && grep -q '"summary":' "$TMP/j.txt"; then
+    pass "JSON stdout pure (1 line, {…}) + schema_version 1 + required keys"
+else
+    fail "JSON purity/schema (lines=$lines first=$first last=$last)"
+fi
+
+# ── Test 5: explicit target errors (never silent skips) ───────────────
+printf 'not lua\n' > "$BROKEN/note.txt"
+rc=0; out=$("$HULL" analyze "$BROKEN" nope.lua note.txt ../outside.lua 2>/dev/null) || rc=$?
+if [ "$rc" = "1" ] \
+   && echo "$out" | grep -q "analyze.not_found" \
+   && echo "$out" | grep -q "analyze.not_lua" \
+   && echo "$out" | grep -q "analyze.outside_root"; then
+    pass "explicit targets → not_found / not_lua / outside_root, exit 1"
+else
+    fail "explicit target errors (rc=$rc, out=$out)"
+fi
+
+# ── Test 6: exclusions (build/, site/build/, vendor/, .git/ not scanned) ─
+EXC="$TMP/exc"
+mkdir -p "$EXC/build" "$EXC/site/build" "$EXC/vendor" "$EXC/.git"
+printf 'app.main(function() return 0 end)\n' > "$EXC/app.lua"
+for d in build site/build vendor .git; do
+    printf 'this is ) not valid lua\n' > "$EXC/$d/gen.lua"
+done
+rc=0; out=$("$HULL" analyze "$EXC" 2>/dev/null) || rc=$?
+if [ "$rc" = "0" ] && echo "$out" | grep -q "no issues"; then
+    pass "excluded dirs (build/site-build/vendor/.git) not scanned → exit 0"
+else
+    fail "exclusions (rc=$rc, out=$out)"
+fi
+
+# ── Test 7: --quiet (clean → empty stdout; broken → diagnostics only) ──
+qc=$("$HULL" analyze "$APP" --quiet 2>/dev/null || true)
+qb=$("$HULL" analyze "$BROKEN" --quiet 2>/dev/null || true)
+if [ -z "$qc" ] && echo "$qb" | grep -q "lua.syntax" && ! echo "$qb" | grep -q "hull analyze:"; then
+    pass "--quiet: clean silent, broken shows diagnostics without the summary"
+else
+    fail "--quiet (qc=[$qc])"
+fi
+
+# ── Test 8: exit code 2 (usage error) → empty stdout, message on stderr ─
+rc=0; out=$("$HULL" analyze --bogus 2>"$TMP/err.txt") || rc=$?
+if [ "$rc" = "2" ] && [ -z "$out" ] && grep -q "unknown flag" "$TMP/err.txt"; then
+    pass "unknown flag → exit 2, empty stdout, stderr message"
+else
+    fail "usage error (rc=$rc, out=[$out])"
+fi
+
+# ── summary ───────────────────────────────────────────────────────────
+echo ""
+echo "=== hull analyze E2E: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Step **C** of the post-build-plan roadmap: `hull analyze`, the **first production consumer** of the `hull.source.lua` layer — a static analyzer that parses an app's whole Lua tree and reports syntax diagnostics **without running or building it**. Catches a syntax error in a non-entry module (`routes/users.lua`) statically, instead of only when it's first `require`d at runtime.

Design + locked contract: `docs/hull_analyze_design.md`.

## Surface
`hull analyze [app_dir] [files...] [--json] [--quiet]` — exit `0` clean / `1` not clean / `2` usage.
- **Positional rule**: first positional is `app_dir` only if it stat's as a directory; otherwise all positionals are files under `.`.
- **Discovery**: deterministic + bounded — `find_files` gives sorted / regular-only / no-symlink; a `{.git,.hull,build,vendor,node_modules}` segment filter covers `site/build`.
- **Explicit files**: validated + de-duplicated + kept inside the root; `analyze.not_found/not_regular/not_lua/unreadable/outside_root` are reported (never silent skips).
- **Full `parse()` boundary**: three-state `complete | incomplete | internal`; `lua.limit.*`, `lua.internal`, and `(nil, err)` all fail exit 1 (never silently "clean").
- **Output**: versioned JSON (`schema_version: 1`) with **pure stdout**; `--quiet` drops the human summary; JSON overrides `--quiet`; operational failures go to stderr.

## Architecture
- C: `analyze.{c,h}` → `hull_tool("hull.source.analyze")` (named to avoid the existing `hull.analyze` = `hull modules analyze`); one dispatch row + one help line; no build-flag gate.
- Lua: `stdlib/cli/lua/hull/source/analyze.lua` over the shipped source layer.
- Two small `mod_tool.c` bindings: `tool.path_kind` (stat-based dir/file detection; `file_exists` is `access(F_OK)` only) and `tool.stdout` (Hull routes `print` to stderr, so DATA output needs a pure-stdout channel).

## Tests
`tests/e2e_analyze.sh` (`make e2e-analyze`), 8 cases: clean, syntax error in a non-entry module, deterministic `--json`, JSON purity + schema, explicit target errors, directory exclusions, `--quiet`, exit code 2. Fixtures built in TMPDIR (kept out of the conformance corpus).

Full unit suite **76/76**; e2e **8/8**; conformance **520 over 225 files** (`analyze.lua` itself parses clean); luacheck clean; full `hull` build OK.
