### PR TITLE
CI architecture Slice 2: orchestrator + applicability-aware ci-success gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,13 @@ jobs:
           if [ "$EVENT" = "pull_request" ]; then
             git fetch -q --no-tags origin "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || true
             MB="$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || echo '')"
-            if [ -n "$MB" ]; then
-              git diff --name-only -z --no-renames "$MB" "$HEAD_SHA" 2>/dev/null \
-                | python3 scripts/ci/classify_changes.py --event pull_request
+            PATHS_FILE="$(mktemp)"
+            # Stage the diff into a file: a FAILING `git diff` falls back to
+            # --force-full (full_all) rather than leaving the pipeline nonzero and
+            # reddening the step. A diff failure EXPANDS coverage; it does not fail
+            # classification.
+            if [ -n "$MB" ] && git diff --name-only -z --no-renames "$MB" "$HEAD_SHA" > "$PATHS_FILE" 2>/dev/null; then
+              python3 scripts/ci/classify_changes.py --event pull_request --paths-from "$PATHS_FILE"
             else
               python3 scripts/ci/classify_changes.py --event pull_request --force-full < /dev/null
             fi
@@ -2263,11 +2267,15 @@ jobs:
         env:
           # A matrix job exposes ONE aggregate result here; ci_gate.py handles it.
           NEEDS_JSON: ${{ toJSON(needs) }}
+          EVENT: ${{ github.event_name }}
         run: |
           printf '%s' "$NEEDS_JSON" > needs.json
-          # `benchmark` is push-only, so it is legitimately skipped on a PR /
-          # workflow_dispatch. Everything else must succeed. `classify` must be
-          # present AND succeed (its self-tests guard the classifier + gate).
+          # `benchmark` is push-only: it may legitimately skip on a PR /
+          # workflow_dispatch, but on a PUSH to main it IS applicable and must
+          # succeed - a mistakenly skipped benchmark on main must not pass.
+          if [ "$EVENT" = "push" ]; then ALLOW=""; else ALLOW="benchmark"; fi
+          # `classify` must be present AND succeed (its self-tests guard the
+          # classifier + gate).
           python3 scripts/ci/ci_gate.py --needs needs.json \
-            --allow-skip benchmark --require-present classify
+            --allow-skip "$ALLOW" --require-present classify
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,68 @@ on:
       - 'LICENSE'
       - 'LICENSING.md'
       - '**.md'
+  # Manual force-full trigger (docs/ci_architecture_design.md section 15). The
+  # mechanism may ADD coverage, never suppress required work.
+  workflow_dispatch:
+    inputs:
+      force_full:
+        description: "Run the full suite regardless of changed paths."
+        type: boolean
+        default: false
 
+# CI-architecture Slice 2 (docs/ci_architecture_design.md): a `classify`
+# orchestrator job + an applicability-aware `ci-success` gate are added at the
+# top and bottom of `jobs:`. They PRESERVE current job execution - no expensive
+# job is skipped yet (classifier-based skipping is a later slice) - and
+# `ci-success` is NOT yet a required check (the branch-protection cutover is a
+# separate, explicitly authorized step). `paths-ignore` above is retained for now
+# to preserve today's behavior (docs-only changes skip the whole workflow); it is
+# removed only at the enforcement cutover, together with classifier skipping, so
+# the orchestrator can always run without exploding docs-only cost.
 jobs:
+  # -- orchestrator: classify the change + run the classifier/gate self-tests --
+  classify:
+    name: Classify changes
+    runs-on: ubuntu-24.04
+    outputs:
+      plan_json: ${{ steps.run.outputs.plan_json }}
+      plan_full_all: ${{ steps.run.outputs.plan_full_all }}
+      plan_full_core: ${{ steps.run.outputs.plan_full_core }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+      - name: Classifier + gate self-tests
+        run: |
+          python3 scripts/ci/test_classify_changes.py
+          python3 scripts/ci/test_ci_gate.py
+          python3 scripts/ci/check_gate_completeness.py
+      - name: Classify the change (informational in Slice 2; drives no skipping yet)
+        id: run
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          FORCE_FULL: ${{ github.event.inputs.force_full }}
+        run: |
+          set -uo pipefail   # NOT -e: a diff hiccup must fail CLOSED (full), never redden CI
+          if [ "$EVENT" = "pull_request" ]; then
+            git fetch -q --no-tags origin "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || true
+            MB="$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || echo '')"
+            if [ -n "$MB" ]; then
+              git diff --name-only -z --no-renames "$MB" "$HEAD_SHA" 2>/dev/null \
+                | python3 scripts/ci/classify_changes.py --event pull_request
+            else
+              python3 scripts/ci/classify_changes.py --event pull_request --force-full < /dev/null
+            fi
+          elif [ "$EVENT" = "push" ]; then
+            python3 scripts/ci/classify_changes.py --event push_main < /dev/null
+          elif [ "$EVENT" = "workflow_dispatch" ] && [ "$FORCE_FULL" != "true" ]; then
+            python3 scripts/ci/classify_changes.py --event push_main < /dev/null
+          else
+            python3 scripts/ci/classify_changes.py --event pull_request --force-full < /dev/null
+          fi
+
   build:
     strategy:
       fail-fast: false
@@ -2141,4 +2201,73 @@ jobs:
 
       - name: Build + emit/run E2E under musl (Docker Alpine)
         run: sh tests/e2e_musl.sh
+
+  # -- applicability-aware result gate (docs/ci_architecture_design.md section 16).
+  # `if: always()` makes it EVALUATE; scripts/ci/ci_gate.py decides pass/fail. It
+  # depends on EVERY job (check_gate_completeness.py enforces that in `classify`),
+  # requires each to succeed, and permits ONLY a declared-inapplicable skip - in
+  # Slice 2 that is just the push-only `benchmark` on a PR. This job is NOT yet a
+  # required status check; making it one is a separate, explicitly authorized
+  # branch-protection step. --
+  ci-success:
+    name: CI success (applicability-aware gate)
+    if: always()
+    runs-on: ubuntu-24.04
+    needs:
+      - classify
+      - build
+      - wasm-readonly-heap-aot
+      - mapped-span-bench
+      - compute-aot-shared-heap
+      - compute-memops-freestanding
+      - stream-meta
+      - spans-example
+      - spans-multi
+      - spans-hugefile
+      - wasm-guarded-aot-arm64
+      - flavors
+      - reproducibility
+      - reproducibility-container
+      - reproducibility-container-interleave
+      - reproducibility-cosmo
+      - reproducibility-cosmo-compare
+      - build-pipeline
+      - sanitizers
+      - msan
+      - tsan
+      - tsan-shared-heap
+      - fuzz
+      - postgres
+      - mysql
+      - valkey
+      - analyze
+      - cosmo
+      - gpu
+      - duckdb
+      - duckdb-feature
+      - gpu-feature
+      - tui-feature
+      - postgres-feature
+      - mysql-feature
+      - project-discovery-lua
+      - coverage
+      - lint
+      - htmx-browser
+      - benchmark
+      - embed-rust
+      - embed-zig
+      - musl
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: Evaluate required job results
+        env:
+          # A matrix job exposes ONE aggregate result here; ci_gate.py handles it.
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          printf '%s' "$NEEDS_JSON" > needs.json
+          # `benchmark` is push-only, so it is legitimately skipped on a PR /
+          # workflow_dispatch. Everything else must succeed. `classify` must be
+          # present AND succeed (its self-tests guard the classifier + gate).
+          python3 scripts/ci/ci_gate.py --needs needs.json \
+            --allow-skip benchmark --require-present classify
 

--- a/docs/ci_architecture_design.md
+++ b/docs/ci_architecture_design.md
@@ -1048,10 +1048,22 @@ self-trust caveat (§8) — governance stays with CODEOWNERS/branch protection.
   full_all; empty component (docs//x, trailing docs/) also rejected; spaces/tabs/newlines inside a path are valid), with pure-Python
   classify() fixtures AND subprocess/CLI tests of the byte decoder. 67/67
   fixtures green. Stops for review before Slice 2.
-- **Slice 2:** always-triggered orchestrator + `ci-success` gate (`if: always()`,
-  static `needs` all jobs, repo-owned result-validation script) + `main`/
-  schedule/force-full=full + branch-protection migration doc. Preserve job
-  contents.
+- **Slice 2 (DONE, this change):** a `classify` orchestrator job (runs the
+  classifier + `check_gate_completeness.py` + all fixture self-tests, then
+  classifies the merge-base diff) + an applicability-aware `ci-success` gate
+  (`if: always()`, static `needs` on EVERY job, repo-owned
+  `scripts/ci/ci_gate.py`: success required, only a declared-inapplicable skip
+  - the push-only `benchmark` on a PR - is permitted; failure / cancellation /
+  disallowed-skip / missing / unknown fail closed; a matrix job's aggregate
+  result is handled). Adds `workflow_dispatch` with a `force_full` input (§15).
+  **PRESERVES current job execution** - no expensive job is classifier-skipped
+  yet, `paths-ignore` is retained, and `ci-success` is NOT yet a required check.
+  Proven by `test_ci_gate.py` (success / failure / cancellation / legit + illegit
+  skip / missing-required / unknown / matrix-aggregate). The branch-protection
+  cutover (make `ci-success` required, likely alongside DCO) is a SEPARATE,
+  explicitly authorized step - `main` currently has NO protection/rulesets/
+  required checks, so it is a clean, reversible addition, not a migration.
+  Stops for review before Slice 3.
 - **Slices 3-6:** focused tooling jobs; domain/native mapping; cache+matrix
   (wamrc cache, kill the 9x rebuild); nightly (schedule) + rollout. Each stops
   for review.

--- a/scripts/ci/check_gate_completeness.py
+++ b/scripts/ci/check_gate_completeness.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# check_gate_completeness.py - assert the ci-success gate depends on EVERY ci.yml
+# job (docs/ci_architecture_design.md section 16: "a required job with skipped,
+# MISSING, failure, or cancellation fails"). A job absent from the gate's `needs`
+# is invisible to the gate, so its failure could pass unnoticed. This guard runs
+# in the `classify` job and fails CI if a job was added without wiring it into
+# the gate. No PyYAML dependency (parses the fixed 2-space job layout + the
+# ci-success block-list `needs`).
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import re
+import sys
+
+WORKFLOW = ".github/workflows/ci.yml"
+GATE = "ci-success"
+
+
+def parse(path):
+    lines = open(path, encoding="utf-8").read().splitlines()
+    # locate the top-level `jobs:` block
+    n = len(lines)
+    i = 0
+    while i < n and not re.match(r"^jobs:\s*$", lines[i]):
+        i += 1
+    i += 1
+    job_ids = []
+    gate_needs = None
+    while i < n:
+        ln = lines[i]
+        if re.match(r"^\S", ln):        # dedented out of jobs:
+            break
+        m = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", ln)
+        if m:
+            jid = m.group(1)
+            job_ids.append(jid)
+            if jid == GATE:
+                gate_needs = parse_needs(lines, i + 1, n)
+        i += 1
+    return job_ids, gate_needs
+
+
+def parse_needs(lines, start, n):
+    """Parse the `needs:` of the job whose body begins at `start`. Supports a
+    block list (`needs:\\n      - a\\n      - b`) and a flow list on one line
+    (`needs: [a, b, c]`). Returns a set of job ids, or None if no needs found
+    before the next job."""
+    i = start
+    while i < n:
+        ln = lines[i]
+        if re.match(r"^  [A-Za-z0-9_-]+:\s*$", ln):   # next job key -> stop
+            return None
+        m_flow = re.match(r"^    needs:\s*\[(.*)\]\s*$", ln)
+        if m_flow:
+            return {s.strip() for s in m_flow.group(1).split(",") if s.strip()}
+        if re.match(r"^    needs:\s*$", ln):
+            got = set()
+            j = i + 1
+            while j < n:
+                mi = re.match(r"^      -\s*([A-Za-z0-9_-]+)\s*$", lines[j])
+                if mi:
+                    got.add(mi.group(1)); j += 1; continue
+                break
+            return got
+        i += 1
+    return None
+
+
+def main():
+    job_ids, gate_needs = parse(WORKFLOW)
+    if GATE not in job_ids:
+        print("check-gate: no %r job found in %s" % (GATE, WORKFLOW)); return 1
+    if gate_needs is None:
+        print("check-gate: %r has no parseable `needs:`" % GATE); return 1
+
+    expected = set(job_ids) - {GATE}
+    missing = expected - gate_needs               # a job not gated
+    extra = gate_needs - set(job_ids)             # a needs entry that is not a real job
+    problems = []
+    if missing:
+        problems.append("jobs NOT in %s.needs (ungated): %s" % (GATE, sorted(missing)))
+    if extra:
+        problems.append("%s.needs references unknown jobs: %s" % (GATE, sorted(extra)))
+    print("check-gate: %d jobs, %d gated." % (len(job_ids), len(gate_needs)))
+    if problems:
+        for p in problems:
+            print("  FAIL:", p)
+        return 1
+    print("check-gate: ci-success depends on every job. OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/ci_gate.py
+++ b/scripts/ci/ci_gate.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# ci_gate.py - the applicability-aware CI result gate (docs/ci_architecture_design.md
+# section 16). Slice 2. Consumes the GitHub `needs` context (toJSON(needs)) and
+# FAILS unless every required job succeeded.
+#
+# `if: always()` on the gate job only makes it EVALUATE; this script decides
+# pass/fail. It must NOT merely accept every `skipped` result:
+#   - success                         -> ok
+#   - skipped AND declared inapplicable (allow_skip) -> ok
+#   - skipped but NOT inapplicable    -> FAIL (a required job was skipped)
+#   - failure / cancelled             -> FAIL
+#   - missing / null / unknown result -> FAIL (fail closed)
+# A matrix job exposes ONE aggregate result to `needs`, so checking that result
+# is correct (a failed/cancelled leg makes the aggregate failure/cancelled).
+#
+# In Slice 2 no job is classifier-skipped, so the only legitimate skip is a
+# genuinely conditional job (e.g. the push-only `benchmark` on a PR), passed via
+# --allow-skip. When classifier-based skipping lands, the inapplicable set is
+# derived from the plan.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import argparse
+import json
+import sys
+
+
+def evaluate(needs, allow_skip=None, require_present=()):
+    """Return a list of problems (empty => the gate passes). `needs` is the
+    toJSON(needs) map {job: {"result": "...", ...}}. `allow_skip` jobs may be
+    skipped; every other job must be success. `require_present` jobs must exist
+    AND be success (catches a required job dropped from the gate's needs)."""
+    allow_skip = set(allow_skip or ())
+    if not isinstance(needs, dict) or not needs:
+        return ["no needs results -> fail closed"]
+    problems = []
+    for job, info in sorted(needs.items()):
+        result = (info or {}).get("result")
+        if result == "success":
+            continue
+        if result == "skipped":
+            if job not in allow_skip:
+                problems.append("%s: required job was SKIPPED" % job)
+            continue
+        if result in ("failure", "cancelled"):
+            problems.append("%s: %s" % (job, result))
+            continue
+        problems.append("%s: unexpected result %r" % (job, result))   # None / "" / unknown
+    for job in require_present:
+        info = needs.get(job)
+        if not info or info.get("result") != "success":
+            problems.append("required job %r missing or not success" % job)
+    return problems
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(description="Applicability-aware CI result gate.")
+    ap.add_argument("--needs", required=True, help="path to a file holding toJSON(needs).")
+    ap.add_argument("--allow-skip", default="", help="comma-separated jobs that may be skipped.")
+    ap.add_argument("--require-present", default="classify",
+                    help="comma-separated jobs that must be present AND success.")
+    args = ap.parse_args(argv)
+
+    try:
+        with open(args.needs, "r", encoding="utf-8") as f:
+            needs = json.load(f)
+    except Exception as e:   # unreadable / malformed needs -> fail closed.
+        print("ci-gate: cannot read needs (%s) -> FAIL closed" % e)
+        return 1
+
+    allow = [s for s in args.allow_skip.split(",") if s]
+    reqp = [s for s in args.require_present.split(",") if s]
+    problems = evaluate(needs, allow_skip=allow, require_present=reqp)
+
+    total = len(needs) if isinstance(needs, dict) else 0
+    ok = sum(1 for v in (needs.values() if isinstance(needs, dict) else [])
+             if (v or {}).get("result") == "success")
+    print("ci-gate: %d/%d jobs succeeded; allow_skip=%s" % (ok, total, allow))
+    if problems:
+        for p in problems:
+            print("  FAIL:", p)
+        print("ci-gate: FAILED (%d problem(s))." % len(problems))
+        return 1
+    print("ci-gate: all required jobs passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/ci/test_ci_gate.py
+++ b/scripts/ci/test_ci_gate.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# test_ci_gate.py - fixtures for the CI result gate (docs/ci_architecture_design.md
+# sections 16 + 19). Pure Python, no GitHub Actions. Proves the gate on success,
+# failure, cancellation, and legitimate/illegitimate skips + fail-closed states.
+# Run: python3 scripts/ci/test_ci_gate.py
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from ci_gate import evaluate  # noqa: E402
+
+_pass = 0
+_fail = 0
+
+
+def R(**kw):
+    """Build a needs-like map from job=result kwargs."""
+    return {k: {"result": v} for k, v in kw.items()}
+
+
+def expect(name, needs, allow_skip=(), require_present=("classify",), should_pass=True):
+    global _pass, _fail
+    problems = evaluate(needs, allow_skip=allow_skip, require_present=require_present)
+    passed = (len(problems) == 0)
+    if passed == should_pass:
+        _pass += 1
+    else:
+        _fail += 1
+        print("FAIL: %s :: expected %s, got problems=%s"
+              % (name, "PASS" if should_pass else "FAIL", problems))
+
+
+# all success -> pass
+expect("all success", R(classify="success", build="success", lint="success"),
+       should_pass=True)
+
+# a single failure -> fail
+expect("one failure", R(classify="success", build="failure", lint="success"),
+       should_pass=False)
+
+# a cancellation -> fail
+expect("one cancelled", R(classify="success", build="cancelled", lint="success"),
+       should_pass=False)
+
+# a required job skipped (not allowed) -> fail
+expect("required job skipped", R(classify="success", build="skipped", lint="success"),
+       should_pass=False)
+
+# a legitimately inapplicable job skipped (allow_skip) -> pass
+expect("legit skip (benchmark on PR)",
+       R(classify="success", build="success", benchmark="skipped", lint="success"),
+       allow_skip=("benchmark",), should_pass=True)
+
+# a job in allow_skip that actually ran and succeeded -> still pass
+expect("allow_skip job succeeded (push)",
+       R(classify="success", build="success", benchmark="success"),
+       allow_skip=("benchmark",), should_pass=True)
+
+# an allow_skip job that FAILED is still a failure (allow_skip only excuses skip)
+expect("allow_skip job failed -> fail",
+       R(classify="success", build="success", benchmark="failure"),
+       allow_skip=("benchmark",), should_pass=False)
+
+# classify missing entirely -> fail closed (require_present)
+expect("classify missing", R(build="success", lint="success"), should_pass=False)
+
+# classify present but not success -> fail
+expect("classify failed", R(classify="failure", build="success"), should_pass=False)
+expect("classify skipped", R(classify="skipped", build="success"),
+       allow_skip=("classify",), should_pass=False)   # even if allowed to skip, require_present forbids
+
+# unknown / null result -> fail closed
+expect("null result", R(classify="success", build="success", weird=None), should_pass=False)
+expect("unknown string result",
+       {"classify": {"result": "success"}, "build": {"result": "neutral"}},
+       should_pass=False)
+expect("missing result key",
+       {"classify": {"result": "success"}, "build": {}}, should_pass=False)
+
+# empty / non-dict needs -> fail closed
+expect("empty needs", {}, should_pass=False)
+expect("non-dict needs", [], should_pass=False)   # type: ignore
+
+# matrix aggregate: a matrix job exposes one aggregate result; a failed leg -> failure
+expect("matrix aggregate failure",
+       R(classify="success", build="failure"), should_pass=False)
+expect("matrix aggregate success",
+       R(classify="success", build="success"), should_pass=True)
+
+# a realistic PR shape: all real jobs success, benchmark skipped -> pass
+expect("realistic PR (benchmark skipped, rest success)",
+       R(classify="success", build="success", sanitizers="success", fuzz="success",
+         cosmo="success", lint="success", benchmark="skipped"),
+       allow_skip=("benchmark",), should_pass=True)
+
+print("ci_gate fixtures: %d passed, %d failed" % (_pass, _fail))
+sys.exit(1 if _fail else 0)

--- a/scripts/ci/test_ci_gate.py
+++ b/scripts/ci/test_ci_gate.py
@@ -54,6 +54,12 @@ expect("legit skip (benchmark on PR)",
        R(classify="success", build="success", benchmark="skipped", lint="success"),
        allow_skip=("benchmark",), should_pass=True)
 
+# benchmark is push-only: on a PUSH plan it IS applicable (allow_skip empty), so a
+# skipped benchmark must FAIL - a mistakenly skipped benchmark on main must not pass.
+expect("benchmark skipped on push plan -> fail",
+       R(classify="success", build="success", benchmark="skipped", lint="success"),
+       allow_skip=(), should_pass=False)
+
 # a job in allow_skip that actually ran and succeeded -> still pass
 expect("allow_skip job succeeded (push)",
        R(classify="success", build="success", benchmark="success"),


### PR DESCRIPTION
Second slice of the change-aware CI rollout (docs/ci_architecture_design.md §16, §24). Adds the always-running orchestrator + result gate **while preserving current job execution** — no expensive job is classifier-skipped, `ci-success` is **not yet a required status check**, and **no repo protection/ruleset is created** (that cutover is a separate, explicitly authorized step; `main` currently has no protection at all).

## What's here
- **`classify` job** — runs the classifier + gate + completeness self-tests, then classifies the merge-base diff (`git diff --name-only -z --no-renames`) into `$GITHUB_OUTPUT`. Informational in this slice (drives no skipping yet).
- **`ci-success` gate job** — `if: always()`, static `needs` on **every** job, runs `scripts/ci/ci_gate.py`. `always()` only makes it *evaluate*; the script decides pass/fail: success required; only a **declared-inapplicable** skip (the push-only `benchmark` on a PR) is permitted; failure / cancellation / disallowed-skip / missing / null / unknown **fail closed**; a matrix job's aggregate result is handled.
- **`scripts/ci/check_gate_completeness.py`** — asserts `ci-success` depends on every ci.yml job (a job invisible to the gate could fail unnoticed); run in `classify`.
- **`scripts/ci/test_ci_gate.py`** — 18 fixtures: success / failure / cancellation / legit + illegit skip / classify missing-or-failed / unknown / empty / matrix-aggregate. All green.
- **`workflow_dispatch` + `force_full`** input (§15).

## Preserved / deferred
- `paths-ignore` retained → today's behavior unchanged (docs-only skips the whole workflow). Removed only at the enforcement cutover (coupled with classifier skipping) so the orchestrator can always run without exploding docs-only cost.
- Classifier-based **skipping** of expensive jobs, the `fuzz` split, and the focused embedded-host frontend job → **Slice 3**.
- Making `ci-success` a **required** check (likely alongside DCO) → separate explicit authorization.

## Local validation
`classify_changes` 67/67, `ci_gate` 18/18, gate-completeness OK, ci.yml parses (44 jobs, 43 gated). The real proof is this PR's own run: `ci-success` should go green by correctly evaluating the full matrix (benchmark skipped on a PR).

Stops for review per §24.