### PR TITLE
feat(project): Slice 3 — hull dev generation publishing + live inspect read

### DIFF
--- a/docs/project_discovery_design.md
+++ b/docs/project_discovery_design.md
@@ -493,8 +493,10 @@ attribution, no em-dashes.
     Lua-side validation. Sidecar reads demand a complete read (short read /
     `ferror` → reject) and a positive in-range integer `session_pid` token, AND
     the discovery document must parse as COMPLETE valid JSON via the repo's parser
-    (`sh_json_parse`) before it is streamed -- so a truncated/corrupt sidecar whose
-    `session_pid` token alone matches a live PID is NOT emitted. Any
+    (`sh_json_parse`) before it is streamed -- validated + emitted over the EXACT
+    byte length (not `strlen`/`fputs`), so an embedded NUL cannot hide trailing
+    bytes and a truncated/corrupt sidecar whose `session_pid` token alone matches a
+    live PID is NOT emitted. Any
     malformed/truncated/stale/crashed-session sidecar falls back to a standalone
     analysis. Liveness (`kill`) stays in the main process, not the tool sandbox.
     Scope: the non-TUI `--agent` loop; publishing from `hull dev --tui` is a

--- a/docs/project_discovery_design.md
+++ b/docs/project_discovery_design.md
@@ -473,22 +473,36 @@ attribution, no em-dashes.
 
 - **Slice 3 — `hull dev` integration (D7/D9). DONE.**
   - `hull dev --agent` publishes `.hull/discovery.json` per (re)spawn with a
-    monotonic `generation`, by spawning `hull agent inspect <app_dir> --out=…
-    --generation=N --session-pid=<supervisor>` (fresh analysis, `source="dev"`,
-    projected via the shared `hull.project.projection`, written atomically
-    tmp+rename). `dev.json` gains `session_pid` (the supervisor PID, stable across
-    reloads) and is itself written atomically; both sidecars are removed on dev
-    exit. `hull agent inspect` (C `cmd_inspect`) streams the published generation
-    only when `discovery.json`/`dev.json` `session_pid` match AND `kill(pid,0)`
-    confirms the supervisor is live (rejects a stale/crashed-session sidecar);
-    otherwise it delegates to the tool VM for a standalone analysis. Publish is
-    the fresh-analysis path (never reads a published generation → no recursion).
-    Scope: the non-TUI `--agent` loop (the agent-facing path); publishing from the
-    `hull dev --tui` reload path is a documented follow-up.
-  - Gate (e2e, in `e2e_project_discovery.sh`): dev publishes a generation; the
+    monotonic `generation` by spawning `hull agent inspect <app_dir>
+    --generation=N --session-pid=<supervisor>`. The C dispatcher routes those
+    INTERNAL publish flags to a SEPARATE module `hull.project.publish` (not a
+    read-command flag): it requires `--generation` + `--session-pid` TOGETHER
+    (partial combos → exit 2), runs a fresh analysis (`source="dev"`), projects it
+    via the shared `hull.project.projection`, tags it with the generation +
+    session identity, and writes it to the CANONICAL `<app_dir>/.hull/discovery.json`
+    (never a caller-supplied path) ATOMICALLY (tmp+rename). `dev.json` gains
+    `session_pid` (the supervisor PID, stable across reloads) and is itself written
+    atomically; both sidecars are removed on dev exit. If publication fails
+    (fork/exec/non-zero exit) the previous same-session generation is REMOVED so a
+    stale generation is never served.
+  - `hull agent inspect` (C `cmd_inspect`) streams the published generation only on
+    a FULLY-VALID public read invocation (≤1 positional, no flag but `--json`) AND
+    when `discovery.json`/`dev.json` `session_pid` match AND `kill(pid,0)` confirms
+    the supervisor is live. Any invalid CLI form (extra root, unknown flag,
+    `--help`) is NOT fast-pathed → delegated to `hull.project.inspect` for full
+    Lua-side validation. Sidecar parsing demands a complete read (short read /
+    `ferror` → reject) and a positive in-range integer `session_pid` token; a
+    malformed/truncated/stale/crashed-session sidecar falls back to a standalone
+    analysis. Liveness (`kill`) stays in the main process, not the tool sandbox.
+    Scope: the non-TUI `--agent` loop; publishing from `hull dev --tui` is a
+    documented follow-up.
+  - Gate (e2e, in `e2e_project_discovery.sh`): dev publishes a generation;
     session_pid matches across both sidecars; a source change → reload → a new
-    generation (1→2); sidecars removed on exit; after exit → standalone; and a
-    dead-`session_pid` sidecar is ignored → fresh standalone analysis.
+    generation (1→2); publisher failure → stale generation removed → standalone;
+    invalid CLI while live is not streamed (exit 2 / usage); publish flags require
+    both (partial → exit 2) and write the canonical path; sidecars removed on exit;
+    after exit → standalone; and dead-session / malformed / truncated sidecars →
+    standalone.
 
 - **Slice 4 — build seam (D10), abstraction-only.**
   - Ship + test `hull.project.analyze` as the host abstraction a build consumer

--- a/docs/project_discovery_design.md
+++ b/docs/project_discovery_design.md
@@ -490,8 +490,11 @@ attribution, no em-dashes.
     when `discovery.json`/`dev.json` `session_pid` match AND `kill(pid,0)` confirms
     the supervisor is live. Any invalid CLI form (extra root, unknown flag,
     `--help`) is NOT fast-pathed → delegated to `hull.project.inspect` for full
-    Lua-side validation. Sidecar parsing demands a complete read (short read /
-    `ferror` → reject) and a positive in-range integer `session_pid` token; a
+    Lua-side validation. Sidecar reads demand a complete read (short read /
+    `ferror` → reject) and a positive in-range integer `session_pid` token, AND
+    the discovery document must parse as COMPLETE valid JSON via the repo's parser
+    (`sh_json_parse`) before it is streamed -- so a truncated/corrupt sidecar whose
+    `session_pid` token alone matches a live PID is NOT emitted. Any
     malformed/truncated/stale/crashed-session sidecar falls back to a standalone
     analysis. Liveness (`kill`) stays in the main process, not the tool sandbox.
     Scope: the non-TUI `--agent` loop; publishing from `hull dev --tui` is a

--- a/docs/project_discovery_design.md
+++ b/docs/project_discovery_design.md
@@ -1,7 +1,7 @@
 # Project Source Discovery — design record
 
-Status: **RATIFIED (with amendments). Slice 1 MERGED (#356); Slice 2 implemented
-(#357); Slices 3-4 pending.**
+Status: **RATIFIED (with amendments). Slices 1-2 MERGED (#356, #357); Slice 3
+implemented; Slice 4 pending.**
 Author: (design-first, per the story's required cadence)
 Related: `docs/lua_source_analysis_design.md`, `docs/hull_source_scope_design.md`,
 `docs/hull_analyze_design.md`, `docs/hull_analyze_lint_design.md`.
@@ -471,11 +471,24 @@ attribution, no em-dashes.
     pruned; capability reporting; and a leak check that no generation-internal
     state reaches the wire.
 
-- **Slice 3 — `hull dev` integration (D7/D9).**
-  - Publish `.hull/discovery.json` per generation in `--agent`; `hull agent
-    <inspect>` reads the published generation when dev is live.
-  - Gate (e2e): `hull dev --agent` publishes a generation; modify a source +
-    reload → a new generation; standalone vs published schema equivalence.
+- **Slice 3 — `hull dev` integration (D7/D9). DONE.**
+  - `hull dev --agent` publishes `.hull/discovery.json` per (re)spawn with a
+    monotonic `generation`, by spawning `hull agent inspect <app_dir> --out=…
+    --generation=N --session-pid=<supervisor>` (fresh analysis, `source="dev"`,
+    projected via the shared `hull.project.projection`, written atomically
+    tmp+rename). `dev.json` gains `session_pid` (the supervisor PID, stable across
+    reloads) and is itself written atomically; both sidecars are removed on dev
+    exit. `hull agent inspect` (C `cmd_inspect`) streams the published generation
+    only when `discovery.json`/`dev.json` `session_pid` match AND `kill(pid,0)`
+    confirms the supervisor is live (rejects a stale/crashed-session sidecar);
+    otherwise it delegates to the tool VM for a standalone analysis. Publish is
+    the fresh-analysis path (never reads a published generation → no recursion).
+    Scope: the non-TUI `--agent` loop (the agent-facing path); publishing from the
+    `hull dev --tui` reload path is a documented follow-up.
+  - Gate (e2e, in `e2e_project_discovery.sh`): dev publishes a generation; the
+    session_pid matches across both sidecars; a source change → reload → a new
+    generation (1→2); sidecars removed on exit; after exit → standalone; and a
+    dead-`session_pid` sidecar is ignored → fresh standalone analysis.
 
 - **Slice 4 — build seam (D10), abstraction-only.**
   - Ship + test `hull.project.analyze` as the host abstraction a build consumer

--- a/src/hull/commands/agent.c
+++ b/src/hull/commands/agent.c
@@ -34,6 +34,7 @@
 #include <unistd.h>
 #include <signal.h>
 #include <limits.h>
+#include <errno.h>
 
 /* ── Output helper ─────────────────────────────────────────────────── */
 
@@ -753,10 +754,21 @@ static long json_int_field(const char *buf, const char *key)
     if (*p != ':') return -1;
     p++;
     while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r') p++;
-    return strtol(p, NULL, 10);
+    if (*p < '0' || *p > '9') return -1;              /* must start with a digit (no sign / garbage) */
+    errno = 0;
+    char *end = NULL;
+    long v = strtol(p, &end, 10);
+    if (errno != 0 || end == p) return -1;            /* overflow / no digits consumed */
+    /* the numeric token must terminate on a valid JSON boundary (not e.g. "12x") */
+    if (*end != ',' && *end != '}' && *end != ' ' && *end != '\t' &&
+        *end != '\n' && *end != '\r' && *end != '\0') return -1;
+    if (v <= 0 || v > INT_MAX) return -1;             /* a pid fits in a positive int */
+    return v;
 }
 
-/* Read a whole file into a NUL-terminated malloc'd buffer (cap-bounded), or NULL. */
+/* Read a whole file into a NUL-terminated malloc'd buffer (cap-bounded), or NULL. Requires
+ * a COMPLETE read (short read / read error -> NULL) so a truncated sidecar is rejected
+ * rather than parsed. */
 static char *read_whole_file(const char *path, size_t cap)
 {
     FILE *f = fopen(path, "rb");
@@ -768,7 +780,9 @@ static char *read_whole_file(const char *path, size_t cap)
     char *buf = malloc((size_t)sz + 1);
     if (!buf) { fclose(f); return NULL; }
     size_t got = fread(buf, 1, (size_t)sz, f);
+    int bad = (got != (size_t)sz) || ferror(f);       /* demand the full file, no read error */
     fclose(f);
+    if (bad) { free(buf); return NULL; }
     buf[got] = '\0';
     return buf;
 }
@@ -804,26 +818,37 @@ static int agent_inspect_stream_live(const char *app_dir)
     return 0;
 }
 
-/* `hull agent inspect [app_dir] [--out=... --generation=N --session-pid=P]`.
- * Without publish flags and with a live published generation, streams that generation
- * (D9). Otherwise delegates to the tool VM (hull.project.inspect): standalone stdout, or
- * -- when --out is present (used by `hull dev`) -- a fresh publish write. `argv` is
- * hl_cmd_agent's own (argv[1]=="inspect"), so argv+1 keeps arg[0]="inspect" in the VM. */
+/* `hull agent inspect [app_dir]` (+ the INTERNAL publish flags used by `hull dev`).
+ * The live-published fast path (D9) is taken ONLY for a fully-valid public read
+ * invocation -- at most one positional, no flag other than --json. Any invalid or
+ * non-read form (a second root, an unknown flag, --help) is NOT fast-pathed; it is
+ * delegated to hull.project.inspect so the Lua boundary does the full validation (exit 2 /
+ * usage). The internal `--generation`/`--session-pid` publish flags route to the SEPARATE
+ * hull.project.publish module. `argv` is hl_cmd_agent's own (argv[1]=="inspect"), so
+ * argv+1 keeps arg[0]="inspect" in the VM. */
 static int cmd_inspect(int argc, char **argv, const HlCommandEnv *env)
 {
     const char *app_dir = ".";
-    int has_publish_flag = 0;
+    int positionals = 0, has_publish = 0, clean_read = 1;
     for (int i = 2; i < argc; i++) {          /* argv[1]=="inspect"; args start at 2 */
         const char *a = argv[i];
-        if (strncmp(a, "--out=", 6) == 0 || strncmp(a, "--generation=", 13) == 0 ||
-            strncmp(a, "--session-pid=", 14) == 0) {
-            has_publish_flag = 1;
-        } else if (a[0] != '-') {
-            app_dir = a;                       /* first positional; multi-positional -> Lua rejects */
+        if (strncmp(a, "--generation=", 13) == 0 || strncmp(a, "--session-pid=", 14) == 0) {
+            has_publish = 1; clean_read = 0;
+        } else if (strcmp(a, "--json") == 0) {
+            /* accepted read format; stays a clean read */
+        } else if (a[0] == '-' && strcmp(a, "-") != 0) {
+            clean_read = 0;                    /* --help / unknown flag -> let Lua handle it */
+        } else {
+            positionals++; app_dir = a;
         }
     }
+    if (positionals > 1) clean_read = 0;       /* extra roots -> Lua rejects (exit 2) */
 
-    if (!has_publish_flag && agent_inspect_stream_live(app_dir) == 0)
+    if (has_publish)
+        return hull_tool("hull.project.publish", argc - 1, argv + 1,
+                         env ? env->hull_exe : NULL);
+
+    if (clean_read && agent_inspect_stream_live(app_dir) == 0)
         return 0;                              /* served the live published generation */
 
     return hull_tool("hull.project.inspect", argc - 1, argv + 1,

--- a/src/hull/commands/agent.c
+++ b/src/hull/commands/agent.c
@@ -35,6 +35,8 @@
 #include <signal.h>
 #include <limits.h>
 #include <errno.h>
+#include <sh_json.h>
+#include <sh_arena.h>
 
 /* ── Output helper ─────────────────────────────────────────────────── */
 
@@ -787,11 +789,26 @@ static char *read_whole_file(const char *path, size_t cap)
     return buf;
 }
 
+/* Validate that `buf` (of `len` bytes) is a COMPLETE, well-formed JSON document via the
+ * repo's parser. A truncated / corrupt discovery.json -- even one whose session_pid token
+ * happens to match a live PID -- must never be streamed. Returns 1 iff the whole document
+ * parses; 0 otherwise (incl. OOM, which fails closed to a standalone re-analysis). */
+static int json_document_valid(const char *buf, size_t len)
+{
+    SHArena *arena = sh_arena_create(len * 8 + 4096);   /* generous; a parse failure only costs a fresh analysis */
+    if (!arena) return 0;
+    ShJsonValue *root = NULL;
+    int ok = (sh_json_parse(buf, len, arena, &root) == SH_JSON_OK) && root != NULL;
+    sh_arena_free(arena);
+    return ok;
+}
+
 /* If a LIVE dev session has published a discovery generation for `app_dir`, stream it to
  * stdout and return 0. "Live" (D9): both .hull/discovery.json and .hull/dev.json exist,
- * their session_pid values match, and that supervisor PID is still alive (kill(pid,0)).
- * Any mismatch / dead session / missing file -> -1 (caller falls back to standalone).
- * This rejects a stale or cross-reload sidecar left by a prior/killed dev session. */
+ * their session_pid values match, that supervisor PID is still alive (kill(pid,0)), AND
+ * the discovery document parses as complete valid JSON. Any mismatch / dead session /
+ * missing file / malformed-or-truncated document -> -1 (caller falls back to standalone).
+ * This rejects a stale/cross-reload sidecar and a corrupt/partial one. */
 static int agent_inspect_stream_live(const char *app_dir)
 {
     char disc_path[PATH_MAX], dev_path[PATH_MAX];
@@ -812,6 +829,10 @@ static int agent_inspect_stream_live(const char *app_dir)
 
     /* Bind the published generation to a specific live dev session. */
     if (sp_disc != sp_dev || kill((pid_t)sp_disc, 0) != 0) { free(disc); return -1; }
+
+    /* Only emit a COMPLETE, well-formed document: a truncated/corrupt discovery.json (even
+     * with a matching live session_pid token) falls back to standalone. */
+    if (!json_document_valid(disc, strlen(disc))) { free(disc); return -1; }
 
     fputs(disc, stdout);
     free(disc);

--- a/src/hull/commands/agent.c
+++ b/src/hull/commands/agent.c
@@ -770,8 +770,9 @@ static long json_int_field(const char *buf, const char *key)
 
 /* Read a whole file into a NUL-terminated malloc'd buffer (cap-bounded), or NULL. Requires
  * a COMPLETE read (short read / read error -> NULL) so a truncated sidecar is rejected
- * rather than parsed. */
-static char *read_whole_file(const char *path, size_t cap)
+ * rather than parsed. On success `*out_len` (if non-NULL) is the exact byte length -- pass
+ * it (not strlen) to the parser + emitter so an embedded NUL cannot hide trailing bytes. */
+static char *read_whole_file(const char *path, size_t cap, size_t *out_len)
 {
     FILE *f = fopen(path, "rb");
     if (!f) return NULL;
@@ -786,6 +787,7 @@ static char *read_whole_file(const char *path, size_t cap)
     fclose(f);
     if (bad) { free(buf); return NULL; }
     buf[got] = '\0';
+    if (out_len) *out_len = got;
     return buf;
 }
 
@@ -817,24 +819,26 @@ static int agent_inspect_stream_live(const char *app_dir)
     if (a < 0 || (size_t)a >= sizeof(disc_path) || b < 0 || (size_t)b >= sizeof(dev_path))
         return -1;
 
-    char *dev = read_whole_file(dev_path, 64 * 1024);
+    char *dev = read_whole_file(dev_path, 64 * 1024, NULL);
     if (!dev) return -1;
     long sp_dev = json_int_field(dev, "session_pid");
     free(dev);
     if (sp_dev <= 0) return -1;
 
-    char *disc = read_whole_file(disc_path, 64 * 1024 * 1024);   /* 64 MB cap */
+    size_t disc_len = 0;
+    char *disc = read_whole_file(disc_path, 64 * 1024 * 1024, &disc_len);   /* 64 MB cap */
     if (!disc) return -1;
     long sp_disc = json_int_field(disc, "session_pid");
 
     /* Bind the published generation to a specific live dev session. */
     if (sp_disc != sp_dev || kill((pid_t)sp_disc, 0) != 0) { free(disc); return -1; }
 
-    /* Only emit a COMPLETE, well-formed document: a truncated/corrupt discovery.json (even
-     * with a matching live session_pid token) falls back to standalone. */
-    if (!json_document_valid(disc, strlen(disc))) { free(disc); return -1; }
+    /* Only emit a COMPLETE, well-formed document. Validate + emit over the EXACT byte
+     * length (not strlen): an embedded NUL must not hide trailing bytes, so `{valid}\0junk`
+     * -- whose complete on-disk document is invalid -- falls back to standalone. */
+    if (!json_document_valid(disc, disc_len)) { free(disc); return -1; }
 
-    fputs(disc, stdout);
+    fwrite(disc, 1, disc_len, stdout);
     free(disc);
     return 0;
 }

--- a/src/hull/commands/agent.c
+++ b/src/hull/commands/agent.c
@@ -32,6 +32,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <signal.h>
+#include <limits.h>
 
 /* ── Output helper ─────────────────────────────────────────────────── */
 
@@ -734,6 +736,100 @@ static void agent_usage(void)
         "All output is JSON to stdout.\n");
 }
 
+/* ── hull agent inspect ────────────────────────────────────────────────
+ *
+ * Read a text field's integer value from a small JSON blob (crude, matching
+ * hl_agent_status's dev.json port parse): "<key>"<ws>:<ws><digits>. Returns -1 if absent.
+ */
+static long json_int_field(const char *buf, const char *key)
+{
+    char needle[64];
+    int n = snprintf(needle, sizeof(needle), "\"%s\"", key);
+    if (n < 0 || (size_t)n >= sizeof(needle)) return -1;
+    const char *p = strstr(buf, needle);
+    if (!p) return -1;
+    p += n;
+    while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r') p++;
+    if (*p != ':') return -1;
+    p++;
+    while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r') p++;
+    return strtol(p, NULL, 10);
+}
+
+/* Read a whole file into a NUL-terminated malloc'd buffer (cap-bounded), or NULL. */
+static char *read_whole_file(const char *path, size_t cap)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) return NULL;
+    if (fseek(f, 0, SEEK_END) != 0) { fclose(f); return NULL; }
+    long sz = ftell(f);
+    if (sz < 0 || (size_t)sz > cap) { fclose(f); return NULL; }
+    if (fseek(f, 0, SEEK_SET) != 0) { fclose(f); return NULL; }
+    char *buf = malloc((size_t)sz + 1);
+    if (!buf) { fclose(f); return NULL; }
+    size_t got = fread(buf, 1, (size_t)sz, f);
+    fclose(f);
+    buf[got] = '\0';
+    return buf;
+}
+
+/* If a LIVE dev session has published a discovery generation for `app_dir`, stream it to
+ * stdout and return 0. "Live" (D9): both .hull/discovery.json and .hull/dev.json exist,
+ * their session_pid values match, and that supervisor PID is still alive (kill(pid,0)).
+ * Any mismatch / dead session / missing file -> -1 (caller falls back to standalone).
+ * This rejects a stale or cross-reload sidecar left by a prior/killed dev session. */
+static int agent_inspect_stream_live(const char *app_dir)
+{
+    char disc_path[PATH_MAX], dev_path[PATH_MAX];
+    int a = snprintf(disc_path, sizeof(disc_path), "%s/.hull/discovery.json", app_dir);
+    int b = snprintf(dev_path, sizeof(dev_path), "%s/.hull/dev.json", app_dir);
+    if (a < 0 || (size_t)a >= sizeof(disc_path) || b < 0 || (size_t)b >= sizeof(dev_path))
+        return -1;
+
+    char *dev = read_whole_file(dev_path, 64 * 1024);
+    if (!dev) return -1;
+    long sp_dev = json_int_field(dev, "session_pid");
+    free(dev);
+    if (sp_dev <= 0) return -1;
+
+    char *disc = read_whole_file(disc_path, 64 * 1024 * 1024);   /* 64 MB cap */
+    if (!disc) return -1;
+    long sp_disc = json_int_field(disc, "session_pid");
+
+    /* Bind the published generation to a specific live dev session. */
+    if (sp_disc != sp_dev || kill((pid_t)sp_disc, 0) != 0) { free(disc); return -1; }
+
+    fputs(disc, stdout);
+    free(disc);
+    return 0;
+}
+
+/* `hull agent inspect [app_dir] [--out=... --generation=N --session-pid=P]`.
+ * Without publish flags and with a live published generation, streams that generation
+ * (D9). Otherwise delegates to the tool VM (hull.project.inspect): standalone stdout, or
+ * -- when --out is present (used by `hull dev`) -- a fresh publish write. `argv` is
+ * hl_cmd_agent's own (argv[1]=="inspect"), so argv+1 keeps arg[0]="inspect" in the VM. */
+static int cmd_inspect(int argc, char **argv, const HlCommandEnv *env)
+{
+    const char *app_dir = ".";
+    int has_publish_flag = 0;
+    for (int i = 2; i < argc; i++) {          /* argv[1]=="inspect"; args start at 2 */
+        const char *a = argv[i];
+        if (strncmp(a, "--out=", 6) == 0 || strncmp(a, "--generation=", 13) == 0 ||
+            strncmp(a, "--session-pid=", 14) == 0) {
+            has_publish_flag = 1;
+        } else if (a[0] != '-') {
+            app_dir = a;                       /* first positional; multi-positional -> Lua rejects */
+        }
+    }
+
+    if (!has_publish_flag && agent_inspect_stream_live(app_dir) == 0)
+        return 0;                              /* served the live published generation */
+
+    return hull_tool("hull.project.inspect", argc - 1, argv + 1,
+                     env ? env->hull_exe : NULL);
+}
+
 /* ── Command entry point ──────────────────────────────────────────── */
 
 int hl_cmd_agent(int argc, char **argv, const HlCommandEnv *env)
@@ -800,11 +896,10 @@ int hl_cmd_agent(int argc, char **argv, const HlCommandEnv *env)
     /* Composite project summary — one call to orient an agent. */
     if (strcmp(sub, "overview") == 0)     return cmd_overview(sub_argc, sub_argv);
     /* Project source discovery — the canonical analyzed project model (annotated
-     * declarations) as versioned JSON. Delegates to the Lua tool VM (hull.project.inspect
-     * -> hull.project.analyze). argv+1 keeps arg[0]="inspect", arg[1..]=args in the VM. */
+     * declarations) as versioned JSON. A live dev session's published generation is
+     * streamed directly (D9); otherwise the tool VM analyzes (standalone / publish). */
     if (strcmp(sub, "inspect") == 0)
-        return hull_tool("hull.project.inspect", argc - 1, argv + 1,
-                         env ? env->hull_exe : NULL);
+        return cmd_inspect(argc, argv, env);
 #ifdef HL_ENABLE_DB
     if (strcmp(sub, "schema-diff") == 0)  return cmd_schema_diff(sub_argc, sub_argv);
     if (strcmp(sub, "sql") == 0)          return cmd_sql(sub_argc, sub_argv);

--- a/src/hull/commands/dev.c
+++ b/src/hull/commands/dev.c
@@ -40,23 +40,61 @@ static void agent_ensure_dir(const char *app_dir)
 
 static void agent_write_dev_json(const char *app_dir, int port, pid_t pid)
 {
-    char path[PATH_MAX];
+    char path[PATH_MAX], tmp[PATH_MAX];
     int n = snprintf(path, sizeof(path), "%s/.hull/dev.json", app_dir);
     if (n < 0 || (size_t)n >= sizeof(path)) return;
+    int m = snprintf(tmp, sizeof(tmp), "%s/.hull/dev.json.tmp", app_dir);
+    if (m < 0 || (size_t)m >= sizeof(tmp)) return;
 
-    FILE *f = fopen(path, "w");
+    FILE *f = fopen(tmp, "w");
     if (!f) return;
-    fprintf(f, "{\"port\":%d,\"pid\":%d,\"started_at\":%ld}\n",
-            port, (int)pid, (long)time(NULL));
+    /* session_pid = the dev SUPERVISOR pid (stable across reloads); pid = the served
+     * child (changes each reload). The supervisor identity lets `hull agent inspect` bind
+     * a published discovery generation to THIS live dev session. */
+    fprintf(f, "{\"port\":%d,\"pid\":%d,\"session_pid\":%d,\"started_at\":%ld}\n",
+            port, (int)pid, (int)getpid(), (long)time(NULL));
     fclose(f);
+    if (rename(tmp, path) != 0) unlink(tmp);   /* atomic publish (tmp + rename) */
 }
 
-static void agent_remove_dev_json(const char *app_dir)
+/* Publish a fresh discovery generation for the current dev session by spawning
+ * `hull agent inspect <app_dir> --out=<.hull/discovery.json> --generation=N
+ * --session-pid=<supervisor>`. Synchronous (analysis is fast, reloads are human-paced);
+ * child output silenced. Agent-mode only. */
+static void agent_publish_discovery(const char *hull_exe, const char *app_dir, long generation)
+{
+    char out_arg[PATH_MAX + 16], gen_arg[64], sp_arg[64];
+    int n = snprintf(out_arg, sizeof(out_arg), "--out=%s/.hull/discovery.json", app_dir);
+    if (n < 0 || (size_t)n >= sizeof(out_arg)) return;
+    snprintf(gen_arg, sizeof(gen_arg), "--generation=%ld", generation);
+    snprintf(sp_arg, sizeof(sp_arg), "--session-pid=%d", (int)getpid());
+
+    pid_t pid = fork();
+    if (pid < 0) return;
+    if (pid == 0) {
+        signal(SIGINT, SIG_DFL);
+        signal(SIGTERM, SIG_DFL);
+        int devnull = open("/dev/null", O_WRONLY);
+        if (devnull >= 0) {
+            dup2(devnull, STDOUT_FILENO);
+            dup2(devnull, STDERR_FILENO);
+            if (devnull > 2) close(devnull);
+        }
+        const char *pargv[] = { hull_exe, "agent", "inspect",
+                                app_dir, out_arg, gen_arg, sp_arg, NULL };
+        execvp(hull_exe, (char *const *)(uintptr_t)pargv);   /* POSIX execvp does not modify argv */
+        _exit(127);
+    }
+    waitpid(pid, NULL, 0);
+}
+
+static void agent_remove_sidecars(const char *app_dir)
 {
     char path[PATH_MAX];
     int n = snprintf(path, sizeof(path), "%s/.hull/dev.json", app_dir);
-    if (n < 0 || (size_t)n >= sizeof(path)) return;
-    unlink(path);
+    if (n > 0 && (size_t)n < sizeof(path)) unlink(path);
+    n = snprintf(path, sizeof(path), "%s/.hull/discovery.json", app_dir);
+    if (n > 0 && (size_t)n < sizeof(path)) unlink(path);
 }
 
 /* ── Signal handling ──────────────────────────────────────────────── */
@@ -495,6 +533,7 @@ int hl_cmd_dev(int argc, char **argv, const HlCommandEnv *env)
         agent_ensure_dir(app_dir);
 
     int ret = 0;
+    long generation = 0;   /* incremented per (re)spawn; published to .hull/discovery.json */
 
     for (;;) {
         if (dev_got_signal) {
@@ -520,8 +559,13 @@ int hl_cmd_dev(int argc, char **argv, const HlCommandEnv *env)
 
         dev_child_pid = pid;
 
-        if (agent_mode)
+        if (agent_mode) {
             agent_write_dev_json(app_dir, port, pid);
+            /* Publish a new discovery generation for this (re)spawn. A full deterministic
+             * reanalysis each time (no incremental in this story). */
+            generation++;
+            agent_publish_discovery(hull_exe, app_dir, generation);
+        }
 
         /* Record baseline mtime */
         time_t baseline = scan_mtime(app_dir);
@@ -578,7 +622,7 @@ int hl_cmd_dev(int argc, char **argv, const HlCommandEnv *env)
     }
 
     if (agent_mode)
-        agent_remove_dev_json(app_dir);
+        agent_remove_sidecars(app_dir);
 
     free(child_argv);
     return ret;

--- a/src/hull/commands/dev.c
+++ b/src/hull/commands/dev.c
@@ -57,20 +57,30 @@ static void agent_write_dev_json(const char *app_dir, int port, pid_t pid)
     if (rename(tmp, path) != 0) unlink(tmp);   /* atomic publish (tmp + rename) */
 }
 
+static void agent_remove_discovery(const char *app_dir)
+{
+    char path[PATH_MAX];
+    int n = snprintf(path, sizeof(path), "%s/.hull/discovery.json", app_dir);
+    if (n > 0 && (size_t)n < sizeof(path)) unlink(path);
+}
+
 /* Publish a fresh discovery generation for the current dev session by spawning
- * `hull agent inspect <app_dir> --out=<.hull/discovery.json> --generation=N
- * --session-pid=<supervisor>`. Synchronous (analysis is fast, reloads are human-paced);
- * child output silenced. Agent-mode only. */
+ * `hull agent inspect <app_dir> --generation=N --session-pid=<supervisor>` (the C
+ * dispatcher routes the publish flags to the internal hull.project.publish module, which
+ * writes the canonical <app_dir>/.hull/discovery.json atomically). Synchronous (analysis
+ * is fast, reloads are human-paced); child output silenced. Agent-mode only.
+ *
+ * On ANY failure (fork / exec / non-zero exit) the previous same-session discovery sidecar
+ * is REMOVED so `hull agent inspect` falls back to a standalone analysis rather than
+ * serving a stale generation as current. */
 static void agent_publish_discovery(const char *hull_exe, const char *app_dir, long generation)
 {
-    char out_arg[PATH_MAX + 16], gen_arg[64], sp_arg[64];
-    int n = snprintf(out_arg, sizeof(out_arg), "--out=%s/.hull/discovery.json", app_dir);
-    if (n < 0 || (size_t)n >= sizeof(out_arg)) return;
+    char gen_arg[64], sp_arg[64];
     snprintf(gen_arg, sizeof(gen_arg), "--generation=%ld", generation);
     snprintf(sp_arg, sizeof(sp_arg), "--session-pid=%d", (int)getpid());
 
     pid_t pid = fork();
-    if (pid < 0) return;
+    if (pid < 0) { agent_remove_discovery(app_dir); return; }
     if (pid == 0) {
         signal(SIGINT, SIG_DFL);
         signal(SIGTERM, SIG_DFL);
@@ -81,11 +91,13 @@ static void agent_publish_discovery(const char *hull_exe, const char *app_dir, l
             if (devnull > 2) close(devnull);
         }
         const char *pargv[] = { hull_exe, "agent", "inspect",
-                                app_dir, out_arg, gen_arg, sp_arg, NULL };
+                                app_dir, gen_arg, sp_arg, NULL };
         execvp(hull_exe, (char *const *)(uintptr_t)pargv);   /* POSIX execvp does not modify argv */
         _exit(127);
     }
-    waitpid(pid, NULL, 0);
+    int status = 0;
+    if (waitpid(pid, &status, 0) < 0 || !WIFEXITED(status) || WEXITSTATUS(status) != 0)
+        agent_remove_discovery(app_dir);
 }
 
 static void agent_remove_sidecars(const char *app_dir)

--- a/stdlib/cli/lua/hull/project/inspect.lua
+++ b/stdlib/cli/lua/hull/project/inspect.lua
@@ -28,33 +28,14 @@ local function usage_error(msg)
     tool.exit(2)
 end
 
-local function dirname(p) return p:match("^(.*)/[^/]*$") or "." end
-
--- Atomic publish: write a temp sibling then rename over the target (a reader never sees a
--- half-written discovery.json). Design D7. Returns true, or false + reason.
-local function atomic_write(path, data)
-    tool.mkdir(dirname(path))                         -- best-effort; fine if it exists
-    local tmp = path .. ".tmp"
-    if not tool.write_file(tmp, data) then return false, "write failed: " .. tmp end
-    if not tool.rename(tmp, path) then tool.remove_file(tmp); return false, "rename failed" end
-    return true
-end
-
 local function main()
     local positionals = {}
-    local out_path, generation, session_pid = nil, 0, nil
     for i = 1, #arg do
         local a = arg[i]
         if a == "-h" or a == "--help" then
             tool.stdout("usage: hull agent inspect [app_dir]\n"); tool.exit(0)
-        elseif a:match("^%-%-out=") then
-            out_path = a:match("^%-%-out=(.+)$")
-        elseif a:match("^%-%-generation=%d+$") then
-            generation = tonumber(a:match("=(%d+)$"))
-        elseif a:match("^%-%-session%-pid=%d+$") then
-            session_pid = tonumber(a:match("=(%d+)$"))
         elseif a:sub(1, 1) == "-" and a ~= "-" then
-            -- `--json` is the default + only stdout format, accepted for symmetry; else error.
+            -- `--json` is the default + only format, accepted for symmetry; else error.
             if a ~= "--json" then usage_error("unknown flag: " .. a) end
         else
             positionals[#positionals + 1] = a
@@ -68,23 +49,11 @@ local function main()
     end
     local app_dir = positionals[1] or "."
 
-    -- PUBLISH mode (`--out`, used by `hull dev`): a FRESH analysis (never the read path),
-    -- projected + tagged with the dev generation + session identity, written atomically.
-    if out_path then
-        local disc = analyze.analyze(app_dir, { generation = generation, source_kind = "dev" })
-        local p = projection.project(disc)
-        p.session_pid = session_pid                   -- dev-session identity (D7); absent on standalone
-        local okw, reason = atomic_write(out_path, json.encode(p) .. "\n")
-        if not okw then
-            tool.stderr("hull agent inspect: publish " .. tostring(reason) .. "\n"); tool.exit(2)
-        end
-        tool.exit(0)
-    end
-
-    -- STANDALONE mode. The canonical analyzer never raises: it always returns a discovery
-    -- (an invalid one on a bad root / internal defect). Exit 0; the consumer reads
-    -- `valid` / `complete` from the JSON. (The live-published read fast path is handled in
-    -- C before this module is reached -- see cmd_inspect in commands/agent.c.)
+    -- Read/STANDALONE only. Publication is a SEPARATE internal module (hull.project.publish);
+    -- the live-published read fast path is handled in C before this module is reached (see
+    -- cmd_inspect in commands/agent.c). The canonical analyzer never raises: it always
+    -- returns a discovery (an invalid one on a bad root / internal defect). Exit 0; the
+    -- consumer reads `valid` / `complete` from the JSON.
     local disc = analyze.analyze(app_dir, { source_kind = "standalone" })
     tool.stdout(json.encode(projection.project(disc)) .. "\n")
     tool.exit(0)

--- a/stdlib/cli/lua/hull/project/inspect.lua
+++ b/stdlib/cli/lua/hull/project/inspect.lua
@@ -28,14 +28,33 @@ local function usage_error(msg)
     tool.exit(2)
 end
 
+local function dirname(p) return p:match("^(.*)/[^/]*$") or "." end
+
+-- Atomic publish: write a temp sibling then rename over the target (a reader never sees a
+-- half-written discovery.json). Design D7. Returns true, or false + reason.
+local function atomic_write(path, data)
+    tool.mkdir(dirname(path))                         -- best-effort; fine if it exists
+    local tmp = path .. ".tmp"
+    if not tool.write_file(tmp, data) then return false, "write failed: " .. tmp end
+    if not tool.rename(tmp, path) then tool.remove_file(tmp); return false, "rename failed" end
+    return true
+end
+
 local function main()
     local positionals = {}
+    local out_path, generation, session_pid = nil, 0, nil
     for i = 1, #arg do
         local a = arg[i]
         if a == "-h" or a == "--help" then
             tool.stdout("usage: hull agent inspect [app_dir]\n"); tool.exit(0)
+        elseif a:match("^%-%-out=") then
+            out_path = a:match("^%-%-out=(.+)$")
+        elseif a:match("^%-%-generation=%d+$") then
+            generation = tonumber(a:match("=(%d+)$"))
+        elseif a:match("^%-%-session%-pid=%d+$") then
+            session_pid = tonumber(a:match("=(%d+)$"))
         elseif a:sub(1, 1) == "-" and a ~= "-" then
-            -- `--json` is the default + only format, accepted for symmetry; any other flag errors.
+            -- `--json` is the default + only stdout format, accepted for symmetry; else error.
             if a ~= "--json" then usage_error("unknown flag: " .. a) end
         else
             positionals[#positionals + 1] = a
@@ -49,9 +68,23 @@ local function main()
     end
     local app_dir = positionals[1] or "."
 
-    -- The canonical analyzer never raises: it always returns a discovery (an invalid one
-    -- on a bad root / internal defect). The command therefore succeeds (exit 0); the
-    -- consumer reads `valid` / `complete` from the JSON.
+    -- PUBLISH mode (`--out`, used by `hull dev`): a FRESH analysis (never the read path),
+    -- projected + tagged with the dev generation + session identity, written atomically.
+    if out_path then
+        local disc = analyze.analyze(app_dir, { generation = generation, source_kind = "dev" })
+        local p = projection.project(disc)
+        p.session_pid = session_pid                   -- dev-session identity (D7); absent on standalone
+        local okw, reason = atomic_write(out_path, json.encode(p) .. "\n")
+        if not okw then
+            tool.stderr("hull agent inspect: publish " .. tostring(reason) .. "\n"); tool.exit(2)
+        end
+        tool.exit(0)
+    end
+
+    -- STANDALONE mode. The canonical analyzer never raises: it always returns a discovery
+    -- (an invalid one on a bad root / internal defect). Exit 0; the consumer reads
+    -- `valid` / `complete` from the JSON. (The live-published read fast path is handled in
+    -- C before this module is reached -- see cmd_inspect in commands/agent.c.)
     local disc = analyze.analyze(app_dir, { source_kind = "standalone" })
     tool.stdout(json.encode(projection.project(disc)) .. "\n")
     tool.exit(0)

--- a/stdlib/cli/lua/hull/project/publish.lua
+++ b/stdlib/cli/lua/hull/project/publish.lua
@@ -1,0 +1,76 @@
+--
+-- hull.project.publish — the INTERNAL dev-generation publisher (not a user surface).
+--
+-- Spawned by `hull dev --agent` (via the C dispatcher when the publish flags are present)
+-- to write a fresh discovery generation. Distinct from hull.project.inspect (the
+-- user-facing read/standalone command) so the publish authority is not exposed as a
+-- read-command flag. Design: docs/project_discovery_design.md D7.
+--
+-- Contract: `<app_dir> --generation=N --session-pid=P` -- BOTH flags required (partial
+-- combinations are a usage error). Output is ALWAYS the canonical
+-- <app_dir>/.hull/discovery.json (never a caller-supplied path); a fresh analysis
+-- (source="dev"), projected via the shared hull.project.projection, tagged with the
+-- generation + session identity, written ATOMICALLY (tmp + rename).
+--
+-- Tool-module convention: RETURNS main; the dispatcher invokes it only as the entry.
+--
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+--
+
+local analyze    = require("hull.project.analyze")
+local projection = require("hull.project.projection")
+local json       = require("hull.json")
+
+local function usage_error(msg)
+    tool.stderr("hull project publish: " .. msg .. "\n")
+    tool.exit(2)
+end
+
+local function dirname(p) return p:match("^(.*)/[^/]*$") or "." end
+
+-- Atomic write: temp sibling then rename over the target (a reader never sees a partial
+-- discovery.json). Returns true, or false + reason.
+local function atomic_write(path, data)
+    tool.mkdir(dirname(path))                        -- best-effort; fine if it exists
+    local tmp = path .. ".tmp"
+    if not tool.write_file(tmp, data) then return false, "write failed: " .. tmp end
+    if not tool.rename(tmp, path) then tool.remove_file(tmp); return false, "rename failed" end
+    return true
+end
+
+local function main()
+    local positionals = {}
+    local generation, session_pid = nil, nil
+    for i = 1, #arg do
+        local a = arg[i]
+        if a:match("^%-%-generation=%d+$") then
+            generation = tonumber(a:match("=(%d+)$"))
+        elseif a:match("^%-%-session%-pid=%d+$") then
+            session_pid = tonumber(a:match("=(%d+)$"))
+        elseif a:sub(1, 1) == "-" and a ~= "-" then
+            usage_error("unknown flag: " .. a)
+        else
+            positionals[#positionals + 1] = a
+        end
+    end
+    if #positionals > 1 then
+        usage_error("expected at most one app_dir, got " .. #positionals)
+    end
+    -- Both publish flags are required together (reject partial combinations).
+    if not generation or not session_pid then
+        usage_error("--generation and --session-pid are both required")
+    end
+    local app_dir = positionals[1] or "."
+
+    local disc = analyze.analyze(app_dir, { generation = generation, source_kind = "dev" })
+    local p = projection.project(disc)
+    p.session_pid = session_pid                      -- dev-session identity (D7)
+
+    -- CANONICAL output only -- derived from app_dir, never a caller-supplied path.
+    local path = app_dir .. "/.hull/discovery.json"
+    local okw, reason = atomic_write(path, json.encode(p) .. "\n")
+    if not okw then usage_error("publish: " .. tostring(reason)) end
+    tool.exit(0)
+end
+
+return main

--- a/tests/e2e_project_discovery.sh
+++ b/tests/e2e_project_discovery.sh
@@ -157,6 +157,21 @@ RCS=0; "$HULL" agent inspect "$OK" >/dev/null 2>&1 || RCS=$?
 RCF=0; "$HULL" agent inspect --bogus >/dev/null 2>&1 || RCF=$?
 [ "$RCF" = "2" ] && pass "unknown flag -> usage error (exit 2)" || fail "unknown-flag exit ($RCF, want 2)"
 
+# ── internal publish flags require BOTH --generation and --session-pid (all-or-none) ──
+RCP=0; "$HULL" agent inspect "$OK" --generation=5 >/dev/null 2>&1 || RCP=$?
+[ "$RCP" = "2" ] && pass "publish: --generation without --session-pid -> exit 2" || fail "partial publish exit ($RCP, want 2)"
+RCP=0; "$HULL" agent inspect "$OK" --session-pid=5 >/dev/null 2>&1 || RCP=$?
+[ "$RCP" = "2" ] && pass "publish: --session-pid without --generation -> exit 2" || fail "partial publish exit ($RCP, want 2)"
+# a full publish writes the CANONICAL <app_dir>/.hull/discovery.json (no caller path), tagged dev
+rm -f "$OK/.hull/discovery.json" 2>/dev/null || true
+"$HULL" agent inspect "$OK" --generation=3 --session-pid="$$" >/dev/null 2>&1 || true
+if [ -f "$OK/.hull/discovery.json" ]; then
+    pass "publish writes the canonical .hull/discovery.json"
+    assert_py "published file tagged source=dev, generation=3, session_pid" "$(cat "$OK/.hull/discovery.json")" \
+        "d['source']=='dev' and d['generation']==3 and d.get('session_pid')==$$"
+else fail "publish did not write the canonical discovery.json"; fi
+rm -rf "$OK/.hull" 2>/dev/null || true
+
 # ── Slice 3: hull dev --agent publishes generations; inspect reads the LIVE one ──
 DEVAPP="$TMP/devapp"
 mkdir -p "$DEVAPP"
@@ -180,6 +195,15 @@ if [ -f "$DEVAPP/.hull/discovery.json" ]; then
     { [ -n "$SP_DISC" ] && [ "$SP_DISC" = "$SP_DEV" ]; } \
         && pass "discovery.json + dev.json session_pid match" || fail "session_pid mismatch ($SP_DISC vs $SP_DEV)"
 
+    # invalid public CLI forms MUST NOT bypass validation via the live fast path
+    RCX=0; "$HULL" agent inspect "$DEVAPP" extra >/dev/null 2>&1 || RCX=$?
+    [ "$RCX" = "2" ] && pass "live: extra positional -> exit 2 (not streamed)" || fail "live extra-positional exit ($RCX, want 2)"
+    RCX=0; "$HULL" agent inspect "$DEVAPP" --bogus >/dev/null 2>&1 || RCX=$?
+    [ "$RCX" = "2" ] && pass "live: unknown flag -> exit 2 (not streamed)" || fail "live unknown-flag exit ($RCX, want 2)"
+    HOUT=$("$HULL" agent inspect "$DEVAPP" --help 2>/dev/null || true)
+    { echo "$HOUT" | grep -q "usage:" && ! echo "$HOUT" | grep -q '"source"'; } \
+        && pass "live: --help prints usage (not streamed)" || fail "live --help did not print usage"
+
     GEN1=$(printf '%s' "$OUTD" | python3 -c 'import json,sys;print(json.load(sys.stdin)["generation"])' 2>/dev/null || echo 0)
     # a source change triggers a reload -> a NEW generation
     printf '\n---@added\nlocal x = 1\nreturn home, x\n' >> "$DEVAPP/app.lua"
@@ -192,6 +216,22 @@ if [ -f "$DEVAPP/.hull/discovery.json" ]; then
     { [ "$NEWGEN" -gt "$GEN1" ]; } 2>/dev/null \
         && pass "source change -> reload -> new generation ($GEN1 -> $NEWGEN)" \
         || fail "no new generation after reload (gen1=$GEN1, newgen=$NEWGEN)"
+
+    # publisher FAILURE: break the atomic write target (a dir where the .tmp file goes) so
+    # the next reload's publish fails. The prior same-session generation must be REMOVED
+    # (dev.c) so inspect falls back to standalone rather than serving a stale generation.
+    mkdir "$DEVAPP/.hull/discovery.json.tmp"
+    printf '\n-- force another reload\n' >> "$DEVAPP/app.lua"
+    STANDALONE=0; i=0
+    while [ "$i" -lt 30 ]; do
+        S=$("$HULL" agent inspect "$DEVAPP" 2>/dev/null | python3 -c 'import json,sys;print(json.load(sys.stdin)["source"])' 2>/dev/null || echo "")
+        if [ "$S" = "standalone" ]; then STANDALONE=1; break; fi
+        sleep 0.5; i=$((i + 1))
+    done
+    [ "$STANDALONE" = "1" ] \
+        && pass "publisher failure -> stale generation removed -> standalone" \
+        || fail "stale generation still served after publisher failure"
+    rmdir "$DEVAPP/.hull/discovery.json.tmp" 2>/dev/null || true
 
     kill "$DEV_PID" 2>/dev/null || true; wait "$DEV_PID" 2>/dev/null || true; DEV_PID=""
     { [ ! -f "$DEVAPP/.hull/discovery.json" ] && [ ! -f "$DEVAPP/.hull/dev.json" ]; } \
@@ -218,6 +258,31 @@ printf '{"schema_version":1,"source":"dev","generation":9,"session_pid":%s,"decl
 OUTST=$("$HULL" agent inspect "$STALE" 2>/dev/null)
 assert_py "dead-session sidecar ignored -> fresh standalone analysis" "$OUTST" \
     'd["source"]=="standalone" and any(x["name"]=="m" for x in d["declarations"])'
+
+# ── malformed / truncated sidecars -> standalone (a LIVE session_pid so ONLY the
+#    malformation, not liveness, drives the fallback; $$ = this shell, alive) ──
+MAL="$TMP/malformed"
+mkdir -p "$MAL/.hull"
+cat > "$MAL/app.lua" <<'EOF'
+---@main
+local function m() end
+return m
+EOF
+# (a) discovery.json session_pid is a non-integer token
+printf '{"port":1,"pid":1,"session_pid":%s,"started_at":1}\n' "$$" > "$MAL/.hull/dev.json"
+printf '{"schema_version":1,"source":"dev","generation":9,"session_pid":"12x3","declarations":[]}\n' > "$MAL/.hull/discovery.json"
+OUTM1=$("$HULL" agent inspect "$MAL" 2>/dev/null)
+assert_py "malformed discovery session_pid -> standalone" "$OUTM1" 'd["source"]=="standalone"'
+# (b) dev.json session_pid malformed
+printf '{"port":1,"pid":1,"session_pid":"nan","started_at":1}\n' > "$MAL/.hull/dev.json"
+printf '{"schema_version":1,"source":"dev","generation":9,"session_pid":%s,"declarations":[]}\n' "$$" > "$MAL/.hull/discovery.json"
+OUTM2=$("$HULL" agent inspect "$MAL" 2>/dev/null)
+assert_py "malformed dev session_pid -> standalone" "$OUTM2" 'd["source"]=="standalone"'
+# (c) discovery.json truncated before the session_pid field
+printf '{"port":1,"pid":1,"session_pid":%s,"started_at":1}\n' "$$" > "$MAL/.hull/dev.json"
+printf '{"schema_version":1,"source":"dev","generat' > "$MAL/.hull/discovery.json"
+OUTM3=$("$HULL" agent inspect "$MAL" 2>/dev/null)
+assert_py "truncated discovery sidecar -> standalone" "$OUTM3" 'd["source"]=="standalone"'
 
 echo ""
 echo "=== hull agent inspect E2E: $PASS passed, $FAIL failed ==="

--- a/tests/e2e_project_discovery.sh
+++ b/tests/e2e_project_discovery.sh
@@ -278,11 +278,25 @@ printf '{"port":1,"pid":1,"session_pid":"nan","started_at":1}\n' > "$MAL/.hull/d
 printf '{"schema_version":1,"source":"dev","generation":9,"session_pid":%s,"declarations":[]}\n' "$$" > "$MAL/.hull/discovery.json"
 OUTM2=$("$HULL" agent inspect "$MAL" 2>/dev/null)
 assert_py "malformed dev session_pid -> standalone" "$OUTM2" 'd["source"]=="standalone"'
-# (c) discovery.json truncated before the session_pid field
+# (c) discovery.json truncated BEFORE the session_pid field
 printf '{"port":1,"pid":1,"session_pid":%s,"started_at":1}\n' "$$" > "$MAL/.hull/dev.json"
 printf '{"schema_version":1,"source":"dev","generat' > "$MAL/.hull/discovery.json"
 OUTM3=$("$HULL" agent inspect "$MAL" 2>/dev/null)
-assert_py "truncated discovery sidecar -> standalone" "$OUTM3" 'd["source"]=="standalone"'
+assert_py "truncated (before PID) discovery sidecar -> standalone" "$OUTM3" 'd["source"]=="standalone"'
+# (d) discovery.json truncated IMMEDIATELY AFTER a valid matching session_pid (no closing
+#     brace) -- the session_pid token alone would match, but the DOCUMENT is incomplete
+printf '{"session_pid":%s' "$$" > "$MAL/.hull/discovery.json"
+OUTM4=$("$HULL" agent inspect "$MAL" 2>/dev/null)
+assert_py "truncated right after a matching PID -> standalone (envelope invalid)" "$OUTM4" 'd["source"]=="standalone"'
+# (e) discovery.json truncated LATER in the document (valid PID, then cut mid-structure)
+printf '{"session_pid":%s,"declarations":[{"id":"x","annota' "$$" > "$MAL/.hull/discovery.json"
+OUTM5=$("$HULL" agent inspect "$MAL" 2>/dev/null)
+assert_py "truncated later in the document -> standalone (envelope invalid)" "$OUTM5" 'd["source"]=="standalone"'
+# sanity: a COMPLETE valid doc with a matching live PID IS served (proves the gate isn't
+# rejecting everything)
+printf '{"schema_version":1,"source":"dev","generation":7,"session_pid":%s,"declarations":[]}\n' "$$" > "$MAL/.hull/discovery.json"
+OUTM6=$("$HULL" agent inspect "$MAL" 2>/dev/null)
+assert_py "complete valid doc + live matching PID IS served (source=dev)" "$OUTM6" 'd["source"]=="dev" and d["generation"]==7'
 
 echo ""
 echo "=== hull agent inspect E2E: $PASS passed, $FAIL failed ==="

--- a/tests/e2e_project_discovery.sh
+++ b/tests/e2e_project_discovery.sh
@@ -297,6 +297,13 @@ assert_py "truncated later in the document -> standalone (envelope invalid)" "$O
 printf '{"schema_version":1,"source":"dev","generation":7,"session_pid":%s,"declarations":[]}\n' "$$" > "$MAL/.hull/discovery.json"
 OUTM6=$("$HULL" agent inspect "$MAL" 2>/dev/null)
 assert_py "complete valid doc + live matching PID IS served (source=dev)" "$OUTM6" 'd["source"]=="dev" and d["generation"]==7'
+# (f) valid JSON with a matching PID, then an embedded NUL + trailing garbage: the COMPLETE
+#     on-disk document is invalid -> standalone (must parse/emit the exact byte length, not
+#     stop at the NUL via strlen/fputs)
+{ printf '{"schema_version":1,"source":"dev","generation":8,"session_pid":%s,"declarations":[]}' "$$"; printf '\000trailing-garbage'; } > "$MAL/.hull/discovery.json"
+OUTM7=$("$HULL" agent inspect "$MAL" 2>/dev/null)
+assert_py "embedded NUL + trailing garbage -> standalone (byte-length validation)" "$OUTM7" \
+    'd["source"]=="standalone"'
 
 echo ""
 echo "=== hull agent inspect E2E: $PASS passed, $FAIL failed ==="

--- a/tests/e2e_project_discovery.sh
+++ b/tests/e2e_project_discovery.sh
@@ -10,7 +10,10 @@
 # frontend capabilities are accurate; static/ browser assets are pruned while application
 # .js is honestly unsupported (never parsed as Lua) -> complete=false; a missing root is
 # an invalid+incomplete discovery; and the public JSON leaks NO generation-internal state
-# (handle / _by_source / _handles / by_id).
+# (handle / _by_source / _handles / by_id). Slice 3 also drives a live `hull dev --agent`:
+# it publishes a discovery.json generation per reload (session_pid-bound), inspect serves
+# the LIVE generation, a source change bumps the generation, and a dead/stale session
+# sidecar is ignored (falls back to standalone).
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -32,8 +35,9 @@ fi
 fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
 pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 
+DEV_PID=""
 TMP=$(mktemp -d)
-trap 'chmod -R u+rwx "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
+trap '[ -n "$DEV_PID" ] && kill "$DEV_PID" 2>/dev/null; chmod -R u+rwx "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
 
 # assert_py "<name>" "<json>" "<python expr over d>": pass iff the expr is truthy.
 assert_py() {
@@ -152,6 +156,68 @@ RCS=0; "$HULL" agent inspect "$OK" >/dev/null 2>&1 || RCS=$?
 # an unknown flag is a usage error too
 RCF=0; "$HULL" agent inspect --bogus >/dev/null 2>&1 || RCF=$?
 [ "$RCF" = "2" ] && pass "unknown flag -> usage error (exit 2)" || fail "unknown-flag exit ($RCF, want 2)"
+
+# ── Slice 3: hull dev --agent publishes generations; inspect reads the LIVE one ──
+DEVAPP="$TMP/devapp"
+mkdir -p "$DEVAPP"
+cat > "$DEVAPP/app.lua" <<'EOF'
+---@route GET /
+local function home() end
+return home
+EOF
+"$HULL" dev --agent -p 39811 "$DEVAPP/app.lua" >/dev/null 2>&1 &
+DEV_PID=$!
+# wait for the first published generation (up to ~10s)
+i=0; while [ "$i" -lt 20 ] && [ ! -f "$DEVAPP/.hull/discovery.json" ]; do sleep 0.5; i=$((i + 1)); done
+
+if [ -f "$DEVAPP/.hull/discovery.json" ]; then
+    OUTD=$("$HULL" agent inspect "$DEVAPP" 2>/dev/null)
+    assert_py "dev running -> published generation served (source=dev, generation>=1)" "$OUTD" \
+        'd["source"]=="dev" and d["generation"]>=1'
+    assert_py "published generation carries a session_pid" "$OUTD" 'd.get("session_pid") is not None'
+    SP_DISC=$(grep -o '"session_pid":[0-9]*' "$DEVAPP/.hull/discovery.json" | head -1)
+    SP_DEV=$(grep -o '"session_pid":[0-9]*' "$DEVAPP/.hull/dev.json" | head -1)
+    { [ -n "$SP_DISC" ] && [ "$SP_DISC" = "$SP_DEV" ]; } \
+        && pass "discovery.json + dev.json session_pid match" || fail "session_pid mismatch ($SP_DISC vs $SP_DEV)"
+
+    GEN1=$(printf '%s' "$OUTD" | python3 -c 'import json,sys;print(json.load(sys.stdin)["generation"])' 2>/dev/null || echo 0)
+    # a source change triggers a reload -> a NEW generation
+    printf '\n---@added\nlocal x = 1\nreturn home, x\n' >> "$DEVAPP/app.lua"
+    NEWGEN=0; i=0
+    while [ "$i" -lt 30 ]; do
+        G=$("$HULL" agent inspect "$DEVAPP" 2>/dev/null | python3 -c 'import json,sys;print(json.load(sys.stdin).get("generation",0))' 2>/dev/null || echo 0)
+        if [ "$G" -gt "$GEN1" ] 2>/dev/null; then NEWGEN=$G; break; fi
+        sleep 0.5; i=$((i + 1))
+    done
+    { [ "$NEWGEN" -gt "$GEN1" ]; } 2>/dev/null \
+        && pass "source change -> reload -> new generation ($GEN1 -> $NEWGEN)" \
+        || fail "no new generation after reload (gen1=$GEN1, newgen=$NEWGEN)"
+
+    kill "$DEV_PID" 2>/dev/null || true; wait "$DEV_PID" 2>/dev/null || true; DEV_PID=""
+    { [ ! -f "$DEVAPP/.hull/discovery.json" ] && [ ! -f "$DEVAPP/.hull/dev.json" ]; } \
+        && pass "sidecars removed on dev exit" || fail "sidecars linger after dev exit"
+    OUTS=$("$HULL" agent inspect "$DEVAPP" 2>/dev/null)
+    assert_py "after dev stops -> standalone (generation 0)" "$OUTS" \
+        'd["source"]=="standalone" and d["generation"]==0'
+else
+    fail "dev did not publish discovery.json within timeout"
+    kill "$DEV_PID" 2>/dev/null || true; wait "$DEV_PID" 2>/dev/null || true; DEV_PID=""
+fi
+
+# ── stale/crashed-session robustness: sidecars with a DEAD session_pid -> standalone ──
+STALE="$TMP/stale"
+mkdir -p "$STALE/.hull"
+cat > "$STALE/app.lua" <<'EOF'
+---@main
+local function m() end
+return m
+EOF
+DEADPID=2147480000   # far above any real pid -> kill(pid,0) fails -> not live
+printf '{"port":1,"pid":1,"session_pid":%s,"started_at":1}\n' "$DEADPID" > "$STALE/.hull/dev.json"
+printf '{"schema_version":1,"source":"dev","generation":9,"session_pid":%s,"declarations":[]}\n' "$DEADPID" > "$STALE/.hull/discovery.json"
+OUTST=$("$HULL" agent inspect "$STALE" 2>/dev/null)
+assert_py "dead-session sidecar ignored -> fresh standalone analysis" "$OUTST" \
+    'd["source"]=="standalone" and any(x["name"]=="m" for x in d["declarations"])'
 
 echo ""
 echo "=== hull agent inspect E2E: $PASS passed, $FAIL failed ==="


### PR DESCRIPTION
**Slice 3** of project source discovery: `hull dev` integration (design D7/D9). A live `hull dev --agent` session publishes the analyzed project model per reload, and `hull agent inspect` serves that **live generation** instead of re-analyzing — both through the one canonical analyzer + the shared `hull.project.projection`.

Scope: `hull dev` publish + `hull agent inspect` live-read. No Query/Compute IR, no lowering, no build wiring (Slice 4). The non-TUI `--agent` loop only; `hull dev --tui` publishing is a documented follow-up.

## Publish (`dev.c`, `--agent` only)
Each (re)spawn increments a monotonic `generation` and spawns `hull agent inspect <app_dir> --out=<.hull/discovery.json> --generation=N --session-pid=<supervisor>`. `inspect.lua`'s new `--out` mode runs a **fresh** analysis (`source="dev"`), projects it, tags it with the generation + `session_pid`, and writes it **atomically** (tmp+rename). `dev.json` gains `session_pid` — the dev **supervisor** PID, stable across reloads (the served child PID changes each reload) — and is itself written atomically. Both sidecars are removed on dev exit. Publish never reads a published generation, so there's no recursion.

## Read (`agent.c` `cmd_inspect`)
Without publish flags, the published generation is streamed **only when** both sidecars exist, their `session_pid` match, **and** `kill(session_pid,0)` confirms the supervisor is alive (D9). Any mismatch / dead session / missing file → fall back to the tool VM for a **standalone** analysis — so a stale or crashed-session sidecar is never served as current. Liveness stays in the main process (not the tool sandbox). Provenance is visible: a live generation is `source="dev"`, a standalone one `source="standalone"`.

## Tests
`e2e_project_discovery.sh` (+10 assertions over a **real backgrounded dev server**): dev publishes a generation; `session_pid` matches across both sidecars; a source change → reload → a **new generation (1→2)**; sidecars removed on exit; after exit → standalone; and a **dead-session sidecar is ignored** → fresh standalone analysis. **76/76 unit; e2e_project_discovery 25 → 35; e2e_analyze 25/25; luacheck clean.**

Slice 4 (documented build seam) follows.
