### PR TITLE
CI Slice 4 checkpoint 3: activate native narrowing (fail-closed)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,24 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       plan_json: ${{ steps.run.outputs.plan_json }}
-      run_full_matrix: ${{ steps.flags.outputs.run_full_matrix }}
+      # Slice 4 checkpoint 3: the monolithic run_full_matrix / run_fuzz_native
+      # flags are replaced by the core-common floor + native subsystem groups +
+      # the broad-only web bucket. The set here MUST equal job_plan.GROUP_FLAG's
+      # values (check_job_plan_consistency.py keeps the job `if:` conditions in
+      # lockstep with this map).
+      run_core_common: ${{ steps.flags.outputs.run_core_common }}
+      run_web: ${{ steps.flags.outputs.run_web }}
+      run_db_postgres: ${{ steps.flags.outputs.run_db_postgres }}
+      run_db_mysql: ${{ steps.flags.outputs.run_db_mysql }}
+      run_db_valkey: ${{ steps.flags.outputs.run_db_valkey }}
+      run_db_duckdb: ${{ steps.flags.outputs.run_db_duckdb }}
+      run_db_any: ${{ steps.flags.outputs.run_db_any }}
+      run_gpu: ${{ steps.flags.outputs.run_gpu }}
+      run_compute: ${{ steps.flags.outputs.run_compute }}
       run_focused_js: ${{ steps.flags.outputs.run_focused_js }}
       run_focused_lua: ${{ steps.flags.outputs.run_focused_lua }}
       run_fuzz_js: ${{ steps.flags.outputs.run_fuzz_js }}
       run_fuzz_lua: ${{ steps.flags.outputs.run_fuzz_lua }}
-      run_fuzz_native: ${{ steps.flags.outputs.run_fuzz_native }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
@@ -91,7 +103,7 @@ jobs:
 
   build:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -427,7 +439,7 @@ jobs:
   # if the AOT sub-case is SKIPPED. That closes the "AOT is dormant in CI" gap.
   wasm-readonly-heap-aot:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_compute == 'true'
     name: WAMR AOT C-API tests (readonly + guarded, x86_64)
     runs-on: ubuntu-24.04
     steps:
@@ -598,7 +610,7 @@ jobs:
   # controlled run is the separate manually-triggered bench_mapped_span_1g.yml.
   mapped-span-bench:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_compute == 'true'
     name: Mapped-span benchmark (96 MiB, x86_64)
     runs-on: ubuntu-24.04
     steps:
@@ -647,7 +659,7 @@ jobs:
   # AOT is exercised non-skippably.
   compute-aot-shared-heap:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_compute == 'true'
     name: Compute AOT shared-heap reads (spans + segments)
     runs-on: ubuntu-24.04
     steps:
@@ -718,7 +730,7 @@ jobs:
   # clang + lld; the AOT leg needs an embedded hull + wamrc.
   compute-memops-freestanding:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_compute == 'true'
     name: Freestanding libc (memcpy/memset/memmove) — interp + AOT
     runs-on: ubuntu-24.04
     steps:
@@ -768,7 +780,7 @@ jobs:
   # compute.stream, Lua + JS, interpreter + AOT. Needs clang + wamrc + embedded hull.
   stream-meta:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_compute == 'true'
     name: compute stream metadata helpers — Lua + JS, interp + AOT
     runs-on: ubuntu-24.04
     steps:
@@ -813,7 +825,7 @@ jobs:
   # embedded hull; runs non-skippably here.
   spans-example:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_compute == 'true'
     name: mapped_spans example — Lua + JS, interp + AOT (public SDK)
     runs-on: ubuntu-24.04
     steps:
@@ -860,7 +872,7 @@ jobs:
   # `hull build` path. Needs a wasm clang + wamrc + an embedded hull; non-skippable.
   spans-multi:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_compute == 'true'
     name: mapped spans — multiple named spans, Lua + JS, interp + AOT
     runs-on: ubuntu-24.04
     steps:
@@ -906,7 +918,7 @@ jobs:
   # completion). Uses a SPARSE 5 GiB file (no real disk) so it runs anywhere.
   spans-hugefile:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_compute == 'true'
     name: mapped spans — >4GiB foffset + setup capacity, Lua + JS, interp + AOT
     runs-on: ubuntu-24.04
     steps:
@@ -953,7 +965,7 @@ jobs:
   # aarch64 build job's `make test`; this closes the arm64 AOT leg.
   wasm-guarded-aot-arm64:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_compute == 'true'
     name: Guarded-subrange AOT C-API test (arm64)
     runs-on: ubuntu-24.04-arm
     steps:
@@ -1088,7 +1100,7 @@ jobs:
   # pure-compute, and pure-compute exercises both HTTP halves off at once.)
   flavors:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     name: Build flavor (${{ matrix.name }})
     runs-on: ubuntu-24.04
     strategy:
@@ -1167,7 +1179,7 @@ jobs:
 
   reproducibility:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     name: Reproducible build (${{ matrix.name }})
     strategy:
       fail-fast: false
@@ -1217,7 +1229,7 @@ jobs:
   # immutability" and .github/docker/README.md.
   reproducibility-container:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     name: Reproducible build (Linux container)
     runs-on: ubuntu-24.04
     steps:
@@ -1248,7 +1260,7 @@ jobs:
   # job is the PR-validatable proxy for that ownership + run path. Roadmap 0.3.1.
   reproducibility-container-interleave:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     name: Reproducible build (Linux container, host interleave)
     runs-on: ubuntu-24.04
     steps:
@@ -1280,7 +1292,7 @@ jobs:
   # the hull-cosmo release binary itself.
   reproducibility-cosmo:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     name: Reproducible build (Cosmo ${{ matrix.n }})
     strategy:
       fail-fast: false
@@ -1309,7 +1321,7 @@ jobs:
           if-no-files-found: error
 
   reproducibility-cosmo-compare:
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     name: Reproducible build (Cosmo compare)
     needs: [reproducibility-cosmo, classify]
     runs-on: ubuntu-24.04
@@ -1335,7 +1347,7 @@ jobs:
 
   build-pipeline:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -1359,7 +1371,7 @@ jobs:
 
   sanitizers:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     name: ASan + UBSan
     runs-on: ubuntu-24.04
 
@@ -1376,7 +1388,7 @@ jobs:
 
   msan:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     name: MSan + UBSan
     runs-on: ubuntu-24.04
 
@@ -1405,7 +1417,7 @@ jobs:
 
   tsan:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     name: TSan (worker pool)
     runs-on: ubuntu-24.04
 
@@ -1440,7 +1452,7 @@ jobs:
   # signal.
   tsan-shared-heap:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_compute == 'true'
     name: TSan (WAMR shared-heap destroy + guarded subrange + spans)
     runs-on: ubuntu-24.04
     steps:
@@ -1461,15 +1473,15 @@ jobs:
   # security fuzzers, the Lua source parser fuzzer, and the JS source parser
   # fuzzer as INDEPENDENT jobs so path-aware selection can run only the relevant
   # target. Each keeps its sanitizer instrumentation + 60s libFuzzer budget. --
-  # Slice 4 checkpoint 2: the former single `fuzz-native-security` job is split
-  # into three atomic jobs owning a FIXED target subset each (core / db-wire /
-  # compute). The UNION of the three equals the former 13-target set (asserted by
-  # scripts/ci/test_job_plan.py :: fuzz_union). In checkpoint 2 all three gate on
-  # the SAME run_fuzz_native flag, so they run/skip exactly as the one job did (no
-  # new skipping); checkpoint 3 regroups them (core-common / db-any / compute).
+  # Slice 4: the former single `fuzz-native-security` job is split into three
+  # atomic jobs owning a FIXED target subset each. The UNION of the three equals
+  # the former 13-target set (asserted by scripts/ci/test_job_plan.py :: fuzz_union).
+  # Checkpoint 3 assigns each to its subsystem group: core fuzzers -> core-common
+  # (run_core_common), DB wire -> the db-any umbrella (run_db_any), compute spans
+  # -> compute (run_compute). So a narrow-native DB change runs only fuzz-db-wire.
   fuzz-core-security:
     needs: [classify]
-    if: needs.classify.outputs.run_fuzz_native == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     name: Fuzz (core security)
     runs-on: ubuntu-24.04
     steps:
@@ -1494,7 +1506,7 @@ jobs:
 
   fuzz-db-wire:
     needs: [classify]
-    if: needs.classify.outputs.run_fuzz_native == 'true'
+    if: needs.classify.outputs.run_db_any == 'true'
     name: Fuzz (DB wire protocols)
     runs-on: ubuntu-24.04
     steps:
@@ -1520,7 +1532,7 @@ jobs:
 
   fuzz-compute-span:
     needs: [classify]
-    if: needs.classify.outputs.run_fuzz_native == 'true'
+    if: needs.classify.outputs.run_compute == 'true'
     name: Fuzz (compute mapped-span SDK)
     runs-on: ubuntu-24.04
     steps:
@@ -1620,7 +1632,7 @@ jobs:
   # HL_ENABLE_POSTGRES=1 and skips cleanly if Docker is unavailable.
   postgres:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_db_postgres == 'true'
     name: PostgreSQL e2e
     runs-on: ubuntu-24.04
 
@@ -1641,7 +1653,7 @@ jobs:
   # TLS. Self-builds with HL_ENABLE_MYSQL=1; skips cleanly without Docker.
   mysql:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_db_mysql == 'true'
     name: MySQL e2e
     runs-on: ubuntu-24.04
 
@@ -1663,7 +1675,7 @@ jobs:
   # redis-server from apt (no Docker); the e2e scripts also fall back to Docker.
   valkey:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_db_valkey == 'true'
     name: Valkey/Redis e2e
     runs-on: ubuntu-24.04
 
@@ -1693,7 +1705,7 @@ jobs:
 
   analyze:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     name: Static Analysis
     runs-on: ubuntu-24.04
 
@@ -1715,7 +1727,7 @@ jobs:
 
   cosmo:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     name: Cosmopolitan (APE)
     runs-on: ubuntu-24.04
 
@@ -1817,7 +1829,7 @@ jobs:
 
   gpu:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_gpu == 'true'
     name: GPU Compute (macOS Metal)
     runs-on: macos-15
 
@@ -1846,7 +1858,7 @@ jobs:
 
   duckdb:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_db_duckdb == 'true'
     name: DuckDB backend (Linux)
     runs-on: ubuntu-24.04
 
@@ -1983,7 +1995,7 @@ jobs:
   # tree with the HL_ENABLE_DUCKDB=1 job above (flag-flip object staleness).
   duckdb-feature:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_db_duckdb == 'true'
     name: DuckDB feature build (Linux)
     runs-on: ubuntu-24.04
     steps:
@@ -2005,7 +2017,7 @@ jobs:
   # devices. See docs/features_and_flavors.md.
   gpu-feature:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_gpu == 'true'
     name: GPU feature build (Linux)
     runs-on: ubuntu-24.04
     steps:
@@ -2026,7 +2038,7 @@ jobs:
   # Pure C, no vendored lib and no extra link libs, so no install step.
   tui-feature:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     name: TUI feature build (Linux)
     runs-on: ubuntu-24.04
     steps:
@@ -2039,7 +2051,7 @@ jobs:
 
   postgres-feature:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_db_postgres == 'true'
     name: Postgres feature build (Linux)
     runs-on: ubuntu-24.04
     steps:
@@ -2052,7 +2064,7 @@ jobs:
 
   mysql-feature:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_db_mysql == 'true'
     name: MySQL feature build (Linux)
     runs-on: ubuntu-24.04
     steps:
@@ -2069,7 +2081,7 @@ jobs:
   # silently skip. The analyzable side is pinned (EXPECT_JS=1) in the main `build` job's step.
   project-discovery-lua:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_web == 'true'
     name: Project source-discovery E2E (lua-only, JS unavailable)
     runs-on: ubuntu-24.04
     steps:
@@ -2082,7 +2094,7 @@ jobs:
 
   coverage:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     name: Code Coverage
     runs-on: ubuntu-24.04
 
@@ -2141,7 +2153,7 @@ jobs:
 
   htmx-browser:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_web == 'true'
     name: HTMX browser tests (${{ matrix.name }})
     strategy:
       fail-fast: false
@@ -2213,7 +2225,7 @@ jobs:
     needs: [classify]
     name: Benchmark (${{ matrix.runtime }})
     runs-on: ubuntu-24.04
-    if: github.event_name == 'push' && needs.classify.outputs.run_full_matrix == 'true'
+    if: github.event_name == 'push' && needs.classify.outputs.run_core_common == 'true'
 
     strategy:
       matrix:
@@ -2245,7 +2257,7 @@ jobs:
   # ran (grep for the OK line) rather than silently pass.
   embed-rust:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     name: libhull embedder (Rust)
     runs-on: ubuntu-24.04
 
@@ -2265,7 +2277,7 @@ jobs:
 
   embed-zig:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     name: libhull embedder (Zig)
     runs-on: ubuntu-24.04
 
@@ -2297,7 +2309,7 @@ jobs:
 
   musl:
     needs: [classify]
-    if: needs.classify.outputs.run_full_matrix == 'true'
+    if: needs.classify.outputs.run_core_common == 'true'
     name: musl (Alpine)
     runs-on: ubuntu-24.04
     # A plain ubuntu runner (not container: alpine) so actions/checkout keeps

--- a/scripts/ci/job_plan.py
+++ b/scripts/ci/job_plan.py
@@ -196,15 +196,34 @@ NATIVE_SUBSYSTEM_GROUPS = frozenset({
 
 
 def _well_formed_plan(plan):
-    """A well-formed plan is a dict whose values are ALL bool, whose keys are ALL
-    known, and that carries the always-on `lint`. An empty `{}`, a list, an unknown
-    key, or a non-bool value is malformed (-> fail closed to broad)."""
+    """A well-formed plan is a coherent CANONICAL plan: the EXACT plan schema (no
+    missing, extra, or unknown key), every value boolean, the always-on `lint`
+    set, AND the classifier's native-selector coherence invariants. Anything
+    else - a partial subset, a syntactically-valid-but-incomplete plan, or an
+    incoherent selector combination - is malformed and fails closed to BROAD (it
+    must not be allowed to narrow to a partial subsystem set). The coherence
+    invariants mirror derive_plan()'s contract:
+      - focused_db is set IFF at least one backend selector is set;
+      - focused_compute and focused_wasm are always paired (set together)."""
     if not isinstance(plan, dict):
         return False
-    for k, v in plan.items():
-        if not isinstance(v, bool) or k not in KNOWN_PLAN_KEYS:
-            return False
-    return bool(plan.get("lint"))
+    if set(plan.keys()) != KNOWN_PLAN_KEYS:
+        return False                                # not the exact plan schema
+    for v in plan.values():
+        if not isinstance(v, bool):
+            return False                            # non-boolean field
+    if not plan["lint"]:
+        return False                                # a real plan always runs lint
+    # native-selector coherence (derive_plan contract): a backend selector without
+    # focused_db, or focused_db without any backend selector, is incoherent.
+    any_backend = (plan["focused_db_postgres"] or plan["focused_db_mysql"]
+                   or plan["focused_db_valkey"] or plan["focused_db_duckdb"])
+    if plan["focused_db"] != any_backend:
+        return False
+    # the classifier always pairs focused_compute + focused_wasm.
+    if plan["focused_compute"] != plan["focused_wasm"]:
+        return False
+    return True
 
 
 def _is_broad_plan(plan):

--- a/scripts/ci/job_plan.py
+++ b/scripts/ci/job_plan.py
@@ -30,13 +30,26 @@ import classify_changes as _classify  # noqa: E402  (the canonical plan schema)
 
 # Each GROUP has a run-flag emitted by the classify job; the ci.yml job `if:`
 # references exactly this flag. `always` has no flag (never skips).
+#
+# Slice 4 checkpoint 3: the monolithic `full-matrix` + `fuzz-native` groups are
+# split into the always-run `core-common` floor + the native subsystem groups
+# (db-* / db-any umbrella / gpu / compute) + the broad-only `web` bucket
+# (htmx-browser, project-discovery-lua) that a native change does not touch. The
+# frontend groups (focused/fuzz js/lua) are unchanged.
 GROUP_FLAG = {
-    "full-matrix": "run_full_matrix",
+    "core-common": "run_core_common",
+    "web": "run_web",
+    "db-postgres": "run_db_postgres",
+    "db-mysql": "run_db_mysql",
+    "db-valkey": "run_db_valkey",
+    "db-duckdb": "run_db_duckdb",
+    "db-any": "run_db_any",
+    "gpu": "run_gpu",
+    "compute": "run_compute",
     "focused-js": "run_focused_js",
     "focused-lua": "run_focused_lua",
     "fuzz-js": "run_fuzz_js",
     "fuzz-lua": "run_fuzz_lua",
-    "fuzz-native": "run_fuzz_native",
 }
 
 # job -> group. Explicit for every gated job. `check_job_plan_consistency.py`
@@ -49,70 +62,86 @@ GROUP = {
     "focused-lua-frontend": "focused-lua",
     "fuzz-js-source": "fuzz-js",
     "fuzz-lua-source": "fuzz-lua",
-    # Slice 4 checkpoint 2: the single fuzz-native-security job is SPLIT into three
-    # atomic jobs (core / db-wire / compute). In checkpoint 2 they stay in the
-    # SAME `fuzz-native` group and gate on the SAME run_fuzz_native flag, so they
-    # run/skip exactly as the one job did (no new skipping). Checkpoint 3 reassigns
-    # them to their final groups (core-common / db-any / compute).
-    "fuzz-core-security": "fuzz-native",
-    "fuzz-db-wire": "fuzz-native",
-    "fuzz-compute-span": "fuzz-native",
-    # everything else = the broad matrix.
-    "build": "full-matrix",
-    "wasm-readonly-heap-aot": "full-matrix",
-    "mapped-span-bench": "full-matrix",
-    "compute-aot-shared-heap": "full-matrix",
-    "compute-memops-freestanding": "full-matrix",
-    "stream-meta": "full-matrix",
-    "spans-example": "full-matrix",
-    "spans-multi": "full-matrix",
-    "spans-hugefile": "full-matrix",
-    "wasm-guarded-aot-arm64": "full-matrix",
-    "flavors": "full-matrix",
-    "reproducibility": "full-matrix",
-    "reproducibility-container": "full-matrix",
-    "reproducibility-container-interleave": "full-matrix",
-    "reproducibility-cosmo": "full-matrix",
-    "reproducibility-cosmo-compare": "full-matrix",
-    "build-pipeline": "full-matrix",
-    "sanitizers": "full-matrix",
-    "msan": "full-matrix",
-    "tsan": "full-matrix",
-    "tsan-shared-heap": "full-matrix",
-    "postgres": "full-matrix",
-    "mysql": "full-matrix",
-    "valkey": "full-matrix",
-    "analyze": "full-matrix",
-    "cosmo": "full-matrix",
-    "gpu": "full-matrix",
-    "duckdb": "full-matrix",
-    "duckdb-feature": "full-matrix",
-    "gpu-feature": "full-matrix",
-    "tui-feature": "full-matrix",
-    "postgres-feature": "full-matrix",
-    "mysql-feature": "full-matrix",
-    "project-discovery-lua": "full-matrix",
-    "coverage": "full-matrix",
-    "htmx-browser": "full-matrix",
-    "embed-rust": "full-matrix",
-    "embed-zig": "full-matrix",
-    "musl": "full-matrix",
-    "benchmark": "full-matrix",
+    # -- core-common: the subsystem-AGNOSTIC floor. Runs for EVERY production-C /
+    # native change AND every broad run (constraint 1). Includes the four-platform
+    # `make test` (all unit binaries), build/link/repro/platform checks, the
+    # sanitizer + static-analysis floor, and the core security fuzzers. Slice 4
+    # checkpoint 3 assigns fuzz-core-security here (was the shared fuzz-native).
+    "build": "core-common",
+    "build-pipeline": "core-common",
+    "flavors": "core-common",
+    "sanitizers": "core-common",
+    "msan": "core-common",
+    "tsan": "core-common",
+    "analyze": "core-common",
+    "coverage": "core-common",
+    "reproducibility": "core-common",
+    "reproducibility-container": "core-common",
+    "reproducibility-container-interleave": "core-common",
+    "reproducibility-cosmo": "core-common",
+    "reproducibility-cosmo-compare": "core-common",
+    "cosmo": "core-common",
+    "musl": "core-common",
+    "embed-rust": "core-common",
+    "embed-zig": "core-common",
+    "tui-feature": "core-common",
+    "fuzz-core-security": "core-common",
+    "benchmark": "core-common",          # push-only (extra event guard in its if:)
+    # -- db subsystem (per-backend integrations) --
+    "postgres": "db-postgres",
+    "postgres-feature": "db-postgres",
+    "mysql": "db-mysql",
+    "mysql-feature": "db-mysql",
+    "valkey": "db-valkey",
+    "duckdb": "db-duckdb",
+    "duckdb-feature": "db-duckdb",
+    # the fuzz-db-wire umbrella (Amendment 1): one atomic job, group db-any =
+    # applicable iff ANY db backend is touched (or broad).
+    "fuzz-db-wire": "db-any",
+    # -- gpu subsystem --
+    "gpu": "gpu",
+    "gpu-feature": "gpu",
+    # -- compute subsystem (AOT cluster + shared-heap TSan + span fuzzer) --
+    "wasm-readonly-heap-aot": "compute",
+    "mapped-span-bench": "compute",
+    "compute-aot-shared-heap": "compute",
+    "compute-memops-freestanding": "compute",
+    "stream-meta": "compute",
+    "spans-example": "compute",
+    "spans-multi": "compute",
+    "spans-hugefile": "compute",
+    "wasm-guarded-aot-arm64": "compute",
+    "tsan-shared-heap": "compute",
+    "fuzz-compute-span": "compute",
+    # -- web/integration (broad-only): a native (db/gpu/compute) change does not
+    # touch these, so a narrow-native plan skips them; a broad plan runs them. --
+    "htmx-browser": "web",
+    "project-discovery-lua": "web",
 }
 
-# POSITIVE narrow allowlist (fail closed). A plan is NARROW - and may skip the
-# broad matrix - ONLY when it is a well-formed plan dict whose TRUE flags ALL lie
-# within APPROVED_NARROW and include at least one real narrow SELECTOR (beyond the
-# always-on lint). An empty plan, a non-dict, a non-boolean field, an unknown
-# field, a true flag outside the approved set (a newly added plan flag, or
-# focused_wasm, ...), or lint-only -> BROAD. This is a positive allowlist, NOT
-# "absence of known broad flags", so a new/unknown/malformed flag can NEVER open
-# a skip.
-APPROVED_NARROW = frozenset({
-    "lint", "docs_only",
+# POSITIVE narrow allowlist (fail closed). A plan may skip the broad matrix ONLY
+# when it is a well-formed plan dict whose TRUE flags ALL lie within
+# APPROVED_NARROW and include at least one real narrow SELECTOR (beyond the
+# always-on lint). Slice 4 checkpoint 3 EXTENDS the allowlist from the frontend
+# classes to the native subsystem selectors. Its OWN positive set is the union of:
+#   - {lint, docs_only}
+#   - FRONTEND_SELECTORS  (the proven source-frontend/parser classes)
+#   - NATIVE_SELECTORS    (the DB backend / gpu / compute classes)
+# A native change MIXED with any NON-approved true flag (focused_tooling,
+# focused_project_discovery, focused_query, focused_tls, focused_native_fuzz,
+# tests/examples -> full_core, or ANY future/unknown/non-boolean field) falls
+# outside the set -> BROAD (constraint: fail closed). This is a positive
+# allowlist, NOT "absence of known broad flags", so a new/unknown/malformed flag
+# can NEVER open a skip.
+FRONTEND_SELECTORS = frozenset({
     "focused_js_frontend", "focused_js_fuzz",
     "focused_lua_frontend", "focused_lua_fuzz",
 })
+NATIVE_SELECTORS = frozenset({
+    "focused_db", "focused_db_postgres", "focused_db_mysql", "focused_db_valkey",
+    "focused_db_duckdb", "focused_gpu", "focused_compute", "focused_wasm",
+})
+APPROVED_NARROW = frozenset({"lint", "docs_only"}) | FRONTEND_SELECTORS | NATIVE_SELECTORS
 NARROW_SELECTORS = APPROVED_NARROW - {"lint"}      # at least one of these must be set
 KNOWN_PLAN_KEYS = frozenset(_classify.PLAN)        # the canonical plan schema (classify_changes)
 
@@ -120,13 +149,10 @@ KNOWN_PLAN_KEYS = frozenset(_classify.PLAN)        # the canonical plan schema (
 def _is_narrow(plan):
     """True iff `plan` is a well-formed plan dict that positively qualifies to
     skip the broad matrix (APPROVED_NARROW). Anything else -> False -> broad."""
-    if not isinstance(plan, dict):
-        return False
-    for k, v in plan.items():
-        if not isinstance(v, bool):
-            return False                            # non-boolean field -> broad
-        if k not in KNOWN_PLAN_KEYS:
-            return False                            # unknown field -> broad
+    if not _well_formed_plan(plan):
+        return False                                # malformed / empty / lint-missing -> broad
+    if plan.get("full_all") or plan.get("full_core"):
+        return False                                # a broad plan -> broad
     true_flags = {k for k, v in plan.items() if v}
     if not true_flags <= APPROVED_NARROW:
         return False                                # a true flag outside the approved set -> broad
@@ -138,29 +164,31 @@ def _is_narrow(plan):
 def applicable_groups(plan):
     """The set of groups that MUST run. `always` is always applicable. A plan is
     only NARROW under the positive allowlist; anything else is BROAD (every group
-    applicable). A narrow plan enables just the matching focused + parser-fuzz
-    groups."""
+    applicable). A narrow plan is ADDITIVE: the matching source-frontend + parser
+    -fuzz groups (from FRONTEND_SELECTORS) PLUS the native subsystem groups (from
+    native_groups(): the core-common floor + the touched db/gpu/compute groups +
+    the db-any umbrella). A native+frontend change therefore runs core-common +
+    its subsystem + the frontend/fuzzer groups; the broad-only `web` group is
+    never added by a narrow plan (a native/frontend change does not touch it)."""
     groups = {"always"}
     if not _is_narrow(plan):
-        groups |= set(GROUP_FLAG.keys())
+        groups |= set(GROUP_FLAG.keys())            # broad: every group applicable
         return groups
     if plan.get("focused_js_frontend") or plan.get("focused_js_fuzz"):
         groups |= {"focused-js", "fuzz-js"}
     if plan.get("focused_lua_frontend") or plan.get("focused_lua_fuzz"):
         groups |= {"focused-lua", "fuzz-lua"}
+    groups |= native_groups(plan)                   # {} for a pure frontend/docs plan
     return groups
 
 
-# -- Slice 4 native-subsystem group scaffolding (Appendix C.2/C.5) ------------
-# The INTENDED checkpoint-3 mapping from a plan to native subsystem groups.
-# core-common is the always-run floor for ANY production-C / native change
-# (constraint 1). db-any is the SINGLE umbrella group whose sole member is the
-# fuzz-db-wire job = the union of the db sub-groups (Amendment 1), keyed off
-# focused_db (set whenever any db file changed, backend or shared). This is INERT
-# in checkpoint 2: proven by fixtures (test_job_plan.py :: native_groups.*) but NOT
-# consulted by applicable_groups - a native plan is not APPROVED_NARROW, so it
-# still evaluates BROAD and NOTHING skips. Checkpoint 3 wires this in AND regroups
-# the current `full-matrix` jobs into `core-common` + these subsystem groups.
+# -- Slice 4 native-subsystem groups (Appendix C.2/C.5) -----------------------
+# The mapping from a plan to native subsystem groups, CONSULTED by
+# applicable_groups (checkpoint 3 - skipping is active). core-common is the
+# always-run floor for ANY production-C / native change (constraint 1). db-any is
+# the SINGLE umbrella group whose sole member is the fuzz-db-wire job = the union
+# of the db sub-groups (Amendment 1), keyed off focused_db (set whenever any db
+# file changed, backend or shared).
 NATIVE_SUBSYSTEM_GROUPS = frozenset({
     "core-common", "db-postgres", "db-mysql", "db-valkey", "db-duckdb", "db-any",
     "gpu", "compute",
@@ -192,8 +220,8 @@ def native_groups(plan):
     """The native subsystem groups a plan selects UNDER the checkpoint-3 mapping.
     Broad/malformed -> every native group. A narrow-native plan -> the always-run
     `core-common` floor plus the specific subsystem group(s), and the `db-any`
-    umbrella iff any db backend is touched (via focused_db). Inert scaffolding in
-    checkpoint 2 (fixture-proven, not yet consulted by applicable_groups)."""
+    umbrella iff any db backend is touched (via focused_db). Returns {} for a plan
+    with no native selector (a pure frontend/docs narrow)."""
     if _is_broad_plan(plan):
         return set(NATIVE_SUBSYSTEM_GROUPS)
     g = set()

--- a/scripts/ci/test_classify_changes.py
+++ b/scripts/ci/test_classify_changes.py
@@ -383,5 +383,32 @@ check("rename under force-full -> full_all",
       ["src/hull/cap/db_postgres.c", "src/hull/cap/db_postgres_v2.c"],
       want_true=["full_all"], force_full=True)
 
+# 6. EVERY tracked src/** file is classified correctly (Slice 4 checkpoint 3,
+#    constraint 4): an allowlisted file -> EXACTLY its subsystem facts; the
+#    deliberate C frontend bridge -> production_core PLUS the js/lua frontend
+#    facts; every OTHER tracked source -> a set INCLUDING production_core_changed
+#    (so an unrecognized/new production file always runs the broad suite).
+import subprocess  # noqa: E402
+_ALLOW_MAP = {}
+for _files, _want in _ALLOWLIST_EXPECT:
+    for _f in _files:
+        _ALLOW_MAP[_f] = _want
+try:
+    _tracked = subprocess.run(["git", "-C", _REPO, "ls-files", "src"],
+                              capture_output=True, text=True, check=True).stdout.split()
+except Exception as _e:                                   # pragma: no cover
+    _tracked = []
+    ck("git ls-files src succeeded", False)
+ck("git ls-files src returned files", len(_tracked) > 0)
+_FRONTEND_BRIDGE = {"production_core_changed", "js_frontend_changed", "lua_frontend_changed"}
+for _f in _tracked:
+    facts = _cc.classify_path(_f)
+    if _f in _ALLOW_MAP:
+        ck("tracked allowlisted exact: %s" % _f, facts == _ALLOW_MAP[_f])
+    elif _f.startswith("src/hull/frontend/"):
+        ck("tracked frontend bridge keeps frontend facts: %s" % _f, facts == _FRONTEND_BRIDGE)
+    else:
+        ck("tracked src includes production_core: %s" % _f, "production_core_changed" in facts)
+
 print("classify_changes fixtures: %d passed, %d failed" % (_pass, _fail))
 sys.exit(1 if _fail else 0)

--- a/scripts/ci/test_job_plan.py
+++ b/scripts/ci/test_job_plan.py
@@ -49,11 +49,11 @@ check("docs-only: fuzz-core-security may skip", "fuzz-core-security" in s)
 check("docs-only: lint never skips", "lint" not in s)
 check("docs-only: classify never skips", "classify" not in s)
 
-# -- pure JS frontend: focused-js + fuzz-js run; matrix + lua skip --
+# -- pure JS frontend: focused-js + fuzz-js run; core-common + native + lua skip --
 f = flags(["stdlib/cli/js/hull/source/parser.js"])
 check("pure-js: run_focused_js", f["run_focused_js"])
 check("pure-js: run_fuzz_js", f["run_fuzz_js"])
-check("pure-js: NOT run_full_matrix", not f["run_full_matrix"])
+check("pure-js: NOT run_core_common (frontend narrow)", not f["run_core_common"])
 check("pure-js: NOT run_focused_lua", not f["run_focused_lua"])
 s = skips(["stdlib/cli/js/hull/source/parser.js"])
 check("pure-js: build may skip", "build" in s)
@@ -66,7 +66,7 @@ check("pure-js: fuzz-js NOT skippable", "fuzz-js-source" not in s)
 f = flags(["stdlib/cli/lua/hull/source/lexer.lua"])
 check("pure-lua: run_focused_lua", f["run_focused_lua"])
 check("pure-lua: run_fuzz_lua", f["run_fuzz_lua"])
-check("pure-lua: NOT run_full_matrix", not f["run_full_matrix"])
+check("pure-lua: NOT run_core_common (frontend narrow)", not f["run_core_common"])
 s = skips(["stdlib/cli/lua/hull/source/lexer.lua"])
 check("pure-lua: focused-lua NOT skippable", "focused-lua-frontend" not in s)
 check("pure-lua: build may skip", "build" in s)
@@ -74,44 +74,44 @@ check("pure-lua: build may skip", "build" in s)
 # -- fuzz-only: a source-parser fuzzer .c sets frontend+fuzz -> narrow --
 f = flags(["fuzz/fuzz_js_source.c"])
 check("js-fuzz .c: run_fuzz_js + focused_js", f["run_fuzz_js"] and f["run_focused_js"])
-check("js-fuzz .c: NOT run_full_matrix", not f["run_full_matrix"])
-# a NATIVE fuzzer .c is NOT a proven narrow class -> broad
+check("js-fuzz .c: NOT run_core_common", not f["run_core_common"])
+# a NATIVE-protocol fuzzer .c is NOT a proven narrow class -> broad
 f = flags(["fuzz/fuzz_pgwire.c"])
-check("native-fuzz .c -> broad (run_full_matrix)", f["run_full_matrix"])
+check("native-fuzz .c -> broad", all(f.values()))
 
-# -- core: broad, everything runs --
-f = flags(["src/hull/cap/db.c"])
-check("core: run_full_matrix", f["run_full_matrix"])
-check("core: all group flags true", all(f.values()))
+# -- core (a genuinely non-allowlisted production file): broad, everything runs --
+f = flags(["src/hull/serve.c"])
+check("core: broad (all group flags true)", all(f.values()))
 check("core: nothing skippable except benchmark(non-push)",
-      skips(["src/hull/cap/db.c"]) == {"benchmark"})
+      skips(["src/hull/serve.c"]) == {"benchmark"})
 
-# -- mixed core + frontend: full core PLUS focused (all run) --
-f = flags(["stdlib/cli/js/hull/source/parser.js", "src/hull/cap/db.c"])
-check("mixed: run_full_matrix", f["run_full_matrix"])
+# -- mixed core + frontend: a core file forces broad --
+f = flags(["stdlib/cli/js/hull/source/parser.js", "src/hull/serve.c"])
+check("mixed core+frontend: broad", all(f.values()))
 check("mixed: run_focused_js", f["run_focused_js"])
-check("mixed: build NOT skippable", "build" not in skips(["stdlib/cli/js/hull/source/parser.js", "src/hull/cap/db.c"]))
+check("mixed: build NOT skippable",
+      "build" not in skips(["stdlib/cli/js/hull/source/parser.js", "src/hull/serve.c"]))
 
 # -- main push / force-full: everything runs regardless of paths --
 f = flags(["docs/x.md"], event="push_main")
-check("push_main: run_full_matrix", f["run_full_matrix"] and all(f.values()))
-check("push_main: only benchmark not force-skippable (event=push => none)",
+check("push_main: broad (all groups)", all(f.values()))
+check("push_main: nothing force-skippable (event=push => none)",
       job_plan.allow_skip_jobs(plan_for(["docs/x.md"], event="push_main"), ALL_JOBS, "push") == set())
 f = flags(["docs/x.md"], force_full=True)
-check("force-full: run_full_matrix", f["run_full_matrix"] and all(f.values()))
+check("force-full: broad (all groups)", all(f.values()))
 
 # -- unexpected skip: build applicable in a broad plan -> NOT in allow-skip --
 check("broad: build must run (not in allow-skip)",
-      "build" not in job_plan.allow_skip_jobs(plan_for(["src/hull/cap/db.c"]), ALL_JOBS, "pull_request"))
+      "build" not in job_plan.allow_skip_jobs(plan_for(["src/hull/serve.c"]), ALL_JOBS, "pull_request"))
 
 # -- missing applicability: an UNMAPPED job defaults to always -> never skips --
 s = job_plan.allow_skip_jobs(plan_for(["docs/x.md"]), ALL_JOBS + ["brand_new_job"], "pull_request")
 check("unmapped job defaults applicable (never skippable)", "brand_new_job" not in s)
-check("but a mapped full-matrix job IS skippable in docs-only", "build" in s)
+check("but a mapped core-common job IS skippable in docs-only", "build" in s)
 
 # -- benchmark: push-only; skippable on PR regardless of plan, NOT on push --
 check("benchmark skippable on PR (broad plan)",
-      "benchmark" in job_plan.allow_skip_jobs(plan_for(["src/hull/cap/db.c"]), ALL_JOBS, "pull_request"))
+      "benchmark" in job_plan.allow_skip_jobs(plan_for(["src/hull/serve.c"]), ALL_JOBS, "pull_request"))
 check("benchmark NOT skippable on push",
       "benchmark" not in job_plan.allow_skip_jobs(plan_for([], event="push_main"), ALL_JOBS, "push"))
 
@@ -125,30 +125,49 @@ check("non-dict (list) plan -> broad", is_broad([]))
 check("unknown true flag -> broad", is_broad({"lint": True, "focused_js_frontend": True, "bogus_flag": True}))
 check("string-valued flag -> broad", is_broad({"lint": True, "focused_js_frontend": "true"}))
 check("int-valued flag -> broad", is_broad({"lint": True, "focused_js_frontend": 1}))
-check("existing non-narrow flag alone (focused_wasm) -> broad", is_broad({"lint": True, "focused_wasm": True}))
 check("lint-only (no narrow selector) -> broad", is_broad({"lint": True}))
 check("full_all present -> broad", is_broad({"lint": True, "full_all": True}))
+check("full_core present -> broad", is_broad({"lint": True, "full_core": True}))
 # a genuinely-approved narrow plan still narrows (positive path still works)
 check("approved narrow (docs_only) -> not broad", not is_broad({"lint": True, "docs_only": True}))
-check("approved narrow (js) -> focused-js only",
+check("approved narrow (js) -> focused-js only, no core-common",
       job_plan.run_flags({"lint": True, "focused_js_frontend": True})["run_focused_js"]
-      and not job_plan.run_flags({"lint": True, "focused_js_frontend": True})["run_full_matrix"])
+      and not job_plan.run_flags({"lint": True, "focused_js_frontend": True})["run_core_common"])
 
-# ---- Slice 4 checkpoint 2: native-subsystem map + fuzz split (Appendix C) ----
-# All ADDITIVE / no-skip: an isolated native change still evaluates BROAD live
-# (nothing skips); the native_groups() helper proves the intended checkpoint-3
-# mapping; the three split fuzz jobs share the fuzz-native group and their target
-# union equals the former single job.
+# ---- Slice 4 checkpoint 3: native narrowing ACTIVE (skipping on) -------------
+# An isolated native change is now NARROW: it runs the core-common floor + its
+# subsystem (+ the db-any umbrella for a db change) and SKIPS the other
+# subsystems, the broad-only web group, and the frontend groups. A native change
+# mixed with any non-approved selector falls closed to BROAD (constraints below).
 
-# no-skip invariant: an isolated backend/gpu/compute change is still BROAD live.
-for _paths in (["src/hull/cap/db_postgres.c"], ["src/hull/cap/gpu_wgpu.c"],
-               ["src/hull/cap/wasm.c"], ["src/hull/cap/db_select.c"]):
-    check("native change still BROAD live (no skip): %s" % _paths[0],
-          all(job_plan.run_flags(plan_for(_paths)).values()))
-    check("native change: only benchmark force-skippable (PR): %s" % _paths[0],
-          skips(_paths) == {"benchmark"})
+# narrow-native (db_postgres): core-common + db-postgres + db-any run; rest skip.
+f = flags(["src/hull/cap/db_postgres.c"])
+check("db_postgres NARROW: core-common on", f["run_core_common"])
+check("db_postgres NARROW: db-postgres + db-any on", f["run_db_postgres"] and f["run_db_any"])
+check("db_postgres NARROW: gpu/compute/web/other-db OFF",
+      not any(f[k] for k in ("run_gpu", "run_compute", "run_web",
+                             "run_db_mysql", "run_db_valkey", "run_db_duckdb")))
+check("db_postgres NARROW: frontend OFF",
+      not any(f[k] for k in ("run_focused_js", "run_focused_lua", "run_fuzz_js", "run_fuzz_lua")))
+_s = skips(["src/hull/cap/db_postgres.c"])
+check("db_postgres NARROW: gpu jobs skippable", {"gpu", "gpu-feature"} <= _s)
+check("db_postgres NARROW: other-backend + compute + web skippable",
+      {"mysql", "valkey", "duckdb", "wasm-readonly-heap-aot",
+       "htmx-browser", "project-discovery-lua"} <= _s)
+check("db_postgres NARROW: core-common jobs NOT skippable",
+      not ({"build", "sanitizers", "reproducibility", "fuzz-core-security"} & _s))
+check("db_postgres NARROW: postgres + fuzz-db-wire NOT skippable",
+      not ({"postgres", "postgres-feature", "fuzz-db-wire"} & _s))
 
-# native_groups() intended checkpoint-3 mapping (inert scaffolding, fixture-proven).
+# gpu-only and compute-only narrow.
+fg = flags(["src/hull/cap/gpu_wgpu.c"])
+check("gpu NARROW: core-common + gpu on, db/compute off",
+      fg["run_core_common"] and fg["run_gpu"] and not fg["run_db_any"] and not fg["run_compute"])
+fc = flags(["src/hull/cap/wasm.c"])
+check("compute NARROW: core-common + compute on, db/gpu off",
+      fc["run_core_common"] and fc["run_compute"] and not fc["run_db_any"] and not fc["run_gpu"])
+
+# native_groups() = the live subsystem mapping consulted by applicable_groups.
 def ng(paths):
     return job_plan.native_groups(plan_for(paths))
 
@@ -178,12 +197,59 @@ check("ng malformed plan -> every native group (fail closed)",
 check("ng docs-only -> no native group",
       ng(["docs/x.md"]) == set())
 
-# the three split fuzz jobs share the fuzz-native group and skip/run together.
-for _j in ("fuzz-core-security", "fuzz-db-wire", "fuzz-compute-span"):
-    check("fuzz split %s in fuzz-native group" % _j, job_plan.GROUP.get(_j) == "fuzz-native")
-    check("fuzz split %s skippable on docs-only" % _j, _j in skips(["docs/x.md"]))
-    check("fuzz split %s runs on broad (not skippable)" % _j,
-          _j not in skips(["src/hull/serve.c"]))
+# ---- CP3 constraint 1: native + any NON-approved selector -> BROAD -----------
+# A native change mixed with tooling / project-discovery / query / tls / generic
+# tests-or-examples / a future-or-unknown selector must fall closed to broad.
+check("backend + tooling -> broad",
+      is_broad(plan_for(["src/hull/cap/db_postgres.c", "stdlib/cli/lua/hull/deploy.lua"])))
+check("backend + project-discovery -> broad",
+      is_broad(plan_for(["src/hull/cap/db_postgres.c", "stdlib/cli/lua/hull/project/model.lua"])))
+check("backend + generic test -> broad",
+      is_broad(plan_for(["src/hull/cap/db_postgres.c", "tests/hull/cap/test_db.c"])))
+check("backend + example -> broad",
+      is_broad(plan_for(["src/hull/cap/db_postgres.c", "examples/todo/app.lua"])))
+# plan-level: focused_query / focused_tls / a future unknown flag mixed with a
+# native selector -> broad (these have no classifier path yet, so assert directly).
+check("plan: backend + focused_query -> broad",
+      is_broad({"lint": True, "focused_db": True, "focused_db_postgres": True, "focused_query": True}))
+check("plan: backend + focused_tls -> broad",
+      is_broad({"lint": True, "focused_db": True, "focused_db_postgres": True, "focused_tls": True}))
+check("plan: backend + focused_native_fuzz -> broad",
+      is_broad({"lint": True, "focused_db": True, "focused_native_fuzz": True}))
+check("plan: backend + FUTURE unknown flag -> broad",
+      is_broad({"lint": True, "focused_db": True, "focused_db_postgres": True, "future_flag": True}))
+
+# ---- CP3 constraint 2: native + approved frontend -> ADDITIVE ----------------
+# core-common + native subsystem + the matching frontend/fuzzer groups; frontend
+# groups are NOT discarded. (The broad-only web group stays off.)
+fj = flags(["src/hull/cap/db_postgres.c", "stdlib/cli/js/hull/source/parser.js"])
+check("backend + JS frontend: additive (core-common + db + js), web off",
+      fj["run_core_common"] and fj["run_db_postgres"] and fj["run_db_any"]
+      and fj["run_focused_js"] and fj["run_fuzz_js"]
+      and not fj["run_web"] and not fj["run_gpu"] and not fj["run_compute"]
+      and not fj["run_focused_lua"])
+_sj = skips(["src/hull/cap/db_postgres.c", "stdlib/cli/js/hull/source/parser.js"])
+check("backend + JS frontend: focused-js-frontend NOT skipped (not discarded)",
+      "focused-js-frontend" not in _sj and "fuzz-js-source" not in _sj)
+# DB + GPU + frontend -> all three additive.
+fdgf = flags(["src/hull/cap/db_postgres.c", "src/hull/cap/gpu.c",
+              "stdlib/cli/js/hull/source/parser.js"])
+check("DB + GPU + JS frontend: additive (core-common + db + gpu + js)",
+      fdgf["run_core_common"] and fdgf["run_db_postgres"] and fdgf["run_db_any"]
+      and fdgf["run_gpu"] and fdgf["run_focused_js"] and fdgf["run_fuzz_js"]
+      and not fdgf["run_compute"] and not fdgf["run_web"] and not fdgf["run_focused_lua"])
+
+# the three split fuzz jobs now belong to their subsystem groups.
+_FUZZ_GROUP = {"fuzz-core-security": "core-common", "fuzz-db-wire": "db-any",
+               "fuzz-compute-span": "compute"}
+for _j, _g in _FUZZ_GROUP.items():
+    check("fuzz %s in group %s" % (_j, _g), job_plan.GROUP.get(_j) == _g)
+    check("fuzz %s skippable on docs-only" % _j, _j in skips(["docs/x.md"]))
+    check("fuzz %s runs on broad (not skippable)" % _j, _j not in skips(["src/hull/serve.c"]))
+check("fuzz-db-wire runs on narrow-DB", "fuzz-db-wire" not in skips(["src/hull/cap/db_postgres.c"]))
+check("fuzz-db-wire skips on gpu-only", "fuzz-db-wire" in skips(["src/hull/cap/gpu_wgpu.c"]))
+check("fuzz-compute-span runs on compute change", "fuzz-compute-span" not in skips(["src/hull/cap/wasm.c"]))
+check("fuzz-compute-span skips on db-only", "fuzz-compute-span" in skips(["src/hull/cap/db_postgres.c"]))
 
 # fuzz coverage-equivalence: the union of the three jobs' build targets in ci.yml
 # equals the former single fuzz-native-security set (no target dropped in the split).

--- a/scripts/ci/test_job_plan.py
+++ b/scripts/ci/test_job_plan.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from classify_changes import classify  # noqa: E402
+from classify_changes import classify, PLAN  # noqa: E402
 import job_plan  # noqa: E402
 
 ALL_JOBS = sorted(job_plan.GROUP.keys())
@@ -20,6 +20,17 @@ _fail = 0
 
 def plan_for(paths, event="pull_request", force_full=False):
     return classify(list(paths), event=event, force_full=force_full)["plan"]
+
+
+def full_plan(**overrides):
+    """A COMPLETE canonical plan (the exact PLAN schema, all-False + lint) with
+    overrides applied. Hand-built partial dicts are now rejected as malformed
+    (_well_formed_plan requires the exact schema), so narrow-positive fixtures
+    must build a full plan the way the classifier does."""
+    p = {k: False for k in PLAN}
+    p["lint"] = True
+    p.update(overrides)
+    return p
 
 
 def check(name, cond):
@@ -128,11 +139,11 @@ check("int-valued flag -> broad", is_broad({"lint": True, "focused_js_frontend":
 check("lint-only (no narrow selector) -> broad", is_broad({"lint": True}))
 check("full_all present -> broad", is_broad({"lint": True, "full_all": True}))
 check("full_core present -> broad", is_broad({"lint": True, "full_core": True}))
-# a genuinely-approved narrow plan still narrows (positive path still works)
-check("approved narrow (docs_only) -> not broad", not is_broad({"lint": True, "docs_only": True}))
+# a genuinely-approved COMPLETE narrow plan still narrows (positive path works)
+check("approved narrow (docs_only) -> not broad", not is_broad(full_plan(docs_only=True)))
 check("approved narrow (js) -> focused-js only, no core-common",
-      job_plan.run_flags({"lint": True, "focused_js_frontend": True})["run_focused_js"]
-      and not job_plan.run_flags({"lint": True, "focused_js_frontend": True})["run_core_common"])
+      job_plan.run_flags(full_plan(focused_js_frontend=True))["run_focused_js"]
+      and not job_plan.run_flags(full_plan(focused_js_frontend=True))["run_core_common"])
 
 # ---- Slice 4 checkpoint 3: native narrowing ACTIVE (skipping on) -------------
 # An isolated native change is now NARROW: it runs the core-common floor + its
@@ -208,16 +219,46 @@ check("backend + generic test -> broad",
       is_broad(plan_for(["src/hull/cap/db_postgres.c", "tests/hull/cap/test_db.c"])))
 check("backend + example -> broad",
       is_broad(plan_for(["src/hull/cap/db_postgres.c", "examples/todo/app.lua"])))
-# plan-level: focused_query / focused_tls / a future unknown flag mixed with a
-# native selector -> broad (these have no classifier path yet, so assert directly).
+# plan-level: a COMPLETE, COHERENT plan whose native selector is mixed with a
+# non-approved known flag (focused_query / focused_tls / focused_native_fuzz) ->
+# broad because of the non-approved flag (not because of a schema defect).
 check("plan: backend + focused_query -> broad",
-      is_broad({"lint": True, "focused_db": True, "focused_db_postgres": True, "focused_query": True}))
+      is_broad(full_plan(focused_db=True, focused_db_postgres=True, focused_query=True)))
 check("plan: backend + focused_tls -> broad",
-      is_broad({"lint": True, "focused_db": True, "focused_db_postgres": True, "focused_tls": True}))
+      is_broad(full_plan(focused_db=True, focused_db_postgres=True, focused_tls=True)))
 check("plan: backend + focused_native_fuzz -> broad",
-      is_broad({"lint": True, "focused_db": True, "focused_native_fuzz": True}))
-check("plan: backend + FUTURE unknown flag -> broad",
-      is_broad({"lint": True, "focused_db": True, "focused_db_postgres": True, "future_flag": True}))
+      is_broad(full_plan(focused_db=True, focused_db_postgres=True, focused_native_fuzz=True)))
+# a FUTURE/unknown selector = an EXTRA key beyond the schema -> broad (exact-schema).
+_future = full_plan(focused_db=True, focused_db_postgres=True)
+_future["future_flag"] = True
+check("plan: backend + FUTURE unknown flag -> broad", is_broad(_future))
+
+# ---- CP3 fail-closed: exact schema + native-selector coherence ---------------
+# A syntactically-valid but INCOMPLETE/INCOHERENT plan must go BROAD, never narrow
+# to a partial subsystem set.
+# valid-looking PARTIAL plan (coherent, but missing keys) -> broad.
+check("partial plan (missing keys) -> broad",
+      is_broad({"lint": True, "focused_db": True, "focused_db_postgres": True}))
+# focused_db with NO backend selector -> incoherent -> broad.
+check("focused_db without a backend -> broad", is_broad(full_plan(focused_db=True)))
+# a backend selector with focused_db=False -> incoherent -> broad.
+check("backend without focused_db -> broad", is_broad(full_plan(focused_db_postgres=True)))
+# mismatched compute/wasm pairing -> broad (both directions).
+check("focused_compute without focused_wasm -> broad", is_broad(full_plan(focused_compute=True)))
+check("focused_wasm without focused_compute -> broad", is_broad(full_plan(focused_wasm=True)))
+# the COMPLETE canonical plans continue to narrow correctly (positive path).
+check("canonical docs_only narrows", not is_broad(full_plan(docs_only=True)))
+check("canonical single-backend narrows",
+      not is_broad(full_plan(focused_db=True, focused_db_postgres=True)))
+check("canonical shared-db narrows",
+      not is_broad(full_plan(focused_db=True, focused_db_postgres=True, focused_db_mysql=True,
+                             focused_db_valkey=True, focused_db_duckdb=True)))
+check("canonical compute (paired wasm+compute) narrows",
+      not is_broad(full_plan(focused_compute=True, focused_wasm=True)))
+check("canonical gpu narrows", not is_broad(full_plan(focused_gpu=True)))
+# and the real classifier output for these paths still narrows (schema always exact).
+check("classifier db_postgres plan still narrows", not is_broad(plan_for(["src/hull/cap/db_postgres.c"])))
+check("classifier wasm plan still narrows", not is_broad(plan_for(["src/hull/cap/wasm.c"])))
 
 # ---- CP3 constraint 2: native + approved frontend -> ADDITIVE ----------------
 # core-common + native subsystem + the matching frontend/fuzzer groups; frontend


### PR DESCRIPTION
**Third checkpoint: design → additive proof → SKIP ACTIVATION.** Splits the monolithic `full-matrix` + `fuzz-native` groups into the always-run **core-common** floor + native subsystem groups (**db-postgres / db-mysql / db-valkey / db-duckdb**, the **db-any** umbrella for `fuzz-db-wire`, **gpu**, **compute**) + a broad-only **web** bucket (`htmx-browser`, `project-discovery-lua`). A narrow-native change runs core-common + its subsystem and **skips the rest**; a shared/broad change runs everything. Branch-protection unchanged.

### Fail-closed constraints (from review)
- **Own positive allowlist** — native narrowing permits only `{lint, docs_only}` + frontend selectors + native selectors. A native change mixed with `focused_tooling` / project-discovery / query / tls / generic tests-or-examples / **any future-or-unknown/non-boolean** flag falls **outside** the set → **BROAD**.
- **Native + approved frontend is ADDITIVE** — core-common + the native subsystem + the matching frontend/fuzzer groups. `native_groups()` is **unioned** with the frontend groups, never substituted, so frontend groups are not discarded. The broad-only `web` group is never added by a narrow plan.
- **Malformed/empty plans** fail closed to every group.

### Behavior (end-to-end sim)
- `src/hull/cap/db_postgres.c` (narrow) → `run_core_common`, `run_db_postgres`, `run_db_any` → **25/50 jobs run**; gpu/compute/other-db/web/frontend skip.
- broad → **49/50 run** (only the push-only `benchmark` skips on a PR).

### Fixtures (all green: classify **433**, gate **19**, job_plan **91**, both consistency checkers)
- narrow-native runs core-common + subsystem, skips the rest; gpu-only / compute-only narrow.
- backend + JS frontend **additive** (frontend not discarded); **DB + GPU + frontend** additive.
- backend + tooling / + project-discovery / + generic-test / + example → **broad**; plan-level backend + query / + tls / + native_fuzz / + **future-unknown** → **broad**.
- the **every-tracked-`src/**`** machine-check: allowlisted → exact facts; the C frontend bridge keeps its js/lua facts; every other tracked source includes `production_core`.

### Live proof
This PR touches `scripts/ci/**` + `.github/**` → **broad** self-proof (all jobs run, self-tests green in the `classify` job). A **narrow-native** live run (a single backend `.c` skipping the other subsystems) is demonstrated separately via a throwaway base-branch (a PR to a feature branch doesn't trigger `ci.yml`). **Stops for review after both.**