### PR TITLE
ci(msan): raise MSan step timeout 15 -> 30 min (TOTP/PBKDF2 wall-clock)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1293,12 +1293,16 @@ jobs:
           sudo apt-get install -y clang
 
       - name: MSan test
-        # Bumped from 10 → 15 min in round-8. The crypto-heavy auth-
-        # stack unit tests (TOTP enrollment / PBKDF2 verify) plus the
-        # round-8 additions push the total MSan runtime past 10 min on
-        # GitHub's shared runners. Bumping the cap is cheaper than
-        # cutting test coverage; PBKDF2 isn't going to get faster.
-        timeout-minutes: 15
+        # Raised 15 -> 30 min. The crypto-heavy auth-stack unit tests
+        # (TOTP enrollment / PBKDF2 verify) dominate MSan runtime and
+        # were tipping the whole suite past the 15 min cap on GitHub's
+        # shared runners, timing out in js_stdlib.totp_brute_force_lockout.
+        # PBKDF2 under MSan instrumentation is inherently slow and its work
+        # must NOT be reduced (that would weaken coverage of the real auth
+        # path), so raising the honest wall-clock cap is the correct fix.
+        # If total runtime keeps growing, split the MSan suite into parallel
+        # jobs rather than cutting work.
+        timeout-minutes: 30
         run: make msan
 
   tsan:


### PR DESCRIPTION
## Problem

The **MSan + UBSan** job is red on `main` - the `MSan test` step times out after 15 minutes inside the crypto-heavy auth-stack unit tests. Under MSan instrumentation, `js_stdlib.totp_enroll_confirm_verify` takes ~47s and `js_stdlib.totp_pending_cleanup` ~34s (PBKDF2 verify), and the whole suite tips past the 15 min cap in `js_stdlib.totp_brute_force_lockout`.

This is a **structural, pre-existing** budget overrun, not caused by any one PR:
- Reproduces on `main` run 32147117016 (commit `904488ce`), timing out at the exact same test.
- The step was already bumped 10 -> 15 min once for the same reason (see the prior comment).

## Fix

Raise the `MSan test` step `timeout-minutes` from **15 to 30**. This is the honest immediate fix: PBKDF2 under MSan is inherently slow, and its work **must not** be reduced - cutting iterations would weaken coverage of the real auth path. If total MSan runtime keeps growing, the follow-up is to **split the MSan suite into parallel jobs**, not to cut work.

CI-only change; no source or test behavior changes.