### PR TITLE
feat(project): host-owned project source discovery — design + Slice 1 (core)

### DIFF
--- a/docs/project_discovery_design.md
+++ b/docs/project_discovery_design.md
@@ -1,0 +1,508 @@
+# Project Source Discovery — design record
+
+Status: **RATIFIED (with amendments). Slice 1 in progress.**
+Author: (design-first, per the story's required cadence)
+Related: `docs/lua_source_analysis_design.md`, `docs/hull_source_scope_design.md`,
+`docs/hull_analyze_design.md`, `docs/hull_analyze_lint_design.md`.
+
+## 0. What this is (and is not)
+
+A **host-owned, frontend-neutral project source-discovery system**: Hull's
+canonical representation of statically discovered, **annotated declarations**
+across an app's source tree. Source text is the input; a normalized
+`ProjectDiscovery` value is the authoritative result. The first production
+frontend is Lua (adapting the shipped `hull.source.*` layer). JavaScript gets a
+genuine, reserved registry slot with an **honest capability model** — no regex
+scanner, no parser, no pretence of parity.
+
+**In scope:** one host analysis entry point; one frontend registry +
+extension→frontend map; one Lua frontend adapter; one `ProjectDiscovery` model
+with deterministic indexes + IDs + structured diagnostics; standalone agent
+inspection; `hull dev` integration on the same analyzer; a narrow, tested
+`hull build` seam.
+
+**Explicitly NOT in scope** (non-goals, restated so the reviewer can hold me to
+them): Query IR / Compute IR / WASM lowering / annotation transformers / a
+generic plugin framework / `build.js` / a JavaScript parser / a universal AST /
+source execution for discovery / incremental dependency analysis / persistent
+identity across arbitrary edits.
+
+## 1. Architectural invariant (target)
+
+```
+Hull host (C dispatcher)
+    ↓  hull_tool("hull.project.analyze", …)   ← the ONLY entry
+Project analyzer            (hull.project.analyze)
+    ↓
+canonical source discovery  (hull.source.discover — the extracted hardened walker)
+    ↓
+frontend registry           (hull.project.registry: ext → frontend + capabilities)
+    ↓
+language frontend           (hull.project.frontend_lua — wraps hull.source.lua)
+    ↓
+normalized ProjectDiscovery (hull.project.model)
+    ├── hull dev
+    ├── hull agent <inspect>
+    └── hull build context   (integration seam — pass-through, not consumed yet)
+```
+
+`build.lua`, a future `build.js`, and future transformers **consume**
+`ProjectDiscovery`. They do not scan or parse application source themselves.
+
+## 2. Investigation findings (assumptions verified against the tree)
+
+Every claim below is cited; these are the load-bearing facts the design rests on.
+
+### 2.1 `hull.source.*` — the shipped analysis layer
+
+- Public contract `hull.source.lua` (`stdlib/cli/lua/hull/source/lua.lua`):
+  `M.parse(source, {path?, limits?}) -> (unit, err)`. Syntax problems land in
+  `unit.diagnostics` with `err == nil`; `err` is reserved for API misuse /
+  internal failure; **never raises, never prints** (lua.lua:1-20, 60-90). Live
+  surface: `unit.ast` (chunk), `unit.tokens`, `unit.comments`,
+  `unit.diagnostics`, `unit:text/position/line_col(range)`,
+  `unit:annotations_for(node)`, `M.walk`, `M.is`.
+- AST declaration node shapes (`stdlib/cli/lua/hull/source/parser.lua`):
+  - `local_declaration` = `{ kind, names=[{name, attrib?, range}, …], values=[…], range }`
+    — **a multi-name `local a, b = …` is ONE node** (parser.lua:535, name
+    entries at :533).
+  - `function_declaration` = `{ kind, name=<name|field-chain>, is_local,
+    is_method?, params, body, range }` (parser.lua:495, 508). `function a.b.c()`
+    → nested `field` chain; `function a:m()` → `is_method=true`.
+  - `assignment` = `{ kind, targets, values }` (parser.lua:556) — **not a
+    declaration.** A global `X = function() end` is an assignment carrying a
+    `function_expr` value, and the annotation layer does not attach to it.
+- Annotation layer (`stdlib/cli/lua/hull/source/annotations.lua`): attaches
+  **only** to `local_declaration` + `function_declaration` (`DECLARATION_KINDS`,
+  annotations.lua:41-44). On the node: `node.annotation_list` (ordered array of
+  `{name, args?, text?, raw, range}`, annotations.lua:70) and `node.annotations`
+  (name → first). Whitelist-free; unknown `@names` are recorded, never errors.
+- Scope resolver (`stdlib/cli/lua/hull/source/scope.lua`): `M.resolve(unit) ->
+  (scope, err)`, pcall-guarded; `scope.bindings[]` +
+  `scope.ref_of[node]`. Ships today (kind `local|localfunc|param`, `reads`,
+  `writes`, `shadows`).
+
+### 2.2 The hardened discovery path (`hull analyze`)
+
+`stdlib/cli/lua/hull/source/analyze.lua` already implements the exact bounded,
+containment-safe walker the story mandates reusing:
+
+- `EXCLUDE_LIST = {".git", ".hull", "build", "vendor", "node_modules"}` pruned
+  **during** traversal via `tool.find_files(root, "*.lua", {exclude_dirs=…})`
+  (analyze.lua:27, 151), plus a cheap `excluded()` segment belt (analyze.lua:60).
+- Canonical containment on `tool.realpath` output (symlinks resolved):
+  `inside_root(canon_root, canon_target)` (analyze.lua:54, 297-316). Root-canon
+  failure is an **operational error, not a lexical fallback** (a locked
+  invariant from the analyze reviews).
+- `tool.path_kind` for dir/file/other classification (analyze.lua:136, 316);
+  `op_fail` → exit 2 stderr-only so JSON stdout stays pure (analyze.lua:78).
+- Deterministic order (`tool.find_files` returns sorted, regular, non-symlink),
+  fail-closed on discovery error (analyze.lua:152).
+
+These helpers (`normalize`, `join`, `inside_root`, `excluded`, the
+`find_files`+`realpath`+`path_kind` sequence) are the extraction target.
+
+### 2.3 Tool VM boundary
+
+- `hull analyze` runs in the **Lua tool VM** via `hull_tool("hull.source.analyze")`
+  (`src/hull/commands/analyze.c`), and `analyze.lua` already
+  `require("hull.source.lua")`. **Therefore `hull.source.*` is resolvable in the
+  tool VM** (a sub-agent guessed otherwise — that guess is wrong; the shipped
+  `hull analyze` proves resolution). New `hull.project.*` modules resolve the
+  same way.
+- `tool.*` bindings relevant here (`src/hull/runtime/lua/mod_tool.c`):
+  `find_files(dir, pat, {exclude_dirs, include_vendor})`, `path_kind`,
+  `realpath`, `read_file`, `file_exists`, `file_mtime`, `stdout`, `sha256_file`;
+  orchestration `modules_resolve`, `build_caps` (`tool_orchestration.c`). The
+  tool VM never has HTTP/DB/network.
+- Tool mode is **Lua-only by design** (CLAUDE.md "Command Dispatch"): there is no
+  JS tool VM. This is why the project analyzer is a Lua tool module even though
+  it will one day host a JS *frontend*.
+
+### 2.4 `hull dev` + `--agent` sidecars
+
+- `src/hull/commands/dev.c`: forks a child `hull` per run; **poll-based** mtime
+  watcher (1s, `scan_mtime` dev.c:101-132) over `.lua/.js/.html/.wgsl/.sql/.json`,
+  skipping dotdirs + `node_modules/vendor/build`; reload = SIGTERM child + refork
+  (dev.c:561-578). No file-watch library; no existing generation counter (the
+  TUI's `reload_count` is in-memory only, `dev_state.h`).
+- `--agent` sidecars under `{app_dir}/.hull/`: `dev.json`
+  (`{"port","pid","started_at"}`, dev.c:41-52, written per spawn, removed on
+  exit) and `last_error.json` (`{"error","timestamp"}`, written by the CHILD's
+  `serve.c:1076-1104` on load failure via `sh_json_*`, cleared on success). Dir
+  created 0755 (dev.c:33-39). Readers: `hull agent status` (reads dev.json,
+  probes the port — hybrid), `hull agent errors` (passes `last_error.json`
+  through — pure sidecar) in `src/hull/agent/request.c`.
+
+### 2.5 `hull agent` surface + the `inspect` question
+
+- ~31 subcommands dispatched in `src/hull/commands/agent.c:738-814`. The one
+  closest in spirit is **`hull agent overview`** (`src/hull/agent/overview.c`):
+  a standalone, filesystem-only composite summary (`runtime`, `routes`,
+  `compute_modules`, `gpu_shaders`, `migrations`, `modules_declared`, `tests`,
+  `build_ready`).
+- **`hull agent inspect` does NOT exist.** A **top-level `hull inspect` DOES
+  exist** (`src/hull/commands/inspect.c` → `hull_tool("hull.inspect")`) and
+  inspects a **built binary** (manifest + signature). Different noun (binary vs
+  project), different dispatch path, so no *dispatch* collision — but a real
+  *semantic-overlap* risk (see Decision 8).
+- Agent JSON is emitted via `ShJsonWriter`; **none of the existing agent
+  commands carry a `schema_version` field** (overview/deploy/routes verified).
+  Our new surface will add one (the source/analyze layers already version their
+  JSON at `schema_version = 2`).
+- Established pattern: standalone-first (overview, deploy), hybrid sidecar+probe
+  (status), pure-sidecar (errors). This licenses our Decision 9.
+
+### 2.6 `hull build` context flow
+
+- `src/hull/commands/build.c` → `hull_tool("hull.build", argv…)`: **only argv is
+  passed, no structured context** (build.c:12-15).
+- `build.lua main()` (`stdlib/cli/lua/hull/build.lua:1698`): `parse_args()` →
+  `discover(opts)` (build.lua:1756) → manifest extract + `tool.modules_resolve`
+  (build.lua:1781-1783). `discover()` (build.lua:1453-1696) runs **several**
+  per-type `tool.find_files` walkers (lua/js/json/html/static/sql/wasm/wgsl) and
+  returns a plain multi-field ctx (build.lua:1690). **Source is not parsed at
+  build time** for declaration discovery; module resolution is manifest-driven.
+- Narrowest seam: between `parse_args()` and `discover()` in `main()` — a
+  pre-flight where the host analyzer can be invoked and its result stashed on
+  ctx, without touching the embedding walkers.
+
+### 2.7 Existing "source-walk" surfaces (relationship, not replaced)
+
+`src/hull/agent/capabilities.c` and `src/hull/agent/validate.c` are **substring /
+heuristic** scanners (self-described: capabilities.c is "a substring scan… a
+heuristic"). They are C-side and crude. The new AST-based analyzer is a strict
+improvement, but **this story does not replace them** — it stands beside them.
+(A later story may re-point `capabilities` at real declarations; out of scope.)
+
+## 3. Surfaced conflicts / ambiguities (require a decision)
+
+1. **`hull agent inspect` vs top-level `hull inspect`** — no dispatch collision,
+   but a naming/semantic overlap (project model vs built binary). Decision 8.
+2. **Ownership language** — "host-owned" is satisfied by a Lua tool module +
+   single C entry (Decision 1); flagged so the reviewer can reject if they want
+   a C-native service.
+3. **Multi-name Lua declarations + annotation application** — the AST gives one
+   node for `local a, b`; the normalized model can be per-name or per-group.
+   Decision 4.
+4. **Dev failure semantics** — block reload / preserve previous valid / publish
+   invalid generation. Decision 7.
+5. **Which unannotated declarations are public** — Decision 4 (retention).
+
+No other collisions found (`hull.project.*` is an unused module namespace;
+`e2e_project_discovery.sh` is an unused test name; `.hull/discovery.json` is an
+unused sidecar name).
+
+## 4. Required design decisions (each explicit; recommendation + alternatives)
+
+### D1 — Host implementation boundary → **trusted Lua tool module + thin C entry (hybrid, Lua-leaning)** [RATIFIED]
+
+The analyzer is a Lua tool module `hull.project.analyze` — the **single canonical
+implementation** of project discovery. The C dispatcher `hull agent inspect`,
+`hull dev`, and (later) any build consumer all route through it via `hull_tool`.
+"Host-owned" is ownership + lifecycle, not access control: `build.lua` and other
+trusted tool modules *can* technically `require` it, and that is fine. Host
+ownership is enforced by **every official consumer using the canonical module**
+(and by review), not by module-access restrictions — there is no attempt to make
+it the only *callable* entry, only the one *authoritative* one. No consumer
+re-implements discovery or parses application source independently. Rationale:
+`hull.source.*` is pure Lua in the tool VM; a C reimplementation would duplicate
+the parser; `hull analyze` already proves the pattern. *Alternative:* C-native
+service — rejected (parser duplication, no payoff for a static, non-hot path).
+
+### D2 — Extract/reuse the hardened walker → **extract into `hull.source.discover`; refactor `hull analyze` onto it**
+
+Move `analyze.lua`'s `normalize/join/inside_root/excluded/EXCLUDE_LIST` + the
+`find_files(exclude_dirs)` + `realpath` containment + `path_kind` sequence into a
+new `hull.source.discover` module exposing e.g. `discover(root, {ext}) ->
+(files[], err)` (canonical, contained, sorted, fail-closed) and the containment
+helpers. `hull.source.analyze` refactors to call it (its **existing 25-case
+`e2e_analyze.sh` is the no-regression proof**). `hull.project.analyze` uses the
+same module. **No second walker.** Placing it under `hull.source.*` keeps the
+dependency direction clean (`project` depends on `source`, never the reverse).
+
+### D3 — Frontend registry + capability vocabulary → **plain table registry; 4-capability vocabulary**
+
+- Registry `hull.project.registry`: a sorted table mapping extension →
+  `{language, frontend_module, capabilities, analyzable}`. One canonical map.
+  Adding a frontend = one row; **no edits to dev/agent/build/consumers** (they
+  ask the registry).
+- Frontend **contract** is a plain table of functions (Hull's table/registry
+  convention, not an OO interface):
+  `{ language, extensions, capabilities, parse(source, path) -> (result, diags),
+  declarations(result) -> decl[], decl_name(d), decl_kind(d), decl_range(d),
+  decl_annotations(d), decl_handle(d) }`. `decl_handle` is a **generation-local
+  opaque** value (an integer index into that generation's frontend table) — not
+  a pointer, not serialized, not stable across generations.
+- Capability **vocabulary** (smallest justified by real consumers):
+  `declarations`, `annotations`, `source_ranges`, `scope`. **Not**
+  `bindings`/`semantic_analysis`/`lowering` — no consumer yet; advertising them
+  would violate "do not advertise capabilities that are not implemented." Lua
+  reports all four (scope ships). *Consumers talk only to this contract, never
+  to Lua AST field layouts.*
+
+### D4 — Multi-name Lua declaration + annotation semantics → **per-name facts with a shared `group_id`; annotations carry `target_group_id`; annotated-only public retention** [RATIFIED: 4a]
+
+The AST gives one `local_declaration` node for `local a, b = …` with
+`names=[{name,range},…]` and one `annotation_list`. **Chosen (4a): one
+declaration fact per NAME.** `local a, b` → two facts. Each fact's `range` is
+that name's own range; both carry:
+
+- a shared **`group_id`** = the identity of the declaration NODE
+  (`<language> ":" <rel_path> ":" <node_kind> ":" <node.range.start> "-"
+  <node.range.stop>`), identical for every name of the same statement; and
+- the **same** `annotations` list, where **each annotation carries
+  `target_group_id = group_id`** — making explicit that the annotation
+  originated on the declaration *group*, not independently on each name.
+
+So a future lowerer can see, per annotation, that it came from a multi-name
+group and **deliberately** dedupe or reject annotated multi-name groups (rather
+than silently applying one `@type` to two unrelated names). A single-name
+declaration still has a `group_id` (a group of one), and its annotations'
+`target_group_id` equals that group — uniform, no special case. Rejected (4b):
+one per-node group fact — non-uniform (`name?` → `names[]`), and by-name lookup +
+the ID scheme would need special-casing.
+
+Normalization of the other sub-questions (all confirmed):
+- **Dotted/method names:** walk the `function_declaration` name chain →
+  normalized string `a.b.c` (dotted) / `a:m` (method). Store `name="a.b.c"` +
+  `kind = "function"` with `is_method` folded into a `receiver`/flag field, so a
+  consumer never parses field layouts.
+- **Nameless declarations:** none of the in-scope kinds are nameless (an
+  anonymous `function()` is the *value* of a named `local`/assignment, not a
+  declaration). Guard anyway: a decl whose name can't resolve to a stable
+  identifier gets `status="unnamed"` and is kept out of the public annotated set.
+- **Retention (public vs internal) [RATIFIED]:** the public `declarations[]` holds
+  **annotated declarations only** — the model's stated purpose is "statically
+  discovered, *annotated* declarations," and the future consumers (Query/Compute
+  IR) key off annotations. The generation **retains total counts** in the summary
+  (`declarations_total`, `declarations_annotated` per source and overall) AND
+  **retains the full per-source declaration data internally** (an internal
+  `_by_source` index carrying every discovered declaration, annotated or not) so
+  a later consumer can reach unannotated declarations without re-analysis. Only
+  the *public serialized* `declarations[]` is filtered to annotated facts;
+  nothing is discarded.
+
+Kinds emitted (Lua frontend): `local`, `local_function`, `function` (with
+`is_method`). Recommend NOT emitting bare `assignment`-as-global-function in
+this story (it is not an annotation-attach target; adding it means widening the
+annotation model — out of scope).
+
+### D5 — Deterministic declaration ID → **`language ":" rel_path ":" kind ":" name ":" start "-" stop`** [RATIFIED]
+
+Per-name `id` (uniquely identifies a declaration fact); `group_id` (D4) is the
+node-level variant (`… ":" node_kind ":" node.start "-" node.stop`). `rel_path`
+is the canonical **project-relative** path (from the contained realpath, minus
+the root prefix). Deterministic within a generation, textual, no
+pointers/table-identities/addresses. For a multi-name declaration, the per-name
+`start-stop` disambiguates each `id` while the shared `group_id` links them.
+**Not** persistent across arbitrary edits (a non-goal) — identity is a
+within-generation key, documented as such.
+
+### D6 — In-memory vs serialized → **in-memory Lua table is authoritative; JSON is the wire/sidecar projection** [RATIFIED]
+
+The `ProjectDiscovery` Lua table is the authoritative in-process value. A
+`schema_version`'d JSON projection is produced for (a) agent inspection stdout
+and (b) the dev sidecar. There is **no persistent generation store / cache** in
+this story (no incremental). Opaque frontend handles are **never** serialized.
+
+**The `ProjectDiscovery` model (serialized shape):**
+
+```
+{ schema_version, generation, project_root,
+  valid,        // the analysis ran with no analyzed source rejected + no internal/operational failure
+  complete,     // every APPLICATION source had an analyzable frontend (see below)
+  sources[]     = { path, language, role, status },   // role ∈ app|asset; status ∈ analyzed|unsupported|error
+  frontends[]   = { language, extensions, capabilities[], analyzable },
+  declarations[]= { id, group_id, language, path, kind, name, range,
+                    annotations[] = { name, args?, value?, range, target_group_id, frontend, raw? },
+                    status },      // PUBLIC: annotated facts only (D4)
+  diagnostics[] = { severity, code, message, path, range?, language? },
+  summary       = { sources_total, sources_analyzed, sources_unsupported,
+                    declarations_total, declarations_annotated, by_language{…} },
+  indexes }     // deterministic access (D-indexes): by_annotation, by_source, by_language, by_id, annotated
+```
+
+`valid` and `complete` are **independent** axes and a consumer that wants a
+"clean, trustworthy generation" checks **`valid && complete`**:
+- `valid = false` when any analyzed source produced a parse error (malformed Lua)
+  or the analyzer hit an internal/operational failure. (A syntactically-clean
+  all-Lua project is `valid = true`.)
+- `complete = false` when any **application source** has no analyzable frontend
+  (e.g. application JavaScript today). An unsupported *application* source can
+  never yield a clean generation, but it does not by itself make the analysis
+  `invalid` — it makes it *incomplete*.
+
+**"Application source" is defined narrowly** so browser assets do not poison a
+Lua project: it is a discovered file whose extension maps to a **known language**
+in the registry (`.lua` today; `.js/.mjs/.cjs` reserved) AND that is **not** under
+the `static/` asset directory (nor under the hardened generated/dependency
+excludes `.git/.hull/build/vendor/node_modules`). Concretely, the project
+analyzer's scan prunes `static/` in addition to the standard `EXCLUDE_LIST`
+(D2's shared walker takes an `extra_exclude` list; `hull analyze` passes none, so
+its behavior is unchanged). A `static/app.js` browser asset is therefore never
+discovered as application source and never affects `complete`; a root-level
+`app.js` / `routes/x.js` IS application source, is recorded
+`role="app", status="unsupported"`, and sets `complete = false`.
+
+### D7 — Dev publication + failure behavior → **publish EVERY new generation (incl. `valid=false`); never preserve stale as current; never gate reload; publish atomically with a session identity** [RATIFIED, amended]
+
+`hull dev` runs the canonical analyzer on startup and on each reload
+(deterministic full reanalysis — no incremental). In **`--agent` mode** it
+publishes `{app_dir}/.hull/discovery.json` with a monotonic `generation` counter
+(consistent scope with `dev.json`/`last_error.json`, which are also
+`--agent`-only). **Every** analysis publishes a new generation — including a
+malformed/partial one, which publishes `valid=false` (and/or `complete=false`) +
+structured diagnostics. It does **not** gate the server reload (discovery is
+advisory metadata, not a serving gate) and does **not** silently keep the prior
+generation as current (that would let a failed analysis masquerade as clean —
+forbidden by the invariant).
+
+**Atomicity + session identity (amendment).** Publication is atomic: write
+`{app_dir}/.hull/discovery.json.tmp` then `rename(2)` over the target (a reader
+never sees a half-written file). Both `dev.json` and `discovery.json` carry a
+**dev-session identity** = the `hull dev` **supervisor (parent) PID** (`session_pid`),
+which is stable across reloads — unlike the served child PID, which changes every
+reload. `dev.json` currently records only the child/served PID; this adds
+`session_pid` (the supervisor) to it and mirrors `session_pid` + `generation`
+into `discovery.json`. This closes the spawn/publication race: a reader can bind
+a published generation to a specific live dev session and reject a stale or
+cross-reload sidecar (see D9). `dev.json` publication becomes atomic (tmp+rename)
+for the same reason.
+
+### D8 — Agent command + collision → **RAISE; recommend `hull agent inspect`, with `hull agent discovery` as the collision-free fallback**
+
+`hull agent inspect` is free at the dispatch level. It reads naturally ("inspect
+the analyzed project model") and matches the story's own prose. The only risk is
+semantic overlap with top-level `hull inspect` (which inspects a *built binary*).
+Recommendation: **`hull agent inspect`**, documented as project-model inspection,
+distinct from the binary-inspecting `hull inspect`. If the reviewer finds that
+overlap confusing, **`hull agent discovery`** (or `hull agent project`) is
+collision-free and unambiguous. Schema: `schema_version`, `generation`, `valid`,
+`project_root`, `sources[]`, `frontends[]`, `declarations[]` (annotated),
+`diagnostics[]`, `indexes` (summary counts). I will not implement until this
+name is picked.
+
+### D9 — Standalone vs running-dev equivalence → **dev running: read the published generation; else: one standalone analysis; identical schema** [RATIFIED]
+
+`hull agent inspect`: accept the **latest published generation** only when
+`{app_dir}/.hull/discovery.json` exists AND its `session_pid` matches
+`dev.json`'s `session_pid` AND that supervisor PID is **live** (the same
+liveness idea `hull agent status` uses). Any mismatch or dead session → fall back
+to **one standalone analysis**. This rejects a stale or cross-reload sidecar
+left by a prior/killed dev session. The sidecar JSON is literally the serialized
+standalone output, so equivalence is structural by construction (same analyzer,
+same projection). Standalone results carry `generation = 0` + a `source:
+"standalone"` marker to signal they were computed on demand rather than published
+by a dev session.
+
+### D10 — Build-context seam → **abstraction-only + a documented seam; NO per-build parse** [RATIFIED]
+
+`hull.project.analyze(app_dir) -> ProjectDiscovery` is the host abstraction. For
+this story build integration is the **abstraction plus a precisely documented
+seam** — build.lua is **not** wired to call the analyzer, and **no build performs
+an unused full parse** merely to stash `ctx.discovery`. Making `build.lua`
+initiate host analysis before any lowering consumer exists would be premature
+work on every build for no consumer. The documented seam: the **first actual
+lowering consumer** (future Query/Compute codegen) is what will justify threading
+discovery into the build context — at that point build.lua calls
+`hull.project.analyze(app_dir)` in `main()` (after `parse_args()`, before
+`discover()`) and passes the result to the codegen step; the file-embedding
+walkers are untouched. This story ships + tests the host abstraction standalone
+and records this exact insertion point, without rewriting the build pipeline or
+adding a dormant per-build cost. (Slice 4 therefore documents + tests the
+abstraction and the seam; it does not modify `build.lua`.)
+
+### D11 — JavaScript honest behavior → **known language, `analyzable=false`, no parse, honest per-file diagnostic, and it makes the generation `complete=false`** [RATIFIED, amended]
+
+The registry knows `javascript` (`.js/.mjs/.cjs`) with `capabilities={}` and
+`analyzable=false`. **`.js/.mjs/.cjs` are NOT registered as analyzable**, so the
+scan does not select a frontend for them. An application `.js` file (per the
+"application source" definition in D6 — i.e. NOT a `static/` browser asset) is
+recorded in `sources[]` with `language="javascript"`, `role="app"`,
+`status="unsupported"`, no declarations, and a discovery diagnostic
+(`severity="warning"`, `code="project.frontend.unsupported"`), and **sets
+`complete = false`** on the generation — an unsupported application source can
+never yield a clean, complete generation. It is **never** parsed as Lua and
+**never** reported as analyzed. A `static/app.js` browser asset is pruned from
+the application-source scan (D6) and does not affect `complete`. A future JS
+frontend flips one registry row (`analyzable=true`) + ships an adapter; nothing
+else changes, and such files then count as analyzed.
+
+### D12 — Slice plan + gates → below (§5).
+
+## 5. Slice plan
+
+Small, reviewable, each green before the next. All commits `-s`
+(`Signed-off-by: Mark Farkas <mark@artalis.io>`), no Co-Authored-By, no
+attribution, no em-dashes.
+
+- **Slice 1 — core (host analyzer + Lua frontend + model).**
+  - Extract `hull.source.discover`; refactor `hull.source.analyze` onto it (D2).
+  - `hull.project.registry` (D3) + `hull.project.frontend_lua` (D3/D4) +
+    `hull.project.model` (IDs D5, indexes, diagnostics) + `hull.project.analyze`
+    (D1) + a C entry (name pending D8).
+  - Vanilla-`lua_State` unit tests (the `hull.source` harness style):
+    declarations/annotations/ranges extracted without executing app source;
+    multi-name semantics (D4); dotted/method normalization; unknown-annotation
+    survival; malformed Lua → `valid=false` + diagnostics; capability reporting
+    accuracy; ID determinism; **no consumer touches Lua AST fields** (adapter is
+    the only AST-aware module).
+  - Gate: `make test`, the source UTEST suite, `luacheck`, and **`e2e_analyze.sh`
+    green** (proves the walker extraction is behavior-preserving).
+
+- **Slice 2 — standalone agent inspection (D8/D9/D11).**
+  - `hull agent <inspect>` standalone path; `schema_version`'d JSON; JS honest
+    handling.
+  - Gate: `tests/e2e_project_discovery.sh` — deterministic output on fixtures;
+    annotated Lua discovered without execution; unknown annotations survive;
+    malformed → invalid; `.js` present but not falsely analyzed; exclusions +
+    containment reuse the hardened behavior.
+
+- **Slice 3 — `hull dev` integration (D7/D9).**
+  - Publish `.hull/discovery.json` per generation in `--agent`; `hull agent
+    <inspect>` reads the published generation when dev is live.
+  - Gate (e2e): `hull dev --agent` publishes a generation; modify a source +
+    reload → a new generation; standalone vs published schema equivalence.
+
+- **Slice 4 — build seam (D10), abstraction-only.**
+  - Ship + test `hull.project.analyze` as the host abstraction a build consumer
+    would call; document the exact `build.lua main()` insertion point for the
+    first lowering consumer. **`build.lua` is not modified** and no per-build
+    parse is added. A test asserts the abstraction returns the same
+    `ProjectDiscovery` a build consumer would receive; the doc records the seam.
+
+**Acceptance (mapped to the story's list):** deterministic output (S1/S2);
+annotations discovered without execution (S1/S2); unknown annotations survive
+(S1/S2); malformed → structured diagnostics + `valid=false` (S1/S2); accurate
+capability reporting (S1); exclusions/containment reuse (S2); standalone agent
+inspection (S2); `hull dev --agent` publishes + exposes an equivalent generation
+(S3); modify+reload → new generation (S3); no consumer imports Lua parser
+internals (S1, enforced by the contract + a test); no `.js` falsely analyzed +
+application `.js` sets `complete=false` while `static/*.js` does not (S2);
+build ownership as a tested abstraction + documented seam (S4).
+
+## 6. Ratification (sign-off recorded)
+
+All decisions ratified with amendments (folded into D1-D12 above):
+1. **D8** — `hull agent inspect` (project model), documented as distinct from
+   top-level `hull inspect` (built binary).
+2. **D4** — per-name facts with a shared `group_id`; each annotation carries
+   `target_group_id` (originated on the declaration group, not per name);
+   public `declarations[]` annotated-only; totals + full per-source data retained
+   internally.
+3. **D7** — publish every new generation incl. `valid=false`/`complete=false`;
+   never preserve stale as current; never gate reload; publish atomically
+   (tmp+rename) with a `session_pid` (supervisor) identity in both sidecars.
+4. **D6/D11** — an unsupported **application** source makes the generation
+   `complete=false` (independent of `valid`); "application source" excludes
+   `static/` browser assets + the generated/dependency dirs, so browser JS
+   cannot poison a Lua project.
+5. **D10** — abstraction-only + a documented build seam; `build.lua` unmodified;
+   no unused per-build parse. The first lowering consumer justifies threading
+   discovery into build context.
+6. **D1/D2** — trusted Lua tool module as the single **canonical** implementation
+   (ownership by consumer convention, not access control); extract the hardened
+   walker into `hull.source.discover` and refactor `hull analyze` onto it.
+
+Implementation proceeds per §5, Slice 1 first.

--- a/docs/project_discovery_design.md
+++ b/docs/project_discovery_design.md
@@ -506,3 +506,27 @@ All decisions ratified with amendments (folded into D1-D12 above):
    walker into `hull.source.discover` and refactor `hull analyze` onto it.
 
 Implementation proceeds per §5, Slice 1 first.
+
+### 6.1 Slice 1 review fixes (folded in)
+
+Four core-contract fixes from the Slice 1 review, all in the shipped code + tests:
+
+- **Root validation/canonicalization.** `hull.project.analyze` requires
+  `tool.realpath(root)` + `path_kind == "dir"` and uses the CANONICAL root for
+  containment + relative paths (covers symlinked roots and `/`). A missing /
+  non-directory root is a `project.discovery_failed` generation
+  (`valid=false, complete=false`), never a valid, complete, empty project (which
+  the ENOENT-benign `find_files` would otherwise produce).
+- **Protected public boundary.** `M.analyze` wraps the unprotected analysis in
+  `pcall`; any frontend/adapter/model defect becomes an INVALID discovery with a
+  structured `project.internal` diagnostic — honoring "never raises."
+- **Generation-unique, resolvable handles.** The per-file adapter index is gone.
+  The analyzer (the generation owner) assigns a **generation-unique** integer per
+  declaration and retains `{frontend, unit, declaration}` in an internal
+  `disc._handles` table; `M.resolve_handle(disc, h)` is the controlled lookup a
+  future lowerer uses to reach frontend-specific semantics through the boundary.
+  Handles are generation-internal and excluded from the serialized projection.
+- **Scope is callable through the boundary.** The advertised `scope` capability is
+  now a real contract method `frontend.scope(unit) -> (scope, err)` (a protected
+  wrapper around `hull.source.scope.resolve`), so a consumer never bypasses the
+  adapter. (Had it not been made callable, the capability would have been removed.)

--- a/stdlib/cli/lua/hull/project/analyze.lua
+++ b/stdlib/cli/lua/hull/project/analyze.lua
@@ -1,0 +1,117 @@
+--
+-- hull.project.analyze — the host-owned, frontend-neutral project analyzer.
+--
+-- The SINGLE canonical implementation of project source discovery (design:
+-- docs/project_discovery_design.md D1). Statically inspects an app's source tree WITHOUT
+-- executing application code, selects a language frontend per file via the registry, and
+-- returns a normalized ProjectDiscovery. Official consumers (hull agent inspect, hull
+-- dev, a future build lowering step) call M.analyze; none re-scan or parse source itself.
+--
+-- Reuses the shared hardened walker (hull.source.discover) -- no second recursive scan.
+-- Pure Lua over the tool VM; never raises, never prints (returns a data model).
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local discover = require("hull.source.discover")
+local registry = require("hull.project.registry")
+local model    = require("hull.project.model")
+
+local M = { SCHEMA_VERSION = model.SCHEMA_VERSION }
+
+-- Project-relative path: strip the root prefix so `path` + IDs are stable + portable.
+local function rel_path(root, path)
+    if root == "." or root == "" then return path end
+    local prefix = root .. "/"
+    if path:sub(1, #prefix) == prefix then return path:sub(#prefix + 1) end
+    return path
+end
+
+local function any_error(diags)
+    for _, d in ipairs(diags or {}) do if d.severity == "error" then return true end end
+    return false
+end
+
+local function stamp_path(diags, rel)
+    for _, d in ipairs(diags or {}) do d.path = d.path or rel end
+    return diags
+end
+
+-- Build per-source declaration facts via the frontend CONTRACT (never the AST).
+local function collect_decls(fe, unit, language, rel)
+    local out = {}
+    for _, d in ipairs(fe.declarations(unit)) do
+        out[#out + 1] = {
+            language    = language,
+            path        = rel,
+            kind        = fe.decl_kind(d),
+            name        = fe.decl_name(d),
+            range       = fe.decl_range(d),
+            group_range = fe.decl_group_range(d),
+            is_method   = fe.decl_is_method(d),
+            handle      = fe.decl_handle(d),
+            annotations = fe.decl_annotations(d),
+        }
+    end
+    return out
+end
+
+-- analyze(root, opts?) -> ProjectDiscovery.
+--   opts.generation  : the dev generation counter (default 0 = standalone).
+--   opts.source_kind : "standalone" (default) | "dev" provenance marker.
+-- Discovers APPLICATION source (known-language extensions, static/ pruned so browser
+-- assets never count -- D6), dispatches each to its frontend, and assembles the model.
+function M.analyze(root, opts)
+    opts = opts or {}
+    root = discover.normalize(root or ".")
+
+    local per_source, op_diags = {}, {}
+    local files, derr = discover.discover(root, { ext = registry.known_exts(), extra_exclude = { "static" } })
+    if derr then
+        -- Operational discovery failure: an invalid generation, never an empty clean scan.
+        op_diags[#op_diags + 1] = { severity = "error", code = "project.discovery_failed",
+                                    message = "source discovery failed: " .. tostring(derr), path = root }
+    else
+        for _, path in ipairs(files) do
+            local ext = path:match("%.([%w]+)$")
+            local row = ext and registry.for_ext(ext)
+            local rel = rel_path(root, path)
+            if row and row.analyzable then
+                local fe = registry.load(row)
+                local src = tool.read_file(path)
+                if not src then
+                    per_source[#per_source + 1] = { path = rel, language = row.language, role = "app",
+                        status = "error", declarations = {},
+                        diagnostics = { { severity = "error", code = "project.unreadable",
+                                          message = "cannot read source file", path = rel } } }
+                else
+                    local unit, diags = fe.parse(src, rel)
+                    stamp_path(diags, rel)
+                    if unit == nil then                          -- frontend internal / API failure
+                        per_source[#per_source + 1] = { path = rel, language = row.language, role = "app",
+                            status = "error", declarations = {}, diagnostics = diags }
+                    else
+                        per_source[#per_source + 1] = { path = rel, language = row.language, role = "app",
+                            status = any_error(diags) and "error" or "analyzed",
+                            declarations = collect_decls(fe, unit, row.language, rel),
+                            diagnostics = diags }
+                    end
+                end
+            elseif row then
+                -- Known but NON-analyzable language (JavaScript): honest unsupported app
+                -- source -> the generation is complete=false (D11). Never parsed as Lua.
+                per_source[#per_source + 1] = { path = rel, language = row.language, role = "app",
+                    status = "unsupported",
+                    diagnostics = { { severity = "warning", code = "project.frontend.unsupported",
+                        message = "no analyzable frontend for language '" .. row.language .. "'",
+                        path = rel, language = row.language } } }
+            end
+            -- An extension not in the registry is not project source; the scan never
+            -- returns it (discover restricts to known_exts), so there is no else branch.
+        end
+    end
+
+    return model.build(root, opts.generation or 0, per_source, op_diags, opts.source_kind or "standalone")
+end
+
+return M

--- a/stdlib/cli/lua/hull/project/analyze.lua
+++ b/stdlib/cli/lua/hull/project/analyze.lua
@@ -146,22 +146,49 @@ local function analyze_unprotected(root_in, opts)
     return disc
 end
 
+-- Emergency INVALID discovery built as a LITERAL, with no call into model.build /
+-- registry (which is where the failure being recovered from may itself live). Used only
+-- on the protected-boundary failure path, so recovery can never re-raise the same defect.
+local function minimal_invalid(root, gen, source_kind, code, message)
+    return {
+        schema_version = model.SCHEMA_VERSION,   -- a constant, not a call
+        generation     = gen,
+        source         = source_kind,
+        project_root   = root,
+        valid          = false,
+        complete       = false,
+        sources        = {},
+        declarations   = {},
+        diagnostics    = { { severity = "error", code = code, message = message, path = root } },
+        frontends      = {},                     -- literal: no registry call on the failure path
+        indexes        = { by_annotation = {}, by_source = {}, by_language = {},
+                           by_id = {}, annotated = {} },
+        summary        = { sources_total = 0, sources_analyzed = 0, sources_unsupported = 0,
+                           declarations_total = 0, declarations_annotated = 0, by_language = {} },
+        _by_source     = {},
+        _handles       = {},
+    }
+end
+
 -- analyze(root, opts?) -> ProjectDiscovery. PROTECTED public boundary: any internal
 -- frontend/adapter/model failure is converted into an INVALID discovery with a structured
 -- project.internal diagnostic (never a raised error, never a clean generation).
 --   opts.generation  : the dev generation counter (default 0 = standalone).
 --   opts.source_kind : "standalone" (default) | "dev" provenance marker.
 function M.analyze(root, opts)
-    opts = opts or {}
-    local ok, result = pcall(analyze_unprotected, root, opts)
+    -- Normalize + validate opts ONCE, up front, so neither the normal nor the recovery
+    -- path ever dereferences a non-table / wrong-typed opts.
+    if type(opts) ~= "table" then opts = {} end
+    local gen         = (type(opts.generation) == "number") and opts.generation or 0
+    local source_kind = (type(opts.source_kind) == "string") and opts.source_kind or "standalone"
+    local root_disp   = tostring(root or ".")
+
+    local ok, result = pcall(analyze_unprotected, root, { generation = gen, source_kind = source_kind })
     if ok then return result end
-    local root_disp = tostring(root or ".")
-    local d = model.build(root_disp, opts.generation or 0, {}, { { severity = "error",
-        code = "project.internal",
-        message = "internal analyzer failure: " .. tostring(result), path = root_disp } },
-        opts.source_kind or "standalone")
-    d.complete = false
-    return d
+    -- Recovery uses the literal constructor -- if model.build was the defect, calling it
+    -- again here would re-raise the same error OUTSIDE the pcall.
+    return minimal_invalid(root_disp, gen, source_kind, "project.internal",
+        "internal analyzer failure: " .. tostring(result))
 end
 
 -- Controlled generation-internal handle lookup: resolve an opaque declaration handle to

--- a/stdlib/cli/lua/hull/project/analyze.lua
+++ b/stdlib/cli/lua/hull/project/analyze.lua
@@ -19,9 +19,12 @@ local model    = require("hull.project.model")
 
 local M = { SCHEMA_VERSION = model.SCHEMA_VERSION }
 
--- Project-relative path: strip the root prefix so `path` + IDs are stable + portable.
+
+-- Project-relative path: strip the CANONICAL root prefix so `path` + IDs are stable +
+-- portable. Handles "/" (prefix is just "/") and "." (already relative).
 local function rel_path(root, path)
     if root == "." or root == "" then return path end
+    if root == "/" then return (path:sub(1, 1) == "/") and path:sub(2) or path end
     local prefix = root .. "/"
     if path:sub(1, #prefix) == prefix then return path:sub(#prefix + 1) end
     return path
@@ -37,10 +40,16 @@ local function stamp_path(diags, rel)
     return diags
 end
 
--- Build per-source declaration facts via the frontend CONTRACT (never the AST).
-local function collect_decls(fe, unit, language, rel)
+-- Build per-source declaration facts via the frontend CONTRACT (never the AST). Each
+-- decl is registered in the GENERATION handle table (`handles`) with a generation-unique
+-- integer key retaining { frontend, unit, declaration } for a future lowerer to resolve
+-- through the frontend boundary (M.resolve_handle). Handles are generation-internal and
+-- excluded from the serialized/public projection.
+local function collect_decls(fe, unit, language, rel, handles)
     local out = {}
     for _, d in ipairs(fe.declarations(unit)) do
+        handles.n = handles.n + 1
+        handles.map[handles.n] = { frontend = fe, unit = unit, declaration = d }
         out[#out + 1] = {
             language    = language,
             path        = rel,
@@ -49,22 +58,43 @@ local function collect_decls(fe, unit, language, rel)
             range       = fe.decl_range(d),
             group_range = fe.decl_group_range(d),
             is_method   = fe.decl_is_method(d),
-            handle      = fe.decl_handle(d),
+            handle      = handles.n,          -- generation-unique (not the per-file index)
             annotations = fe.decl_annotations(d),
         }
     end
     return out
 end
 
--- analyze(root, opts?) -> ProjectDiscovery.
---   opts.generation  : the dev generation counter (default 0 = standalone).
---   opts.source_kind : "standalone" (default) | "dev" provenance marker.
--- Discovers APPLICATION source (known-language extensions, static/ pruned so browser
--- assets never count -- D6), dispatches each to its frontend, and assembles the model.
-function M.analyze(root, opts)
-    opts = opts or {}
-    root = discover.normalize(root or ".")
+-- The UNPROTECTED analysis: root validation/canonicalization + discovery + per-file
+-- frontend dispatch + model assembly. May raise on a frontend/adapter/model defect; the
+-- public M.analyze wraps this in a protected boundary (D1: "never raises").
+local function analyze_unprotected(root_in, opts)
+    local root_disp = tostring(root_in or ".")
+    local gen        = opts.generation or 0
+    local source_kind = opts.source_kind or "standalone"
 
+    -- Root validation + canonicalization (symlinks resolved). A missing / non-directory
+    -- root is a project.discovery_failed generation (invalid AND incomplete), never a
+    -- valid, complete, empty project. Containment + relative paths use the CANONICAL root.
+    local canon, reason = tool.realpath(discover.normalize(root_disp))
+    if not canon then
+        local d = model.build(root_disp, gen, {}, { { severity = "error",
+            code = "project.discovery_failed",
+            message = "cannot resolve project root '" .. root_disp .. "' (" .. tostring(reason) .. ")",
+            path = root_disp } }, source_kind)
+        d.complete = false
+        return d
+    end
+    if tool.path_kind(canon) ~= "dir" then
+        local d = model.build(canon, gen, {}, { { severity = "error",
+            code = "project.discovery_failed",
+            message = "project root is not a directory: " .. canon, path = canon } }, source_kind)
+        d.complete = false
+        return d
+    end
+    local root = canon
+
+    local handles = { n = 0, map = {} }
     local per_source, op_diags = {}, {}
     local files, derr = discover.discover(root, { ext = registry.known_exts(), extra_exclude = { "static" } })
     if derr then
@@ -93,7 +123,7 @@ function M.analyze(root, opts)
                     else
                         per_source[#per_source + 1] = { path = rel, language = row.language, role = "app",
                             status = any_error(diags) and "error" or "analyzed",
-                            declarations = collect_decls(fe, unit, row.language, rel),
+                            declarations = collect_decls(fe, unit, row.language, rel, handles),
                             diagnostics = diags }
                     end
                 end
@@ -111,7 +141,35 @@ function M.analyze(root, opts)
         end
     end
 
-    return model.build(root, opts.generation or 0, per_source, op_diags, opts.source_kind or "standalone")
+    local disc = model.build(root, gen, per_source, op_diags, source_kind)
+    disc._handles = handles.map            -- generation-internal; NOT serialized (D6)
+    return disc
+end
+
+-- analyze(root, opts?) -> ProjectDiscovery. PROTECTED public boundary: any internal
+-- frontend/adapter/model failure is converted into an INVALID discovery with a structured
+-- project.internal diagnostic (never a raised error, never a clean generation).
+--   opts.generation  : the dev generation counter (default 0 = standalone).
+--   opts.source_kind : "standalone" (default) | "dev" provenance marker.
+function M.analyze(root, opts)
+    opts = opts or {}
+    local ok, result = pcall(analyze_unprotected, root, opts)
+    if ok then return result end
+    local root_disp = tostring(root or ".")
+    local d = model.build(root_disp, opts.generation or 0, {}, { { severity = "error",
+        code = "project.internal",
+        message = "internal analyzer failure: " .. tostring(result), path = root_disp } },
+        opts.source_kind or "standalone")
+    d.complete = false
+    return d
+end
+
+-- Controlled generation-internal handle lookup: resolve an opaque declaration handle to
+-- { frontend, unit, declaration } so a future lowerer can invoke frontend-specific
+-- semantics (e.g. frontend.scope(unit)) THROUGH the adapter boundary. Handles are unique
+-- within one generation and are not stable across generations/processes.
+function M.resolve_handle(disc, handle)
+    return disc and disc._handles and disc._handles[handle] or nil
 end
 
 return M

--- a/stdlib/cli/lua/hull/project/frontend_lua.lua
+++ b/stdlib/cli/lua/hull/project/frontend_lua.lua
@@ -20,11 +20,14 @@
 --
 
 local lua = require("hull.source.lua")
+local scope = require("hull.source.scope")
 
 local M = {
     language     = "lua",
     extensions   = { "lua" },
-    -- Only capabilities Lua actually SHIPS (D3). Not bindings/semantic_analysis/lowering.
+    -- Only capabilities Lua actually SHIPS (D3), and each is callable THROUGH this
+    -- contract (declarations/annotations/source_ranges via decl_*; scope via M.scope).
+    -- Nothing unimplemented is advertised.
     capabilities = { "declarations", "annotations", "source_ranges", "scope" },
     analyzable   = true,
 }
@@ -105,21 +108,21 @@ end
 
 -- declarations(result) -> decl[]. ONE decl per declared NAME (D4): a multi-name
 -- `local a, b` yields two decls sharing the declaration NODE's group range; each carries
--- its own name range + the node's annotations. Handles are generation-local indices.
+-- its own name range + the node's annotations. The GENERATION-unique handle is assigned
+-- by the analyzer (which owns the generation), not here -- this returns opaque decl
+-- objects the analyzer retains behind its handle table.
 function M.declarations(unit)
-    local out, idx = {}, 0
+    local out = {}
     lua.walk(unit.ast, function(n)
         if n.kind == "local_declaration" then
             local anns, grp = norm_annotations(unit, n), mkrange(unit, n.range)
             for _, nm in ipairs(n.names or {}) do
-                idx = idx + 1
                 out[#out + 1] = { _kind = "local", _name = nm.name, _range = mkrange(unit, nm.range),
-                                  _group = grp, _is_method = false, _anns = anns, _index = idx }
+                                  _group = grp, _is_method = false, _anns = anns }
             end
         elseif n.kind == "function_declaration" then
             local name = flatten_fnname(n.name, n.is_method)
             if name then
-                idx = idx + 1
                 out[#out + 1] = {
                     _kind = n.is_local and "local_function" or "function",
                     _name = name,
@@ -127,7 +130,6 @@ function M.declarations(unit)
                     _group = mkrange(unit, n.range),
                     _is_method = n.is_method == true,
                     _anns = norm_annotations(unit, n),
-                    _index = idx,
                 }
             end
         end
@@ -141,6 +143,18 @@ function M.decl_range(d)       return d._range end
 function M.decl_group_range(d) return d._group end
 function M.decl_annotations(d) return d._anns end
 function M.decl_is_method(d)   return d._is_method == true end
-function M.decl_handle(d)      return d._index end      -- generation-local; never serialized as-is
+
+-- scope(result) -> (scope, err): the advertised "scope" capability, callable THROUGH the
+-- adapter (D-scope fix). Protected wrapper around hull.source.scope.resolve so a consumer
+-- (e.g. a future lowerer, via M.resolve_handle -> {frontend, unit, ...}) never bypasses
+-- the frontend boundary or sees a raised error. `err` is a Diagnostic-shaped table.
+function M.scope(unit)
+    local ok, sc, err = pcall(scope.resolve, unit)
+    if not ok then
+        return nil, { severity = "error", code = "lua.internal",
+                      message = "scope resolution failed: " .. tostring(sc) }
+    end
+    return sc, err
+end
 
 return M

--- a/stdlib/cli/lua/hull/project/frontend_lua.lua
+++ b/stdlib/cli/lua/hull/project/frontend_lua.lua
@@ -1,0 +1,146 @@
+--
+-- hull.project.frontend_lua — the production Lua FRONTEND ADAPTER.
+--
+-- Adapts the shipped hull.source.lua AST into the frontend contract the project
+-- analyzer consumes (design: docs/project_discovery_design.md D3/D4). This is the ONLY
+-- project module that knows Lua node-field layouts; the analyzer + model talk to the
+-- contract accessors below, never to the AST.
+--
+-- Contract (a plain table of functions, Hull's registry convention -- not an OO class):
+--   language, extensions, capabilities, analyzable
+--   parse(source, path) -> (result, diagnostics[])   result is opaque (the SourceUnit)
+--   declarations(result) -> decl[]                    each decl opaque to the caller
+--   decl_name(d) / decl_kind(d) / decl_range(d) / decl_group_range(d)
+--   decl_annotations(d) -> normalized annotation[]    { name, args?, value?, raw, range }
+--   decl_is_method(d) / decl_handle(d)                handle = generation-local opaque int
+--
+-- Pure Lua; never raises, never prints (parse() surfaces problems as diagnostics data).
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local lua = require("hull.source.lua")
+
+local M = {
+    language     = "lua",
+    extensions   = { "lua" },
+    -- Only capabilities Lua actually SHIPS (D3). Not bindings/semantic_analysis/lowering.
+    capabilities = { "declarations", "annotations", "source_ranges", "scope" },
+    analyzable   = true,
+}
+
+-- ── AST-aware internals (the containment boundary: nothing below escapes this file) ──
+
+-- A range as a plain {start, stop, line, col} table (1-based line/col at `start`).
+local function mkrange(unit, r)
+    if type(r) ~= "table" or type(r.start) ~= "number" then return nil end
+    local line, col = unit:line_col(r)
+    return { start = r.start, stop = r.stop, line = line, col = col }
+end
+
+-- Normalize a declaration node's attached `---@` annotations into plain records. The
+-- annotation layer already ran during parse (lua.parse -> annotations.attach), so the
+-- node carries annotation_list. `value` is the trailing free text after the name/args.
+local function norm_annotations(unit, node)
+    local out = {}
+    for _, a in ipairs(node.annotation_list or {}) do
+        out[#out + 1] = {
+            name  = a.name,
+            args  = a.args,          -- balanced (...) group text, or nil
+            value = a.text,          -- trailing text after name/(...), trimmed, or nil
+            raw   = a.raw,
+            range = mkrange(unit, a.range),
+        }
+    end
+    return out
+end
+
+-- Flatten a function_declaration name (a `name` node or a `field` chain) to a dotted /
+-- method string: `a.b.c` for `function a.b.c()`, `a:m` for `function a:m()`, `f` for a
+-- plain / local function. Consumers never see the chain (D4).
+local function flatten_fnname(namenode, is_method)
+    local parts, n = {}, namenode
+    while type(n) == "table" do
+        if n.kind == "name" then parts[#parts + 1] = n.name; break
+        elseif n.kind == "field" then parts[#parts + 1] = n.name; n = n.obj
+        else break end
+    end
+    local rev = {}
+    for i = #parts, 1, -1 do rev[#rev + 1] = parts[i] end
+    if #rev == 0 then return nil end
+    if is_method and #rev >= 2 then
+        return table.concat(rev, ".", 1, #rev - 1) .. ":" .. rev[#rev]
+    end
+    return table.concat(rev, ".")
+end
+
+-- ── the contract ──
+
+-- parse(source, path) -> (result, diagnostics[]). result is the opaque SourceUnit;
+-- diagnostics are normalized { severity, code, message, range? }. On API-misuse /
+-- internal failure (unit == nil) returns (nil, { one internal diagnostic }).
+function M.parse(source, path)
+    local unit, err = lua.parse(source, { path = path })
+    if unit == nil then
+        local d
+        if type(err) == "table" then
+            d = { severity = err.severity or "error", code = err.code or "lua.internal",
+                  message = err.message or "internal parser failure", range = err.range }
+        else
+            d = { severity = "error", code = "lua.internal", message = tostring(err) }
+        end
+        return nil, { d }
+    end
+    local diags = {}
+    for _, d in ipairs(unit.diagnostics) do
+        diags[#diags + 1] = {
+            severity = d.severity or "error",
+            code     = d.code or "lua.syntax",
+            message  = d.message or "",
+            range    = mkrange(unit, d.range),
+        }
+    end
+    return unit, diags
+end
+
+-- declarations(result) -> decl[]. ONE decl per declared NAME (D4): a multi-name
+-- `local a, b` yields two decls sharing the declaration NODE's group range; each carries
+-- its own name range + the node's annotations. Handles are generation-local indices.
+function M.declarations(unit)
+    local out, idx = {}, 0
+    lua.walk(unit.ast, function(n)
+        if n.kind == "local_declaration" then
+            local anns, grp = norm_annotations(unit, n), mkrange(unit, n.range)
+            for _, nm in ipairs(n.names or {}) do
+                idx = idx + 1
+                out[#out + 1] = { _kind = "local", _name = nm.name, _range = mkrange(unit, nm.range),
+                                  _group = grp, _is_method = false, _anns = anns, _index = idx }
+            end
+        elseif n.kind == "function_declaration" then
+            local name = flatten_fnname(n.name, n.is_method)
+            if name then
+                idx = idx + 1
+                out[#out + 1] = {
+                    _kind = n.is_local and "local_function" or "function",
+                    _name = name,
+                    _range = mkrange(unit, (n.name and n.name.range) or n.range),
+                    _group = mkrange(unit, n.range),
+                    _is_method = n.is_method == true,
+                    _anns = norm_annotations(unit, n),
+                    _index = idx,
+                }
+            end
+        end
+    end)
+    return out
+end
+
+function M.decl_name(d)        return d._name end
+function M.decl_kind(d)        return d._kind end
+function M.decl_range(d)       return d._range end
+function M.decl_group_range(d) return d._group end
+function M.decl_annotations(d) return d._anns end
+function M.decl_is_method(d)   return d._is_method == true end
+function M.decl_handle(d)      return d._index end      -- generation-local; never serialized as-is
+
+return M

--- a/stdlib/cli/lua/hull/project/model.lua
+++ b/stdlib/cli/lua/hull/project/model.lua
@@ -1,0 +1,133 @@
+--
+-- hull.project.model — the frontend-neutral ProjectDiscovery model + indexes + IDs.
+--
+-- Design: docs/project_discovery_design.md D4/D5/D6. Assembles per-source frontend facts
+-- into a normalized ProjectDiscovery: deterministic textual IDs, per-name declaration
+-- facts sharing a group_id (annotations carry target_group_id), annotated-only PUBLIC
+-- declarations[] with full per-source data retained internally (_by_source), the
+-- valid/complete axes, indexes, and a summary. No Lua AST knowledge (it consumes the
+-- frontend adapter's already-normalized facts).
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local registry = require("hull.project.registry")
+
+local M = { SCHEMA_VERSION = 1 }
+
+local function range_tok(r) return r and (tostring(r.start) .. "-" .. tostring(r.stop)) or "0-0" end
+
+-- Per-NAME id (D5): unique per declaration fact. group_id (D4): the declaration NODE's
+-- identity, shared by every name of a multi-name declaration. Deterministic, textual,
+-- no pointers; a within-generation key (not stable across arbitrary edits).
+local function decl_id(language, path, kind, name, range)
+    return table.concat({ language, path, kind, name or "?", range_tok(range) }, ":")
+end
+local function group_id(language, path, kind, group)
+    return table.concat({ language, path, kind, "g" .. range_tok(group) }, ":")
+end
+
+local function count_status(sources, status)
+    local n = 0
+    for _, s in ipairs(sources) do if s.status == status then n = n + 1 end end
+    return n
+end
+
+local function lang_counts(sources)
+    local by = {}
+    for _, s in ipairs(sources) do by[s.language] = (by[s.language] or 0) + 1 end
+    return by
+end
+
+-- build(root, generation, per_source, op_diags, source_kind) -> ProjectDiscovery.
+--   per_source[i] = { path, language, role, status, declarations[]?, diagnostics[]? }
+--     declaration fact = { language, path, kind, name, range, group_range, is_method?,
+--                          handle?, annotations[] = { name, args?, value?, raw, range } }
+--   op_diags: discovery-level (operational) diagnostics.
+--   source_kind: "standalone" | "dev" provenance marker.
+function M.build(root, generation, per_source, op_diags, source_kind)
+    local disc = {
+        schema_version = M.SCHEMA_VERSION,
+        generation     = generation or 0,
+        source         = source_kind or "standalone",
+        project_root   = root,
+        valid          = true,
+        complete       = true,
+        sources        = {},
+        declarations   = {},          -- PUBLIC: annotated facts only (D4)
+        diagnostics    = {},
+        frontends      = registry.frontends(),
+        _by_source     = {},          -- INTERNAL: ALL decls (annotated + not), per source
+        indexes        = {},
+        summary        = {},
+    }
+
+    for _, d in ipairs(op_diags or {}) do
+        disc.diagnostics[#disc.diagnostics + 1] = d
+        if d.severity == "error" then disc.valid = false end
+    end
+
+    local total, annotated = 0, 0
+    local by_annotation, by_source, by_language, by_id, annotated_ids = {}, {}, {}, {}, {}
+
+    for _, s in ipairs(per_source) do
+        disc.sources[#disc.sources + 1] =
+            { path = s.path, language = s.language, role = s.role or "app", status = s.status }
+        if s.status == "unsupported" then disc.complete = false end   -- unsupported app source (D6/D11)
+        if s.status == "error" then disc.valid = false end            -- unreadable / parse-failed source
+        for _, d in ipairs(s.diagnostics or {}) do
+            disc.diagnostics[#disc.diagnostics + 1] = d
+            if d.severity == "error" then disc.valid = false end       -- malformed source (D7)
+        end
+
+        disc._by_source[s.path] = disc._by_source[s.path] or {}
+        for _, f in ipairs(s.declarations or {}) do
+            total = total + 1
+            local gid = group_id(f.language, f.path, f.kind, f.group_range)
+            local id  = decl_id(f.language, f.path, f.kind, f.name, f.range)
+            local anns = {}
+            for _, a in ipairs(f.annotations or {}) do
+                anns[#anns + 1] = { name = a.name, args = a.args, value = a.value, raw = a.raw,
+                                    range = a.range, target_group_id = gid, frontend = f.language }
+            end
+            local decl = { id = id, group_id = gid, language = f.language, path = f.path,
+                           kind = f.kind, name = f.name, range = f.range,
+                           is_method = f.is_method or nil, annotations = anns,
+                           status = "declared", handle = f.handle }
+            disc._by_source[s.path][#disc._by_source[s.path] + 1] = decl
+
+            if #anns > 0 then
+                annotated = annotated + 1
+                disc.declarations[#disc.declarations + 1] = decl
+                by_id[id] = decl
+                annotated_ids[#annotated_ids + 1] = id
+                by_source[f.path] = by_source[f.path] or {}
+                by_source[f.path][#by_source[f.path] + 1] = id
+                by_language[f.language] = by_language[f.language] or {}
+                by_language[f.language][#by_language[f.language] + 1] = id
+                local seen_names = {}
+                for _, a in ipairs(anns) do
+                    if not seen_names[a.name] then     -- one id per annotation NAME per decl
+                        seen_names[a.name] = true
+                        by_annotation[a.name] = by_annotation[a.name] or {}
+                        by_annotation[a.name][#by_annotation[a.name] + 1] = id
+                    end
+                end
+            end
+        end
+    end
+
+    disc.indexes = { by_annotation = by_annotation, by_source = by_source,
+                     by_language = by_language, by_id = by_id, annotated = annotated_ids }
+    disc.summary = {
+        sources_total       = #disc.sources,
+        sources_analyzed    = count_status(disc.sources, "analyzed"),
+        sources_unsupported = count_status(disc.sources, "unsupported"),
+        declarations_total     = total,
+        declarations_annotated = annotated,
+        by_language = lang_counts(disc.sources),
+    }
+    return disc
+end
+
+return M

--- a/stdlib/cli/lua/hull/project/registry.lua
+++ b/stdlib/cli/lua/hull/project/registry.lua
@@ -1,0 +1,76 @@
+--
+-- hull.project.registry — the ONE canonical extension -> frontend mapping.
+--
+-- Design: docs/project_discovery_design.md D3/D11. Adding a frontend is one row here;
+-- hull dev / hull agent / build consumers ask the registry and never change. Lua is the
+-- only ANALYZABLE frontend today. JavaScript is a KNOWN language, reserved
+-- architecturally, analyzable = false (no parser, no regex scanner, no parity pretence):
+-- a `.js` application source is honestly reported unsupported, never parsed as Lua.
+--
+-- Pure Lua; the Lua frontend module is loaded lazily (require) only when a `.lua` source
+-- is actually analyzed.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local M = {}
+
+-- Extension (no dot) -> registry row. `frontend_module` present + analyzable => a real
+-- frontend to require; analyzable=false => a reserved, known-but-unanalyzable language.
+local FRONTENDS = {
+    lua = { language = "lua",        frontend_module = "hull.project.frontend_lua",
+            analyzable = true,  extra_capabilities = nil },
+    js  = { language = "javascript", analyzable = false, extra_capabilities = {} },
+    mjs = { language = "javascript", analyzable = false, extra_capabilities = {} },
+    cjs = { language = "javascript", analyzable = false, extra_capabilities = {} },
+}
+
+-- Every known-language extension (sorted). These are the extensions the project scan
+-- collects as candidate APPLICATION source; analyzable ones get a frontend, the rest are
+-- reported unsupported (D11). An extension NOT here is not project source at all.
+function M.known_exts()
+    local out = {}
+    for ext in pairs(FRONTENDS) do out[#out + 1] = ext end
+    table.sort(out)
+    return out
+end
+
+-- The registry row for an extension (no dot), or nil if the extension is not known.
+function M.for_ext(ext) return FRONTENDS[ext] end
+
+-- Load (require) the frontend module for an analyzable row. Returns the frontend table,
+-- or nil for a non-analyzable / unknown row.
+function M.load(row)
+    if not (row and row.analyzable and row.frontend_module) then return nil end
+    return require(row.frontend_module)
+end
+
+-- Frontend summary for the ProjectDiscovery model: one entry per distinct LANGUAGE with
+-- its extensions grouped, its capabilities (from the loaded frontend, or the row's
+-- reserved set), and analyzable flag. Deterministic order.
+function M.frontends()
+    local by_lang = {}
+    for _, ext in ipairs(M.known_exts()) do
+        local row = FRONTENDS[ext]
+        local e = by_lang[row.language]
+        if not e then
+            local caps = {}
+            local fe = M.load(row)
+            if fe and fe.capabilities then
+                for _, c in ipairs(fe.capabilities) do caps[#caps + 1] = c end
+            elseif row.extra_capabilities then
+                for _, c in ipairs(row.extra_capabilities) do caps[#caps + 1] = c end
+            end
+            e = { language = row.language, extensions = {}, capabilities = caps,
+                  analyzable = row.analyzable == true }
+            by_lang[row.language] = e
+        end
+        e.extensions[#e.extensions + 1] = ext
+    end
+    local out = {}
+    for _, e in pairs(by_lang) do table.sort(e.extensions); out[#out + 1] = e end
+    table.sort(out, function(a, b) return a.language < b.language end)
+    return out
+end
+
+return M

--- a/stdlib/cli/lua/hull/project/tests/test_project.lua
+++ b/stdlib/cli/lua/hull/project/tests/test_project.lua
@@ -1,0 +1,250 @@
+--
+-- test_project.lua — Slice 1 tests for the project source-discovery layer.
+--
+-- Covers the Lua frontend adapter (declarations/annotations/ranges without executing
+-- app source), the frontend-neutral model (IDs, indexes, valid/complete, annotated-only
+-- public retention), the registry (honest capabilities), and the analyze orchestrator
+-- (discovery dispatch, static/ pruning, unsupported JS -> complete=false, malformed ->
+-- valid=false, determinism). Pure Lua; run by tests/hull/source/test_lua_source.c. The
+-- orchestrator's tool.find_files/read_file are stubbed over an in-memory fixture tree.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local frontend = require("hull.project.frontend_lua")
+local registry = require("hull.project.registry")
+local model    = require("hull.project.model")
+
+local pass, fail, failures = 0, 0, {}
+local function ok(cond, name)
+    if cond then pass = pass + 1
+    else fail = fail + 1; failures[#failures + 1] = name; print("FAIL: " .. name) end
+end
+local function eq(a, b, name)
+    ok(a == b, name .. " (expected " .. tostring(b) .. ", got " .. tostring(a) .. ")")
+end
+
+-- Find the first frontend decl for a given name (adapter-level).
+local function decl_named(fe, unit, name)
+    for _, d in ipairs(fe.declarations(unit)) do
+        if fe.decl_name(d) == name then return d end
+    end
+    return nil
+end
+
+-- ── frontend adapter: declarations without executing app source ──────
+do
+    local unit = frontend.parse("local x = 1\nreturn x", "t.lua")
+    ok(unit ~= nil, "adapter parses clean Lua")
+    local dx = decl_named(frontend, unit, "x")
+    ok(dx ~= nil, "local decl 'x' discovered")
+    eq(frontend.decl_kind(dx), "local", "'x' kind is local")
+    ok(frontend.decl_range(dx) and frontend.decl_range(dx).start ~= nil, "decl carries a range")
+    ok(frontend.decl_range(dx).line ~= nil, "decl range carries line/col")
+end
+
+-- ── dotted / method / local-function normalization ──────────────────
+do
+    local unit = frontend.parse(
+        "local function f() end\nfunction a.b.c() end\nfunction a:m() end\n", "t.lua")
+    local f = decl_named(frontend, unit, "f")
+    eq(frontend.decl_kind(f), "local_function", "local function kind")
+    local abc = decl_named(frontend, unit, "a.b.c")
+    ok(abc ~= nil, "dotted function name normalized to 'a.b.c'")
+    eq(frontend.decl_kind(abc), "function", "dotted function kind is function")
+    ok(not frontend.decl_is_method(abc), "dotted function is not a method")
+    local am = decl_named(frontend, unit, "a:m")
+    ok(am ~= nil, "method function name normalized to 'a:m'")
+    ok(frontend.decl_is_method(am), "method function flagged is_method")
+end
+
+-- ── multi-name local: two facts, one shared group range ─────────────
+do
+    local unit = frontend.parse("local a, b = 1, 2\nreturn a + b", "t.lua")
+    local da, db = decl_named(frontend, unit, "a"), decl_named(frontend, unit, "b")
+    ok(da ~= nil and db ~= nil, "both names of 'local a, b' discovered as facts")
+    ok(frontend.decl_range(da).start ~= frontend.decl_range(db).start, "each name has its OWN range")
+    local ga, gb = frontend.decl_group_range(da), frontend.decl_group_range(db)
+    ok(ga.start == gb.start and ga.stop == gb.stop, "both names share ONE declaration group range")
+end
+
+-- ── annotations attached (known + unknown survive) ──────────────────
+do
+    local unit = frontend.parse(
+        "---@type Widget\nlocal w = {}\n---@wild(1) freeform text\nlocal y = 2\nreturn w, y", "t.lua")
+    local dw = decl_named(frontend, unit, "w")
+    local aw = frontend.decl_annotations(dw)
+    ok(#aw == 1 and aw[1].name == "type", "known @type annotation attached to 'w'")
+    eq(aw[1].value, "Widget", "annotation value captured")
+    local dy = decl_named(frontend, unit, "y")
+    local ay = frontend.decl_annotations(dy)
+    ok(#ay == 1 and ay[1].name == "wild", "UNKNOWN @wild annotation survives (not an error)")
+    eq(ay[1].args, "1", "unknown annotation args captured (inner content)")
+end
+
+-- ── malformed Lua: parse still returns, diagnostics are errors ──────
+do
+    local unit, diags = frontend.parse("local = = )", "bad.lua")
+    -- Either a returned unit with error diagnostics, or (nil, {internal}); both are errors.
+    local has_error = false
+    for _, d in ipairs(diags or {}) do if d.severity == "error" then has_error = true end end
+    ok(has_error, "malformed Lua yields error diagnostics (never a clean parse)")
+    if unit ~= nil then
+        ok(#diags > 0, "malformed unit carries diagnostics")
+    end
+end
+
+-- ── model: IDs, group sharing, annotated-only public, valid/complete ─
+do
+    -- Two facts of one multi-name group: one annotated, one not.
+    local grp = { start = 1, stop = 12 }
+    local per_source = { {
+        path = "app.lua", language = "lua", role = "app", status = "analyzed",
+        declarations = {
+            { language = "lua", path = "app.lua", kind = "local", name = "a",
+              range = { start = 7, stop = 8 }, group_range = grp, annotations = {
+                { name = "type", value = "Foo" } } },
+            { language = "lua", path = "app.lua", kind = "local", name = "b",
+              range = { start = 10, stop = 11 }, group_range = grp, annotations = {} },
+        },
+        diagnostics = {},
+    } }
+    local disc = model.build("app", 0, per_source, {}, "standalone")
+    eq(disc.schema_version, 1, "model schema_version is 1")
+    eq(disc.summary.declarations_total, 2, "totals retain ALL declarations")
+    eq(disc.summary.declarations_annotated, 1, "annotated count is 1")
+    eq(#disc.declarations, 1, "PUBLIC declarations[] is annotated-only")
+    eq(disc.declarations[1].name, "a", "the annotated fact 'a' is public")
+    ok(disc._by_source["app.lua"] and #disc._by_source["app.lua"] == 2,
+        "internal _by_source retains BOTH facts (annotated + not)")
+    local da = disc.declarations[1]
+    ok(da.id:find("app.lua") and da.id:find(":a:"), "id is deterministic + textual")
+    -- group_id shared by both names (same group_range) even though only one is public
+    local ga = da.group_id
+    local gb = disc._by_source["app.lua"][2].group_id
+    eq(ga, gb, "both names share one group_id")
+    eq(da.annotations[1].target_group_id, ga, "annotation carries target_group_id = group_id")
+    eq(da.annotations[1].frontend, "lua", "annotation carries frontend provenance")
+    ok(disc.indexes.by_annotation["type"] and disc.indexes.by_annotation["type"][1] == da.id,
+        "by_annotation index points at the annotated decl")
+    eq(disc.indexes.by_id[da.id].name, "a", "by_id index resolves the decl")
+    ok(disc.valid and disc.complete, "clean facts -> valid + complete")
+end
+
+-- ── model: unsupported source -> complete=false; error diag -> valid=false
+do
+    local d1 = model.build("app", 0, { { path = "x.js", language = "javascript",
+        role = "app", status = "unsupported", diagnostics = {} } }, {}, "standalone")
+    ok(not d1.complete, "an unsupported application source -> complete=false")
+    ok(d1.valid, "unsupported does NOT by itself make it invalid")
+    local d2 = model.build("app", 0, { { path = "bad.lua", language = "lua", role = "app",
+        status = "error", diagnostics = { { severity = "error", code = "lua.syntax", message = "x" } } } },
+        {}, "standalone")
+    ok(not d2.valid, "an error diagnostic -> valid=false")
+end
+
+-- ── registry: honest capabilities + reserved JS ─────────────────────
+do
+    local exts = registry.known_exts()
+    eq(table.concat(exts, ","), "cjs,js,lua,mjs", "known_exts sorted + reserves JS variants")
+    ok(registry.for_ext("lua").analyzable, "lua is analyzable")
+    ok(not registry.for_ext("js").analyzable, "js is known but NOT analyzable")
+    ok(registry.for_ext("py") == nil, "unknown extension is not registered")
+    local fr = registry.frontends()
+    local lua_e, js_e
+    for _, e in ipairs(fr) do
+        if e.language == "lua" then lua_e = e elseif e.language == "javascript" then js_e = e end
+    end
+    ok(lua_e and lua_e.analyzable and #lua_e.capabilities == 4, "lua frontend reports its 4 shipped capabilities")
+    ok(js_e and not js_e.analyzable and #js_e.capabilities == 0, "javascript reserved: analyzable=false, no capabilities")
+end
+
+-- ── orchestrator end-to-end (stubbed tool over an in-memory tree) ────
+-- A minimal fake filesystem so analyze() runs its full discovery + dispatch path.
+local function make_tool(fs)
+    return {
+        find_files = function(root, pat, opts)
+            local ext = pat:match("%*%.(.+)$")
+            local excl = {}
+            for _, e in ipairs((opts and opts.exclude_dirs) or {}) do excl[e] = true end
+            local out = {}
+            for path in pairs(fs) do
+                local under = (root == "." or root == "") or (path:sub(1, #root + 1) == root .. "/")
+                if under and path:sub(- (#ext + 1)) == "." .. ext then
+                    local skip = false
+                    for seg in path:gmatch("[^/]+") do if excl[seg] then skip = true; break end end
+                    if not skip then out[#out + 1] = path end
+                end
+            end
+            table.sort(out)
+            return out
+        end,
+        read_file = function(path) return fs[path] end,
+    }
+end
+
+do
+    -- require analyze AFTER stubbing is fine: it reads the `tool` global at call time.
+    local analyze = require("hull.project.analyze")
+    local FS = {
+        ["app/app.lua"]            = "---@route\nlocal handler = function() end\nreturn handler\n",
+        ["app/routes/users.lua"]   = "---@resource\nlocal function list() end\nreturn list\n",
+        ["app/static/vendor.js"]   = "window.x = 1;",     -- browser asset: must be PRUNED
+        ["app/client.js"]          = "export const q = 1;", -- app JS: unsupported
+        ["app/broken.lua"]         = "local = = )",         -- malformed: valid=false
+    }
+    _G.tool = make_tool(FS)
+    local disc = analyze.analyze("app")
+    _G.tool = nil
+
+    -- static/vendor.js must NOT appear as a source (pruned); the app JS must.
+    local paths = {}
+    for _, s in ipairs(disc.sources) do paths[s.path] = s.status end
+    ok(paths["static/vendor.js"] == nil, "static/*.js browser asset is pruned (not application source)")
+    eq(paths["client.js"], "unsupported", "application .js is honestly unsupported (not parsed as Lua)")
+    eq(paths["app.lua"], "analyzed", "app.lua analyzed")
+    eq(paths["routes/users.lua"], "analyzed", "nested routes/users.lua analyzed")
+    eq(paths["broken.lua"], "error", "malformed broken.lua is an error source")
+
+    ok(not disc.complete, "an application .js makes the generation complete=false")
+    ok(not disc.valid, "a malformed Lua source makes the generation valid=false")
+
+    -- annotations discovered without executing app source
+    ok(disc.indexes.by_annotation["route"], "@route discovered in app.lua")
+    ok(disc.indexes.by_annotation["resource"], "@resource discovered in routes/users.lua")
+    -- client.js contributed NO declarations (never parsed as Lua)
+    ok(disc._by_source["client.js"] == nil or #disc._by_source["client.js"] == 0,
+        "unsupported JS contributes zero declarations")
+    eq(disc.source, "standalone", "standalone provenance marker")
+    eq(disc.generation, 0, "standalone generation is 0")
+end
+
+-- ── a genuinely clean all-Lua project -> valid + complete ───────────
+do
+    local analyze = require("hull.project.analyze")
+    _G.tool = make_tool({
+        ["ok/app.lua"] = "---@main\nlocal function main() end\nreturn main\n",
+        ["ok/lib/util.lua"] = "---@util\nlocal function u() end\nreturn u\n",
+    })
+    local disc = analyze.analyze("ok")
+    _G.tool = nil
+    ok(disc.valid and disc.complete, "clean all-Lua project -> valid + complete")
+    eq(disc.summary.sources_analyzed, 2, "both Lua sources analyzed")
+    eq(disc.summary.sources_unsupported, 0, "no unsupported sources")
+end
+
+-- ── determinism: two runs, identical declaration id ordering ────────
+do
+    local analyze = require("hull.project.analyze")
+    local FS = { ["p/a.lua"] = "---@x\nlocal a=1\n---@y\nlocal b=2\nreturn a,b\n",
+                 ["p/b.lua"] = "---@z\nlocal c=3\nreturn c\n" }
+    _G.tool = make_tool(FS); local d1 = analyze.analyze("p"); _G.tool = nil
+    _G.tool = make_tool(FS); local d2 = analyze.analyze("p"); _G.tool = nil
+    local ids1, ids2 = {}, {}
+    for _, x in ipairs(d1.declarations) do ids1[#ids1 + 1] = x.id end
+    for _, x in ipairs(d2.declarations) do ids2[#ids2 + 1] = x.id end
+    eq(table.concat(ids1, "|"), table.concat(ids2, "|"), "analyze() is deterministic across runs")
+end
+
+print(string.format("test_project: %d passed, %d failed", pass, fail))
+return { pass = pass, fail = fail, failures = failures }

--- a/stdlib/cli/lua/hull/project/tests/test_project.lua
+++ b/stdlib/cli/lua/hull/project/tests/test_project.lua
@@ -161,7 +161,15 @@ end
 
 -- ── orchestrator end-to-end (stubbed tool over an in-memory tree) ────
 -- A minimal fake filesystem so analyze() runs its full discovery + dispatch path.
+-- Fixture paths are treated as already-canonical (realpath is identity for anything that
+-- "exists"; path_kind reports dir for a prefix-of-some-file, file for an exact file).
 local function make_tool(fs)
+    local function is_file(p) return fs[p] ~= nil end
+    local function is_dir(p)
+        if p == "." or p == "" then return true end
+        for path in pairs(fs) do if path:sub(1, #p + 1) == p .. "/" then return true end end
+        return false
+    end
     return {
         find_files = function(root, pat, opts)
             local ext = pat:match("%*%.(.+)$")
@@ -180,6 +188,14 @@ local function make_tool(fs)
             return out
         end,
         read_file = function(path) return fs[path] end,
+        realpath  = function(p)
+            if is_file(p) or is_dir(p) then return p end
+            return nil, "missing"
+        end,
+        path_kind = function(p)
+            if is_file(p) then return "file" elseif is_dir(p) then return "dir" end
+            return nil
+        end,
     }
 end
 
@@ -244,6 +260,73 @@ do
     for _, x in ipairs(d1.declarations) do ids1[#ids1 + 1] = x.id end
     for _, x in ipairs(d2.declarations) do ids2[#ids2 + 1] = x.id end
     eq(table.concat(ids1, "|"), table.concat(ids2, "|"), "analyze() is deterministic across runs")
+end
+
+-- ── root validation: a missing / non-directory root is NOT a clean empty project ──
+do
+    local analyze = require("hull.project.analyze")
+    _G.tool = make_tool({ ["real/app.lua"] = "return 1\n" })
+    local missing = analyze.analyze("nope")        -- root does not exist
+    local afile   = analyze.analyze("real/app.lua") -- root is a FILE, not a dir
+    _G.tool = nil
+    ok(not missing.valid and not missing.complete, "missing root -> invalid + incomplete")
+    ok(#missing.sources == 0, "missing root -> no sources (never a valid empty scan)")
+    local found = false
+    for _, d in ipairs(missing.diagnostics) do if d.code == "project.discovery_failed" then found = true end end
+    ok(found, "missing root emits project.discovery_failed")
+    ok(not afile.valid, "a file (non-directory) root is invalid too")
+end
+
+-- ── protected boundary: an internal frontend failure -> project.internal, not a raise ──
+do
+    local analyze = require("hull.project.analyze")
+    local orig = frontend.declarations
+    frontend.declarations = function() error("injected frontend defect") end   -- luacheck: ignore
+    _G.tool = make_tool({ ["x/app.lua"] = "local a = 1\nreturn a\n" })
+    local ok_call, disc = pcall(analyze.analyze, "x")     -- must NOT raise
+    _G.tool = nil
+    frontend.declarations = orig
+    ok(ok_call, "analyze never raises on an internal frontend defect")
+    ok(disc and not disc.valid, "internal defect -> invalid discovery")
+    local found = false
+    for _, d in ipairs(disc.diagnostics or {}) do if d.code == "project.internal" then found = true end end
+    ok(found, "internal defect surfaces a structured project.internal diagnostic")
+end
+
+-- ── handles: generation-unique across sources + resolvable to {frontend, unit, decl} ──
+do
+    local analyze = require("hull.project.analyze")
+    _G.tool = make_tool({
+        ["h/a.lua"] = "local a = 1\nlocal b = 2\nreturn a, b\n",   -- 2 decls
+        ["h/b.lua"] = "local c = 3\nreturn c\n",                    -- 1 decl
+    })
+    local disc = analyze.analyze("h")
+    _G.tool = nil
+    -- collect every handle across both sources from the internal per-source data
+    local seen, count = {}, 0
+    for _, decls in pairs(disc._by_source) do
+        for _, d in ipairs(decls) do
+            count = count + 1
+            ok(d.handle ~= nil and not seen[d.handle], "handle is generation-unique: " .. tostring(d.handle))
+            seen[d.handle] = true
+        end
+    end
+    eq(count, 3, "three declarations across two sources")
+    -- resolve one handle back through the controlled lookup
+    local any_handle = next(seen)
+    local resolved = analyze.resolve_handle(disc, any_handle)
+    ok(resolved and resolved.frontend and resolved.unit and resolved.declaration,
+        "resolve_handle returns {frontend, unit, declaration}")
+    ok(analyze.resolve_handle(disc, 99999) == nil, "an unknown handle resolves to nil")
+end
+
+-- ── scope capability is callable THROUGH the frontend boundary ──────
+do
+    local unit = frontend.parse("local x = 1\nreturn x\n", "t.lua")
+    ok(type(frontend.scope) == "function", "frontend exposes a scope operation (advertised capability is callable)")
+    local sc, serr = frontend.scope(unit)
+    ok(sc ~= nil and serr == nil, "frontend.scope(unit) resolves a scope model")
+    ok(sc.bindings ~= nil, "scope model carries bindings")
 end
 
 print(string.format("test_project: %d passed, %d failed", pass, fail))

--- a/stdlib/cli/lua/hull/project/tests/test_project.lua
+++ b/stdlib/cli/lua/hull/project/tests/test_project.lua
@@ -329,5 +329,39 @@ do
     ok(sc.bindings ~= nil, "scope model carries bindings")
 end
 
+-- ── recovery path: a model.build defect must NOT re-raise outside the pcall ──
+do
+    local analyze = require("hull.project.analyze")
+    local orig = model.build
+    model.build = function() error("injected model.build defect") end   -- luacheck: ignore
+    _G.tool = make_tool({ ["m/app.lua"] = "local a = 1\nreturn a\n" })
+    -- also pass numeric opts: the recovery path must not deref a non-table either
+    local ok_call, disc = pcall(analyze.analyze, "m", 5)
+    _G.tool = nil
+    model.build = orig
+    ok(ok_call, "analyze never raises even when model.build ITSELF fails")
+    ok(disc and not disc.valid and not disc.complete, "model.build defect -> invalid + incomplete")
+    local found = false
+    for _, d in ipairs(disc.diagnostics or {}) do if d.code == "project.internal" then found = true end end
+    ok(found, "model.build defect surfaces project.internal (recovery uses the literal constructor)")
+    ok(disc.schema_version == 1 and disc.indexes and disc.summary and disc._handles ~= nil,
+        "the emergency model is structurally complete + consumable")
+end
+
+-- ── malformed opts: never raises, wrong-typed fields normalized to defaults ──
+do
+    local analyze = require("hull.project.analyze")
+    _G.tool = make_tool({ ["o/app.lua"] = "local a = 1\nreturn a\n" })
+    local ok1 = pcall(analyze.analyze, "o", 5)               -- numeric opts
+    local ok2 = pcall(analyze.analyze, "o", "nope")          -- string opts
+    local ok3, d3 = pcall(analyze.analyze, "o", { generation = "x", source_kind = 7 })
+    _G.tool = nil
+    ok(ok1, "analyze never raises on numeric opts")
+    ok(ok2, "analyze never raises on string opts")
+    ok(ok3, "analyze never raises on wrong-typed opts fields")
+    ok(d3 and d3.generation == 0 and d3.source == "standalone",
+        "wrong-typed opts.generation / opts.source_kind normalized to defaults")
+end
+
 print(string.format("test_project: %d passed, %d failed", pass, fail))
 return { pass = pass, fail = fail, failures = failures }

--- a/stdlib/cli/lua/hull/source/analyze.lua
+++ b/stdlib/cli/lua/hull/source/analyze.lua
@@ -14,6 +14,7 @@
 local lua = require("hull.source.lua")
 local lint = require("hull.source.lint")
 local scope = require("hull.source.scope")
+local discover_mod = require("hull.source.discover")   -- the shared hardened walker (D2)
 local json = require("hull.json")
 
 -- Generous limits so lua.limit.* only trips on genuinely pathological input; a trip is
@@ -21,48 +22,11 @@ local json = require("hull.json")
 local LIMITS = { max_bytes = 64 * 1024 * 1024, max_tokens = 5000000,
                  max_comments = 5000000, max_depth = 2000 }
 
--- generated / dependency dirs (build covers site/build). EXCLUDE_LIST prunes them
--- DURING traversal (tool.find_files exclude_dirs); EXCLUDE_SEGMENT is a cheap belt on
--- the returned paths.
-local EXCLUDE_LIST = { ".git", ".hull", "build", "vendor", "node_modules" }
-local EXCLUDE_SEGMENT = {}
-for _, s in ipairs(EXCLUDE_LIST) do EXCLUDE_SEGMENT[s] = true end
-
--- ── small path helpers (pure Lua; no path-normalize binding in the tool VM) ──
-local function normalize(p)
-    local absolute = p:sub(1, 1) == "/"
-    local segs = {}
-    for seg in p:gmatch("[^/]+") do
-        if seg == ".." then
-            if #segs > 0 and segs[#segs] ~= ".." then table.remove(segs)
-            elseif not absolute then segs[#segs + 1] = ".." end   -- absolute: .. at root stays root
-        elseif seg ~= "." then                               -- "." is dropped
-            segs[#segs + 1] = seg
-        end
-    end
-    return (absolute and "/" or "") .. table.concat(segs, "/")
-end
-
-local function join(root, rel)
-    if rel:sub(1, 1) == "/" then return rel end              -- absolute stays absolute
-    if root == "" or root == "." then return rel end
-    return root .. "/" .. rel
-end
-
--- Containment on CANONICAL absolute paths (from tool.realpath, symlinks resolved).
--- Handles the `/` root correctly (prefix is "/", not "//").
-local function inside_root(canon_root, canon_target)
-    if canon_root == canon_target then return true end
-    local prefix = (canon_root == "/") and "/" or (canon_root .. "/")
-    return canon_target:sub(1, #prefix) == prefix
-end
-
-local function excluded(path)
-    for seg in path:gmatch("[^/]+") do
-        if EXCLUDE_SEGMENT[seg] then return true end
-    end
-    return false
-end
+-- Path helpers + the exclusion set now live in the shared hardened walker
+-- (hull.source.discover, D2); alias the ones the files-mode path still uses.
+local normalize   = discover_mod.normalize
+local join        = discover_mod.join
+local inside_root = discover_mod.inside_root
 
 local function ends_lua(path) return path:sub(-4) == ".lua" end
 
@@ -143,22 +107,13 @@ local function resolve_inputs(o)
     return { root = ".", mode = "files", targets = pos }     -- all positionals are files under .
 end
 
--- ── discovery (walk mode): sorted, regular .lua, no symlink, exclusions ──
+-- ── discovery (walk mode): the shared hardened walker, .lua only for `hull analyze` ──
+-- A discovery error (OOM / access) is an OPERATIONAL failure (op_fail exit 2), not an
+-- empty scan -- the shared module returns (nil, err) and this CLI decides fail-closed.
 local function discover(root)
-    -- exclude_dirs prunes DURING traversal (a large build/ tree is never walked);
-    -- find_files already returns sorted/regular/no-symlink. excluded() is a belt.
-    -- A discovery error (OOM / access) is an OPERATIONAL failure, not an empty scan.
-    local files, err = tool.find_files(root, "*.lua", { exclude_dirs = EXCLUDE_LIST })
+    local files, err = discover_mod.discover(root)           -- default ext {"lua"}, DEFAULT_EXCLUDE
     if err then op_fail("discovery failed: " .. tostring(err)) end
-    local out, seen = {}, {}
-    for _, p in ipairs(files) do
-        local n = normalize(p)
-        if not excluded(n) and not seen[n] then
-            seen[n] = true; out[#out + 1] = n
-        end
-    end
-    table.sort(out)
-    return out
+    return files
 end
 
 -- ── analyze one readable Lua file: returns (state, diagnostics[]) ──

--- a/stdlib/cli/lua/hull/source/discover.lua
+++ b/stdlib/cli/lua/hull/source/discover.lua
@@ -1,0 +1,105 @@
+--
+-- hull.source.discover — the canonical, hardened, bounded source-file walker.
+--
+-- Extracted from hull.source.analyze so `hull analyze` and the project analyzer
+-- (hull.project.*) share ONE discovery path (design: docs/project_discovery_design.md
+-- D2). No second recursive walker exists in Hull. The behavior is exactly what
+-- `hull analyze` shipped: exclude dirs pruned DURING traversal, canonical containment
+-- via tool.realpath, deterministic sorted/regular/no-symlink results, fail-closed on a
+-- discovery error (returned as (nil, err) -- the CALLER decides policy: `hull analyze`
+-- op_fails, the project analyzer records a diagnostic).
+--
+-- Pure Lua over the tool VM's tool.* bindings (find_files/realpath/path_kind). Never
+-- raises, never prints.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local M = {}
+
+-- Generated / dependency dirs pruned by default (build covers site/build). The project
+-- analyzer adds "static" via opts.extra_exclude so browser assets never count as
+-- application source (design D6).
+M.DEFAULT_EXCLUDE = { ".git", ".hull", "build", "vendor", "node_modules" }
+
+-- ── small path helpers (pure Lua; no path-normalize binding in the tool VM) ──
+-- Collapse ./ and ../ segments. Absolute paths keep a leading "/"; a ".." at an
+-- absolute root stays at root.
+function M.normalize(p)
+    local absolute = p:sub(1, 1) == "/"
+    local segs = {}
+    for seg in p:gmatch("[^/]+") do
+        if seg == ".." then
+            if #segs > 0 and segs[#segs] ~= ".." then table.remove(segs)
+            elseif not absolute then segs[#segs + 1] = ".." end   -- absolute: .. at root stays root
+        elseif seg ~= "." then                               -- "." is dropped
+            segs[#segs + 1] = seg
+        end
+    end
+    return (absolute and "/" or "") .. table.concat(segs, "/")
+end
+
+function M.join(root, rel)
+    if rel:sub(1, 1) == "/" then return rel end              -- absolute stays absolute
+    if root == "" or root == "." then return rel end
+    return root .. "/" .. rel
+end
+
+-- Containment on CANONICAL absolute paths (from tool.realpath, symlinks resolved).
+-- Handles the `/` root correctly (prefix is "/", not "//").
+function M.inside_root(canon_root, canon_target)
+    if canon_root == canon_target then return true end
+    local prefix = (canon_root == "/") and "/" or (canon_root .. "/")
+    return canon_target:sub(1, #prefix) == prefix
+end
+
+-- Build the { seg -> true } exclusion set for a run.
+local function exclude_set(extra)
+    local set = {}
+    for _, s in ipairs(M.DEFAULT_EXCLUDE) do set[s] = true end
+    for _, s in ipairs(extra or {}) do set[s] = true end
+    return set
+end
+
+-- A path is excluded if ANY of its segments is an excluded dir name (belt over the
+-- returned paths, complementing exclude_dirs pruning during traversal).
+local function excluded(path, set)
+    for seg in path:gmatch("[^/]+") do
+        if set[seg] then return true end
+    end
+    return false
+end
+
+-- ── discovery (walk mode): sorted, regular, no symlink, exclusions ──
+-- discover(root, opts?) -> (files[], err)
+--   opts.ext           : array of extensions WITHOUT the dot (default {"lua"}). One
+--                        find_files glob per extension; results merged + deduped.
+--   opts.extra_exclude : extra dir names pruned on top of DEFAULT_EXCLUDE (e.g.
+--                        {"static"} for the project analyzer's application-source scan).
+-- exclude_dirs prunes DURING traversal (a large build/ tree is never walked); find_files
+-- already returns sorted/regular/no-symlink; excluded() is the belt. A discovery error
+-- (OOM / access) is returned as (nil, err) -- an OPERATIONAL failure, never an empty scan.
+function M.discover(root, opts)
+    opts = opts or {}
+    local exts = opts.ext or { "lua" }
+    local exclude_list = {}
+    for _, s in ipairs(M.DEFAULT_EXCLUDE) do exclude_list[#exclude_list + 1] = s end
+    for _, s in ipairs(opts.extra_exclude or {}) do exclude_list[#exclude_list + 1] = s end
+    local set = exclude_set(opts.extra_exclude)
+
+    local out, seen = {}, {}
+    for _, ext in ipairs(exts) do
+        local files, err = tool.find_files(root, "*." .. ext, { exclude_dirs = exclude_list })
+        if err then return nil, err end                      -- fail closed; caller decides
+        for _, p in ipairs(files) do
+            local n = M.normalize(p)
+            if not excluded(n, set) and not seen[n] then
+                seen[n] = true; out[#out + 1] = n
+            end
+        end
+    end
+    table.sort(out)
+    return out
+end
+
+return M

--- a/tests/hull/source/test_lua_source.c
+++ b/tests/hull/source/test_lua_source.c
@@ -301,4 +301,14 @@ UTEST(lua_source, analyze_core)
     EXPECT_GT(pass, 0LL);
 }
 
+/* Project source-discovery layer: Lua frontend adapter + model + registry + orchestrator. */
+UTEST(lua_source, project_discovery)
+{
+    long long pass = 0, fail = -1;
+    int rc = run_lua_test("stdlib/cli/lua/hull/project/tests/test_project.lua", &pass, &fail);
+    ASSERT_EQ(rc, 0);
+    EXPECT_EQ(fail, 0LL);
+    EXPECT_GT(pass, 0LL);
+}
+
 UTEST_MAIN()


### PR DESCRIPTION
Design record + **Slice 1** of the host-owned, frontend-neutral **project source-discovery** system (design: `docs/project_discovery_design.md`, ratified with amendments). Source text is the input; a normalized **`ProjectDiscovery`** is the authoritative result. Lua is the first production frontend (adapting the shipped `hull.source.*` layer); JavaScript is a genuine **reserved** registry slot (`analyzable=false`), never parsed, never regex-scanned.

Scope note: this is the discovery **core**. No Query/Compute IR, no WASM lowering, no annotation transformers, no `build.js`, no JS parser, no universal AST, no source execution — per the story's non-goals.

## What's here
- **`hull.source.discover`** — the hardened bounded walker **extracted** from `hull analyze` so there is **one** discovery path (no second recursive scanner). Same behavior `hull analyze` shipped (exclude-dirs pruned during traversal, canonical containment, deterministic sorted/regular/no-symlink, fail-closed). Parameterized by `ext[]` + `extra_exclude[]`. `hull analyze` refactored onto it; **its 25-case e2e is the no-regression proof**.
- **`hull.project.frontend_lua`** — the Lua **frontend adapter**, the *only* project module that knows Lua AST layouts. Thin table-of-functions contract. **One fact per declared name**; a multi-name `local a, b` → two facts sharing the declaration node's group range. Dotted/method names → `a.b.c` / `a:m`. Advertises only the 4 capabilities Lua ships.
- **`hull.project.registry`** — the one canonical extension→frontend map (Lua analyzable; `js/mjs/cjs` reserved, `analyzable=false`).
- **`hull.project.model`** — deterministic textual IDs; per-name facts share a `group_id`; each annotation carries `target_group_id` + `frontend`; **annotated-only public `declarations[]`** with full per-source data retained internally; indexes; the independent **`valid`** and **`complete`** axes.
- **`hull.project.analyze`** — the single canonical host analyzer: discovers application source, dispatches per frontend, assembles the model. Application `.js` → honestly `unsupported` → `complete=false`; `static/*.js` pruned; malformed Lua → `valid=false`; unknown annotations survive.

## Ratified decisions honored
`hull agent inspect` name (Slice 2); per-name facts + `group_id`/`target_group_id`; annotated-only public + retained totals/internal data; `valid`+`complete` (unsupported app source → incomplete, `static/` assets excluded); Lua tool-module as the **canonical** analyzer; walker extracted into `hull.source.discover`.

## Tests
New `test_project.lua` (58 assertions, UTEST leg `project_discovery`): declarations/annotations/ranges **without executing app source**; dotted/method/multi-name; model IDs + group sharing + annotated-only + `valid`/`complete`; registry capabilities; orchestrator end-to-end over a stubbed `tool` fs (static pruning, unsupported JS, malformed→invalid, determinism). **76/76 unit; e2e_analyze 25/25; luacheck clean.**

Slices 2–4 (standalone `hull agent inspect`; `hull dev` generations + atomic sidecar; documented build seam) follow as stacked work.
