### PR TITLE
docs(source): design records for analyze v2 lint rules + continuous fuzz harness

### DIFF
--- a/docs/hull_analyze_lint_design.md
+++ b/docs/hull_analyze_lint_design.md
@@ -103,7 +103,7 @@ A **rule** is a small declarative record:
 | id | severity | needs | flags |
 |---|---|---|---|
 | `unused-local` | warning | scope | a `local` never read (excludes a leading `_`-named local — the idiomatic "ignore") |
-| `unused-param` | warning | scope | a function parameter never read (excludes `_`, `self`, and (config) a trailing run of unused params, since Lua callbacks often ignore tail args) |
+| `unused-param` | warning | scope | a function parameter never read. Exempt ONLY: `_`, any underscore-prefixed name (`_x`), and the implicit method `self`. **No trailing-unused-run suppression by default** — suppressing a trailing run would hide every unused parameter in a function and gut the rule. Broader callback suppression is a later add, gated on evidence or explicit config. |
 | `shadowed-local` | warning | scope | a `local`/param that hides an outer binding of the same name in an enclosing scope |
 | `undefined-global` | warning (default OFF) | scope | a global read that is not a known Lua/Hull global (needs a global allowlist → off by default until the allowlist is curated) |
 | `empty-block` | warning | — | an `if`/`elseif`/`else`/`while`/`for`/`do` body with zero statements |
@@ -186,15 +186,16 @@ is the explicit signal that lint data may be present.
 Each slice is a design-first → ratify → implement → green → merge cycle, matching how
 the layer itself was built.
 
-## 11. Open decisions (for ratification)
+## 11. Decisions (ratified)
 
-1. **Scope now vs later.** Include the scope pass + scope rules in v2 (slices 2–3), or
-   ship structural-only first (slice 1) and treat scope as v2.1? Recommendation:
-   **commit to all three slices** — `shadowed-local` / `unused-local` are the rules with
-   real value and were explicitly requested; slice 1 alone is thin.
-2. **Initial rule set** (the §5 table). Recommendation: as tabled, with
-   `undefined-global` **off by default** (needs the global allowlist).
-3. **`--strict` default.** Warnings advisory by default (exit 0), `--strict` to gate.
-   Recommendation: **advisory by default** (standard; non-breaking for CI that runs
-   `hull analyze` today expecting exit 0 on warning-free syntax).
-4. **Schema bump to 2.** Recommendation: **yes** — explicit signal, backward-compatible.
+1. **All three slices** — engine + structural rules, the `hull.source.scope` pass, and
+   the scope rules (`unused-local` / `unused-param` / `shadowed-local` /
+   `undefined-global`).
+2. **Rule set as tabled**, with `undefined-global` **off by default** (needs the global
+   allowlist). `unused-param` exempts ONLY `_`, underscore-prefixed names, and the
+   implicit method `self` — **no trailing-unused-run suppression by default** (it would
+   hide every unused param; broader callback suppression is a later, evidence/config-
+   gated add).
+3. **`--strict` advisory-by-default** — warnings/infos do not affect the exit code
+   unless `--strict` (non-breaking for CI running `hull analyze` today).
+4. **JSON `schema_version: 2`** — backward-compatible superset.

--- a/docs/hull_analyze_lint_design.md
+++ b/docs/hull_analyze_lint_design.md
@@ -1,0 +1,200 @@
+# `hull analyze` v2 — lint rules (design)
+
+Status: DESIGN (pre-implementation). Extends the shipped `hull analyze` (syntax-only,
+[hull_analyze_design.md](hull_analyze_design.md)) with a **rule-based linter** over the
+AST + comments + a light lexical **scope** pass — still without running or building the
+app. This is the "AST/annotation lint rules" follow-up named in §10 of the v1 design.
+
+## 1. Goal
+
+Turn `hull analyze` from a syntax checker into a real linter: flag likely bugs and
+dead code that are valid syntax but wrong or wasteful — `unused-local`,
+`shadowed-local`, `unused-param`, `empty-block`, duplicate table keys, `TODO`/`FIXME`
+markers — each a small **rule** over `lua.walk` + a scope model + `unit.comments`,
+behind a **rule registry** with per-rule enable/disable and a `--strict` gate. The
+infrastructure (registry, severities, config surface, JSON) is designed so new rules
+are ~20 lines each.
+
+Why it matters: these are the errors a syntax check can't see — a `local cfg` that's
+never read (a typo'd later reference), a loop var that shadows an outer one, an
+`if ... then end` with an empty body. Caught statically, across the whole tree, in one
+shot.
+
+## 2. Scope + boundaries
+
+- **Per-file rules** in v2. Cross-file rules (e.g. a `---@deprecated` function called
+  from another module) need a project-wide symbol graph — a later version.
+- **NOT `undeclared-import` / `unused-require`** — that is DECLARATION analysis
+  (require/import vs `manifest.modules`), already shipped as `hull modules analyze`
+  (module `hull.analyze`). v2 is orthogonal: syntactic / scope / comment rules. The two
+  compose; they do not overlap. (A future `hull analyze` could *surface* modules-analyze
+  findings, but it will not re-implement them.)
+- **NOT type inference, NOT control-flow/data-flow** beyond simple reachability. Lua
+  makes `return`/`break` block-terminating at the syntax level already, so
+  "unreachable after return" is a *syntax* error, not a lint.
+- **NOT auto-fix** (unchanged from v1).
+
+## 3. The scope pass — `hull.source.scope` (the motivated Step B)
+
+The high-value rules (`unused-local`, `shadowed-local`, `unused-param`,
+`undefined-global`) all need **name resolution**: which declaration each `name`
+reference binds to. This is the "semantic/binding pass" the roadmap deferred "only if a
+consumer needs it" — the linter is that consumer. It ships as a new, reusable
+source-layer module `hull.source.scope` (future codegen consumers may want it too).
+
+`scope.resolve(unit)` walks `unit.ast` and produces a **scope model** with Lua 5.4
+scoping semantics:
+- **Lexical scopes**: the chunk, and each block that introduces bindings — function
+  bodies (params + locals), `do`, `while`/`repeat` bodies, `if` clause bodies, numeric-
+  and generic-`for` bodies (loop vars scoped to the body).
+- **Declaration visibility**: a `local x = ...` is visible only to statements **after**
+  it in its block (Lua's "a local is in scope from *after* its declaration"), so
+  `local x = x` binds the RHS `x` to an *outer* `x`. `local function f` is visible
+  **inside its own body** (recursion) — distinct from `local f = function() end`.
+- **Resolution**: every `name` node resolves to (a) a specific local/param declaration
+  in an enclosing scope (nearest wins — this is where **shadowing** is observed), or
+  (b) an **upvalue** (a local from an enclosing *function*, across a function boundary),
+  or (c) a **global** (no binding found). `self` in a `function a:m()` method is an
+  implicit first param.
+- **Per-declaration usage**: each local/param records whether it is ever **read**
+  (a `name` reference that isn't the assignment target of its own declaration). Powers
+  `unused-*`. (An assignment to a local — `x = 1` where `x` is local — counts as a
+  write, not a read; `unused-local` flags a local written/declared but never read.)
+
+Output shape (attached to the unit, or returned):
+```
+scope = {
+  bindings = { <decl>, ... },     -- every local/param declaration
+  -- <decl> = { name, kind = "local"|"param"|"localfunc"|"loopvar",
+  --            range, scope_id, reads = <int>, writes = <int>,
+  --            shadows = <decl|nil> }   -- the outer decl it hides, if any
+  ref_of = <map: name-node -> decl | "global" | "upvalue-decl">,
+}
+```
+The pass NEVER raises (best-effort over a possibly error-bearing AST); an `error` node
+or a missing field degrades to "unresolved", never a crash. It is conformance-adjacent:
+a dedicated test suite pins resolution on hand-built cases (shadowing, recursion,
+`local x = x`, loop-var scope, method `self`, upvalues).
+
+## 4. Rule engine + registry
+
+A **rule** is a small declarative record:
+```
+{ id = "unused-local",
+  severity = "warning",          -- "error" | "warning" | "info"
+  default = true,                -- on unless --disable'd
+  needs = { "scope" },           -- "scope" pass required? (else AST/comments only)
+  describe = "a local variable that is never read",
+  check = function(unit, scope, emit)
+      -- walk / inspect; emit { code, message, range } per finding
+  end }
+```
+- **Registry**: a sorted table `RULES` in `hull.source.lint` (the new rule module). One
+  row per rule; `check` is pure (no I/O, no cross-file state). Adding a rule is one row.
+- **Codes**: each finding's `code` is `lua.lint.<id>` (namespaced, distinct from
+  `lua.syntax` / `lua.limit.*` / `analyze.*`). Deterministic: findings sorted by
+  `(path, range.start, code)` like v1.
+- **Engine**: for each file's `unit`, run `scope.resolve(unit)` once (only if any active
+  rule `needs` it), then invoke each active rule's `check`, collecting findings. The
+  scope pass is computed at most once per file.
+
+## 5. Curated v2 rule set
+
+| id | severity | needs | flags |
+|---|---|---|---|
+| `unused-local` | warning | scope | a `local` never read (excludes a leading `_`-named local — the idiomatic "ignore") |
+| `unused-param` | warning | scope | a function parameter never read (excludes `_`, `self`, and (config) a trailing run of unused params, since Lua callbacks often ignore tail args) |
+| `shadowed-local` | warning | scope | a `local`/param that hides an outer binding of the same name in an enclosing scope |
+| `undefined-global` | warning (default OFF) | scope | a global read that is not a known Lua/Hull global (needs a global allowlist → off by default until the allowlist is curated) |
+| `empty-block` | warning | — | an `if`/`elseif`/`else`/`while`/`for`/`do` body with zero statements |
+| `duplicate-table-key` | warning | — | a table constructor with two `field_name`/`field_expr` entries for the same literal key |
+| `todo-comment` | info | — | a comment containing `TODO`/`FIXME`/`XXX` (surfaced, never fails a build) |
+
+`undefined-global` ships **off by default** (it needs a curated global allowlist — Lua
+intrinsics + Hull's injected globals like `app`, `db`, `http`, `tool`… — to avoid false
+positives); it's enabled with `--enable=undefined-global` and hardened over time.
+
+## 6. CLI surface (additions)
+
+```
+hull analyze [app_dir] [files...] [--json] [--quiet]
+             [--strict] [--rules=a,b] [--disable=c,d] [--enable=e] [--list-rules] [--max-depth=N]
+```
+- `--list-rules` → print every rule (`id`, severity, default, one-line describe), exit 0
+  (human) or a `{ rules: [...] }` JSON with `--json`.
+- `--rules=<ids>` → run ONLY these rules (comma-separated) — overrides defaults.
+- `--disable=<ids>` / `--enable=<ids>` → adjust the default set (compose: defaults −
+  disabled + enabled). An unknown id is a usage error (exit 2).
+- `--strict` → treat **warnings** as failures (they contribute to exit 1). Without it,
+  warnings/infos are advisory (exit 0 if there are no errors).
+- Syntax analysis (v1) always runs first; lint rules run on the `complete` files. An
+  `incomplete`/`internal` file is NOT linted (its AST is unreliable) — it already
+  drives exit 1 from v1.
+
+## 7. Exit codes + severities (extends v1 honestly)
+
+v1's contract is preserved: **error**-severity diagnostics (`lua.syntax`,
+`lua.unsupported`, `lua.internal`, `lua.limit.*`, `analyze.*` targets) drive exit 1.
+Lint findings add **warning** and **info** severities:
+- `0` — no error-severity diagnostics, and (no warnings OR `--strict` not set).
+- `1` — any error-severity diagnostic, OR (`--strict` AND ≥1 warning).
+- `2` — usage / operational failure (unknown flag/rule, discovery failure) — unchanged.
+
+`info` (e.g. `todo-comment`) never affects the exit code. This matches the ubiquitous
+linter convention (warnings advisory, `-Werror`/`--strict` to gate).
+
+## 8. JSON schema evolution → `schema_version: 2`
+
+Backward-compatible superset of v1 (same top-level keys; new codes + severities +
+counts). Bumped to `2` to signal the lint capability:
+- `diagnostics[].severity` gains `"warning"` / `"info"`; `code` gains `lua.lint.<id>`.
+- `summary` gains `warnings`, `infos` (alongside `errors`, `incomplete`, `internal`);
+  `clean` stays "exit 0". A new `summary.by_rule` map (`{ "unused-local": 3, ... }`)
+  gives per-rule counts for dashboards.
+- `--list-rules --json` emits `{ "schema_version": 2, "rules": [ { id, severity,
+  default, description } ] }`.
+A v1 consumer still parses a v2 document (it just sees new codes/severities); the bump
+is the explicit signal that lint data may be present.
+
+## 9. Architecture + files
+
+- **`stdlib/cli/lua/hull/source/scope.lua`** — `hull.source.scope`, the binding pass
+  (§3). Pure Lua over the AST; no new C.
+- **`stdlib/cli/lua/hull/source/lint.lua`** — `hull.source.lint`: the `RULES` registry,
+  the engine (`lint.run(unit, scope, opts) -> findings`), and the rule `check`
+  functions. Pure Lua.
+- **`analyze.lua`** — extended: parse args (new flags), after a `complete` parse run
+  `scope.resolve` + `lint.run`, merge lint findings into the diagnostics list, apply the
+  `--strict` exit logic, add `--list-rules`.
+- **Tests**: `test_scope.lua` (resolution cases via the vanilla-`lua_State` harness, a
+  new `UTEST(lua_source, scope)` leg) + `test_lint.lua` (each rule: a positive fixture
+  that fires and a negative that must not) + `tests/e2e_analyze.sh` additions (a
+  `--strict` run flips exit 0→1; `--list-rules`; `unused-local`/`shadowed-local`/
+  `todo-comment` end to end; `--rules=`/`--disable=` selection; JSON `schema_version:2`
+  + `lua.lint.*` codes + `summary.warnings`). No new C.
+
+## 10. Slice plan
+
+1. **Engine + structural rules** — `lint.lua` registry/engine + `empty-block`,
+   `duplicate-table-key`, `todo-comment` (no scope), the CLI flags (`--strict`,
+   `--rules`/`--disable`/`--enable`/`--list-rules`), JSON `schema_version: 2`. Ships the
+   infrastructure with immediately-useful rules.
+2. **Scope pass** — `hull.source.scope` + `test_scope.lua` (the reusable Step B).
+3. **Scope rules** — `unused-local`, `unused-param`, `shadowed-local`, and
+   `undefined-global` (off by default) on top of the pass.
+
+Each slice is a design-first → ratify → implement → green → merge cycle, matching how
+the layer itself was built.
+
+## 11. Open decisions (for ratification)
+
+1. **Scope now vs later.** Include the scope pass + scope rules in v2 (slices 2–3), or
+   ship structural-only first (slice 1) and treat scope as v2.1? Recommendation:
+   **commit to all three slices** — `shadowed-local` / `unused-local` are the rules with
+   real value and were explicitly requested; slice 1 alone is thin.
+2. **Initial rule set** (the §5 table). Recommendation: as tabled, with
+   `undefined-global` **off by default** (needs the global allowlist).
+3. **`--strict` default.** Warnings advisory by default (exit 0), `--strict` to gate.
+   Recommendation: **advisory by default** (standard; non-breaking for CI that runs
+   `hull analyze` today expecting exit 0 on warning-free syntax).
+4. **Schema bump to 2.** Recommendation: **yes** — explicit signal, backward-compatible.

--- a/docs/lua_source_fuzz_design.md
+++ b/docs/lua_source_fuzz_design.md
@@ -1,0 +1,135 @@
+# `hull.source.lua` continuous libFuzzer harness (design)
+
+Status: DESIGN (pre-implementation). The documented follow-up to the differential
+conformance gate ([lua_source_conformance_design.md](lua_source_conformance_design.md)
+§8): a continuous **libFuzzer** harness that feeds arbitrary bytes to `lua.parse` and
+asserts the parser's INTRINSIC invariants under sanitizers, mirroring Hull's existing
+`fuzz_*` harnesses (sh_json, pgwire, mysqlwire, host_match) that each run 60s in CI.
+
+## 1. Goal + relationship to the conformance gate
+
+Two complementary oracles:
+- **Conformance gate** (shipped): DIFFERENTIAL vs real Lua 5.4 `load()` over a fixed
+  corpus + a bounded seeded mutation fuzz. Answers "does the parser AGREE with Lua on
+  accept/reject + ranges?".
+- **This harness** (new): INTRINSIC + continuous. Answers "can ANY byte string make the
+  parser crash, hang, leak, raise, or violate a structural invariant?". No `load()`
+  comparison — that stays the conformance gate's job (a `load()` call inside a
+  high-throughput libFuzzer loop is heavier and less reproducible); the value here is
+  millions of coverage-guided mutations under ASan/UBSan.
+
+Together: the gate proves *correctness against ground truth*; the fuzzer proves
+*robustness against adversarial input*.
+
+## 2. What it asserts (the intrinsic oracle)
+
+For each input `data[0..size)` treated as Lua source, `lua.parse(data, { limits })` must:
+1. **Never raise** — the C-level call returns normally (the Lua `pcall` around
+   `M.parse` returns `LUA_OK`); a Lua error escaping `parse()` is a contract breach →
+   `abort()` (libFuzzer crash).
+2. **Return a valid shape** — either a `unit` table with a `diagnostics` array (and an
+   `ast`), or `(nil, err)` with a diagnostic-shaped/`string` `err`. Anything else →
+   abort.
+3. **Respect its bounds** — run with the DEFAULT limits; the parser's
+   `max_bytes`/`max_tokens`/`max_depth` must bound work so no input hangs (libFuzzer
+   `-timeout` catches a regression) or OOMs (a memory cap catches unbounded growth).
+4. **Structural range sanity** (cheap post-check on a returned unit) — walk the AST and
+   assert every node's range is in `[1, #src+1]`, non-inverted, and `unit:text(node)`
+   slices without error. A violation → abort. (Reuses the conformance harness's range
+   checker logic.)
+5. **No sanitizer finding** — ASan (heap/stack overflow, UAF, leaks), UBSan (UB) run the
+   whole thing; a finding is a crash libFuzzer records with the reproducer.
+
+Note the parser is pure Lua, so "crash" surfaces as: a Lua **stack overflow** from deep
+recursion (parser / `walk`) that the `max_depth` guard must prevent; **non-termination**
+(a stall the guards must prevent); a raised error escaping `parse()`; or a memory error
+in the vendored Lua VM itself exercised by pathological input.
+
+## 3. Harness structure
+
+A C file `fuzz/fuzz_lua_source.c` in the same mold as the existing `fuzz/fuzz_*.c`
+harnesses — but it LINKS `$(LUA_OBJS)` and runs from the repo root (so `package.path`
+resolves `stdlib/cli/lua`), the same scaffolding the conformance harness uses. (Unlike
+the pure-C codec fuzzers — pgwire, sh_json — this one drives a `lua_State`.)
+
+- **`LLVMFuzzerInitialize`** (once): create a persistent vanilla `lua_State`
+  (`luaL_newstate` + `luaL_openlibs`, the same as the conformance harness), set
+  `package.path` to `stdlib/cli/lua/?.lua`, `require("hull.source.lua")`, and stash the
+  `M.parse` function + a small Lua driver in the registry. Reusing one state across
+  inputs is essential for throughput (a fresh state per input would dominate runtime).
+- **`LLVMFuzzerTestOneInput(data, size)`**:
+  1. push the driver + the input string (`lua_pushlstring`, binary-safe) and `lua_pcall`
+     it;
+  2. the **Lua driver** does `local u, e = parse(input, LIMITS)`, then the shape +
+     range checks (§2.2, §2.4), and returns a status; a check failure is signalled back
+     to C (a distinguished return / a raised error) → C `abort()`s with a message;
+  3. after the call, reset the stack (`lua_settop`) and periodically
+     `lua_gc(L, LUA_GCCOLLECT)` (every N inputs) so accumulated per-parse tables don't
+     grow memory unboundedly across the run.
+- **Memory cap**: install a Lua allocator (or use Hull's tracking allocator) with a hard
+  ceiling so a pathological input that tries to allocate unboundedly fails the parse
+  (returned as a diagnostic / `(nil,err)`) rather than OOM-killing the fuzzer — turning
+  "unbounded growth" into a catchable contract check rather than an ambiguous OOM.
+
+The Lua driver lives inline in the C file as a string (or a tiny co-located
+`fuzz_driver.lua`), keeping the "what to assert" in Lua next to `lua.parse` while C owns
+the fuzz loop.
+
+## 4. Corpus + dictionary
+
+- **Seed corpus**: the repo's own `.lua` (the conformance corpus) + the parser/lexer
+  test snippets, under `fuzz/corpus/lua_source/`. Seeding from valid Lua gives
+  coverage-guided mutation a strong start.
+- **Dictionary** (`fuzz/lua_source.dict`): Lua keywords, operators, long-bracket
+  forms (`[[`, `]==]`), string escapes (`\u{`, `\x`, `\z`), numeral forms (`0x`, `p`,
+  `..`), and `---@` so the mutator reaches annotation + edge lexer paths quickly.
+
+## 5. Build + CI integration
+
+Mirror the existing fuzz targets (`mk/tests.mk`, `FUZZ_CFLAGS`, `FUZZ_TIME ?= 60`):
+- **Makefile**: a `fuzz/fuzz_lua_source: fuzz/fuzz_lua_source.c $(LUA_OBJS)` rule built
+  with `$(FUZZ_CFLAGS)` (`-fsanitize=fuzzer,address,undefined`, clang) + the Lua include
+  path, exactly like `fuzz/fuzz_pgwire` / `fuzz/fuzz_sh_json` but adding `$(LUA_OBJS)`.
+  Run from repo root so `package.path` resolves.
+- **CI**: add `lua_source` to the fuzz matrix in `.github/workflows/ci.yml` — a
+  `-max_total_time=$(FUZZ_TIME)` (**60s**) run over the seed corpus with a per-input
+  `-timeout` for hang detection, on clang/Linux (where the other fuzzers run). A finding
+  fails CI with the crashing input attached.
+- **Non-blocking on non-clang**: the fuzz job is clang-only (libFuzzer), already gated
+  that way for the other harnesses; nothing changes for macOS/cosmo builds.
+
+## 6. Determinism, triage, regressions
+
+- A discovered crash is saved by libFuzzer as a reproducer file; the fix workflow is the
+  same as the other fuzzers (add the reproducer to the corpus, fix, re-run).
+- Because the harness is intrinsic (no `load()`), a finding is unambiguously a Hull
+  parser robustness bug (raise / hang / OOM / OOB / bad shape), not an oracle
+  disagreement.
+- The seeded mutation fuzz inside the conformance gate stays (bounded, differential,
+  in-`make test`); this harness is the UNBOUNDED, coverage-guided, sanitizer-backed
+  complement that only runs in the fuzz CI job.
+
+## 7. Non-goals
+
+- **Not differential vs `load()`** (§1) — the conformance gate owns that.
+- **Not fuzzing the C `hl_cap_*` layer** — this targets `hull.source.lua` (the pure-Lua
+  parser). The cap layer has its own harnesses.
+- **Not a `make test` gate** — it is a continuous CI job (like the other fuzzers), not a
+  unit test (the conformance gate is the in-`make test` robustness check).
+
+## 8. Open decisions (for ratification)
+
+1. **Range post-check in the hot loop.** Include the per-node range sanity check on
+   every returned unit (§2.4) — a small constant cost that catches range bugs the
+   never-raise check alone would miss — vs. never-raise + shape only for max throughput.
+   Recommendation: **include it** (cheap, high-value; it's the same checker the gate
+   uses).
+2. **Memory cap mechanism.** A custom bounded Lua allocator in the harness vs. relying
+   on libFuzzer's `-rss_limit_mb`. Recommendation: **a bounded allocator** — it turns
+   "unbounded growth" into a clean, catchable `(nil, err)`/diagnostic contract check
+   rather than an ambiguous RSS kill, and it exercises the parser's own OOM paths.
+3. **Corpus location + size.** Seed from the full repo `.lua` corpus vs. a curated small
+   set. Recommendation: **full corpus** (matches the conformance seed; more coverage),
+   gitignored generated crash artifacts.
+4. **CI time budget.** 60s (matches the other fuzzers) vs. longer. Recommendation:
+   **60s** for parity; a nightly longer run is a later add.

--- a/docs/lua_source_fuzz_design.md
+++ b/docs/lua_source_fuzz_design.md
@@ -30,9 +30,11 @@ For each input `data[0..size)` treated as Lua source, `lua.parse(data, { limits 
 2. **Return a valid shape** — either a `unit` table with a `diagnostics` array (and an
    `ast`), or `(nil, err)` with a diagnostic-shaped/`string` `err`. Anything else →
    abort.
-3. **Respect its bounds** — run with the DEFAULT limits; the parser's
-   `max_bytes`/`max_tokens`/`max_depth` must bound work so no input hangs (libFuzzer
-   `-timeout` catches a regression) or OOMs (a memory cap catches unbounded growth).
+3. **Respect its bounds** — run with the DEFAULT limits; `max_bytes`/`max_tokens`/
+   `max_depth` bound work so no input hangs (libFuzzer `-timeout` catches a regression).
+   A per-input **bounded allocator** (§3.1) caps memory: exceeding it raises an EXPECTED
+   `LUA_ERRMEM` (classified as resource exhaustion, not a never-raise breach), catching
+   unbounded growth without an ambiguous RSS kill.
 4. **Structural range sanity** (cheap post-check on a returned unit) — walk the AST and
    assert every node's range is in `[1, #src+1]`, non-inverted, and `unit:text(node)`
    slices without error. A violation → abort. (Reuses the conformance harness's range
@@ -57,29 +59,50 @@ the pure-C codec fuzzers — pgwire, sh_json — this one drives a `lua_State`.)
   `package.path` to `stdlib/cli/lua/?.lua`, `require("hull.source.lua")`, and stash the
   `M.parse` function + a small Lua driver in the registry. Reusing one state across
   inputs is essential for throughput (a fresh state per input would dominate runtime).
-- **`LLVMFuzzerTestOneInput(data, size)`**:
-  1. push the driver + the input string (`lua_pushlstring`, binary-safe) and `lua_pcall`
-     it;
-  2. the **Lua driver** does `local u, e = parse(input, LIMITS)`, then the shape +
-     range checks (§2.2, §2.4), and returns a status; a check failure is signalled back
-     to C (a distinguished return / a raised error) → C `abort()`s with a message;
-  3. after the call, reset the stack (`lua_settop`) and periodically
-     `lua_gc(L, LUA_GCCOLLECT)` (every N inputs) so accumulated per-parse tables don't
-     grow memory unboundedly across the run.
-- **Memory cap**: install a Lua allocator (or use Hull's tracking allocator) with a hard
-  ceiling so a pathological input that tries to allocate unboundedly fails the parse
-  (returned as a diagnostic / `(nil,err)`) rather than OOM-killing the fuzzer — turning
-  "unbounded growth" into a catchable contract check rather than an ambiguous OOM.
+- **`LLVMFuzzerTestOneInput(data, size)`** — one input, one bounded parse:
+  1. arm the per-input allocator allowance (§3.1): ceiling = `baseline + PER_INPUT_BYTES`;
+  2. push the driver + input string (`lua_pushlstring`, binary-safe) and `lua_pcall` it;
+  3. **classify the `pcall` result**:
+     - `LUA_OK` → run the shape + range checks (§2.2/§2.4) via the driver's return; a
+       check FAILURE is the only in-band way to `abort()` (a real robustness bug);
+     - `LUA_ERRMEM` (from the bounded allocator) → **expected resource exhaustion, NOT a
+       never-raise violation**: the per-input allowance was exceeded. Tolerated and
+       counted — because an allocation failure can prevent `parse()` from even
+       constructing its normal `(nil, err)` result, so its own `pcall` may re-raise
+       `LUA_ERRMEM`. Not a crash.
+     - **any other** Lua error (`LUA_ERRRUN`, `LUA_ERRERR`, …) → a raised error escaped
+       `parse()` → `abort()` (a never-raise breach).
+  4. **always**: reset the stack (`lua_settop(L, base)`) and force a full collection
+     (`lua_gc(L, LUA_GCCOLLECT)`) BEFORE the next input, so per-parse garbage never bleeds
+     across inputs and each input's allowance is measured from a clean baseline.
+
+### 3.1 The bounded-allocator contract
+A custom Lua allocator wrapping Hull's tracking allocator, with a hard ceiling:
+- **Baseline**: captured ONCE, right after `LLVMFuzzerInitialize` finishes (state +
+  `openlibs` + `require("hull.source.lua")` loaded), so the standing VM footprint is
+  never charged against an input. The ceiling is `baseline + PER_INPUT_BYTES`.
+- **Per-input allowance** (`PER_INPUT_BYTES`): a fixed budget — comfortably above any
+  legitimate parse of a bounded input, low enough to catch runaway growth. Effectively
+  reset each input by step 4's forced GC (which returns live memory toward baseline).
+- **On exhaustion**: the allocator returns `NULL` → Lua raises `LUA_ERRMEM`, caught by
+  the `pcall` and classified **expected** (step 3). This turns "unbounded growth" into a
+  clean, catchable resource-exhaustion signal — not an ambiguous RSS kill, and never
+  mislabeled a never-raise violation.
 
 The Lua driver lives inline in the C file as a string (or a tiny co-located
 `fuzz_driver.lua`), keeping the "what to assert" in Lua next to `lua.parse` while C owns
-the fuzz loop.
+the fuzz loop + the allocator.
 
 ## 4. Corpus + dictionary
 
-- **Seed corpus**: the repo's own `.lua` (the conformance corpus) + the parser/lexer
-  test snippets, under `fuzz/corpus/lua_source/`. Seeding from valid Lua gives
-  coverage-guided mutation a strong start.
+- **Checked-in seed (small + curated)**: a SMALL set of `.lua` snippets under
+  `fuzz/corpus/lua_source/` covering tricky lexer/parser/annotation edge cases —
+  **not** a duplicated snapshot of every repository `.lua` file.
+- **Full corpus staged at run time**: the fuzz runner stages the repo's own `.lua` (the
+  conformance corpus) DETERMINISTICALLY into a TEMPORARY corpus dir (e.g. copied under
+  `build/fuzz-corpus/lua_source/`), unioned with the checked-in seed, and points
+  libFuzzer there. The broad coverage seed is thus always fresh + in sync with the tree,
+  with zero duplication committed to git.
 - **Dictionary** (`fuzz/lua_source.dict`): Lua keywords, operators, long-bracket
   forms (`[[`, `]==]`), string escapes (`\u{`, `\x`, `\z`), numeral forms (`0x`, `p`,
   `..`), and `---@` so the mutator reaches annotation + edge lexer paths quickly.
@@ -117,19 +140,17 @@ Mirror the existing fuzz targets (`mk/tests.mk`, `FUZZ_CFLAGS`, `FUZZ_TIME ?= 60
 - **Not a `make test` gate** — it is a continuous CI job (like the other fuzzers), not a
   unit test (the conformance gate is the in-`make test` robustness check).
 
-## 8. Open decisions (for ratification)
+## 8. Decisions (ratified)
 
-1. **Range post-check in the hot loop.** Include the per-node range sanity check on
-   every returned unit (§2.4) — a small constant cost that catches range bugs the
-   never-raise check alone would miss — vs. never-raise + shape only for max throughput.
-   Recommendation: **include it** (cheap, high-value; it's the same checker the gate
-   uses).
-2. **Memory cap mechanism.** A custom bounded Lua allocator in the harness vs. relying
-   on libFuzzer's `-rss_limit_mb`. Recommendation: **a bounded allocator** — it turns
-   "unbounded growth" into a clean, catchable `(nil, err)`/diagnostic contract check
-   rather than an ambiguous RSS kill, and it exercises the parser's own OOM paths.
-3. **Corpus location + size.** Seed from the full repo `.lua` corpus vs. a curated small
-   set. Recommendation: **full corpus** (matches the conformance seed; more coverage),
-   gitignored generated crash artifacts.
-4. **CI time budget.** 60s (matches the other fuzzers) vs. longer. Recommendation:
-   **60s** for parity; a nightly longer run is a later add.
+1. **Range post-check IN the hot loop** — every returned unit gets the per-node range
+   sanity check (§2.4); cheap, high-value, reuses the gate's checker.
+2. **Bounded allocator** (over `-rss_limit_mb`), with the §3.1 contract: post-init
+   baseline, per-input allowance, forced GC + stack reset between inputs, and
+   **`LUA_ERRMEM` classified as EXPECTED resource exhaustion** — any OTHER escaping Lua
+   error is a crash (the distinction matters because allocation failure can prevent
+   `parse()` from building its normal `(nil, err)`).
+3. **Corpus**: a SMALL curated seed set + dictionary checked in; the FULL repo `.lua`
+   corpus staged DETERMINISTICALLY into a temporary dir at run time — no duplicated
+   snapshot committed to git. Generated crash artifacts are gitignored.
+4. **60s CI budget** (`FUZZ_TIME`), matching the other fuzzers; a nightly longer run is
+   a later add.


### PR DESCRIPTION
Two design-first records (pre-implementation) for the next `hull.source.lua` arc, following the established design→ratify→implement cadence:

- **`hull_analyze_lint_design.md`** — `hull analyze` v2: a rule-based linter over AST + comments + a light lexical **scope** pass (`hull.source.scope`, the motivated Step B), behind a rule registry with per-rule enable/disable + `--strict`. Curated set: unused-local, unused-param, shadowed-local, undefined-global (off by default), empty-block, duplicate-table-key, todo-comment. `lua.lint.<id>` codes, warning/info severities (advisory unless `--strict`), JSON `schema_version: 2`. Explicitly NOT undeclared-import/unused-require (that's `hull modules analyze`). Three-slice plan.
- **`lua_source_fuzz_design.md`** — a continuous libFuzzer harness (`fuzz/fuzz_lua_source.c`, links `LUA_OBJS`, persistent `lua_State`) asserting the parser's **intrinsic** invariants (never-raise / valid shape / bounded / range sanity / no sanitizer finding) over coverage-guided mutations, 60s in CI. Complements the differential conformance gate.

Both carry open decisions for ratification; implementation follows per-slice on approval.