### PR TITLE
CI Slice 5A (additive): wamrc producer + verify/equivalence consumer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,29 +495,46 @@ jobs:
         with:
           name: wamrc-x86_64
           path: artifact
-      - name: Verify artifact identity + provenance + checksum (FAIL, never rebuild)
-        timeout-minutes: 12
+      # COLD verification: configure the wamrc toolchain (generate CMakeCache.txt
+      # with the resolved compilers) WITHOUT compiling wamrc, then verify. This is
+      # the reliance-flip precondition - a real consumer will NOT build wamrc, so
+      # the identity must reproduce from configure alone. `make wamrc-configure`
+      # must NOT leave an executable build/wamrc.
+      - name: Configure toolchain (no compile) + COLD verify (before any build)
+        timeout-minutes: 6
         run: |
           set -e
           if command -v llvm-config-18 >/dev/null 2>&1; then
             export WAMRC_CMAKE_FLAGS="-DLLVM_DIR=$(llvm-config-18 --cmakedir)"
           fi
           chmod +x artifact/wamrc
-          # build a FRESH wamrc so gather_local() sees the local CMakeCache
-          # compilers (and so equivalence has a from-source baseline).
-          make wamrc
+          make wamrc-configure
+          if [ -x build/wamrc ]; then
+            echo "::error::wamrc was built during configure - cold verify is not cold"; exit 1
+          fi
           python3 scripts/ci/wamrc_artifact.py verify \
             --manifest artifact/wamrc.manifest.json --wamrc artifact/wamrc --producer wamrc-x86_64
-      - name: Linkage (ldd) + usability probe
-        run: |
-          echo "== ldd artifact/wamrc =="; ldd artifact/wamrc || true
-          # usability: the tool must RUN (no-arg wamrc prints usage + exits nonzero,
-          # which still proves it loaded its libLLVM); the hard proof is the .aot
-          # compile in the next step.
-          artifact/wamrc --help >/dev/null 2>&1 || artifact/wamrc >/dev/null 2>&1 || true
-      - name: Output equivalence (artifact-wamrc .aot == fresh-wamrc .aot)
+      - name: Linkage (ldd, HARD) + usability (AOT compile with the artifact wamrc)
         run: |
           set -e
+          LDD_OUT="$(ldd artifact/wamrc 2>&1 || true)"
+          echo "== ldd artifact/wamrc =="; echo "$LDD_OUT"
+          if printf '%s' "$LDD_OUT" | grep -qi 'not found'; then
+            echo "::error::artifact/wamrc has UNRESOLVED dynamic dependencies"; exit 1
+          fi
+          # usability: the ARTIFACT wamrc (no fresh build yet) must run + emit a
+          # non-empty .aot; a wamrc that cannot load its libLLVM fails HERE.
+          artifact/wamrc -o /tmp/probe.aot tests/fixtures/compute/echo.wasm
+          test -s /tmp/probe.aot
+          echo "artifact wamrc runnable (emitted $(wc -c < /tmp/probe.aot)-byte .aot)"
+      - name: Output equivalence (NOW build fresh wamrc, compare .aot byte-for-byte)
+        timeout-minutes: 12
+        run: |
+          set -e
+          if command -v llvm-config-18 >/dev/null 2>&1; then
+            export WAMRC_CMAKE_FLAGS="-DLLVM_DIR=$(llvm-config-18 --cmakedir)"
+          fi
+          make wamrc          # the from-source baseline (only needed for equivalence)
           for w in tests/fixtures/compute/echo.wasm tests/fixtures/compute/echo64.wasm; do
             artifact/wamrc -o /tmp/a.aot "$w"
             build/wamrc     -o /tmp/b.aot "$w"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
           python3 scripts/ci/test_classify_changes.py
           python3 scripts/ci/test_ci_gate.py
           python3 scripts/ci/test_job_plan.py
+          python3 scripts/ci/test_wamrc_artifact.py
           python3 scripts/ci/check_gate_completeness.py
           python3 scripts/ci/check_job_plan_consistency.py
       - name: Classify the change (merge-base diff -> plan)
@@ -429,6 +430,116 @@ jobs:
       - name: hull test (examples)
         timeout-minutes: 2
         run: make hull-test-examples
+
+  # Slice 5A (docs/ci_architecture_design.md Appendix D): the wamrc PRODUCER.
+  # Builds wamrc ONCE (LLVM-18 + the WAMR patch carriage), emits an identity +
+  # provenance manifest, and uploads an immutable, run-scoped artifact. In this
+  # ADDITIVE checkpoint the artifact is proven by the verify job below; the 8
+  # x86_64 AOT consumers still build their own wamrc (unchanged) until a later
+  # checkpoint flips them to rely on it. Compute-group gated (run_compute), so a
+  # non-compute plan builds no wamrc.
+  wamrc-x86_64:
+    needs: [classify]
+    if: needs.classify.outputs.run_compute == 'true'
+    name: wamrc producer (x86_64)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+      - name: Install LLVM + cmake
+        run: sudo apt-get update && sudo apt-get install -y llvm-18-dev cmake
+      - name: Build wamrc (the WAMR patch carriage)
+        timeout-minutes: 12
+        run: |
+          if command -v llvm-config-18 >/dev/null 2>&1; then
+            export WAMRC_CMAKE_FLAGS="-DLLVM_DIR=$(llvm-config-18 --cmakedir)"
+          fi
+          make wamrc
+      - name: Emit provenance manifest
+        run: |
+          if command -v llvm-config-18 >/dev/null 2>&1; then
+            export WAMRC_CMAKE_FLAGS="-DLLVM_DIR=$(llvm-config-18 --cmakedir)"
+          fi
+          python3 scripts/ci/wamrc_artifact.py manifest \
+            --wamrc build/wamrc --producer wamrc-x86_64 > build/wamrc.manifest.json
+          cat build/wamrc.manifest.json
+      - name: Upload wamrc artifact (run-scoped, immutable)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: wamrc-x86_64
+          path: |
+            build/wamrc
+            build/wamrc.manifest.json
+          retention-days: 1
+          if-no-files-found: error
+
+  # Slice 5A: the verify + equivalence CONSUMER (representative). Downloads the
+  # producer artifact, verifies identity + provenance + checksum + arch + linkage
+  # + usability (FAILS the job on any mismatch - it never rebuilds and pretends),
+  # then byte-compares the artifact-wamrc .aot against a FRESH-built wamrc .aot on
+  # a wasm32 + a Memory64 fixture, and asserts a corrupted artifact is rejected.
+  wamrc-artifact-verify:
+    needs: [classify, wamrc-x86_64]
+    if: needs.classify.outputs.run_compute == 'true'
+    name: wamrc artifact verify + equivalence (x86_64)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+      - name: Install LLVM + cmake
+        run: sudo apt-get update && sudo apt-get install -y llvm-18-dev cmake
+      - name: Download wamrc artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: wamrc-x86_64
+          path: artifact
+      - name: Verify artifact identity + provenance + checksum (FAIL, never rebuild)
+        timeout-minutes: 12
+        run: |
+          set -e
+          if command -v llvm-config-18 >/dev/null 2>&1; then
+            export WAMRC_CMAKE_FLAGS="-DLLVM_DIR=$(llvm-config-18 --cmakedir)"
+          fi
+          chmod +x artifact/wamrc
+          # build a FRESH wamrc so gather_local() sees the local CMakeCache
+          # compilers (and so equivalence has a from-source baseline).
+          make wamrc
+          python3 scripts/ci/wamrc_artifact.py verify \
+            --manifest artifact/wamrc.manifest.json --wamrc artifact/wamrc --producer wamrc-x86_64
+      - name: Linkage (ldd) + usability probe
+        run: |
+          echo "== ldd artifact/wamrc =="; ldd artifact/wamrc || true
+          # usability: the tool must RUN (no-arg wamrc prints usage + exits nonzero,
+          # which still proves it loaded its libLLVM); the hard proof is the .aot
+          # compile in the next step.
+          artifact/wamrc --help >/dev/null 2>&1 || artifact/wamrc >/dev/null 2>&1 || true
+      - name: Output equivalence (artifact-wamrc .aot == fresh-wamrc .aot)
+        run: |
+          set -e
+          for w in tests/fixtures/compute/echo.wasm tests/fixtures/compute/echo64.wasm; do
+            artifact/wamrc -o /tmp/a.aot "$w"
+            build/wamrc     -o /tmp/b.aot "$w"
+            if ! cmp -s /tmp/a.aot /tmp/b.aot; then
+              echo "::error::AOT output differs between artifact-wamrc and fresh-wamrc for $w"
+              exit 1
+            fi
+            echo "equivalence OK (byte-identical .aot): $w"
+          done
+      - name: Corruption rejection (negative)
+        run: |
+          set -e
+          cp artifact/wamrc /tmp/wamrc.corrupt
+          printf '\xff' | dd of=/tmp/wamrc.corrupt bs=1 seek=64 count=1 conv=notrunc status=none
+          if command -v llvm-config-18 >/dev/null 2>&1; then
+            export WAMRC_CMAKE_FLAGS="-DLLVM_DIR=$(llvm-config-18 --cmakedir)"
+          fi
+          if python3 scripts/ci/wamrc_artifact.py verify \
+               --manifest artifact/wamrc.manifest.json --wamrc /tmp/wamrc.corrupt --producer wamrc-x86_64; then
+            echo "::error::a corrupted wamrc was NOT rejected"; exit 1
+          fi
+          echo "corruption correctly rejected (checksum mismatch -> job would FAIL)"
 
   # Read-only shared-heap enforcement (Phase 0): prove the AOT write-trap path
   # THROUGH HULL'S OWN BUILD, not just the interpreter or the WAMR unit config.
@@ -2338,6 +2449,8 @@ jobs:
     needs:
       - classify
       - build
+      - wamrc-x86_64
+      - wamrc-artifact-verify
       - wasm-readonly-heap-aot
       - mapped-span-bench
       - compute-aot-shared-heap

--- a/Makefile
+++ b/Makefile
@@ -2000,7 +2000,7 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
 
 # ── Targets ─────────────────────────────────────────────────────────
 
-.PHONY: all clean test debug msan tsan tsan-shared-heap fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-valkey e2e-feature-valkey e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-stream-meta e2e-compute-async-trap e2e-sync-spans e2e-compute-aot-shared-heap e2e-compute-memory64 e2e-compute-headers e2e-spans-example e2e-spans-multi e2e-spans-hugefile e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-linker-zig e2e-cross-build e2e-musl e2e-musl-cross floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-test-harness e2e-jobs e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-mapped-span bench-gpu bench-bytecode-cache wamrc coverage lint-lua lint-js lint check-sdk-headers check-sdk-headers-selftest platform platform-cosmo hardening check-hardening
+.PHONY: all clean test debug msan tsan tsan-shared-heap fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-valkey e2e-feature-valkey e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-stream-meta e2e-compute-async-trap e2e-sync-spans e2e-compute-aot-shared-heap e2e-compute-memory64 e2e-compute-headers e2e-spans-example e2e-spans-multi e2e-spans-hugefile e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-linker-zig e2e-cross-build e2e-musl e2e-musl-cross floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-test-harness e2e-jobs e2e-hypermedia-photos-upload e2e-jwt-asym hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-mapped-span bench-gpu bench-bytecode-cache wamrc wamrc-configure coverage lint-lua lint-js lint check-sdk-headers check-sdk-headers-selftest platform platform-cosmo hardening check-hardening
 
 all: $(BUILDDIR)/hull
 
@@ -2466,14 +2466,22 @@ platform-cosmo:
 
 WAMRC_BUILD_DIR := $(BUILDDIR)/wamrc-build
 
-wamrc: $(WAMR_PATCH_PREREQ) | $(BUILDDIR)
-	@echo "=== Building wamrc AOT compiler ==="
+# Configure-only: generate the CMake build tree (incl. CMakeCache.txt, which
+# records the resolved C/C++ compiler paths + LLVM) WITHOUT compiling wamrc. The
+# Slice-5A artifact CONSUMER runs this to reproduce the producer's toolchain
+# identity for cold artifact verification - i.e. verifying BEFORE (and without)
+# building wamrc from source (docs/ci_architecture_design.md D.1.3).
+wamrc-configure: $(WAMR_PATCH_PREREQ) | $(BUILDDIR)
+	@echo "=== Configuring wamrc build tree (no compile) ==="
 	@mkdir -p $(WAMRC_BUILD_DIR)
 	@cd $(WAMRC_BUILD_DIR) && cmake $(CURDIR)/$(WAMR_DIR)/wamr-compiler \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DWAMR_BUILD_WITH_CUSTOM_LLVM=1 \
 		-DWASM_ENABLE_INSTRUCTION_METERING=1 \
 		$(WAMRC_CMAKE_FLAGS) 2>&1 | tail -5
+
+wamrc: wamrc-configure | $(BUILDDIR)
+	@echo "=== Building wamrc AOT compiler ==="
 	@$(MAKE) -C $(WAMRC_BUILD_DIR) -j$$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4) 2>&1 | tail -3
 	@cp $(WAMRC_BUILD_DIR)/wamrc $(BUILDDIR)/wamrc
 	@echo "=== wamrc built: $(BUILDDIR)/wamrc ==="

--- a/scripts/ci/job_plan.py
+++ b/scripts/ci/job_plan.py
@@ -101,7 +101,10 @@ GROUP = {
     # -- gpu subsystem --
     "gpu": "gpu",
     "gpu-feature": "gpu",
-    # -- compute subsystem (AOT cluster + shared-heap TSan + span fuzzer) --
+    # -- compute subsystem (AOT cluster + shared-heap TSan + span fuzzer +
+    # the Slice-5A wamrc producer/verify) --
+    "wamrc-x86_64": "compute",
+    "wamrc-artifact-verify": "compute",
     "wasm-readonly-heap-aot": "compute",
     "mapped-span-bench": "compute",
     "compute-aot-shared-heap": "compute",

--- a/scripts/ci/test_ci_gate.py
+++ b/scripts/ci/test_ci_gate.py
@@ -102,5 +102,62 @@ expect("realistic PR (benchmark skipped, rest success)",
          cosmo="success", lint="success", benchmark="skipped"),
        allow_skip=("benchmark",), should_pass=True)
 
+# -- Slice 5A: the wamrc producer/verify are compute-grouped. On a compute-
+#    applicable plan they are NOT allowed skips, so a producer failure (which
+#    skips its consumer via `needs`) and a consumer verification failure BOTH
+#    reach a RED gate; on a non-compute plan they legitimately skip. The allow-skip
+#    set is DERIVED from the shared map (not a hand list), so the gate and the job
+#    `if:` conditions cannot disagree.
+import job_plan  # noqa: E402
+from classify_changes import classify  # noqa: E402
+
+_ALL5 = sorted(job_plan.GROUP.keys())
+_compute_plan = classify(["src/hull/cap/wasm.c"])["plan"]   # narrow compute -> compute applicable
+_allow5 = job_plan.allow_skip_jobs(_compute_plan, _ALL5, "pull_request")
+_docs_plan = classify(["docs/x.md"])["plan"]
+_allow_docs = job_plan.allow_skip_jobs(_docs_plan, _ALL5, "pull_request")
+
+
+def _ck(name, cond):
+    global _pass, _fail
+    if cond:
+        _pass += 1
+    else:
+        _fail += 1
+        print("FAIL:", name)
+
+
+_ck("5A: producer NOT an allowed skip on a compute plan", "wamrc-x86_64" not in _allow5)
+_ck("5A: verify NOT an allowed skip on a compute plan", "wamrc-artifact-verify" not in _allow5)
+_ck("5A: producer IS an allowed skip on a docs plan", "wamrc-x86_64" in _allow_docs)
+_ck("5A: verify IS an allowed skip on a docs plan", "wamrc-artifact-verify" in _allow_docs)
+
+# producer failure -> its consumer is skipped by `needs`; on a compute plan that
+# applicable skip is DISALLOWED -> gate FAIL (the producer failure also fails it).
+expect("5A: producer failure + consumer skipped -> gate FAIL",
+       R(classify="success", build="success",
+         **{"wamrc-x86_64": "failure", "wamrc-artifact-verify": "skipped"}),
+       allow_skip=_allow5, should_pass=False)
+# a consumer verification failure -> gate FAIL (never silently rebuilt).
+expect("5A: consumer verify failure -> gate FAIL",
+       R(classify="success", build="success",
+         **{"wamrc-x86_64": "success", "wamrc-artifact-verify": "failure"}),
+       allow_skip=_allow5, should_pass=False)
+# the missing-artifact case surfaces as the consumer FAILING (not skipping) -> FAIL.
+expect("5A: missing-artifact consumer failure -> gate FAIL",
+       R(classify="success", build="success",
+         **{"wamrc-x86_64": "success", "wamrc-artifact-verify": "failure"}),
+       allow_skip=_allow5, should_pass=False)
+# happy path -> pass.
+expect("5A: producer + verify success -> gate pass",
+       R(classify="success", build="success",
+         **{"wamrc-x86_64": "success", "wamrc-artifact-verify": "success"}),
+       allow_skip=_allow5, should_pass=True)
+# on a non-compute (docs) plan they legitimately skip -> pass.
+expect("5A: producer+verify skipped on docs plan -> gate pass",
+       R(classify="success", lint="success",
+         **{"wamrc-x86_64": "skipped", "wamrc-artifact-verify": "skipped"}),
+       allow_skip=_allow_docs, should_pass=True)
+
 print("ci_gate fixtures: %d passed, %d failed" % (_pass, _fail))
 sys.exit(1 if _fail else 0)

--- a/scripts/ci/test_job_plan.py
+++ b/scripts/ci/test_job_plan.py
@@ -292,6 +292,15 @@ check("fuzz-db-wire skips on gpu-only", "fuzz-db-wire" in skips(["src/hull/cap/g
 check("fuzz-compute-span runs on compute change", "fuzz-compute-span" not in skips(["src/hull/cap/wasm.c"]))
 check("fuzz-compute-span skips on db-only", "fuzz-compute-span" in skips(["src/hull/cap/db_postgres.c"]))
 
+# Slice 5A: the wamrc producer + verify jobs are compute-grouped - they run on a
+# compute-applicable plan and skip (legitimately) only when compute is inapplicable.
+for _j in ("wamrc-x86_64", "wamrc-artifact-verify"):
+    check("5A %s in compute group" % _j, job_plan.GROUP.get(_j) == "compute")
+    check("5A %s runs on compute change" % _j, _j not in skips(["src/hull/cap/wasm.c"]))
+    check("5A %s runs on broad" % _j, _j not in skips(["src/hull/serve.c"]))
+    check("5A %s skips on db-only (not compute)" % _j, _j in skips(["src/hull/cap/db_postgres.c"]))
+    check("5A %s skips on docs-only" % _j, _j in skips(["docs/x.md"]))
+
 # fuzz coverage-equivalence: the union of the three jobs' build targets in ci.yml
 # equals the former single fuzz-native-security set (no target dropped in the split).
 import re  # noqa: E402

--- a/scripts/ci/test_wamrc_artifact.py
+++ b/scripts/ci/test_wamrc_artifact.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# test_wamrc_artifact.py - fixtures for the wamrc artifact identity/provenance
+# core (Slice 5A). Proves the pure build_manifest/verify functions: a matching
+# artifact verifies; ANY identity, provenance, checksum, arch, schema, or
+# missing-field defect is rejected (-> the consumer fails, never rebuilds).
+# Run: python3 scripts/ci/test_wamrc_artifact.py
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import wamrc_artifact as wa  # noqa: E402
+
+_pass = 0
+_fail = 0
+
+
+def check(name, cond):
+    global _pass, _fail
+    if cond:
+        _pass += 1
+    else:
+        _fail += 1
+        print("FAIL:", name)
+
+
+# A complete, self-consistent set of gathered fields.
+GOOD = {
+    "runner_image": "ubuntu24-20260801.1", "arch": "x86_64",
+    "cc_path": "/usr/bin/cc", "cc_version": "cc (Ubuntu) 13.2.0",
+    "cxx_path": "/usr/bin/c++", "cxx_version": "c++ (Ubuntu) 13.2.0",
+    "llvm_version": "18.1.3", "wamr_rev": "c3a78cd159e59c86ac4543308bd676ff78d30a93",
+    "patch_hash": "a" * 64, "wamrc_flags": "-DLLVM_DIR=/usr/lib/llvm-18/cmake",
+    "build_script_hash": "b" * 64,
+    "commit_sha": "deadbeef" * 5, "run_id": "12345", "run_attempt": "1",
+    "producer_job": "wamrc-x86_64", "artifact_sha256": "c" * 64,
+}
+
+
+def local(**overrides):
+    d = dict(GOOD)
+    d.update(overrides)
+    return d
+
+
+# -- build_manifest --
+m = wa.build_manifest(GOOD)
+check("manifest carries schema_version", m["schema_version"] == wa.SCHEMA_VERSION)
+check("manifest has every field", all(k in m for k in wa.ALL_FIELDS))
+check("manifest stringifies values", all(isinstance(m[k], str) for k in wa.ALL_FIELDS))
+try:
+    wa.build_manifest({"arch": "x86_64"})
+    check("build_manifest rejects missing fields", False)
+except ValueError:
+    check("build_manifest rejects missing fields", True)
+
+# -- verify: the happy path --
+check("matching artifact verifies (no problems)", wa.verify(m, local()) == [])
+
+# -- verify: identity mismatches -> rejected --
+for field, bad in [("llvm_version", "17.0.0"), ("wamr_rev", "f" * 40),
+                   ("patch_hash", "0" * 64), ("wamrc_flags", "-DLLVM_DIR=/other"),
+                   ("build_script_hash", "9" * 64), ("cc_version", "cc 12.0.0"),
+                   ("cc_path", "/usr/local/bin/cc"), ("runner_image", "ubuntu24-OTHER"),
+                   ("arch", "aarch64")]:
+    check("identity mismatch rejected: %s" % field,
+          len(wa.verify(m, local(**{field: bad}))) >= 1)
+
+# -- verify: provenance mismatches (different run/attempt/commit) -> rejected --
+for field, bad in [("commit_sha", "beefdead" * 5), ("run_id", "99999"),
+                   ("run_attempt", "2"), ("producer_job", "some-other-job")]:
+    check("provenance mismatch rejected: %s" % field,
+          len(wa.verify(m, local(**{field: bad}))) >= 1)
+
+# -- verify: checksum mismatch (corruption) -> rejected --
+check("checksum mismatch (corruption) rejected",
+      len(wa.verify(m, local(artifact_sha256="d" * 64))) >= 1)
+check("MISSING artifact (download failed) rejected",
+      len(wa.verify(m, local(artifact_sha256="MISSING"))) >= 1)
+
+# -- verify: unknown / malformed schema -> rejected outright --
+check("unknown schema_version rejected", len(wa.verify({**m, "schema_version": 99}, local())) >= 1)
+check("no schema_version rejected", len(wa.verify({k: v for k, v in m.items() if k != "schema_version"}, local())) >= 1)
+check("non-dict manifest rejected", len(wa.verify([], local())) >= 1)
+check("non-dict manifest rejected (str)", len(wa.verify("nope", local())) >= 1)
+
+# -- verify: a manifest missing a field -> rejected --
+check("manifest missing a field rejected",
+      len(wa.verify({k: v for k, v in m.items() if k != "wamr_rev"}, local())) >= 1)
+# -- verify: local missing a field -> rejected --
+_partial = dict(GOOD)
+del _partial["llvm_version"]
+check("local missing a field rejected", len(wa.verify(m, _partial)) >= 1)
+
+print("wamrc_artifact fixtures: %d passed, %d failed" % (_pass, _fail))
+sys.exit(1 if _fail else 0)

--- a/scripts/ci/test_wamrc_artifact.py
+++ b/scripts/ci/test_wamrc_artifact.py
@@ -94,5 +94,49 @@ _partial = dict(GOOD)
 del _partial["llvm_version"]
 check("local missing a field rejected", len(wa.verify(m, _partial)) >= 1)
 
+# -- hardening: build_manifest rejects hollow / unavailable / empty fields --
+for field, bad in [("cc_path", "unknown"), ("cxx_path", "MISSING"),
+                   ("cc_version", "unknown"), ("llvm_version", "MISSING"),
+                   ("patch_hash", "MISSING"), ("build_script_hash", "MISSING"),
+                   ("wamr_rev", "unknown"), ("artifact_sha256", "MISSING"),
+                   ("wamrc_flags", ""), ("runner_image", "unknown")]:
+    try:
+        wa.build_manifest(local(**{field: bad}))
+        check("build_manifest rejects hollow %s=%r" % (field, bad), False)
+    except ValueError:
+        check("build_manifest rejects hollow %s=%r" % (field, bad), True)
+# None-valued field -> rejected
+try:
+    wa.build_manifest(local(llvm_version=None))
+    check("build_manifest rejects None field", False)
+except ValueError:
+    check("build_manifest rejects None field", True)
+
+# -- hardening: verify rejects a HOLLOW LOCAL field (a cold consumer that
+#    verified WITHOUT first configuring the wamrc toolchain -> cc_path unknown) --
+check("verify rejects local cc_path=unknown (cold, no configure)",
+      any("cc_path" in p for p in wa.verify(m, local(cc_path="unknown"))))
+check("verify rejects local llvm_version=MISSING",
+      len(wa.verify(m, local(llvm_version="MISSING"))) >= 1)
+check("verify rejects local wamrc_flags='' (empty)",
+      len(wa.verify(m, local(wamrc_flags=""))) >= 1)
+
+# -- cold-verify seam: cmake_compiler_paths reads a CONFIGURE-ONLY cache (no
+#    compiled wamrc), proving a consumer can reproduce the producer's compiler
+#    identity without building wamrc first (the reliance-flip precondition) --
+import tempfile  # noqa: E402
+with tempfile.TemporaryDirectory() as d:
+    cache = os.path.join(d, "CMakeCache.txt")
+    with open(cache, "w") as f:
+        f.write("//comment\nCMAKE_C_COMPILER:FILEPATH=/usr/bin/cc\n"
+                "CMAKE_CXX_COMPILER:FILEPATH=/usr/bin/c++\nOTHER:STRING=x\n")
+    cc, cxx = wa.cmake_compiler_paths(cache)
+    check("cold cache: cc_path read from configure-only cache", cc == "/usr/bin/cc")
+    check("cold cache: cxx_path read from configure-only cache", cxx == "/usr/bin/c++")
+    check("cold cache: NO wamrc binary needed to read identity",
+          not os.path.exists(os.path.join(d, "wamrc")))
+check("absent cache -> MISSING paths (fail closed)",
+      wa.cmake_compiler_paths("/no/such/CMakeCache.txt") == ("MISSING", "MISSING"))
+
 print("wamrc_artifact fixtures: %d passed, %d failed" % (_pass, _fail))
 sys.exit(1 if _fail else 0)

--- a/scripts/ci/wamrc_artifact.py
+++ b/scripts/ci/wamrc_artifact.py
@@ -44,13 +44,32 @@ CHECKSUM_FIELD = "artifact_sha256"
 
 ALL_FIELDS = IDENTITY_FIELDS + PROVENANCE_FIELDS + [CHECKSUM_FIELD]
 
+# Sentinels a probe emits when a value could not be determined. In this CI profile
+# EVERY field must be concrete: a manifest carrying any of these (or an empty
+# string, e.g. an empty WAMRC_CMAKE_FLAGS, or an absent Makefile-rule / script /
+# patch input) is REJECTED at creation rather than shipped with a hollow identity.
+INVALID_VALUES = frozenset({"", "unknown", "MISSING", "none", "None"})
+
+
+def _invalid_fields(fields):
+    """Return the fields whose value is absent/unavailable/hollow."""
+    bad = []
+    for k in ALL_FIELDS:
+        v = fields.get(k, None)
+        if v is None or str(v).strip() in INVALID_VALUES:
+            bad.append(k)
+    return bad
+
 
 def build_manifest(fields):
     """Wrap gathered fields into a schema-versioned manifest. Raises if any
-    required field is absent (a producer that cannot describe itself must fail)."""
-    missing = [k for k in ALL_FIELDS if k not in fields]
-    if missing:
-        raise ValueError("manifest missing required fields: %s" % ", ".join(missing))
+    required field is absent OR unavailable/hollow (a producer that cannot fully
+    describe its toolchain identity must FAIL, not ship a manifest with `unknown`
+    / `MISSING` / empty fields that a consumer could never reproduce)."""
+    bad = _invalid_fields(fields)
+    if bad:
+        raise ValueError("cannot build manifest; unavailable/invalid fields: %s"
+                         % ", ".join("%s=%r" % (k, fields.get(k)) for k in bad))
     m = {"schema_version": SCHEMA_VERSION}
     for k in ALL_FIELDS:
         m[k] = str(fields[k])
@@ -75,19 +94,39 @@ def verify(manifest, local):
             problems.append("manifest missing field %s" % k)
         if k not in local:
             problems.append("local missing field %s" % k)
+    # The consumer's OWN identity must be fully determined; a hollow local field
+    # (e.g. `cc_path=unknown` because a cold consumer verified WITHOUT first
+    # configuring the wamrc toolchain) is a verification failure, not a silent
+    # mismatch.
+    for k in _invalid_fields(local):
+        problems.append("local field %s is unavailable/invalid: %r" % (k, local.get(k)))
     for k in ALL_FIELDS:
         if k in manifest and k in local and str(manifest[k]) != str(local[k]):
             problems.append("%s mismatch: manifest=%r local=%r" % (k, manifest[k], local[k]))
     return problems
 
 
-# -- environment probing (impure; not unit-tested, kept thin) -----------------
+# -- environment probing (impure; kept thin) ---------------------------------
 
 def _run(cmd):
+    """Run a command; return its stripped stdout on SUCCESS (exit 0), or None on a
+    nonzero exit or spawn failure. A nonzero command is a REJECTED probe (its field
+    becomes unavailable and the manifest fails), NOT an accepted empty string."""
     try:
-        return subprocess.run(cmd, capture_output=True, text=True).stdout.strip()
+        r = subprocess.run(cmd, capture_output=True, text=True)
     except Exception:
-        return ""
+        return None
+    if r.returncode != 0:
+        return None
+    return r.stdout.strip()
+
+
+def _first_line(cmd):
+    out = _run(cmd)
+    if not out:
+        return None
+    lines = out.splitlines()
+    return lines[0] if lines else None
 
 
 def _sha256_file(path):
@@ -98,59 +137,82 @@ def _sha256_file(path):
     return h.hexdigest()
 
 
+def cmake_compiler_paths(cache_path):
+    """Read (cc_path, cxx_path) from a CMakeCache.txt. This is the COLD-verify seam:
+    it works off a configure-only cache (no compiled wamrc), so a consumer can
+    reproduce the producer's compiler identity without building wamrc. Returns
+    ('MISSING', 'MISSING') if the cache is absent, and leaves a compiler 'MISSING'
+    if its line is not present. Pure file parse (fixture-tested)."""
+    cc = cxx = "MISSING"
+    if not os.path.exists(cache_path):
+        return cc, cxx
+    for ln in open(cache_path, encoding="utf-8", errors="replace"):
+        if ln.startswith("CMAKE_C_COMPILER:"):
+            cc = ln.split("=", 1)[1].strip() or "MISSING"
+        elif ln.startswith("CMAKE_CXX_COMPILER:"):
+            cxx = ln.split("=", 1)[1].strip() or "MISSING"
+    return cc, cxx
+
+
 def gather_local(wamrc_path, producer_job, root):
     """Probe the current environment for every identity + provenance field, and
-    compute the sha256 of `wamrc_path` (the local or downloaded wamrc)."""
+    compute the sha256 of `wamrc_path`. Every probe that cannot determine a value
+    yields a `MISSING`/`unknown` sentinel so build_manifest / verify fail closed
+    (an absent patch set, an unmatched Makefile rule, a missing script, an empty
+    WAMRC_CMAKE_FLAGS, or a compiler the CMakeCache did not record)."""
     env = os.environ
     runner_image = "%s-%s" % (env.get("ImageOS", "unknown"), env.get("ImageVersion", "unknown"))
-    llvm_version = _run(["llvm-config-18", "--version"]) or "unknown"
-    wamr_rev = _run(["git", "-C", os.path.join(root, "vendor", "wamr"), "rev-parse", "HEAD"]) or "unknown"
 
     ph = hashlib.sha256()
-    for p in sorted(glob.glob(os.path.join(root, "patches", "wamr", "*.patch"))):
-        with open(p, "rb") as f:
-            ph.update(f.read())
-    patch_hash = ph.hexdigest()
+    patches = sorted(glob.glob(os.path.join(root, "patches", "wamr", "*.patch")))
+    if patches:
+        for p in patches:
+            with open(p, "rb") as f:
+                ph.update(f.read())
+        patch_hash = ph.hexdigest()
+    else:
+        patch_hash = "MISSING"        # no expected patch inputs -> reject
 
+    # build-script hash: the wamrc-configure + wamrc make-rule region AND
+    # ci_ensure_wamrc.sh. A missing rule match or missing script -> MISSING.
     bh = hashlib.sha256()
+    rule_ok = script_ok = False
     try:
         mk = open(os.path.join(root, "Makefile"), encoding="utf-8").read()
-        m = re.search(r"(?ms)^wamrc:.*?wamrc built.*?$", mk)
-        bh.update((m.group(0) if m else "").encode("utf-8"))
+        m = re.search(r"(?ms)^wamrc-configure:.*?wamrc built.*?$", mk)
+        if m:
+            bh.update(m.group(0).encode("utf-8"))
+            rule_ok = True
     except Exception:
         pass
     try:
         with open(os.path.join(root, "tests", "ci_ensure_wamrc.sh"), "rb") as f:
             bh.update(f.read())
+        script_ok = True
     except Exception:
         pass
-    build_script_hash = bh.hexdigest()
+    build_script_hash = bh.hexdigest() if (rule_ok and script_ok) else "MISSING"
 
-    cc_path = cxx_path = "unknown"
     cache = os.path.join(root, "build", "wamrc-build", "CMakeCache.txt")
-    if os.path.exists(cache):
-        for ln in open(cache, encoding="utf-8", errors="replace"):
-            if ln.startswith("CMAKE_C_COMPILER:"):
-                cc_path = ln.split("=", 1)[1].strip()
-            elif ln.startswith("CMAKE_CXX_COMPILER:"):
-                cxx_path = ln.split("=", 1)[1].strip()
-    cc_version = (_run([cc_path, "--version"]).splitlines() or ["unknown"])[0] if cc_path != "unknown" else "unknown"
-    cxx_version = (_run([cxx_path, "--version"]).splitlines() or ["unknown"])[0] if cxx_path != "unknown" else "unknown"
-
-    artifact_sha256 = _sha256_file(wamrc_path) if os.path.exists(wamrc_path) else "MISSING"
+    cc_path, cxx_path = cmake_compiler_paths(cache)
+    cc_version = _first_line([cc_path, "--version"]) if cc_path not in INVALID_VALUES else None
+    cxx_version = _first_line([cxx_path, "--version"]) if cxx_path not in INVALID_VALUES else None
 
     return {
-        "runner_image": runner_image, "arch": _run(["uname", "-m"]) or "unknown",
-        "cc_path": cc_path, "cc_version": cc_version,
-        "cxx_path": cxx_path, "cxx_version": cxx_version,
-        "llvm_version": llvm_version, "wamr_rev": wamr_rev, "patch_hash": patch_hash,
-        "wamrc_flags": env.get("WAMRC_CMAKE_FLAGS", ""),
+        "runner_image": runner_image,
+        "arch": _run(["uname", "-m"]) or "unknown",
+        "cc_path": cc_path, "cc_version": cc_version or "unknown",
+        "cxx_path": cxx_path, "cxx_version": cxx_version or "unknown",
+        "llvm_version": _run(["llvm-config-18", "--version"]) or "unknown",
+        "wamr_rev": _run(["git", "-C", os.path.join(root, "vendor", "wamr"), "rev-parse", "HEAD"]) or "unknown",
+        "patch_hash": patch_hash,
+        "wamrc_flags": env.get("WAMRC_CMAKE_FLAGS", ""),   # empty -> invalid (rejected)
         "build_script_hash": build_script_hash,
         "commit_sha": env.get("GITHUB_SHA", "unknown"),
         "run_id": env.get("GITHUB_RUN_ID", "unknown"),
         "run_attempt": env.get("GITHUB_RUN_ATTEMPT", "unknown"),
         "producer_job": producer_job,
-        "artifact_sha256": artifact_sha256,
+        "artifact_sha256": _sha256_file(wamrc_path) if os.path.exists(wamrc_path) else "MISSING",
     }
 
 

--- a/scripts/ci/wamrc_artifact.py
+++ b/scripts/ci/wamrc_artifact.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# wamrc_artifact.py - the wamrc producer/consumer artifact identity + provenance
+# core for Slice 5A (docs/ci_architecture_design.md Appendix D).
+#
+# The PRODUCER builds `wamrc` once and emits a metadata manifest (identity +
+# same-run provenance + sha256). Each CONSUMER downloads the run-scoped artifact,
+# recomputes its OWN identity/provenance, and verifies it against the manifest.
+# ANY mismatch is a hard failure (the consumer exits non-zero and FAILS its job -
+# it does NOT silently rebuild from source; that would mask broken producer/upload
+# wiring - Appendix D.1.3, amendment 1).
+#
+# Pure functions (build_manifest / verify) are fixture-tested in
+# test_wamrc_artifact.py; gather_local() does the environment probing.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import argparse
+import glob
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+
+SCHEMA_VERSION = 1
+
+# The reuse-identity inputs (a change to any -> a different key -> no reuse).
+IDENTITY_FIELDS = [
+    "runner_image",        # ImageOS-ImageVersion (not just "ubuntu-24.04")
+    "arch",                # uname -m
+    "cc_path", "cc_version",     # the actual CMake C compiler path + version
+    "cxx_path", "cxx_version",   # the actual CMake C++ compiler path + version
+    "llvm_version",        # llvm-config-18 --version
+    "wamr_rev",            # vendor/wamr submodule HEAD
+    "patch_hash",          # sha256 of patches/wamr/*.patch
+    "wamrc_flags",         # WAMRC_CMAKE_FLAGS
+    "build_script_hash",   # sha256 of the wamrc make rule region + ci_ensure_wamrc.sh
+]
+# Same-run provenance (proves the artifact belongs to THIS run).
+PROVENANCE_FIELDS = ["commit_sha", "run_id", "run_attempt", "producer_job"]
+# The artifact digest (checksum integrity).
+CHECKSUM_FIELD = "artifact_sha256"
+
+ALL_FIELDS = IDENTITY_FIELDS + PROVENANCE_FIELDS + [CHECKSUM_FIELD]
+
+
+def build_manifest(fields):
+    """Wrap gathered fields into a schema-versioned manifest. Raises if any
+    required field is absent (a producer that cannot describe itself must fail)."""
+    missing = [k for k in ALL_FIELDS if k not in fields]
+    if missing:
+        raise ValueError("manifest missing required fields: %s" % ", ".join(missing))
+    m = {"schema_version": SCHEMA_VERSION}
+    for k in ALL_FIELDS:
+        m[k] = str(fields[k])
+    return m
+
+
+def verify(manifest, local):
+    """Return a list of problems (empty => the artifact is trusted). `manifest` is
+    the producer's recorded metadata; `local` is the consumer's freshly-recomputed
+    identity/provenance (including the sha256 of the DOWNLOADED wamrc). An unknown
+    schema, a missing field, or ANY field mismatch is a problem -> the caller fails
+    the job. Fail closed: a non-dict manifest, or a schema it does not understand,
+    is rejected outright."""
+    if not isinstance(manifest, dict):
+        return ["manifest is not a JSON object"]
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        return ["unknown manifest schema_version %r (expected %d)"
+                % (manifest.get("schema_version"), SCHEMA_VERSION)]
+    problems = []
+    for k in ALL_FIELDS:
+        if k not in manifest:
+            problems.append("manifest missing field %s" % k)
+        if k not in local:
+            problems.append("local missing field %s" % k)
+    for k in ALL_FIELDS:
+        if k in manifest and k in local and str(manifest[k]) != str(local[k]):
+            problems.append("%s mismatch: manifest=%r local=%r" % (k, manifest[k], local[k]))
+    return problems
+
+
+# -- environment probing (impure; not unit-tested, kept thin) -----------------
+
+def _run(cmd):
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True).stdout.strip()
+    except Exception:
+        return ""
+
+
+def _sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def gather_local(wamrc_path, producer_job, root):
+    """Probe the current environment for every identity + provenance field, and
+    compute the sha256 of `wamrc_path` (the local or downloaded wamrc)."""
+    env = os.environ
+    runner_image = "%s-%s" % (env.get("ImageOS", "unknown"), env.get("ImageVersion", "unknown"))
+    llvm_version = _run(["llvm-config-18", "--version"]) or "unknown"
+    wamr_rev = _run(["git", "-C", os.path.join(root, "vendor", "wamr"), "rev-parse", "HEAD"]) or "unknown"
+
+    ph = hashlib.sha256()
+    for p in sorted(glob.glob(os.path.join(root, "patches", "wamr", "*.patch"))):
+        with open(p, "rb") as f:
+            ph.update(f.read())
+    patch_hash = ph.hexdigest()
+
+    bh = hashlib.sha256()
+    try:
+        mk = open(os.path.join(root, "Makefile"), encoding="utf-8").read()
+        m = re.search(r"(?ms)^wamrc:.*?wamrc built.*?$", mk)
+        bh.update((m.group(0) if m else "").encode("utf-8"))
+    except Exception:
+        pass
+    try:
+        with open(os.path.join(root, "tests", "ci_ensure_wamrc.sh"), "rb") as f:
+            bh.update(f.read())
+    except Exception:
+        pass
+    build_script_hash = bh.hexdigest()
+
+    cc_path = cxx_path = "unknown"
+    cache = os.path.join(root, "build", "wamrc-build", "CMakeCache.txt")
+    if os.path.exists(cache):
+        for ln in open(cache, encoding="utf-8", errors="replace"):
+            if ln.startswith("CMAKE_C_COMPILER:"):
+                cc_path = ln.split("=", 1)[1].strip()
+            elif ln.startswith("CMAKE_CXX_COMPILER:"):
+                cxx_path = ln.split("=", 1)[1].strip()
+    cc_version = (_run([cc_path, "--version"]).splitlines() or ["unknown"])[0] if cc_path != "unknown" else "unknown"
+    cxx_version = (_run([cxx_path, "--version"]).splitlines() or ["unknown"])[0] if cxx_path != "unknown" else "unknown"
+
+    artifact_sha256 = _sha256_file(wamrc_path) if os.path.exists(wamrc_path) else "MISSING"
+
+    return {
+        "runner_image": runner_image, "arch": _run(["uname", "-m"]) or "unknown",
+        "cc_path": cc_path, "cc_version": cc_version,
+        "cxx_path": cxx_path, "cxx_version": cxx_version,
+        "llvm_version": llvm_version, "wamr_rev": wamr_rev, "patch_hash": patch_hash,
+        "wamrc_flags": env.get("WAMRC_CMAKE_FLAGS", ""),
+        "build_script_hash": build_script_hash,
+        "commit_sha": env.get("GITHUB_SHA", "unknown"),
+        "run_id": env.get("GITHUB_RUN_ID", "unknown"),
+        "run_attempt": env.get("GITHUB_RUN_ATTEMPT", "unknown"),
+        "producer_job": producer_job,
+        "artifact_sha256": artifact_sha256,
+    }
+
+
+def _root():
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(description="wamrc artifact manifest / verify (Slice 5A).")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    mp = sub.add_parser("manifest", help="emit the producer manifest JSON to stdout.")
+    mp.add_argument("--wamrc", required=True)
+    mp.add_argument("--producer", required=True)
+    vp = sub.add_parser("verify", help="verify a downloaded artifact against this run.")
+    vp.add_argument("--manifest", required=True)
+    vp.add_argument("--wamrc", required=True)
+    vp.add_argument("--producer", required=True)
+    args = ap.parse_args(argv)
+    root = _root()
+
+    if args.cmd == "manifest":
+        local = gather_local(args.wamrc, args.producer, root)
+        print(json.dumps(build_manifest(local), sort_keys=True, indent=2))
+        return 0
+
+    # verify
+    try:
+        with open(args.manifest, "r", encoding="utf-8") as f:
+            manifest = json.load(f)
+    except Exception as e:
+        print("wamrc-verify: cannot read manifest (%s) -> FAIL" % e)
+        return 1
+    local = gather_local(args.wamrc, args.producer, root)
+    problems = verify(manifest, local)
+    if problems:
+        for p in problems:
+            print("  FAIL:", p)
+        print("wamrc-verify: artifact REJECTED (%d problem(s)); NOT rebuilding - failing the job."
+              % len(problems))
+        return 1
+    print("wamrc-verify: artifact identity + provenance + checksum verified.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
**The additive 5A checkpoint (Appendix D).** Adds a wamrc **producer** and a representative **verify/equivalence consumer**, proving the producer → immutable run-scoped artifact → consumer machinery — **without** the 8 existing AOT consumers relying on it yet (they still build their own wamrc, unchanged). No wall-clock or coverage regression; the cost win lands at the *next* checkpoint when consumers flip to the artifact. Branch-protection / nightly / release-cache-trust untouched.

### Producer `wamrc-x86_64` (compute group, `run_compute`)
Builds wamrc once; emits an **identity + provenance manifest** (`scripts/ci/wamrc_artifact.py`): schema_version · runner image+version · actual CMake C/C++ compiler paths+versions · LLVM version · WAMR submodule rev · patch hash · WAMRC flags · build-script hash · commit SHA · run id+attempt · producer identity · artifact sha256. Uploads an **immutable run-scoped** artifact.

### Consumer `wamrc-artifact-verify` (compute group)
Downloads the artifact → verifies identity+provenance+checksum+arch (**FAILS the job on any mismatch — never rebuilds**, amendment 1) → `ldd` + usability probe → **byte-compares** artifact-wamrc `.aot` vs a **fresh-built** wamrc `.aot` on a wasm32 (`echo`) + Memory64 (`echo64`) fixture → asserts a **corrupted artifact is rejected**.

### Wiring + fixtures (all green)
- Both jobs compute-grouped (`run_compute`) + in `ci-success.needs`; both guards pass (**52 jobs**).
- `wamrc_artifact` core **26** — matching verifies; every identity/provenance/checksum/arch/schema/missing-field defect rejected.
- `ci_gate` **+9** — producer-failure → consumer skipped → **DISALLOWED → gate FAIL**; consumer verify failure → **FAIL**; happy path → pass; legit skip on a non-compute plan → pass.
- `job_plan` **+10** — both jobs run on compute/broad, skip on db-only/docs.
- Self-tests: classify 433 · gate 28 · job_plan 113 · wamrc_artifact 26 · both guards.

### Live proof in this PR
Touches `scripts/ci/**` + `.github/**` → **broad** → the full compute group runs, including the new producer + verify jobs: producer builds+uploads, verify downloads+verifies, byte-equivalence + corruption-rejection green, gate green. **Stops for review.**

(Producer-failure / missing-artifact / verification-failure → red gate are proven by the `ci_gate` fixtures — they can't be forced live without breaking the run.)