### PR TITLE
CI architecture Slice 3a: split fuzz + focused frontend jobs (additive, no skipping)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1419,128 +1419,97 @@ jobs:
         timeout-minutes: 20
         run: make CC=clang tsan-shared-heap
 
-  fuzz:
-    name: Fuzz Testing
+  # -- fuzz split (docs/ci_architecture_design.md section 11): native protocol /
+  # security fuzzers, the Lua source parser fuzzer, and the JS source parser
+  # fuzzer as INDEPENDENT jobs so path-aware selection can run only the relevant
+  # target. Each keeps its sanitizer instrumentation + 60s libFuzzer budget. --
+  fuzz-native-security:
+    name: Fuzz (native security)
     runs-on: ubuntu-24.04
-
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           submodules: true
-
       - name: Install clang
+        run: sudo apt-get update && sudo apt-get install -y clang
+      - name: Build native fuzz targets
         run: |
-          sudo apt-get update
-          sudo apt-get install -y clang
+          make CC=clang \
+            fuzz/fuzz_sh_json fuzz/fuzz_path_normalize fuzz/fuzz_mime_sniff \
+            fuzz/fuzz_host_match fuzz/fuzz_pgwire fuzz/fuzz_pg_dsn fuzz/fuzz_pg_rewrite \
+            fuzz/fuzz_mysqlwire fuzz/fuzz_mysql_dsn fuzz/fuzz_respwire \
+            fuzz/fuzz_valkey_dsn fuzz/fuzz_span_sdk fuzz/fuzz_span_window
+      - name: Run native fuzzers (60s each)
+        timeout-minutes: 20
+        run: |
+          set -e
+          for f in sh_json path_normalize mime_sniff host_match pgwire pg_dsn \
+                   pg_rewrite mysqlwire mysql_dsn respwire valkey_dsn span_sdk span_window; do
+            echo "== fuzz $f =="
+            ./fuzz/fuzz_$f fuzz/corpus_$f/ -max_total_time=60
+          done
 
-      - name: Build fuzz targets
-        run: make fuzz CC=clang
-
-      - name: Fuzz sh_json (60s)
-        # Parses untrusted request-body / config JSON. ASan + UBSan over
-        # 60s of libFuzzer; a crash writes crash-<sha> and fails the job.
-        timeout-minutes: 3
-        run: ./fuzz/fuzz_sh_json fuzz/corpus_sh_json/ -max_total_time=60
-
-      - name: Fuzz path_normalize (60s)
-        # require()/import() path canonicaliser — a .. escape or OOB write
-        # is a sandbox-traversal primitive.
-        timeout-minutes: 3
-        run: ./fuzz/fuzz_path_normalize fuzz/corpus_path_normalize/ -max_total_time=60
-
-      - name: Fuzz mime_sniff (60s)
-        # Magic-byte / shape sniffer over the first ~4 KiB of untrusted stored
-        # upload bytes — an over-read past len is a crash / info-leak.
-        timeout-minutes: 3
-        run: ./fuzz/fuzz_mime_sniff fuzz/corpus_mime_sniff/ -max_total_time=60
-
-      - name: Fuzz host_match (60s)
-        # Host-allowlist matcher: glob + CIDR (inet_pton / bit compare) over
-        # attacker-influenced allowlist patterns and hosts (dynamic DB conns).
-        timeout-minutes: 3
-        run: ./fuzz/fuzz_host_match fuzz/corpus_host_match/ -max_total_time=60
-
-      - name: Fuzz pgwire (60s)
-        # PostgreSQL v3 wire-protocol reader over untrusted server bytes. The
-        # bounds-checked framing / cursor is the trust boundary for a
-        # malicious or MITM'd Postgres; an OOB read is an info-leak / crash.
-        timeout-minutes: 3
-        run: ./fuzz/fuzz_pgwire fuzz/corpus_pgwire/ -max_total_time=60
-
-      - name: Fuzz pg_dsn (60s)
-        # DSN parser: percent-decoding + bounded field splitting over a
-        # user-supplied connection string.
-        timeout-minutes: 3
-        run: ./fuzz/fuzz_pg_dsn fuzz/corpus_pg_dsn/ -max_total_time=60
-
-      - name: Fuzz pg_rewrite (60s)
-        # ?-to-$n placeholder rewriter: literal / comment / dollar-quote-aware
-        # SQL scan. A miscount or OOB write here corrupts the parameterized
-        # query the app sends.
-        timeout-minutes: 3
-        run: ./fuzz/fuzz_pg_rewrite fuzz/corpus_pg_rewrite/ -max_total_time=60
-
-      - name: Fuzz mysqlwire (60s)
-        # MySQL/MariaDB wire reader over untrusted server bytes: bounds-checked
-        # framing + length-encoded int/string cursor is the trust boundary for a
-        # malicious or MITM'd MySQL. An OOB read is an info-leak / crash.
-        timeout-minutes: 3
-        run: ./fuzz/fuzz_mysqlwire fuzz/corpus_mysqlwire/ -max_total_time=60
-
-      - name: Fuzz mysql_dsn (60s)
-        # MySQL/MariaDB DSN parser: percent-decoding + bounded field splitting
-        # over a user-supplied connection string.
-        timeout-minutes: 3
-        run: ./fuzz/fuzz_mysql_dsn fuzz/corpus_mysql_dsn/ -max_total_time=60
-
-      - name: Fuzz respwire (60s)
-        # RESP2/3 reply parser over untrusted server bytes: bounds-checked,
-        # depth-capped decode is the trust boundary for a malicious / MITM'd
-        # Valkey/Redis. An OOB read or unbounded recursion is a crash / DoS.
-        timeout-minutes: 3
-        run: ./fuzz/fuzz_respwire fuzz/corpus_respwire/ -max_total_time=60
-
-      - name: Fuzz valkey_dsn (60s)
-        # Valkey/Redis DSN parser: percent-decoding + bounded field splitting
-        # over a user-supplied connection string.
-        timeout-minutes: 3
-        run: ./fuzz/fuzz_valkey_dsn fuzz/corpus_valkey_dsn/ -max_total_time=60
-
-      - name: Fuzz span SDK (60s)
-        # Mapped-span guest SDK math (templates/hull_span.h): the attacker-
-        # controlled span-metadata decode + window-read offset arithmetic a WASM
-        # plugin runs. Adversarial offsets over a truthful window under ASan prove
-        # hull_span__fits() never lets an OOB / width-straddling read through.
-        timeout-minutes: 3
-        run: ./fuzz/fuzz_span_sdk fuzz/corpus_span_sdk/ -max_total_time=60
-
-      - name: Fuzz span window geometry (60s)
-        # Mapped-window geometry (hl_cap_fs_mmap_window_geometry): page-align +
-        # EOF-clamp + overflow-safe page-rounding of an (offset,length) request.
-        # UBSan + invariant asserts catch any overflow or logically-wrong mapping.
-        timeout-minutes: 3
-        run: ./fuzz/fuzz_span_window fuzz/corpus_span_window/ -max_total_time=60
-
-      - name: Fuzz lua source parser (60s)
-        # hull.source.lua: adversarial bytes -> lua.parse() over a bounded lua_State.
-        # Intrinsic invariants (never-raise / valid shape / range sanity / bounded via
-        # a per-input allocator, with LUA_ERRMEM classified as expected exhaustion) +
-        # ASan/UBSan on the instrumented Lua VM. `make fuzz-lua-source` stages the full
-        # repo .lua corpus deterministically first (from the repo root, so package.path
-        # resolves). Complements the differential conformance gate.
-        timeout-minutes: 3
+  fuzz-lua-source:
+    name: Fuzz (Lua source parser)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+      - name: Install clang
+        run: sudo apt-get update && sudo apt-get install -y clang
+      - name: Fuzz Lua source parser (60s)
+        # hull.source.lua: adversarial bytes -> lua.parse() over a bounded lua_State,
+        # ASan/UBSan on the instrumented VM; corpus staged from the repo root.
+        timeout-minutes: 5
         run: make fuzz-lua-source CC=clang FUZZ_TIME=60
 
+  fuzz-js-source:
+    name: Fuzz (JS source parser)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+      - name: Install clang
+        run: sudo apt-get update && sudo apt-get install -y clang
       - name: Fuzz JS source parser (60s)
-        # hull:source:parser (JS): adversarial bytes -> parse() through the restricted QuickJS
-        # session, via the test-only compact entry hull:source:tests:fuzz_parse. Intrinsic
-        # invariants (never-raise / valid SourceUnit shape / range + nesting + raw-slice + no
-        # cycles / diagnostic-budget / js.internal aborts / active session-reuse proof after
-        # host js.limit.*). Sanitizer split keeps UBSan off vendored QuickJS (fuzzer-no-link,
-        # address) while retaining coverage + ASan; full sanitizers on Hull code.
-        # `make fuzz-js-source` stages the full repo .js/.mjs/.cjs corpus first.
-        timeout-minutes: 3
+        # hull:source:parser through the restricted QuickJS session (fuzz_parse entry);
+        # sanitizer split keeps UBSan off vendored QuickJS. Corpus staged first.
+        timeout-minutes: 5
         run: make fuzz-js-source CC=clang FUZZ_TIME=60
+
+  # -- focused source-frontend jobs (docs/ci_architecture_design.md sections 4, 9):
+  # a FRESH embedded-host build + the frontend unit suite + the discovery /
+  # dev-agent / inspect lifecycle. ADDITIVE in this checkpoint (they run on every
+  # PR/push alongside the full matrix); classifier-based skipping of the redundant
+  # full build for tooling PRs is the next checkpoint, gated on coverage
+  # equivalence. --
+  focused-js-frontend:
+    name: Focused JS frontend (fresh embedded host)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: recursive
+      - name: JS frontend tests (fresh registry embed)
+        run: make test-js-frontend
+      - name: Project source-discovery lifecycle (hull dev --agent -> inspect, JS)
+        timeout-minutes: 6
+        run: make e2e-project-discovery
+
+  focused-lua-frontend:
+    name: Focused Lua frontend (fresh embedded host)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: recursive
+      - name: Lua source + frontend tests (fresh registry embed)
+        run: make test-lua-frontend
+      - name: Project source-discovery lifecycle (lua-only)
+        timeout-minutes: 6
+        run: make e2e-project-discovery-lua
 
   # End-to-end against a real PostgreSQL 16 (started in Docker by the script).
   # Exercises the whole path the unit tests can't: DSN -> SCRAM-SHA-256 auth
@@ -2240,7 +2209,11 @@ jobs:
       - msan
       - tsan
       - tsan-shared-heap
-      - fuzz
+      - fuzz-native-security
+      - fuzz-lua-source
+      - fuzz-js-source
+      - focused-js-frontend
+      - focused-lua-frontend
       - postgres
       - mysql
       - valkey

--- a/docs/ci_architecture_design.md
+++ b/docs/ci_architecture_design.md
@@ -1064,6 +1064,18 @@ self-trust caveat (§8) — governance stays with CODEOWNERS/branch protection.
   explicitly authorized step - `main` currently has NO protection/rulesets/
   required checks, so it is a clean, reversible addition, not a migration.
   Stops for review before Slice 3.
-- **Slices 3-6:** focused tooling jobs; domain/native mapping; cache+matrix
-  (wamrc cache, kill the 9x rebuild); nightly (schedule) + rollout. Each stops
-  for review.
+- **Slice 3 (IN PROGRESS):** two review checkpoints.
+  - **Checkpoint 3a (DONE, this change):** ADD + prove, preserving all existing
+    execution. Split the combined `fuzz` job into `fuzz-native-security` /
+    `fuzz-lua-source` / `fuzz-js-source` (§11), and add `focused-js-frontend` /
+    `focused-lua-frontend` jobs (a FRESH embedded-host build via the new
+    `make test-js-frontend` / `test-lua-frontend` targets + the discovery /
+    dev-agent / inspect lifecycle, §4/§9/§20). These run on EVERY PR/push
+    alongside the full matrix (nothing skipped); `ci-success.needs` updated
+    (48 jobs, 47 gated). No classifier skipping, no branch-protection change.
+  - **Checkpoint 3b (NEXT):** ONLY after coverage equivalence is demonstrated -
+    wire classifier-based skipping of the redundant full-matrix jobs for
+    tooling/frontend PRs and update `ci-success` applicability (the plan-derived
+    allow-skip set), removing `paths-ignore` so the orchestrator always runs.
+- **Slices 4-6:** domain/native mapping; cache+matrix (wamrc cache, kill the 9x
+  rebuild); nightly (schedule) + rollout. Each stops for review.

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -579,6 +579,29 @@ $(BUILDDIR)/test_cacert: $(TESTDIR)/hull/test_cacert.c $(CACERT_OBJ) $(MBEDTLS_O
 	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< \
 		$(CACERT_OBJ) $(MBEDTLS_OBJS)
 
+# ── Focused source-frontend test groups (docs/ci_architecture_design.md sections 4, 9) ──
+# Build the frontend test binaries FRESH (they embed the current stdlib registry
+# via STDLIB_JS_CLI_REGISTRY_O / LUA_OBJS) and run them - the "fresh embedded
+# host" a tooling/frontend PR needs, without the full platform matrix. Used by
+# the focused CI jobs; runnable locally too.
+JS_FRONTEND_TEST_BINS := $(addprefix $(BUILDDIR)/,\
+	test_js_session test_js_lexer test_js_parser test_js_conformance \
+	test_js_annotations test_js_scope test_js_frontend test_js_generation test_js_fuzz_entry)
+
+.PHONY: test-js-frontend
+test-js-frontend: $(JS_FRONTEND_TEST_BINS)
+	@pass=0; fail=0; \
+	for t in $(JS_FRONTEND_TEST_BINS); do \
+		echo "=== $$(basename $$t) ==="; \
+		if HULL_QUIET_AOT=1 $$t; then pass=$$((pass+1)); else fail=$$((fail+1)); fi; \
+	done; \
+	echo "test-js-frontend: $$pass ok, $$fail failed"; \
+	[ $$fail -eq 0 ]
+
+.PHONY: test-lua-frontend
+test-lua-frontend: $(BUILDDIR)/test_lua_source
+	$(BUILDDIR)/test_lua_source
+
 test: $(TEST_BINS)
 	@echo "Running tests..."
 	@pass=0; fail=0; total=0; \


### PR DESCRIPTION
First of Slice 3's two checkpoints (docs/ci_architecture_design.md §4/§9/§11/§24). **Add + prove**, **preserving all existing execution** — nothing is classifier-skipped, `ci-success` stays non-required, no branch-protection change. Coverage-equivalence proof + classifier-based skipping is **checkpoint 2 (separate PR)**.

## What's added
- **Fuzz split** (§11): the combined `fuzz` job → three independent jobs — `fuzz-native-security` (the 13 native protocol/security fuzzers), `fuzz-lua-source`, `fuzz-js-source`. Each keeps its sanitizer instrumentation + 60s libFuzzer budget, so path-aware selection can later run only the relevant target.
- **Focused frontend jobs** (§4/§9/§20): `focused-js-frontend` and `focused-lua-frontend` — a **fresh embedded-host build** (the frontend test binaries embed the current stdlib registry) via new `make test-js-frontend` / `test-lua-frontend` targets, plus the project source-discovery lifecycle (`hull dev --agent` → `inspect`) via `e2e-project-discovery` / `-lua`.

## Preserved / deferred
- Both focused jobs run on **every PR/push alongside the full matrix** in this checkpoint (additive; the full `build` matrix still runs `make test` + discovery). Skipping the redundant full build for tooling PRs is **checkpoint 2**, gated on demonstrated coverage equivalence.
- `ci-success.needs` updated to the new job set (48 jobs, 47 gated); `check_gate_completeness.py` enforces it.
- No `paths-ignore` removal, no classifier skipping, no required-check/ruleset change.

## Validation
`classify` 67/67, `ci_gate` 19/19, gate-completeness OK; `make test-js-frontend` (9 suites) + `make test-lua-frontend` (10 legs incl. official Lua 5.4.7 corpus) build + pass fresh locally. The live run proves the new jobs + the gate over the expanded `needs`.

Stops for review (checkpoint 1).