### PR TITLE
feat(source): hull.source.scope — lexical binding pass (lint slice 2)

### DIFF
--- a/docs/hull_analyze_lint_design.md
+++ b/docs/hull_analyze_lint_design.md
@@ -183,7 +183,9 @@ is the explicit signal that lint data may be present.
    severities, `lua.lint.<id>` codes, JSON `schema_version: 2` (+ `summary.warnings`/
    `infos`/`by_rule`). `test_lint.lua` + `tests/e2e_analyze.sh` (23 cases). Lint runs
    only on a CLEANLY-parsed file (complete + no syntax errors).
-2. **Scope pass** — `hull.source.scope` + `test_scope.lua` (the reusable Step B).
+2. **Scope pass** — DONE. `hull.source.scope` (`resolve -> scope, err`; pcall-guarded)
+   + `test_scope.lua`. The reusable Step B; not yet wired into a rule (slice 3).
+   Design: [hull_source_scope_design.md](hull_source_scope_design.md).
 3. **Scope rules** — `unused-local`, `unused-param`, `shadowed-local`, and
    `undefined-global` (off by default) on top of the pass.
 

--- a/docs/hull_source_scope_design.md
+++ b/docs/hull_source_scope_design.md
@@ -80,7 +80,9 @@ scope = {
 --   reads = <int>, writes = <int>,
 --   shadows = <decl|nil>,-- the binding it hides (§5), if any
 -- }
--- resolution = { decl = <decl>, kind = "local"|"upvalue" } | { kind = "global" }
+-- resolution = { decl = <decl>?, kind = "local"|"upvalue"|"global",
+--                access = "read"|"write" }   -- access is on EVERY resolution, so a
+--                consumer can tell a global READ (undefined-global) from a global write
 ```
 `ref_of` is keyed by the `name` node table identity, so a consumer walking the AST can
 ask "what does this name resolve to?". `bindings` drives the `unused-*` rules;

--- a/docs/hull_source_scope_design.md
+++ b/docs/hull_source_scope_design.md
@@ -1,6 +1,7 @@
-# `hull.source.scope` — lexical binding pass (design)
+# `hull.source.scope` — lexical binding pass
 
-Status: DESIGN (pre-implementation). Slice 2 of `hull analyze` v2
+Status: IMPLEMENTED (`stdlib/cli/lua/hull/source/scope.lua`, `test_scope.lua`). Not yet
+wired into any rule (slice 3 consumes it). Slice 2 of `hull analyze` v2
 ([hull_analyze_lint_design.md](hull_analyze_lint_design.md) §3) — the light lexical
 scope / name-resolution pass the scope-backed lint rules (slice 3: `unused-local`,
 `unused-param`, `shadowed-local`, `undefined-global`) need. It is the "semantic /

--- a/docs/hull_source_scope_design.md
+++ b/docs/hull_source_scope_design.md
@@ -1,0 +1,200 @@
+# `hull.source.scope` — lexical binding pass (design)
+
+Status: DESIGN (pre-implementation). Slice 2 of `hull analyze` v2
+([hull_analyze_lint_design.md](hull_analyze_lint_design.md) §3) — the light lexical
+scope / name-resolution pass the scope-backed lint rules (slice 3: `unused-local`,
+`unused-param`, `shadowed-local`, `undefined-global`) need. It is the "semantic /
+binding pass" the roadmap deferred "only if a consumer needs it"; the linter is that
+consumer. Reusable (future codegen may want it), so it ships as its own source-layer
+module, not lint-internal.
+
+## 1. Goal
+
+`scope.resolve(unit) -> scope, err` resolves, for a cleanly-parsed `unit.ast`, **which
+declaration each `name` reference binds to** (a local / parameter / loop-var in an
+enclosing scope, an **upvalue** across a function boundary, or a **global**), and
+records **per-declaration usage** (was it ever read? written?) and **shadowing** (does
+it hide a binding of the same name?).
+
+**Two failure modes, distinguished.** A *recovered error node* or a locally-missing
+field degrades **locally** to "unresolved" (never a crash) — the model is still usable.
+An *internal resolver failure* (a bug that raises) must NOT silently return a partial
+model that suppresses findings: the traversal is `pcall`-guarded and, on a raise,
+`resolve` returns `(nil, err)` where `err` is a diagnostic-shaped table. The analyzer
+then surfaces an **internal diagnostic** for the file and **skips the scope-backed
+rules** for it (never a false "clean"). On success, `err == nil`.
+
+## 2. Lua 5.4 scoping rules the pass must honor
+
+These are the subtleties that make a naive walk wrong:
+
+1. **A `local` is visible only AFTER its declaration statement**, within the rest of
+   its block. So in `local x = x`, the RHS `x` binds to an *outer* `x` (or a global),
+   NOT the one being declared. Process a `local_declaration`'s **values before** adding
+   its names to the scope.
+2. **`local function f` is visible inside its own body** (for recursion) — add the
+   binding **before** descending the function body. `local f = function() ... end` is
+   NOT (the name is added after the value, per rule 1).
+3. **Parameters** scope to the function body; a method `function a:m()` has an implicit
+   first parameter **`self`**.
+4. **Loop variables** scope to the loop body: numeric-for's `var`, generic-for's
+   `names`. (They are NOT visible in the loop's control expressions — those are
+   evaluated in the enclosing scope.)
+5. **`repeat <body> until <cond>`**: the `until` condition is evaluated **in the scope
+   of the body's locals** (a Lua special case — unlike every other loop). A local
+   declared in the repeat body IS visible in the `until` expression.
+6. **Blocks introduce scopes**: the chunk, each function body, `do`, `while`/`repeat`
+   bodies, each `if`-clause body, and each for body. A binding leaves scope at the end
+   of its block.
+7. **Function boundary = upvalue**: a reference resolving to a binding in an enclosing
+   *function* (not just an enclosing block of the same function) is an **upvalue**. The
+   pass records the distinction (local-in-this-function vs upvalue).
+
+## 3. What is a reference vs a declaration
+
+The parser represents local/param/loop **declaration names as plain string records**
+(`{ name = "x", range }`), NOT `name` AST nodes — so they are never visited as
+references. A `name` **node** (`{ kind = "name", name, range }`) is always a use:
+- as an **assignment target** (`target.kind == "name"`) → a **write** to the resolved
+  binding (or a global write);
+- anywhere else (a value, a call callee, the object of a `field`/`index`, a table
+  value, a return value, …) → a **read**.
+
+So `unused-local` = a local/param with **zero reads** (writes don't count as use). An
+underscore-prefixed name (`_`, `_x`) and the implicit `self` are exempt (slice 3).
+
+## 4. Output shape (attached to `unit`, returned)
+
+```
+scope = {
+  bindings = { <decl>, ... },   -- every local / param / loopvar, in source order
+  ref_of   = <table: name-node -> resolution>,
+}
+-- <decl> = {
+--   name, kind = "local"|"param"|"localfunc"|"loopvar",
+--   range,               -- the declaration's range (for an implicit self, the anchor)
+--   implicit = true?,    -- ONLY the method `self` param -- a synthetic binding, not
+--                        --   a "real source" decl (its range is an anchor, see §6)
+--   func_id,             -- which function scope owns it (for upvalue detection)
+--   reads = <int>, writes = <int>,
+--   shadows = <decl|nil>,-- the binding it hides (§5), if any
+-- }
+-- resolution = { decl = <decl>, kind = "local"|"upvalue" } | { kind = "global" }
+```
+`ref_of` is keyed by the `name` node table identity, so a consumer walking the AST can
+ask "what does this name resolve to?". `bindings` drives the `unused-*` rules;
+`shadows` drives `shadowed-local`; a `resolution.kind == "global"` read (of a name not
+in a known-globals allowlist) drives `undefined-global`.
+
+## 5. Shadowing semantics (a decision, §8)
+
+`shadows` is set when a new declaration hides an enclosing binding **of the same name**.
+The **default** flags shadowing of a binding **in the same function** (an enclosing
+block: an outer `local`, a param, an enclosing loop var) — the genuinely bug-prone
+case (`local x` in a nested block hiding the function's `local x`). It does **NOT** flag
+shadowing an **upvalue** from an *outer function* by default: a parameter or local
+named the same as something in an enclosing closure is extremely common and idiomatic
+(e.g. a callback `function(err) ... end` where an outer `err` exists), so flagging it
+would be noise. (An `--enable`-able stricter variant is a later add.)
+
+## 6. Algorithm
+
+A single **recursive, scope-aware traversal** of the AST (NOT `lua.walk`, which
+flattens and loses block/statement ordering), `pcall`-guarded (§1). State: a stack of
+scopes; each scope has a name→decl map and a `func_id`; a `func_id` counter. **The chunk
+(main) is itself a function scope with `func_id = 1`** (the main chunk is a vararg
+function in Lua); nested function bodies get `func_id = 2, 3, …`, so a nested function
+capturing a chunk-level local correctly classifies it as an **upvalue**
+(binding.func_id 1 ≠ the nested func_id).
+
+- **Enter a block** → push a scope. **Leave** → pop (its bindings persist in
+  `scope.bindings`; only visibility ends).
+- **Resolve a `name` node** → search the scope stack top-down for the name; first hit is
+  the binding. If the binding's `func_id` ≠ the current function's `func_id` →
+  `kind = "upvalue"`, else `"local"`; increment its `reads` (or `writes` if it's an
+  assignment target). No hit → `global`.
+- **`local_declaration`** → resolve the **values first** (rule 1), then add each name as
+  a `local` decl to the current scope.
+- **`local function`** → add the `localfunc` decl to the current scope **first** (rule
+  2), then descend the body (a new function scope).
+- **simple `function f()`** → the declaration name is an **assignment** to the resolved
+  `f` binding: a **local write** if `f` is a local in scope, else a **global write** —
+  NOT inherently global. (The body is a new function scope.)
+- **dotted/method `function a.b:m()`** → the **base** `a` is a **read** (a `name` node);
+  the field keys `b` / `m` are NOT `name` references (they are string keys on the
+  `field` chain). Resolve only the base name; the body is a new function scope with
+  `self` (if method) + params.
+- **`function_expr` / function bodies** → new function scope (`func_id`++); add params
+  (+ implicit `self` for methods); descend the body.
+- **numeric_for / generic_for** → resolve control expressions in the ENCLOSING scope
+  (rule 4), then push the body scope with the loop var(s), descend the body.
+- **`repeat`** → push the body scope, descend the body, THEN resolve the `until`
+  condition **in that same scope** (rule 5), then pop.
+- **`assignment`** → resolve values (reads), then each target: a bare `name` target is a
+  **write** to its resolution; a `field`/`index` target reads its object/key.
+- **shadowing** → when adding a decl, look up the same name in the current scope **and**
+  the enclosing scopes of the **same function** — the current scope INCLUDED, so a
+  same-block redeclaration (`local x; local x`) and a repeated name within one
+  declaration (`local x, x`) both count as shadowing (each added left-to-right, so the
+  later one sees the earlier). If found, set `shadows` (§5).
+- **implicit `self`** → a method's `self` param is added as
+  `{ name = "self", kind = "param", implicit = true, range = <anchor> }`, where the
+  anchor is the method declaration's name range (a stable, real span) — explicitly
+  marked synthetic, NOT a zero-width fake "real source" decl.
+
+`goto`/labels are ignored for binding purposes (they do not introduce value bindings;
+Lua's goto-scope validation is out of scope for v2 — §7).
+
+## 7. Non-goals
+
+- **No goto/label scope validation** (Lua's "jumps into the scope of a local" is a
+  `load()` semantic check, not a binding question; the conformance gate already pins it
+  as an expected divergence).
+- **No type/flow analysis**; `reads`/`writes` are lexical counts, not reachability.
+- **No cross-file / project symbol graph** (per-file, like the rest of v2).
+- **Not** wired into any rule in slice 2 — this slice ships the pass + its own tests;
+  slice 3 consumes it.
+
+## 8. Testing
+
+`test_scope.lua` (a new `UTEST(lua_source, scope)` leg) over hand-built cases, asserting
+`ref_of` resolutions + per-decl `reads`/`writes`/`shadows`:
+- `local x = x` → the RHS resolves to an outer `x` / global, not the new local.
+- `local function f() return f() end` → `f` inside the body resolves to itself (recursion).
+- `local f = function() return f end` → the inner `f` does NOT resolve to `f` (global).
+- a nested block `local x; do local x end` → the inner `x` `shadows` the outer.
+- **same-block redeclaration** `local x; local x` → the second `shadows` the first.
+- **repeated names in one declaration** `local x, x = 1, 2` → the second `shadows` the first.
+- **`function f() end`** where `f` is a local → recorded as a WRITE to that local (not a
+  global); where `f` is not local → a global write.
+- **implicit `self`** → present as a `param` decl with `implicit = true` and a non-empty
+  anchor range.
+- a param / callback shadowing an **upvalue** → NOT flagged (default).
+- numeric/generic-for var scoped to the body; control exprs in the enclosing scope.
+- method `function a:m()` → `self` is a param, resolvable in the body.
+- `repeat local y = 1 until y` → the `until y` resolves to the body's `y`.
+- upvalue: an inner function reading an outer local → `resolution.kind == "upvalue"`.
+- an unused local (0 reads) vs a read one; a written-but-never-read local (0 reads, ≥1
+  write) → still "unused" for slice 3.
+- never-raises on a recovered/error-bearing AST.
+
+## 9. Decisions (ratified)
+
+1. **Shadowing** flags **same-function** bindings only by default (the current scope
+   INCLUDED, so same-block redeclaration counts); NOT upvalue shadowing from an outer
+   function.
+2. **`goto`/labels** validation stays out of scope (a `load()` semantic check, already a
+   pinned conformance divergence).
+3. **Only reads count as use**; a write with no read is dead (`unused-local` still
+   fires).
+4. **`self` / underscore exemptions live in the lint rules** (slice 3), not the reusable
+   pass — the pass records them as ordinary bindings (with `self` marked `implicit`) and
+   the rule filters.
+
+Contract tightenings folded in: `resolve -> (scope, err)` with a `pcall`-guarded
+traversal (an internal failure surfaces an internal diagnostic + skips scope-backed
+rules, never a silent partial); `function f()` is a write to the resolved `f` binding
+(local or global), dotted/method decls read only the base name; same-block +
+same-declaration redeclaration count as shadowing; implicit `self` is an explicit
+`implicit = true` binding with a real anchor range; the chunk is `func_id = 1` so nested
+captures of chunk locals classify as upvalues.

--- a/stdlib/cli/lua/hull/source/scope.lua
+++ b/stdlib/cli/lua/hull/source/scope.lua
@@ -1,0 +1,203 @@
+--
+-- hull.source.scope — lexical binding / name-resolution pass (lint slice 2).
+--
+-- scope.resolve(unit) -> scope, err : resolves every `name` AST node to its binding
+-- (a local/param/loopvar, an upvalue across a function boundary, or a global) and
+-- records per-declaration reads/writes + shadowing. The reusable "Step B" that slice-3
+-- scope-backed rules (unused-local, shadowed-local, ...) consume.
+--
+-- Design + Lua-5.4 scoping subtleties: docs/hull_source_scope_design.md. The traversal
+-- is pcall-guarded: a recovered error node degrades LOCALLY, but an internal failure
+-- returns (nil, err) so the caller surfaces an internal diagnostic and skips scope
+-- rules -- never a silent partial model.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local M = {}
+
+-- The core traversal, in a fresh local state per call (reentrant). Returns the scope
+-- model; raising is caught by M.resolve's pcall.
+local function do_resolve(unit)
+    local scopes = { { vars = {}, func_id = 1 } }   -- the chunk IS function scope 1
+    local func_id_counter = 1
+    local bindings, ref_of = {}, {}
+
+    local function cur() return scopes[#scopes] end
+    local function cur_func() return cur().func_id end
+
+    local function push_block()
+        scopes[#scopes + 1] = { vars = {}, func_id = cur_func() }
+    end
+    local function push_function()
+        func_id_counter = func_id_counter + 1
+        scopes[#scopes + 1] = { vars = {}, func_id = func_id_counter }
+    end
+    local function pop() scopes[#scopes] = nil end
+
+    -- Add a declaration to the current scope; set `shadows` if a same-name binding is
+    -- visible in the current scope or an enclosing block OF THE SAME FUNCTION (current
+    -- scope included -> same-block redeclaration counts).
+    local function add_decl(name, kind, range, implicit)
+        local my_func = cur_func()
+        local shadows = nil
+        for i = #scopes, 1, -1 do
+            local sc = scopes[i]
+            if sc.func_id ~= my_func then break end   -- crossed a function boundary
+            if sc.vars[name] then shadows = sc.vars[name]; break end
+        end
+        local decl = {
+            name = name, kind = kind, range = range, implicit = implicit or nil,
+            func_id = my_func, reads = 0, writes = 0, shadows = shadows,
+        }
+        cur().vars[name] = decl                       -- shadow any prior in this scope
+        bindings[#bindings + 1] = decl
+        return decl
+    end
+
+    -- Resolve a `name` node: nearest enclosing binding wins (local if in the current
+    -- function, else upvalue); no binding -> global. Counts a read or a write.
+    local function resolve_ref(node, is_write)
+        local name = node.name
+        for i = #scopes, 1, -1 do
+            local decl = scopes[i].vars[name]
+            if decl then
+                if is_write then decl.writes = decl.writes + 1
+                else decl.reads = decl.reads + 1 end
+                ref_of[node] = { decl = decl, kind = (decl.func_id == cur_func()) and "local" or "upvalue" }
+                return
+            end
+        end
+        ref_of[node] = { kind = "global" }
+    end
+
+    local visit_expr, visit_stat, visit_block, visit_function
+
+    function visit_expr(node)
+        if type(node) ~= "table" or not node.kind then return end
+        local k = node.kind
+        if k == "name" then
+            resolve_ref(node, false)                  -- a read (writes handled at target sites)
+        elseif k == "field" then
+            visit_expr(node.obj)                      -- .name is a key, not a ref
+        elseif k == "index" then
+            visit_expr(node.obj); visit_expr(node.key)
+        elseif k == "call" then
+            visit_expr(node.callee)
+            for _, a in ipairs(node.args or {}) do visit_expr(a) end
+        elseif k == "method_call" then
+            visit_expr(node.obj)                      -- :method is a key
+            for _, a in ipairs(node.args or {}) do visit_expr(a) end
+        elseif k == "binary" then
+            visit_expr(node.lhs); visit_expr(node.rhs)
+        elseif k == "unary" then
+            visit_expr(node.operand)
+        elseif k == "paren" then
+            visit_expr(node.expr)
+        elseif k == "table" then
+            for _, f in ipairs(node.fields or {}) do
+                if f.kind == "field_expr" then visit_expr(f.key); visit_expr(f.value)
+                else visit_expr(f.value) end          -- field_name key is not a ref; field_item value
+            end
+        elseif k == "function_expr" then
+            visit_function(node, nil)
+        end
+        -- literal / vararg / error / unknown: no refs (degrade locally)
+    end
+
+    function visit_function(node, self_anchor)
+        push_function()
+        if self_anchor then add_decl("self", "param", self_anchor, true) end
+        for _, p in ipairs(node.params or {}) do
+            if p.kind == "param" and p.name then add_decl(p.name, "param", p.range) end
+            -- a vararg param is not a name binding
+        end
+        visit_block(node.body or {})
+        pop()
+    end
+
+    function visit_stat(s)
+        if type(s) ~= "table" or not s.kind then return end
+        local k = s.kind
+        if k == "local_declaration" then
+            for _, v in ipairs(s.values or {}) do visit_expr(v) end   -- values FIRST (local visible after)
+            for _, nm in ipairs(s.names or {}) do
+                if nm.name then add_decl(nm.name, "local", nm.range) end
+            end
+        elseif k == "function_declaration" then
+            local nm = s.name
+            if s.is_local then
+                if nm and nm.kind == "name" then add_decl(nm.name, "localfunc", nm.range) end  -- visible in body
+                visit_function(s, nil)
+            else
+                if nm and nm.kind == "name" then
+                    resolve_ref(nm, true)             -- `function f()` = a write to the resolved f
+                elseif nm and nm.kind == "field" then
+                    local base = nm
+                    while type(base) == "table" and base.kind == "field" do base = base.obj end
+                    if type(base) == "table" and base.kind == "name" then resolve_ref(base, false) end
+                end
+                local anchor = (s.is_method and nm and nm.range) or nil
+                visit_function(s, anchor)
+            end
+        elseif k == "assignment" then
+            for _, v in ipairs(s.values or {}) do visit_expr(v) end
+            for _, t in ipairs(s.targets or {}) do
+                if type(t) == "table" and t.kind == "name" then resolve_ref(t, true)
+                else visit_expr(t) end                -- field/index target: reads obj/key
+            end
+        elseif k == "call_statement" then
+            visit_expr(s.call)
+        elseif k == "do" then
+            push_block(); visit_block(s.body or {}); pop()
+        elseif k == "while" then
+            visit_expr(s.cond)                        -- cond in the enclosing scope
+            push_block(); visit_block(s.body or {}); pop()
+        elseif k == "repeat" then
+            push_block(); visit_block(s.body or {})
+            visit_expr(s.cond)                        -- until: IN the body scope (Lua special case)
+            pop()
+        elseif k == "if" then
+            for _, c in ipairs(s.clauses or {}) do
+                if c.cond then visit_expr(c.cond) end -- cond in the enclosing scope
+                push_block(); visit_block(c.body or {}); pop()
+            end
+        elseif k == "numeric_for" then
+            visit_expr(s.from); visit_expr(s.to); if s.step then visit_expr(s.step) end
+            push_block()
+            if s.var and s.var.name then add_decl(s.var.name, "loopvar", s.var.range) end
+            visit_block(s.body or {}); pop()
+        elseif k == "generic_for" then
+            for _, e in ipairs(s.exprs or {}) do visit_expr(e) end
+            push_block()
+            for _, nm in ipairs(s.names or {}) do
+                if nm.name then add_decl(nm.name, "loopvar", nm.range) end
+            end
+            visit_block(s.body or {}); pop()
+        elseif k == "return" then
+            for _, v in ipairs(s.values or {}) do visit_expr(v) end
+        end
+        -- break / goto / label / error: no bindings or refs
+    end
+
+    function visit_block(stmts)
+        for _, s in ipairs(stmts) do visit_stat(s) end
+    end
+
+    if type(unit) == "table" and type(unit.ast) == "table" then
+        visit_block(unit.ast.body or {})
+    end
+    return { bindings = bindings, ref_of = ref_of }
+end
+
+-- Public boundary: (scope, err). err ~= nil (and scope == nil) ONLY on an internal
+-- resolver failure -- a recovered/error-bearing AST degrades locally, not here.
+function M.resolve(unit)
+    local ok, result = pcall(do_resolve, unit)
+    if not ok then
+        return nil, { code = "lua.internal", message = "scope resolver failed: " .. tostring(result) }
+    end
+    return result, nil
+end
+
+return M

--- a/stdlib/cli/lua/hull/source/scope.lua
+++ b/stdlib/cli/lua/hull/source/scope.lua
@@ -14,6 +14,8 @@
 -- SPDX-License-Identifier: AGPL-3.0-or-later
 --
 
+local diag = require("hull.source.diagnostic")
+
 local M = {}
 
 -- The core traversal, in a fresh local state per call (reentrant). Returns the scope
@@ -56,19 +58,25 @@ local function do_resolve(unit)
     end
 
     -- Resolve a `name` node: nearest enclosing binding wins (local if in the current
-    -- function, else upvalue); no binding -> global. Counts a read or a write.
+    -- function, else upvalue); no binding -> global. Records the access MODE too, so a
+    -- consumer can tell a global read (undefined-global) from a global write.
     local function resolve_ref(node, is_write)
+        local access = is_write and "write" or "read"
         local name = node.name
         for i = #scopes, 1, -1 do
             local decl = scopes[i].vars[name]
             if decl then
                 if is_write then decl.writes = decl.writes + 1
                 else decl.reads = decl.reads + 1 end
-                ref_of[node] = { decl = decl, kind = (decl.func_id == cur_func()) and "local" or "upvalue" }
+                ref_of[node] = {
+                    decl = decl,
+                    kind = (decl.func_id == cur_func()) and "local" or "upvalue",
+                    access = access,
+                }
                 return
             end
         end
-        ref_of[node] = { kind = "global" }
+        ref_of[node] = { kind = "global", access = access }
     end
 
     local visit_expr, visit_stat, visit_block, visit_function
@@ -191,11 +199,17 @@ local function do_resolve(unit)
 end
 
 -- Public boundary: (scope, err). err ~= nil (and scope == nil) ONLY on an internal
--- resolver failure -- a recovered/error-bearing AST degrades locally, not here.
+-- resolver failure -- a recovered/error-bearing AST degrades locally, not here. The
+-- error is a proper diagnostic (severity/code/path/range) via hull.source.diagnostic,
+-- so the analyzer surfaces it on the shared contract before skipping scope rules.
 function M.resolve(unit)
     local ok, result = pcall(do_resolve, unit)
     if not ok then
-        return nil, { code = "lua.internal", message = "scope resolver failed: " .. tostring(result) }
+        local path = (type(unit) == "table") and unit.path or nil
+        local range = ((type(unit) == "table") and type(unit.ast) == "table" and unit.ast.range)
+            or { start = 1, stop = 1 }
+        return nil, diag.error("lua.internal",
+            "scope resolver failed: " .. tostring(result), path, range)
     end
     return result, nil
 end

--- a/stdlib/cli/lua/hull/source/tests/test_scope.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_scope.lua
@@ -1,0 +1,152 @@
+--
+-- test_scope.lua — slice-2 tests for hull.source.scope (the lexical binding pass).
+--
+-- Asserts ref_of resolutions (local / upvalue / global) + per-decl reads/writes/shadows
+-- over the Lua-5.4 scoping edge cases. Pure Lua; run by tests/hull/source/test_lua_source.c.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local lua = require("hull.source.lua")
+local scope = require("hull.source.scope")
+
+local pass, fail, failures = 0, 0, {}
+local function ok(cond, name)
+    if cond then pass = pass + 1
+    else fail = fail + 1; failures[#failures + 1] = name; print("FAIL: " .. name) end
+end
+local function eq(a, b, name)
+    ok(a == b, name .. " (expected " .. tostring(b) .. ", got " .. tostring(a) .. ")")
+end
+
+local function analyze(src)
+    local u = lua.parse(src, { path = "t.lua" })
+    ok(u ~= nil and #u.diagnostics == 0, "scope fixture parses clean: " .. src:gsub("%s+", " "):sub(1, 40))
+    local sc, err = scope.resolve(u)
+    ok(err == nil and sc ~= nil, "scope.resolve ok: " .. src:gsub("%s+", " "):sub(1, 40))
+    return u, sc
+end
+
+-- resolution of the first RESOLVED name node with this text (in source order)
+local function first_ref(u, sc, name)
+    local found
+    lua.walk(u.ast, function(n)
+        if not found and n.kind == "name" and n.name == name and sc.ref_of[n] then
+            found = sc.ref_of[n]
+        end
+    end)
+    return found
+end
+-- all bindings with a given name, in source order
+local function binds(sc, name)
+    local out = {}
+    for _, d in ipairs(sc.bindings) do if d.name == name then out[#out + 1] = d end end
+    return out
+end
+
+-- ── declaration-after-use (local x = x) + recursion vs closure ────────
+do
+    local u, sc = analyze("local x = x")
+    eq(first_ref(u, sc, "x").kind, "global", "local x = x: RHS binds to global, not the new local")
+    eq(binds(sc, "x")[1].reads, 0, "new local x is unread")
+
+    -- local function f captures itself: the body reference is an UPVALUE (a chunk-scope
+    -- local captured by the closure), and it resolves to the f declaration (recursion).
+    local u2, sc2 = analyze("local function f() return f() end")
+    local fref = first_ref(u2, sc2, "f")
+    ok(fref.decl == binds(sc2, "f")[1], "local function f: body f resolves to the f decl (recursion)")
+    eq(fref.kind, "upvalue", "recursive self-reference is an upvalue capture")
+    eq(binds(sc2, "f")[1].reads, 1, "the recursive call counts as a read of f")
+
+    local u3, sc3 = analyze("local f = function() return f end")
+    eq(first_ref(u3, sc3, "f").kind, "global", "local f = function() return f end: inner f is global")
+end
+
+-- ── shadowing: nested block, same-block, same-declaration ─────────────
+do
+    local _, sc = analyze("local x = 1\ndo local x = 2\nreturn x end")
+    local xs = binds(sc, "x")
+    eq(#xs, 2, "two x bindings")
+    ok(xs[2].shadows == xs[1], "nested-block x shadows the outer x")
+
+    local _, sc2 = analyze("local x = 1\nlocal x = 2\nreturn x")
+    local xs2 = binds(sc2, "x")
+    ok(xs2[2].shadows == xs2[1], "same-block redeclaration shadows")
+
+    local _, sc3 = analyze("local x, x = 1, 2\nreturn x")
+    local xs3 = binds(sc3, "x")
+    eq(#xs3, 2, "two x from one declaration")
+    ok(xs3[2].shadows == xs3[1], "repeated name within one declaration shadows")
+
+    -- a callback param shadowing an UPVALUE from an outer function is NOT flagged
+    local _, sc4 = analyze("local err = 1\nlocal g = function(err) return err end\nreturn err, g")
+    local errs = binds(sc4, "err")
+    ok(errs[2].shadows == nil, "param shadowing an outer-function upvalue is NOT flagged")
+end
+
+-- ── function declarations: write to local / global / dotted base read ─
+do
+    local _, sc = analyze("local f\nfunction f() end\nreturn f")
+    local fb = binds(sc, "f")[1]
+    ok(fb.writes >= 1, "function f() writes to the resolved LOCAL f")
+    eq(fb.reads, 1, "f read once (the return)")
+
+    local u2, sc2 = analyze("function g() end")
+    eq(first_ref(u2, sc2, "g").kind, "global", "function g() (no local g) is a global write")
+
+    local u3, sc3 = analyze("local a = {}\nfunction a.b.c() end\nreturn a")
+    eq(first_ref(u3, sc3, "a").kind, "local", "dotted function decl reads the base name a (local)")
+end
+
+-- ── loop-variable scope + control-expr scope ──────────────────────────
+do
+    local u, sc = analyze("for i = 1, 3 do return i end")
+    eq(first_ref(u, sc, "i").kind, "local", "numeric-for var i is local in the body")
+    eq(binds(sc, "i")[1].kind, "loopvar", "i is a loopvar")
+
+    local u2, sc2 = analyze("for k, v in pairs(t) do return k end")
+    eq(first_ref(u2, sc2, "k").kind, "local", "generic-for var k local in body")
+    eq(first_ref(u2, sc2, "pairs").kind, "global", "for control expr resolved in enclosing scope (pairs global)")
+end
+
+-- ── method self (implicit, anchored) + upvalue + repeat-until ─────────
+do
+    local u, sc = analyze("local obj = {}\nfunction obj:m() return self end\nreturn obj")
+    eq(first_ref(u, sc, "self").kind, "local", "method self is resolvable in the body")
+    local selfd = binds(sc, "self")[1]
+    ok(selfd and selfd.implicit == true, "self is an implicit binding")
+    ok(selfd and selfd.range ~= nil and selfd.range.start ~= nil, "implicit self has a real anchor range")
+
+    local u2, sc2 = analyze("local x = 1\nlocal function f() return x end\nreturn f")
+    eq(first_ref(u2, sc2, "x").kind, "upvalue", "inner function capturing a chunk local is an upvalue")
+
+    local u3, sc3 = analyze("repeat local y = 1 until y")
+    eq(first_ref(u3, sc3, "y").kind, "local", "repeat: until condition sees the body's local y")
+    eq(binds(sc3, "y")[1].reads, 1, "y read by the until condition")
+end
+
+-- ── usage: reads vs writes (unused = zero reads) ──────────────────────
+do
+    local _, sc = analyze("local a = 1\nlocal b = 1\nreturn b")
+    eq(binds(sc, "a")[1].reads, 0, "a unused (0 reads)")
+    eq(binds(sc, "b")[1].reads, 1, "b read once")
+
+    local _, sc2 = analyze("local x = 1\nx = 2")
+    local xb = binds(sc2, "x")[1]
+    eq(xb.reads, 0, "written-but-never-read x has 0 reads (still unused)")
+    ok(xb.writes >= 1, "x has a write (the assignment)")
+end
+
+-- ── robustness: never-raises on a recovered AST; internal failure -> err ─
+do
+    local u = lua.parse("local x = (", { path = "t.lua" })     -- broken: recovered AST
+    local sc, err = scope.resolve(u)
+    ok(sc ~= nil and err == nil, "resolve degrades locally on a recovered AST (no raise)")
+
+    local bad, berr = scope.resolve({ ast = { body = 42 } })   -- forces ipairs(42) to raise
+    ok(bad == nil and type(berr) == "table" and berr.code == "lua.internal",
+        "internal resolver failure -> (nil, lua.internal), never a silent partial")
+end
+
+print(string.format("test_scope: %d passed, %d failed", pass, fail))
+return { pass = pass, fail = fail, failures = failures }

--- a/stdlib/cli/lua/hull/source/tests/test_scope.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_scope.lua
@@ -137,15 +137,40 @@ do
     ok(xb.writes >= 1, "x has a write (the assignment)")
 end
 
--- ── robustness: never-raises on a recovered AST; internal failure -> err ─
+-- ── ref_of access mode: read vs write (undefined-global is over READS) ─
+do
+    -- ordinary assignment to a global -> write; a plain reference -> read
+    local u, sc = analyze("y = 1")
+    eq(first_ref(u, sc, "y").kind, "global", "y = 1: y is global")
+    eq(first_ref(u, sc, "y").access, "write", "y = 1: global WRITE")
+
+    local u2, sc2 = analyze("return z")
+    eq(first_ref(u2, sc2, "z").access, "read", "return z: global read")
+
+    -- a simple function declaration is a write to the resolved binding
+    local u3, sc3 = analyze("function g() end")
+    eq(first_ref(u3, sc3, "g").access, "write", "function g(): a WRITE (not a read)")
+
+    -- local read vs local write
+    local u4, sc4 = analyze("local a = 1\nreturn a")
+    eq(first_ref(u4, sc4, "a").access, "read", "return a: local read")
+    local u5, sc5 = analyze("local x = 1\nx = 2")
+    eq(first_ref(u5, sc5, "x").access, "write", "x = 2: local write")
+end
+
+-- ── robustness: never-raises on a recovered AST; internal failure -> diagnostic ─
 do
     local u = lua.parse("local x = (", { path = "t.lua" })     -- broken: recovered AST
     local sc, err = scope.resolve(u)
     ok(sc ~= nil and err == nil, "resolve degrades locally on a recovered AST (no raise)")
 
-    local bad, berr = scope.resolve({ ast = { body = 42 } })   -- forces ipairs(42) to raise
-    ok(bad == nil and type(berr) == "table" and berr.code == "lua.internal",
-        "internal resolver failure -> (nil, lua.internal), never a silent partial")
+    -- forces ipairs(42) to raise; err must be a PROPER diagnostic (severity/code/path/range)
+    local bad, berr = scope.resolve({ ast = { body = 42, range = { start = 1, stop = 2 } }, path = "x.lua" })
+    ok(bad == nil and type(berr) == "table", "internal failure -> (nil, err)")
+    eq(berr and berr.code, "lua.internal", "internal error code")
+    eq(berr and berr.severity, "error", "internal error is diagnostic-shaped (severity)")
+    eq(berr and berr.path, "x.lua", "internal error carries unit.path")
+    ok(berr and type(berr.range) == "table" and berr.range.start ~= nil, "internal error carries a range")
 end
 
 print(string.format("test_scope: %d passed, %d failed", pass, fail))

--- a/tests/hull/source/test_lua_source.c
+++ b/tests/hull/source/test_lua_source.c
@@ -279,4 +279,13 @@ UTEST(lua_source, lint_slice1)
     EXPECT_GT(pass, 0LL);
 }
 
+UTEST(lua_source, scope_slice2)
+{
+    long long pass = 0, fail = -1;
+    int rc = run_lua_test("stdlib/cli/lua/hull/source/tests/test_scope.lua", &pass, &fail);
+    ASSERT_EQ(rc, 0);
+    EXPECT_EQ(fail, 0LL);
+    EXPECT_GT(pass, 0LL);
+}
+
 UTEST_MAIN()


### PR DESCRIPTION
Slice 2 of `hull analyze` v2 (ratified design: `docs/hull_source_scope_design.md`) — the reusable **lexical binding pass** slice 3's scope-backed rules (`unused-local`, `shadowed-local`, `unused-param`, `undefined-global`) need.

`scope.resolve(unit) -> (scope, err)`: a scope-aware recursive traversal resolving every `name` node to its binding — **local / upvalue** (across a function boundary) / **global** — with per-declaration **reads / writes / shadows**.

## Honors the Lua 5.4 subtleties
- a `local` is visible only **after** its declaration (`local x = x` RHS binds outer);
- `local function f` is visible in its own body (captured as an **upvalue** → recursion);
- params scope to the body, with implicit method **`self`**;
- loop vars scope to the body (control exprs in the enclosing scope);
- **`repeat…until`** sees the body's locals.

## Ratified tightenings
- **`function f()` is a WRITE** to the resolved `f` (local or global — not inherently global); dotted/method decls read only the **base** name.
- **same-block + same-declaration redeclaration** count as shadowing; shadowing is **same-function only** by default (upvalue shadowing not flagged); **reads-only** count as use.
- implicit `self` is **explicit** (`implicit = true` + a real anchor range).
- the chunk is **`func_id = 1`**, so nested captures of chunk locals classify as upvalues.
- the traversal is **`pcall`-guarded**: a recovered error node degrades locally, but an internal failure returns `(nil, lua.internal)` so the caller skips scope rules — never a silent partial.

Not wired into any rule (slice 3 consumes it). `test_scope.lua` (**66 cases**). lexer 115 + parser 133 + statements 130 + annotations 77 + conformance 528 + lint 67 + **scope 66**; **76/76** unit; luacheck clean; full build OK.
