### PR TITLE
docs: document project source discovery + hull agent inspect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ hull agent db schema .                 # show database tables and columns
 hull agent request GET /health         # HTTP request to the running server
 hull agent status .                    # check if dev server is running
 hull agent test .                      # run tests with JSON output
+hull agent inspect .                   # analyzed project model: annotated declarations
 ```
 
 ## Architecture Overview
@@ -276,6 +277,26 @@ Eighteen additional subcommands close the iterative-edit loop. All JSON to stdou
 #### `hull agent overview [app_dir]`
 
 One-shot snapshot. Composes manifest + modules + capabilities + routes + compute/gpu inventory + cache state into a single JSON document. Cheaper than calling each subcommand individually when an agent just wants "what's this app's overall shape".
+
+#### `hull agent inspect [app_dir]`
+
+The **project source-discovery** model as versioned JSON: a static analysis of the app's Lua source (parsed by the pure-Lua `hull.source.*` layer, **without executing app code**) that reports the **annotated declarations** — `---@name` annotations attached to `local` / `local function` / `function` declarations — with exact ranges, deterministic IDs, and `by_annotation` / `by_source` / `by_language` / `by_id` indexes.
+
+- Top-level fields: `schema_version`, `generation`, `source` (`"standalone"` | `"dev"`), `project_root`, `valid` (no source rejected/failed), `complete` (every application source had an analyzable frontend), `sources[]`, `frontends[]`, `declarations[]` (annotated-only), `diagnostics[]`, `summary`, `indexes`.
+- Runs **standalone**, or — when a live `hull dev --agent` session has published a generation — serves that live `.hull/discovery.json` generation (same schema; `source: "dev"`, `generation >= 1`).
+- Exit 0 whenever a discovery is produced (validity is data: read `valid` / `complete`); exit 2 only on a usage error (e.g. a second positional root).
+- JavaScript is a reserved-but-not-yet-analyzable frontend: an application `.js` is reported `status: "unsupported"` and sets `complete: false`, and is **never parsed as Lua**; `static/*.js` browser assets are pruned.
+- CLI-only (not exposed via `hull mcp`). Foundation for a future codegen step (Query/Compute IR). Design: [docs/project_discovery_design.md](docs/project_discovery_design.md).
+
+```json
+{"schema_version":1,"generation":0,"source":"standalone","project_root":"myapp",
+ "valid":true,"complete":true,
+ "declarations":[{"id":"lua:app.lua:local_function:home:32-36","kind":"local_function",
+   "name":"home","path":"app.lua","range":{"start":32,"stop":36,"line":3,"col":16},
+   "annotations":[{"name":"route","value":"GET /","frontend":"lua",
+     "target_group_id":"lua:app.lua:local_function:g20-45"}]}],
+ "indexes":{"by_annotation":{"route":["lua:app.lua:local_function:home:32-36"]}}}
+```
 
 #### `hull agent auth-status [app_dir]` (v0.3.0)
 

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -184,6 +184,7 @@ from the CLI:
 | What does the manifest resolve to | `hull agent manifest` |
 | Is my app ready to deploy | `hull agent deploy` |
 | Run a request without booting the full server | `hull agent endpoint POST /items` |
+| What `---@`-annotated declarations does my Lua source define (analyzed statically, no execution) | `hull agent inspect` |
 
 There are dozens of `hull agent` subcommands - see [README.md § Using Hull
 with AI Agents](README.md#using-hull-with-ai-agents) for the full

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -843,6 +843,13 @@ stdlib/                 # Embedded standard library
                         #   what apps can import. `hull new`'s modular
                         #   templates (templates_rest.lua, etc.) also live
                         #   here. They're embedded scaffolds, not user code.
+    source/             #     Pure-Lua Lua-5.4 source analysis (lexer/parser/
+                        #     ranges/diagnostics/annotations/scope/lint/discover)
+                        #     + hull.source.analyze (`hull analyze`). Never load().
+    project/            #     Frontend-neutral project source discovery on top of
+                        #     source/: registry, frontend_lua, model, analyze,
+                        #     projection, inspect, publish (`hull agent inspect`,
+                        #     `hull dev --agent` generations). See docs/project_discovery_design.md
 vendor/                 # Vendored libraries (do not modify)
 tests/                  # Unit tests (test_*.c) and E2E scripts (e2e_*.sh)
   fixtures/             #   Test fixtures (null_app, etc.)
@@ -1168,6 +1175,48 @@ The naming pattern is `HULL_NO_<KIND>_CACHE` where `<KIND>` is the registry's `e
 
 **`hull agent overview [app_dir]`**. Single-shot composite project summary an agent can read when dropped into an unfamiliar app dir. Composes runtime detection, route stats (count + methods + ws/sse flags), compute modules + AOT readiness + wamrc state, GPU shaders, migrations, declared modules, tests, and a `build_ready` flag. No DB connection; agents needing pending-migration counts call `hull agent migrate` separately.
 
+**`hull agent inspect [app_dir]`**. Emit the **project source-discovery** model (annotated declarations) as versioned JSON. Delegates to the Lua tool VM (`hull.project.inspect` → `hull.project.analyze`) — the one canonical, host-owned analyzer; it never re-scans or parses source itself. Standalone by default; when a live `hull dev --agent` session has published a generation, the C dispatcher (`cmd_inspect`) streams that generation instead (bound to the session by `session_pid` + `kill(pid,0)` liveness + a full `sh_json_parse` envelope validation). At most one positional root (`inspect a b` → exit 2). Exit 0 whenever a discovery is produced — validity is data in the JSON (`valid` / `complete`). This is a CLI-only agent subcommand (not MCP-wired). See "Project source discovery" below and [docs/project_discovery_design.md](docs/project_discovery_design.md).
+
+### Project source discovery (`hull.source.*` + `hull.project.*`)
+
+Hull statically analyzes an app's **Lua source WITHOUT executing it**, producing a canonical
+representation of annotated declarations that a future codegen step (Query/Compute IR) can
+consume. Two layers, both **pure Lua in the sandboxed tool VM** (the whole analysis brain is
+zero C):
+
+- **`hull.source.*`** (`stdlib/cli/lua/hull/source/`) — the language-analysis layer: a
+  pure-Lua recursive-descent Lua 5.4 lexer/parser (NEVER `load()`), half-open byte ranges,
+  diagnostics, the generic `---@` annotation attach (to `local_declaration` /
+  `function_declaration` only), a scope/binding resolver, and the `hull analyze` lint engine.
+  Public contract `hull.source.lua` (`parse(source, {path?}) -> (unit, err)`, never raises).
+  `hull.source.discover` is the shared hardened bounded walker (extracted from `hull analyze`;
+  exclude-dirs pruned during traversal, canonical containment, deterministic/regular/no-symlink)
+  — the ONE recursive source walker in Hull. Design: [docs/lua_source_analysis_design.md](docs/lua_source_analysis_design.md), [docs/hull_analyze_design.md](docs/hull_analyze_design.md).
+- **`hull.project.*`** (`stdlib/cli/lua/hull/project/`) — the frontend-neutral project layer
+  on top: `registry` (extension → frontend map; Lua analyzable, `js/mjs/cjs` reserved +
+  `analyzable=false`, never parsed as Lua), `frontend_lua` (the ONLY module that knows Lua AST
+  layouts), `model` (the `ProjectDiscovery` — deterministic textual IDs, per-name facts sharing
+  a `group_id` with each annotation carrying `target_group_id` + `frontend`, annotated-only
+  public `declarations[]`, independent `valid` / `complete` axes, `by_annotation`/`by_source`/
+  `by_language`/`by_id`/`annotated` indexes), `analyze` (the single canonical host analyzer:
+  root canonicalization, a `pcall` boundary that converts any internal defect into a
+  `project.internal` invalid discovery, a generation-unique handle table + `resolve_handle`),
+  `projection` (the one side-effect-free wire-schema, dropping all generation-internal state),
+  `inspect` (the `hull agent inspect` read/standalone entry), and `publish` (the internal
+  dev-generation publisher). Design: [docs/project_discovery_design.md](docs/project_discovery_design.md).
+
+`hull dev --agent` publishes a `.hull/discovery.json` **generation** per (re)spawn (fresh
+analysis, atomic tmp+rename, tagged with the supervisor `session_pid`); `hull agent inspect`
+serves that live generation or, absent a live session, runs one standalone analysis — same
+schema either way (`source: "dev"` vs `"standalone"`). The build seam is documented + tested
+but **abstraction-only**: `build.lua` is unchanged and does no per-build parse; a future
+lowering consumer calls `hull.project.analyze(app_dir)` in `main()` (after `parse_args()`,
+before `discover()`). ~180 lines of hardened C (in `agent.c` + `dev.c`) handle only the
+live-read/sidecar/publish glue; all source parsing stays in Lua. Tests:
+`stdlib/cli/lua/hull/project/tests/test_project.lua` (UTEST leg `project_discovery`) +
+`tests/e2e_project_discovery.sh` (`make e2e-project-discovery`, incl. a live backgrounded
+`hull dev --agent`).
+
 **`hull sign-release <manifest> --key <secret_key>`**. Sign a release manifest (typically `hull.sha256`) with an Ed25519 secret key. Writes `<manifest>.sig` (128 hex chars). Used by the GitHub Actions release workflow; never invoked by end users. See [docs/release_signing.md](docs/release_signing.md).
 
 **`hull verify-release <manifest> <signature> [--pubkey <hex>]`**. Verify an Ed25519 signature over a release manifest using the embedded release public key (or an explicit override). Exit 0 = valid, 1 = invalid / placeholder. For offline auditing of a downloaded release.
@@ -1207,6 +1256,7 @@ hull agent test [app_dir]                # run tests with JSON output
 hull agent context --task=T --level=L    # task-relevant documentation
 hull agent migrate [app_dir] [-d path]   # migration status
 hull agent deploy [app_dir]              # deployment readiness analysis
+hull agent inspect [app_dir]             # analyzed project model: annotated declarations (JSON)
 ```
 
 `hull dev --agent` enables sidecar files: `.hull/dev.json` (port, PID) on start, `.hull/last_error.json` on load failure. See [AGENTS.md](AGENTS.md) for the full agent development guide.

--- a/README.md
+++ b/README.md
@@ -1195,7 +1195,7 @@ workflow, and sets up a `PLATFORM_GAPS.md` log so the agent flags
 Hull-side gaps instead of coding around them. Same prompt works for
 any product spec — fully app-agnostic.
 
-Hull provides structured JSON interfaces for AI coding agents via the `hull agent` command. The same interfaces work for any automation (CI scripts, service orchestrators, or human developers who prefer structured output. **Twenty-seven machine-readable subcommands** cover routes, database schema, test results, server status, HTTP responses, deployment readiness, capability analysis, request preview, one-shot eval, and more) no screen-scraping or log parsing required.
+Hull provides structured JSON interfaces for AI coding agents via the `hull agent` command. The same interfaces work for any automation (CI scripts, service orchestrators, or human developers who prefer structured output. **Twenty-eight machine-readable subcommands** cover routes, database schema, test results, server status, HTTP responses, deployment readiness, capability analysis, request preview, one-shot eval, the analyzed project model, and more) no screen-scraping or log parsing required.
 
 ```
 # Core introspection (Phase 1–5)
@@ -1216,6 +1216,7 @@ hull agent endpoint METHOD PATH [dir]    # request preview (no execution)
 hull agent middleware METHOD PATH [dir]  # middleware stack for path
 hull agent capabilities [app_dir]        # declared vs used analysis
 hull agent modules [app_dir]             # declared + intrinsic modules + build caps
+hull agent inspect [app_dir]             # analyzed project model: annotated declarations (JSON)
 hull agent validate <file>               # single-file syntax + sandbox check
 hull agent vfs [app_dir]                 # list embedded files
 hull agent compute [app_dir]             # WASM modules + AOT
@@ -1229,9 +1230,11 @@ hull agent schema-diff [app_dir]         # DB schema drift vs migrations
 hull agent sql named <qname> [--params J] [dir]  # named query from queries.json
 ```
 
-All 27 are also exposed via MCP (`hull mcp [app_dir]`) for IDE integrations like Cursor / Claude Code's MCP support.
+27 of these (all but `hull agent inspect`, which delegates to the source-analysis tool VM) are also exposed via MCP (`hull mcp [app_dir]`) for IDE integrations like Cursor / Claude Code's MCP support.
 
-Combined with `hull dev --agent` (which writes `.hull/dev.json` and `.hull/last_error.json` as sidecar files), agents get a complete feedback loop: edit code, check for errors, run tests, inspect the database, make HTTP requests, validate manifest coverage. All structured.
+Combined with `hull dev --agent` (which writes `.hull/dev.json`, `.hull/last_error.json`, and a per-reload `.hull/discovery.json` generation as sidecar files), agents get a complete feedback loop: edit code, check for errors, run tests, inspect the database, make HTTP requests, validate manifest coverage. All structured.
+
+`hull agent inspect` surfaces Hull's **project source-discovery** model: a static, host-owned analysis of the app's Lua source (via the pure-Lua `hull.source.*` layer, without executing app code) that reports the annotated declarations — `---@` annotations attached to `local` / `local function` / `function` declarations, with exact ranges, deterministic IDs, and by-annotation indexes. It runs standalone, or serves the live generation a running `hull dev --agent` session has published. JavaScript is a reserved-but-not-yet-analyzable frontend (honestly reported, never parsed as Lua). This is the foundation a future codegen step (e.g. Query/Compute IR) consumes.
 
 ### Agent Development Workflow
 


### PR DESCRIPTION
Documents the new host-owned project source-discovery subsystem (`hull.source.*` + `hull.project.*`, PRs #356-#359) and the `hull agent inspect` command across README.md, CLAUDE.md, AGENTS.md, and BOOTSTRAP.md.

- **README.md**: `hull agent inspect` in the agent command list; subcommand count 27 → 28 (27 via MCP — `inspect` is CLI-only); a project-source-discovery paragraph.
- **CLAUDE.md**: a "Project source discovery" section (the two pure-Lua layers, the ProjectDiscovery model, the ~180 hardened-C lines for live-read/sidecar/publish glue, the abstraction-only build seam, tests) + the command doc + the `source/`/`project/` subtrees in Project Structure.
- **AGENTS.md**: a `hull agent inspect` section with the JSON shape + a worked example; quick-start entry.
- **BOOTSTRAP.md**: a discovery-table row for finding `---@`-annotated declarations.

Docs-only. Design: `docs/project_discovery_design.md`.