### PR TITLE
build: gate TUI toolchain per-runtime bridges on RUNTIME so lua-only links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -669,20 +669,25 @@ HULL_HAS_TUI := 0
 endif
 
 ifeq ($(HL_TUI_TOOLCHAIN),1)
-# The cap core lives in libhull_feature-tui.a; the per-runtime bridges are now
-# separate archives (issue #114, Phase D). hull links both runtime VMs, so
-# force-load all three (cap core + both bridges) for its own --tui commands.
-TUI_TOOLCHAIN_ARCHIVE := $(BUILDDIR)/libhull_feature-tui.a \
-                         $(BUILDDIR)/libhull_feature-tui-lua.a \
-                         $(BUILDDIR)/libhull_feature-tui-js.a
+# The cap core lives in libhull_feature-tui.a; the per-runtime bridges are separate
+# archives (issue #114, Phase D). Force-load the cap core + ONLY the per-runtime
+# bridge(s) whose VM this build actually links (the js bridge references QuickJS, so
+# a lua-only hull that omits QuickJS must NOT force-load it -- it would not link).
+# Mirrors the runtime VM selection (RUNTIME=all links both; lua/js link one).
+TUI_TOOLCHAIN_RT_LIBS :=
+ifneq ($(RUNTIME),js)
+TUI_TOOLCHAIN_RT_LIBS += $(BUILDDIR)/libhull_feature-tui-lua.a
+endif
+ifneq ($(RUNTIME),lua)
+TUI_TOOLCHAIN_RT_LIBS += $(BUILDDIR)/libhull_feature-tui-js.a
+endif
+TUI_TOOLCHAIN_ARCHIVE := $(BUILDDIR)/libhull_feature-tui.a $(TUI_TOOLCHAIN_RT_LIBS)
 ifeq ($(UNAME_S),Darwin)
 TUI_TOOLCHAIN_LDFLAGS := -Wl,-force_load,$(BUILDDIR)/libhull_feature-tui.a \
-                         -Wl,-force_load,$(BUILDDIR)/libhull_feature-tui-lua.a \
-                         -Wl,-force_load,$(BUILDDIR)/libhull_feature-tui-js.a
+                         $(foreach lib,$(TUI_TOOLCHAIN_RT_LIBS),-Wl,-force_load,$(lib))
 else
 TUI_TOOLCHAIN_LDFLAGS := -Wl,--whole-archive $(BUILDDIR)/libhull_feature-tui.a \
-                         $(BUILDDIR)/libhull_feature-tui-lua.a \
-                         $(BUILDDIR)/libhull_feature-tui-js.a -Wl,--no-whole-archive
+                         $(TUI_TOOLCHAIN_RT_LIBS) -Wl,--no-whole-archive
 endif
 else
 TUI_TOOLCHAIN_ARCHIVE :=


### PR DESCRIPTION
## Problem

A `RUNTIME=lua` build of hull fails to link with undefined `JS_*` symbols
(`JS_AddModuleExport`, `JS_Call`, ...). The cause is pre-existing and
independent of any application code: the TUI toolchain (`HL_TUI_TOOLCHAIN=1`,
default on the TUI-free native base) unconditionally force-loads **both**
per-runtime TUI bridge archives so `hull`'s own `--tui` commands resolve:

- `libhull_feature-tui-lua.a`
- `libhull_feature-tui-js.a`  ← `js_mod_tui.o`, references QuickJS

A lua-only hull omits QuickJS, so force-loading the js bridge cannot link.

## Fix

Gate the per-runtime bridge selection on `RUNTIME`, mirroring the runtime VM
composition already done for `VEND_OBJS`:

- include `libhull_feature-tui-lua.a` unless `RUNTIME=js`
- include `libhull_feature-tui-js.a` unless `RUNTIME=lua`
- `RUNTIME=all` (the default) still force-loads both.

Makefile-only, link-gating change. No functional TUI change.

## Proof

- `make clean && make RUNTIME=lua` links; `nm build/hull` shows **0** JS
  symbols; Lua app + `hull doctor` run.
- `make clean && make RUNTIME=js` links.
- `make clean && make` (default, both bridges) links; TUI symbols present.