### PR TITLE
fix(e2e): repair discovery-E2E (build/hull purge root cause) + surface failures

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -916,7 +916,15 @@ e2e-analyze: $(BUILDDIR)/hull
 	sh tests/e2e_analyze.sh
 
 .PHONY: e2e-project-discovery
-e2e-project-discovery: $(BUILDDIR)/hull
+# This E2E runs late in the CI job, after many steps that churn the shared build/ tree
+# with config-sentinel flag flips (feature/flavor/cross-build tests). Those can leave
+# build/hull stale/incomplete (observed: a hull missing the `inspect` subcommand), and the
+# plain $(BUILDDIR)/hull prerequisite treats a stale-but-present binary as up-to-date. Force
+# a clean rebuild of the binary (and cmd_agent.o, which carries the `inspect` dispatch) from
+# current source, matching the "don't trust mutable build/ state" convention used elsewhere.
+e2e-project-discovery:
+	rm -f $(BUILDDIR)/hull $(BUILDDIR)/cmd_agent.o
+	$(MAKE) $(BUILDDIR)/hull
 	sh tests/e2e_project_discovery.sh
 
 # PostgreSQL backend end-to-end (needs Docker; builds its own POSTGRES hull).

--- a/tests/e2e_build_flavor.sh
+++ b/tests/e2e_build_flavor.sh
@@ -86,8 +86,12 @@ m=$(nm "$WORK/pc/slim" 2>/dev/null | grep -cE ' [Tt] _?mbedtls_ssl_handshake' ||
 [ "$m" = 0 ] || fail "compute app on the TLS-less base should carry no mbedTLS (got $m)"
 rc=0; "$WORK/pc/slim" >/dev/null 2>&1 || rc=$?
 [ "$rc" = 7 ] || fail "the Keel/TLS-less pure-compute app should still exit 7, got $rc"
-# leave build/ as a full base again for any following target
-make -C "$ROOT" platform >/dev/null 2>&1 || true
+# Leave build/ as a full base again for any following target. This flag flip back to
+# the default config makes the sentinel purge build/hull; `make platform` alone rebuilds
+# only the platform LIB, not the binary, leaving following targets (e2e-ca-bundle,
+# e2e-project-discovery, ...) to relink a stale/incomplete build/hull from the mutable
+# tree. Build the DEFAULT target so build/hull is fully rebuilt + correct.
+make -C "$ROOT" >/dev/null 2>&1 || true
 pass "compute app on a Keel+TLS-less base drops Keel + mbedTLS entirely (0/0) + runs"
 
 echo "PASS: e2e_build_flavor"

--- a/tests/e2e_project_discovery.sh
+++ b/tests/e2e_project_discovery.sh
@@ -49,6 +49,21 @@ sys.exit(0 if ('"$_expr"') else 1)
 ' 2>/dev/null; then pass "$_name"; else fail "$_name"; fi
 }
 
+# inspect <args...>: run `hull agent inspect <args>`, capturing stdout in OUT and the exit
+# code in RC, WITHOUT tripping `set -e` (the `OUT=$(...); RC=$?` form aborts the whole script
+# on a non-zero exit before RC can be read -- true in every shell, see the `|| RC=$?` idiom
+# already used below). `hull agent inspect` is contracted to exit 0 whenever a discovery is
+# produced (validity is data in the JSON), so a non-zero exit is a genuine defect; capture
+# its stderr and DIAG-dump it so CI surfaces the real cause instead of a bare `Error 1`.
+INSPECT_ERR="$TMP/inspect.stderr"
+inspect() {
+    OUT=$("$HULL" agent inspect "$@" 2>"$INSPECT_ERR") && RC=0 || RC=$?
+    if [ "$RC" != 0 ]; then
+        echo "  DIAG: 'hull agent inspect $*' exited $RC; stderr follows:"
+        sed 's/^/    | /' "$INSPECT_ERR" 2>/dev/null || true
+    fi
+}
+
 echo ""
 echo "=== E2E: hull agent inspect (project source discovery) ==="
 
@@ -70,7 +85,7 @@ EOF
 printf 'window.x = 1;\n' > "$APP/static/vendor.js"   # browser asset -> pruned
 printf 'export const q = 1;\n' > "$APP/client.js"    # application JS -> unsupported
 
-OUT=$("$HULL" agent inspect "$APP" 2>/dev/null); RC=$?
+inspect "$APP"
 [ "$RC" = "0" ] && pass "exit 0 (a discovery was produced)" || fail "exit code ($RC)"
 
 assert_py "schema_version + standalone provenance" "$OUT" 'd["schema_version"]==1 and d["source"]=="standalone" and d["generation"]==0'
@@ -139,7 +154,7 @@ assert_py "clean all-Lua project -> valid AND complete" "$OUTC" 'd["valid"] is T
 assert_py "both annotated Lua declarations public" "$OUTC" 'sorted(x["name"] for x in d["declarations"])==["main","u"]'
 
 # ── missing root -> invalid + incomplete, project.discovery_failed, still exit 0 ──
-OUTM=$("$HULL" agent inspect "$TMP/does-not-exist" 2>/dev/null); RCM=$?
+inspect "$TMP/does-not-exist"; OUTM="$OUT"; RCM="$RC"
 assert_py "missing root -> invalid + incomplete + no sources" "$OUTM" \
     'd["valid"] is False and d["complete"] is False and len(d["sources"])==0'
 assert_py "missing root emits project.discovery_failed" "$OUTM" \


### PR DESCRIPTION
The **Project source-discovery E2E** (`hull agent inspect`) is red on `main` across all platforms but passes in isolation. Two problems, both in the test harness:

## Root cause (the actual fix)

`hull agent inspect` exited 1 with `unknown subcommand 'inspect'` because `build/hull` was a **stale/purged binary** by the time the step ran.

`tests/e2e_build_flavor.sh` runs `make platform` twice with config-sentinel flag flips (`HL_KEEL_FEATURE` / `HL_TLS_FEATURE` on, then off). Each flip makes the sentinel **purge `build/`, including `build/hull`**. Its final step was `make platform` - intended (per its comment) to "leave build/ as a full base again" - but `make platform` rebuilds only the platform **library**, not the binary. So after `e2e-build-flavor`, `build/hull` is gone, and the following steps that share the mutable `build/` tree (`e2e-ca-bundle`, then `e2e-project-discovery`) relink an incomplete `build/hull`, which the discovery step runs.

**Reproduced deterministically:** with the platform lib present (as in CI), `make e2e-build-flavor` flips `hull agent inspect` from PRESENT to ABSENT and leaves `build/hull` missing. Fix: build the **default target** (not just the platform lib) at the end of `e2e_build_flavor.sh`, so `build/hull` is fully rebuilt and correct. With the fix, `make e2e-build-flavor && make e2e-project-discovery` passes **51/51**.

## Why it was invisible (harness robustness)

The discovery harness's first `hull agent inspect` used `OUT=$("$HULL" ... 2>/dev/null); RC=$?`, which under `set -e` aborts the whole script **before** `RC=$?` runs (true in bash and dash), and `2>/dev/null` discarded the real error - so CI showed only a bare `Error 1`. Added an `inspect()` helper that captures the exit code without tripping `set -e` and **DIAG-dumps stderr** on a non-zero exit; converted the two fragile RC-checking sites. This is what surfaced the `unknown subcommand 'inspect'` message that pinpointed the root cause.

Test-harness only; no production code touched. Diagnosed from CI logs (not by increasing sleeps); production `hull agent inspect` behavior is unchanged (it does exit 0 when given a correct binary).