### PR TITLE
CI Slice 6: durable nightly failure logs (tested wrapper + container logs)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -209,20 +209,24 @@ jobs:
       - name: Build + smoke ${{ matrix.label }}
         env:
           FLAGS: ${{ matrix.flags }}
+          LOG: nightly-rare-config-${{ strategy.job-index }}.log
         run: |
-          set -e
+          cat > /tmp/rareconfig.sh <<'SCRIPT'
+          set -euo pipefail
           make $FLAGS
           ./build/hull version
           printf 'app.main(function() return 0 end)\n' > /tmp/nightly_smoke.lua
           ./build/hull /tmp/nightly_smoke.lua
-          echo "config links + runs: ${{ matrix.label }}"
+          echo "config links + runs"
+          SCRIPT
+          bash tests/ci_run_logged.sh "$LOG" bash /tmp/rareconfig.sh
       - name: Upload build log on failure
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: nightly-rare-configs-${{ strategy.job-index }}
-          path: build/*.log
-          if-no-files-found: ignore
+          name: nightly-rare-config-${{ strategy.job-index }}-log
+          path: nightly-rare-config-${{ strategy.job-index }}.log
+          if-no-files-found: error
           retention-days: 14
 
   # -- version / compat: wamrc across LLVM versions. --
@@ -243,15 +247,29 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y llvm-${{ matrix.llvm }}-dev cmake
       - name: Build wamrc against LLVM ${{ matrix.llvm }} + AOT smoke
         timeout-minutes: 20
+        env:
+          LLVM: ${{ matrix.llvm }}
+          LOG: nightly-compat-llvm-${{ matrix.llvm }}.log
         run: |
-          set -e
-          if command -v llvm-config-${{ matrix.llvm }} >/dev/null 2>&1; then
-            export WAMRC_CMAKE_FLAGS="-DLLVM_DIR=$(llvm-config-${{ matrix.llvm }} --cmakedir)"
+          cat > /tmp/compat_llvm.sh <<'SCRIPT'
+          set -euo pipefail
+          if command -v "llvm-config-$LLVM" >/dev/null 2>&1; then
+            export WAMRC_CMAKE_FLAGS="-DLLVM_DIR=$(llvm-config-$LLVM --cmakedir)"
           fi
           make wamrc
           build/wamrc -o /tmp/echo.aot tests/fixtures/compute/echo.wasm
           test -s /tmp/echo.aot
-          echo "wamrc builds + AOT-compiles against LLVM ${{ matrix.llvm }}"
+          echo "wamrc builds + AOT-compiles against LLVM $LLVM"
+          SCRIPT
+          bash tests/ci_run_logged.sh "$LOG" bash /tmp/compat_llvm.sh
+      - name: Upload build log on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: nightly-compat-llvm-${{ matrix.llvm }}-log
+          path: nightly-compat-llvm-${{ matrix.llvm }}.log
+          if-no-files-found: error
+          retention-days: 14
 
   # -- version / compat: the DB wire clients against multiple engine versions.
   #    SUPPORTED nightly set: PostgreSQL 15/16 + MySQL 8.0 (what the e2e harness
@@ -283,11 +301,25 @@ jobs:
           IMG_ENV: ${{ matrix.img_env }}
           IMAGE: ${{ matrix.image }}
           TARGET: ${{ matrix.target }}
+          LOG: nightly-compat-db-${{ strategy.job-index }}.log
         run: |
-          set -e
+          cat > /tmp/compat_db.sh <<'SCRIPT'
+          set -euo pipefail
           export "${IMG_ENV}=${IMAGE}"
           echo "== ${TARGET} against ${IMAGE} =="
           make "$TARGET"
+          SCRIPT
+          # the e2e harness dumps `docker logs` on failure, so the captured LOG
+          # includes the engine's own container startup output.
+          bash tests/ci_run_logged.sh "$LOG" bash /tmp/compat_db.sh
+      - name: Upload e2e + container log on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: nightly-compat-db-${{ strategy.job-index }}-log
+          path: nightly-compat-db-${{ strategy.job-index }}.log
+          if-no-files-found: error
+          retention-days: 14
 
   # -- fail-closed gate (amendment 3): mirrors ci-success. `needs` EVERY nightly
   #    job; a failure / cancellation / missing result / unexpected skip fails it.
@@ -318,6 +350,11 @@ jobs:
       # 8.4 / MariaDB (the pending slot) are re-added without the harness work.
       - name: Compat-db version inventory pin
         run: python3 scripts/ci/test_nightly_matrix.py
+      # Validate the durable-log wrapper: exit-status preservation (a failed
+      # command still fails the job) + artifact-path coverage (the promised log is
+      # created with combined stdout+stderr).
+      - name: Logging wrapper self-test
+        run: bash tests/ci_run_logged_selftest.sh
       - name: Evaluate nightly results (fail-closed; nothing may skip)
         if: always()
         env:

--- a/tests/ci_run_logged.sh
+++ b/tests/ci_run_logged.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# ci_run_logged.sh LOGFILE CMD [ARGS...]
+#
+# Nightly durable-diagnostics wrapper (Slice 6, docs/ci_architecture_design.md
+# Appendix F). Runs CMD, captures its COMBINED stdout+stderr to LOGFILE (a
+# deterministic path), and exits with CMD's REAL exit status - so a failing
+# command still fails the job, AND the unattended nightly leaves a downloadable
+# log artifact (uploaded on failure) rather than only the ephemeral Actions run
+# log. Fuzz jobs keep their own crash-* artifacts and do not use this.
+#
+# Only the command's own output is captured - no environment dumps or secrets
+# beyond what the command already prints (which is already CI-log-safe).
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -o pipefail
+
+if [ "$#" -lt 2 ]; then
+    echo "usage: ci_run_logged.sh LOGFILE CMD [ARGS...]" >&2
+    exit 2
+fi
+
+log="$1"
+shift
+mkdir -p "$(dirname "$log")" 2>/dev/null || true
+
+# `tee` writes LOGFILE even when CMD fails; PIPESTATUS[0] is CMD's real status
+# (NOT tee's), so the wrapper's exit status equals CMD's.
+"$@" 2>&1 | tee "$log"
+exit "${PIPESTATUS[0]}"

--- a/tests/ci_run_logged_selftest.sh
+++ b/tests/ci_run_logged_selftest.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# ci_run_logged_selftest.sh - fixtures for the nightly logging wrapper (Slice 6).
+# Validates exit-status preservation (the load-bearing property: a failed command
+# must still fail the job) and artifact-path coverage (the promised log file is
+# created and contains the combined stdout+stderr).
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -u
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+W="$ROOT/tests/ci_run_logged.sh"
+fail=0
+
+ck() {  # ck GOT WANT NAME
+    if [ "$1" = "$2" ]; then
+        :
+    else
+        echo "FAIL: $3 (got '$1' want '$2')"; fail=1
+    fi
+}
+
+tmp="$(mktemp -d)"
+
+# 1. success path: exit 0; log created with BOTH stdout and stderr (2>&1).
+bash "$W" "$tmp/ok.log" bash -c 'echo the-stdout; echo the-stderr >&2; exit 0'
+ck "$?" 0 "success: exit status 0 preserved"
+test -f "$tmp/ok.log"; ck "$?" 0 "success: promised log file created"
+grep -q the-stdout "$tmp/ok.log"; ck "$?" 0 "success: stdout captured"
+grep -q the-stderr "$tmp/ok.log"; ck "$?" 0 "success: stderr captured (combined 2>&1)"
+
+# 2. failure path: CMD's real non-zero status is preserved (NOT tee's 0), and the
+#    log is still written (so the artifact exists on failure).
+bash "$W" "$tmp/bad.log" bash -c 'echo boom-before-exit; exit 7'
+ck "$?" 7 "failure: CMD exit status 7 preserved (not masked by tee)"
+test -f "$tmp/bad.log"; ck "$?" 0 "failure: log file still created"
+grep -q boom-before-exit "$tmp/bad.log"; ck "$?" 0 "failure: output captured before exit"
+
+# 3. a different non-zero code is preserved (not collapsed to 1).
+bash "$W" "$tmp/c2.log" bash -c 'exit 2'
+ck "$?" 2 "failure: exit status 2 preserved distinctly"
+
+# 4. nested log dir is created (deterministic path under a subdir).
+bash "$W" "$tmp/sub/dir/nested.log" bash -c 'echo hi'
+ck "$?" 0 "nested log path: exit ok"
+test -f "$tmp/sub/dir/nested.log"; ck "$?" 0 "nested log path: file created (mkdir -p)"
+
+# 5. usage error (too few args) exits 2 without creating a log.
+bash "$W" only-one-arg
+ck "$?" 2 "usage error exits 2"
+
+rm -rf "$tmp"
+if [ "$fail" = 0 ]; then
+    echo "ci_run_logged selftest: OK"
+else
+    echo "ci_run_logged selftest: FAILED"
+fi
+exit "$fail"

--- a/tests/e2e_mysql.sh
+++ b/tests/e2e_mysql.sh
@@ -22,6 +22,16 @@ DSN="mysql://hull:s3cretpw@127.0.0.1:${MYPORT}/hulldb?sslmode=disable"
 DSN_TLS="mysql://hull:s3cretpw@127.0.0.1:${MYPORT}/hulldb?sslmode=require"
 
 cleanup() {
+    rc=$?
+    # On failure, dump the DB container's own logs (bounded) BEFORE removing it,
+    # so an unattended nightly captures WHY the engine never became ready (e.g. a
+    # removed startup option on a newer version). Startup/init output only - no
+    # secrets echoed.
+    if [ "$rc" -ne 0 ]; then
+        echo "=== docker logs $CONTAINER (tail 200; e2e failed rc=$rc) ==="
+        docker logs --tail 200 "$CONTAINER" 2>&1 || true
+        echo "=== end docker logs $CONTAINER ==="
+    fi
     [ -n "${SVR:-}" ] && kill "$SVR" 2>/dev/null || true
     docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
     [ -n "${APPDIR:-}" ] && rm -rf "$APPDIR"

--- a/tests/e2e_postgres.sh
+++ b/tests/e2e_postgres.sh
@@ -20,6 +20,16 @@ DSN="postgres://hull:s3cretpw@127.0.0.1:${PGPORT}/hulldb?sslmode=disable"
 DSN_TLS="postgres://hull:s3cretpw@127.0.0.1:${PGPORT}/hulldb?sslmode=require"
 
 cleanup() {
+    rc=$?
+    # On failure, dump the DB container's own logs (bounded) BEFORE removing it,
+    # so an unattended nightly captures WHY the engine never became ready (e.g. a
+    # removed startup option on a newer version). Startup/init output only - no
+    # secrets echoed.
+    if [ "$rc" -ne 0 ]; then
+        echo "=== docker logs $CONTAINER (tail 200; e2e failed rc=$rc) ==="
+        docker logs --tail 200 "$CONTAINER" 2>&1 || true
+        echo "=== end docker logs $CONTAINER ==="
+    fi
     [ -n "${SVR:-}" ] && kill "$SVR" 2>/dev/null || true
     docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
     [ -n "${APPDIR:-}" ] && rm -rf "$APPDIR"


### PR DESCRIPTION
Option A per review — durable failure diagnostics for the unattended nightly (the Actions UI log alone isn't enough). **ci.yml stays byte-identical to the pre-Slice-6 baseline.**

### What
- **`tests/ci_run_logged.sh`** — logging wrapper: tees a command's **combined** stdout+stderr to a deterministic LOG and exits with the command's **real status** (`PIPESTATUS[0]`), so `tee`'s success never masks a failure.
- **`tests/ci_run_logged_selftest.sh`** — fixtures validating **exit-status preservation** (0/1/2/7) and **artifact-path coverage** (log created, combined output, nested path, usage error). Runs in `nightly-success`.
- **`nightly.yml`** — `nightly-rare-configs` / `nightly-compat-llvm` / `nightly-compat-db` wrap their build/e2e through the logger and **upload the log on failure**: stable collision-free names (`nightly-<job>-<index|llvm>-log`), **14-day retention**, **`if-no-files-found: error`** (a failed job missing its promised diagnostic is a harness defect; the wrapper always writes the log). **Fuzz artifacts unchanged.**
- **`e2e_postgres.sh` / `e2e_mysql.sh`** — `cleanup()` dumps `docker logs --tail 200` of the DB container **on failure** before removal, so a compat-db failure captures the engine's own startup output. Success path unchanged; safe for the existing ci.yml pg/mysql jobs (same scripts).

Requirements met: combined output + pipefail exit status; build/config + e2e + container logs; stable names; bounded retention; `if-no-files-found: error`; no secrets/env dumps. After merge I'll re-dispatch one clean nightly to confirm success paths are unaffected (upload steps skip on green), then stop — cron remains the final separate checkpoint.