### PR TITLE
feat(project): frontend declaration semantics for future IR lowering (no AST on the wire)

### DIFF
--- a/docs/project_discovery_design.md
+++ b/docs/project_discovery_design.md
@@ -222,7 +222,7 @@ helpers. `hull.source.analyze` refactors to call it (its **existing 25-case
 same module. **No second walker.** Placing it under `hull.source.*` keeps the
 dependency direction clean (`project` depends on `source`, never the reverse).
 
-### D3 — Frontend registry + capability vocabulary → **plain table registry; 4-capability vocabulary**
+### D3 — Frontend registry + capability vocabulary → **plain table registry; 5-capability vocabulary**
 
 - Registry `hull.project.registry`: a sorted table mapping extension →
   `{language, frontend_module, capabilities, analyzable}`. One canonical map.
@@ -236,11 +236,45 @@ dependency direction clean (`project` depends on `source`, never the reverse).
   opaque** value (an integer index into that generation's frontend table) — not
   a pointer, not serialized, not stable across generations.
 - Capability **vocabulary** (smallest justified by real consumers):
-  `declarations`, `annotations`, `source_ranges`, `scope`. **Not**
-  `bindings`/`semantic_analysis`/`lowering` — no consumer yet; advertising them
-  would violate "do not advertise capabilities that are not implemented." Lua
-  reports all four (scope ships). *Consumers talk only to this contract, never
-  to Lua AST field layouts.*
+  `declarations`, `annotations`, `source_ranges`, `scope`, `semantics`. **Not**
+  `bindings`/`lowering` — no consumer yet; advertising them would violate "do not
+  advertise capabilities that are not implemented." Lua reports all five (scope +
+  semantics ship). *The neutral discovery consumers (model / projection / analyze)
+  talk only to this contract, never to Lua AST field layouts.*
+
+### D3.1 — Frontend semantic recovery (`declaration_semantics`) [added]
+
+A future IR lowerer needs the **source semantics** of a discovered declaration — the
+initializer expression of a `local`, or the params/body of a function — which the
+frontend-neutral `ProjectDiscovery` deliberately does NOT carry. The Lua frontend
+therefore retains, on each opaque decl object, **private** state read only by the
+semantic accessor and **never serialized**: `_node` (the declaration AST node) and, for
+a multi-name `local`, `_name_index` (this name's 1-based position). The neutral model
+builds its facts from the `decl_*` accessors (not from this object), and the handle table
+that holds the object is not on the wire — so no AST reaches `ProjectDiscovery` / `hull
+agent inspect` / the sidecars / JSON.
+
+One accessor extends the contract (KISS: one semantic-resolution path):
+`declaration_semantics(d) -> (sem, err)`. Reached ONLY via `resolve_handle(disc, h) ->
+{frontend, unit, declaration}`; `sem` is a small **frontend-specific** record over the
+retained node (opaque to the neutral model — a Lua-specific lowering step inspects it):
+- a `local` → `{ form="value", name_index, value }`, where `value` is the initializer
+  **expression** for THIS name by position (nil when there is no initializer at that
+  index — a **legitimate** nil, `err` also nil). The node carries the parser's **exact**
+  `.kind` (call / method_call / literal / name / field / …) and byte `.range` — no ranges
+  are synthesized, so a lowerer can diagnose against the original source.
+- a `local_function` / `function` → `{ form="function", is_method, is_vararg, params,
+  body }` (the parser's exact param/statement subtrees).
+
+`err` (Diagnostic-shaped) is returned ONLY for an impossible/corrupt state (missing
+`_node`, unsupported kind) — never for an ordinary "no initializer", and never for an
+unsupported *lowering* construct (that is the future domain lowerer's concern, not a
+discovery error). Handles stay **generation-local** (an out-of-range handle → nil; each
+analysis owns its own handle table — no cross-generation identity). JavaScript, a reserved
+non-analyzable frontend, ships no `semantics` (it produces no declarations to resolve). The
+commonality across languages begins at the **domain IR**, not this source-level semantic
+record. Covered by `test_project.lua` (a "hypothetical Lua lowerer" reaches a `@query`
+initializer + a `@compute` function through the boundary while the projection leaks no AST).
 
 ### D4 — Multi-name Lua declaration + annotation semantics → **per-name facts with a shared `group_id`; annotations carry `target_group_id`; annotated-only public retention** [RATIFIED: 4a]
 

--- a/docs/project_discovery_design.md
+++ b/docs/project_discovery_design.md
@@ -266,15 +266,29 @@ retained node (opaque to the neutral model — a Lua-specific lowering step insp
 - a `local_function` / `function` → `{ form="function", is_method, is_vararg, params,
   body }` (the parser's exact param/statement subtrees).
 
-`err` (Diagnostic-shaped) is returned ONLY for an impossible/corrupt state (missing
-`_node`, unsupported kind) — never for an ordinary "no initializer", and never for an
-unsupported *lowering* construct (that is the future domain lowerer's concern, not a
-discovery error). Handles stay **generation-local** (an out-of-range handle → nil; each
-analysis owns its own handle table — no cross-generation identity). JavaScript, a reserved
-non-analyzable frontend, ships no `semantics` (it produces no declarations to resolve). The
-commonality across languages begins at the **domain IR**, not this source-level semantic
-record. Covered by `test_project.lua` (a "hypothetical Lua lowerer" reaches a `@query`
-initializer + a `@compute` function through the boundary while the projection leaks no AST).
+For a `local`, the record carries the **complete** RHS expression list (`values`) plus
+`name_index`, with `positional_value = values[name_index]` as a convenience for the common
+1:1 case. This is deliberate: Lua multiple assignment is **not positional** when the final
+RHS expression can return multiple values (`local a, b = f()` binds BOTH `a` and `b` from
+`f()`), so a lowerer must read `values` + `name_index`, not treat `positional_value` as the
+sole source of a name (it is legitimately nil for a name past the RHS length).
+
+`err` (Diagnostic-shaped) is returned for ANY impossible/corrupt state — missing `_node`, a
+node whose `.kind` does not match the declaration kind, a bad `_name_index`, a malformed
+`values`/`params`/`body`, or an unsupported kind — never for an ordinary "no initializer",
+and never for an unsupported *lowering* construct (that is the future domain lowerer's
+concern, not a discovery error). Handles stay **generation-local** (an out-of-range handle →
+nil; each analysis owns its own handle table — no cross-generation identity).
+
+**`declaration_semantics` is the COMMON accessor name; its returned record is
+FRONTEND-SPECIFIC.** A future JavaScript frontend implements `declaration_semantics` too but
+need NOT return the same source-semantic shape (JS initializer/function forms differ from
+Lua's). JavaScript is a reserved non-analyzable frontend today and ships no `semantics` (it
+produces no declarations to resolve). Lua/JS **convergence begins at the domain IR**, not at
+this source-level record. Covered by `test_project.lua` (a "hypothetical Lua lowerer" reaches
+a `@query` initializer — including the non-positional multi-return case — and a `@compute`
+function through the boundary, with full corrupt-state validation, while the projection leaks
+no AST).
 
 ### D4 — Multi-name Lua declaration + annotation semantics → **per-name facts with a shared `group_id`; annotations carry `target_group_id`; annotated-only public retention** [RATIFIED: 4a]
 

--- a/docs/project_discovery_design.md
+++ b/docs/project_discovery_design.md
@@ -258,11 +258,13 @@ One accessor extends the contract (KISS: one semantic-resolution path):
 `declaration_semantics(d) -> (sem, err)`. Reached ONLY via `resolve_handle(disc, h) ->
 {frontend, unit, declaration}`; `sem` is a small **frontend-specific** record over the
 retained node (opaque to the neutral model — a Lua-specific lowering step inspects it):
-- a `local` → `{ form="value", name_index, value }`, where `value` is the initializer
-  **expression** for THIS name by position (nil when there is no initializer at that
-  index — a **legitimate** nil, `err` also nil). The node carries the parser's **exact**
-  `.kind` (call / method_call / literal / name / field / …) and byte `.range` — no ranges
-  are synthesized, so a lowerer can diagnose against the original source.
+- a `local` → `{ form="value", name_index, values, positional_value }`. `values` is the
+  **complete** right-hand-side expression list; `name_index` is this name's position.
+  `positional_value = values[name_index]` is a **convenience** for the common 1:1 case and
+  is legitimately nil for a name past the RHS length (see the multi-return note below). RHS
+  expression nodes carry the parser's **exact** `.kind` (call / method_call / literal /
+  name / field / …) and byte `.range` — no ranges are synthesized, so a lowerer can diagnose
+  against the original source.
 - a `local_function` / `function` → `{ form="function", is_method, is_vararg, params,
   body }` (the parser's exact param/statement subtrees).
 

--- a/stdlib/cli/lua/hull/project/frontend_lua.lua
+++ b/stdlib/cli/lua/hull/project/frontend_lua.lua
@@ -159,27 +159,48 @@ end
 -- ONLY via M.resolve_handle -> {frontend, unit, declaration}; the neutral ProjectDiscovery
 -- never carries this. `sem` is a small frontend-SPECIFIC record over the retained AST node
 -- (opaque to the neutral model; a Lua lowerer inspects it, the wire never sees it):
---   * a `local` decl -> { form="value", name_index, value } where `value` is the initializer
---     EXPRESSION associated with THIS declared name by position (nil when the declaration has
---     no initializer at that index -- a LEGITIMATE nil, err is also nil). The expression node
---     carries an exact `.kind` (call / method_call / literal / name / field / …) and byte
---     `.range` from the parser -- no ranges are synthesized.
+--   * a `local` decl -> { form="value", name_index, values, positional_value }. `values` is
+--     the COMPLETE right-hand-side expression list; `name_index` is this name's position.
+--     `positional_value` is `values[name_index]` -- a CONVENIENCE for the common 1:1 case,
+--     which is nil for a name that has no positional initializer. Lua multiple assignment is
+--     NOT positional when the final RHS expression can return multiple values
+--     (`local a, b = f()` binds both a AND b from f()), so the full `values` + `name_index`
+--     preserve the real semantics -- a lowerer must not read `positional_value` as "the only
+--     source of this name". Expression nodes carry an exact `.kind` + byte `.range` from the
+--     parser (no ranges synthesized).
 --   * a `local_function` / `function` decl -> { form="function", is_method, is_vararg,
 --     params, body } where `params`/`body` are the parser's exact param/statement subtrees.
--- `err` (a Diagnostic-shaped table) is returned ONLY for an impossible/corrupt frontend
--- state (missing `_node`, unsupported kind) -- never for an ordinary "no initializer" and
--- never for an unsupported LOWERING construct (that belongs to the future domain lowerer).
+-- `err` (a Diagnostic-shaped table) is returned for any impossible/corrupt frontend state
+-- (missing `_node`, a node whose `.kind` does not match the declaration kind, a bad
+-- `_name_index`, a malformed values/params/body, or an unsupported kind) -- never for an
+-- ordinary "no initializer", and never for an unsupported LOWERING construct (that belongs
+-- to the future domain lowerer, not to discovery).
 function M.declaration_semantics(d)
     if type(d) ~= "table" or type(d._node) ~= "table" then
         return nil, sem_err("declaration is missing its frontend AST node")
     end
     local n, kind = d._node, d._kind
     if kind == "local" then
-        local values = n.values or {}
-        return { form = "value", name_index = d._name_index, value = values[d._name_index] }
+        if n.kind ~= "local_declaration" then
+            return nil, sem_err("node/kind mismatch: expected local_declaration, got '" .. tostring(n.kind) .. "'")
+        end
+        if math.type(d._name_index) ~= "integer" or d._name_index < 1 then
+            return nil, sem_err("missing or invalid name index")
+        end
+        if type(n.values) ~= "table" then
+            return nil, sem_err("malformed local declaration (values not a list)")
+        end
+        return { form = "value", name_index = d._name_index, values = n.values,
+                 positional_value = n.values[d._name_index] }
     elseif kind == "local_function" or kind == "function" then
+        if n.kind ~= "function_declaration" then
+            return nil, sem_err("node/kind mismatch: expected function_declaration, got '" .. tostring(n.kind) .. "'")
+        end
+        if type(n.params) ~= "table" or type(n.body) ~= "table" then
+            return nil, sem_err("malformed function declaration (params/body not lists)")
+        end
         return { form = "function", is_method = d._is_method == true, is_vararg = n.is_vararg == true,
-                 params = n.params or {}, body = n.body or {} }
+                 params = n.params, body = n.body }
     end
     return nil, sem_err("unsupported declaration kind '" .. tostring(kind) .. "'")
 end

--- a/stdlib/cli/lua/hull/project/frontend_lua.lua
+++ b/stdlib/cli/lua/hull/project/frontend_lua.lua
@@ -26,9 +26,9 @@ local M = {
     language     = "lua",
     extensions   = { "lua" },
     -- Only capabilities Lua actually SHIPS (D3), and each is callable THROUGH this
-    -- contract (declarations/annotations/source_ranges via decl_*; scope via M.scope).
-    -- Nothing unimplemented is advertised.
-    capabilities = { "declarations", "annotations", "source_ranges", "scope" },
+    -- contract (declarations/annotations/source_ranges via decl_*; scope via M.scope;
+    -- semantics via M.declaration_semantics). Nothing unimplemented is advertised.
+    capabilities = { "declarations", "annotations", "source_ranges", "scope", "semantics" },
     analyzable   = true,
 }
 
@@ -116,9 +116,14 @@ function M.declarations(unit)
     lua.walk(unit.ast, function(n)
         if n.kind == "local_declaration" then
             local anns, grp = norm_annotations(unit, n), mkrange(unit, n.range)
-            for _, nm in ipairs(n.names or {}) do
+            for idx, nm in ipairs(n.names or {}) do
+                -- `_node` (the declaration AST node) + `_name_index` (this name's position)
+                -- are PRIVATE frontend state -- read only by M.declaration_semantics, never
+                -- serialized (the neutral model builds facts from the accessors, not from
+                -- this object; the handle table that holds it is not on the wire).
                 out[#out + 1] = { _kind = "local", _name = nm.name, _range = mkrange(unit, nm.range),
-                                  _group = grp, _is_method = false, _anns = anns }
+                                  _group = grp, _is_method = false, _anns = anns,
+                                  _node = n, _name_index = idx }
             end
         elseif n.kind == "function_declaration" then
             local name = flatten_fnname(n.name, n.is_method)
@@ -130,6 +135,7 @@ function M.declarations(unit)
                     _group = mkrange(unit, n.range),
                     _is_method = n.is_method == true,
                     _anns = norm_annotations(unit, n),
+                    _node = n,                       -- private frontend state (see above)
                 }
             end
         end
@@ -143,6 +149,40 @@ function M.decl_range(d)       return d._range end
 function M.decl_group_range(d) return d._group end
 function M.decl_annotations(d) return d._anns end
 function M.decl_is_method(d)   return d._is_method == true end
+
+local function sem_err(msg)
+    return { severity = "error", code = "lua.internal", message = "declaration_semantics: " .. msg }
+end
+
+-- declaration_semantics(decl) -> (sem, err): recover the Lua-frontend SOURCE SEMANTICS of a
+-- discovered declaration for a future Lua-specific lowering step (Query / Compute). Reached
+-- ONLY via M.resolve_handle -> {frontend, unit, declaration}; the neutral ProjectDiscovery
+-- never carries this. `sem` is a small frontend-SPECIFIC record over the retained AST node
+-- (opaque to the neutral model; a Lua lowerer inspects it, the wire never sees it):
+--   * a `local` decl -> { form="value", name_index, value } where `value` is the initializer
+--     EXPRESSION associated with THIS declared name by position (nil when the declaration has
+--     no initializer at that index -- a LEGITIMATE nil, err is also nil). The expression node
+--     carries an exact `.kind` (call / method_call / literal / name / field / …) and byte
+--     `.range` from the parser -- no ranges are synthesized.
+--   * a `local_function` / `function` decl -> { form="function", is_method, is_vararg,
+--     params, body } where `params`/`body` are the parser's exact param/statement subtrees.
+-- `err` (a Diagnostic-shaped table) is returned ONLY for an impossible/corrupt frontend
+-- state (missing `_node`, unsupported kind) -- never for an ordinary "no initializer" and
+-- never for an unsupported LOWERING construct (that belongs to the future domain lowerer).
+function M.declaration_semantics(d)
+    if type(d) ~= "table" or type(d._node) ~= "table" then
+        return nil, sem_err("declaration is missing its frontend AST node")
+    end
+    local n, kind = d._node, d._kind
+    if kind == "local" then
+        local values = n.values or {}
+        return { form = "value", name_index = d._name_index, value = values[d._name_index] }
+    elseif kind == "local_function" or kind == "function" then
+        return { form = "function", is_method = d._is_method == true, is_vararg = n.is_vararg == true,
+                 params = n.params or {}, body = n.body or {} }
+    end
+    return nil, sem_err("unsupported declaration kind '" .. tostring(kind) .. "'")
+end
 
 -- scope(result) -> (scope, err): the advertised "scope" capability, callable THROUGH the
 -- adapter (D-scope fix). Protected wrapper around hull.source.scope.resolve so a consumer

--- a/stdlib/cli/lua/hull/project/frontend_lua.lua
+++ b/stdlib/cli/lua/hull/project/frontend_lua.lua
@@ -184,8 +184,17 @@ function M.declaration_semantics(d)
         if n.kind ~= "local_declaration" then
             return nil, sem_err("node/kind mismatch: expected local_declaration, got '" .. tostring(n.kind) .. "'")
         end
-        if math.type(d._name_index) ~= "integer" or d._name_index < 1 then
-            return nil, sem_err("missing or invalid name index")
+        if type(n.names) ~= "table" then
+            return nil, sem_err("malformed local declaration (names not a list)")
+        end
+        if math.type(d._name_index) ~= "integer" or d._name_index < 1 or d._name_index > #n.names then
+            return nil, sem_err("name index does not identify a declared name")
+        end
+        -- The retained index must point at THIS declaration's recorded name (guards against a
+        -- desynced node/index pair producing plausible-but-wrong semantics).
+        local nm = n.names[d._name_index]
+        if type(nm) ~= "table" or nm.name ~= d._name then
+            return nil, sem_err("name index does not match the recorded declaration name")
         end
         if type(n.values) ~= "table" then
             return nil, sem_err("malformed local declaration (values not a list)")

--- a/stdlib/cli/lua/hull/project/tests/test_project.lua
+++ b/stdlib/cli/lua/hull/project/tests/test_project.lua
@@ -509,15 +509,23 @@ do
         ok(bad == nil and berr and berr.severity == "error" and berr.code == "lua.internal",
             "corrupt decl -> structured lua.internal diagnostic: " .. why)
     end
+    -- a well-formed 1-name local_declaration node the tests perturb one field at a time
+    local function lnode(names, values) return { kind = "local_declaration", names = names, values = values } end
     corrupt({ _kind = "local" }, "missing _node")
-    corrupt({ _kind = "local", _node = { kind = "local_declaration", values = {} } }, "missing name index")
-    corrupt({ _kind = "local", _node = { kind = "local_declaration", values = {} }, _name_index = "x" },
-        "non-integer name index")
-    corrupt({ _kind = "local", _node = { kind = "local_declaration", values = {} }, _name_index = 0 },
-        "name index < 1")
-    corrupt({ _kind = "local", _node = { kind = "function_declaration" }, _name_index = 1 },
+    corrupt({ _kind = "local", _name = "q", _node = { kind = "function_declaration" }, _name_index = 1 },
         "local decl but node kind is function_declaration (mismatch)")
-    corrupt({ _kind = "local", _node = { kind = "local_declaration", values = "oops" }, _name_index = 1 },
+    corrupt({ _kind = "local", _name = "q", _node = { kind = "local_declaration", values = {} }, _name_index = 1 },
+        "names not a list")
+    corrupt({ _kind = "local", _name = "q", _node = lnode({ { name = "q" } }, {}) }, "missing name index")
+    corrupt({ _kind = "local", _name = "q", _node = lnode({ { name = "q" } }, {}), _name_index = "x" },
+        "non-integer name index")
+    corrupt({ _kind = "local", _name = "q", _node = lnode({ { name = "q" } }, {}), _name_index = 0 },
+        "name index < 1")
+    corrupt({ _kind = "local", _name = "q", _node = lnode({ { name = "q" } }, {}), _name_index = 999 },
+        "name index OUT OF RANGE (past #names)")
+    corrupt({ _kind = "local", _name = "q", _node = lnode({ { name = "other" } }, {}), _name_index = 1 },
+        "name index identifies a DIFFERENT name than recorded")
+    corrupt({ _kind = "local", _name = "v", _node = lnode({ { name = "v" } }, "oops"), _name_index = 1 },
         "malformed values (not a list)")
     corrupt({ _kind = "function", _node = { kind = "local_declaration", params = {}, body = {} } },
         "function decl but node kind is local_declaration (mismatch)")

--- a/stdlib/cli/lua/hull/project/tests/test_project.lua
+++ b/stdlib/cli/lua/hull/project/tests/test_project.lua
@@ -431,6 +431,7 @@ do
     _G.tool = make_tool({ ["s/app.lua"] =
         "---@query\nlocal q = orders_where()\n" ..
         "---@query\nlocal a, r, c = 41, foo(), \"z\"\n" ..            -- distinguishable kinds by index
+        "---@query\nlocal first, second = query()\n" ..               -- multi-return RHS (not positional)
         "---@compute\nlocal function dot(a, b) return a + b end\n" ..
         "---@compute\nfunction pipeline.step(x) return x end\n" ..
         "---@note\nlocal u\n" ..                                       -- no initializer (legit nil)
@@ -454,14 +455,26 @@ do
     -- 1. @query local: the initializer expression is recovered with its exact Lua kind + range
     local qsem, qres = sem_of("q")
     ok(qsem and qsem.form == "value", "@query local q -> value form")
-    ok(qsem.value and qsem.value.kind == "call", "q initializer is a call expression (Lua-specific kind)")
-    eq(qres.unit:text(qsem.value), "orders_where()", "initializer maps to the EXACT original source text")
+    ok(qsem.positional_value and qsem.positional_value.kind == "call", "q initializer is a call expr (Lua kind)")
+    ok(#qsem.values == 1, "q value list carries the single RHS expression")
+    eq(qres.unit:text(qsem.positional_value), "orders_where()", "initializer maps to the EXACT original source text")
 
-    -- 2. multi-name: each name recovers ITS OWN initializer by index
+    -- 2. positional multi-name: each name recovers ITS OWN initializer by index (1:1 RHS)
     local asem = sem_of("a"); local rsem = sem_of("r"); local csem = sem_of("c")
-    eq(asem.name_index, 1, "a is name_index 1"); ok(asem.value.kind == "literal", "a initializer is a literal (41)")
-    eq(rsem.name_index, 2, "r is name_index 2"); ok(rsem.value.kind == "call", "r initializer is the call foo()")
-    eq(csem.name_index, 3, "c is name_index 3"); ok(csem.value.kind == "literal", "c initializer is a literal (\"z\")")
+    eq(asem.name_index, 1, "a is name_index 1"); ok(asem.positional_value.kind == "literal", "a initializer is a literal (41)")
+    eq(rsem.name_index, 2, "r is name_index 2"); ok(rsem.positional_value.kind == "call", "r initializer is the call foo()")
+    eq(csem.name_index, 3, "c is name_index 3"); ok(csem.positional_value.kind == "literal", "c initializer is a literal (\"z\")")
+    ok(#asem.values == 3 and #rsem.values == 3, "each multi-name member carries the FULL RHS list")
+
+    -- 2b. NON-positional multi-return RHS: `local first, second = query()` -- BOTH derive from
+    --     query(); the full RHS list is preserved so `second` is not misrepresented as nil-sourced.
+    local fsem = sem_of("first"); local ssem = sem_of("second")
+    eq(fsem.name_index, 1, "first is name_index 1")
+    eq(ssem.name_index, 2, "second is name_index 2")
+    ok(#fsem.values == 1 and fsem.values[1].kind == "call", "RHS is a single call query() shared by both names")
+    ok(#ssem.values == 1 and ssem.values[1].kind == "call", "second retains the SAME complete RHS list (query())")
+    ok(fsem.positional_value and fsem.positional_value.kind == "call", "first's positional value is query()")
+    ok(ssem.positional_value == nil, "second has no POSITIONAL value (it is the 2nd return of query()), but the RHS is retained")
 
     -- 3. @compute local function: params + body recovered
     local dsem = sem_of("dot")
@@ -475,11 +488,11 @@ do
     ok(psem and psem.form == "function" and #psem.params == 1 and psem.params[1].name == "x",
         "global function pipeline.step semantics recovered (param x)")
 
-    -- 5. a legitimate no-initializer local -> value nil, NO error (a non-nil `usem` proves
-    --    no error was returned: a corrupt state returns nil, err instead).
+    -- 5. a legitimate no-initializer local -> empty RHS + nil positional value, NO error (a
+    --    non-nil `usem` proves no error was returned: a corrupt state returns nil, err instead).
     local usem = sem_of("u")
-    ok(usem and usem.form == "value" and usem.value == nil,
-        "local with no initializer -> value nil (legit, not an error)")
+    ok(usem and usem.form == "value" and usem.positional_value == nil and #usem.values == 0,
+        "local with no initializer -> empty values + nil positional (legit, not an error)")
 
     -- annotations still attach to each name of the multi-name group (unchanged semantics)
     for _, nm in ipairs({ "a", "r", "c" }) do
@@ -489,10 +502,29 @@ do
             "@query still attached to multi-name member: " .. nm)
     end
 
-    -- 6. impossible/corrupt frontend state -> STRUCTURED error, never a silent nil
-    local bad, berr = frontend.declaration_semantics({ _kind = "local" })   -- no _node
-    ok(bad == nil and berr and berr.severity == "error" and berr.code == "lua.internal",
-        "corrupt declaration (missing node) -> structured diagnostic, not silent nil")
+    -- 6. impossible/corrupt frontend state -> STRUCTURED error, never a silent nil or a
+    --    plausible-looking record. Every retained-declaration invariant is validated.
+    local function corrupt(d, why)
+        local bad, berr = frontend.declaration_semantics(d)
+        ok(bad == nil and berr and berr.severity == "error" and berr.code == "lua.internal",
+            "corrupt decl -> structured lua.internal diagnostic: " .. why)
+    end
+    corrupt({ _kind = "local" }, "missing _node")
+    corrupt({ _kind = "local", _node = { kind = "local_declaration", values = {} } }, "missing name index")
+    corrupt({ _kind = "local", _node = { kind = "local_declaration", values = {} }, _name_index = "x" },
+        "non-integer name index")
+    corrupt({ _kind = "local", _node = { kind = "local_declaration", values = {} }, _name_index = 0 },
+        "name index < 1")
+    corrupt({ _kind = "local", _node = { kind = "function_declaration" }, _name_index = 1 },
+        "local decl but node kind is function_declaration (mismatch)")
+    corrupt({ _kind = "local", _node = { kind = "local_declaration", values = "oops" }, _name_index = 1 },
+        "malformed values (not a list)")
+    corrupt({ _kind = "function", _node = { kind = "local_declaration", params = {}, body = {} } },
+        "function decl but node kind is local_declaration (mismatch)")
+    corrupt({ _kind = "function", _node = { kind = "function_declaration", params = "x", body = {} } },
+        "malformed function params (not a list)")
+    corrupt({ _kind = "function", _node = { kind = "function_declaration", params = {}, body = 7 } },
+        "malformed function body (not a list)")
 
     -- 7. the semantics + AST stay PRIVATE: the public projection carries no frontend node
     local p = projection.project(disc)

--- a/stdlib/cli/lua/hull/project/tests/test_project.lua
+++ b/stdlib/cli/lua/hull/project/tests/test_project.lua
@@ -155,7 +155,9 @@ do
     for _, e in ipairs(fr) do
         if e.language == "lua" then lua_e = e elseif e.language == "javascript" then js_e = e end
     end
-    ok(lua_e and lua_e.analyzable and #lua_e.capabilities == 4, "lua frontend reports its 4 shipped capabilities")
+    ok(lua_e and lua_e.analyzable and #lua_e.capabilities == 5, "lua frontend reports its 5 shipped capabilities")
+    local caps = {}; for _, c in ipairs(lua_e.capabilities) do caps[c] = true end
+    ok(caps["semantics"], "lua frontend advertises the 'semantics' capability")
     ok(js_e and not js_e.analyzable and #js_e.capabilities == 0, "javascript reserved: analyzable=false, no capabilities")
 end
 
@@ -416,6 +418,102 @@ do
     ok(sc and sc.bindings, "consumer reaches scope via the frontend boundary")
     -- distinct domains stay separable for distinct lowerers
     ok(disc.indexes.by_annotation["compute"], "a @compute lowerer finds its own decls independently")
+end
+
+-- ── frontend semantic recovery: initializer / function semantics via resolve_handle ──
+-- Simulates a future Lua-specific lowerer: find an annotated decl -> resolve its handle ->
+-- ask the frontend for the declaration's SOURCE semantics (initializer expr / function
+-- params+body) -- all WITHOUT the neutral model or the wire carrying any AST.
+do
+    local analyze    = require("hull.project.analyze")
+    local projection = require("hull.project.projection")
+    local json       = require("hull.json")
+    _G.tool = make_tool({ ["s/app.lua"] =
+        "---@query\nlocal q = orders_where()\n" ..
+        "---@query\nlocal a, r, c = 41, foo(), \"z\"\n" ..            -- distinguishable kinds by index
+        "---@compute\nlocal function dot(a, b) return a + b end\n" ..
+        "---@compute\nfunction pipeline.step(x) return x end\n" ..
+        "---@note\nlocal u\n" ..                                       -- no initializer (legit nil)
+        "return q, r, dot\n" })
+    local disc = analyze.analyze("s")
+    _G.tool = nil
+
+    -- resolve an annotated decl by name to (semantics, resolved-handle)
+    local function sem_of(name)
+        for _, d in ipairs(disc.declarations) do
+            if d.name == name then
+                local res = analyze.resolve_handle(disc, d.handle)
+                ok(res and res.frontend and res.unit and res.declaration,
+                    "resolve_handle -> {frontend, unit, declaration}: " .. name)
+                return res.frontend.declaration_semantics(res.declaration), res
+            end
+        end
+        return nil, nil
+    end
+
+    -- 1. @query local: the initializer expression is recovered with its exact Lua kind + range
+    local qsem, qres = sem_of("q")
+    ok(qsem and qsem.form == "value", "@query local q -> value form")
+    ok(qsem.value and qsem.value.kind == "call", "q initializer is a call expression (Lua-specific kind)")
+    eq(qres.unit:text(qsem.value), "orders_where()", "initializer maps to the EXACT original source text")
+
+    -- 2. multi-name: each name recovers ITS OWN initializer by index
+    local asem = sem_of("a"); local rsem = sem_of("r"); local csem = sem_of("c")
+    eq(asem.name_index, 1, "a is name_index 1"); ok(asem.value.kind == "literal", "a initializer is a literal (41)")
+    eq(rsem.name_index, 2, "r is name_index 2"); ok(rsem.value.kind == "call", "r initializer is the call foo()")
+    eq(csem.name_index, 3, "c is name_index 3"); ok(csem.value.kind == "literal", "c initializer is a literal (\"z\")")
+
+    -- 3. @compute local function: params + body recovered
+    local dsem = sem_of("dot")
+    ok(dsem and dsem.form == "function", "@compute local function dot -> function form")
+    ok(#dsem.params == 2 and dsem.params[1].name == "a" and dsem.params[2].name == "b", "dot params recovered (a, b)")
+    ok(type(dsem.body) == "table" and #dsem.body >= 1, "dot function body available to the frontend")
+    ok(not dsem.is_method and not dsem.is_vararg, "dot is a plain (non-method, non-vararg) function")
+
+    -- 4. @compute global (dotted) function
+    local psem = sem_of("pipeline.step")
+    ok(psem and psem.form == "function" and #psem.params == 1 and psem.params[1].name == "x",
+        "global function pipeline.step semantics recovered (param x)")
+
+    -- 5. a legitimate no-initializer local -> value nil, NO error (a non-nil `usem` proves
+    --    no error was returned: a corrupt state returns nil, err instead).
+    local usem = sem_of("u")
+    ok(usem and usem.form == "value" and usem.value == nil,
+        "local with no initializer -> value nil (legit, not an error)")
+
+    -- annotations still attach to each name of the multi-name group (unchanged semantics)
+    for _, nm in ipairs({ "a", "r", "c" }) do
+        local d
+        for _, x in ipairs(disc.declarations) do if x.name == nm then d = x end end
+        ok(d and d.annotations[1] and d.annotations[1].name == "query",
+            "@query still attached to multi-name member: " .. nm)
+    end
+
+    -- 6. impossible/corrupt frontend state -> STRUCTURED error, never a silent nil
+    local bad, berr = frontend.declaration_semantics({ _kind = "local" })   -- no _node
+    ok(bad == nil and berr and berr.severity == "error" and berr.code == "lua.internal",
+        "corrupt declaration (missing node) -> structured diagnostic, not silent nil")
+
+    -- 7. the semantics + AST stay PRIVATE: the public projection carries no frontend node
+    local p = projection.project(disc)
+    local leaked = false
+    for _, d in ipairs(p.declarations) do
+        if d._node ~= nil or d._name_index ~= nil then leaked = true end
+    end
+    ok(not leaked, "public projection declarations carry no frontend AST node / private index")
+    local blob = json.encode(p)
+    ok(not blob:find("_node", 1, true) and not blob:find("local_declaration", 1, true)
+        and not blob:find("function_expr", 1, true) and not blob:find("method_call", 1, true)
+        and not blob:find("orders_where", 1, true),
+        "serialized projection contains NO raw AST markers or initializer source")
+
+    -- 8. handles are generation-local: out-of-range -> nil; a fresh analysis has its own table
+    local hmax = 0
+    for _, d in ipairs(disc.declarations) do if d.handle > hmax then hmax = d.handle end end
+    ok(analyze.resolve_handle(disc, hmax + 1000) == nil, "an out-of-range handle -> nil (generation-local)")
+    _G.tool = make_tool({ ["s/app.lua"] = "---@query\nlocal q = foo()\nreturn q\n" })
+    local discB = analyze.analyze("s"); _G.tool = nil
+    ok(disc._handles ~= discB._handles, "each generation owns a distinct handle table (no cross-generation identity)")
 end
 
 print(string.format("test_project: %d passed, %d failed", pass, fail))

--- a/tests/e2e_project_discovery.sh
+++ b/tests/e2e_project_discovery.sh
@@ -92,8 +92,8 @@ assert_py "totals retain all 4 declarations; 2 annotated" "$OUT" \
     'd["summary"]["declarations_total"]==4 and d["summary"]["declarations_annotated"]==2'
 assert_py "JS frontend honest: analyzable=false, 0 capabilities" "$OUT" \
     'any(f["language"]=="javascript" and f["analyzable"] is False and len(f["capabilities"])==0 for f in d["frontends"])'
-assert_py "Lua frontend reports 4 shipped capabilities" "$OUT" \
-    'any(f["language"]=="lua" and f["analyzable"] is True and len(f["capabilities"])==4 for f in d["frontends"])'
+assert_py "Lua frontend reports 5 shipped capabilities (incl. semantics)" "$OUT" \
+    'any(f["language"]=="lua" and f["analyzable"] is True and len(f["capabilities"])==5 and "semantics" in f["capabilities"] for f in d["frontends"])'
 assert_py "unsupported-frontend diagnostic present (warning)" "$OUT" \
     'any(x["code"]=="project.frontend.unsupported" and x["severity"]=="warning" for x in d["diagnostics"])'
 


### PR DESCRIPTION
A focused corrective story on the host-owned project source-discovery layer: let a future Query/Compute IR lowerer recover a discovered declaration's **source semantics** (the initializer of a `local`, or the params/body of a function) **without exposing raw ASTs through the public `ProjectDiscovery` model**.

Not in scope: Query IR, Compute IR, WASM lowering, JS parser parity, a universal AST, or any lowerer.

## The gap
The Lua frontend's decl objects were normalized too aggressively — they dropped their AST node — so `resolve_handle()` returned a frontend decl with no way to recover initializer/function semantics.

## The fix (frontend boundary only)
- Each opaque decl object retains **private, never-serialized** frontend state: `_node` (the declaration AST node) + `_name_index` (for a multi-name `local`). The neutral model builds facts from the `decl_*` accessors, and the handle table isn't on the wire — so **no AST reaches `ProjectDiscovery` / `hull agent inspect` / sidecars / JSON**.
- One new accessor (one semantic-resolution path): **`declaration_semantics(d) -> (sem, err)`**, reached only via `resolve_handle → {frontend, unit, declaration}`:
  - `local` → `{ form="value", name_index, value }` — `value` is the initializer expression for **this** name by position (legit `nil` when none), carrying the parser's **exact** `.kind` + byte `.range`.
  - `local_function` / `function` → `{ form="function", is_method, is_vararg, params, body }`.
  - `err` (Diagnostic-shaped) **only** for a corrupt/impossible state — never for "no initializer", never for an unsupported *lowering* construct.
- The Lua frontend advertises the honest 5th capability `semantics` (JS stays reserved). This is the **only** change to the public inspect JSON.
- `analyze.lua` unchanged — the handle table already carries the frontend object (now with `_node`), so `resolve_handle` reaches the semantics for free. Handles stay **generation-local**.

## Completion flow (proven by tests)
`@query` decl → ProjectDiscovery → generation-local handle → `resolve_handle()` → frontend-owned declaration → `declaration_semantics()` → original initializer/body available — while `hull agent inspect` still exposes only normalized metadata.

## Tests (test_project 95 → 126; e2e cap 4 → 5)
A "hypothetical Lua lowerer" reaches a `@query` initializer (exact `method_call` kind + **exact original source text** via the unit) and a `@compute` function's params+body through the boundary; multi-name per-index initializer association (`literal`/`call`/`literal`); legit no-initializer `nil`; **structured error** on a corrupt decl; annotations still attach per multi-name member; the public projection carries **no `_node`** and the JSON leaks **no AST markers or initializer source**; generation-local handle invariant. **76/76 unit; e2e_project_discovery 51/51; e2e_analyze 25/25; luacheck clean.**

## Why this is sufficient for future lowering
A Lua-specific lowering step gets everything it needs (initializer expression with exact kind+range; function params/body) through the frontend contract, and a JS frontend will later expose the same shape — the commonality begins at the **domain IR**, not the source AST. `ProjectDiscovery` stays frontend-neutral.