### PR TITLE
[THROWAWAY] CP3 narrow-native live proof (db_postgres.c only)

### DIFF
--- a/src/hull/cap/db_postgres.c
+++ b/src/hull/cap/db_postgres.c
@@ -559,3 +559,5 @@ const HlDbBackend hl_db_backend_postgres = {
 };
 
 #endif /* HL_ENABLE_POSTGRES */
+
+/* CI Slice 4 checkpoint-3 narrow-native live demo: throwaway, do not merge. */


### PR DESCRIPTION
Throwaway demo to prove Slice 4 checkpoint 3 narrow-native skipping live. Touches only src/hull/cap/db_postgres.c -> should classify narrow-native: core-common + db-postgres + db-any run, gpu/compute/other-db/web/frontend SKIP, gate passes. Do not merge; auto-cleaned.