### PR TITLE
feat(project): Slice 2 — standalone `hull agent inspect` (versioned JSON)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,6 +347,10 @@ jobs:
         timeout-minutes: 2
         run: make e2e-update
 
+      - name: Project source-discovery E2E tests (hull agent inspect)
+        timeout-minutes: 2
+        run: make e2e-project-discovery
+
       - name: hull test (examples)
         timeout-minutes: 2
         run: make hull-test-examples

--- a/docs/project_discovery_design.md
+++ b/docs/project_discovery_design.md
@@ -451,13 +451,20 @@ attribution, no em-dashes.
   - Gate: `make test`, the source UTEST suite, `luacheck`, and **`e2e_analyze.sh`
     green** (proves the walker extraction is behavior-preserving).
 
-- **Slice 2 — standalone agent inspection (D8/D9/D11).**
-  - `hull agent <inspect>` standalone path; `schema_version`'d JSON; JS honest
-    handling.
-  - Gate: `tests/e2e_project_discovery.sh` — deterministic output on fixtures;
-    annotated Lua discovered without execution; unknown annotations survive;
-    malformed → invalid; `.js` present but not falsely analyzed; exclusions +
-    containment reuse the hardened behavior.
+- **Slice 2 — standalone agent inspection (D8/D9/D11). DONE.**
+  - `hull agent inspect [app_dir]` (C dispatch in `agent.c` → `hull_tool(
+    "hull.project.inspect")` → `hull.project.analyze`). `hull.project.inspect`
+    emits an EXPLICIT, `schema_version`'d JSON projection to stdout that DROPS
+    every generation-internal value (per-decl `handle`, `_by_source`, `_handles`,
+    and the `by_id` decl map). Exit 0 when a discovery was produced (validity is
+    data: `valid`/`complete`); exit 2 on a usage error. Standalone only (the
+    dev-running published-generation path is Slice 3).
+  - Gate: `tests/e2e_project_discovery.sh` (25 assertions, wired into CI) over the
+    REAL tool VM — deterministic output; annotations discovered without execution;
+    unknown annotations survive; malformed → `valid=false` + diagnostics; `.js`
+    present but not falsely analyzed (→ `complete=false`) while `static/*.js` is
+    pruned; capability reporting; and a leak check that no generation-internal
+    state reaches the wire.
 
 - **Slice 3 — `hull dev` integration (D7/D9).**
   - Publish `.hull/discovery.json` per generation in `--agent`; `hull agent

--- a/docs/project_discovery_design.md
+++ b/docs/project_discovery_design.md
@@ -1,6 +1,7 @@
 # Project Source Discovery — design record
 
-Status: **RATIFIED (with amendments). Slice 1 in progress.**
+Status: **RATIFIED (with amendments). Slice 1 MERGED (#356); Slice 2 implemented
+(#357); Slices 3-4 pending.**
 Author: (design-first, per the story's required cadence)
 Related: `docs/lua_source_analysis_design.md`, `docs/hull_source_scope_design.md`,
 `docs/hull_analyze_design.md`, `docs/hull_analyze_lint_design.md`.
@@ -453,12 +454,16 @@ attribution, no em-dashes.
 
 - **Slice 2 — standalone agent inspection (D8/D9/D11). DONE.**
   - `hull agent inspect [app_dir]` (C dispatch in `agent.c` → `hull_tool(
-    "hull.project.inspect")` → `hull.project.analyze`). `hull.project.inspect`
-    emits an EXPLICIT, `schema_version`'d JSON projection to stdout that DROPS
-    every generation-internal value (per-decl `handle`, `_by_source`, `_handles`,
-    and the `by_id` decl map). Exit 0 when a discovery was produced (validity is
-    data: `valid`/`complete`); exit 2 on a usage error. Standalone only (the
-    dev-running published-generation path is Slice 3).
+    "hull.project.inspect")` → `hull.project.analyze`). The wire schema lives in a
+    SINGLE side-effect-free module `hull.project.projection` (`M.project(disc) ->
+    plain table`) that DROPS every generation-internal value (per-decl `handle`,
+    `_by_source`, `_handles`, the `by_id` decl map); both standalone inspection and
+    Slice 3's `discovery.json` publication call it, so there is one wire-schema
+    definition. `hull.project.inspect` follows the tool-module convention (`return
+    main`; the dispatcher invokes it only as the entry command -- requiring it
+    never runs the CLI). At most one positional root (`inspect a b` → exit 2). Exit
+    0 when a discovery was produced (validity is data: `valid`/`complete`); exit 2
+    on a usage error. Standalone only (the dev-running path is Slice 3).
   - Gate: `tests/e2e_project_discovery.sh` (25 assertions, wired into CI) over the
     REAL tool VM — deterministic output; annotations discovered without execution;
     unknown annotations survive; malformed → `valid=false` + diagnostics; `.js`

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -915,6 +915,10 @@ e2e-migrate: $(BUILDDIR)/hull
 e2e-analyze: $(BUILDDIR)/hull
 	sh tests/e2e_analyze.sh
 
+.PHONY: e2e-project-discovery
+e2e-project-discovery: $(BUILDDIR)/hull
+	sh tests/e2e_project_discovery.sh
+
 # PostgreSQL backend end-to-end (needs Docker; builds its own POSTGRES hull).
 e2e-postgres:
 	sh tests/e2e_postgres.sh

--- a/src/hull/commands/agent.c
+++ b/src/hull/commands/agent.c
@@ -729,6 +729,7 @@ static void agent_usage(void)
         "  sql named <qname> [--params J] [dir]  Run a named query from queries.json\n"
         "  tools                          Side-loaded tool registry + install state\n"
         "  overview [app_dir]             Composite project summary (one shot)\n"
+        "  inspect [app_dir]              Analyzed project model: annotated declarations (JSON)\n"
         "\n"
         "All output is JSON to stdout.\n");
 }
@@ -798,6 +799,12 @@ int hl_cmd_agent(int argc, char **argv, const HlCommandEnv *env)
     }
     /* Composite project summary — one call to orient an agent. */
     if (strcmp(sub, "overview") == 0)     return cmd_overview(sub_argc, sub_argv);
+    /* Project source discovery — the canonical analyzed project model (annotated
+     * declarations) as versioned JSON. Delegates to the Lua tool VM (hull.project.inspect
+     * -> hull.project.analyze). argv+1 keeps arg[0]="inspect", arg[1..]=args in the VM. */
+    if (strcmp(sub, "inspect") == 0)
+        return hull_tool("hull.project.inspect", argc - 1, argv + 1,
+                         env ? env->hull_exe : NULL);
 #ifdef HL_ENABLE_DB
     if (strcmp(sub, "schema-diff") == 0)  return cmd_schema_diff(sub_argc, sub_argv);
     if (strcmp(sub, "sql") == 0)          return cmd_sql(sub_argc, sub_argv);

--- a/stdlib/cli/lua/hull/project/inspect.lua
+++ b/stdlib/cli/lua/hull/project/inspect.lua
@@ -1,0 +1,96 @@
+--
+-- hull.project.inspect — `hull agent inspect [app_dir]`: standalone project discovery.
+--
+-- Slice 2 (design: docs/project_discovery_design.md D8/D9/D11). Invokes the ONE canonical
+-- analyzer (hull.project.analyze) on the app tree and emits an EXPLICIT, versioned JSON
+-- projection to stdout. It does NOT re-scan or parse source itself. This is the
+-- standalone path; the dev-running path (read a published generation) lands in Slice 3.
+--
+-- The projection is EXPLICIT: it copies only the public fields and DROPS every
+-- generation-internal value -- the opaque `handle` on each decl, the internal `_by_source`
+-- and `_handles` tables, and the by_id decl map (its ids are already in `annotated` +
+-- each decl's `id`). Handles/state never reach the wire (D6).
+--
+-- Output: pure JSON on stdout (Hull routes `print` to stderr, so JSON goes via
+-- tool.stdout). Exit 0 when a discovery was produced (validity is DATA in the JSON:
+-- `valid` / `complete`); exit 2 only on a usage error.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local analyze = require("hull.project.analyze")
+local json    = require("hull.json")
+
+local function usage_error(msg)
+    tool.stderr("hull agent inspect: " .. msg .. "\n")
+    tool.stderr("usage: hull agent inspect [app_dir]\n")
+    tool.exit(2)
+end
+
+-- Public projection of one normalized annotation (keeps provenance; `raw` retained -- it
+-- is the exact source text, useful to a consumer, and carries no internal state).
+local function project_annotation(a)
+    return { name = a.name, args = a.args, value = a.value, raw = a.raw, range = a.range,
+             target_group_id = a.target_group_id, frontend = a.frontend }
+end
+
+-- Public projection of one declaration fact -- explicitly WITHOUT `handle` (generation
+-- -internal; resolvable only in-process via analyze.resolve_handle, never serialized).
+local function project_decl(d)
+    local anns = {}
+    for _, a in ipairs(d.annotations or {}) do anns[#anns + 1] = project_annotation(a) end
+    return { id = d.id, group_id = d.group_id, language = d.language, path = d.path,
+             kind = d.kind, name = d.name, range = d.range, is_method = d.is_method,
+             status = d.status, annotations = anns }
+end
+
+-- Explicit public projection of the whole ProjectDiscovery. Only named public fields are
+-- copied; _by_source / _handles / per-decl handle / the by_id decl map are omitted.
+local function project(disc)
+    local decls = {}
+    for _, d in ipairs(disc.declarations or {}) do decls[#decls + 1] = project_decl(d) end
+    local idx = disc.indexes or {}
+    return {
+        schema_version = disc.schema_version,
+        generation     = disc.generation,
+        source         = disc.source,
+        project_root   = disc.project_root,
+        valid          = disc.valid,
+        complete       = disc.complete,
+        sources        = disc.sources,
+        frontends      = disc.frontends,
+        declarations   = decls,
+        diagnostics    = disc.diagnostics,
+        summary        = disc.summary,
+        indexes        = {
+            by_annotation = idx.by_annotation,
+            by_source     = idx.by_source,
+            by_language   = idx.by_language,
+            annotated     = idx.annotated,
+        },
+    }
+end
+
+local function main()
+    local app_dir = "."
+    for i = 1, #arg do
+        local a = arg[i]
+        if a == "-h" or a == "--help" then
+            tool.stdout("usage: hull agent inspect [app_dir]\n"); tool.exit(0)
+        elseif a:sub(1, 1) == "-" and a ~= "-" then
+            -- `--json` is the default + only format, accepted for symmetry; any other flag errors.
+            if a ~= "--json" then usage_error("unknown flag: " .. a) end
+        else
+            app_dir = a
+        end
+    end
+
+    -- The canonical analyzer never raises: it always returns a discovery (an invalid one
+    -- on a bad root / internal defect). The command therefore succeeds (exit 0); the
+    -- consumer reads `valid` / `complete` from the JSON.
+    local disc = analyze.analyze(app_dir, { source_kind = "standalone" })
+    tool.stdout(json.encode(project(disc)) .. "\n")
+    tool.exit(0)
+end
+
+main()

--- a/stdlib/cli/lua/hull/project/inspect.lua
+++ b/stdlib/cli/lua/hull/project/inspect.lua
@@ -2,24 +2,25 @@
 -- hull.project.inspect — `hull agent inspect [app_dir]`: standalone project discovery.
 --
 -- Slice 2 (design: docs/project_discovery_design.md D8/D9/D11). Invokes the ONE canonical
--- analyzer (hull.project.analyze) on the app tree and emits an EXPLICIT, versioned JSON
--- projection to stdout. It does NOT re-scan or parse source itself. This is the
--- standalone path; the dev-running path (read a published generation) lands in Slice 3.
+-- analyzer (hull.project.analyze) on the app tree and emits the shared public JSON
+-- projection (hull.project.projection) to stdout. It does NOT re-scan or parse source
+-- itself. This is the standalone path; the dev-running path (read a published generation)
+-- lands in Slice 3 and reuses the SAME projection module.
 --
--- The projection is EXPLICIT: it copies only the public fields and DROPS every
--- generation-internal value -- the opaque `handle` on each decl, the internal `_by_source`
--- and `_handles` tables, and the by_id decl map (its ids are already in `annotated` +
--- each decl's `id`). Handles/state never reach the wire (D6).
+-- Tool-module convention: this module RETURNS its main entry (like hull.build /
+-- hull.init); the tool dispatcher (src/hull/tool.c) invokes it only when `inspect` is the
+-- entry command. Requiring this module never runs the CLI.
 --
 -- Output: pure JSON on stdout (Hull routes `print` to stderr, so JSON goes via
 -- tool.stdout). Exit 0 when a discovery was produced (validity is DATA in the JSON:
--- `valid` / `complete`); exit 2 only on a usage error.
+-- `valid` / `complete`); exit 2 on a usage error.
 --
 -- SPDX-License-Identifier: AGPL-3.0-or-later
 --
 
-local analyze = require("hull.project.analyze")
-local json    = require("hull.json")
+local analyze    = require("hull.project.analyze")
+local projection = require("hull.project.projection")
+local json       = require("hull.json")
 
 local function usage_error(msg)
     tool.stderr("hull agent inspect: " .. msg .. "\n")
@@ -27,52 +28,8 @@ local function usage_error(msg)
     tool.exit(2)
 end
 
--- Public projection of one normalized annotation (keeps provenance; `raw` retained -- it
--- is the exact source text, useful to a consumer, and carries no internal state).
-local function project_annotation(a)
-    return { name = a.name, args = a.args, value = a.value, raw = a.raw, range = a.range,
-             target_group_id = a.target_group_id, frontend = a.frontend }
-end
-
--- Public projection of one declaration fact -- explicitly WITHOUT `handle` (generation
--- -internal; resolvable only in-process via analyze.resolve_handle, never serialized).
-local function project_decl(d)
-    local anns = {}
-    for _, a in ipairs(d.annotations or {}) do anns[#anns + 1] = project_annotation(a) end
-    return { id = d.id, group_id = d.group_id, language = d.language, path = d.path,
-             kind = d.kind, name = d.name, range = d.range, is_method = d.is_method,
-             status = d.status, annotations = anns }
-end
-
--- Explicit public projection of the whole ProjectDiscovery. Only named public fields are
--- copied; _by_source / _handles / per-decl handle / the by_id decl map are omitted.
-local function project(disc)
-    local decls = {}
-    for _, d in ipairs(disc.declarations or {}) do decls[#decls + 1] = project_decl(d) end
-    local idx = disc.indexes or {}
-    return {
-        schema_version = disc.schema_version,
-        generation     = disc.generation,
-        source         = disc.source,
-        project_root   = disc.project_root,
-        valid          = disc.valid,
-        complete       = disc.complete,
-        sources        = disc.sources,
-        frontends      = disc.frontends,
-        declarations   = decls,
-        diagnostics    = disc.diagnostics,
-        summary        = disc.summary,
-        indexes        = {
-            by_annotation = idx.by_annotation,
-            by_source     = idx.by_source,
-            by_language   = idx.by_language,
-            annotated     = idx.annotated,
-        },
-    }
-end
-
 local function main()
-    local app_dir = "."
+    local positionals = {}
     for i = 1, #arg do
         local a = arg[i]
         if a == "-h" or a == "--help" then
@@ -81,16 +38,24 @@ local function main()
             -- `--json` is the default + only format, accepted for symmetry; any other flag errors.
             if a ~= "--json" then usage_error("unknown flag: " .. a) end
         else
-            app_dir = a
+            positionals[#positionals + 1] = a
         end
     end
+    -- At most one positional (the app_dir). Reject `inspect a b` explicitly (exit 2)
+    -- instead of silently using the last root.
+    if #positionals > 1 then
+        usage_error("expected at most one app_dir, got " .. #positionals ..
+                    " (" .. table.concat(positionals, " ") .. ")")
+    end
+    local app_dir = positionals[1] or "."
 
     -- The canonical analyzer never raises: it always returns a discovery (an invalid one
     -- on a bad root / internal defect). The command therefore succeeds (exit 0); the
     -- consumer reads `valid` / `complete` from the JSON.
     local disc = analyze.analyze(app_dir, { source_kind = "standalone" })
-    tool.stdout(json.encode(project(disc)) .. "\n")
+    tool.stdout(json.encode(projection.project(disc)) .. "\n")
     tool.exit(0)
 end
 
-main()
+-- Hand main() back to the dispatcher; do NOT call it here (see the convention note above).
+return main

--- a/stdlib/cli/lua/hull/project/projection.lua
+++ b/stdlib/cli/lua/hull/project/projection.lua
@@ -1,0 +1,62 @@
+--
+-- hull.project.projection — the ONE public wire-schema projection of a ProjectDiscovery.
+--
+-- Side-effect-free (requiring this module runs NO CLI): both `hull agent inspect`
+-- (standalone) and, in Slice 3, `hull dev`'s discovery.json publication call M.project so
+-- there is a SINGLE definition of the serialized shape. It copies only named public
+-- fields and DROPS every generation-internal value -- the per-declaration opaque `handle`,
+-- the internal `_by_source` and `_handles` tables, and the `by_id` decl map (its ids are
+-- already in `annotated` + each decl's `id`). Design: docs/project_discovery_design.md D6.
+--
+-- Returns a plain serializable Lua table (the caller json.encodes it). Never raises.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local M = {}
+
+-- Public projection of one normalized annotation (keeps provenance; `raw` retained -- it
+-- is exact source text and carries no internal state).
+local function project_annotation(a)
+    return { name = a.name, args = a.args, value = a.value, raw = a.raw, range = a.range,
+             target_group_id = a.target_group_id, frontend = a.frontend }
+end
+
+-- Public projection of one declaration fact -- explicitly WITHOUT `handle` (generation
+-- -internal; resolvable only in-process via analyze.resolve_handle, never serialized).
+local function project_decl(d)
+    local anns = {}
+    for _, a in ipairs(d.annotations or {}) do anns[#anns + 1] = project_annotation(a) end
+    return { id = d.id, group_id = d.group_id, language = d.language, path = d.path,
+             kind = d.kind, name = d.name, range = d.range, is_method = d.is_method,
+             status = d.status, annotations = anns }
+end
+
+-- project(disc) -> plain serializable table. Only named public fields; _by_source /
+-- _handles / per-decl handle / the by_id decl map are omitted.
+function M.project(disc)
+    local decls = {}
+    for _, d in ipairs(disc.declarations or {}) do decls[#decls + 1] = project_decl(d) end
+    local idx = disc.indexes or {}
+    return {
+        schema_version = disc.schema_version,
+        generation     = disc.generation,
+        source         = disc.source,
+        project_root   = disc.project_root,
+        valid          = disc.valid,
+        complete       = disc.complete,
+        sources        = disc.sources,
+        frontends      = disc.frontends,
+        declarations   = decls,
+        diagnostics    = disc.diagnostics,
+        summary        = disc.summary,
+        indexes        = {
+            by_annotation = idx.by_annotation,
+            by_source     = idx.by_source,
+            by_language   = idx.by_language,
+            annotated     = idx.annotated,
+        },
+    }
+end
+
+return M

--- a/stdlib/cli/lua/hull/project/tests/test_project.lua
+++ b/stdlib/cli/lua/hull/project/tests/test_project.lua
@@ -363,5 +363,26 @@ do
         "wrong-typed opts.generation / opts.source_kind normalized to defaults")
 end
 
+-- ── shared projection: public fields kept, generation-internal state dropped ──
+do
+    local projection = require("hull.project.projection")
+    local analyze = require("hull.project.analyze")
+    _G.tool = make_tool({ ["pj/app.lua"] = "---@x\nlocal a = 1\nreturn a\n" })
+    local disc = analyze.analyze("pj")
+    _G.tool = nil
+    -- the in-memory model carries internal state...
+    ok(disc._handles ~= nil and disc._by_source ~= nil, "in-memory model retains internal state")
+    ok(disc.declarations[1].handle ~= nil, "in-memory decl carries a handle")
+    -- ...the projection drops ALL of it, keeps the public fields
+    local p = projection.project(disc)
+    ok(p._handles == nil and p._by_source == nil, "projection drops _handles / _by_source")
+    ok(p.indexes.by_id == nil, "projection drops the by_id decl map")
+    ok(p.declarations[1].handle == nil, "projection drops per-decl handle")
+    ok(p.schema_version == 1 and p.valid ~= nil and p.complete ~= nil and p.summary ~= nil,
+        "projection keeps the public wire fields")
+    ok(p.declarations[1].id ~= nil and p.declarations[1].annotations[1].name == "x",
+        "projection keeps public decl id + annotations")
+end
+
 print(string.format("test_project: %d passed, %d failed", pass, fail))
 return { pass = pass, fail = fail, failures = failures }

--- a/tests/e2e_project_discovery.sh
+++ b/tests/e2e_project_discovery.sh
@@ -142,6 +142,17 @@ assert_py "missing root emits project.discovery_failed" "$OUTM" \
     'any(x["code"]=="project.discovery_failed" for x in d["diagnostics"])'
 [ "$RCM" = "0" ] && pass "missing root still exits 0 (validity is in the JSON)" || fail "missing-root exit ($RCM)"
 
+# ── usage: multiple positional roots is an error (exit 2), not "use the last" ──
+# (|| RC=$? captures the non-zero exit without tripping `set -e`.)
+RCU=0; "$HULL" agent inspect "$OK" "$BAD" >/dev/null 2>&1 || RCU=$?
+[ "$RCU" = "2" ] && pass "two positional roots -> usage error (exit 2)" || fail "multi-positional exit ($RCU, want 2)"
+# a single positional still works (exit 0)
+RCS=0; "$HULL" agent inspect "$OK" >/dev/null 2>&1 || RCS=$?
+[ "$RCS" = "0" ] && pass "single positional root still exits 0" || fail "single-positional exit ($RCS)"
+# an unknown flag is a usage error too
+RCF=0; "$HULL" agent inspect --bogus >/dev/null 2>&1 || RCF=$?
+[ "$RCF" = "2" ] && pass "unknown flag -> usage error (exit 2)" || fail "unknown-flag exit ($RCF, want 2)"
+
 echo ""
 echo "=== hull agent inspect E2E: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]

--- a/tests/e2e_project_discovery.sh
+++ b/tests/e2e_project_discovery.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+# E2E tests — `hull agent inspect` (standalone project source discovery)
+#
+# Usage: sh tests/e2e_project_discovery.sh
+# Requires: build/hull already built; python3 (for JSON assertions, as the oauth e2e uses).
+#
+# Exercises the REAL tool VM end-to-end (not the unit harness's stubbed fs): the canonical
+# analyzer produces deterministic output; Lua annotations are discovered WITHOUT executing
+# app source; unknown annotations survive; malformed Lua -> valid=false + diagnostics;
+# frontend capabilities are accurate; static/ browser assets are pruned while application
+# .js is honestly unsupported (never parsed as Lua) -> complete=false; a missing root is
+# an invalid+incomplete discovery; and the public JSON leaks NO generation-internal state
+# (handle / _by_source / _handles / by_id).
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -e
+
+HULL=./build/hull
+PASS=0
+FAIL=0
+
+if [ ! -x "$HULL" ]; then
+    echo "e2e-project-discovery: hull binary not found at $HULL — run 'make' first"
+    exit 1
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "e2e-project-discovery: python3 not found — skipping (JSON assertions need it)"
+    exit 0
+fi
+
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+
+TMP=$(mktemp -d)
+trap 'chmod -R u+rwx "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
+
+# assert_py "<name>" "<json>" "<python expr over d>": pass iff the expr is truthy.
+assert_py() {
+    _name="$1"; _json="$2"; _expr="$3"
+    if printf '%s' "$_json" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+sys.exit(0 if ('"$_expr"') else 1)
+' 2>/dev/null; then pass "$_name"; else fail "$_name"; fi
+}
+
+echo ""
+echo "=== E2E: hull agent inspect (project source discovery) ==="
+
+# ── a mixed modular app: annotated Lua, nested source, browser asset, app JS ──
+APP="$TMP/app"
+mkdir -p "$APP/routes" "$APP/static"
+cat > "$APP/app.lua" <<'EOF'
+---@route GET /
+---@custom freeform tag
+local function home() end
+local a, b = 1, 2
+return home, a, b
+EOF
+cat > "$APP/routes/users.lua" <<'EOF'
+---@resource users
+local function list() end
+return list
+EOF
+printf 'window.x = 1;\n' > "$APP/static/vendor.js"   # browser asset -> pruned
+printf 'export const q = 1;\n' > "$APP/client.js"    # application JS -> unsupported
+
+OUT=$("$HULL" agent inspect "$APP" 2>/dev/null); RC=$?
+[ "$RC" = "0" ] && pass "exit 0 (a discovery was produced)" || fail "exit code ($RC)"
+
+assert_py "schema_version + standalone provenance" "$OUT" 'd["schema_version"]==1 and d["source"]=="standalone" and d["generation"]==0'
+assert_py "valid (no malformed source)" "$OUT" 'd["valid"] is True'
+assert_py "complete=false (an application .js is unsupported)" "$OUT" 'd["complete"] is False'
+assert_py "static/*.js browser asset is pruned (not a source)" "$OUT" \
+    'not any(s["path"]=="static/vendor.js" for s in d["sources"])'
+assert_py "application client.js honestly unsupported" "$OUT" \
+    'any(s["path"]=="client.js" and s["status"]=="unsupported" and s["language"]=="javascript" for s in d["sources"])'
+assert_py "app.lua + routes/users.lua analyzed" "$OUT" \
+    'sum(1 for s in d["sources"] if s["status"]=="analyzed")==2'
+assert_py "annotations discovered WITHOUT executing source" "$OUT" \
+    'set(d["indexes"]["by_annotation"].keys())=={"route","custom","resource"}'
+assert_py "UNKNOWN @custom annotation survives" "$OUT" \
+    'any(a["name"]=="custom" for x in d["declarations"] for a in x["annotations"])'
+assert_py "annotated-only public declarations (home + list)" "$OUT" \
+    'sorted(x["name"] for x in d["declarations"])==["home","list"]'
+assert_py "totals retain all 4 declarations; 2 annotated" "$OUT" \
+    'd["summary"]["declarations_total"]==4 and d["summary"]["declarations_annotated"]==2'
+assert_py "JS frontend honest: analyzable=false, 0 capabilities" "$OUT" \
+    'any(f["language"]=="javascript" and f["analyzable"] is False and len(f["capabilities"])==0 for f in d["frontends"])'
+assert_py "Lua frontend reports 4 shipped capabilities" "$OUT" \
+    'any(f["language"]=="lua" and f["analyzable"] is True and len(f["capabilities"])==4 for f in d["frontends"])'
+assert_py "unsupported-frontend diagnostic present (warning)" "$OUT" \
+    'any(x["code"]=="project.frontend.unsupported" and x["severity"]=="warning" for x in d["diagnostics"])'
+
+# multi-name group: both @route/@custom annotations target the SAME declaration group
+assert_py "annotation target_group_id points at the declaration group" "$OUT" \
+    'all(a["target_group_id"]==x["group_id"] for x in d["declarations"] for a in x["annotations"])'
+
+# NO generation-internal state on the wire
+assert_py "no handle / _by_source / _handles / by_id leaked" "$OUT" \
+    '"handle" not in json.dumps(d) and "_by_source" not in json.dumps(d) and "_handles" not in json.dumps(d) and "by_id" not in d["indexes"]'
+
+# determinism
+OUT2=$("$HULL" agent inspect "$APP" 2>/dev/null)
+[ "$OUT" = "$OUT2" ] && pass "deterministic (two runs byte-identical)" || fail "non-deterministic output"
+
+# ── malformed Lua -> valid=false, structured diagnostics, status error ──
+BAD="$TMP/bad"
+mkdir -p "$BAD"
+printf 'local function ok() end\nreturn ok\n' > "$BAD/good.lua"
+printf 'local = = )\n' > "$BAD/broken.lua"
+OUTB=$("$HULL" agent inspect "$BAD" 2>/dev/null)
+assert_py "malformed Lua -> valid=false" "$OUTB" 'd["valid"] is False'
+assert_py "malformed source status=error + error diagnostic" "$OUTB" \
+    'any(s["path"]=="broken.lua" and s["status"]=="error" for s in d["sources"]) and any(x["severity"]=="error" for x in d["diagnostics"])'
+assert_py "the clean sibling still analyzed" "$OUTB" \
+    'any(s["path"]=="good.lua" and s["status"]=="analyzed" for s in d["sources"])'
+
+# ── a genuinely clean all-Lua project -> valid + complete ──
+OK="$TMP/okproj"
+mkdir -p "$OK/lib"
+cat > "$OK/app.lua" <<'EOF'
+---@main
+local function main() end
+return main
+EOF
+cat > "$OK/lib/util.lua" <<'EOF'
+---@util
+local function u() end
+return u
+EOF
+OUTC=$("$HULL" agent inspect "$OK" 2>/dev/null)
+assert_py "clean all-Lua project -> valid AND complete" "$OUTC" 'd["valid"] is True and d["complete"] is True'
+assert_py "both annotated Lua declarations public" "$OUTC" 'sorted(x["name"] for x in d["declarations"])==["main","u"]'
+
+# ── missing root -> invalid + incomplete, project.discovery_failed, still exit 0 ──
+OUTM=$("$HULL" agent inspect "$TMP/does-not-exist" 2>/dev/null); RCM=$?
+assert_py "missing root -> invalid + incomplete + no sources" "$OUTM" \
+    'd["valid"] is False and d["complete"] is False and len(d["sources"])==0'
+assert_py "missing root emits project.discovery_failed" "$OUTM" \
+    'any(x["code"]=="project.discovery_failed" for x in d["diagnostics"])'
+[ "$RCM" = "0" ] && pass "missing root still exits 0 (validity is in the JSON)" || fail "missing-root exit ($RCM)"
+
+echo ""
+echo "=== hull agent inspect E2E: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
**Slice 2** of project source discovery: the first user-facing surface, `hull agent inspect [app_dir]` (design: `docs/project_discovery_design.md` D8/D9/D11). It runs the one canonical analyzer (`hull.project.analyze`, merged in #356) over the app tree and emits the analyzed project model — **annotated declarations** — as versioned JSON. It never re-scans or parses source itself.

Scope: standalone inspection only. No Query/Compute IR, no lowering, no build wiring, no JS parser — per the story's non-goals. The dev-running published-generation path is Slice 3; the build seam is Slice 4.

## Command
A C dispatch case in `agent.c` delegates to the Lua tool VM via `hull_tool("hull.project.inspect", argc-1, argv+1, …)` so the VM sees `arg[0]="inspect"`, `arg[1..]=args` (mirrors `hull.source.analyze`). **No collision** with top-level `hull inspect` (which inspects a *built binary* — a different noun; documented).

## Explicit public projection
`hull.project.inspect.lua` copies only named public fields and **drops every generation-internal value** — the per-declaration opaque `handle`, the internal `_by_source`/`_handles` tables, and the `by_id` decl map. Pure JSON to stdout (Hull routes `print` to stderr, so it uses `tool.stdout`). Exit 0 whenever a discovery was produced — **validity is data** in the JSON (`valid`/`complete`), the agent-command convention; exit 2 only on a usage error.

## Honest JavaScript, end to end
An application `.js` is reported `unsupported` → `complete=false` and **never parsed as Lua**; a `static/*.js` browser asset is pruned.

## Tests
`tests/e2e_project_discovery.sh` — **25 assertions over the real tool VM** (wired into CI + the Makefile): schema_version + provenance; **deterministic byte-identical** output; annotations discovered **without executing source**; unknown annotations survive; annotated-only public decls with retained totals; JS honest / `static/` pruned / `complete=false`; malformed Lua → `valid=false` + error diagnostics; missing root → invalid+incomplete + `project.discovery_failed` (still exit 0); frontend capability accuracy; and a hard **leak check** that no `handle`/`_by_source`/`_handles`/`by_id` reaches the wire.

**76/76 unit; e2e_project_discovery 25/25; `hull analyze` reports `inspect.lua` clean; luacheck clean.**

Slices 3–4 (`hull dev` generations + atomic sidecar; documented build seam) follow.
