### PR TITLE
CI Slice 4 checkpoint 2: additive DB/GPU/compute classification + fuzz split (no skipping)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1461,10 +1461,16 @@ jobs:
   # security fuzzers, the Lua source parser fuzzer, and the JS source parser
   # fuzzer as INDEPENDENT jobs so path-aware selection can run only the relevant
   # target. Each keeps its sanitizer instrumentation + 60s libFuzzer budget. --
-  fuzz-native-security:
+  # Slice 4 checkpoint 2: the former single `fuzz-native-security` job is split
+  # into three atomic jobs owning a FIXED target subset each (core / db-wire /
+  # compute). The UNION of the three equals the former 13-target set (asserted by
+  # scripts/ci/test_job_plan.py :: fuzz_union). In checkpoint 2 all three gate on
+  # the SAME run_fuzz_native flag, so they run/skip exactly as the one job did (no
+  # new skipping); checkpoint 3 regroups them (core-common / db-any / compute).
+  fuzz-core-security:
     needs: [classify]
     if: needs.classify.outputs.run_fuzz_native == 'true'
-    name: Fuzz (native security)
+    name: Fuzz (core security)
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -1472,19 +1478,65 @@ jobs:
           submodules: true
       - name: Install clang
         run: sudo apt-get update && sudo apt-get install -y clang
-      - name: Build native fuzz targets
+      - name: Build core fuzz targets
         run: |
           make CC=clang \
             fuzz/fuzz_sh_json fuzz/fuzz_path_normalize fuzz/fuzz_mime_sniff \
-            fuzz/fuzz_host_match fuzz/fuzz_pgwire fuzz/fuzz_pg_dsn fuzz/fuzz_pg_rewrite \
-            fuzz/fuzz_mysqlwire fuzz/fuzz_mysql_dsn fuzz/fuzz_respwire \
-            fuzz/fuzz_valkey_dsn fuzz/fuzz_span_sdk fuzz/fuzz_span_window
-      - name: Run native fuzzers (60s each)
-        timeout-minutes: 20
+            fuzz/fuzz_host_match
+      - name: Run core fuzzers (60s each)
+        timeout-minutes: 10
         run: |
           set -e
-          for f in sh_json path_normalize mime_sniff host_match pgwire pg_dsn \
-                   pg_rewrite mysqlwire mysql_dsn respwire valkey_dsn span_sdk span_window; do
+          for f in sh_json path_normalize mime_sniff host_match; do
+            echo "== fuzz $f =="
+            ./fuzz/fuzz_$f fuzz/corpus_$f/ -max_total_time=60
+          done
+
+  fuzz-db-wire:
+    needs: [classify]
+    if: needs.classify.outputs.run_fuzz_native == 'true'
+    name: Fuzz (DB wire protocols)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+      - name: Install clang
+        run: sudo apt-get update && sudo apt-get install -y clang
+      - name: Build DB wire fuzz targets
+        run: |
+          make CC=clang \
+            fuzz/fuzz_pgwire fuzz/fuzz_pg_dsn fuzz/fuzz_pg_rewrite \
+            fuzz/fuzz_mysqlwire fuzz/fuzz_mysql_dsn fuzz/fuzz_respwire \
+            fuzz/fuzz_valkey_dsn
+      - name: Run DB wire fuzzers (60s each)
+        timeout-minutes: 15
+        run: |
+          set -e
+          for f in pgwire pg_dsn pg_rewrite mysqlwire mysql_dsn respwire valkey_dsn; do
+            echo "== fuzz $f =="
+            ./fuzz/fuzz_$f fuzz/corpus_$f/ -max_total_time=60
+          done
+
+  fuzz-compute-span:
+    needs: [classify]
+    if: needs.classify.outputs.run_fuzz_native == 'true'
+    name: Fuzz (compute mapped-span SDK)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+      - name: Install clang
+        run: sudo apt-get update && sudo apt-get install -y clang
+      - name: Build compute fuzz targets
+        run: |
+          make CC=clang fuzz/fuzz_span_sdk fuzz/fuzz_span_window
+      - name: Run compute fuzzers (60s each)
+        timeout-minutes: 10
+        run: |
+          set -e
+          for f in span_sdk span_window; do
             echo "== fuzz $f =="
             ./fuzz/fuzz_$f fuzz/corpus_$f/ -max_total_time=60
           done
@@ -2294,7 +2346,9 @@ jobs:
       - msan
       - tsan
       - tsan-shared-heap
-      - fuzz-native-security
+      - fuzz-core-security
+      - fuzz-db-wire
+      - fuzz-compute-span
       - fuzz-lua-source
       - fuzz-js-source
       - focused-js-frontend

--- a/scripts/ci/classify_changes.py
+++ b/scripts/ci/classify_changes.py
@@ -45,6 +45,12 @@ FACTS = [
     "wasm_changed",
     "gpu_changed",
     "native_db_changed",
+    # per-backend DB facts (Slice 4 / Appendix C): an isolated backend `.c`
+    # narrows to its own backend; a shared-DB `.c` sets ALL FOUR (fan-out).
+    "db_postgres_changed",
+    "db_mysql_changed",
+    "db_valkey_changed",
+    "db_duckdb_changed",
     "tls_network_changed",
     "production_core_changed",
     "build_composition_changed",
@@ -69,6 +75,10 @@ PLAN = [
     "focused_query",
     "focused_compute",
     "focused_db",
+    "focused_db_postgres",
+    "focused_db_mysql",
+    "focused_db_valkey",
+    "focused_db_duckdb",
     "focused_wasm",
     "focused_gpu",
     "focused_tls",
@@ -78,6 +88,52 @@ PLAN = [
     "docs_only",
     "lint",
 ]
+
+
+# -- Slice 4 isolated-subsystem allowlist (Appendix C.2/C.3) -----------------
+# A CURATED, EXACT-PATH positive allowlist of production `.c` files whose
+# compile/link/dependency closure is confined to ONE native subsystem. A matched
+# file emits ONLY its subsystem fact(s), NOT production_core; every OTHER src/**
+# path stays production_core (broad, fail closed). The allowlist is layered OVER
+# the broad default, so a renamed/deleted entry loses its narrow route and reverts
+# to broad - it can never mis-narrow. Every path here is machine-verified to exist
+# (test_classify_changes.py :: allowlist_files_exist).
+#
+# IMPORTANT (checkpoint 2, additive/no-skip): none of the focused_* flags these
+# facts drive are in job_plan.APPROVED_NARROW, so a plan carrying them still
+# evaluates BROAD - the classifier narrows the FACTS but NOTHING skips yet. Skip
+# activation (adding the native narrow class + regrouping the matrix) is
+# checkpoint 3.
+DB_POSTGRES_FILES = frozenset({
+    "src/hull/cap/db_postgres.c", "src/hull/cap/pgwire.c", "src/hull/cap/pg_conn.c",
+})
+DB_MYSQL_FILES = frozenset({
+    "src/hull/cap/db_mysql.c", "src/hull/cap/mysqlwire.c", "src/hull/cap/mysql_conn.c",
+})
+DB_VALKEY_FILES = frozenset({
+    "src/hull/cap/valkey.c", "src/hull/cap/valkey_conn.c",
+    "src/hull/cap/valkey_register.c", "src/hull/cap/respwire.c",
+})
+DB_DUCKDB_FILES = frozenset({"src/hull/cap/db_duckdb.c"})
+# Shared DB core: on EVERY backend's link path (the db_select.c BACKENDS[] registry
+# + the shared cap/registry/dynamic/udf/kv files). A change here fans out to ALL
+# backends (constraint 3).
+DB_SHARED_FILES = frozenset({
+    "src/hull/cap/db.c", "src/hull/cap/db_common.c", "src/hull/cap/db_registry.c",
+    "src/hull/cap/db_select.c", "src/hull/cap/db_dynamic.c", "src/hull/cap/db_udf.c",
+    "src/hull/cap/kv.c", "src/hull/cap/kv_dynamic.c", "src/hull/cap/kv_feature.c",
+})
+GPU_FILES = frozenset({
+    "src/hull/cap/gpu_wgpu.c", "src/hull/cap/gpu_feature.c", "src/hull/cap/gpu.c",
+})
+COMPUTE_FILES = frozenset({
+    "src/hull/cap/wasm.c", "src/hull/cap/wasm_buffer.c", "src/hull/cap/wasm_data.c",
+    "src/hull/cap/wasm_spans.c", "src/hull/cap/wasm_stream.c", "src/hull/worker_wasm.c",
+    "src/hull/runtime/lua/mod_compute.c", "src/hull/runtime/js/mod_compute.c",
+})
+_ALL_DB_BACKEND_FACTS = frozenset({
+    "db_postgres_changed", "db_mysql_changed", "db_valkey_changed", "db_duckdb_changed",
+})
 
 
 def _has_component(path, name):
@@ -115,6 +171,26 @@ def classify_path(path):
         # tests (docs section 7.2).
         if p.startswith("src/hull/frontend/"):
             return {"production_core_changed", "js_frontend_changed", "lua_frontend_changed"}
+        # Slice 4 isolated-subsystem allowlist (Appendix C): an EXACT match narrows
+        # to its subsystem fact(s) and does NOT set production_core. A shared-DB
+        # file fans out to all four backends (constraint 3). Anything NOT on the
+        # allowlist stays production_core -> broad (fail closed). Because these
+        # focused_* flags are not APPROVED_NARROW, the live plan is still broad
+        # (checkpoint 2: narrow the facts, skip nothing).
+        if p in DB_POSTGRES_FILES:
+            return {"native_db_changed", "db_postgres_changed"}
+        if p in DB_MYSQL_FILES:
+            return {"native_db_changed", "db_mysql_changed"}
+        if p in DB_VALKEY_FILES:
+            return {"native_db_changed", "db_valkey_changed"}
+        if p in DB_DUCKDB_FILES:
+            return {"native_db_changed", "db_duckdb_changed"}
+        if p in DB_SHARED_FILES:
+            return {"native_db_changed"} | set(_ALL_DB_BACKEND_FACTS)
+        if p in GPU_FILES:
+            return {"gpu_changed"}
+        if p in COMPUTE_FILES:
+            return {"compute_changed"}
         return {"production_core_changed"}
 
     # -- embedded tooling (alters bytes linked into hull -> needs fresh host) --
@@ -228,6 +304,17 @@ def derive_plan(facts):
         plan["focused_gpu"] = True
     if facts.get("native_db_changed"):
         plan["focused_db"] = True
+    # per-backend narrowing (Appendix C): a shared-DB change set all four backend
+    # facts above, so it lights every focused_db_<backend>; an isolated backend
+    # change lights only its own.
+    if facts.get("db_postgres_changed"):
+        plan["focused_db_postgres"] = True
+    if facts.get("db_mysql_changed"):
+        plan["focused_db_mysql"] = True
+    if facts.get("db_valkey_changed"):
+        plan["focused_db_valkey"] = True
+    if facts.get("db_duckdb_changed"):
+        plan["focused_db_duckdb"] = True
     if facts.get("tls_network_changed"):
         plan["focused_tls"] = True
     if facts.get("js_fuzz_changed"):

--- a/scripts/ci/job_plan.py
+++ b/scripts/ci/job_plan.py
@@ -49,7 +49,14 @@ GROUP = {
     "focused-lua-frontend": "focused-lua",
     "fuzz-js-source": "fuzz-js",
     "fuzz-lua-source": "fuzz-lua",
-    "fuzz-native-security": "fuzz-native",
+    # Slice 4 checkpoint 2: the single fuzz-native-security job is SPLIT into three
+    # atomic jobs (core / db-wire / compute). In checkpoint 2 they stay in the
+    # SAME `fuzz-native` group and gate on the SAME run_fuzz_native flag, so they
+    # run/skip exactly as the one job did (no new skipping). Checkpoint 3 reassigns
+    # them to their final groups (core-common / db-any / compute).
+    "fuzz-core-security": "fuzz-native",
+    "fuzz-db-wire": "fuzz-native",
+    "fuzz-compute-span": "fuzz-native",
     # everything else = the broad matrix.
     "build": "full-matrix",
     "wasm-readonly-heap-aot": "full-matrix",
@@ -142,6 +149,71 @@ def applicable_groups(plan):
     if plan.get("focused_lua_frontend") or plan.get("focused_lua_fuzz"):
         groups |= {"focused-lua", "fuzz-lua"}
     return groups
+
+
+# -- Slice 4 native-subsystem group scaffolding (Appendix C.2/C.5) ------------
+# The INTENDED checkpoint-3 mapping from a plan to native subsystem groups.
+# core-common is the always-run floor for ANY production-C / native change
+# (constraint 1). db-any is the SINGLE umbrella group whose sole member is the
+# fuzz-db-wire job = the union of the db sub-groups (Amendment 1), keyed off
+# focused_db (set whenever any db file changed, backend or shared). This is INERT
+# in checkpoint 2: proven by fixtures (test_job_plan.py :: native_groups.*) but NOT
+# consulted by applicable_groups - a native plan is not APPROVED_NARROW, so it
+# still evaluates BROAD and NOTHING skips. Checkpoint 3 wires this in AND regroups
+# the current `full-matrix` jobs into `core-common` + these subsystem groups.
+NATIVE_SUBSYSTEM_GROUPS = frozenset({
+    "core-common", "db-postgres", "db-mysql", "db-valkey", "db-duckdb", "db-any",
+    "gpu", "compute",
+})
+
+
+def _well_formed_plan(plan):
+    """A well-formed plan is a dict whose values are ALL bool, whose keys are ALL
+    known, and that carries the always-on `lint`. An empty `{}`, a list, an unknown
+    key, or a non-bool value is malformed (-> fail closed to broad)."""
+    if not isinstance(plan, dict):
+        return False
+    for k, v in plan.items():
+        if not isinstance(v, bool) or k not in KNOWN_PLAN_KEYS:
+            return False
+    return bool(plan.get("lint"))
+
+
+def _is_broad_plan(plan):
+    """A plan that runs the whole suite: a shared/core/composition/main/force-full
+    change (full_all / full_core), OR anything malformed (fail closed). Native
+    narrowing only applies to a well-formed, non-broad, native-fact plan."""
+    if not _well_formed_plan(plan):
+        return True
+    return bool(plan.get("full_all") or plan.get("full_core"))
+
+
+def native_groups(plan):
+    """The native subsystem groups a plan selects UNDER the checkpoint-3 mapping.
+    Broad/malformed -> every native group. A narrow-native plan -> the always-run
+    `core-common` floor plus the specific subsystem group(s), and the `db-any`
+    umbrella iff any db backend is touched (via focused_db). Inert scaffolding in
+    checkpoint 2 (fixture-proven, not yet consulted by applicable_groups)."""
+    if _is_broad_plan(plan):
+        return set(NATIVE_SUBSYSTEM_GROUPS)
+    g = set()
+    if plan.get("focused_db_postgres"):
+        g.add("db-postgres")
+    if plan.get("focused_db_mysql"):
+        g.add("db-mysql")
+    if plan.get("focused_db_valkey"):
+        g.add("db-valkey")
+    if plan.get("focused_db_duckdb"):
+        g.add("db-duckdb")
+    if plan.get("focused_db"):
+        g.add("db-any")                        # the fuzz-db-wire umbrella
+    if plan.get("focused_gpu"):
+        g.add("gpu")
+    if plan.get("focused_compute") or plan.get("focused_wasm"):
+        g.add("compute")
+    if g:
+        g.add("core-common")                   # the always-run floor for any native change
+    return g
 
 
 def run_flags(plan):

--- a/scripts/ci/test_classify_changes.py
+++ b/scripts/ci/test_classify_changes.py
@@ -77,7 +77,7 @@ check("shared native header", ["include/hull/cap/db.h"],
       want_true=["full_core"],
       want_false=["full_all", "docs_only"])
 
-check("other production C", ["src/hull/cap/db.c"],
+check("other production C", ["src/hull/serve.c"],
       want_true=["full_core"], want_false=["full_all"])
 
 check("vendored dep bump", ["vendor/lua/lua.h"],
@@ -118,7 +118,7 @@ check("project discovery runs both frontends", ["stdlib/cli/lua/hull/project/mod
       want_false=["full_core", "full_all"])
 
 check("mixed tooling + core -> full_core plus focused tooling",
-      ["stdlib/cli/js/hull/source/parser.js", "src/hull/cap/db.c"],
+      ["stdlib/cli/js/hull/source/parser.js", "src/hull/serve.c"],
       want_true=["full_core", "focused_js_frontend"],
       want_false=["full_all", "docs_only"])
 
@@ -305,6 +305,83 @@ if r1["plan"] == r2["plan"] and r1["facts"] == r2["facts"]:
 else:
     _fail += 1
     print("FAIL: determinism/order-independence")
+
+# ---- Slice 4 checkpoint 2: source-inventory machine-check (Appendix C.7) ----
+# Grounds the isolated-subsystem allowlist in the ACTUAL repository so it cannot
+# silently rot: every allowlisted path exists, maps to EXACTLY its subsystem
+# fact(s), every unlisted src/** stays broad, shared-DB fans out to all backends,
+# and a deleted/renamed allowlisted file classifies safely via both diff paths.
+import classify_changes as _cc  # noqa: E402
+
+_REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def ck(name, cond):
+    global _pass, _fail
+    if cond:
+        _pass += 1
+    else:
+        _fail += 1
+        print("FAIL(machine-check): %s" % name)
+
+
+_ALLOWLIST_EXPECT = [
+    (_cc.DB_POSTGRES_FILES, {"native_db_changed", "db_postgres_changed"}),
+    (_cc.DB_MYSQL_FILES,    {"native_db_changed", "db_mysql_changed"}),
+    (_cc.DB_VALKEY_FILES,   {"native_db_changed", "db_valkey_changed"}),
+    (_cc.DB_DUCKDB_FILES,   {"native_db_changed", "db_duckdb_changed"}),
+    (_cc.DB_SHARED_FILES,   {"native_db_changed", "db_postgres_changed",
+                             "db_mysql_changed", "db_valkey_changed", "db_duckdb_changed"}),
+    (_cc.GPU_FILES,         {"gpu_changed"}),
+    (_cc.COMPUTE_FILES,     {"compute_changed"}),
+]
+
+# 1. every allowlisted file EXISTS at HEAD (exact path resolves to a regular file).
+for _files, _ in _ALLOWLIST_EXPECT:
+    for _f in sorted(_files):
+        ck("allowlist file exists: %s" % _f, os.path.isfile(os.path.join(_REPO, _f)))
+
+# 2. every allowlisted file maps to EXACTLY its intended subsystem fact(s).
+for _files, _want in _ALLOWLIST_EXPECT:
+    for _f in sorted(_files):
+        ck("exact map: %s" % _f, _cc.classify_path(_f) == _want)
+
+# 3. every UNLISTED src/** path stays broad (production_core). Representative real
+#    core files NOT on any allowlist + a synthetic new file must all be core.
+_ALLOWLISTED = set().union(*[fs for fs, _ in _ALLOWLIST_EXPECT])
+for _f in ["src/hull/serve.c", "src/hull/cap/http.c", "src/hull/cap/crypto.c",
+           "src/hull/cap/db_sqlite.c", "src/hull/manifest.c", "src/hull/cap/fs.c",
+           "src/hull/cap/db_postgres.h", "src/hull/cap/brand_new_backend.c"]:
+    ck("unlisted src is broad: %s" % _f,
+       _f not in _ALLOWLISTED and _cc.classify_path(_f) == {"production_core_changed"})
+
+# 4. shared-DB files select ALL db backends (fan-out, constraint 3).
+for _f in sorted(_cc.DB_SHARED_FILES):
+    facts = _cc.classify_path(_f)
+    ck("shared-db fans out: %s" % _f,
+       {"db_postgres_changed", "db_mysql_changed", "db_valkey_changed",
+        "db_duckdb_changed"} <= facts)
+
+# 5. delete/rename safety through BOTH diff paths.
+#    A rename = delete(old allowlisted) + add(new non-allowlisted). --no-renames
+#    reports both; the new path is not yet allowlisted -> production_core -> the
+#    union is BROAD (full_core). Neither path mis-narrows.
+check("rename allowlisted->new: union broad (paths path)",
+      ["src/hull/cap/db_postgres.c", "src/hull/cap/db_postgres_v2.c"],
+      want_true=["full_core"])
+check_cli("cli rename allowlisted->new: union broad",
+          b"src/hull/cap/db_postgres.c\x00src/hull/cap/db_postgres_v2.c\x00",
+          want_true=["full_core"])
+#    A pure DELETE of an allowlisted file still classifies by name to its subsystem
+#    facts, but the plan is NOT narrow-approved -> BROAD -> nothing skips (safe).
+_del = classify(["src/hull/cap/db_postgres.c"])["plan"]
+ck("pure delete of allowlisted stays safe (no full_core, focused only)",
+   _del["focused_db_postgres"] and _del["focused_db"] and not _del["full_core"])
+#    force-full path ignores the stream entirely -> full_all (broad), regardless of
+#    whether an allowlisted file was renamed/deleted.
+check("rename under force-full -> full_all",
+      ["src/hull/cap/db_postgres.c", "src/hull/cap/db_postgres_v2.c"],
+      want_true=["full_all"], force_full=True)
 
 print("classify_changes fixtures: %d passed, %d failed" % (_pass, _fail))
 sys.exit(1 if _fail else 0)

--- a/scripts/ci/test_job_plan.py
+++ b/scripts/ci/test_job_plan.py
@@ -45,7 +45,7 @@ check("docs-only: no group runs", not any(f.values()))
 s = skips(["docs/x.md"])
 check("docs-only: build may skip", "build" in s)
 check("docs-only: focused-js may skip", "focused-js-frontend" in s)
-check("docs-only: fuzz-native may skip", "fuzz-native-security" in s)
+check("docs-only: fuzz-core-security may skip", "fuzz-core-security" in s)
 check("docs-only: lint never skips", "lint" not in s)
 check("docs-only: classify never skips", "classify" not in s)
 
@@ -58,7 +58,7 @@ check("pure-js: NOT run_focused_lua", not f["run_focused_lua"])
 s = skips(["stdlib/cli/js/hull/source/parser.js"])
 check("pure-js: build may skip", "build" in s)
 check("pure-js: focused-lua may skip", "focused-lua-frontend" in s)
-check("pure-js: fuzz-native may skip", "fuzz-native-security" in s)
+check("pure-js: fuzz-core-security may skip", "fuzz-core-security" in s)
 check("pure-js: focused-js NOT skippable", "focused-js-frontend" not in s)
 check("pure-js: fuzz-js NOT skippable", "fuzz-js-source" not in s)
 
@@ -133,6 +133,91 @@ check("approved narrow (docs_only) -> not broad", not is_broad({"lint": True, "d
 check("approved narrow (js) -> focused-js only",
       job_plan.run_flags({"lint": True, "focused_js_frontend": True})["run_focused_js"]
       and not job_plan.run_flags({"lint": True, "focused_js_frontend": True})["run_full_matrix"])
+
+# ---- Slice 4 checkpoint 2: native-subsystem map + fuzz split (Appendix C) ----
+# All ADDITIVE / no-skip: an isolated native change still evaluates BROAD live
+# (nothing skips); the native_groups() helper proves the intended checkpoint-3
+# mapping; the three split fuzz jobs share the fuzz-native group and their target
+# union equals the former single job.
+
+# no-skip invariant: an isolated backend/gpu/compute change is still BROAD live.
+for _paths in (["src/hull/cap/db_postgres.c"], ["src/hull/cap/gpu_wgpu.c"],
+               ["src/hull/cap/wasm.c"], ["src/hull/cap/db_select.c"]):
+    check("native change still BROAD live (no skip): %s" % _paths[0],
+          all(job_plan.run_flags(plan_for(_paths)).values()))
+    check("native change: only benchmark force-skippable (PR): %s" % _paths[0],
+          skips(_paths) == {"benchmark"})
+
+# native_groups() intended checkpoint-3 mapping (inert scaffolding, fixture-proven).
+def ng(paths):
+    return job_plan.native_groups(plan_for(paths))
+
+check("ng db_postgres -> core-common + db-postgres + db-any",
+      ng(["src/hull/cap/db_postgres.c"]) == {"core-common", "db-postgres", "db-any"})
+check("ng gpu -> core-common + gpu",
+      ng(["src/hull/cap/gpu_wgpu.c"]) == {"core-common", "gpu"})
+check("ng wasm -> core-common + compute",
+      ng(["src/hull/cap/wasm.c"]) == {"core-common", "compute"})
+check("ng shared-db -> core-common + all four sub-groups + db-any",
+      ng(["src/hull/cap/db_select.c"]) ==
+      {"core-common", "db-postgres", "db-mysql", "db-valkey", "db-duckdb", "db-any"})
+# additive: DB + GPU -> both sets.
+check("ng additive (gpu + db_postgres)",
+      ng(["src/hull/cap/gpu.c", "src/hull/cap/db_postgres.c"]) ==
+      {"core-common", "db-postgres", "db-any", "gpu"})
+# two backends -> both sub-groups + ONE db-any umbrella (Amendment 1).
+check("ng two-backend -> both sub-groups + single db-any",
+      ng(["src/hull/cap/db_postgres.c", "src/hull/cap/db_mysql.c"]) ==
+      {"core-common", "db-postgres", "db-mysql", "db-any"})
+# broad / malformed / docs -> fail closed / empty appropriately.
+check("ng broad (core file) -> every native group",
+      ng(["src/hull/serve.c"]) == set(job_plan.NATIVE_SUBSYSTEM_GROUPS))
+check("ng malformed plan -> every native group (fail closed)",
+      job_plan.native_groups({}) == set(job_plan.NATIVE_SUBSYSTEM_GROUPS)
+      and job_plan.native_groups([]) == set(job_plan.NATIVE_SUBSYSTEM_GROUPS))
+check("ng docs-only -> no native group",
+      ng(["docs/x.md"]) == set())
+
+# the three split fuzz jobs share the fuzz-native group and skip/run together.
+for _j in ("fuzz-core-security", "fuzz-db-wire", "fuzz-compute-span"):
+    check("fuzz split %s in fuzz-native group" % _j, job_plan.GROUP.get(_j) == "fuzz-native")
+    check("fuzz split %s skippable on docs-only" % _j, _j in skips(["docs/x.md"]))
+    check("fuzz split %s runs on broad (not skippable)" % _j,
+          _j not in skips(["src/hull/serve.c"]))
+
+# fuzz coverage-equivalence: the union of the three jobs' build targets in ci.yml
+# equals the former single fuzz-native-security set (no target dropped in the split).
+import re  # noqa: E402
+CANONICAL_FUZZ = {
+    "sh_json", "path_normalize", "mime_sniff", "host_match",          # core
+    "pgwire", "pg_dsn", "pg_rewrite", "mysqlwire", "mysql_dsn", "respwire", "valkey_dsn",  # db wire
+    "span_sdk", "span_window",                                        # compute
+}
+_WF = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+                   ".github", "workflows", "ci.yml")
+_wf_lines = open(_WF, encoding="utf-8").read().splitlines()
+
+
+def _job_slice(job):
+    out, cur = [], False
+    for ln in _wf_lines:
+        m = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", ln)
+        if m:
+            cur = (m.group(1) == job)
+            continue
+        if cur:
+            out.append(ln)
+    return "\n".join(out)
+
+
+_split_targets, _overlap = set(), []
+for _j in ("fuzz-core-security", "fuzz-db-wire", "fuzz-compute-span"):
+    _t = set(re.findall(r"fuzz/fuzz_([a-z0-9_]+)", _job_slice(_j)))
+    if _split_targets & _t:
+        _overlap.append(_j)
+    _split_targets |= _t
+check("fuzz_union: split targets == canonical set", _split_targets == CANONICAL_FUZZ)
+check("fuzz_union: sub-jobs are disjoint (no target in two jobs)", not _overlap)
 
 print("job_plan fixtures: %d passed, %d failed" % (_pass, _fail))
 sys.exit(1 if _fail else 0)


### PR DESCRIPTION
**Second of Slice 4's three checkpoints: design → ADDITIVE PROOF → skip activation.** Lands the classification, the `job_plan` map extension, and the fuzz split — with **nothing newly skipped**. Branch-protection unchanged; `ci-success` stays reported-not-required.

### What changes live
Only the **fuzz job split** (same trigger). Everything else is inert scaffolding proven by fixtures until checkpoint 3.

- **`classify_changes.py`** — an exact-path isolated-subsystem allowlist for `src/**`: DB backend files, the shared-DB core (fans out to **all four** backends), GPU files, compute files now emit subsystem facts instead of `production_core`. Every other `src/**` path (and all `include`/`vendor`/`Makefile`/`mk`/composition/unknown) stays `production_core` → **broad, fail closed**. New per-backend facts + `focused_db_<backend>` flags.
- **No-skip invariant** — none of the `focused_*` flags are in `APPROVED_NARROW`, so a plan carrying them **still evaluates broad** (`run_full_matrix == true`). The classifier narrows the *facts*; the live plan skips **nothing**. (Verified for `db_postgres.c` / `gpu_wgpu.c` / `wasm.c` / `db_select.c`.)
- **`job_plan.py`** — `NATIVE_SUBSYSTEM_GROUPS` + a `native_groups()` helper encoding the intended checkpoint-3 mapping (core-common floor + per-backend sub-groups + the single **`db-any`** umbrella for `fuzz-db-wire` per Amendment 1 + gpu + compute). Inert (not consulted by `applicable_groups`); fixture-proven. `_is_broad_plan` reuses a well-formedness check so an empty/malformed plan fails closed to every native group.
- **`ci.yml`** — `fuzz-native-security` → `fuzz-core-security` + `fuzz-db-wire` + `fuzz-compute-span`, each a FIXED disjoint target subset (union == the former 13), all gated on the **same** `run_fuzz_native` flag → run/skip exactly as the one job did. `ci-success` needs all three.

### Machine-check fixtures (Appendix C.7)
Every allowlisted file **exists at HEAD**; each maps to **exactly** its subsystem fact(s); every unlisted `src/**` stays broad; shared-DB fans out to all backends; a **deleted/renamed** allowlisted file classifies safely through **both** the `--paths-from` and `--force-full` diff paths; the fuzz target union equals the canonical set and the sub-jobs are disjoint.

Self-tests green locally: classify **150**, gate **19**, job_plan **75**, both consistency checkers OK.

### Live proof in this PR
This PR touches `scripts/ci/**` + `.github/**` → self-classifies **broad** (`full_all`): every job runs, **including the 3 new fuzz jobs**, and nothing that used to run is skipped. The narrow behavior (`db_postgres.c` → `db-postgres` only) is **fixture-proven** here and becomes live at checkpoint 3. **Stops for review.**