### PR TITLE
docs(project): make declaration_semantics' read-only reference contract explicit

### DIFF
--- a/docs/project_discovery_design.md
+++ b/docs/project_discovery_design.md
@@ -268,6 +268,15 @@ retained node (opaque to the neutral model - a Lua-specific lowering step inspec
 - a `local_function` / `function` → `{ form="function", is_method, is_vararg, params,
   body }` (the parser's exact param/statement subtrees).
 
+**Read-only contract.** `values` / `positional_value` / `params` / `body` are **live
+references** into that generation's parsed AST — deliberately not deep-copied, so byte
+ranges stay exact and nothing is duplicated. A consumer **must treat them read-only**:
+mutating a returned subtree corrupts the generation's AST (and any sibling declaration that
+shares the same node — every name of a multi-name `local` shares one node). This is
+trusted-consumer discipline (app code never reaches `resolve_handle`; only in-process
+build/tool lowerers do, and each analysis re-parses fresh), so no copy/freeze is imposed on
+the hot path.
+
 For a `local`, the record carries the **complete** RHS expression list (`values`) plus
 `name_index`, with `positional_value = values[name_index]` as a convenience for the common
 1:1 case. This is deliberate: Lua multiple assignment is **not positional** when the final

--- a/docs/project_discovery_design.md
+++ b/docs/project_discovery_design.md
@@ -269,10 +269,10 @@ retained node (opaque to the neutral model - a Lua-specific lowering step inspec
   body }` (the parser's exact param/statement subtrees).
 
 **Read-only contract.** `values` / `positional_value` / `params` / `body` are **live
-references** into that generation's parsed AST — deliberately not deep-copied, so byte
+references** into that generation's parsed AST: deliberately not deep-copied, so byte
 ranges stay exact and nothing is duplicated. A consumer **must treat them read-only**:
 mutating a returned subtree corrupts the generation's AST (and any sibling declaration that
-shares the same node — every name of a multi-name `local` shares one node). This is
+shares the same node, since every name of a multi-name `local` shares one node). This is
 trusted-consumer discipline (app code never reaches `resolve_handle`; only in-process
 build/tool lowerers do, and each analysis re-parses fresh), so no copy/freeze is imposed on
 the hot path.

--- a/stdlib/cli/lua/hull/project/frontend_lua.lua
+++ b/stdlib/cli/lua/hull/project/frontend_lua.lua
@@ -170,6 +170,13 @@ end
 --     parser (no ranges synthesized).
 --   * a `local_function` / `function` decl -> { form="function", is_method, is_vararg,
 --     params, body } where `params`/`body` are the parser's exact param/statement subtrees.
+-- READ-ONLY CONTRACT: `values` / `positional_value` / `params` / `body` are LIVE REFERENCES
+-- into this generation's parsed AST (deliberately NOT deep-copied -- so byte ranges stay
+-- exact and nothing is duplicated). A consumer MUST treat them as read-only: mutating a
+-- returned subtree corrupts this generation's AST (and any sibling decl that shares the same
+-- node -- every name of a multi-name `local` shares one node). This is trusted-consumer
+-- discipline: app code never reaches resolve_handle; only in-process build/tool lowerers do,
+-- and each analysis generation re-parses fresh, so a read-only lowerer is always safe.
 -- `err` (a Diagnostic-shaped table) is returned for any impossible/corrupt frontend state
 -- (missing `_node`, a node whose `.kind` does not match the declaration kind, a bad
 -- `_name_index`, a malformed values/params/body, or an unsupported kind) -- never for an


### PR DESCRIPTION
Follow-up to the #361 audit's one Low observation. `declaration_semantics`'s `values` / `positional_value` / `params` / `body` are **live references** into the generation's parsed AST (not deep-copied — so ranges stay exact and nothing is duplicated). This makes the **read-only** expectation an explicit contract in the accessor doc comment (`frontend_lua.lua`) and in D3.1: a consumer must not mutate a returned subtree (it would corrupt that generation's AST, and any sibling decl sharing the node — every name of a multi-name `local` shares one node).

Trusted-consumer discipline: app code never reaches `resolve_handle`; only in-process build/tool lowerers do, and each analysis re-parses fresh, so a read-only lowerer is always safe and no copy/freeze is imposed on the hot path.

**Docs/comment only — no behavior change.** luacheck clean.