### PR TITLE
[skip proof, throwaway] pure JS-frontend change under Slice 3b

### DIFF
--- a/stdlib/cli/js/hull/source/parser.js
+++ b/stdlib/cli/js/hull/source/parser.js
@@ -1184,3 +1184,5 @@ function parseInternal(bytes, opts, inject) {
     const valid = allDiags.every(function (d) { return d.severity !== "error"; });
     return { ast: ast, comments: tk.comments, diagnostics: allDiags, linemap: tk.linemap, valid: valid };
 }
+
+// slice3b skip proof (throwaway).


### PR DESCRIPTION
Throwaway live proof of Slice 3b classifier skipping. Narrow diff (comment-only parser.js) against a base carrying the 3b logic; expected: only classify + focused-js-frontend + fuzz-js-source + lint + ci-success run, ~43 jobs skip, gate green. Deleted after proof.