### PR TITLE
[skip demo] pure JS-frontend change — proves classifier skipping (do not merge)

### DIFF
--- a/stdlib/cli/js/hull/source/parser.js
+++ b/stdlib/cli/js/hull/source/parser.js
@@ -1184,3 +1184,6 @@ function parseInternal(bytes, opts, inject) {
     const valid = allDiags.every(function (d) { return d.severity !== "error"; });
     return { ast: ast, comments: tk.comments, diagnostics: allDiags, linemap: tk.linemap, valid: valid };
 }
+
+// ci-slice3b skip demo: a pure JS-frontend change (comment only) to show the
+// classifier skip the full matrix down to the focused JS jobs. Reverted after proof.


### PR DESCRIPTION
**Demonstration only — do not merge; closed after proof.** Base is `feat/ci-slice3b` (not `main`), so the merge-base diff is genuinely narrow: a single comment-only change to `stdlib/cli/js/hull/source/parser.js`.

Expected live behavior under Slice 3b's skipping:
- `classify` emits the JS-frontend narrow plan → `run_focused_js=true`, `run_fuzz_js=true`, everything else false.
- Only **`classify` + `focused-js-frontend` + `fuzz-js-source` + `lint` + `ci-success`** run; the ~43 broad-matrix + Lua/native jobs **skip**.
- `ci-success` derives the SAME allow-skip from the plan → gate **green** with those skips.

This is the live proof of "expected skips + final gate" for Slice 3b, complementing PR #375 (which proves the broad path, since it changes `.github/**` → `full_all`).