### PR TITLE
CI architecture Slice 3b: classifier-based skipping (single applicability map)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,31 +1,16 @@
 name: CI
 
 on:
+  # NO paths-ignore (docs/ci_architecture_design.md sections 3, 10): the
+  # orchestrator must ALWAYS run so `classify` + `ci-success` always appear as
+  # checks and can never leave a required check pending because the whole
+  # workflow was path-skipped. A docs-only change now runs `classify` (-> the
+  # docs-only plan) + `lint` + `ci-success` and skips everything else via the
+  # classifier, instead of skipping the entire workflow.
   push:
     branches: [main]
-    # Site / docs / changelog updates don't touch any C, Lua, JS, Makefile,
-    # or workflow surface that CI validates — skip the full build matrix
-    # for those. deploy-site.yml handles site/** independently.
-    paths-ignore:
-      - 'site/**'
-      - 'docs/**'
-      - 'CHANGELOG.md'
-      - 'README.md'
-      - 'CONTRIBUTING.md'
-      - 'LICENSE'
-      - 'LICENSING.md'
-      - '**.md'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'site/**'
-      - 'docs/**'
-      - 'CHANGELOG.md'
-      - 'README.md'
-      - 'CONTRIBUTING.md'
-      - 'LICENSE'
-      - 'LICENSING.md'
-      - '**.md'
   # Manual force-full trigger (docs/ci_architecture_design.md section 15). The
   # mechanism may ADD coverage, never suppress required work.
   workflow_dispatch:
@@ -35,34 +20,41 @@ on:
         type: boolean
         default: false
 
-# CI-architecture Slice 2 (docs/ci_architecture_design.md): a `classify`
-# orchestrator job + an applicability-aware `ci-success` gate are added at the
-# top and bottom of `jobs:`. They PRESERVE current job execution - no expensive
-# job is skipped yet (classifier-based skipping is a later slice) - and
-# `ci-success` is NOT yet a required check (the branch-protection cutover is a
-# separate, explicitly authorized step). `paths-ignore` above is retained for now
-# to preserve today's behavior (docs-only changes skip the whole workflow); it is
-# removed only at the enforcement cutover, together with classifier skipping, so
-# the orchestrator can always run without exploding docs-only cost.
+# CI-architecture Slice 3b (docs/ci_architecture_design.md): the `classify`
+# orchestrator emits per-group run-flags from the change plan; each expensive job
+# gates on its flag (`if: needs.classify.outputs.run_*`), and the `ci-success`
+# gate derives its allow-skip from the SAME job-applicability map
+# (scripts/ci/job_plan.py, enforced by check_job_plan_consistency.py). Only the
+# PROVEN narrow classes skip - docs-only, JS frontend/fuzz, Lua frontend/fuzz -
+# every other plan (core, tooling, domain, examples, generic tests, unknown,
+# main/full/force-full) runs the broad suite. `ci-success` is still NOT a
+# required check; branch protection is unchanged.
 jobs:
-  # -- orchestrator: classify the change + run the classifier/gate self-tests --
+  # -- orchestrator: classify the change, self-test the classifier/gate/map, then
+  # emit the per-group run-flags every expensive job gates on. --
   classify:
     name: Classify changes
     runs-on: ubuntu-24.04
     outputs:
       plan_json: ${{ steps.run.outputs.plan_json }}
-      plan_full_all: ${{ steps.run.outputs.plan_full_all }}
-      plan_full_core: ${{ steps.run.outputs.plan_full_core }}
+      run_full_matrix: ${{ steps.flags.outputs.run_full_matrix }}
+      run_focused_js: ${{ steps.flags.outputs.run_focused_js }}
+      run_focused_lua: ${{ steps.flags.outputs.run_focused_lua }}
+      run_fuzz_js: ${{ steps.flags.outputs.run_fuzz_js }}
+      run_fuzz_lua: ${{ steps.flags.outputs.run_fuzz_lua }}
+      run_fuzz_native: ${{ steps.flags.outputs.run_fuzz_native }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
-      - name: Classifier + gate self-tests
+      - name: Classifier + gate + applicability self-tests
         run: |
           python3 scripts/ci/test_classify_changes.py
           python3 scripts/ci/test_ci_gate.py
+          python3 scripts/ci/test_job_plan.py
           python3 scripts/ci/check_gate_completeness.py
-      - name: Classify the change (informational in Slice 2; drives no skipping yet)
+          python3 scripts/ci/check_job_plan_consistency.py
+      - name: Classify the change (merge-base diff -> plan)
         id: run
         env:
           EVENT: ${{ github.event_name }}
@@ -91,8 +83,15 @@ jobs:
           else
             python3 scripts/ci/classify_changes.py --event pull_request --force-full < /dev/null
           fi
+      - name: Emit per-group run-flags (the single map the job `if:` conditions use)
+        id: flags
+        run: python3 scripts/ci/job_plan.py --plan "$PLAN"
+        env:
+          PLAN: ${{ steps.run.outputs.plan_json }}
 
   build:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -427,6 +426,8 @@ jobs:
   # builds + runs the C-API test with a real wamrc-emitted .aot fixture and FAILS
   # if the AOT sub-case is SKIPPED. That closes the "AOT is dormant in CI" gap.
   wasm-readonly-heap-aot:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: WAMR AOT C-API tests (readonly + guarded, x86_64)
     runs-on: ubuntu-24.04
     steps:
@@ -596,6 +597,8 @@ jobs:
   # baselines stabilize (docs/mapped_span_benchmark_design.md D11). A 1 GiB
   # controlled run is the separate manually-triggered bench_mapped_span_1g.yml.
   mapped-span-bench:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: Mapped-span benchmark (96 MiB, x86_64)
     runs-on: ubuntu-24.04
     steps:
@@ -643,6 +646,8 @@ jobs:
   # Drives the REAL production `hull build` path (embedded hull + wamrc), so the
   # AOT is exercised non-skippably.
   compute-aot-shared-heap:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: Compute AOT shared-heap reads (spans + segments)
     runs-on: ubuntu-24.04
     steps:
@@ -712,6 +717,8 @@ jobs:
   # Drives the real driver (needs a wasm clang + wasm-ld), so this job installs
   # clang + lld; the AOT leg needs an embedded hull + wamrc.
   compute-memops-freestanding:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: Freestanding libc (memcpy/memset/memmove) — interp + AOT
     runs-on: ubuntu-24.04
     steps:
@@ -760,6 +767,8 @@ jobs:
   # (#331): hull_stream_is_first/is_last/chunk_index over a real 3-chunk
   # compute.stream, Lua + JS, interpreter + AOT. Needs clang + wamrc + embedded hull.
   stream-meta:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: compute stream metadata helpers — Lua + JS, interp + AOT
     runs-on: ubuntu-24.04
     steps:
@@ -803,6 +812,8 @@ jobs:
   # `hull build` path (--enable-shared-heap). Needs a wasm clang + wamrc + an
   # embedded hull; runs non-skippably here.
   spans-example:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: mapped_spans example — Lua + JS, interp + AOT (public SDK)
     runs-on: ubuntu-24.04
     steps:
@@ -848,6 +859,8 @@ jobs:
   # lookup (+ unknown -1), Lua AND JS, interpreter AND AOT via the production
   # `hull build` path. Needs a wasm clang + wamrc + an embedded hull; non-skippable.
   spans-multi:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: mapped spans — multiple named spans, Lua + JS, interp + AOT
     runs-on: ubuntu-24.04
     steps:
@@ -892,6 +905,8 @@ jobs:
   # (first/exact-end/one-past/straddle), Lua + JS, interpreter + AOT (3b
   # completion). Uses a SPARSE 5 GiB file (no real disk) so it runs anywhere.
   spans-hugefile:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: mapped spans — >4GiB foffset + setup capacity, Lua + JS, interp + AOT
     runs-on: ubuntu-24.04
     steps:
@@ -937,6 +952,8 @@ jobs:
   # shipped arch rather than assuming it. Interp coverage on arm64 comes from the
   # aarch64 build job's `make test`; this closes the arm64 AOT leg.
   wasm-guarded-aot-arm64:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: Guarded-subrange AOT C-API test (arm64)
     runs-on: ubuntu-24.04-arm
     steps:
@@ -1070,6 +1087,8 @@ jobs:
   # / client-only were removed as products in #114; the HTTP axis is now full vs
   # pure-compute, and pure-compute exercises both HTTP halves off at once.)
   flavors:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: Build flavor (${{ matrix.name }})
     runs-on: ubuntu-24.04
     strategy:
@@ -1147,6 +1166,8 @@ jobs:
           fi
 
   reproducibility:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: Reproducible build (${{ matrix.name }})
     strategy:
       fail-fast: false
@@ -1195,6 +1216,8 @@ jobs:
   # the macos-15 Xcode runner. See docs/security.md "Build-environment
   # immutability" and .github/docker/README.md.
   reproducibility-container:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: Reproducible build (Linux container)
     runs-on: ubuntu-24.04
     steps:
@@ -1224,6 +1247,8 @@ jobs:
   # hull), and release.yml is tag-only so it cannot be exercised on a PR. This
   # job is the PR-validatable proxy for that ownership + run path. Roadmap 0.3.1.
   reproducibility-container-interleave:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: Reproducible build (Linux container, host interleave)
     runs-on: ubuntu-24.04
     steps:
@@ -1254,6 +1279,8 @@ jobs:
   # "Cosmopolitan produces deterministic output" claim (docs/security.md) for
   # the hull-cosmo release binary itself.
   reproducibility-cosmo:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: Reproducible build (Cosmo ${{ matrix.n }})
     strategy:
       fail-fast: false
@@ -1282,8 +1309,9 @@ jobs:
           if-no-files-found: error
 
   reproducibility-cosmo-compare:
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: Reproducible build (Cosmo compare)
-    needs: reproducibility-cosmo
+    needs: [reproducibility-cosmo, classify]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
@@ -1306,6 +1334,8 @@ jobs:
           fi
 
   build-pipeline:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -1328,6 +1358,8 @@ jobs:
         run: make e2e-build
 
   sanitizers:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: ASan + UBSan
     runs-on: ubuntu-24.04
 
@@ -1343,6 +1375,8 @@ jobs:
           make DEBUG=1 test
 
   msan:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: MSan + UBSan
     runs-on: ubuntu-24.04
 
@@ -1370,6 +1404,8 @@ jobs:
         run: make msan
 
   tsan:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: TSan (worker pool)
     runs-on: ubuntu-24.04
 
@@ -1403,6 +1439,8 @@ jobs:
   # Isolated from the worker-pool job so instrumenting WAMR does not perturb that
   # signal.
   tsan-shared-heap:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: TSan (WAMR shared-heap destroy + guarded subrange + spans)
     runs-on: ubuntu-24.04
     steps:
@@ -1424,6 +1462,8 @@ jobs:
   # fuzzer as INDEPENDENT jobs so path-aware selection can run only the relevant
   # target. Each keeps its sanitizer instrumentation + 60s libFuzzer budget. --
   fuzz-native-security:
+    needs: [classify]
+    if: needs.classify.outputs.run_fuzz_native == 'true'
     name: Fuzz (native security)
     runs-on: ubuntu-24.04
     steps:
@@ -1450,6 +1490,8 @@ jobs:
           done
 
   fuzz-lua-source:
+    needs: [classify]
+    if: needs.classify.outputs.run_fuzz_lua == 'true'
     name: Fuzz (Lua source parser)
     runs-on: ubuntu-24.04
     steps:
@@ -1465,6 +1507,8 @@ jobs:
         run: make fuzz-lua-source CC=clang FUZZ_TIME=60
 
   fuzz-js-source:
+    needs: [classify]
+    if: needs.classify.outputs.run_fuzz_js == 'true'
     name: Fuzz (JS source parser)
     runs-on: ubuntu-24.04
     steps:
@@ -1486,6 +1530,8 @@ jobs:
   # full build for tooling PRs is the next checkpoint, gated on coverage
   # equivalence. --
   focused-js-frontend:
+    needs: [classify]
+    if: needs.classify.outputs.run_focused_js == 'true'
     name: Focused JS frontend (fresh embedded host)
     runs-on: ubuntu-24.04
     steps:
@@ -1499,6 +1545,8 @@ jobs:
         run: make e2e-project-discovery
 
   focused-lua-frontend:
+    needs: [classify]
+    if: needs.classify.outputs.run_focused_lua == 'true'
     name: Focused Lua frontend (fresh embedded host)
     runs-on: ubuntu-24.04
     steps:
@@ -1519,6 +1567,8 @@ jobs:
   # / auth-health) on Postgres. The script self-builds with
   # HL_ENABLE_POSTGRES=1 and skips cleanly if Docker is unavailable.
   postgres:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: PostgreSQL e2e
     runs-on: ubuntu-24.04
 
@@ -1538,6 +1588,8 @@ jobs:
   # / insert_if_absent) on the MySQL dialect; and caching_sha2 full-auth over
   # TLS. Self-builds with HL_ENABLE_MYSQL=1; skips cleanly without Docker.
   mysql:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: MySQL e2e
     runs-on: ubuntu-24.04
 
@@ -1558,6 +1610,8 @@ jobs:
   # network_outbound sandbox grant (e2e-feature-valkey builds its own base).
   # redis-server from apt (no Docker); the e2e scripts also fall back to Docker.
   valkey:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: Valkey/Redis e2e
     runs-on: ubuntu-24.04
 
@@ -1586,6 +1640,8 @@ jobs:
         run: make e2e-feature-valkey
 
   analyze:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: Static Analysis
     runs-on: ubuntu-24.04
 
@@ -1606,6 +1662,8 @@ jobs:
         run: make cppcheck
 
   cosmo:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: Cosmopolitan (APE)
     runs-on: ubuntu-24.04
 
@@ -1706,6 +1764,8 @@ jobs:
       # `make e2e-build-flavor`.)
 
   gpu:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: GPU Compute (macOS Metal)
     runs-on: macos-15
 
@@ -1733,6 +1793,8 @@ jobs:
         run: make e2e-compute HL_ENABLE_GPU=1
 
   duckdb:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: DuckDB backend (Linux)
     runs-on: ubuntu-24.04
 
@@ -1868,6 +1930,8 @@ jobs:
   # archive, then `hull build --with=duckdb` an app and runs it. Must not share a
   # tree with the HL_ENABLE_DUCKDB=1 job above (flag-flip object staleness).
   duckdb-feature:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: DuckDB feature build (Linux)
     runs-on: ubuntu-24.04
     steps:
@@ -1888,6 +1952,8 @@ jobs:
   # library and pulls in the runtime loader (libvulkan1) so it boots with 0
   # devices. See docs/features_and_flavors.md.
   gpu-feature:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: GPU feature build (Linux)
     runs-on: ubuntu-24.04
     steps:
@@ -1907,6 +1973,8 @@ jobs:
   # `hull build --with=tui` an app and boots it (asserts hull.tui registered).
   # Pure C, no vendored lib and no extra link libs, so no install step.
   tui-feature:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: TUI feature build (Linux)
     runs-on: ubuntu-24.04
     steps:
@@ -1918,6 +1986,8 @@ jobs:
         run: sh tests/e2e_feature_tui.sh
 
   postgres-feature:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: Postgres feature build (Linux)
     runs-on: ubuntu-24.04
     steps:
@@ -1929,6 +1999,8 @@ jobs:
         run: sh tests/e2e_feature_postgres.sh
 
   mysql-feature:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: MySQL feature build (Linux)
     runs-on: ubuntu-24.04
     steps:
@@ -1944,6 +2016,8 @@ jobs:
   # so this job FAILS if JavaScript is somehow analyzable here - the JS-less branch can never
   # silently skip. The analyzable side is pinned (EXPECT_JS=1) in the main `build` job's step.
   project-discovery-lua:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: Project source-discovery E2E (lua-only, JS unavailable)
     runs-on: ubuntu-24.04
     steps:
@@ -1955,6 +2029,8 @@ jobs:
         run: make e2e-project-discovery-lua
 
   coverage:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: Code Coverage
     runs-on: ubuntu-24.04
 
@@ -2012,6 +2088,8 @@ jobs:
         run: make check-sdk-headers-selftest
 
   htmx-browser:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: HTMX browser tests (${{ matrix.name }})
     strategy:
       fail-fast: false
@@ -2080,9 +2158,10 @@ jobs:
           if-no-files-found: ignore
 
   benchmark:
+    needs: [classify]
     name: Benchmark (${{ matrix.runtime }})
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && needs.classify.outputs.run_full_matrix == 'true'
 
     strategy:
       matrix:
@@ -2113,6 +2192,8 @@ jobs:
   # The make target skips when the toolchain is absent, so we assert it actually
   # ran (grep for the OK line) rather than silently pass.
   embed-rust:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: libhull embedder (Rust)
     runs-on: ubuntu-24.04
 
@@ -2131,6 +2212,8 @@ jobs:
             || { echo "::error::embed_rust did not run to completion"; exit 1; }
 
   embed-zig:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: libhull embedder (Zig)
     runs-on: ubuntu-24.04
 
@@ -2161,6 +2244,8 @@ jobs:
             || { echo "::error::embed_zig did not run to completion"; exit 1; }
 
   musl:
+    needs: [classify]
+    if: needs.classify.outputs.run_full_matrix == 'true'
     name: musl (Alpine)
     runs-on: ubuntu-24.04
     # A plain ubuntu runner (not container: alpine) so actions/checkout keeps
@@ -2240,15 +2325,15 @@ jobs:
         env:
           # A matrix job exposes ONE aggregate result here; ci_gate.py handles it.
           NEEDS_JSON: ${{ toJSON(needs) }}
+          PLAN: ${{ needs.classify.outputs.plan_json }}
           EVENT: ${{ github.event_name }}
         run: |
           printf '%s' "$NEEDS_JSON" > needs.json
-          # `benchmark` is push-only: it may legitimately skip on a PR /
-          # workflow_dispatch, but on a PUSH to main it IS applicable and must
-          # succeed - a mistakenly skipped benchmark on main must not pass.
-          if [ "$EVENT" = "push" ]; then ALLOW=""; else ALLOW="benchmark"; fi
-          # `classify` must be present AND succeed (its self-tests guard the
-          # classifier + gate).
+          # Allow-skip is DERIVED from the classifier plan via scripts/ci/job_plan.py
+          # - the SAME map the job `if:` conditions use, so the gate and the skips
+          # cannot disagree. A job whose group is inapplicable may skip; everything
+          # else (and `classify`) must succeed. benchmark (push-only) may skip on
+          # non-push.
           python3 scripts/ci/ci_gate.py --needs needs.json \
-            --allow-skip "$ALLOW" --require-present classify
+            --plan "$PLAN" --event "$EVENT" --require-present classify
 

--- a/docs/ci_architecture_design.md
+++ b/docs/ci_architecture_design.md
@@ -1073,9 +1073,23 @@ self-trust caveat (§8) — governance stays with CODEOWNERS/branch protection.
     dev-agent / inspect lifecycle, §4/§9/§20). These run on EVERY PR/push
     alongside the full matrix (nothing skipped); `ci-success.needs` updated
     (48 jobs, 47 gated). No classifier skipping, no branch-protection change.
-  - **Checkpoint 3b (NEXT):** ONLY after coverage equivalence is demonstrated -
-    wire classifier-based skipping of the redundant full-matrix jobs for
-    tooling/frontend PRs and update `ci-success` applicability (the plan-derived
-    allow-skip set), removing `paths-ignore` so the orchestrator always runs.
+  - **Checkpoint 3b (DONE, this change):** classifier-based skipping, driven by a
+    SINGLE job-applicability map (`scripts/ci/job_plan.py`). The `classify` job
+    emits per-group run-flags; each expensive job gates on
+    `if: needs.classify.outputs.run_*`; the `ci-success` gate derives its
+    allow-skip from the SAME map (`ci_gate.py --plan`), and
+    `check_job_plan_consistency.py` (run in `classify`) proves the `if:`
+    conditions and the map never drift. Only PROVEN narrow classes skip -
+    docs-only, JS frontend/fuzz, Lua frontend/fuzz; every other plan (core,
+    tooling, project-discovery, query, compute, db, gpu, tls, examples, generic
+    tests, unknown) and every main/full/force-full run the broad suite. Every job
+    DEFAULTS applicable (an unmapped job -> `always` -> never skips); mixed
+    core+frontend runs full core PLUS focused; `benchmark` stays push-only.
+    `paths-ignore` removed so `classify` + `ci-success` always appear. Fixtures:
+    `test_job_plan.py` (docs-only / pure-JS / pure-Lua / fuzz-only / core / mixed
+    / main / force-full / unexpected-skip / missing-applicability) + updated
+    `ci_gate` plan-derived path. Branch protection UNCHANGED (`ci-success` still
+    not required). Proven live: a pure-frontend PR skips ~43 jobs while the gate
+    passes; an unexpected skip of an applicable job fails the gate.
 - **Slices 4-6:** domain/native mapping; cache+matrix (wamrc cache, kill the 9x
   rebuild); nightly (schedule) + rollout. Each stops for review.

--- a/docs/ci_architecture_design.md
+++ b/docs/ci_architecture_design.md
@@ -1082,7 +1082,11 @@ self-trust caveat (§8) — governance stays with CODEOWNERS/branch protection.
     conditions and the map never drift. Only PROVEN narrow classes skip -
     docs-only, JS frontend/fuzz, Lua frontend/fuzz; every other plan (core,
     tooling, project-discovery, query, compute, db, gpu, tls, examples, generic
-    tests, unknown) and every main/full/force-full run the broad suite. Every job
+    tests, unknown) and every main/full/force-full run the broad suite. Narrowness is a POSITIVE, fail-closed allowlist: a plan may skip the broad
+    matrix only when it is a well-formed plan dict whose true flags all lie in
+    the approved narrow set (docs_only / focused_js/lua_frontend / _fuzz + lint)
+    and include a real selector - an empty/unknown/non-boolean/newly-added or
+    otherwise non-approved flag (e.g. focused_wasm) yields BROAD. Every job
     DEFAULTS applicable (an unmapped job -> `always` -> never skips); mixed
     core+frontend runs full core PLUS focused; `benchmark` stays push-only.
     `paths-ignore` removed so `classify` + `ci-success` always appear. Fixtures:

--- a/scripts/ci/check_job_plan_consistency.py
+++ b/scripts/ci/check_job_plan_consistency.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# check_job_plan_consistency.py - assert the ci.yml job `if:` conditions and the
+# ci-success gate's allow-skip derive from the SAME job-applicability map
+# (job_plan.py). Slice 3b safety guard: prevents a job's skip-condition from
+# drifting away from what the gate believes may skip. Run in the `classify` job.
+#
+# Checks (all must hold):
+#   - every ci.yml job (except the always-on classify/lint/ci-success) is mapped
+#     in job_plan.GROUP -> a new job must be DELIBERATELY classified;
+#   - a job in a SKIPPABLE group has an `if:` referencing exactly that group's
+#     run-flag (needs.classify.outputs.<flag>);
+#   - an `always` job has NO run-flag `if:` (it must never skip);
+#   - no GROUP entry references a non-existent job.
+# No PyYAML dependency (parses the fixed job layout + each job's `if:`).
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import job_plan  # noqa: E402
+
+WORKFLOW = ".github/workflows/ci.yml"
+ALWAYS = {"classify", "lint", "ci-success"}
+
+
+def parse_jobs_with_if(path):
+    lines = open(path, encoding="utf-8").read().splitlines()
+    n = len(lines); i = 0
+    while i < n and not re.match(r"^jobs:\s*$", lines[i]):
+        i += 1
+    i += 1
+    jobs = {}          # job_id -> if-text (or None)
+    cur = None
+    while i < n:
+        ln = lines[i]
+        if re.match(r"^\S", ln):
+            break
+        m = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", ln)
+        if m:
+            cur = m.group(1); jobs[cur] = None
+        elif cur is not None:
+            mi = re.match(r"^    if:\s*(.*)$", ln)
+            if mi:
+                jobs[cur] = mi.group(1)
+        i += 1
+    return jobs
+
+
+def main():
+    jobs = parse_jobs_with_if(WORKFLOW)
+    problems = []
+
+    # every job mapped (except always-on, which are allowed implicit)
+    for j in jobs:
+        if j not in job_plan.GROUP:
+            problems.append("job %r is not mapped in job_plan.GROUP" % j)
+
+    # GROUP entries must all be real jobs
+    for j in job_plan.GROUP:
+        if j not in jobs:
+            problems.append("job_plan.GROUP maps unknown job %r" % j)
+
+    # if-condition <-> group flag consistency
+    for j, iftext in jobs.items():
+        grp = job_plan.GROUP.get(j)
+        if grp is None:
+            continue
+        iftext = iftext or ""
+        refs = set(re.findall(r"needs\.classify\.outputs\.(run_[a-z_]+)", iftext))
+        if grp == "always" or j in ALWAYS:
+            if refs:
+                problems.append("always-on job %r must not gate on a run-flag (found %s)" % (j, sorted(refs)))
+            continue
+        flag = job_plan.GROUP_FLAG.get(grp)
+        if flag is None:
+            problems.append("group %r for job %r has no run-flag" % (grp, j))
+        elif flag not in refs:
+            problems.append("job %r (group %s) must gate on %s; if=%r" % (j, grp, flag, iftext))
+
+    print("check-job-plan: %d jobs, %d mapped groups." % (len(jobs), len(job_plan.GROUP)))
+    if problems:
+        for p in problems:
+            print("  FAIL:", p)
+        return 1
+    print("check-job-plan: job `if:` conditions match the shared applicability map. OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_job_plan_consistency.py
+++ b/scripts/ci/check_job_plan_consistency.py
@@ -77,8 +77,11 @@ def main():
         flag = job_plan.GROUP_FLAG.get(grp)
         if flag is None:
             problems.append("group %r for job %r has no run-flag" % (grp, j))
-        elif flag not in refs:
-            problems.append("job %r (group %s) must gate on %s; if=%r" % (j, grp, flag, iftext))
+        elif refs != {flag}:
+            # the `if:` must reference EXACTLY this group's flag - no more, no
+            # fewer - so a job cannot gate on a different / additional run-flag.
+            problems.append("job %r (group %s) must gate on EXACTLY {%s}; found %s in if=%r"
+                            % (j, grp, flag, sorted(refs), iftext))
 
     print("check-job-plan: %d jobs, %d mapped groups." % (len(jobs), len(job_plan.GROUP)))
     if problems:

--- a/scripts/ci/ci_gate.py
+++ b/scripts/ci/ci_gate.py
@@ -22,7 +22,11 @@
 
 import argparse
 import json
+import os
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import job_plan  # noqa: E402  (the SINGLE applicability map, shared with the job `if:` conditions)
 
 
 def evaluate(needs, allow_skip=None, require_present=()):
@@ -56,7 +60,11 @@ def evaluate(needs, allow_skip=None, require_present=()):
 def main(argv):
     ap = argparse.ArgumentParser(description="Applicability-aware CI result gate.")
     ap.add_argument("--needs", required=True, help="path to a file holding toJSON(needs).")
-    ap.add_argument("--allow-skip", default="", help="comma-separated jobs that may be skipped.")
+    ap.add_argument("--plan", default="", help="the classifier plan_json; allow-skip is derived "
+                    "from job_plan (the SAME map the job `if:` conditions use).")
+    ap.add_argument("--event", default="pull_request", help="the CI event (push/pull_request/...).")
+    ap.add_argument("--allow-skip", default="", help="explicit comma-separated jobs that may skip "
+                    "(fallback when --plan is not given).")
     ap.add_argument("--require-present", default="classify",
                     help="comma-separated jobs that must be present AND success.")
     args = ap.parse_args(argv)
@@ -68,7 +76,18 @@ def main(argv):
         print("ci-gate: cannot read needs (%s) -> FAIL closed" % e)
         return 1
 
-    allow = [s for s in args.allow_skip.split(",") if s]
+    # Allow-skip is DERIVED from the plan via the shared job-applicability map, so
+    # the gate and the job `if:` conditions can never disagree. A missing/malformed
+    # plan fails CLOSED to broad (allow_skip = only push-only benchmark on non-push,
+    # i.e. every real job must run/succeed).
+    if args.plan:
+        try:
+            plan = json.loads(args.plan)
+        except Exception:
+            plan = {"full_all": True}
+        allow = job_plan.allow_skip_jobs(plan, list(needs.keys()) if isinstance(needs, dict) else [], args.event)
+    else:
+        allow = [s for s in args.allow_skip.split(",") if s]
     reqp = [s for s in args.require_present.split(",") if s]
     problems = evaluate(needs, allow_skip=allow, require_present=reqp)
 

--- a/scripts/ci/job_plan.py
+++ b/scripts/ci/job_plan.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# job_plan.py - the SINGLE job-applicability map (docs/ci_architecture_design.md
+# section 16). Slice 3b. Both the ci.yml job `if:` conditions AND the ci-success
+# gate's allow-skip derive from THIS map, so they can never drift apart.
+#
+# Model (per the ratified 3b constraints):
+#   - Every job DEFAULTS to applicable; only an EXPLICITLY mapped job may skip.
+#     An unmapped job falls in the `always` group and must always run + succeed.
+#   - Only PROVEN narrow classes skip today: docs-only, JS frontend/fuzz, Lua
+#     frontend/fuzz. Any other plan (focused_tooling, project-discovery, query,
+#     compute, db, gpu, tls, examples, generic tests, unknown, full_core,
+#     full_all) triggers the BROAD suite.
+#   - main pushes / full_all / force-full run everything.
+#   - Mixed core+frontend runs full core PLUS the relevant focused jobs.
+#
+# A job belongs to exactly one GROUP. The classifier PLAN maps to a set of
+# APPLICABLE groups; a job whose group is not applicable may skip. `benchmark`
+# is additionally push-only, so it may skip on any non-push event regardless of
+# plan (matches its `if:` in ci.yml).
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import argparse
+import json
+import os
+import sys
+
+# Each GROUP has a run-flag emitted by the classify job; the ci.yml job `if:`
+# references exactly this flag. `always` has no flag (never skips).
+GROUP_FLAG = {
+    "full-matrix": "run_full_matrix",
+    "focused-js": "run_focused_js",
+    "focused-lua": "run_focused_lua",
+    "fuzz-js": "run_fuzz_js",
+    "fuzz-lua": "run_fuzz_lua",
+    "fuzz-native": "run_fuzz_native",
+}
+
+# job -> group. Explicit for every gated job. `check_job_plan_consistency.py`
+# asserts this matches the ci.yml `if:` flags AND covers every ci.yml job.
+GROUP = {
+    # always-on (never skip): the orchestrator, lint, and the gate itself.
+    "classify": "always", "lint": "always", "ci-success": "always",
+    # focused source-frontend + parser fuzz (the proven narrow classes).
+    "focused-js-frontend": "focused-js",
+    "focused-lua-frontend": "focused-lua",
+    "fuzz-js-source": "fuzz-js",
+    "fuzz-lua-source": "fuzz-lua",
+    "fuzz-native-security": "fuzz-native",
+    # everything else = the broad matrix.
+    "build": "full-matrix",
+    "wasm-readonly-heap-aot": "full-matrix",
+    "mapped-span-bench": "full-matrix",
+    "compute-aot-shared-heap": "full-matrix",
+    "compute-memops-freestanding": "full-matrix",
+    "stream-meta": "full-matrix",
+    "spans-example": "full-matrix",
+    "spans-multi": "full-matrix",
+    "spans-hugefile": "full-matrix",
+    "wasm-guarded-aot-arm64": "full-matrix",
+    "flavors": "full-matrix",
+    "reproducibility": "full-matrix",
+    "reproducibility-container": "full-matrix",
+    "reproducibility-container-interleave": "full-matrix",
+    "reproducibility-cosmo": "full-matrix",
+    "reproducibility-cosmo-compare": "full-matrix",
+    "build-pipeline": "full-matrix",
+    "sanitizers": "full-matrix",
+    "msan": "full-matrix",
+    "tsan": "full-matrix",
+    "tsan-shared-heap": "full-matrix",
+    "postgres": "full-matrix",
+    "mysql": "full-matrix",
+    "valkey": "full-matrix",
+    "analyze": "full-matrix",
+    "cosmo": "full-matrix",
+    "gpu": "full-matrix",
+    "duckdb": "full-matrix",
+    "duckdb-feature": "full-matrix",
+    "gpu-feature": "full-matrix",
+    "tui-feature": "full-matrix",
+    "postgres-feature": "full-matrix",
+    "mysql-feature": "full-matrix",
+    "project-discovery-lua": "full-matrix",
+    "coverage": "full-matrix",
+    "htmx-browser": "full-matrix",
+    "embed-rust": "full-matrix",
+    "embed-zig": "full-matrix",
+    "musl": "full-matrix",
+    "benchmark": "full-matrix",
+}
+
+# A plan is NARROW (broad matrix may skip) only if it carries NONE of these.
+BROAD_FLAGS = (
+    "full_all", "full_core", "focused_tooling", "focused_project_discovery",
+    "focused_query", "focused_compute", "focused_db", "focused_gpu",
+    "focused_tls", "focused_native_fuzz",
+)
+
+
+def applicable_groups(plan):
+    """The set of groups that MUST run for this plan. `always` is always in it.
+    A non-narrow plan makes every group applicable (broad). A narrow plan
+    (docs-only or pure JS/Lua frontend/fuzz) makes only the matching focused +
+    parser-fuzz groups applicable."""
+    groups = {"always"}
+    is_narrow = not any(plan.get(f) for f in BROAD_FLAGS)
+    if not is_narrow:
+        groups |= set(GROUP_FLAG.keys())
+        return groups
+    if plan.get("focused_js_frontend") or plan.get("focused_js_fuzz"):
+        groups |= {"focused-js", "fuzz-js"}
+    if plan.get("focused_lua_frontend") or plan.get("focused_lua_fuzz"):
+        groups |= {"focused-lua", "fuzz-lua"}
+    # docs-only alone -> only `always` (lint + classify + gate).
+    return groups
+
+
+def run_flags(plan):
+    """The classify-job outputs the ci.yml job `if:` conditions key off."""
+    g = applicable_groups(plan)
+    return {flag: (grp in g) for grp, flag in GROUP_FLAG.items()}
+
+
+def allow_skip_jobs(plan, all_jobs, event):
+    """The jobs the gate PERMITS to skip. A job may skip iff its group is not
+    applicable AND its group is not `always`. An unmapped job -> `always` ->
+    never skippable (default applicable). `benchmark` is push-only: it may also
+    skip on any non-push event regardless of plan."""
+    g = applicable_groups(plan)
+    skip = set()
+    for j in all_jobs:
+        grp = GROUP.get(j, "always")
+        if grp != "always" and grp not in g:
+            skip.add(j)
+    if event != "push" and "benchmark" in all_jobs:
+        skip.add("benchmark")
+    return skip
+
+
+def _emit_github_output(flags):
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as f:
+        for k, v in sorted(flags.items()):
+            f.write("%s=%s\n" % (k, "true" if v else "false"))
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(description="Emit per-group run flags from a classifier plan.")
+    ap.add_argument("--plan", required=True, help="the plan JSON (from classify_changes.py plan_json).")
+    args = ap.parse_args(argv)
+    try:
+        plan = json.loads(args.plan)
+    except Exception:
+        # A malformed plan must fail CLOSED to broad (run everything).
+        plan = {"full_all": True}
+    flags = run_flags(plan)
+    print(json.dumps(flags, sort_keys=True, indent=2))
+    _emit_github_output(flags)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/ci/job_plan.py
+++ b/scripts/ci/job_plan.py
@@ -25,6 +25,9 @@ import json
 import os
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import classify_changes as _classify  # noqa: E402  (the canonical plan schema)
+
 # Each GROUP has a run-flag emitted by the classify job; the ci.yml job `if:`
 # references exactly this flag. `always` has no flag (never skips).
 GROUP_FLAG = {
@@ -90,29 +93,54 @@ GROUP = {
     "benchmark": "full-matrix",
 }
 
-# A plan is NARROW (broad matrix may skip) only if it carries NONE of these.
-BROAD_FLAGS = (
-    "full_all", "full_core", "focused_tooling", "focused_project_discovery",
-    "focused_query", "focused_compute", "focused_db", "focused_gpu",
-    "focused_tls", "focused_native_fuzz",
-)
+# POSITIVE narrow allowlist (fail closed). A plan is NARROW - and may skip the
+# broad matrix - ONLY when it is a well-formed plan dict whose TRUE flags ALL lie
+# within APPROVED_NARROW and include at least one real narrow SELECTOR (beyond the
+# always-on lint). An empty plan, a non-dict, a non-boolean field, an unknown
+# field, a true flag outside the approved set (a newly added plan flag, or
+# focused_wasm, ...), or lint-only -> BROAD. This is a positive allowlist, NOT
+# "absence of known broad flags", so a new/unknown/malformed flag can NEVER open
+# a skip.
+APPROVED_NARROW = frozenset({
+    "lint", "docs_only",
+    "focused_js_frontend", "focused_js_fuzz",
+    "focused_lua_frontend", "focused_lua_fuzz",
+})
+NARROW_SELECTORS = APPROVED_NARROW - {"lint"}      # at least one of these must be set
+KNOWN_PLAN_KEYS = frozenset(_classify.PLAN)        # the canonical plan schema (classify_changes)
+
+
+def _is_narrow(plan):
+    """True iff `plan` is a well-formed plan dict that positively qualifies to
+    skip the broad matrix (APPROVED_NARROW). Anything else -> False -> broad."""
+    if not isinstance(plan, dict):
+        return False
+    for k, v in plan.items():
+        if not isinstance(v, bool):
+            return False                            # non-boolean field -> broad
+        if k not in KNOWN_PLAN_KEYS:
+            return False                            # unknown field -> broad
+    true_flags = {k for k, v in plan.items() if v}
+    if not true_flags <= APPROVED_NARROW:
+        return False                                # a true flag outside the approved set -> broad
+    if not (true_flags & NARROW_SELECTORS):
+        return False                                # lint-only / no real narrow selector -> broad
+    return True
 
 
 def applicable_groups(plan):
-    """The set of groups that MUST run for this plan. `always` is always in it.
-    A non-narrow plan makes every group applicable (broad). A narrow plan
-    (docs-only or pure JS/Lua frontend/fuzz) makes only the matching focused +
-    parser-fuzz groups applicable."""
+    """The set of groups that MUST run. `always` is always applicable. A plan is
+    only NARROW under the positive allowlist; anything else is BROAD (every group
+    applicable). A narrow plan enables just the matching focused + parser-fuzz
+    groups."""
     groups = {"always"}
-    is_narrow = not any(plan.get(f) for f in BROAD_FLAGS)
-    if not is_narrow:
+    if not _is_narrow(plan):
         groups |= set(GROUP_FLAG.keys())
         return groups
     if plan.get("focused_js_frontend") or plan.get("focused_js_fuzz"):
         groups |= {"focused-js", "fuzz-js"}
     if plan.get("focused_lua_frontend") or plan.get("focused_lua_fuzz"):
         groups |= {"focused-lua", "fuzz-lua"}
-    # docs-only alone -> only `always` (lint + classify + gate).
     return groups
 
 

--- a/scripts/ci/test_job_plan.py
+++ b/scripts/ci/test_job_plan.py
@@ -115,5 +115,24 @@ check("benchmark skippable on PR (broad plan)",
 check("benchmark NOT skippable on push",
       "benchmark" not in job_plan.allow_skip_jobs(plan_for([], event="push_main"), ALL_JOBS, "push"))
 
+# -- fail-closed: the positive narrow allowlist. Anything not positively narrow
+#    (empty, non-dict, non-boolean, unknown, or a non-approved true flag) -> BROAD --
+def is_broad(plan):
+    return all(job_plan.run_flags(plan).values())
+
+check("empty plan {} -> broad", is_broad({}))
+check("non-dict (list) plan -> broad", is_broad([]))
+check("unknown true flag -> broad", is_broad({"lint": True, "focused_js_frontend": True, "bogus_flag": True}))
+check("string-valued flag -> broad", is_broad({"lint": True, "focused_js_frontend": "true"}))
+check("int-valued flag -> broad", is_broad({"lint": True, "focused_js_frontend": 1}))
+check("existing non-narrow flag alone (focused_wasm) -> broad", is_broad({"lint": True, "focused_wasm": True}))
+check("lint-only (no narrow selector) -> broad", is_broad({"lint": True}))
+check("full_all present -> broad", is_broad({"lint": True, "full_all": True}))
+# a genuinely-approved narrow plan still narrows (positive path still works)
+check("approved narrow (docs_only) -> not broad", not is_broad({"lint": True, "docs_only": True}))
+check("approved narrow (js) -> focused-js only",
+      job_plan.run_flags({"lint": True, "focused_js_frontend": True})["run_focused_js"]
+      and not job_plan.run_flags({"lint": True, "focused_js_frontend": True})["run_full_matrix"])
+
 print("job_plan fixtures: %d passed, %d failed" % (_pass, _fail))
 sys.exit(1 if _fail else 0)

--- a/scripts/ci/test_job_plan.py
+++ b/scripts/ci/test_job_plan.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# test_job_plan.py - fixtures for the job-applicability map (Slice 3b). Proves
+# run-flags + gate allow-skip for: docs-only, pure JS, pure Lua, fuzz-only, core,
+# mixed, main, force-full, unexpected skip, and missing applicability.
+# Run: python3 scripts/ci/test_job_plan.py
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from classify_changes import classify  # noqa: E402
+import job_plan  # noqa: E402
+
+ALL_JOBS = sorted(job_plan.GROUP.keys())
+_pass = 0
+_fail = 0
+
+
+def plan_for(paths, event="pull_request", force_full=False):
+    return classify(list(paths), event=event, force_full=force_full)["plan"]
+
+
+def check(name, cond):
+    global _pass, _fail
+    if cond:
+        _pass += 1
+    else:
+        _fail += 1
+        print("FAIL:", name)
+
+
+def flags(paths, **kw):
+    return job_plan.run_flags(plan_for(paths, **kw))
+
+
+def skips(paths, event="pull_request", **kw):
+    return job_plan.allow_skip_jobs(plan_for(paths, event=event, **kw), ALL_JOBS, event)
+
+
+# -- docs-only: nothing but always-on runs; everything else may skip --
+f = flags(["docs/x.md"])
+check("docs-only: no group runs", not any(f.values()))
+s = skips(["docs/x.md"])
+check("docs-only: build may skip", "build" in s)
+check("docs-only: focused-js may skip", "focused-js-frontend" in s)
+check("docs-only: fuzz-native may skip", "fuzz-native-security" in s)
+check("docs-only: lint never skips", "lint" not in s)
+check("docs-only: classify never skips", "classify" not in s)
+
+# -- pure JS frontend: focused-js + fuzz-js run; matrix + lua skip --
+f = flags(["stdlib/cli/js/hull/source/parser.js"])
+check("pure-js: run_focused_js", f["run_focused_js"])
+check("pure-js: run_fuzz_js", f["run_fuzz_js"])
+check("pure-js: NOT run_full_matrix", not f["run_full_matrix"])
+check("pure-js: NOT run_focused_lua", not f["run_focused_lua"])
+s = skips(["stdlib/cli/js/hull/source/parser.js"])
+check("pure-js: build may skip", "build" in s)
+check("pure-js: focused-lua may skip", "focused-lua-frontend" in s)
+check("pure-js: fuzz-native may skip", "fuzz-native-security" in s)
+check("pure-js: focused-js NOT skippable", "focused-js-frontend" not in s)
+check("pure-js: fuzz-js NOT skippable", "fuzz-js-source" not in s)
+
+# -- pure Lua frontend --
+f = flags(["stdlib/cli/lua/hull/source/lexer.lua"])
+check("pure-lua: run_focused_lua", f["run_focused_lua"])
+check("pure-lua: run_fuzz_lua", f["run_fuzz_lua"])
+check("pure-lua: NOT run_full_matrix", not f["run_full_matrix"])
+s = skips(["stdlib/cli/lua/hull/source/lexer.lua"])
+check("pure-lua: focused-lua NOT skippable", "focused-lua-frontend" not in s)
+check("pure-lua: build may skip", "build" in s)
+
+# -- fuzz-only: a source-parser fuzzer .c sets frontend+fuzz -> narrow --
+f = flags(["fuzz/fuzz_js_source.c"])
+check("js-fuzz .c: run_fuzz_js + focused_js", f["run_fuzz_js"] and f["run_focused_js"])
+check("js-fuzz .c: NOT run_full_matrix", not f["run_full_matrix"])
+# a NATIVE fuzzer .c is NOT a proven narrow class -> broad
+f = flags(["fuzz/fuzz_pgwire.c"])
+check("native-fuzz .c -> broad (run_full_matrix)", f["run_full_matrix"])
+
+# -- core: broad, everything runs --
+f = flags(["src/hull/cap/db.c"])
+check("core: run_full_matrix", f["run_full_matrix"])
+check("core: all group flags true", all(f.values()))
+check("core: nothing skippable except benchmark(non-push)",
+      skips(["src/hull/cap/db.c"]) == {"benchmark"})
+
+# -- mixed core + frontend: full core PLUS focused (all run) --
+f = flags(["stdlib/cli/js/hull/source/parser.js", "src/hull/cap/db.c"])
+check("mixed: run_full_matrix", f["run_full_matrix"])
+check("mixed: run_focused_js", f["run_focused_js"])
+check("mixed: build NOT skippable", "build" not in skips(["stdlib/cli/js/hull/source/parser.js", "src/hull/cap/db.c"]))
+
+# -- main push / force-full: everything runs regardless of paths --
+f = flags(["docs/x.md"], event="push_main")
+check("push_main: run_full_matrix", f["run_full_matrix"] and all(f.values()))
+check("push_main: only benchmark not force-skippable (event=push => none)",
+      job_plan.allow_skip_jobs(plan_for(["docs/x.md"], event="push_main"), ALL_JOBS, "push") == set())
+f = flags(["docs/x.md"], force_full=True)
+check("force-full: run_full_matrix", f["run_full_matrix"] and all(f.values()))
+
+# -- unexpected skip: build applicable in a broad plan -> NOT in allow-skip --
+check("broad: build must run (not in allow-skip)",
+      "build" not in job_plan.allow_skip_jobs(plan_for(["src/hull/cap/db.c"]), ALL_JOBS, "pull_request"))
+
+# -- missing applicability: an UNMAPPED job defaults to always -> never skips --
+s = job_plan.allow_skip_jobs(plan_for(["docs/x.md"]), ALL_JOBS + ["brand_new_job"], "pull_request")
+check("unmapped job defaults applicable (never skippable)", "brand_new_job" not in s)
+check("but a mapped full-matrix job IS skippable in docs-only", "build" in s)
+
+# -- benchmark: push-only; skippable on PR regardless of plan, NOT on push --
+check("benchmark skippable on PR (broad plan)",
+      "benchmark" in job_plan.allow_skip_jobs(plan_for(["src/hull/cap/db.c"]), ALL_JOBS, "pull_request"))
+check("benchmark NOT skippable on push",
+      "benchmark" not in job_plan.allow_skip_jobs(plan_for([], event="push_main"), ALL_JOBS, "push"))
+
+print("job_plan fixtures: %d passed, %d failed" % (_pass, _fail))
+sys.exit(1 if _fail else 0)


### PR DESCRIPTION
Checkpoint 2 of Slice 3 (docs/ci_architecture_design.md §3/§10/§16/§24) — the **safety-boundary** change: classifier-based skipping of the redundant matrix for the proven narrow classes, driven by **one applicability map** so the job `if:` conditions and the gate's allow-skip can never disagree. **Branch protection unchanged; `ci-success` still not required.**

## Design (per the ratified constraints)
- **`scripts/ci/job_plan.py`** — the single map. Every job **defaults applicable** (an unmapped job → `always` → never skips); only explicitly mapped groups skip. **Only** docs-only + JS frontend/fuzz + Lua frontend/fuzz are narrow (skip the broad matrix); every other plan (core, tooling, project-discovery, query, compute, db, gpu, tls, examples, generic tests, unknown) and **main / full_all / force-full** run the broad suite. **Mixed core+frontend** runs full core **plus** focused. `benchmark` stays push-only.
- **`ci.yml`** — `classify` emits per-group run-flags; each expensive job gates on `if: needs.classify.outputs.run_*`; **`ci-success` derives allow-skip from the SAME map** (`ci_gate.py --plan --event`). **`paths-ignore` removed** so `classify` + `ci-success` always appear.
- **`check_job_plan_consistency.py`** (run in `classify`) — asserts every job is mapped and its `if:` flag matches the map: no drift between skips and the gate.
- **`test_job_plan.py`** — docs-only / pure-JS / pure-Lua / fuzz-only / core / mixed / main / force-full / **unexpected-skip** / **missing-applicability**.

## Proof
- **This PR** changes `.github/**` → `full_all` → **broad**: everything runs and the gate passes over all 48 jobs (the broad + gate proof).
- **Live skip proof**: a companion demo PR (based off this branch, touching only `parser.js`) whose diff is genuinely narrow — its run skips ~43 jobs down to `classify` + `focused-js-frontend` + `fuzz-js-source` + `lint` + `ci-success`, gate green. (Linked separately.)
- Local: classify 67/67, ci_gate 19/19, job_plan 37/37, gate-completeness + consistency OK; simulated pure-JS PR skips 43 jobs (gate passes), and a skipped-but-applicable job fails the gate.

Stops for review after both the broad run (here) and the skip run (demo) are green.