### PR TITLE
fix(analyze): canonical containment, traversal-pruned exclusions, honest target errors

### DIFF
--- a/docs/hull_analyze_design.md
+++ b/docs/hull_analyze_design.md
@@ -83,6 +83,17 @@ top-level `build/` and `site/build/`), plus a cheap post-filter belt. The result
 sorted, de-duplicated list of regular `.lua` files. If the root is not a readable
 directory, that is a discovery failure (exit 2), not an empty scan.
 
+**Fail closed (no silent degradation).** `tool.find_files` returns `(files, err)`; any
+allocation or traversal failure in the C walk — or a failure to build the exclusion
+list — propagates as `err` (never a partial or UNPRUNED result masquerading as
+success), and `analyze` turns it into an operational failure (exit 2). The C side
+mirrors this: `find_files_recurse` returns `-1` on any `strdup`/`realloc` failure,
+`hl_tool_find_files_ex` frees and returns `NULL` on that `-1` (and on a failed final
+grow — the old `final = results` fallback wrote one past the array), and
+`l_tool_find_files` fails closed if `exclude_dirs` was requested but could not be
+built. Likewise, **root canonicalization failure is operational (exit 2), never a
+fallback to lexical containment** (which would let a symlink escape the root).
+
 ## 4. What it does (pipeline)
 
 1. **Resolve inputs** (positional rule, §3). Walk mode → filtered `tool.find_files`.

--- a/docs/hull_analyze_design.md
+++ b/docs/hull_analyze_design.md
@@ -53,9 +53,12 @@ app root is `.` and ALL positionals are explicit files relative to `.`. So:
 
 **Flags.**
 - `--json` → machine output (one JSON object on stdout, §6).
-- `--quiet` → human-mode only: suppress the per-file "ok" chatter, print diagnostics +
-  summary. In `--json` mode `--quiet` is a **no-op** (JSON overrides it; stdout stays
-  pure JSON) — documented, not an error.
+- `--quiet` → human-mode only: suppress the summary chatter, print diagnostics. In
+  `--json` mode `--quiet` is a **no-op** (JSON overrides it; stdout stays pure JSON) —
+  documented, not an error.
+- `--max-depth=N` → cap parse nesting (default 2000); a deeper file is reported
+  `incomplete`. A knob for the rare huge/generated file and for controlled testing of
+  the incomplete state (the first of the §10 `--max-*` knobs).
 
 **Exit codes.**
 - `0` — analysis ran to completion on every input and found **zero** diagnostics.
@@ -69,13 +72,15 @@ app root is `.` and ALL positionals are explicit files relative to `.`. So:
 
 ## Discovery (walk mode) — deterministic + bounded
 
-`tool.find_files(root, "*.lua")` already returns **sorted**, **regular-file-only**,
-**no-symlink-traversal** results (it `lstat`s each entry and never descends a
-symlinked dir) and skips dotdirs (`.git`, `.hull`), `node_modules`, and `vendor`.
-`analyze` adds a Lua post-filter dropping any path with a segment in the explicit
-exclusion set `{.git, .hull, build, vendor, node_modules}` — the `build` segment
-covers both top-level `build/` and `site/build/`. The result is a sorted, de-duplicated
-list of regular `.lua` files under the root. If the root itself is not a readable
+`tool.find_files(root, "*.lua", { exclude_dirs = {...} })` returns **sorted**,
+**regular-file-only**, **no-symlink-traversal** results (it `lstat`s each entry and
+never descends a symlinked dir), skips dotdirs (`.git`, `.hull`), `node_modules`, and
+`vendor` — and, via the new `exclude_dirs` option, **prunes the excluded set DURING
+traversal** so a large `build/` (or `vendor/`, `node_modules/`) tree is never walked
+(post-filtering alone would still traverse it). `analyze` passes
+`{.git, .hull, build, vendor, node_modules}` (the `build` segment covers both
+top-level `build/` and `site/build/`), plus a cheap post-filter belt. The result is a
+sorted, de-duplicated list of regular `.lua` files. If the root is not a readable
 directory, that is a discovery failure (exit 2), not an empty scan.
 
 ## 4. What it does (pipeline)
@@ -90,13 +95,25 @@ directory, that is a discovery failure (exit 2), not an empty scan.
    diagnostic reports `line/col = null`.
 4. **Aggregate + report** (human or JSON), set the exit code.
 
-**Explicit-target validation (no silent skips).** For each explicit file, `analyze`
-resolves it under the app root and emits a per-target error diagnostic (not a skip)
-for any of: **outside the root** (`analyze.outside_root`), **missing**
-(`analyze.not_found`), **not a regular file** (`analyze.not_regular`, e.g. a directory
-or device via `tool.path_kind`), **unreadable** (`analyze.unreadable`), or **not
-`.lua`** (`analyze.not_lua`). Each marks that target's analysis state `internal` and
-drives exit 1. Duplicated paths (after normalization) are analyzed once.
+**Explicit-target validation (no silent skips, CANONICAL containment).** Containment
+is checked on the **canonical** path (`tool.realpath`, symlinks resolved), NOT the
+lexical spelling — a symlink whose spelling is inside the root but which resolves
+OUTSIDE must be rejected (a lexical check would let it through while `path_kind`
+follows the link). The root and each target are canonicalized for the containment
+comparison; the user-facing **logical** path is preserved for diagnostics; dedup is by
+canonical path (two spellings of one file → analyzed once). Symlinked app roots/files
+are thus intentionally supported (they canonicalize to their target). The containment
+prefix handles the `/` root correctly (prefix `/`, not `//`). For each target,
+`analyze` emits a per-target error diagnostic (never a skip), in order:
+- `tool.realpath` fails → **missing** (`analyze.not_found`, `errno` ENOENT/ENOTDIR) vs
+  **inaccessible** (`analyze.unreadable`, EACCES) — distinguished honestly, not
+  collapsed;
+- canonical target not under the canonical root → `analyze.outside_root`;
+- not a regular file (`tool.path_kind` on the resolved path is `dir`/`other`) →
+  `analyze.not_regular`;
+- logical name not `.lua` → `analyze.not_lua`;
+- read fails despite being a regular file → `analyze.unreadable`.
+Each marks that target's analysis state `internal` and drives exit 1.
 
 `lua.parse` never raises and returns diagnostics as data, so `analyze` is pure glue +
 formatting over the already-conformance-tested layer.
@@ -218,21 +235,24 @@ same as `hull build` / `hull init` / `hull deploy`):
   already embedded in the platform VFS (under `stdlib/cli/lua/hull/source/`), so the
   tool VM `require`s it with no new wiring. (Verify at implementation:
   `require("hull.source.lua")` resolves in the tool VM.)
-- **Two new tool bindings** (both small, in `src/hull/runtime/lua/mod_tool.c`):
-  - `tool.path_kind(path)` → `"dir" | "file" | "other" | nil` (via `stat`, missing →
-    nil). Needed for the positional rule (§3) and explicit-target regular-file checks
-    (§4); `file_exists` is `access(F_OK)` and cannot distinguish a directory.
-    Discovery still uses `find_files` (which `lstat`s and excludes symlinks);
-    `path_kind` `stat`s (follows) because an explicitly-named root/target may
-    legitimately be a symlink.
+- **Three small tool bindings** (in `src/hull/runtime/lua/mod_tool.c`) + a
+  `find_files` option:
+  - `tool.path_kind(path)` → `"dir" | "file" | "other" | nil` (via `stat`). For the
+    positional rule (§3) and the regular-file check on a resolved target (§4).
+  - `tool.realpath(path)` → canonical absolute path, or `(nil, "missing"|"denied"|
+    "error")` from `errno`. The canonicalization + missing-vs-inaccessible oracle for
+    explicit-target containment (§4).
   - `tool.stdout(str)` → write verbatim to **stdout** (and flush). Hull routes `print`
-    to **stderr** in every Lua VM (`hl_lua_print`), so a command whose primary output
-    is DATA needs an explicit stdout channel to satisfy JSON purity (§6). `analyze`'s
-    real output (human diagnostics + JSON) goes through `tool.stdout`; `print` /
-    `tool.stderr` carry only operational messages.
+    to **stderr** in every Lua VM (`hl_lua_print`), so DATA output needs an explicit
+    stdout channel for JSON purity (§6).
+  - `tool.find_files(dir, pattern, { exclude_dirs = {...} })` — the `exclude_dirs`
+    option prunes those directory names during traversal (`cap/tool.c`
+    `should_skip_dir`/`find_files_recurse` thread a NULL-terminated list), so discovery
+    is bounded by the exclusion policy, not merely post-filtered.
 
-Net new C surface: the ~15-line dispatcher + one table row + one help line + the two
-small `tool.*` bindings. Everything else is Lua over the shipped layer.
+Net new C surface: the ~15-line dispatcher + one table row + one help line + the three
+small `tool.*` bindings + the `find_files` `exclude_dirs` thread. Everything else is
+Lua over the shipped layer.
 
 ## 9. Testing
 
@@ -242,27 +262,33 @@ formatting + exit codes, best covered end to end via **`tests/e2e_analyze.sh`**
 and deliberately NOT committed — an intentionally-broken `.lua` under `tests/fixtures/`
 would otherwise enter the conformance corpus). Required cases:
 
+15 cases, all passing:
 - **Clean app** → exit 0, "no issues".
 - **Syntax error in a NON-entry module** (`routes/*.lua`) → exit 1; the error's
   path/line/col/code present in BOTH human and `--json` output (proves whole-tree
   discovery, not just the entry).
-- **Deterministic ordering** → the diagnostics/files order is identical across two
-  runs and matches the documented sort.
-- **Explicit files**: a valid file (analyzed), a **missing** file, an **unreadable**
-  file, a **non-Lua** file, and a path **outside the root** → each yields its
-  `analyze.*` diagnostic (never a silent skip) and exit 1.
-- **Exclusions**: a `.lua` planted under `build/` (and `site/build/`, `vendor/`,
-  `.git/`) is NOT scanned; one outside the excluded dirs IS.
-- **JSON purity + schema**: `--json` stdout parses as one object, matches
-  `schema_version: 1` with all required keys, and carries NO non-JSON bytes; a usage
-  error (exit 2) writes to stderr with EMPTY stdout.
-- **Quiet**: `--quiet` suppresses human "ok" chatter but still prints diagnostics; with
-  `--json` it is a no-op (stdout stays pure JSON).
-- **All three exit codes** exercised (0 clean, 1 diagnostics/targets, 2 usage/discovery
-  failure such as a non-existent app root).
+- **Deterministic ordering** → two `--json` runs are byte-identical.
+- **JSON purity + schema** → `--json` stdout is one object, `schema_version: 1` with
+  all required keys, no non-JSON bytes.
+- **Explicit target errors** → **missing** (`not_found`), **non-Lua** (`not_lua`),
+  **non-regular** (a directory → `not_regular`), and **unreadable** (chmod 000, EXISTS)
+  vs **missing** as DISTINCT codes (skipped as root, where perms are bypassed).
+- **Duplicate explicit targets** → analyzed once.
+- **Symlink inside the app pointing OUTSIDE** → rejected by canonical containment
+  (exit 1, an `analyze.*` error, the outside file's content NOT followed).
+- **Symlinked app ROOT** → supported (resolved, analyzed).
+- **Exclusions pruned during traversal** → broken `.lua` under `build/`, `site/build/`,
+  `vendor/`, `.git/`, `.hull/`, `node_modules/` is NOT scanned (exit 0).
+- **`--quiet`** → clean silent; broken shows diagnostics without the summary.
+- **`--json --quiet`** → JSON overrides quiet, stdout stays pure JSON.
+- **Incomplete state** → a `--max-depth=5` limit trip yields JSON `state: "incomplete"`
+  + `lua.limit.max_depth` + exit 1 (the same non-`complete` path an `internal` state
+  takes).
+- **Exit code 2** → unknown flag, empty stdout, stderr message.
 
-The pure aggregation/format/sort helpers may additionally be factored into functions
-unit-tested via the vanilla-`lua_State` harness style if the e2e proves too coarse.
+Fixtures are TMPDIR-built (self-contained; keeps broken `.lua` out of the conformance
+corpus). The pure aggregation/format/sort helpers may additionally be unit-tested via
+the vanilla-`lua_State` harness if the e2e proves too coarse.
 
 ## 10. Extension path (documented, NOT v1)
 

--- a/docs/hull_analyze_design.md
+++ b/docs/hull_analyze_design.md
@@ -84,9 +84,14 @@ sorted, de-duplicated list of regular `.lua` files. If the root is not a readabl
 directory, that is a discovery failure (exit 2), not an empty scan.
 
 **Fail closed (no silent degradation).** `tool.find_files` returns `(files, err)`; any
-allocation or traversal failure in the C walk — or a failure to build the exclusion
-list — propagates as `err` (never a partial or UNPRUNED result masquerading as
-success), and `analyze` turns it into an operational failure (exit 2). The C side
+allocation or **filesystem traversal** failure in the C walk — or a failure to build
+the exclusion list — propagates as `err` (never a partial or UNPRUNED result
+masquerading as success), and `analyze` turns it into an operational failure (exit 2).
+Traversal failures are classified: `opendir`/`lstat` returning **`ENOENT`** (a dir or
+entry that does not exist / raced away between `readdir` and use) is an
+explicitly-classified benign skip; **any other** `opendir`/`lstat` failure (notably
+`EACCES` — an unreadable directory, at the root or nested) and a **`readdir` error**
+(distinguished from end-of-dir via `errno`) propagate `-1`. The C side
 mirrors this: `find_files_recurse` returns `-1` on any `strdup`/`realloc` failure,
 `hl_tool_find_files_ex` frees and returns `NULL` on that `-1` (and on a failed final
 grow — the old `final = results` fallback wrote one past the array), and

--- a/include/hull/cap/tool.h
+++ b/include/hull/cap/tool.h
@@ -165,10 +165,15 @@ char **hl_tool_find_files(const char *dir, const char *pattern,
  * `static/vendor/htmx.min.js` is a legitimate vendored asset that
  * MUST be embedded. node_modules / dotfiles are still skipped
  * unconditionally (no legitimate reason to recurse into them).
+ *
+ * `extra`: an optional NULL-terminated list of directory names to
+ * prune DURING traversal (in addition to the built-in skips), or NULL.
+ * Lets a caller bound discovery by its own exclusion policy (e.g.
+ * `hull analyze` excluding `build/`) without walking the excluded tree.
  */
 char **hl_tool_find_files_ex(const char *dir, const char *pattern,
                              const HlToolUnveilCtx *ctx,
-                             int include_vendor);
+                             int include_vendor, const char *const *extra);
 
 /*
  * Copy a file (binary-safe).

--- a/src/hull/cap/tool.c
+++ b/src/hull/cap/tool.c
@@ -713,25 +713,31 @@ char *hl_tool_spawn_read(const char *const argv[], size_t *out_len)
  * vendor-skip default (which is correct for source walks but
  * wrong for `static/vendor/`, where apps legitimately put
  * vendored CSS/JS that must be embedded). */
-static int should_skip_dir(const char *name, int include_vendor)
+/* `extra`: an optional NULL-terminated list of directory names to prune DURING
+ * traversal (in addition to the built-in dot/vendor/node_modules skips), so a large
+ * excluded tree (e.g. build/) is never walked. */
+static int should_skip_dir(const char *name, int include_vendor,
+                           const char *const *extra)
 {
     if (name[0] == '.') return 1;
     if (strcmp(name, "node_modules") == 0) return 1;
     if (!include_vendor && strcmp(name, "vendor") == 0) return 1;
+    for (const char *const *e = extra; e && *e; e++)
+        if (strcmp(name, *e) == 0) return 1;
     return 0;
 }
 
 /* Recursive helper for find_files */
 static int find_files_recurse(const char *dir, const char *pattern,
                                char ***results, size_t *count, size_t *cap,
-                               int include_vendor)
+                               int include_vendor, const char *const *extra)
 {
     DIR *d = opendir(dir);
     if (!d) return 0; /* skip unreadable dirs */
 
     struct dirent *ent;
     while ((ent = readdir(d)) != NULL) {
-        if (should_skip_dir(ent->d_name, include_vendor)) continue;
+        if (should_skip_dir(ent->d_name, include_vendor, extra)) continue;
 
         /* Build full path */
         size_t dlen = strlen(dir);
@@ -747,7 +753,7 @@ static int find_files_recurse(const char *dir, const char *pattern,
 
         if (S_ISDIR(st.st_mode)) {
             find_files_recurse(path, pattern, results, count, cap,
-                               include_vendor);
+                               include_vendor, extra);
         } else if (S_ISREG(st.st_mode)) {
             if (fnmatch(pattern, ent->d_name, 0) == 0) {
                 /* Add to results */
@@ -778,7 +784,7 @@ static int str_compare(const void *a, const void *b)
 
 char **hl_tool_find_files_ex(const char *dir, const char *pattern,
                              const HlToolUnveilCtx *ctx,
-                             int include_vendor)
+                             int include_vendor, const char *const *extra)
 {
     if (!dir || !pattern) return NULL;
 
@@ -790,7 +796,7 @@ char **hl_tool_find_files_ex(const char *dir, const char *pattern,
     char **results = malloc(cap * sizeof(char *));
     if (!results) return NULL;
 
-    find_files_recurse(dir, pattern, &results, &count, &cap, include_vendor);
+    find_files_recurse(dir, pattern, &results, &count, &cap, include_vendor, extra);
 
     /* Sort alphabetically for deterministic ordering */
     if (count > 1)
@@ -811,7 +817,7 @@ char **hl_tool_find_files(const char *dir, const char *pattern,
      * source walks, where vendor/ is third-party noise). New
      * callers that need vendor included use hl_tool_find_files_ex
      * with include_vendor=1. */
-    return hl_tool_find_files_ex(dir, pattern, ctx, 0);
+    return hl_tool_find_files_ex(dir, pattern, ctx, 0, NULL);
 }
 
 /* ── File copy ─────────────────────────────────────────────────────── */

--- a/src/hull/cap/tool.c
+++ b/src/hull/cap/tool.c
@@ -752,8 +752,13 @@ static int find_files_recurse(const char *dir, const char *pattern,
         if (lstat(path, &st) != 0) continue;
 
         if (S_ISDIR(st.st_mode)) {
-            find_files_recurse(path, pattern, results, count, cap,
-                               include_vendor, extra);
+            /* Propagate an allocation failure from a subdirectory: never return a
+             * partial "success" under memory pressure. */
+            if (find_files_recurse(path, pattern, results, count, cap,
+                                   include_vendor, extra) < 0) {
+                closedir(d);
+                return -1;
+            }
         } else if (S_ISREG(st.st_mode)) {
             if (fnmatch(pattern, ent->d_name, 0) == 0) {
                 /* Add to results */
@@ -765,9 +770,9 @@ static int find_files_recurse(const char *dir, const char *pattern,
                     *results = nr;
                     *cap = newcap;
                 }
-                (*results)[*count] = strdup(path);
-                if ((*results)[*count])
-                    (*count)++;
+                char *dup = strdup(path);
+                if (!dup) { closedir(d); return -1; }   /* fail closed, not a silent drop */
+                (*results)[(*count)++] = dup;
             }
         }
     }
@@ -796,15 +801,27 @@ char **hl_tool_find_files_ex(const char *dir, const char *pattern,
     char **results = malloc(cap * sizeof(char *));
     if (!results) return NULL;
 
-    find_files_recurse(dir, pattern, &results, &count, &cap, include_vendor, extra);
+    /* An allocation failure anywhere in the walk returns NULL (an error), never a
+     * partial or unpruned "success" -- callers must fail closed on NULL. */
+    if (find_files_recurse(dir, pattern, &results, &count, &cap,
+                           include_vendor, extra) < 0) {
+        for (size_t i = 0; i < count; i++) free(results[i]);
+        free(results);
+        return NULL;
+    }
 
     /* Sort alphabetically for deterministic ordering */
     if (count > 1)
         qsort(results, count, sizeof(char *), str_compare);
 
-    /* NULL-terminate */
+    /* NULL-terminate (a failed grow here would leave the array one short, so the
+     * old `final = results` fallback wrote past its end -- treat it as an error). */
     char **final = realloc(results, (count + 1) * sizeof(char *));
-    if (!final) final = results;
+    if (!final) {
+        for (size_t i = 0; i < count; i++) free(results[i]);
+        free(results);
+        return NULL;
+    }
     final[count] = NULL;
 
     return final;

--- a/src/hull/cap/tool.c
+++ b/src/hull/cap/tool.c
@@ -733,10 +733,19 @@ static int find_files_recurse(const char *dir, const char *pattern,
                                int include_vendor, const char *const *extra)
 {
     DIR *d = opendir(dir);
-    if (!d) return 0; /* skip unreadable dirs */
+    if (!d) {
+        /* ENOENT = the directory does not exist / raced away: an explicitly-classified
+         * benign skip (also lets callers probe an optional dir). Any other failure --
+         * notably EACCES (an unreadable dir), at the root or nested -- is a real
+         * traversal error and must fail closed, never a partial "clean" scan. */
+        return (errno == ENOENT) ? 0 : -1;
+    }
 
-    struct dirent *ent;
-    while ((ent = readdir(d)) != NULL) {
+    int rc = 0;
+    for (;;) {
+        errno = 0;
+        struct dirent *ent = readdir(d);
+        if (!ent) break;                    /* end-of-dir (errno 0) OR a readdir error */
         if (should_skip_dir(ent->d_name, include_vendor, extra)) continue;
 
         /* Build full path */
@@ -749,36 +758,39 @@ static int find_files_recurse(const char *dir, const char *pattern,
         if (pn < 0 || (size_t)pn >= sizeof(path)) continue;
 
         struct stat st;
-        if (lstat(path, &st) != 0) continue;
+        if (lstat(path, &st) != 0) {
+            if (errno == ENOENT) continue;  /* entry raced away after readdir: benign */
+            rc = -1; break;                 /* a real lstat failure -> fail closed */
+        }
 
         if (S_ISDIR(st.st_mode)) {
-            /* Propagate an allocation failure from a subdirectory: never return a
-             * partial "success" under memory pressure. */
+            /* Propagate a subdirectory failure (traversal OR allocation): never return
+             * a partial "success". */
             if (find_files_recurse(path, pattern, results, count, cap,
-                                   include_vendor, extra) < 0) {
-                closedir(d);
-                return -1;
-            }
+                                   include_vendor, extra) < 0) { rc = -1; break; }
         } else if (S_ISREG(st.st_mode)) {
             if (fnmatch(pattern, ent->d_name, 0) == 0) {
                 /* Add to results */
                 if (*count >= *cap) {
-                    if (*cap > SIZE_MAX / (2 * sizeof(char *))) { closedir(d); return -1; }
+                    if (*cap > SIZE_MAX / (2 * sizeof(char *))) { rc = -1; break; }
                     size_t newcap = *cap * 2;
                     char **nr = realloc(*results, newcap * sizeof(char *));
-                    if (!nr) { closedir(d); return -1; }
+                    if (!nr) { rc = -1; break; }
                     *results = nr;
                     *cap = newcap;
                 }
                 char *dup = strdup(path);
-                if (!dup) { closedir(d); return -1; }   /* fail closed, not a silent drop */
+                if (!dup) { rc = -1; break; }   /* fail closed, not a silent drop */
                 (*results)[(*count)++] = dup;
             }
         }
     }
+    /* readdir() returns NULL at end-of-dir AND on error; distinguish via errno (reset
+     * before each call above). Only meaningful when the loop ended normally (rc == 0). */
+    if (rc == 0 && errno != 0) rc = -1;
 
     closedir(d);
-    return 0;
+    return rc;
 }
 
 /* String comparison for qsort */

--- a/src/hull/runtime/lua/mod_tool.c
+++ b/src/hull/runtime/lua/mod_tool.c
@@ -203,14 +203,33 @@ static int l_tool_find_files(lua_State *L)
     const char *dir = luaL_checkstring(L, 1);
     const char *pattern = luaL_checkstring(L, 2);
     int include_vendor = 0;
+    char **extra = NULL;                  /* NULL-terminated, C-owned dir names to prune */
     if (lua_type(L, 3) == LUA_TTABLE) {
         lua_getfield(L, 3, "include_vendor");
         include_vendor = lua_toboolean(L, -1);
         lua_pop(L, 1);
+        lua_getfield(L, 3, "exclude_dirs");
+        if (lua_type(L, -1) == LUA_TTABLE) {
+            size_t n = lua_rawlen(L, -1);
+            extra = calloc(n + 1, sizeof(char *));
+            if (extra) {
+                size_t k = 0;
+                for (size_t i = 1; i <= n; i++) {
+                    lua_rawgeti(L, -1, (lua_Integer)i);
+                    const char *s = lua_tostring(L, -1);
+                    if (s) { char *dup = strdup(s); if (dup) extra[k++] = dup; }
+                    lua_pop(L, 1);
+                }
+                extra[k] = NULL;
+            }
+        }
+        lua_pop(L, 1);                    /* pop exclude_dirs (table or nil) */
     }
     HlToolUnveilCtx *ctx = get_unveil_ctx(L);
 
-    char **files = hl_tool_find_files_ex(dir, pattern, ctx, include_vendor);
+    char **files = hl_tool_find_files_ex(dir, pattern, ctx, include_vendor,
+                                         (const char *const *)extra);
+    if (extra) { for (char **e = extra; *e; e++) free(*e); free(extra); }
     if (!files) {
         lua_newtable(L);
         return 1;
@@ -452,6 +471,34 @@ static int l_tool_path_kind(lua_State *L)
     } else {
         lua_pushstring(L, "other");
     }
+    return 1;
+}
+
+/* tool.realpath(path) -> canonical_abs | (nil, "missing"|"denied"|"error").
+ * Resolves symlinks + . / .. to a canonical absolute path. Used by hull analyze to
+ * enforce containment on the REAL location of an explicit target (a symlink whose
+ * spelling is inside the root but which resolves outside must be rejected), and to
+ * distinguish a missing target (ENOENT) from an inaccessible one (EACCES). */
+static int l_tool_realpath(lua_State *L)
+{
+    const char *path = luaL_checkstring(L, 1);
+    HlToolUnveilCtx *ctx = get_unveil_ctx(L);
+
+    if (ctx && hl_tool_unveil_check(ctx, path, 'r') != 0) {
+        lua_pushnil(L);
+        lua_pushstring(L, "denied");
+        return 2;
+    }
+
+    char buf[PATH_MAX];
+    if (realpath(path, buf) == NULL) {
+        int e = errno;
+        lua_pushnil(L);
+        lua_pushstring(L, (e == ENOENT || e == ENOTDIR) ? "missing"
+                          : (e == EACCES ? "denied" : "error"));
+        return 2;
+    }
+    lua_pushstring(L, buf);
     return 1;
 }
 
@@ -1530,6 +1577,7 @@ static const luaL_Reg tool_funcs[] = {
     { "write_file",             l_tool_write_file },
     { "file_exists",            l_tool_file_exists },
     { "path_kind",              l_tool_path_kind },
+    { "realpath",               l_tool_realpath },
     { "file_mtime",             l_tool_file_mtime },
     { "stderr",                 l_tool_stderr },
     { "stdout",                 l_tool_stdout },

--- a/src/hull/runtime/lua/mod_tool.c
+++ b/src/hull/runtime/lua/mod_tool.c
@@ -203,36 +203,54 @@ static int l_tool_find_files(lua_State *L)
     const char *dir = luaL_checkstring(L, 1);
     const char *pattern = luaL_checkstring(L, 2);
     int include_vendor = 0;
-    char **extra = NULL;                  /* NULL-terminated, C-owned dir names to prune */
+    char **extra = NULL;                  /* NULL-terminated (calloc-zeroed), C-owned */
+    int exclude_requested = 0, exclude_ok = 1;
     if (lua_type(L, 3) == LUA_TTABLE) {
         lua_getfield(L, 3, "include_vendor");
         include_vendor = lua_toboolean(L, -1);
         lua_pop(L, 1);
         lua_getfield(L, 3, "exclude_dirs");
         if (lua_type(L, -1) == LUA_TTABLE) {
+            exclude_requested = 1;
             size_t n = lua_rawlen(L, -1);
-            extra = calloc(n + 1, sizeof(char *));
-            if (extra) {
+            extra = calloc(n + 1, sizeof(char *));   /* zeroed -> NULL-terminated at any k */
+            if (!extra) {
+                exclude_ok = 0;
+            } else {
                 size_t k = 0;
                 for (size_t i = 1; i <= n; i++) {
                     lua_rawgeti(L, -1, (lua_Integer)i);
                     const char *s = lua_tostring(L, -1);
-                    if (s) { char *dup = strdup(s); if (dup) extra[k++] = dup; }
                     lua_pop(L, 1);
+                    if (!s) continue;
+                    char *dup = strdup(s);
+                    if (!dup) { exclude_ok = 0; break; }   /* fail closed: no unpruned run */
+                    extra[k++] = dup;
                 }
-                extra[k] = NULL;
             }
         }
         lua_pop(L, 1);                    /* pop exclude_dirs (table or nil) */
     }
+
+    /* Exclusions requested but not buildable -> fail closed rather than run an UNPRUNED
+     * discovery the caller would treat as authoritative. */
+    if (exclude_requested && !exclude_ok) {
+        if (extra) { for (char **e = extra; *e; e++) free(*e); free(extra); }
+        lua_newtable(L);
+        lua_pushstring(L, "find_files: could not build exclusion list (out of memory)");
+        return 2;
+    }
+
     HlToolUnveilCtx *ctx = get_unveil_ctx(L);
 
     char **files = hl_tool_find_files_ex(dir, pattern, ctx, include_vendor,
                                          (const char *const *)extra);
     if (extra) { for (char **e = extra; *e; e++) free(*e); free(extra); }
-    if (!files) {
+
+    if (!files) {                        /* NULL = error (OOM / access denied), NOT empty */
         lua_newtable(L);
-        return 1;
+        lua_pushstring(L, "find_files: discovery failed (out of memory or access denied)");
+        return 2;
     }
 
     lua_newtable(L);

--- a/stdlib/cli/lua/hull/source/analyze.lua
+++ b/stdlib/cli/lua/hull/source/analyze.lua
@@ -71,6 +71,13 @@ local function usage_error(msg)
     tool.exit(2)
 end
 
+-- Operational / discovery failure: exit 2, stderr only (JSON stdout stays pure). Used
+-- to FAIL CLOSED -- never a fallback to lexical containment or a reduced scan.
+local function op_fail(msg)
+    tool.stderr("hull analyze: " .. msg .. "\n")
+    tool.exit(2)
+end
+
 local function parse_args()
     local o = { json = false, quiet = false, positionals = {} }
     for i = 1, #arg do
@@ -105,8 +112,11 @@ end
 local function discover(root)
     -- exclude_dirs prunes DURING traversal (a large build/ tree is never walked);
     -- find_files already returns sorted/regular/no-symlink. excluded() is a belt.
+    -- A discovery error (OOM / access) is an OPERATIONAL failure, not an empty scan.
+    local files, err = tool.find_files(root, "*.lua", { exclude_dirs = EXCLUDE_LIST })
+    if err then op_fail("discovery failed: " .. tostring(err)) end
     local out, seen = {}, {}
-    for _, p in ipairs(tool.find_files(root, "*.lua", { exclude_dirs = EXCLUDE_LIST })) do
+    for _, p in ipairs(files) do
         local n = normalize(p)
         if not excluded(n) and not seen[n] then
             seen[n] = true; out[#out + 1] = n
@@ -184,7 +194,10 @@ local function run()
         -- checked on the REAL location: a symlink whose spelling is inside the root but
         -- which resolves outside must be rejected. The user-facing LOGICAL path is kept
         -- for diagnostics; dedup is by canonical path (or logical when it doesn't resolve).
-        local canon_root = tool.realpath(inp.root) or root_norm
+        -- Root canonicalization failure is an OPERATIONAL error, never a fallback to
+        -- lexical containment (which would let a symlink escape the root).
+        local canon_root = tool.realpath(inp.root)
+        if not canon_root then op_fail("cannot resolve app root: " .. inp.root) end
         local seen = {}
         for _, raw in ipairs(inp.targets) do
             local logical = normalize(join(inp.root, raw))

--- a/stdlib/cli/lua/hull/source/analyze.lua
+++ b/stdlib/cli/lua/hull/source/analyze.lua
@@ -19,9 +19,12 @@ local json = require("hull.json")
 local LIMITS = { max_bytes = 64 * 1024 * 1024, max_tokens = 5000000,
                  max_comments = 5000000, max_depth = 2000 }
 
-local EXCLUDE_SEGMENT = {   -- generated / dependency dirs (build covers site/build)
-    [".git"] = true, [".hull"] = true, build = true, vendor = true, node_modules = true,
-}
+-- generated / dependency dirs (build covers site/build). EXCLUDE_LIST prunes them
+-- DURING traversal (tool.find_files exclude_dirs); EXCLUDE_SEGMENT is a cheap belt on
+-- the returned paths.
+local EXCLUDE_LIST = { ".git", ".hull", "build", "vendor", "node_modules" }
+local EXCLUDE_SEGMENT = {}
+for _, s in ipairs(EXCLUDE_LIST) do EXCLUDE_SEGMENT[s] = true end
 
 -- ── small path helpers (pure Lua; no path-normalize binding in the tool VM) ──
 local function normalize(p)
@@ -44,11 +47,12 @@ local function join(root, rel)
     return root .. "/" .. rel
 end
 
--- Is `target_norm` inside `root_norm`? (root_norm "" means cwd.)
-local function inside_root(root_norm, target_norm)
-    if target_norm == ".." or target_norm:sub(1, 3) == "../" then return false end
-    if root_norm == "" then return target_norm:sub(1, 1) ~= "/" end
-    return target_norm == root_norm or target_norm:sub(1, #root_norm + 1) == root_norm .. "/"
+-- Containment on CANONICAL absolute paths (from tool.realpath, symlinks resolved).
+-- Handles the `/` root correctly (prefix is "/", not "//").
+local function inside_root(canon_root, canon_target)
+    if canon_root == canon_target then return true end
+    local prefix = (canon_root == "/") and "/" or (canon_root .. "/")
+    return canon_target:sub(1, #prefix) == prefix
 end
 
 local function excluded(path)
@@ -74,6 +78,7 @@ local function parse_args()
         if a == "--json" then o.json = true
         elseif a == "--quiet" then o.quiet = true
         elseif a == "-h" or a == "--help" then o.help = true
+        elseif a:match("^%-%-max%-depth=%d+$") then o.max_depth = tonumber(a:match("=(%d+)"))
         elseif a:sub(1, 1) == "-" and a ~= "-" then usage_error("unknown flag: " .. a)
         else o.positionals[#o.positionals + 1] = a end
     end
@@ -98,8 +103,10 @@ end
 
 -- ── discovery (walk mode): sorted, regular .lua, no symlink, exclusions ──
 local function discover(root)
+    -- exclude_dirs prunes DURING traversal (a large build/ tree is never walked);
+    -- find_files already returns sorted/regular/no-symlink. excluded() is a belt.
     local out, seen = {}, {}
-    for _, p in ipairs(tool.find_files(root, "*.lua")) do    -- already sorted/regular/no-symlink
+    for _, p in ipairs(tool.find_files(root, "*.lua", { exclude_dirs = EXCLUDE_LIST })) do
         local n = normalize(p)
         if not excluded(n) and not seen[n] then
             seen[n] = true; out[#out + 1] = n
@@ -138,10 +145,12 @@ end
 local function run()
     local o = parse_args()
     if o.help then
-        tool.stdout("usage: hull analyze [app_dir] [files...] [--json] [--quiet]\n" ..
-            "  static syntax analysis of an app's Lua source (parses, never runs).\n")
+        tool.stdout("usage: hull analyze [app_dir] [files...] [--json] [--quiet] [--max-depth=N]\n" ..
+            "  static syntax analysis of an app's Lua source (parses, never runs).\n" ..
+            "  --max-depth=N   cap parse nesting (default 2000); a deeper file is reported incomplete.\n")
         tool.exit(0)
     end
+    if o.max_depth then LIMITS.max_depth = o.max_depth end   -- controlled low limit (testing / huge files)
     local inp = resolve_inputs(o)
     local root_norm = normalize(inp.root)
 
@@ -171,27 +180,39 @@ local function run()
             end
         end
     else                                                     -- explicit files
+        -- Canonicalize the root and each target (symlinks resolved) so containment is
+        -- checked on the REAL location: a symlink whose spelling is inside the root but
+        -- which resolves outside must be rejected. The user-facing LOGICAL path is kept
+        -- for diagnostics; dedup is by canonical path (or logical when it doesn't resolve).
+        local canon_root = tool.realpath(inp.root) or root_norm
         local seen = {}
         for _, raw in ipairs(inp.targets) do
-            local path = normalize(join(inp.root, raw))
-            if seen[path] then goto continue end
-            seen[path] = true
-            if not inside_root(root_norm, path) then
-                target_error(path, "analyze.outside_root", "path is outside the app root")
-            else
-                local kind = tool.path_kind(path)
-                if kind == nil then
-                    target_error(path, "analyze.not_found", "no such file")
-                elseif kind ~= "file" then
-                    target_error(path, "analyze.not_regular", "not a regular file (" .. kind .. ")")
-                elseif not ends_lua(path) then
-                    target_error(path, "analyze.not_lua", "not a Lua (.lua) file")
+            local logical = normalize(join(inp.root, raw))
+            local canon, reason = tool.realpath(logical)
+            local key = canon or logical
+            if seen[key] then goto continue end
+            seen[key] = true
+            if canon == nil then                             -- distinguish missing vs inaccessible
+                if reason == "missing" then
+                    target_error(logical, "analyze.not_found", "no such file")
                 else
-                    local src = tool.read_file(path)
+                    target_error(logical, "analyze.unreadable",
+                        "cannot access file (" .. tostring(reason) .. ")")
+                end
+            elseif not inside_root(canon_root, canon) then
+                target_error(logical, "analyze.outside_root", "path resolves outside the app root")
+            else
+                local kind = tool.path_kind(canon)           -- canon exists -> dir/file/other
+                if kind ~= "file" then
+                    target_error(logical, "analyze.not_regular", "not a regular file (" .. tostring(kind) .. ")")
+                elseif not ends_lua(logical) then
+                    target_error(logical, "analyze.not_lua", "not a Lua (.lua) file")
+                else
+                    local src = tool.read_file(canon)
                     if not src then
-                        target_error(path, "analyze.unreadable", "cannot read file")
+                        target_error(logical, "analyze.unreadable", "cannot read file")
                     else
-                        record(path, analyze_source(path, src))
+                        record(logical, analyze_source(logical, src))
                     end
                 end
             end

--- a/tests/e2e_analyze.sh
+++ b/tests/e2e_analyze.sh
@@ -5,15 +5,18 @@
 # Requires: build/hull already built
 #
 # Fixtures are built in a TMPDIR (self-contained; keeps intentionally-broken .lua out
-# of the repo / the conformance corpus). Covers: deterministic ordering, syntax error
-# in a NON-entry module, explicit-file target errors, directory exclusions, JSON
-# purity + schema, --quiet, and all three exit codes.
+# of the repo / the conformance corpus). Covers the locked contract: deterministic
+# ordering, syntax error in a NON-entry module, explicit-file target errors (missing /
+# unreadable / non-regular / non-Lua / outside-root), symlink containment (canonical),
+# symlinked app root, duplicate targets, directory exclusions, JSON purity + schema,
+# --quiet, --json overriding --quiet, an incomplete analysis state, and all exit codes.
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 set -e
 
 HULL=./build/hull
+HULL_ABS=$(pwd)/build/hull      # absolute (subtests cd into the TMPDIR)
 PASS=0
 FAIL=0
 
@@ -26,7 +29,7 @@ fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
 pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 
 TMP=$(mktemp -d)
-trap 'rm -rf "$TMP"' EXIT
+trap 'chmod -R u+rwx "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
 
 echo ""
 echo "=== E2E: hull analyze ==="
@@ -47,20 +50,15 @@ printf 'local M = {}\nfunction M.oops() return { ok = ) end\nreturn M\n' > "$BRO
 rc=0; out=$("$HULL" analyze "$APP" 2>/dev/null) || rc=$?
 if [ "$rc" = "0" ] && echo "$out" | grep -q "no issues"; then
     pass "clean app → exit 0 + no issues"
-else
-    fail "clean app (rc=$rc, out=$out)"
-fi
+else fail "clean app (rc=$rc, out=$out)"; fi
 
 # ── Test 2: syntax error in non-entry module → exit 1 + located ───────
 rc=0; out=$("$HULL" analyze "$BROKEN" 2>/dev/null) || rc=$?
 if [ "$rc" = "1" ] && echo "$out" | grep -q "routes/bad.lua:2:" && echo "$out" | grep -q "lua.syntax"; then
     pass "broken non-entry module → exit 1 + path:line + lua.syntax"
-else
-    fail "broken app (rc=$rc, out=$out)"
-fi
+else fail "broken app (rc=$rc, out=$out)"; fi
 
 # ── Test 3: deterministic ordering (two --json runs are byte-identical) ─
-# (a broken app exits 1; guard the substitutions so `set -e` does not abort)
 a=$("$HULL" analyze "$BROKEN" --json 2>/dev/null) || true
 b=$("$HULL" analyze "$BROKEN" --json 2>/dev/null) || true
 if [ "$a" = "$b" ] && [ -n "$a" ]; then pass "deterministic --json output"; else fail "non-deterministic --json"; fi
@@ -68,61 +66,111 @@ if [ "$a" = "$b" ] && [ -n "$a" ]; then pass "deterministic --json output"; else
 # ── Test 4: JSON purity + schema ──────────────────────────────────────
 "$HULL" analyze "$BROKEN" --json 2>/dev/null > "$TMP/j.txt" || true
 lines=$(wc -l < "$TMP/j.txt" | tr -d ' ')
-first=$(head -c1 "$TMP/j.txt")
-last=$(tail -c2 "$TMP/j.txt" | head -c1)
+first=$(head -c1 "$TMP/j.txt"); last=$(tail -c2 "$TMP/j.txt" | head -c1)
 if [ "$lines" = "1" ] && [ "$first" = "{" ] && [ "$last" = "}" ] \
-   && grep -q '"schema_version":1' "$TMP/j.txt" \
-   && grep -q '"root":' "$TMP/j.txt" \
-   && grep -q '"code":"lua.syntax"' "$TMP/j.txt" \
-   && grep -q '"files_scanned":' "$TMP/j.txt" \
+   && grep -q '"schema_version":1' "$TMP/j.txt" && grep -q '"root":' "$TMP/j.txt" \
+   && grep -q '"code":"lua.syntax"' "$TMP/j.txt" && grep -q '"files_scanned":' "$TMP/j.txt" \
    && grep -q '"summary":' "$TMP/j.txt"; then
     pass "JSON stdout pure (1 line, {…}) + schema_version 1 + required keys"
-else
-    fail "JSON purity/schema (lines=$lines first=$first last=$last)"
-fi
+else fail "JSON purity/schema (lines=$lines first=$first last=$last)"; fi
 
-# ── Test 5: explicit target errors (never silent skips) ───────────────
+# ── Test 5: explicit target errors — missing + non-Lua (outside-root is
+# covered by the symlink test 9, since canonical containment reports a
+# non-existent ../path as not_found, honestly, before any containment check) ─
 printf 'not lua\n' > "$BROKEN/note.txt"
-rc=0; out=$("$HULL" analyze "$BROKEN" nope.lua note.txt ../outside.lua 2>/dev/null) || rc=$?
-if [ "$rc" = "1" ] \
-   && echo "$out" | grep -q "analyze.not_found" \
-   && echo "$out" | grep -q "analyze.not_lua" \
-   && echo "$out" | grep -q "analyze.outside_root"; then
-    pass "explicit targets → not_found / not_lua / outside_root, exit 1"
+rc=0; out=$("$HULL" analyze "$BROKEN" nope.lua note.txt 2>/dev/null) || rc=$?
+if [ "$rc" = "1" ] && echo "$out" | grep -q "analyze.not_found" \
+   && echo "$out" | grep -q "analyze.not_lua"; then
+    pass "explicit targets → not_found / not_lua, exit 1"
+else fail "explicit target errors (rc=$rc, out=$out)"; fi
+
+# ── Test 6: non-regular explicit target (a directory) → not_regular ───
+mkdir -p "$APP/adir.lua"
+rc=0; out=$("$HULL" analyze "$APP" adir.lua 2>/dev/null) || rc=$?
+if [ "$rc" = "1" ] && echo "$out" | grep -q "analyze.not_regular"; then
+    pass "non-regular explicit target → analyze.not_regular"
+else fail "non-regular target (rc=$rc, out=$out)"; fi
+rmdir "$APP/adir.lua"
+
+# ── Test 7: unreadable vs missing (skipped as root: perms are bypassed) ─
+if [ "$(id -u)" = "0" ]; then
+    pass "unreadable-vs-missing (skipped: running as root)"
 else
-    fail "explicit target errors (rc=$rc, out=$out)"
+    printf 'x = 1\n' > "$APP/noread.lua"; chmod 000 "$APP/noread.lua"
+    rc=0; out=$("$HULL" analyze "$APP" noread.lua gone.lua 2>/dev/null) || rc=$?
+    if [ "$rc" = "1" ] && echo "$out" | grep -q "noread.lua.*analyze.unreadable" \
+       && echo "$out" | grep -q "gone.lua.*analyze.not_found"; then
+        pass "unreadable (exists, chmod 000) vs missing → distinct codes"
+    else fail "unreadable-vs-missing (rc=$rc, out=$out)"; fi
+    chmod 644 "$APP/noread.lua"; rm -f "$APP/noread.lua"
 fi
 
-# ── Test 6: exclusions (build/, site/build/, vendor/, .git/ not scanned) ─
+# ── Test 8: duplicate explicit targets analyzed once ──────────────────
+n=$("$HULL" analyze "$APP" app.lua app.lua --json 2>/dev/null | grep -o '"files_scanned":[0-9]*') || true
+if [ "$n" = '"files_scanned":1' ]; then pass "duplicate explicit targets analyzed once"; else fail "dedup ($n)"; fi
+
+# ── Test 9: symlink INSIDE the app pointing OUTSIDE is not followed ────
+# outside.lua is VALID lua, so if the symlink were followed the run would be clean;
+# canonical containment must instead reject link.lua (exit 1, an analyze.* error, no
+# lua.syntax leaking from the outside file).
+mkdir -p "$TMP/sym/app"
+printf 'x = 1\n' > "$TMP/sym/outside.lua"
+printf 'app.main(function() return 0 end)\n' > "$TMP/sym/app/app.lua"
+ln -s "$TMP/sym/outside.lua" "$TMP/sym/app/link.lua"
+rc=0; out=$(cd "$TMP/sym" && "$HULL_ABS" analyze app link.lua 2>/dev/null) || rc=$?
+if [ "$rc" = "1" ] && echo "$out" | grep -q "link.lua.*analyze\." && ! echo "$out" | grep -q "link.lua.*lua.syntax"; then
+    pass "symlink inside app → outside is rejected (containment holds), exit 1"
+else fail "symlink containment (rc=$rc, out=$out)"; fi
+
+# ── Test 10: symlinked app ROOT is supported (resolved via realpath) ──
+ln -s "$TMP/sym/app" "$TMP/sym/rootlink"
+rc=0; out=$(cd "$TMP/sym" && "$HULL_ABS" analyze rootlink 2>/dev/null) || rc=$?
+if [ "$rc" = "0" ] && echo "$out" | grep -q "no issues"; then
+    pass "symlinked app root supported → analyzed"
+else fail "symlinked root (rc=$rc, out=$out)"; fi
+
+# ── Test 11: exclusions pruned during traversal (build/site-build/vendor/.git/.hull/node_modules) ─
 EXC="$TMP/exc"
-mkdir -p "$EXC/build" "$EXC/site/build" "$EXC/vendor" "$EXC/.git"
+mkdir -p "$EXC/build" "$EXC/site/build" "$EXC/vendor" "$EXC/.git" "$EXC/.hull" "$EXC/node_modules"
 printf 'app.main(function() return 0 end)\n' > "$EXC/app.lua"
-for d in build site/build vendor .git; do
+for d in build site/build vendor .git .hull node_modules; do
     printf 'this is ) not valid lua\n' > "$EXC/$d/gen.lua"
 done
 rc=0; out=$("$HULL" analyze "$EXC" 2>/dev/null) || rc=$?
 if [ "$rc" = "0" ] && echo "$out" | grep -q "no issues"; then
-    pass "excluded dirs (build/site-build/vendor/.git) not scanned → exit 0"
-else
-    fail "exclusions (rc=$rc, out=$out)"
-fi
+    pass "excluded dirs (build/site-build/vendor/.git/.hull/node_modules) not scanned → exit 0"
+else fail "exclusions (rc=$rc, out=$out)"; fi
 
-# ── Test 7: --quiet (clean → empty stdout; broken → diagnostics only) ──
+# ── Test 12: --quiet (clean → empty stdout; broken → diagnostics only) ─
 qc=$("$HULL" analyze "$APP" --quiet 2>/dev/null || true)
 qb=$("$HULL" analyze "$BROKEN" --quiet 2>/dev/null || true)
 if [ -z "$qc" ] && echo "$qb" | grep -q "lua.syntax" && ! echo "$qb" | grep -q "hull analyze:"; then
     pass "--quiet: clean silent, broken shows diagnostics without the summary"
-else
-    fail "--quiet (qc=[$qc])"
-fi
+else fail "--quiet (qc=[$qc])"; fi
 
-# ── Test 8: exit code 2 (usage error) → empty stdout, message on stderr ─
+# ── Test 13: --json overrides --quiet (stdout stays pure JSON) ─────────
+jq=$("$HULL" analyze "$APP" --json --quiet 2>/dev/null || true)
+if [ -n "$jq" ] && [ "$(printf '%s' "$jq" | head -c1)" = "{" ] && echo "$jq" | grep -q '"schema_version":1'; then
+    pass "--json --quiet → JSON overrides quiet, pure JSON stdout"
+else fail "--json --quiet override (jq=$jq)"; fi
+
+# ── Test 14: incomplete analysis state (a limit trip) in JSON, exit 1 ──
+i=1; parens=""; cparens=""
+while [ $i -le 30 ]; do parens="(${parens}"; cparens="${cparens})"; i=$((i + 1)); done
+printf 'local x = %s1%s\n' "$parens" "$cparens" > "$APP/deep.lua"
+"$HULL" analyze "$APP" deep.lua --max-depth=5 --json 2>/dev/null > "$TMP/deep.json" || true
+rc=0; "$HULL" analyze "$APP" deep.lua --max-depth=5 >/dev/null 2>&1 || rc=$?
+if [ "$rc" = "1" ] && grep -q '"state":"incomplete"' "$TMP/deep.json" \
+   && grep -q '"code":"lua.limit.max_depth"' "$TMP/deep.json" && grep -q '"clean":false' "$TMP/deep.json"; then
+    pass "incomplete state (limit trip) → JSON state=incomplete + exit 1"
+else fail "incomplete state (rc=$rc)"; fi
+rm -f "$APP/deep.lua"
+
+# ── Test 15: exit code 2 (usage error) → empty stdout, message on stderr ─
 rc=0; out=$("$HULL" analyze --bogus 2>"$TMP/err.txt") || rc=$?
 if [ "$rc" = "2" ] && [ -z "$out" ] && grep -q "unknown flag" "$TMP/err.txt"; then
     pass "unknown flag → exit 2, empty stdout, stderr message"
-else
-    fail "usage error (rc=$rc, out=[$out])"
-fi
+else fail "usage error (rc=$rc, out=[$out])"; fi
 
 # ── summary ───────────────────────────────────────────────────────────
 echo ""

--- a/tests/e2e_analyze.sh
+++ b/tests/e2e_analyze.sh
@@ -172,6 +172,22 @@ if [ "$rc" = "2" ] && [ -z "$out" ] && grep -q "unknown flag" "$TMP/err.txt"; th
     pass "unknown flag → exit 2, empty stdout, stderr message"
 else fail "usage error (rc=$rc, out=[$out])"; fi
 
+# ── Test 16: unreadable NON-excluded discovered subdir → fail closed (exit 2) ─
+if [ "$(id -u)" = "0" ]; then
+    pass "unreadable subdir fail-closed (skipped: running as root)"
+else
+    UNR="$TMP/unreadable"
+    mkdir -p "$UNR/sub"
+    printf 'app.main(function() return 0 end)\n' > "$UNR/app.lua"
+    printf 'x = 1\n' > "$UNR/sub/ok.lua"
+    chmod 000 "$UNR/sub"
+    rc=0; out=$("$HULL" analyze "$UNR" 2>"$TMP/unr_err.txt") || rc=$?
+    chmod 755 "$UNR/sub"
+    if [ "$rc" = "2" ] && [ -z "$out" ] && grep -q "discovery failed" "$TMP/unr_err.txt"; then
+        pass "unreadable discovered subdir → exit 2 + discovery failed (fail closed)"
+    else fail "unreadable subdir (rc=$rc, out=[$out], err=$(cat "$TMP/unr_err.txt"))"; fi
+fi
+
 # ── summary ───────────────────────────────────────────────────────────
 echo ""
 echo "=== hull analyze E2E: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
Follow-up to #349 (already merged) addressing the post-merge review: two path-safety issues + missing acceptance coverage on `hull analyze`.

## 1. Canonical containment (was lexical → symlinks could escape)
`inside_root()` compared normalized *spellings*, so an explicit `app/link.lua` symlink pointing outside the app passed containment while `path_kind()` followed it and accepted the external file. Now the root and every explicit target are **canonicalized** via a new `tool.realpath` binding before the comparison; the **logical** path is preserved for diagnostics; dedup is by canonical path. **Symlinked app roots/files are intentionally supported** (they canonicalize to their target). Also fixes the **`/` root** edge (the prefix was `//`, wrongly rejecting targets beneath root `/`).

## 2. Exclusions pruned DURING traversal (were post-filtered)
`tool.find_files` gains an `exclude_dirs` option (`cap/tool.c` threads a NULL-terminated list through `should_skip_dir`/`find_files_recurse`), so a large `build/` (or `vendor/`, `node_modules/`) tree is **never walked**. `analyze` passes `{.git,.hull,build,vendor,node_modules}`.

## 3. Honest missing vs inaccessible
`tool.realpath` returns `(nil, "missing"|"denied")` from `errno`, so a missing target is `analyze.not_found` and an inaccessible/unreadable one is `analyze.unreadable` — no longer collapsed to `not_found` by `path_kind`'s `nil`.

## Coverage
Adds `--max-depth=N` (first of the planned `--max-*` knobs) to enable a controlled **incomplete-state** test. E2E expanded to **15 cases**: symlink-inside→outside rejected, symlinked app root supported, unreadable-vs-missing (skipped as root, where perms are bypassed), non-regular target, duplicate targets, `.hull`/`node_modules` exclusions, `--json --quiet` override, incomplete state in JSON + exit 1, plus the original set.

Two new tool bindings (`tool.realpath`; `tool.stdout` from #349) + the `find_files` `exclude_dirs` thread. Full unit suite **76/76**; e2e **15/15**; conformance **520 over 225 files**; luacheck clean; full `hull` build OK.
