### PR TITLE
feat(analyze): v2 lint slice 3 — scope-backed rules (completes the lint arc)

### DIFF
--- a/docs/hull_analyze_lint_design.md
+++ b/docs/hull_analyze_lint_design.md
@@ -122,7 +122,10 @@ registration, NOT guessed.** It contains exactly:
   library remains: `assert, collectgarbage, error, getmetatable, ipairs, next, pairs,
   pcall, print, rawequal, rawget, rawlen, rawset, select, setmetatable, tonumber,
   tostring, type, warn, xpcall, _G, _VERSION`, plus the surviving library tables
-  `coroutine, math, string, table, utf8`.
+  `coroutine, math, string, table, utf8`. `_ENV` is also allowlisted: Lua 5.4 supplies
+  it as the implicit environment upvalue (valid code may reference it directly), and the
+  lightweight scope pass does not synthesize that binding, so without the allowlist entry
+  a direct `_ENV` read is a false positive.
 - **Hull-injected app/test globals**: `app` + `hull` (`runtime/lua/modules.c`),
   `require` (`mod_fs.c`), `test` (`mod_test.c`).
 
@@ -210,9 +213,12 @@ is the explicit signal that lint data may be present.
    `_`/implicit-exempt), and `undefined-global` (OFF by default, evidence-based app
    allowlist, reads only) on top of `hull.source.scope`. The engine gains `needs_scope`
    (rules declare it; skipped when scope is unavailable); `analyze.lua` computes the
-   scope once per clean file and, on a resolver failure, surfaces the internal
-   diagnostic + skips scope-backed rules (structural rules still run). test_lint.lua
-   (173) + e2e (25).
+   scope once per clean file and, on a resolver failure, DOWNGRADES the file to state
+   `internal` (so JSON `files[].state` + `summary.internal` stay consistent with exit 1),
+   surfaces the internal diagnostic, and skips scope-backed rules (structural rules still
+   run). `analyze_source` is exported (module return, CLI entry guarded on `tool`) so the
+   three-state contract is unit-tested with an injected resolver failure. test_lint (177)
+   + test_analyze (9) + e2e (25).
 
 Each slice is a design-first → ratify → implement → green → merge cycle, matching how
 the layer itself was built.

--- a/docs/hull_analyze_lint_design.md
+++ b/docs/hull_analyze_lint_design.md
@@ -104,17 +104,36 @@ A **rule** is a small declarative record:
 
 | id | severity | needs | flags |
 |---|---|---|---|
-| `unused-local` | warning | scope | a `local` never read (excludes a leading `_`-named local — the idiomatic "ignore") |
-| `unused-param` | warning | scope | a function parameter never read. Exempt ONLY: `_`, any underscore-prefixed name (`_x`), and the implicit method `self`. **No trailing-unused-run suppression by default** — suppressing a trailing run would hide every unused parameter in a function and gut the rule. Broader callback suppression is a later add, gated on evidence or explicit config. |
-| `shadowed-local` | warning | scope | a `local`/param that hides an outer binding of the same name in an enclosing scope |
-| `undefined-global` | warning (default OFF) | scope | a global read that is not a known Lua/Hull global (needs a global allowlist → off by default until the allowlist is curated) |
+| `unused-local` | warning | scope | a `local` or `local function` (`kind` local/localfunc) never READ. Loop vars (own concern, deferred) and params (→ `unused-param`) are excluded; a leading-`_` name is exempt. |
+| `unused-param` | warning | scope | a parameter never read. Exempt ONLY: `_`, any underscore-prefixed name (`_x`), and the implicit method `self`. **No trailing-unused-run suppression by default** — it would hide every unused parameter in a function; broader callback suppression is a later add, evidence/config-gated. |
+| `shadowed-local` | warning | scope | a declaration whose `shadows ~= nil` (same-function shadowing; §3/scope). Exempt: `_`/underscore names and the implicit `self`. |
+| `undefined-global` | warning (default OFF) | scope | a global READ not in the evidence-based app allowlist (above). Off by default; over reads only. |
 | `empty-block` | warning | — | an `if`/`elseif`/`else`/`while`/`for`/`do` body with zero statements |
 | `duplicate-table-key` | warning | — | a table constructor with two `field_name`/`field_expr` entries for the same literal key |
 | `todo-comment` | info | — | a comment containing `TODO`/`FIXME`/`XXX` (surfaced, never fails a build) |
 
-`undefined-global` ships **off by default** (it needs a curated global allowlist — Lua
-intrinsics + Hull's injected globals like `app`, `db`, `http`, `tool`… — to avoid false
-positives); it's enabled with `--enable=undefined-global` and hardened over time.
+`undefined-global` ships **off by default** and reads over global **reads** only
+(`access == "read"`), enabled with `--enable=undefined-global`.
+
+**The allowlist is EVIDENCE-BASED, derived from Hull's app-runtime sandbox +
+registration, NOT guessed.** It contains exactly:
+- **Lua base globals surviving the sandbox.** `hl_lua_sandbox` (`runtime/lua/runtime.c`)
+  removes `io, os, load, loadfile, dofile, package, debug`; the rest of Lua 5.4's base
+  library remains: `assert, collectgarbage, error, getmetatable, ipairs, next, pairs,
+  pcall, print, rawequal, rawget, rawlen, rawset, select, setmetatable, tonumber,
+  tostring, type, warn, xpcall, _G, _VERSION`, plus the surviving library tables
+  `coroutine, math, string, table, utf8`.
+- **Hull-injected app/test globals**: `app` + `hull` (`runtime/lua/modules.c`),
+  `require` (`mod_fs.c`), `test` (`mod_test.c`).
+
+Deliberately **NOT** in the app allowlist (so they correctly trigger when read as a
+global): `req` / `res` are handler **parameters**; `db, fs, http, json, log, crypto,
+compute, gpu, …` are **imported locals** (`require("hull.X")`); `io, os, load, loadfile,
+dofile, package, debug` are **sandbox-removed**; `tool` / `arg` and promoted short
+module names belong to the **tool VM** (`mod_tool.c`), not app code. A later explicit
+`--tool-mode` profile can add the tool-VM globals without weakening app analysis. The
+list is locked with positive tests (allowed globals do NOT fire) AND negative tests
+(`db`, `req`, `os`, `json` DO fire when read globally).
 
 ## 6. CLI surface (additions)
 
@@ -186,8 +205,14 @@ is the explicit signal that lint data may be present.
 2. **Scope pass** — DONE. `hull.source.scope` (`resolve -> scope, err`; pcall-guarded)
    + `test_scope.lua`. The reusable Step B; not yet wired into a rule (slice 3).
    Design: [hull_source_scope_design.md](hull_source_scope_design.md).
-3. **Scope rules** — `unused-local`, `unused-param`, `shadowed-local`, and
-   `undefined-global` (off by default) on top of the pass.
+3. **Scope rules** — DONE. `unused-local` (local/localfunc, `_`-exempt),
+   `unused-param` (`_`/implicit-`self`-exempt), `shadowed-local` (same-function,
+   `_`/implicit-exempt), and `undefined-global` (OFF by default, evidence-based app
+   allowlist, reads only) on top of `hull.source.scope`. The engine gains `needs_scope`
+   (rules declare it; skipped when scope is unavailable); `analyze.lua` computes the
+   scope once per clean file and, on a resolver failure, surfaces the internal
+   diagnostic + skips scope-backed rules (structural rules still run). test_lint.lua
+   (173) + e2e (25).
 
 Each slice is a design-first → ratify → implement → green → merge cycle, matching how
 the layer itself was built.

--- a/stdlib/cli/lua/hull/source/analyze.lua
+++ b/stdlib/cli/lua/hull/source/analyze.lua
@@ -194,8 +194,11 @@ local function analyze_source(path, src, enabled)
         if lint.needs_scope(enabled) then
             local resolved, serr = scope.resolve(unit)
             if serr then
-                -- resolver internal failure: surface it, and SKIP scope-backed rules
-                -- (sc stays nil) -- structural rules still run.
+                -- resolver internal failure: surface it, downgrade the file to "internal"
+                -- (so JSON files[].state + summary.internal stay consistent with the exit
+                -- code), and SKIP scope-backed rules (sc stays nil). Structural rules,
+                -- already independent of scope, still run below.
+                state = "internal"
                 local line, col
                 if serr.range then line, col = unit:line_col(serr.range) end
                 diags[#diags + 1] = {
@@ -404,10 +407,20 @@ local function emit_human(o, files, diagnostics, summary, no_findings)
     if #out > 0 then tool.stdout(table.concat(out, "\n") .. "\n") end
 end
 
-local o, _, root_norm, files, diagnostics, summary, no_findings = run()
-if o.json then
-    emit_json(root_norm, files, diagnostics, summary)        -- JSON overrides --quiet; stdout is pure JSON
-else
-    emit_human(o, files, diagnostics, summary, no_findings)
+-- `analyze_source` is the pure core (parse + lint, no I/O). Expose it so the test
+-- harness can drive the three-state contract (incl. an injected resolver failure)
+-- without the CLI shell. The CLI entry runs ONLY in the tool VM, where `tool` is a
+-- global; a plain `require` (test env, no `tool`) returns the module without exiting.
+local M = { analyze_source = analyze_source }
+
+if tool then
+    local o, _, root_norm, files, diagnostics, summary, no_findings = run()
+    if o.json then
+        emit_json(root_norm, files, diagnostics, summary)    -- JSON overrides --quiet; stdout is pure JSON
+    else
+        emit_human(o, files, diagnostics, summary, no_findings)
+    end
+    tool.exit(summary.clean and 0 or 1)
 end
-tool.exit(summary.clean and 0 or 1)
+
+return M

--- a/stdlib/cli/lua/hull/source/analyze.lua
+++ b/stdlib/cli/lua/hull/source/analyze.lua
@@ -13,6 +13,7 @@
 
 local lua = require("hull.source.lua")
 local lint = require("hull.source.lint")
+local scope = require("hull.source.scope")
 local json = require("hull.json")
 
 -- Generous limits so lua.limit.* only trips on genuinely pathological input; a trip is
@@ -189,7 +190,24 @@ local function analyze_source(path, src, enabled)
     -- Lint only a cleanly-parsed file (complete + no syntax errors): a recovered,
     -- error-bearing AST would yield spurious lint findings.
     if state == "complete" and not has_syntax and enabled and next(enabled) then
-        for _, f in ipairs(lint.run(unit, enabled)) do
+        local sc = nil
+        if lint.needs_scope(enabled) then
+            local resolved, serr = scope.resolve(unit)
+            if serr then
+                -- resolver internal failure: surface it, and SKIP scope-backed rules
+                -- (sc stays nil) -- structural rules still run.
+                local line, col
+                if serr.range then line, col = unit:line_col(serr.range) end
+                diags[#diags + 1] = {
+                    code = serr.code, severity = serr.severity or "error", message = serr.message,
+                    range = serr.range and { start = serr.range.start, stop = serr.range.stop } or nil,
+                    line = line, col = col,
+                }
+            else
+                sc = resolved
+            end
+        end
+        for _, f in ipairs(lint.run(unit, enabled, sc)) do
             local line, col
             if f.range then line, col = unit:line_col(f.range) end
             diags[#diags + 1] = {

--- a/stdlib/cli/lua/hull/source/lint.lua
+++ b/stdlib/cli/lua/hull/source/lint.lua
@@ -45,12 +45,34 @@ local function table_key(field)
     return nil
 end
 
+-- An idiomatic "ignore" name (`_`, `_x`) is exempt from unused/shadow rules.
+local function is_ignored(name) return type(name) == "string" and name:sub(1, 1) == "_" end
+
+-- EVIDENCE-BASED app-runtime global allowlist for undefined-global (design §5).
+-- Derived from Hull's sandbox + registration, NOT guessed:
+--   * Lua base globals surviving hl_lua_sandbox (runtime/lua/runtime.c removes
+--     io/os/load/loadfile/dofile/package/debug) + surviving library tables;
+--   * Hull app/test globals: app + hull (modules.c), require (mod_fs.c), test (mod_test.c).
+-- Deliberately absent (so they correctly fire): req/res (params), db/fs/http/json/log/
+-- crypto/compute/gpu (imported locals), the sandbox-removed names, and tool/arg
+-- (tool VM). A future --tool-mode profile adds the tool-VM globals.
+local GLOBAL_ALLOWLIST = {}
+for _, g in ipairs({
+    "assert", "collectgarbage", "error", "getmetatable", "ipairs", "next", "pairs",
+    "pcall", "print", "rawequal", "rawget", "rawlen", "rawset", "select", "setmetatable",
+    "tonumber", "tostring", "type", "warn", "xpcall", "_G", "_VERSION",
+    "coroutine", "math", "string", "table", "utf8",
+    "app", "hull", "require", "test",
+}) do GLOBAL_ALLOWLIST[g] = true end
+
 -- ── rules (sorted by id; the registry order is deterministic) ─────────
+-- check(unit, scope, emit): `scope` is the hull.source.scope model (nil for a rule that
+-- does not need it, or when resolution failed -- a needs_scope rule is then skipped).
 M.RULES = {
     {
         id = "duplicate-table-key", severity = "warning", default = true,
         describe = "a table constructor with a repeated literal key",
-        check = function(unit, emit)
+        check = function(unit, _scope, emit)
             lua.walk(unit.ast, function(n)
                 if n.kind ~= "table" then return end
                 local seen = {}
@@ -67,7 +89,7 @@ M.RULES = {
     {
         id = "empty-block", severity = "warning", default = true,
         describe = "a control-flow block with an empty body",
-        check = function(unit, emit)
+        check = function(unit, _scope, emit)
             lua.walk(unit.ast, function(n)
                 local k = n.kind
                 if (k == "do" or k == "while" or k == "repeat"
@@ -85,15 +107,62 @@ M.RULES = {
         end,
     },
     {
+        id = "shadowed-local", severity = "warning", default = true, needs_scope = true,
+        describe = "a declaration that shadows an enclosing binding of the same name",
+        check = function(_unit, scope, emit)
+            for _, d in ipairs(scope.bindings) do
+                if d.shadows and not d.implicit and not is_ignored(d.name) then
+                    emit({ range = d.range, message = "'" .. d.name .. "' shadows an outer declaration" })
+                end
+            end
+        end,
+    },
+    {
         id = "todo-comment", severity = "info", default = true,
         describe = "a comment containing TODO / FIXME / XXX",
-        check = function(unit, emit)
+        check = function(unit, _scope, emit)
             for _, c in ipairs(unit.comments or {}) do
                 local text = c.text or ""
                 for _, m in ipairs({ "TODO", "FIXME", "XXX" }) do
                     if text:find(m, 1, true) then
                         emit({ range = c.range, message = m .. " comment" }); break
                     end
+                end
+            end
+        end,
+    },
+    {
+        id = "undefined-global", severity = "warning", default = false, needs_scope = true,
+        describe = "a read of a global not in Hull's app-runtime allowlist",
+        check = function(_unit, scope, emit)
+            for node, res in pairs(scope.ref_of) do
+                if res.kind == "global" and res.access == "read"
+                    and not GLOBAL_ALLOWLIST[node.name] then
+                    emit({ range = node.range, message = "undefined global '" .. node.name .. "'" })
+                end
+            end
+        end,
+    },
+    {
+        id = "unused-local", severity = "warning", default = true, needs_scope = true,
+        describe = "a local (or local function) that is never read",
+        check = function(_unit, scope, emit)
+            for _, d in ipairs(scope.bindings) do
+                if (d.kind == "local" or d.kind == "localfunc") and d.reads == 0
+                    and not is_ignored(d.name) then
+                    emit({ range = d.range, message = "unused local '" .. d.name .. "'" })
+                end
+            end
+        end,
+    },
+    {
+        id = "unused-param", severity = "warning", default = true, needs_scope = true,
+        describe = "a function parameter that is never read",
+        check = function(_unit, scope, emit)
+            for _, d in ipairs(scope.bindings) do
+                if d.kind == "param" and d.reads == 0 and not d.implicit
+                    and not is_ignored(d.name) then
+                    emit({ range = d.range, message = "unused parameter '" .. d.name .. "'" })
                 end
             end
         end,
@@ -114,13 +183,23 @@ function M.default_enabled()
     return e
 end
 
--- Run the enabled rules over a (cleanly-parsed) unit -> findings[] with each finding's
--- { code = "lua.lint.<id>", severity, rule = <id>, range, message }.
-function M.run(unit, enabled)
+-- Does any enabled rule require the scope model? (drives whether the analyzer computes
+-- it; a needs_scope rule is skipped if scope is unavailable.)
+function M.needs_scope(enabled)
+    for _, rule in ipairs(M.RULES) do
+        if enabled[rule.id] and rule.needs_scope then return true end
+    end
+    return false
+end
+
+-- Run the enabled rules over a (cleanly-parsed) unit -> findings[], each with
+-- { code = "lua.lint.<id>", severity, rule = <id>, range, message }. `scope` is the
+-- hull.source.scope model (or nil); a needs_scope rule is skipped when scope is nil.
+function M.run(unit, enabled, scope)
     local findings = {}
     for _, rule in ipairs(M.RULES) do          -- registry order = deterministic
-        if enabled[rule.id] then
-            rule.check(unit, function(f)
+        if enabled[rule.id] and (not rule.needs_scope or scope) then
+            rule.check(unit, scope, function(f)
                 f.code = "lua.lint." .. rule.id
                 f.severity = rule.severity
                 f.rule = rule.id

--- a/stdlib/cli/lua/hull/source/lint.lua
+++ b/stdlib/cli/lua/hull/source/lint.lua
@@ -60,7 +60,7 @@ local GLOBAL_ALLOWLIST = {}
 for _, g in ipairs({
     "assert", "collectgarbage", "error", "getmetatable", "ipairs", "next", "pairs",
     "pcall", "print", "rawequal", "rawget", "rawlen", "rawset", "select", "setmetatable",
-    "tonumber", "tostring", "type", "warn", "xpcall", "_G", "_VERSION",
+    "tonumber", "tostring", "type", "warn", "xpcall", "_G", "_VERSION", "_ENV",
     "coroutine", "math", "string", "table", "utf8",
     "app", "hull", "require", "test",
 }) do GLOBAL_ALLOWLIST[g] = true end

--- a/stdlib/cli/lua/hull/source/tests/test_analyze.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_analyze.lua
@@ -1,0 +1,75 @@
+--
+-- test_analyze.lua — the analyze_source three-state contract (state x diagnostics).
+--
+-- Focus: the resolver-failure path. When hull.source.scope.resolve returns (nil, err),
+-- analyze_source must (1) DOWNGRADE the file to state "internal" (so JSON files[].state
+-- and summary.internal stay consistent with the exit code), (2) surface the internal
+-- diagnostic, (3) SKIP scope-backed rules, yet (4) still run structural rules. We inject
+-- the failure by monkeypatching scope.resolve (the same cached module analyze uses).
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local analyze = require("hull.source.analyze")   -- no `tool` global here -> module, not CLI
+local scope = require("hull.source.scope")
+local lint = require("hull.source.lint")
+local diag = require("hull.source.diagnostic")
+
+local pass, fail, failures = 0, 0, {}
+local function ok(cond, name)
+    if cond then pass = pass + 1
+    else fail = fail + 1; failures[#failures + 1] = name; print("FAIL: " .. name) end
+end
+local function eq(a, b, name)
+    ok(a == b, name .. " (expected " .. tostring(b) .. ", got " .. tostring(a) .. ")")
+end
+
+local function has(diags, code)
+    for _, d in ipairs(diags) do if d.code == code then return true end end
+    return false
+end
+
+-- analyze_source is the pure core, exported for exactly this test.
+ok(type(analyze.analyze_source) == "function", "analyze_source is exported for testing")
+
+-- ── success path: clean file, scope rule runs, state complete ─────────
+do
+    local state, diags = analyze.analyze_source("t.lua", "local x = 1\nreturn 0", lint.default_enabled())
+    eq(state, "complete", "clean file -> state complete")
+    ok(has(diags, "lua.lint.unused-local"), "scope rule runs on a clean parse (unused x)")
+end
+
+-- ── injected resolver failure: state internal, diag surfaced, structural still runs ──
+do
+    local orig = scope.resolve
+    scope.resolve = function(u)
+        return nil, diag.error("lua.internal", "injected resolver failure",
+            u and u.path or "t.lua", { start = 1, stop = 2 })
+    end
+    -- unused-local (scope) is enabled AND `if y then end` trips empty-block (structural).
+    local state, diags = analyze.analyze_source("t.lua",
+        "local x = 1\nif y then end\nreturn 0", lint.default_enabled())
+    scope.resolve = orig                                       -- restore before asserting
+
+    eq(state, "internal", "resolver failure -> file state internal (not complete)")
+    ok(has(diags, "lua.internal"), "resolver failure surfaces a lua.internal diagnostic")
+    ok(has(diags, "lua.lint.empty-block"), "structural rules STILL run after a resolver failure")
+    ok(not has(diags, "lua.lint.unused-local"), "scope-backed rules SKIPPED after a resolver failure")
+end
+
+-- ── the internal diagnostic carries the resolver's own code/message ───
+do
+    local orig = scope.resolve
+    scope.resolve = function(u)
+        return nil, diag.error("lua.internal", "boom", u and u.path or "t.lua", { start = 3, stop = 4 })
+    end
+    local _, diags = analyze.analyze_source("t.lua", "local x = 1\nreturn 0", { ["unused-local"] = true })
+    scope.resolve = orig
+    local found
+    for _, d in ipairs(diags) do if d.code == "lua.internal" then found = d end end
+    ok(found ~= nil and found.message == "boom", "internal diagnostic keeps the resolver message")
+    ok(found ~= nil and found.line ~= nil and found.col ~= nil, "internal diagnostic is positioned (line/col)")
+end
+
+print(string.format("test_analyze: %d passed, %d failed", pass, fail))
+return { pass = pass, fail = fail, failures = failures }

--- a/stdlib/cli/lua/hull/source/tests/test_lint.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_lint.lua
@@ -9,6 +9,7 @@
 
 local lua = require("hull.source.lua")
 local lint = require("hull.source.lint")
+local scope = require("hull.source.scope")
 
 local pass, fail, failures = 0, 0, {}
 local function ok(cond, name)
@@ -19,12 +20,16 @@ local function eq(a, b, name)
     ok(a == b, name .. " (expected " .. tostring(b) .. ", got " .. tostring(a) .. ")")
 end
 
--- count of findings for a given rule id in `src` (all rules enabled unless given)
+-- count of findings for a given rule id in `src` (all default rules unless given).
+-- Computes the scope model when a needs_scope rule is active.
 local function count(src, ruleid, enabled)
     local u = lua.parse(src, { path = "t.lua" })
     ok(u ~= nil and #u.diagnostics == 0, "lint fixture parses clean: " .. src:gsub("%s+", " "):sub(1, 40))
+    local en = enabled or lint.default_enabled()
+    local sc = nil
+    if lint.needs_scope(en) then sc = (scope.resolve(u)) end
     local n = 0
-    for _, f in ipairs(lint.run(u, enabled or lint.default_enabled())) do
+    for _, f in ipairs(lint.run(u, en, sc)) do
         if f.rule == ruleid then
             n = n + 1
             -- every finding carries a namespaced code, severity, and a range
@@ -82,6 +87,55 @@ do
     local de = lint.default_enabled()
     ok(de["empty-block"] and de["duplicate-table-key"] and de["todo-comment"],
         "default_enabled has all slice-1 rules on")
+end
+
+-- ── unused-local (local + localfunc; loop vars / params excluded; _ exempt) ─
+do
+    ok(count("local x = 1\nreturn 0", "unused-local") == 1, "unused local fires")
+    ok(count("local function f() end\nreturn 0", "unused-local") == 1, "unused local function fires")
+    ok(count("local x = 1\nreturn x", "unused-local") == 0, "used local clean")
+    ok(count("local _ = 1\nreturn 0", "unused-local") == 0, "_ exempt from unused-local")
+    ok(count("for i = 1, 3 do print(0) end", "unused-local") == 0, "loop var not flagged by unused-local")
+    ok(count("local function f(a) return 0 end\nreturn f", "unused-param") == 1, "unused-local does not double-flag a param")
+end
+
+-- ── unused-param (_ / implicit self exempt) ───────────────────────────
+do
+    ok(count("local function f(a, b) return a end\nreturn f", "unused-param") == 1, "unused param b fires")
+    ok(count("local function f(a) return a end\nreturn f", "unused-param") == 0, "used param clean")
+    ok(count("local function f(_a) return 1 end\nreturn f", "unused-param") == 0, "_-prefixed param exempt")
+    ok(count("local o = {}\nfunction o:m() return 1 end\nreturn o", "unused-param") == 0, "implicit self exempt")
+end
+
+-- ── shadowed-local (_ / implicit exempt) ──────────────────────────────
+do
+    ok(count("local x = 1\ndo local x = 2\nprint(x) end\nreturn x", "shadowed-local") == 1, "shadowing fires")
+    ok(count("local x = 1\nreturn x", "shadowed-local") == 0, "no shadow -> clean")
+    ok(count("local _ = 1\nlocal _ = 2\nreturn 0", "shadowed-local") == 0, "_ shadowing exempt")
+end
+
+-- ── undefined-global: OFF by default; evidence-based allowlist; reads only ─
+do
+    local en = lint.default_enabled(); en["undefined-global"] = true
+    for _, g in ipairs({ "pairs", "string", "app", "hull", "require", "print", "math", "test", "coroutine" }) do
+        ok(count("return " .. g, "undefined-global", en) == 0, "allowed global NOT flagged: " .. g)
+    end
+    for _, g in ipairs({ "db", "req", "res", "json", "os", "io", "load", "tool", "arg", "debug", "package" }) do
+        ok(count("return " .. g, "undefined-global", en) == 1, "undefined global flagged: " .. g)
+    end
+    ok(count("return db", "undefined-global") == 0, "undefined-global OFF by default")
+    ok(count("undefinedthing = 1", "undefined-global", en) == 0, "a global WRITE is not flagged (reads only)")
+end
+
+-- ── engine: a scope-backed rule is SKIPPED when scope is nil (resolver failed) ─
+do
+    local u = lua.parse("local x = 1\nreturn 0", { path = "t.lua" })
+    eq(#lint.run(u, { ["unused-local"] = true }, nil), 0, "needs_scope rule skipped when scope is nil")
+    ok(lint.needs_scope({ ["unused-local"] = true }), "needs_scope true for a scope rule")
+    ok(not lint.needs_scope({ ["todo-comment"] = true }), "needs_scope false for structural-only")
+    -- structural rules still run without scope
+    ok(#lint.run(lua.parse("if x then end", { path = "t.lua" }), { ["empty-block"] = true }, nil) == 1,
+        "structural rule still runs without scope")
 end
 
 print(string.format("test_lint: %d passed, %d failed", pass, fail))

--- a/stdlib/cli/lua/hull/source/tests/test_lint.lua
+++ b/stdlib/cli/lua/hull/source/tests/test_lint.lua
@@ -117,7 +117,8 @@ end
 -- ── undefined-global: OFF by default; evidence-based allowlist; reads only ─
 do
     local en = lint.default_enabled(); en["undefined-global"] = true
-    for _, g in ipairs({ "pairs", "string", "app", "hull", "require", "print", "math", "test", "coroutine" }) do
+    for _, g in ipairs({ "pairs", "string", "app", "hull", "require", "print", "math",
+                         "test", "coroutine", "_ENV", "_G" }) do
         ok(count("return " .. g, "undefined-global", en) == 0, "allowed global NOT flagged: " .. g)
     end
     for _, g in ipairs({ "db", "req", "res", "json", "os", "io", "load", "tool", "arg", "debug", "package" }) do

--- a/tests/e2e_analyze.sh
+++ b/tests/e2e_analyze.sh
@@ -38,7 +38,7 @@ echo "=== E2E: hull analyze ==="
 APP="$TMP/clean"
 mkdir -p "$APP/routes" "$APP/lib"
 printf 'app.manifest({ modules = {} })\napp.main(function() return 0 end)\n' > "$APP/app.lua"
-printf 'local M = {}\nfunction M.register(app) app.get("/u", function(req, res) res:json({ ok = true }) end) end\nreturn M\n' > "$APP/routes/users.lua"
+printf 'local M = {}\nfunction M.register(app) app.get("/u", function(req, res) res:json({ path = req.path }) end) end\nreturn M\n' > "$APP/routes/users.lua"
 printf 'local M = {}\nfunction M.add(a, b) return a + b end\nreturn M\n' > "$APP/lib/util.lua"
 
 # ── a broken app: a syntax error in a NON-entry module ────────────────
@@ -242,6 +242,26 @@ if [ "$n" = "0" ] && [ "$rc" = "1" ]; then
     pass "syntax-broken file: no spurious lint, exit 1 from the syntax error"
 else fail "broken-not-linted (n=$n, rc=$rc)"; fi
 rm -f "$LINT/oops.lua"
+
+# ── slice-3 scope-backed rules fixture ────────────────────────────────
+SCOPEAPP="$TMP/scopeapp"
+mkdir -p "$SCOPEAPP"
+printf 'local unused_var = 1\nlocal shadowed = 2\nlocal function helper(a, b)\n  return a + shadowed\nend\ndo\n  local shadowed = 3\n  helper(shadowed, 0)\nend\nreturn os.time()\n' > "$SCOPEAPP/app.lua"
+
+# ── Test 24: unused-local / unused-param / shadowed-local fire ─────────
+out=$("$HULL" analyze "$SCOPEAPP" 2>/dev/null || true)
+if echo "$out" | grep -q "lua.lint.unused-local" && echo "$out" | grep -q "lua.lint.unused-param" \
+   && echo "$out" | grep -q "lua.lint.shadowed-local"; then
+    pass "scope rules: unused-local + unused-param + shadowed-local fire"
+else fail "scope rules ($out)"; fi
+
+# ── Test 25: undefined-global OFF by default, --enable fires (os), allowed silent ─
+off=$("$HULL" analyze "$SCOPEAPP" 2>/dev/null || true)
+on=$("$HULL" analyze "$SCOPEAPP" --enable=undefined-global 2>/dev/null || true)
+if ! echo "$off" | grep -q "undefined-global" && echo "$on" | grep -q "undefined global 'os'" \
+   && ! echo "$on" | grep -q "undefined global 'string'"; then
+    pass "undefined-global: OFF by default, --enable fires os, allowlisted globals silent"
+else fail "undefined-global (on=$on)"; fi
 
 # ── summary ───────────────────────────────────────────────────────────
 echo ""

--- a/tests/hull/source/test_lua_source.c
+++ b/tests/hull/source/test_lua_source.c
@@ -42,9 +42,12 @@ static int run_lua_test(const char *script_path, long long *pass_out, long long 
     if (!L) return -1;
     luaL_openlibs(L);
 
-    /* Resolve require("hull.source.X") from the source tree (repo-root relative). */
+    /* Resolve require("hull.source.X") from the source tree (repo-root relative).
+     * stdlib/lua is also on the path so hull.source.analyze can pull in hull.json
+     * (the tool VM resolves it via the embedded VFS; the harness has no VFS). */
     if (luaL_dostring(L,
-            "package.path = 'stdlib/cli/lua/?.lua;stdlib/cli/lua/?/init.lua;' .. package.path")
+            "package.path = 'stdlib/cli/lua/?.lua;stdlib/cli/lua/?/init.lua;"
+            "stdlib/lua/?.lua;stdlib/lua/?/init.lua;' .. package.path")
         != LUA_OK) {
         fprintf(stderr, "package.path setup failed: %s\n", lua_tostring(L, -1));
         lua_close(L);
@@ -283,6 +286,16 @@ UTEST(lua_source, scope_slice2)
 {
     long long pass = 0, fail = -1;
     int rc = run_lua_test("stdlib/cli/lua/hull/source/tests/test_scope.lua", &pass, &fail);
+    ASSERT_EQ(rc, 0);
+    EXPECT_EQ(fail, 0LL);
+    EXPECT_GT(pass, 0LL);
+}
+
+/* analyze_source's three-state contract, incl. an injected resolver failure. */
+UTEST(lua_source, analyze_core)
+{
+    long long pass = 0, fail = -1;
+    int rc = run_lua_test("stdlib/cli/lua/hull/source/tests/test_analyze.lua", &pass, &fail);
     ASSERT_EQ(rc, 0);
     EXPECT_EQ(fail, 0LL);
     EXPECT_GT(pass, 0LL);


### PR DESCRIPTION
Slice 3 (final) of `hull analyze` v2 — wires `hull.source.scope` into the lint engine and adds the four scope-backed rules, completing the v2 lint arc.

## Rules (all `needs_scope`)
- **`unused-local`** — a `local` / `local function` never **read** (loop vars + params excluded; `_`-prefixed exempt).
- **`unused-param`** — a parameter never read (`_` / implicit `self` exempt).
- **`shadowed-local`** — a declaration with `shadows ~= nil` (same-function; `_` / implicit exempt).
- **`undefined-global`** — **OFF by default**; a global **read** not in an **evidence-based** app-runtime allowlist.

## The allowlist is derived, not guessed
From Hull's actual sandbox + registration: the Lua base globals surviving `hl_lua_sandbox` (which removes `io/os/load/loadfile/dofile/package/debug`) + surviving library tables + the app/test globals `app`/`hull`/`require`/`test` (`modules.c` / `mod_fs.c` / `mod_test.c`). Deliberately **absent** so they fire when read globally: `req`/`res` (params), `db`/`fs`/`http`/`json`/`log`/… (imported locals), the sandbox-removed names, and `tool`/`arg` (tool VM — a future `--tool-mode` profile adds them). Locked with **positive** (allowed silent) *and* **negative** (`db`/`req`/`os`/`json` fire) tests.

## Engine + integration
Rules declare `needs_scope`; `lint.run(unit, enabled, scope)` skips a `needs_scope` rule when `scope` is nil; `lint.needs_scope(enabled)` tells the analyzer whether to resolve. `analyze.lua` computes the scope once per cleanly-parsed file and, on a resolver failure, surfaces the diagnostic-shaped internal error **and skips scope-backed rules** (structural rules still run).

## Tests
`test_lint` 67 → **173** (rules + the allowlist positive/negative matrix + the `needs_scope` skip); `e2e_analyze` 23 → **25**. The "clean app" fixture now uses its `req` param (an unused `req` was a *correct* `unused-param` finding). 76/76 unit; conformance 528; luacheck clean; full build OK.

**`hull.source.lua` v2 lint (engine + scope + rules) is complete.**
