### PR TITLE
test(frontend): drop dead pad local in the Test262 leg SHA-256

### DIFF
--- a/tests/hull/frontend/test_js_conformance.c
+++ b/tests/hull/frontend/test_js_conformance.c
@@ -515,9 +515,9 @@ static void t262_sha_hex(const void *data, size_t len, char out[65]) {
     while (rem) { size_t k = 64 - c.bl; if (k > rem) k = rem; memcpy(c.b + c.bl, p, k); c.bl += k; p += k; rem -= k;
         if (c.bl == 64) { t262_block(&c, c.b); c.bl = 0; } }
     c.n = (uint64_t)len * 8;
-    uint8_t pad = 0x80; size_t z = (c.bl < 56) ? (56 - c.bl) : (120 - c.bl);
+    size_t z = (c.bl < 56) ? (56 - c.bl) : (120 - c.bl);
     Sha256 *cp = &c;
-    { const uint8_t one = 0x80; (void)pad; memcpy(cp->b + cp->bl, &one, 1); cp->bl++; z--; if (cp->bl==64){t262_block(cp,cp->b);cp->bl=0;} }
+    { const uint8_t one = 0x80; memcpy(cp->b + cp->bl, &one, 1); cp->bl++; z--; if (cp->bl==64){t262_block(cp,cp->b);cp->bl=0;} }
     while (z) { cp->b[cp->bl++] = 0; z--; if (cp->bl==64){t262_block(cp,cp->b);cp->bl=0;} }
     for (int i = 7; i >= 0; i--) { cp->b[cp->bl++] = (uint8_t)(cp->n >> (i*8)); if (cp->bl==64){t262_block(cp,cp->b);cp->bl=0;} }
     static const char hx[] = "0123456789abcdef";


### PR DESCRIPTION
Audit follow-up (L1 from the /c-audit of #369/#370): the Test262 leg's self-contained SHA-256 finalization was rewritten inline (`const uint8_t one = 0x80`), leaving `uint8_t pad = 0x80;` dead (kept alive only by `(void)pad;`). Delete both per the project's no-dead-code convention. No behavior change — the digest is unchanged (the `test262` leg only passes when its self-SHA matches MANIFEST.sha256, which it still does).