### PR TITLE
feat(analyze): v2 lint slice 1 — rule engine + structural rules

### DIFF
--- a/docs/hull_analyze_lint_design.md
+++ b/docs/hull_analyze_lint_design.md
@@ -1,6 +1,8 @@
 # `hull analyze` v2 — lint rules (design)
 
-Status: DESIGN (pre-implementation). Extends the shipped `hull analyze` (syntax-only,
+Status: SLICE 1 IMPLEMENTED (engine + structural rules + CLI + schema 2);
+slices 2-3 (scope pass + scope rules) pending. Extends the shipped `hull analyze`
+(syntax-only,
 [hull_analyze_design.md](hull_analyze_design.md)) with a **rule-based linter** over the
 AST + comments + a light lexical **scope** pass — still without running or building the
 app. This is the "AST/annotation lint rules" follow-up named in §10 of the v1 design.
@@ -175,10 +177,12 @@ is the explicit signal that lint data may be present.
 
 ## 10. Slice plan
 
-1. **Engine + structural rules** — `lint.lua` registry/engine + `empty-block`,
-   `duplicate-table-key`, `todo-comment` (no scope), the CLI flags (`--strict`,
-   `--rules`/`--disable`/`--enable`/`--list-rules`), JSON `schema_version: 2`. Ships the
-   infrastructure with immediately-useful rules.
+1. **Engine + structural rules** — DONE. `hull.source.lint` registry/engine +
+   `empty-block`, `duplicate-table-key`, `todo-comment` (no scope), the CLI flags
+   (`--strict`, `--rules`/`--disable`/`--enable`/`--list-rules`), per-diagnostic
+   severities, `lua.lint.<id>` codes, JSON `schema_version: 2` (+ `summary.warnings`/
+   `infos`/`by_rule`). `test_lint.lua` + `tests/e2e_analyze.sh` (23 cases). Lint runs
+   only on a CLEANLY-parsed file (complete + no syntax errors).
 2. **Scope pass** — `hull.source.scope` + `test_scope.lua` (the reusable Step B).
 3. **Scope rules** — `unused-local`, `unused-param`, `shadowed-local`, and
    `undefined-global` (off by default) on top of the pass.

--- a/stdlib/cli/lua/hull/source/analyze.lua
+++ b/stdlib/cli/lua/hull/source/analyze.lua
@@ -12,6 +12,7 @@
 --
 
 local lua = require("hull.source.lua")
+local lint = require("hull.source.lint")
 local json = require("hull.json")
 
 -- Generous limits so lua.limit.* only trips on genuinely pathological input; a trip is
@@ -78,18 +79,51 @@ local function op_fail(msg)
     tool.exit(2)
 end
 
+local function split_csv(s)
+    local out = {}
+    for part in s:gmatch("[^,]+") do out[#out + 1] = part end
+    return out
+end
+
 local function parse_args()
-    local o = { json = false, quiet = false, positionals = {} }
+    local o = { json = false, quiet = false, strict = false, positionals = {} }
     for i = 1, #arg do
         local a = arg[i]
         if a == "--json" then o.json = true
         elseif a == "--quiet" then o.quiet = true
+        elseif a == "--strict" then o.strict = true
+        elseif a == "--list-rules" then o.list_rules = true
         elseif a == "-h" or a == "--help" then o.help = true
         elseif a:match("^%-%-max%-depth=%d+$") then o.max_depth = tonumber(a:match("=(%d+)"))
+        elseif a:match("^%-%-rules=.+$") then o.rules = split_csv(a:match("=(.+)$"))
+        elseif a:match("^%-%-disable=.+$") then o.disable = split_csv(a:match("=(.+)$"))
+        elseif a:match("^%-%-enable=.+$") then o.enable = split_csv(a:match("=(.+)$"))
         elseif a:sub(1, 1) == "-" and a ~= "-" then usage_error("unknown flag: " .. a)
         else o.positionals[#o.positionals + 1] = a end
     end
     return o
+end
+
+-- Resolve the active lint-rule set from --rules / --disable / --enable, validating
+-- every referenced id (an unknown rule is a usage error). --rules restricts to exactly
+-- that set; otherwise the default-on set minus --disable plus --enable.
+local function resolve_rules(o)
+    local function check_ids(list)
+        for _, id in ipairs(list or {}) do
+            if not lint.exists(id) then usage_error("unknown lint rule: " .. id) end
+        end
+    end
+    check_ids(o.rules); check_ids(o.disable); check_ids(o.enable)
+    local enabled
+    if o.rules then
+        enabled = {}
+        for _, id in ipairs(o.rules) do enabled[id] = true end
+    else
+        enabled = lint.default_enabled()
+        for _, id in ipairs(o.disable or {}) do enabled[id] = nil end
+        for _, id in ipairs(o.enable or {}) do enabled[id] = true end
+    end
+    return enabled
 end
 
 -- ── resolve inputs into { root, mode, targets? } ──
@@ -127,39 +161,82 @@ local function discover(root)
 end
 
 -- ── analyze one readable Lua file: returns (state, diagnostics[]) ──
-local function analyze_source(path, src)
+-- Syntax diagnostics are severity "error"; lint findings (only on a CLEANLY-parsed
+-- file) carry their rule's severity (warning / info).
+local function analyze_source(path, src, enabled)
     local unit, err = lua.parse(src, { path = path, limits = LIMITS })
     if unit == nil then                                      -- (nil, err): API/internal failure
         local msg = (type(err) == "table" and err.message) or tostring(err)
         local code = (type(err) == "table" and err.code) or "lua.internal"
-        return "internal", { { code = code, message = msg } }
+        return "internal", { { code = code, severity = "error", message = msg } }
     end
-    local diags, has_limit, has_internal = {}, false, false
+    local diags, has_limit, has_internal, has_syntax = {}, false, false, false
     for _, d in ipairs(unit.diagnostics) do
         local code = d.code or ""
         if code:find("^lua%.limit%.") then has_limit = true
-        elseif code == "lua.internal" then has_internal = true end
+        elseif code == "lua.internal" then has_internal = true
+        else has_syntax = true end                           -- lua.syntax / lua.unsupported
         local line, col
         if d.range then line, col = unit:line_col(d.range) end
         diags[#diags + 1] = {
-            code = code, message = d.message or "",
+            code = code, severity = "error", message = d.message or "",
             range = d.range and { start = d.range.start, stop = d.range.stop } or nil,
             line = line, col = col,
         }
     end
     local state = has_internal and "internal" or (has_limit and "incomplete") or "complete"
+
+    -- Lint only a cleanly-parsed file (complete + no syntax errors): a recovered,
+    -- error-bearing AST would yield spurious lint findings.
+    if state == "complete" and not has_syntax and enabled and next(enabled) then
+        for _, f in ipairs(lint.run(unit, enabled)) do
+            local line, col
+            if f.range then line, col = unit:line_col(f.range) end
+            diags[#diags + 1] = {
+                code = f.code, severity = f.severity, message = f.message, rule = f.rule,
+                range = f.range and { start = f.range.start, stop = f.range.stop } or nil,
+                line = line, col = col,
+            }
+        end
+    end
     return state, diags
+end
+
+-- ── --list-rules: enumerate the lint registry, then exit ──
+local function list_rules(o)
+    if o.json then
+        local rules = {}
+        for _, r in ipairs(lint.RULES) do
+            rules[#rules + 1] = { id = r.id, severity = r.severity, default = r.default, description = r.describe }
+        end
+        tool.stdout(json.encode({ schema_version = 2, rules = rules }) .. "\n")
+    else
+        local out = {}
+        for _, r in ipairs(lint.RULES) do
+            out[#out + 1] = string.format("%-22s %-8s %-4s %s",
+                r.id, r.severity, r.default and "on" or "off", r.describe)
+        end
+        tool.stdout(table.concat(out, "\n") .. "\n")
+    end
+    tool.exit(0)
 end
 
 -- ── build the result set: files[] + diagnostics[] + summary ──
 local function run()
     local o = parse_args()
     if o.help then
-        tool.stdout("usage: hull analyze [app_dir] [files...] [--json] [--quiet] [--max-depth=N]\n" ..
-            "  static syntax analysis of an app's Lua source (parses, never runs).\n" ..
+        tool.stdout(
+            "usage: hull analyze [app_dir] [files...] [--json] [--quiet] [--strict]\n" ..
+            "                    [--rules=a,b] [--disable=c,d] [--enable=e] [--list-rules] [--max-depth=N]\n" ..
+            "  static analysis of an app's Lua source (parses, never runs): syntax + lint rules.\n" ..
+            "  --strict        warnings fail the run (exit 1); advisory by default.\n" ..
+            "  --rules=a,b     run ONLY these lint rules;  --disable / --enable adjust the default set.\n" ..
+            "  --list-rules    list the lint rules and exit.\n" ..
             "  --max-depth=N   cap parse nesting (default 2000); a deeper file is reported incomplete.\n")
         tool.exit(0)
     end
+    if o.list_rules then list_rules(o) end
+    local enabled = resolve_rules(o)                         -- validates --rules/--disable/--enable
     if o.max_depth then LIMITS.max_depth = o.max_depth end   -- controlled low limit (testing / huge files)
     local inp = resolve_inputs(o)
     local root_norm = normalize(inp.root)
@@ -171,12 +248,12 @@ local function run()
     local function record(path, state, diags)
         files[#files + 1] = { path = path, state = state }
         for _, d in ipairs(diags) do
-            d.path = path; d.severity = "error"; d.state = state
+            d.path = path; d.state = state                   -- severity is set per-diag already
             diagnostics[#diagnostics + 1] = d
         end
     end
     local function target_error(path, code, message)
-        record(path, "internal", { { code = code, message = message } })
+        record(path, "internal", { { code = code, severity = "error", message = message } })
     end
 
     if inp.mode == "walk" then
@@ -186,7 +263,7 @@ local function run()
             if not src then                                  -- fail closed: never a silent skip
                 target_error(path, "analyze.unreadable", "cannot read file")
             else
-                record(path, analyze_source(path, src))
+                record(path, analyze_source(path, src, enabled))
             end
         end
     else                                                     -- explicit files
@@ -225,7 +302,7 @@ local function run()
                     if not src then
                         target_error(logical, "analyze.unreadable", "cannot read file")
                     else
-                        record(logical, analyze_source(logical, src))
+                        record(logical, analyze_source(logical, src, enabled))
                     end
                 end
             end
@@ -242,29 +319,37 @@ local function run()
         return a.code < b.code
     end)
 
-    -- summary
-    local errors, incomplete, internal, with_issues = 0, 0, 0, 0
-    local seen_issue = {}
+    -- summary (per-severity; warnings are advisory unless --strict)
+    local errors, warnings, infos, incomplete, internal, with_issues = 0, 0, 0, 0, 0, 0
+    local by_rule, seen_issue = {}, {}
     for _, f in ipairs(files) do
         if f.state == "incomplete" then incomplete = incomplete + 1 end
         if f.state == "internal" then internal = internal + 1 end
     end
     for _, d in ipairs(diagnostics) do
-        errors = errors + 1
+        if d.severity == "error" then errors = errors + 1
+        elseif d.severity == "warning" then warnings = warnings + 1
+        elseif d.severity == "info" then infos = infos + 1 end
+        if d.rule then by_rule[d.rule] = (by_rule[d.rule] or 0) + 1 end
         if not seen_issue[d.path] then seen_issue[d.path] = true; with_issues = with_issues + 1 end
     end
-    local clean = (errors == 0 and incomplete == 0 and internal == 0)
+    -- exit 0 iff no errors / incomplete / internal, and (warnings advisory unless --strict)
+    local exit_ok = (errors == 0 and incomplete == 0 and internal == 0
+                     and (not o.strict or warnings == 0))
+    local no_findings = (#diagnostics == 0 and incomplete == 0 and internal == 0)
 
     return o, inp, root_norm, files, diagnostics, {
-        errors = errors, files_with_issues = with_issues,
-        incomplete = incomplete, internal = internal, clean = clean,
-    }
+        errors = errors, warnings = warnings, infos = infos,
+        incomplete = incomplete, internal = internal,
+        files_with_issues = with_issues, by_rule = by_rule,
+        clean = exit_ok,                                     -- clean == exit 0 (design §8)
+    }, no_findings
 end
 
 -- ── output (real output on STDOUT via tool.stdout; print is routed to stderr) ──
 local function emit_json(root_norm, files, diagnostics, summary)
     tool.stdout(json.encode({
-        schema_version = 1,
+        schema_version = 2,                                  -- v2: lint findings + severities
         root = (root_norm == "") and "." or root_norm,
         files_scanned = #files,
         files = files,
@@ -273,33 +358,38 @@ local function emit_json(root_norm, files, diagnostics, summary)
     }) .. "\n")
 end
 
-local function emit_human(o, files, diagnostics, summary)
+local function pluralize(n, word)
+    return n .. " " .. word .. (n == 1 and "" or "s")
+end
+
+local function emit_human(o, files, diagnostics, summary, no_findings)
     local out = {}
     for _, d in ipairs(diagnostics) do
         local pos = (d.line and d.col) and (d.line .. ":" .. d.col) or "?:?"
         out[#out + 1] = string.format("%s:%s: %s: %s [%s]", d.path, pos, d.severity, d.message, d.code)
     end
     if not o.quiet then                                      -- --quiet drops the summary chatter
-        if summary.clean then
+        if no_findings then
             out[#out + 1] = string.format("hull analyze: no issues (%d files scanned)", #files)
         else
-            local parts = { summary.errors .. " error" .. (summary.errors == 1 and "" or "s") ..
-                            " in " .. summary.files_with_issues .. " file" ..
-                            (summary.files_with_issues == 1 and "" or "s") }
+            local parts = {}
+            if summary.errors > 0 then parts[#parts + 1] = pluralize(summary.errors, "error") end
+            if summary.warnings > 0 then parts[#parts + 1] = pluralize(summary.warnings, "warning") end
+            if summary.infos > 0 then parts[#parts + 1] = summary.infos .. " info" end
             if summary.incomplete > 0 then parts[#parts + 1] = summary.incomplete .. " incomplete" end
             if summary.internal > 0 then parts[#parts + 1] = summary.internal .. " internal" end
             if #diagnostics > 0 then out[#out + 1] = "" end
-            out[#out + 1] = string.format("hull analyze: %s (%d files scanned)",
-                table.concat(parts, ", "), #files)
+            out[#out + 1] = string.format("hull analyze: %s in %s (%d files scanned)",
+                table.concat(parts, ", "), pluralize(summary.files_with_issues, "file"), #files)
         end
     end
     if #out > 0 then tool.stdout(table.concat(out, "\n") .. "\n") end
 end
 
-local o, _, root_norm, files, diagnostics, summary = run()
+local o, _, root_norm, files, diagnostics, summary, no_findings = run()
 if o.json then
     emit_json(root_norm, files, diagnostics, summary)        -- JSON overrides --quiet; stdout is pure JSON
 else
-    emit_human(o, files, diagnostics, summary)
+    emit_human(o, files, diagnostics, summary, no_findings)
 end
 tool.exit(summary.clean and 0 or 1)

--- a/stdlib/cli/lua/hull/source/lint.lua
+++ b/stdlib/cli/lua/hull/source/lint.lua
@@ -1,0 +1,134 @@
+--
+-- hull.source.lint — the lint rule registry + engine for `hull analyze` v2.
+--
+-- Each rule is a small declarative record; check(unit, emit) walks the AST / comments
+-- (via hull.source.lua) and calls emit{ range, message } per finding. The engine tags
+-- each finding with `lua.lint.<id>` + the rule's severity. Pure: no I/O, no cross-file
+-- state (per-file rules). Design: docs/hull_analyze_lint_design.md.
+--
+-- SLICE 1 (this file): the engine + STRUCTURAL rules (no scope pass yet):
+-- empty-block, duplicate-table-key, todo-comment. Scope-backed rules (unused-local,
+-- shadowed-local, ...) land in slices 2-3 on hull.source.scope.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local lua = require("hull.source.lua")
+
+local M = {}
+
+-- ── rule helpers ──────────────────────────────────────────────────────
+-- Content of a SHORT string literal with no escapes, else nil (conservative: a long
+-- string or an escaped one is not statically compared). Used to unify `a = 1` with
+-- `["a"] = 1` (the same table key in Lua).
+local function short_string_content(lit)
+    if type(lit) ~= "table" or lit.kind ~= "literal" or lit.subtype ~= "string" then return nil end
+    return lit.text:match('^"([^"\\]*)"$') or lit.text:match("^'([^'\\]*)'$")
+end
+
+-- Normalized static key of a table field, or nil when not determinable (a positional
+-- item, a non-literal `[expr]`, or an escaped/long string key).
+local function table_key(field)
+    if field.kind == "field_name" then
+        return "s:" .. field.name
+    elseif field.kind == "field_expr" and type(field.key) == "table" then
+        local k = field.key
+        if k.kind == "literal" then
+            if k.subtype == "string" then
+                local c = short_string_content(k)
+                return c and ("s:" .. c) or nil
+            elseif k.subtype == "number" then
+                return "n:" .. (k.text or "")
+            end
+        end
+    end
+    return nil
+end
+
+-- ── rules (sorted by id; the registry order is deterministic) ─────────
+M.RULES = {
+    {
+        id = "duplicate-table-key", severity = "warning", default = true,
+        describe = "a table constructor with a repeated literal key",
+        check = function(unit, emit)
+            lua.walk(unit.ast, function(n)
+                if n.kind ~= "table" then return end
+                local seen = {}
+                for _, f in ipairs(n.fields or {}) do
+                    local key = table_key(f)
+                    if key then
+                        if seen[key] then emit({ range = f.range, message = "duplicate table key" })
+                        else seen[key] = true end
+                    end
+                end
+            end)
+        end,
+    },
+    {
+        id = "empty-block", severity = "warning", default = true,
+        describe = "a control-flow block with an empty body",
+        check = function(unit, emit)
+            lua.walk(unit.ast, function(n)
+                local k = n.kind
+                if (k == "do" or k == "while" or k == "repeat"
+                    or k == "numeric_for" or k == "generic_for")
+                    and type(n.body) == "table" and #n.body == 0 then
+                    emit({ range = n.range, message = "empty " .. k:gsub("_", " ") .. " block" })
+                elseif k == "if" and type(n.clauses) == "table" then
+                    for _, c in ipairs(n.clauses) do
+                        if type(c.body) == "table" and #c.body == 0 then
+                            emit({ range = n.range, message = "empty if branch" }); break
+                        end
+                    end
+                end
+            end)
+        end,
+    },
+    {
+        id = "todo-comment", severity = "info", default = true,
+        describe = "a comment containing TODO / FIXME / XXX",
+        check = function(unit, emit)
+            for _, c in ipairs(unit.comments or {}) do
+                local text = c.text or ""
+                for _, m in ipairs({ "TODO", "FIXME", "XXX" }) do
+                    if text:find(m, 1, true) then
+                        emit({ range = c.range, message = m .. " comment" }); break
+                    end
+                end
+            end
+        end,
+    },
+}
+
+-- id -> rule
+local BY_ID = {}
+for _, r in ipairs(M.RULES) do BY_ID[r.id] = r end
+
+function M.exists(id) return BY_ID[id] ~= nil end
+function M.get(id) return BY_ID[id] end
+
+-- The default-on set (a fresh table each call).
+function M.default_enabled()
+    local e = {}
+    for _, r in ipairs(M.RULES) do if r.default then e[r.id] = true end end
+    return e
+end
+
+-- Run the enabled rules over a (cleanly-parsed) unit -> findings[] with each finding's
+-- { code = "lua.lint.<id>", severity, rule = <id>, range, message }.
+function M.run(unit, enabled)
+    local findings = {}
+    for _, rule in ipairs(M.RULES) do          -- registry order = deterministic
+        if enabled[rule.id] then
+            rule.check(unit, function(f)
+                f.code = "lua.lint." .. rule.id
+                f.severity = rule.severity
+                f.rule = rule.id
+                findings[#findings + 1] = f
+            end)
+        end
+    end
+    return findings
+end
+
+return M

--- a/stdlib/cli/lua/hull/source/tests/test_lint.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_lint.lua
@@ -1,0 +1,88 @@
+--
+-- test_lint.lua — slice-1 tests for hull.source.lint (the structural rule engine).
+--
+-- Each rule: a positive case that MUST fire and a negative that must NOT. Plus the
+-- engine (selection, registry). Pure Lua; run by tests/hull/source/test_lua_source.c.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local lua = require("hull.source.lua")
+local lint = require("hull.source.lint")
+
+local pass, fail, failures = 0, 0, {}
+local function ok(cond, name)
+    if cond then pass = pass + 1
+    else fail = fail + 1; failures[#failures + 1] = name; print("FAIL: " .. name) end
+end
+local function eq(a, b, name)
+    ok(a == b, name .. " (expected " .. tostring(b) .. ", got " .. tostring(a) .. ")")
+end
+
+-- count of findings for a given rule id in `src` (all rules enabled unless given)
+local function count(src, ruleid, enabled)
+    local u = lua.parse(src, { path = "t.lua" })
+    ok(u ~= nil and #u.diagnostics == 0, "lint fixture parses clean: " .. src:gsub("%s+", " "):sub(1, 40))
+    local n = 0
+    for _, f in ipairs(lint.run(u, enabled or lint.default_enabled())) do
+        if f.rule == ruleid then
+            n = n + 1
+            -- every finding carries a namespaced code, severity, and a range
+            ok(f.code == "lua.lint." .. ruleid, "finding code namespaced: " .. tostring(f.code))
+            ok(f.range ~= nil and f.range.start ~= nil, "finding has a range: " .. ruleid)
+        end
+    end
+    return n
+end
+
+-- ── empty-block ───────────────────────────────────────────────────────
+do
+    ok(count("if x then end", "empty-block") == 1, "empty if branch fires")
+    ok(count("while c do end", "empty-block") == 1, "empty while fires")
+    ok(count("for i = 1, 3 do end", "empty-block") == 1, "empty numeric for fires")
+    ok(count("for k in pairs(t) do end", "empty-block") == 1, "empty generic for fires")
+    ok(count("do end", "empty-block") == 1, "empty do fires")
+    -- negatives: a non-empty block, and an empty FUNCTION body (intentional stub)
+    ok(count("if x then y() end", "empty-block") == 0, "non-empty if does not fire")
+    ok(count("local f = function() end", "empty-block") == 0, "empty function body does NOT fire")
+    ok(count("while c do g() end", "empty-block") == 0, "non-empty while does not fire")
+end
+
+-- ── duplicate-table-key ───────────────────────────────────────────────
+do
+    ok(count("local t = { a = 1, a = 2 }", "duplicate-table-key") == 1, "dup name key fires")
+    ok(count('local t = { a = 1, ["a"] = 2 }', "duplicate-table-key") == 1, "name vs [\"a\"] unify")
+    ok(count("local t = { [1] = x, [1] = y }", "duplicate-table-key") == 1, "dup number key fires")
+    -- negatives
+    ok(count("local t = { a = 1, b = 2 }", "duplicate-table-key") == 0, "distinct keys clean")
+    ok(count("local t = { 1, 2, 3 }", "duplicate-table-key") == 0, "positional items clean")
+    ok(count("local t = { [x] = 1, [y] = 2 }", "duplicate-table-key") == 0, "non-literal keys not compared")
+end
+
+-- ── todo-comment ──────────────────────────────────────────────────────
+do
+    ok(count("-- TODO fix this\nreturn 1", "todo-comment") == 1, "TODO fires")
+    ok(count("--[[ FIXME later ]]\nreturn 1", "todo-comment") == 1, "FIXME in long comment fires")
+    ok(count("-- XXX\nreturn 1", "todo-comment") == 1, "XXX fires")
+    ok(count("-- an ordinary note\nreturn 1", "todo-comment") == 0, "ordinary comment clean")
+    -- severity is info
+    local u = lua.parse("-- TODO\nreturn 1", { path = "t.lua" })
+    local f = lint.run(u, lint.default_enabled())[1]
+    eq(f.severity, "info", "todo-comment severity is info")
+end
+
+-- ── engine: selection + registry ──────────────────────────────────────
+do
+    ok(lint.exists("empty-block") and not lint.exists("nope"), "exists() checks the registry")
+    local only_todo = { ["todo-comment"] = true }
+    ok(count("-- TODO\nlocal t={a=1,a=2}\nif x then end", "duplicate-table-key", only_todo) == 0,
+        "selection: dup-key disabled when only todo enabled")
+    ok(count("-- TODO\nlocal t={a=1,a=2}\nif x then end", "todo-comment", only_todo) == 1,
+        "selection: todo still fires when selected")
+    local de = lint.default_enabled()
+    ok(de["empty-block"] and de["duplicate-table-key"] and de["todo-comment"],
+        "default_enabled has all slice-1 rules on")
+end
+
+print(string.format("test_lint: %d passed, %d failed", pass, fail))
+return { pass = pass, fail = fail, failures = failures }

--- a/tests/e2e_analyze.sh
+++ b/tests/e2e_analyze.sh
@@ -68,10 +68,10 @@ if [ "$a" = "$b" ] && [ -n "$a" ]; then pass "deterministic --json output"; else
 lines=$(wc -l < "$TMP/j.txt" | tr -d ' ')
 first=$(head -c1 "$TMP/j.txt"); last=$(tail -c2 "$TMP/j.txt" | head -c1)
 if [ "$lines" = "1" ] && [ "$first" = "{" ] && [ "$last" = "}" ] \
-   && grep -q '"schema_version":1' "$TMP/j.txt" && grep -q '"root":' "$TMP/j.txt" \
+   && grep -q '"schema_version":2' "$TMP/j.txt" && grep -q '"root":' "$TMP/j.txt" \
    && grep -q '"code":"lua.syntax"' "$TMP/j.txt" && grep -q '"files_scanned":' "$TMP/j.txt" \
    && grep -q '"summary":' "$TMP/j.txt"; then
-    pass "JSON stdout pure (1 line, {…}) + schema_version 1 + required keys"
+    pass "JSON stdout pure (1 line, {…}) + schema_version 2 + required keys"
 else fail "JSON purity/schema (lines=$lines first=$first last=$last)"; fi
 
 # ── Test 5: explicit target errors — missing + non-Lua (outside-root is
@@ -150,7 +150,7 @@ else fail "--quiet (qc=[$qc])"; fi
 
 # ── Test 13: --json overrides --quiet (stdout stays pure JSON) ─────────
 jq=$("$HULL" analyze "$APP" --json --quiet 2>/dev/null || true)
-if [ -n "$jq" ] && [ "$(printf '%s' "$jq" | head -c1)" = "{" ] && echo "$jq" | grep -q '"schema_version":1'; then
+if [ -n "$jq" ] && [ "$(printf '%s' "$jq" | head -c1)" = "{" ] && echo "$jq" | grep -q '"schema_version":2'; then
     pass "--json --quiet → JSON overrides quiet, pure JSON stdout"
 else fail "--json --quiet override (jq=$jq)"; fi
 
@@ -187,6 +187,61 @@ else
         pass "unreadable discovered subdir → exit 2 + discovery failed (fail closed)"
     else fail "unreadable subdir (rc=$rc, out=[$out], err=$(cat "$TMP/unr_err.txt"))"; fi
 fi
+
+# ── lint (v2) fixture: a duplicate table key, an empty block, a TODO ──
+LINT="$TMP/lint"
+mkdir -p "$LINT"
+printf -- '-- TODO: finish this\napp.main(function()\n  local t = { a = 1, a = 2 }\n  if t.a then end\n  return 0\nend)\n' > "$LINT/app.lua"
+
+# ── Test 17: lint warnings are advisory (exit 0), findings still printed ─
+rc=0; out=$("$HULL" analyze "$LINT" 2>/dev/null) || rc=$?
+if [ "$rc" = "0" ] && echo "$out" | grep -q "lua.lint.duplicate-table-key" \
+   && echo "$out" | grep -q "lua.lint.empty-block" && echo "$out" | grep -q "lua.lint.todo-comment"; then
+    pass "lint findings advisory (exit 0) with dup-key + empty-block + todo"
+else fail "lint advisory (rc=$rc, out=$out)"; fi
+
+# ── Test 18: --strict makes warnings fail (exit 1) ────────────────────
+rc=0; "$HULL" analyze "$LINT" --strict >/dev/null 2>&1 || rc=$?
+if [ "$rc" = "1" ]; then pass "--strict: warnings fail (exit 1)"; else fail "--strict (rc=$rc)"; fi
+
+# ── Test 19: --list-rules enumerates the registry ─────────────────────
+lr=$("$HULL" analyze --list-rules 2>/dev/null || true)
+if echo "$lr" | grep -q "duplicate-table-key" && echo "$lr" | grep -q "empty-block" \
+   && echo "$lr" | grep -q "todo-comment"; then
+    pass "--list-rules lists the rules"
+else fail "--list-rules ($lr)"; fi
+
+# ── Test 20: --disable / --rules selection ────────────────────────────
+d=$("$HULL" analyze "$LINT" --disable=empty-block,todo-comment 2>/dev/null || true)
+r=$("$HULL" analyze "$LINT" --rules=todo-comment 2>/dev/null || true)
+if ! echo "$d" | grep -q "empty-block" && echo "$d" | grep -q "duplicate-table-key" \
+   && echo "$r" | grep -q "todo-comment" && ! echo "$r" | grep -q "empty-block"; then
+    pass "--disable / --rules select the active rules"
+else fail "rule selection (d=$d)(r=$r)"; fi
+
+# ── Test 21: unknown rule → exit 2 ────────────────────────────────────
+rc=0; out=$("$HULL" analyze "$LINT" --rules=nope 2>"$TMP/lr.txt") || rc=$?
+if [ "$rc" = "2" ] && [ -z "$out" ] && grep -q "unknown lint rule" "$TMP/lr.txt"; then
+    pass "unknown lint rule → exit 2, stderr message"
+else fail "unknown rule (rc=$rc)"; fi
+
+# ── Test 22: JSON v2 schema — lint codes + severities + summary counts ─
+"$HULL" analyze "$LINT" --json 2>/dev/null > "$TMP/lint.json" || true
+if grep -q '"schema_version":2' "$TMP/lint.json" \
+   && grep -q '"code":"lua.lint.duplicate-table-key"' "$TMP/lint.json" \
+   && grep -q '"severity":"warning"' "$TMP/lint.json" && grep -q '"severity":"info"' "$TMP/lint.json" \
+   && grep -q '"warnings":' "$TMP/lint.json" && grep -q '"by_rule":' "$TMP/lint.json"; then
+    pass "JSON v2: lua.lint.* codes + warning/info severities + summary.warnings/by_rule"
+else fail "lint JSON schema"; fi
+
+# ── Test 23: a syntax-broken file is NOT linted (no spurious lint) ────
+printf 'local t = { a = ) }\n' > "$LINT/oops.lua"
+n=$("$HULL" analyze "$LINT" oops.lua --json 2>/dev/null | grep -c 'lua.lint' || true)
+rc=0; "$HULL" analyze "$LINT" oops.lua >/dev/null 2>&1 || rc=$?
+if [ "$n" = "0" ] && [ "$rc" = "1" ]; then
+    pass "syntax-broken file: no spurious lint, exit 1 from the syntax error"
+else fail "broken-not-linted (n=$n, rc=$rc)"; fi
+rm -f "$LINT/oops.lua"
 
 # ── summary ───────────────────────────────────────────────────────────
 echo ""

--- a/tests/hull/source/test_lua_source.c
+++ b/tests/hull/source/test_lua_source.c
@@ -270,4 +270,13 @@ UTEST(lua_source, conformance)
     EXPECT_GT(pass, 0LL);
 }
 
+UTEST(lua_source, lint_slice1)
+{
+    long long pass = 0, fail = -1;
+    int rc = run_lua_test("stdlib/cli/lua/hull/source/tests/test_lint.lua", &pass, &fail);
+    ASSERT_EQ(rc, 0);
+    EXPECT_EQ(fail, 0LL);
+    EXPECT_GT(pass, 0LL);
+}
+
 UTEST_MAIN()


### PR DESCRIPTION
Slice 1 of `hull analyze` v2 (ratified design: `docs/hull_analyze_lint_design.md`) — the lint rule engine + structural rules, turning `hull analyze` from a syntax checker into a linter (still no run/build).

## New: `hull.source.lint`
A sorted `RULES` registry + engine (`lint.run(unit, enabled)` → findings tagged `lua.lint.<id>` + the rule's severity). Slice-1 rules (pure Lua over `lua.walk` / `unit.comments`, no scope pass yet):
- **`empty-block`** (warning) — a control-flow block (`do`/`while`/`for`/`repeat`/`if` branch) with an empty body; deliberately **not** empty function stubs.
- **`duplicate-table-key`** (warning) — a repeated literal key, unifying `a =` with `["a"] =`.
- **`todo-comment`** (info) — `TODO`/`FIXME`/`XXX`.

## `analyze.lua`
- `--strict` (warnings fail; **advisory by default**), `--rules` / `--disable` / `--enable` (validated — unknown id → exit 2), `--list-rules` (human or `--json`).
- Each diagnostic carries its own **severity** (error for syntax/targets, warning/info for lint); exit 0 unless an error/incomplete/internal **or** (`--strict` and a warning).
- JSON bumped to **`schema_version: 2`** with `summary.warnings` / `infos` / `by_rule`.
- Lint runs **only on a cleanly-parsed file** (complete + zero syntax errors), so a recovered AST never yields spurious findings.

## Tests
`test_lint.lua` (67 cases — each rule positive + negative, engine selection); `tests/e2e_analyze.sh` +7 (**23 total**: advisory vs `--strict`, `--list-rules`, `--rules`/`--disable`, unknown-rule exit 2, JSON v2 schema, broken-file-not-linted); e2e schema assertions bumped 1→2.

lexer 115 + parser 133 + statements 130 + annotations 77 + conformance 524 + lint 67; **76/76** unit; luacheck clean; full `hull` build OK. Slices 2 (`hull.source.scope`) + 3 (scope rules) follow.
