### PR TITLE
fix(serve): WASM=0 build broken (unused hl_resolve_wasm_config) - found by nightly

### DIFF
--- a/src/hull/serve.c
+++ b/src/hull/serve.c
@@ -585,10 +585,15 @@ static int hl_parse_serve_args(int argc, char **argv, HlServeConfig *cfg)
 
 /* ── Manifest processing ──────────────────────────────────────────── */
 
+/* Gated as a WHOLE: the only call site (hl_serve_wire_caps) is itself inside
+ * `#ifdef HL_ENABLE_WASM`, so on a WASM-less build the definition must ALSO be
+ * compiled out - otherwise it is defined-but-unused (-Werror=unused-function).
+ * Surfaced by the nightly rare-configs job (HL_ENABLE_WASM=0), a combo the normal
+ * CI matrix does not build. */
+#ifdef HL_ENABLE_WASM
 static void hl_resolve_wasm_config(HlRuntime *rt, const HlManifest *manifest,
                                     const HlServeConfig *cfg)
 {
-#ifdef HL_ENABLE_WASM
     uint32_t wh = manifest->wasm_heap;
     uint32_t ws = manifest->wasm_stack;
     int64_t  wg = manifest->wasm_gas;
@@ -614,10 +619,8 @@ static void hl_resolve_wasm_config(HlRuntime *rt, const HlManifest *manifest,
     rt->wasm_config.gas        = wg;
     rt->wasm_config.max_input  = wi;
     rt->wasm_config.max_output = wo;
-#else
-    (void)rt; (void)manifest; (void)cfg;
-#endif
 }
+#endif
 
 /* ── Server state (persists for server lifetime) ──────────────────── */
 


### PR DESCRIPTION
The Slice-6 nightly `nightly-rare-configs` job (combo `HL_ENABLE_IMAGE=0 HL_ENABLE_WASM=0`) found a real latent bug: `hl_resolve_wasm_config` in serve.c was defined-but-unused on a WASM-less build (`-Werror=unused-function`), because its body was `#ifdef`-gated while its only call site is fully inside an outer `#ifdef HL_ENABLE_WASM`. Fix: gate the whole definition under `HL_ENABLE_WASM`. `HL_ENABLE_WASM=0` is a supported flag but is not in the normal CI matrix, which is why it went unnoticed until the exhaustive nightly tier built it. Verified locally: `make HL_ENABLE_WASM=0 HL_ENABLE_IMAGE=0` links + `hull version` + app.main smoke exit 0; default WASM=1 path unchanged. This is the honest fix for the nightly failure (not weakening the job).