### PR TITLE
CI Slice 6: scope nightly DB-compat to PG 15/16 + MySQL 8.0; pin the 8.4/MariaDB slot

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -253,8 +253,15 @@ jobs:
           test -s /tmp/echo.aot
           echo "wamrc builds + AOT-compiles against LLVM ${{ matrix.llvm }}"
 
-  # -- version / compat: the DB wire clients against multiple engine versions
-  #    (main tests only PG 16 / MySQL 8.0; nightly adds the neighbours). --
+  # -- version / compat: the DB wire clients against multiple engine versions.
+  #    SUPPORTED nightly set: PostgreSQL 15/16 + MySQL 8.0 (what the e2e harness
+  #    can reach today). MySQL 8.4 and MariaDB are a PENDING SLOT, NOT executed
+  #    here (Appendix F): 8.4 removed the `--default-authentication-plugin` startup
+  #    option, disables `mysql_native_password` by default, and defaults to
+  #    caching_sha2_password whose full-auth Hull only does over TLS - none of
+  #    which the current harness sets up. The pin scripts/ci/test_nightly_matrix.py
+  #    fails if this image set drifts, so 8.4/MariaDB cannot be casually re-added
+  #    without the real caching_sha2/TLS + version-aware-container harness work. --
   nightly-compat-db:
     if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
     name: Nightly compat (${{ matrix.label }})
@@ -267,7 +274,6 @@ jobs:
           - { label: "PostgreSQL 15", target: e2e-postgres, img_env: PG_IMAGE, image: "postgres:15-alpine" }
           - { label: "PostgreSQL 16", target: e2e-postgres, img_env: PG_IMAGE, image: "postgres:16-alpine" }
           - { label: "MySQL 8.0", target: e2e-mysql, img_env: MYSQL_IMAGE, image: "mysql:8.0" }
-          - { label: "MySQL 8.4", target: e2e-mysql, img_env: MYSQL_IMAGE, image: "mysql:8.4" }
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
@@ -308,6 +314,10 @@ jobs:
         run: |
           python3 scripts/ci/check_gate_completeness.py \
             --workflow .github/workflows/nightly.yml --gate nightly-success
+      # Pin the compat-db engine inventory (PG 15/16 + MySQL 8.0). Fails if MySQL
+      # 8.4 / MariaDB (the pending slot) are re-added without the harness work.
+      - name: Compat-db version inventory pin
+        run: python3 scripts/ci/test_nightly_matrix.py
       - name: Evaluate nightly results (fail-closed; nothing may skip)
         if: always()
         env:

--- a/docs/ci_architecture_design.md
+++ b/docs/ci_architecture_design.md
@@ -1854,7 +1854,7 @@ never a fetch.
 |---|---|---|---|
 | native + parser fuzzing | 60 s smoke on the committed corpora | SAME targets + SAME committed corpora at a long budget | yes (in-repo corpora) |
 | rare build configs | the 7-leg `flavors` matrix | CONCRETE uncommon `HL_ENABLE_*` combinations (F.2b), link + smoke | yes |
-| version / compatibility | single LLVM-18, single pinned engine version | multiple PINNED LLVM + pinned real engine versions (F.2b) | yes (pinned pkgs/digests) |
+| version / compatibility | single LLVM-18, single pinned engine version | pinned LLVM 17 + 18; pinned PostgreSQL 15/16 + MySQL 8.0 (F.2b; MySQL 8.4 + MariaDB are a pending slot) | yes (pinned pkgs/images) |
 | conformance-corpus expansion | 614 / 33-case pinned subsets (in `make test`) | **SLOT ONLY** - deferred to its own reviewed design; Slice 6 does not broaden it | n/a |
 
 ## F.2b Additive job inventory (defined BEFORE writing the workflow - amendment 2)
@@ -1874,7 +1874,26 @@ placeholder "rare combinations" jobs - every row names concrete targets/configs
 | `nightly-fuzz-lua` | fuzz_lua_source @ 600 s | 20 min | clang | `crash-*` inputs | deep Lua-parser coverage | ~10 min |
 | `nightly-rare-configs` | link + `hull version` + `app.main` smoke for (a) `DB=0 HTTP=0 WASM=0 IMAGE=0` minimal; (b) `POSTGRES=1 MYSQL=1` (both wire backends); (c) `SQLITE=0 POSTGRES=1 MYSQL=1`; (d) `IMAGE=0 WASM=0` | 30 min | gcc (ubuntu-24.04) | build/link log | uncommon link combos NOT in the 7-leg matrix | ~10 min |
 | `nightly-compat-llvm` | build `wamrc` against llvm-17 AND llvm-18; AOT smoke each | 30 min | llvm-17, llvm-18 | wamrc build log | wamrc builds across LLVM versions | ~10 min |
-| `nightly-compat-db` | `e2e_postgres` vs pinned `postgres` 15 & 16; `e2e_mysql` vs pinned `mysql:8.0` + `mariadb` | 40 min | pinned image DIGESTS | e2e logs | wire compat across engine versions | ~25 min |
+| `nightly-compat-db` | `e2e_postgres` vs pinned `postgres:15` & `16`; `e2e_mysql` vs pinned `mysql:8.0` | 40 min | pinned images | e2e logs | wire compat across engine versions | ~20 min |
+
+**Supported nightly DB-compat set: PostgreSQL 15/16 + MySQL 8.0.** This is what the
+e2e harness can reach today; it is machine-pinned by
+`scripts/ci/test_nightly_matrix.py` (run inside `nightly-success`), which fails if
+the `nightly-compat-db` image inventory drifts.
+
+**PENDING SLOT (NOT executed): MySQL 8.4 + MariaDB.** The first nightly dispatch
+proved WHY these are not yet valid nightly tests: MySQL **8.4** removed the
+`--default-authentication-plugin` startup option the harness uses, **disables
+`mysql_native_password` by default**, and defaults to `caching_sha2_password` -
+whose full-auth Hull performs only over **TLS**, which the harness does not set up.
+So `mysql:8.4` never reaches the Hull client (the container fails to start). Merely
+forcing legacy `mysql_native_password` would test a compatibility escape hatch, not
+Hull's intended 8.4 path, so 8.4 is NOT re-added that way. The follow-up
+compatibility story must implement the REAL path: **TLS-enabled
+`caching_sha2_password` full-auth, version-aware container configuration, and
+MariaDB's distinct authentication behavior** - and is out of Slice 6's scope
+(parallel to the deferred conformance-expansion slot). The version pin above blocks
+a casual re-add of 8.4 / MariaDB without that work.
 
 Conformance is intentionally absent: running the committed corpora under ASan/MSan
 is ALREADY covered by main's `sanitizers` + `msan` jobs (no property beyond main);

--- a/scripts/ci/test_nightly_matrix.py
+++ b/scripts/ci/test_nightly_matrix.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# test_nightly_matrix.py - PIN the nightly compat-db engine-version inventory
+# (docs/ci_architecture_design.md Appendix F). Slice 6 supports PostgreSQL 15/16
+# and MySQL 8.0 - the versions the e2e harness can actually reach. MySQL 8.4 and
+# MariaDB are a PENDING SLOT: 8.4 removed `--default-authentication-plugin`,
+# disables mysql_native_password by default, and defaults to caching_sha2_password
+# whose full-auth Hull only does over TLS - none set up by the current harness.
+#
+# This fixture FAILS if nightly.yml's nightly-compat-db image set drifts from the
+# approved inventory, so 8.4 / MariaDB cannot be casually re-added without ALSO
+# updating this pin - which forces the real compatibility work (TLS-enabled
+# caching_sha2_password, version-aware container config, MariaDB's distinct auth).
+# Do NOT loosen this pin by forcing legacy mysql_native_password; that tests a
+# compatibility escape hatch, not Hull's intended 8.4 path.
+#
+# No PyYAML dependency (regex over the fixed 2-space job layout, like the other
+# scripts/ci checkers).
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import os
+import re
+import sys
+
+WORKFLOW = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))), ".github", "workflows", "nightly.yml")
+
+# The APPROVED nightly compat-db engine images. Changing this set is a DELIBERATE
+# act that must come WITH the harness work (see the header) - never a casual edit.
+APPROVED_COMPAT_DB_IMAGES = frozenset({
+    "postgres:15-alpine",
+    "postgres:16-alpine",
+    "mysql:8.0",
+})
+# Explicitly NOT supported yet (the pending slot). Their presence is a hard error.
+FORBIDDEN_SUBSTRINGS = ("mysql:8.4", "mariadb", "mysql:9", "mysql:8.1", "mysql:8.2", "mysql:8.3")
+
+_pass = 0
+_fail = 0
+
+
+def check(name, cond):
+    global _pass, _fail
+    if cond:
+        _pass += 1
+    else:
+        _fail += 1
+        print("FAIL:", name)
+
+
+def compat_db_block(path):
+    """Return the text of the `nightly-compat-db:` job (up to the next 2-space job
+    key or the end of file)."""
+    lines = open(path, encoding="utf-8").read().splitlines()
+    out, cur = [], False
+    for ln in lines:
+        m = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", ln)
+        if m:
+            cur = (m.group(1) == "nightly-compat-db")
+            continue
+        if cur:
+            out.append(ln)
+    return "\n".join(out)
+
+
+block = compat_db_block(WORKFLOW)
+check("nightly-compat-db job exists", bool(block.strip()))
+
+images = set(re.findall(r'image:\s*"([^"]+)"', block))
+check("compat-db images == approved inventory (PG 15/16 + MySQL 8.0)",
+      images == set(APPROVED_COMPAT_DB_IMAGES))
+if images != set(APPROVED_COMPAT_DB_IMAGES):
+    print("   found:   ", sorted(images))
+    print("   approved:", sorted(APPROVED_COMPAT_DB_IMAGES))
+    print("   -> re-adding an engine version requires updating THIS pin + the "
+          "harness (TLS caching_sha2 / version-aware container), not a casual edit.")
+
+for _bad in FORBIDDEN_SUBSTRINGS:
+    check("pending-slot engine absent from executable matrix: %s" % _bad, _bad not in block)
+
+print("nightly_matrix fixtures: %d passed, %d failed" % (_pass, _fail))
+sys.exit(1 if _fail else 0)


### PR DESCRIPTION
Option A per review. The first nightly dispatch proved the mechanism by catching **two real issues** — a WASM=0 build bug (fixed, #388) and this.

**MySQL 8.4 is not a valid nightly test today:** 8.4 removed the `--default-authentication-plugin` startup option the harness uses, disables `mysql_native_password` by default, and defaults to `caching_sha2_password` — whose full-auth Hull only does over **TLS**, which the harness doesn't set up. So `mysql:8.4` never reaches the Hull client (container fails to start). Forcing legacy `mysql_native_password` would test a compatibility escape hatch, not Hull's intended 8.4 path.

### Changes
- **`nightly.yml`**: `nightly-compat-db` = **PostgreSQL 15/16 + MySQL 8.0** (8.4 leg removed).
- **`scripts/ci/test_nightly_matrix.py`** (new): **pins** the compat-db image inventory and hard-fails on `mysql:8.4` / `mariadb` (+ unpinned MySQL 9/8.1–8.3), so 8.4 can't be casually re-added without updating the pin **and** doing the harness work. Runs inside `nightly-success` — **`ci.yml` stays byte-identical to main.**
- **Appendix F**: supported set (PG 15/16 + MySQL 8.0) + explicit **pending slot** (MySQL 8.4 + MariaDB) + the *why* + the follow-up requirements (TLS caching_sha2 full-auth, version-aware container, MariaDB's distinct auth; **not** `mysql_native_password` as the long-term solution).

After merge I'll re-dispatch and require **every nightly job + `nightly-success` green**, then stop before `schedule:`.