### PR TITLE
CI Slice 5A reliance flip: 8 x86_64 AOT consumers use the verified wamrc artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,7 +566,7 @@ jobs:
   # builds + runs the C-API test with a real wamrc-emitted .aot fixture and FAILS
   # if the AOT sub-case is SKIPPED. That closes the "AOT is dormant in CI" gap.
   wasm-readonly-heap-aot:
-    needs: [classify]
+    needs: [classify, wamrc-x86_64]
     if: needs.classify.outputs.run_compute == 'true'
     name: WAMR AOT C-API tests (readonly + guarded, x86_64)
     runs-on: ubuntu-24.04
@@ -580,14 +580,20 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y llvm-18-dev cmake
 
-      - name: Build wamrc (applies the WAMR read-only patch carriage)
+      - name: Download verified wamrc artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: wamrc-x86_64
+          path: artifact
+
+      - name: Consume verified wamrc artifact (cold-verify, no build)
         timeout-minutes: 12
         run: |
           if command -v llvm-config-18 >/dev/null 2>&1; then
             llvm_cmakedir=$(llvm-config-18 --cmakedir)
             export WAMRC_CMAKE_FLAGS="-DLLVM_DIR=${llvm_cmakedir}"
           fi
-          make wamrc
+          sh tests/ci_wamrc_consume.sh
 
       - name: Build + run the AOT C-API case (must NOT skip)
         timeout-minutes: 12
@@ -737,7 +743,7 @@ jobs:
   # baselines stabilize (docs/mapped_span_benchmark_design.md D11). A 1 GiB
   # controlled run is the separate manually-triggered bench_mapped_span_1g.yml.
   mapped-span-bench:
-    needs: [classify]
+    needs: [classify, wamrc-x86_64]
     if: needs.classify.outputs.run_compute == 'true'
     name: Mapped-span benchmark (96 MiB, x86_64)
     runs-on: ubuntu-24.04
@@ -753,13 +759,19 @@ jobs:
           # wabt provides wasm-objdump for the G4 static bytecode gate.
           sudo apt-get install -y llvm-18-dev cmake wabt clang lld
 
-      - name: Build wamrc
+      - name: Download verified wamrc artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: wamrc-x86_64
+          path: artifact
+
+      - name: Consume verified wamrc artifact (cold-verify, no build)
         timeout-minutes: 12
         run: |
           if command -v llvm-config-18 >/dev/null 2>&1; then
             export WAMRC_CMAKE_FLAGS="-DLLVM_DIR=$(llvm-config-18 --cmakedir)"
           fi
-          make wamrc
+          sh tests/ci_wamrc_consume.sh
 
       - name: Run mapped-span benchmark (must NOT skip AOT)
         timeout-minutes: 30
@@ -786,7 +798,7 @@ jobs:
   # Drives the REAL production `hull build` path (embedded hull + wamrc), so the
   # AOT is exercised non-skippably.
   compute-aot-shared-heap:
-    needs: [classify]
+    needs: [classify, wamrc-x86_64]
     if: needs.classify.outputs.run_compute == 'true'
     name: Compute AOT shared-heap reads (spans + segments)
     runs-on: ubuntu-24.04
@@ -800,14 +812,20 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y llvm-18-dev cmake
 
-      - name: Build embedded hull (platform lib) + wamrc
+      - name: Download verified wamrc artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: wamrc-x86_64
+          path: artifact
+
+      - name: Build embedded hull (platform lib) + consume verified wamrc
         timeout-minutes: 15
         run: |
           make platform
           if command -v llvm-config-18 >/dev/null 2>&1; then
             export WAMRC_CMAKE_FLAGS="-DLLVM_DIR=$(llvm-config-18 --cmakedir)"
           fi
-          make wamrc
+          sh tests/ci_wamrc_consume.sh
           # Embed LAST: a later bare `make` would clobber the embedding
           # (EMBED_PLATFORM is not in the config sentinel), and the e2e needs it.
           make EMBED_PLATFORM=1
@@ -857,7 +875,7 @@ jobs:
   # Drives the real driver (needs a wasm clang + wasm-ld), so this job installs
   # clang + lld; the AOT leg needs an embedded hull + wamrc.
   compute-memops-freestanding:
-    needs: [classify]
+    needs: [classify, wamrc-x86_64]
     if: needs.classify.outputs.run_compute == 'true'
     name: Freestanding libc (memcpy/memset/memmove) — interp + AOT
     runs-on: ubuntu-24.04
@@ -874,14 +892,20 @@ jobs:
           # are for building wamrc.
           sudo apt-get install -y clang lld wabt llvm-18-dev cmake
 
-      - name: Build embedded hull (platform lib) + wamrc
+      - name: Download verified wamrc artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: wamrc-x86_64
+          path: artifact
+
+      - name: Build embedded hull (platform lib) + consume verified wamrc
         timeout-minutes: 15
         run: |
           make platform
           if command -v llvm-config-18 >/dev/null 2>&1; then
             export WAMRC_CMAKE_FLAGS="-DLLVM_DIR=$(llvm-config-18 --cmakedir)"
           fi
-          make wamrc
+          sh tests/ci_wamrc_consume.sh
           # Embed LAST: a later bare `make` would clobber the embedding
           # (EMBED_PLATFORM is not in the config sentinel), and the e2e needs it.
           make EMBED_PLATFORM=1
@@ -907,7 +931,7 @@ jobs:
   # (#331): hull_stream_is_first/is_last/chunk_index over a real 3-chunk
   # compute.stream, Lua + JS, interpreter + AOT. Needs clang + wamrc + embedded hull.
   stream-meta:
-    needs: [classify]
+    needs: [classify, wamrc-x86_64]
     if: needs.classify.outputs.run_compute == 'true'
     name: compute stream metadata helpers — Lua + JS, interp + AOT
     runs-on: ubuntu-24.04
@@ -921,14 +945,20 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang lld llvm-18-dev cmake
 
-      - name: Build embedded hull (platform lib) + wamrc
+      - name: Download verified wamrc artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: wamrc-x86_64
+          path: artifact
+
+      - name: Build embedded hull (platform lib) + consume verified wamrc
         timeout-minutes: 15
         run: |
           make platform
           if command -v llvm-config-18 >/dev/null 2>&1; then
             export WAMRC_CMAKE_FLAGS="-DLLVM_DIR=$(llvm-config-18 --cmakedir)"
           fi
-          make wamrc
+          sh tests/ci_wamrc_consume.sh
           make EMBED_PLATFORM=1
 
       - name: Stream-metadata E2E (Lua + JS, interp + AOT, must NOT skip)
@@ -952,7 +982,7 @@ jobs:
   # `hull build` path (--enable-shared-heap). Needs a wasm clang + wamrc + an
   # embedded hull; runs non-skippably here.
   spans-example:
-    needs: [classify]
+    needs: [classify, wamrc-x86_64]
     if: needs.classify.outputs.run_compute == 'true'
     name: mapped_spans example — Lua + JS, interp + AOT (public SDK)
     runs-on: ubuntu-24.04
@@ -966,14 +996,20 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang lld llvm-18-dev cmake
 
-      - name: Build embedded hull (platform lib) + wamrc
+      - name: Download verified wamrc artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: wamrc-x86_64
+          path: artifact
+
+      - name: Build embedded hull (platform lib) + consume verified wamrc
         timeout-minutes: 15
         run: |
           make platform
           if command -v llvm-config-18 >/dev/null 2>&1; then
             export WAMRC_CMAKE_FLAGS="-DLLVM_DIR=$(llvm-config-18 --cmakedir)"
           fi
-          make wamrc
+          sh tests/ci_wamrc_consume.sh
           # Embed LAST: a later bare `make` would clobber the embedding
           # (EMBED_PLATFORM is not in the config sentinel), and the e2e needs it.
           make EMBED_PLATFORM=1
@@ -999,7 +1035,7 @@ jobs:
   # lookup (+ unknown -1), Lua AND JS, interpreter AND AOT via the production
   # `hull build` path. Needs a wasm clang + wamrc + an embedded hull; non-skippable.
   spans-multi:
-    needs: [classify]
+    needs: [classify, wamrc-x86_64]
     if: needs.classify.outputs.run_compute == 'true'
     name: mapped spans — multiple named spans, Lua + JS, interp + AOT
     runs-on: ubuntu-24.04
@@ -1013,14 +1049,20 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang lld llvm-18-dev cmake
 
-      - name: Build embedded hull (platform lib) + wamrc
+      - name: Download verified wamrc artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: wamrc-x86_64
+          path: artifact
+
+      - name: Build embedded hull (platform lib) + consume verified wamrc
         timeout-minutes: 15
         run: |
           make platform
           if command -v llvm-config-18 >/dev/null 2>&1; then
             export WAMRC_CMAKE_FLAGS="-DLLVM_DIR=$(llvm-config-18 --cmakedir)"
           fi
-          make wamrc
+          sh tests/ci_wamrc_consume.sh
           # Embed LAST: a later bare `make` would clobber the embedding
           # (EMBED_PLATFORM is not in the config sentinel), and the e2e needs it.
           make EMBED_PLATFORM=1
@@ -1045,7 +1087,7 @@ jobs:
   # (first/exact-end/one-past/straddle), Lua + JS, interpreter + AOT (3b
   # completion). Uses a SPARSE 5 GiB file (no real disk) so it runs anywhere.
   spans-hugefile:
-    needs: [classify]
+    needs: [classify, wamrc-x86_64]
     if: needs.classify.outputs.run_compute == 'true'
     name: mapped spans — >4GiB foffset + setup capacity, Lua + JS, interp + AOT
     runs-on: ubuntu-24.04
@@ -1059,14 +1101,20 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang lld llvm-18-dev cmake
 
-      - name: Build embedded hull (platform lib) + wamrc
+      - name: Download verified wamrc artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: wamrc-x86_64
+          path: artifact
+
+      - name: Build embedded hull (platform lib) + consume verified wamrc
         timeout-minutes: 15
         run: |
           make platform
           if command -v llvm-config-18 >/dev/null 2>&1; then
             export WAMRC_CMAKE_FLAGS="-DLLVM_DIR=$(llvm-config-18 --cmakedir)"
           fi
-          make wamrc
+          sh tests/ci_wamrc_consume.sh
           make EMBED_PLATFORM=1
 
       - name: Huge-file / setup-capacity E2E (Lua + JS, interp + AOT, must NOT skip)

--- a/tests/ci_wamrc_consume.sh
+++ b/tests/ci_wamrc_consume.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# ci_wamrc_consume.sh - the SINGLE shared reliance-flip consumer helper (Slice 5A).
+#
+# Every x86_64 AOT consumer calls this INSTEAD of building wamrc from source. It
+# performs an INDEPENDENT COLD verification of the run-scoped wamrc artifact and
+# installs the verified binary where the UNCHANGED downstream AOT commands (and
+# tests/ci_ensure_wamrc.sh) expect it - so no consumer rebuilds wamrc:
+#
+#   1. require the downloaded artifact (wamrc + manifest) - a missing artifact is
+#      a HARD failure, never a rebuild;
+#   2. configure the wamrc toolchain (cmake configure ONLY, NO compile) to
+#      establish this consumer's OWN compiler identity for cold verification;
+#   3. cold-verify identity / provenance / checksum / arch against the manifest -
+#      any mismatch FAILS the job (scripts/ci/wamrc_artifact.py verify; it never
+#      rebuilds);
+#   4. install the VERIFIED wamrc at build/wamrc AND build/wamrc-build/wamrc so the
+#      downstream `make build/gen_* ...` + ci_ensure_wamrc.sh find an executable
+#      wamrc (the "already present -> do nothing" path) and can never fall through
+#      to a from-source build.
+#
+# There is NO fallback rebuild here by design: a bad/absent artifact must redden
+# the consumer job (and, via the gate, the whole run), not silently disappear the
+# optimization. Local from-source builds still use `make wamrc` directly; the
+# arm64 AOT job stays self-building (single consumer, nothing to share).
+#
+# Usage: sh tests/ci_wamrc_consume.sh [artifact_dir]   (default: artifact)
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+ARTIFACT_DIR="${1:-artifact}"
+PRODUCER="wamrc-x86_64"
+
+if [ ! -f "$ARTIFACT_DIR/wamrc" ]; then
+    echo "::error::wamrc artifact missing ($ARTIFACT_DIR/wamrc) - NOT rebuilding, failing"; exit 1
+fi
+if [ ! -f "$ARTIFACT_DIR/wamrc.manifest.json" ]; then
+    echo "::error::wamrc manifest missing ($ARTIFACT_DIR/wamrc.manifest.json) - NOT rebuilding, failing"; exit 1
+fi
+chmod +x "$ARTIFACT_DIR/wamrc"
+
+if command -v llvm-config-18 >/dev/null 2>&1; then
+    WAMRC_CMAKE_FLAGS="-DLLVM_DIR=$(llvm-config-18 --cmakedir)"
+    export WAMRC_CMAKE_FLAGS
+fi
+
+# Configure ONLY (generate CMakeCache.txt with the resolved compilers) - this
+# establishes the local identity WITHOUT compiling wamrc, so verification is cold.
+make wamrc-configure
+if [ -x build/wamrc ]; then
+    echo "::error::wamrc was built during configure - the consumer must verify COLD"; exit 1
+fi
+
+# Independent cold verification; fails the job on any identity/checksum/arch/
+# provenance mismatch. NO rebuild.
+python3 scripts/ci/wamrc_artifact.py verify \
+    --manifest "$ARTIFACT_DIR/wamrc.manifest.json" \
+    --wamrc "$ARTIFACT_DIR/wamrc" \
+    --producer "$PRODUCER"
+
+# Install the VERIFIED wamrc where downstream expects it. Populate BOTH slots so
+# ci_ensure_wamrc.sh's re-copy path (if the mutable build/wamrc ever vanishes
+# mid-job) restores the VERIFIED binary and never builds from scratch.
+mkdir -p build build/wamrc-build
+cp "$ARTIFACT_DIR/wamrc" build/wamrc
+cp "$ARTIFACT_DIR/wamrc" build/wamrc-build/wamrc
+chmod +x build/wamrc build/wamrc-build/wamrc
+echo "verified wamrc installed at build/wamrc (from artifact; no from-source build)"


### PR DESCRIPTION
**The separate reliance-flip checkpoint** (after the additive proof #383). The eight x86_64 AOT consumers stop building wamrc from source and instead **download + independently cold-verify** the run-scoped artifact via one shared helper — where the actual runner-minute saving lands. Branch-protection / nightly / cross-run-cache / release-trust untouched; 5B not started.

### Locked constraints — all honored
- **One shared helper** `tests/ci_wamrc_consume.sh`: require artifact → **configure-only** (cold identity, no compile) → **cold-verify** identity/provenance/checksum/arch (`wamrc_artifact.py`, **fail hard, no fallback rebuild**) → install verified wamrc at `build/wamrc` + `build/wamrc-build/wamrc` so the **unchanged** downstream AOT commands + `ci_ensure_wamrc.sh` find it and never rebuild.
- **Independent cold verification in every consumer** (each runs the helper — 8 independent verifications, plus the canary's).
- **No fallback rebuild** — a missing/bad artifact fails the job (never `make wamrc`).
- **Unchanged downstream AOT test commands + assertions** — only the wamrc-provisioning step changed.
- **arm64 (`wasm-guarded-aot-arm64`) stays self-building.**
- **Equivalence canary retained** — `wamrc-artifact-verify` still builds fresh + byte-compares every run.
- **Producer/consumer failures stay gate-fatal** — all compute-grouped + in `ci-success.needs`, so producer-failure → consumers skipped → disallowed skip → red; verify-failure → red.

### Each consumer
`needs += wamrc-x86_64`; a download-artifact step; `make wamrc` → `sh tests/ci_wamrc_consume.sh`. Producer + canary + arm64 still build from source (verified untouched).

### Proof
- Self-tests green: classify 433 · gate 28 · job_plan 113 · wamrc_artifact 44 · both guards. 52 jobs.
- **Live (this PR, broad):** all 8 consumers download + cold-verify + run their AOT tests green **without a from-source build**; canary green; arm64 self-builds green; gate green. **Runner-minute savings + critical-path impact measured** against the pre-flip run and reported. **Stops for review after all eight are proven live.**