### PR TITLE
feat(project): Slice 4 — build seam (abstraction-only, documented + tested)

### DIFF
--- a/docs/project_discovery_design.md
+++ b/docs/project_discovery_design.md
@@ -1,7 +1,7 @@
 # Project Source Discovery — design record
 
-Status: **RATIFIED (with amendments). Slices 1-2 MERGED (#356, #357); Slice 3
-implemented; Slice 4 pending.**
+Status: **RATIFIED (with amendments). COMPLETE — Slices 1-3 MERGED (#356, #357,
+#358); Slice 4 implemented (build seam documented + tested, no `build.lua` change).**
 Author: (design-first, per the story's required cadence)
 Related: `docs/lua_source_analysis_design.md`, `docs/hull_source_scope_design.md`,
 `docs/hull_analyze_design.md`, `docs/hull_analyze_lint_design.md`.
@@ -414,6 +414,34 @@ and records this exact insertion point, without rewriting the build pipeline or
 adding a dormant per-build cost. (Slice 4 therefore documents + tests the
 abstraction and the seam; it does not modify `build.lua`.)
 
+**The seam recipe (for the first lowering consumer).** When a Query/Compute IR
+codegen step lands, it wires into `stdlib/cli/lua/hull/build.lua`'s `main()` at
+the one marked point — **after `parse_args()` (so `opts.app_dir` is resolved) and
+before `discover()` (so the produced sources can be emitted)** — like:
+
+```lua
+-- (future) only when a lowering consumer is present:
+local project = require("hull.project.analyze")
+local discovery = project.analyze(opts.app_dir)        -- the canonical model, once
+if not discovery.valid then error("project analysis failed: see diagnostics") end
+for _, id in ipairs(discovery.indexes.by_annotation["query"] or {}) do
+    local decl = discovery.indexes.by_id[id]           -- name/kind/range/annotations
+    local ctx = project.resolve_handle(discovery, decl.handle)  -- {frontend, unit, declaration}
+    -- ctx.frontend.scope(ctx.unit) etc. -> frontend semantics THROUGH the boundary
+    emit_query_ir(decl, ctx)                            -- the codegen step (a separate story)
+end
+```
+
+The consumer reaches everything it needs — annotated declarations by annotation
+name, the normalized decl facts, and frontend-specific semantics via the opaque
+handle + the frontend contract — **without traversing any AST and without
+`build.lua` owning discovery**. `hull.project.analyze` is the sole entry; the
+build step is a consumer. This whole consumer path (`by_annotation` → `by_id` →
+`resolve_handle` → `frontend.scope`) is exercised by a `test_project.lua` case so
+the abstraction is proven build-ready before any codegen exists, and
+`e2e_project_discovery.sh` runs the analyzer over a real repository example app
+tree. **Nothing in `build.lua` changes in this story.**
+
 ### D11 — JavaScript honest behavior → **known language, `analyzable=false`, no parse, honest per-file diagnostic, and it makes the generation `complete=false`** [RATIFIED, amended]
 
 The registry knows `javascript` (`.js/.mjs/.cjs`) with `capabilities={}` and
@@ -509,12 +537,15 @@ attribution, no em-dashes.
     after exit → standalone; and dead-session / malformed / truncated sidecars →
     standalone.
 
-- **Slice 4 — build seam (D10), abstraction-only.**
-  - Ship + test `hull.project.analyze` as the host abstraction a build consumer
-    would call; document the exact `build.lua main()` insertion point for the
-    first lowering consumer. **`build.lua` is not modified** and no per-build
-    parse is added. A test asserts the abstraction returns the same
-    `ProjectDiscovery` a build consumer would receive; the doc records the seam.
+- **Slice 4 — build seam (D10), abstraction-only. DONE.**
+  - `hull.project.analyze` is the host abstraction a build consumer calls; the
+    exact `build.lua main()` insertion point (after `parse_args()`, before
+    `discover()`) + a consumer recipe are documented in D10. **`build.lua` is NOT
+    modified** and no per-build parse is added. A `test_project.lua` case exercises
+    the full consumer path (`by_annotation` → `by_id` → `resolve_handle` →
+    `frontend.scope`) proving the abstraction is build-ready before any codegen
+    exists; `e2e_project_discovery.sh` runs the analyzer over a real repository
+    example app tree.
 
 **Acceptance (mapped to the story's list):** deterministic output (S1/S2);
 annotations discovered without execution (S1/S2); unknown annotations survive

--- a/stdlib/cli/lua/hull/project/tests/test_project.lua
+++ b/stdlib/cli/lua/hull/project/tests/test_project.lua
@@ -384,5 +384,39 @@ do
         "projection keeps public decl id + annotations")
 end
 
+-- ── build seam (D10): the abstraction is consumable by a future lowering consumer ──
+-- Simulates what a Query/Compute IR lowerer does through the PUBLIC model + the frontend
+-- boundary -- annotation-name -> ids -> decl -> handle -> frontend semantics -- with no
+-- AST traversal and no build.lua involvement.
+do
+    local analyze = require("hull.project.analyze")
+    _G.tool = make_tool({
+        ["q/app.lua"] =
+            "---@query users\nlocal function list_users() end\n" ..
+            "---@compute score\nlocal function score() end\nreturn list_users, score\n",
+    })
+    local disc = analyze.analyze("q")   -- exactly what a build consumer would call
+    _G.tool = nil
+
+    ok(disc.valid and disc.complete, "a build-ready project analyzes valid + complete")
+    -- 1. reach annotated decls by annotation NAME (no per-frontend AST walk)
+    ok(disc.indexes.by_annotation["query"] and #disc.indexes.by_annotation["query"] == 1,
+        "consumer finds @query-annotated decls by annotation name")
+    -- 2. resolve the id to the normalized decl fact
+    local qid = disc.indexes.by_annotation["query"][1]
+    local qdecl = disc.indexes.by_id[qid]
+    ok(qdecl and qdecl.name == "list_users" and qdecl.kind == "local_function",
+        "consumer resolves the @query decl (name + kind) via by_id")
+    -- 3. reach FRONTEND-specific semantics THROUGH the boundary via the handle
+    local resolved = analyze.resolve_handle(disc, qdecl.handle)
+    ok(resolved and resolved.frontend and resolved.unit and resolved.declaration,
+        "consumer resolves the decl handle to {frontend, unit, declaration}")
+    -- 4. the frontend exposes scope through the contract (consumer never touches the AST)
+    local sc = resolved.frontend.scope(resolved.unit)
+    ok(sc and sc.bindings, "consumer reaches scope via the frontend boundary")
+    -- distinct domains stay separable for distinct lowerers
+    ok(disc.indexes.by_annotation["compute"], "a @compute lowerer finds its own decls independently")
+end
+
 print(string.format("test_project: %d passed, %d failed", pass, fail))
 return { pass = pass, fail = fail, failures = failures }

--- a/tests/e2e_project_discovery.sh
+++ b/tests/e2e_project_discovery.sh
@@ -305,6 +305,13 @@ OUTM7=$("$HULL" agent inspect "$MAL" 2>/dev/null)
 assert_py "embedded NUL + trailing garbage -> standalone (byte-length validation)" "$OUTM7" \
     'd["source"]=="standalone"'
 
+# ── build-readiness (Slice 4): the analyzer runs on a REAL repository example tree ──
+if [ -d examples/hello ]; then
+    OUTE=$("$HULL" agent inspect examples/hello 2>/dev/null)
+    assert_py "analyzes a real example app tree (valid, >=1 Lua source analyzed)" "$OUTE" \
+        'd["valid"] is True and d["summary"]["sources_analyzed"] >= 1'
+fi
+
 echo ""
 echo "=== hull agent inspect E2E: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
**Slice 4 (final)** of project source discovery: the build-context seam (design D10). It establishes the seam as a **documented, tested abstraction** — **without** wiring `build.lua` or adding a per-build parse. Making `build.lua` initiate host analysis before any lowering consumer exists would be premature work on every build for no consumer.

Scope: the abstraction + the documented seam. No Query/Compute IR, no lowering, no `build.lua` change — exactly the ratified D10 shape. This closes the story.

## What's here
- **Documented seam (D10):** `hull.project.analyze` is the host abstraction a future Query/Compute IR codegen step calls. The exact insertion point is recorded — `build.lua main()`, **after `parse_args()` (app_dir resolved), before `discover()` (produced sources emittable)** — with a concrete consumer recipe: `analyze(app_dir)` → `indexes.by_annotation[name]` → `by_id` → decl → `resolve_handle` → `frontend.scope`.
- **Consumer-simulation test** (`test_project.lua`, 89 → 95): exercises the full public path a lowerer uses (`by_annotation` → `by_id` → `resolve_handle` → `frontend.scope`) on a controlled fixture, with distinct annotation domains (`@query` / `@compute`) staying separable for distinct lowerers — proving the abstraction is build-ready *before* any codegen exists, with **no AST traversal** and no `build.lua` ownership of discovery.
- **Build-readiness e2e** (`e2e_project_discovery.sh`, 50 → 51): the analyzer runs over a **real repository example app tree** (`examples/hello`) — valid, ≥1 Lua source analyzed.

**`build.lua` is not modified.** 76/76 unit; e2e_project_discovery 51/51; e2e_analyze 25/25; luacheck clean.

## Story complete
This is the last slice of the host-owned, frontend-neutral project source-discovery system:
- **S1** (#356): the canonical analyzer + Lua frontend + `ProjectDiscovery` model.
- **S2** (#357): standalone `hull agent inspect` + shared projection.
- **S3** (#358): `hull dev` generation publishing + live inspect read.
- **S4** (this): the documented, tested build seam.

Tracked follow-up (unchanged): `hull dev --tui --agent` publishing (currently the non-TUI agent loop is covered).
