### PR TITLE
fix(hull.path): join reset on absolute component; is_within leading-.. escape

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -708,6 +708,7 @@ Every module except the intrinsic core must be listed in `manifest.modules`. The
 | `cookie` | `require("hull.web.cookie")` | `import { cookie } from "hull:web:cookie"` | `"hull/web/cookie@1"` | Cookie helpers |
 | `jwt` | `require("hull.jwt")` | `import { jwt } from "hull:jwt"` | `"hull/jwt@1"` | JWT sign/verify (deps: `crypto`) |
 | `csv` | `require("hull.csv")` | `import { csv } from "hull:csv"` | `"hull/csv@1"` | CSV parse/encode |
+| `path` | `require("hull.path")` | `import { path } from "hull:path"` | `"hull/path@1"` | Pure LEXICAL path-name manipulation (`normalize`/`join`/`dirname`/`basename`/`extension`/`stem`/`is_absolute`/`relative`/`is_within`). No fs authority; NOT a security boundary (use `hull.fs` for containment against the resolved object) |
 | `search` | `require("hull.search")` | `import { search } from "hull:search"` | `"hull/search@1"` | FTS5 search (deps: `db`) |
 | `rbac` | `require("hull.web.middleware.rbac")` | `import { rbac } from "hull:web:middleware:rbac"` | `"hull/web/middleware/rbac@1"` | RBAC (deps: `db`) |
 | `i18n` | `require("hull.i18n")` | `import { i18n } from "hull:i18n"` | `"hull/i18n@1"` | Translations |

--- a/docs/hull_fs_buildcontext_audit.md
+++ b/docs/hull_fs_buildcontext_audit.md
@@ -1,0 +1,174 @@
+# hull.fs + BuildContext filesystem audit / design
+
+Status: **AUDIT + DESIGN (awaiting review). NOTHING implemented.** This is the
+design/audit checkpoint that must precede any `hull.fs` change and the Build
+Plugin / BuildArtifact work. Per the review scope it FIRST inventories the current
+APIs and the concrete BuildArtifact needs, THEN proposes the minimal additions.
+Design only - stop after this checkpoint.
+
+Prerequisite already shipped: **`hull.path`** (pure lexical names, no authority;
+#392). The rule this design preserves: **`hull.path` manipulates NAMES; `hull.fs`
+exercises AUTHORITY.** BuildContext is a THIRD, narrower authority surface - not a
+re-use of the application `hull.fs`.
+
+## 1. Inventory - current `hull.fs`
+
+### 1.1 Capability layer (`include/hull/cap/fs.h`, `src/hull/cap/fs.c`)
+
+| function | purpose |
+|---|---|
+| `hl_cap_fs_validate` | reject `..`, absolute paths, and paths outside `base_dir` |
+| `hl_cap_fs_read` | read a file's bytes |
+| `hl_cap_fs_write` | write bytes to a file |
+| `hl_cap_fs_exists` | existence probe |
+| `hl_cap_fs_delete` | unlink |
+| `hl_cap_fs_mmap` / `_mmap_window` / `_munmap` / `_borrow` / `_release` | zero-copy read-only file windows (the compute mapped-span path) |
+
+`HlFsConfig` carries `base_dir` + the manifest `fs.read` / `fs.write` allowlists.
+
+### 1.2 Application surface (Lua `hull.fs` / JS `hull:fs`)
+
+Deliberately SMALL: `read`, `write`, `exists`, `delete`, `mmap` (+ `close`/`len`
+on the mapped buffer). **There is NO enumeration (list/readdir), NO stat/metadata,
+NO staging/rename, NO dependency-hash primitive.**
+
+### 1.3 Authority model
+
+Two independent gates (as elsewhere in Hull): a build-time module gate
+(`hull/fs@1`) and a per-call capability gate. `hl_cap_fs_validate` enforces
+`manifest.fs.read` / `manifest.fs.write` allowlists + containment under `base_dir`.
+
+### 1.4 The load-bearing finding: current resolution is TOCTOU-susceptible
+
+`hl_cap_fs_validate` resolves with **`realpath()`** and then a later call opens the
+path (`realpath -> check -> open`). Between the `realpath` check and the `open`, a
+path component can be swapped (e.g. a directory replaced by a symlink), so the
+check does not bind the actual `open` target. A comment already claims "use
+resolved base_dir to avoid TOCTOU," but resolve-then-open remains a genuine TOCTOU
+window. This is exactly the pattern to NOT carry into the build-plugin surface.
+
+Precedent for the fix already exists in-tree: `src/hull/shared/blob_store.c` opens
+with `O_DIRECTORY | O_CLOEXEC` and `O_NOFOLLOW` - Hull can build on that.
+
+## 2. Concrete BuildArtifact needs (drives every proposal below)
+
+A build plugin, given a workspace, must be able to:
+1. **read its DECLARED inputs** (and only those) - not arbitrary workspace files;
+2. **enumerate** input directories DETERMINISTICALLY (stable order) with per-entry
+   **metadata** (type, size, mtime policy) to discover sources;
+3. **hash dependencies from the EXACT bytes** it read (+ a defined metadata
+   policy) so a build is reproducible and cache-keyable;
+4. **stage outputs transactionally** and **publish atomically** (all-or-nothing;
+   a crashed build leaves no half-written artifact);
+5. do all of the above **race-resistantly** (a workspace may be mutated
+   concurrently) and with **explicit, safe symlink behavior**.
+
+None of (2)-(4) exists today; (1) and (5) exist only via the TOCTOU-susceptible
+`base_dir` path check.
+
+## 3. Design proposals (minimal additions)
+
+### 3.1 Descriptor-relative, race-resistant resolution (NOT realpath->check->open)
+
+Introduce a resolver that, from a **base directory FILE DESCRIPTOR** (`dirfd`),
+walks the path ONE COMPONENT at a time with `openat(dfd, comp, O_NOFOLLOW |
+O_DIRECTORY | O_CLOEXEC)` for interior components and `openat(dfd, leaf, O_RDONLY |
+O_NOFOLLOW | O_CLOEXEC)` (or `O_WRONLY|O_CREAT` for writes) for the leaf. Because
+each step is relative to a fd that was itself opened `O_NOFOLLOW`, containment is
+enforced against the OBJECT actually opened - there is no resolve-then-open
+window, and a swapped component is refused, not silently followed. Lexical
+pre-validation uses `hull.path` (reject absolute, reject `..` for the plugin
+surface) BEFORE the descriptor walk, but the descriptor walk is the AUTHORITY.
+
+Platform notes to resolve at implementation: `openat`/`O_NOFOLLOW`/`O_DIRECTORY`
+are POSIX and available on Linux/macOS and via Cosmopolitan's shim; `O_NOFOLLOW`
+semantics differ subtly on macOS (fails only on a trailing symlink - hence the
+component-wise walk, which makes EVERY component a trailing check). A Windows
+native build (not today's cosmo APE) would need the reparse-point-aware
+equivalent; scope that when a native Windows target exists. Where a platform
+cannot offer a race-resistant primitive, the operation must **fail closed**, not
+downgrade to `realpath`.
+
+### 3.2 Deterministic enumeration + metadata
+
+A `list(dir)` that returns entries in a **defined, stable order** (byte-wise sort
+of names) with per-entry `{ name, type, size }` and a **metadata policy** for
+mtime (see 3.5 - hashing should not depend on mtime by default). Enumeration is
+descriptor-relative (`fdopendir` on a `dirfd` opened per 3.1). No recursion in the
+primitive; a plugin composes recursion with `hull.path`.
+
+### 3.3 Declared-input reads (the BuildContext.inputs view)
+
+Build plugins receive a **BuildContext.inputs** view, NOT the general `hull.fs`.
+It exposes only `read` / `stat` / `list` over a set of **declared** input roots
+(each opened as a `dirfd` per 3.1), and **records every read** (path + content
+hash) for dependency tracking (3.4). A read outside a declared input is refused.
+This is a strictly NARROWER authority than application `hull.fs`.
+
+### 3.4 Dependency hashing from exact bytes + metadata policy
+
+Every input read through BuildContext.inputs is hashed from the **exact bytes
+returned to the plugin** (reuse `hl_cap_crypto_sha256`), accumulating a
+`{ path -> sha256 }` dependency set. The default hash covers CONTENT only; the
+**metadata policy** (whether mode/size/mtime participate) is explicit and
+defaults to content-addressed (mtime excluded, for reproducibility). The
+dependency set becomes the build's cache key input.
+
+### 3.5 Transactional staging + atomic publication (BuildContext.outputs - Hull-owned)
+
+Outputs are written to a **staging** area (a private temp dir under the workspace,
+`O_DIRECTORY` dirfd) via `BuildContext.outputs`, then **published atomically** by a
+single `rename(2)` (same filesystem, atomic) of the staged tree/file into place -
+or discarded wholesale on failure, so a crashed build leaves no partial artifact.
+`fsync` the file + the directory before the publish rename for durability.
+
+**HARD BOUNDARY (explicit):** staging and publication primitives are **NEVER**
+exposed through ordinary application `hull.fs`. They belong ONLY to the
+Hull-OWNED `BuildContext` handed to a plugin. An application cannot obtain a
+staging/publish handle; a plugin cannot obtain the general `hull.fs`. The two
+authorities are distinct surfaces, not one surface with flags.
+
+### 3.6 Explicit symlink behavior
+
+Stated, not implicit: within a plugin BuildContext, symlink components are
+**refused** during resolution (`O_NOFOLLOW` at every step, 3.1); a symlink is
+never transparently followed out of a declared root. The application `hull.fs`
+retains its current documented behavior (manifest-authorized, `base_dir`-contained)
+until separately migrated to the descriptor-relative resolver - a migration
+tracked but out of THIS checkpoint.
+
+## 4. The two authority surfaces (kept separate)
+
+| surface | who | authority | operations |
+|---|---|---|---|
+| **application `hull.fs`** | app code | manifest `fs.read`/`fs.write` allowlists, `base_dir` | read/write/exists/delete/mmap (today) + (later) descriptor-relative resolution + enumeration where the app API exposes it |
+| **plugin `BuildContext`** | Hull-owned, handed to a build plugin | declared input roots + a private staging root; NARROWER | inputs: read/stat/list (recorded); outputs: staged write + atomic publish |
+
+Build plugins do NOT receive `hull.fs` "because it exists." They receive a
+BuildContext with strictly the authority a build needs.
+
+## 5. Lua/JS parity - only where the application API exposes the operation
+
+Parity (Lua == JS, like `hull.path`) applies ONLY to operations exposed on the
+APPLICATION `hull.fs` surface. BuildContext is Hull-owned orchestration handed to
+plugins; its inputs/outputs views are provided by Hull to the plugin runtime and
+do not need a symmetric hand-written Lua/JS user API surface beyond what a plugin
+actually calls. So: add descriptor-relative resolution + (if exposed) enumeration
+with Lua/JS parity on `hull.fs`; provide BuildContext to plugins without duplicating
+a second public user-facing fs module.
+
+## 6. Non-scope (this checkpoint)
+
+Design only. No implementation. No change to application `hull.fs` behavior yet, no
+BuildContext code, no plugin loader, no dependency-hash wiring, no Query IR. The
+application-`hull.fs` migration to the descriptor-relative resolver is a tracked
+follow-up, sequenced AFTER BuildContext proves the primitive.
+
+## 7. Checkpoints
+
+1. **Audit + design** (this doc) - STOP for review.
+2. Implement the descriptor-relative resolver + enumeration/metadata primitive
+   (application `hull.fs`), with parity tests - STOP.
+3. Implement `BuildContext.inputs` (declared reads + dependency hashing) + STOP.
+4. Implement `BuildContext.outputs` (transactional staging + atomic publish) +
+   STOP. Then Build Plugin / BuildArtifact. **Not Query IR yet.**

--- a/stdlib/js/hull/path.js
+++ b/stdlib/js/hull/path.js
@@ -70,10 +70,13 @@ function normalize(p) {
 
 /** Join components with `/` and normalize; empty components ignored. */
 function join(...parts) {
-    const buf = [];
+    let buf = [];
     for (const c of parts) {
         checkString(c, "join");
-        if (c !== "") buf.push(c);
+        if (c !== "") {
+            if (c.charAt(0) === "/") buf = [c];   // an absolute component RESETS the accumulator
+            else buf.push(c);
+        }
     }
     if (buf.length === 0) return ".";
     return normalize(buf.join("/"));
@@ -162,6 +165,10 @@ function isWithin(base, candidate) {
     for (let i = 0; i < b.segs.length; i++) {
         if (b.segs[i] !== c.segs[i]) return false;
     }
+    // A candidate component immediately after the base prefix that is ".." escapes
+    // ABOVE base (relative paths only, where normalize keeps leading ".."):
+    // isWithin(".", "../x") / isWithin("..", "../../x"). Reject it.
+    if (c.segs.length > b.segs.length && c.segs[b.segs.length] === "..") return false;
     return true;
 }
 

--- a/stdlib/lua/hull/path.lua
+++ b/stdlib/lua/hull/path.lua
@@ -85,15 +85,20 @@ end
 -- @treturn string
 function path.join(...)
     local parts = { ... }
-    local buf = {}
+    local buf, n = {}, 0
     for i = 1, select("#", ...) do
         local c = parts[i]
         checktype(c, "join")
         if c ~= "" then
-            buf[#buf + 1] = c
+            if c:sub(1, 1) == "/" then    -- an absolute component RESETS the accumulator
+                buf, n = { c }, 1
+            else
+                n = n + 1
+                buf[n] = c
+            end
         end
     end
-    if #buf == 0 then
+    if n == 0 then
         return "."
     end
     return path.normalize(table.concat(buf, "/"))
@@ -233,6 +238,13 @@ function path.is_within(base, candidate)
         if bsegs[i] ~= csegs[i] then
             return false
         end
+    end
+    -- A candidate component immediately after the base prefix that is ".." escapes
+    -- ABOVE base (only possible for relative paths, where normalize keeps leading
+    -- ".."): e.g. is_within(".", "../x") or is_within("..", "../../x"). Lexical
+    -- containment must reject it - matching the base prefix is not enough.
+    if #csegs > #bsegs and csegs[#bsegs + 1] == ".." then
+        return false
     end
     return true
 end

--- a/tests/e2e_path_parity.sh
+++ b/tests/e2e_path_parity.sh
@@ -3,13 +3,12 @@
 #
 # hull.path is PURE lexical name manipulation (no filesystem authority). This
 # runs the required case matrix (normalize/join/dirname/basename/extension/stem/
-# is_absolute/relative/is_within), the algebraic invariants
-# (normalize(normalize(x))==normalize(x); normalize(join(a,relative(a,b)))==
-# normalize(b)), and the security-boundary cases (component-aware containment;
-# normalize-before-contain) through BOTH runtimes, using an IDENTICAL expected
-# vector in each app - so the two implementations cannot silently diverge, and a
-# self-check failure in either runtime fails the job. Both apps then print a
-# fingerprint that must match byte-for-byte across runtimes.
+# is_absolute/relative/is_within), the algebraic invariants, and the
+# security-boundary cases through BOTH runtimes with an IDENTICAL expected vector
+# per app (so the two implementations cannot silently diverge). Each app then
+# prints a COMPREHENSIVE fingerprint that exercises EVERY operation; the two
+# fingerprints must match byte-for-byte AND equal the golden vector, so the
+# parity claim covers all nine ops, not just those with duplicated asserts.
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 set -eu
@@ -19,7 +18,7 @@ HULL="${HULL:-./build/hull}"
 WD=$(mktemp -d)
 trap 'rm -rf "$WD"' EXIT
 
-# ── Lua app: self-checks the required semantics, prints a fingerprint ──────────
+# ── Lua app ───────────────────────────────────────────────────────────────────
 cat > "$WD/p.lua" <<'LUA'
 local path = require("hull.path")
 app.manifest({ modules = { "hull/path@1" } })
@@ -47,13 +46,16 @@ app.main(function(ctx)
     eq(path.normalize("foo/.."), ".", "n11")
     eq(path.normalize(".."), "..", "n12")
     eq(path.normalize("/foo/../bar"), "/bar", "n13")
-    -- join
+    -- join (absolute component RESETS the accumulator)
     eq(path.join("foo", "bar"), "foo/bar", "j1")
     eq(path.join("foo/", "bar"), "foo/bar", "j2")
     eq(path.join("foo", ".", "bar"), "foo/bar", "j3")
     eq(path.join("src", "plugins", "foo.lua"), "src/plugins/foo.lua", "j4")
     eq(path.join(), ".", "j5 empty")
     eq(path.join("", "foo", ""), "foo", "j6 empties")
+    eq(path.join("a", "/b"), "/b", "j7 abs-reset")
+    eq(path.join("/a", "/b"), "/b", "j8 abs-reset2")
+    eq(path.join("a", "b/", "/c/d"), "/c/d", "j9 abs-reset-mid")
     -- dirname
     eq(path.dirname("/foo/bar.txt"), "/foo", "d1")
     eq(path.dirname("/foo"), "/", "d2")
@@ -91,6 +93,11 @@ app.main(function(ctx)
     eq(b(path.is_within("/workspace", "/workspace/a/../../etc")), "F", "w6 escape-normd")
     eq(b(path.is_within("a", "a/b")), "T", "w7 rel")
     eq(b(path.is_within("a", "../a")), "F", "w8 rel-up")
+    -- is_within: a relative candidate with MORE leading `..` than base escapes
+    eq(b(path.is_within(".", "../x")), "F", "w9 dot-escape")
+    eq(b(path.is_within("", "../../x")), "F", "w10 empty-escape")
+    eq(b(path.is_within(".", "x")), "T", "w11 dot-child")
+    eq(b(path.is_within("..", "../x")), "T", "w12 dotdot-child")
     -- invariants
     for _, x in ipairs({ "foo/./bar", "/a/../../b", "../../foo", "foo//bar/", "./x", "/a/b/../c" }) do
         eq(path.normalize(path.normalize(x)), path.normalize(x), "idem " .. x)
@@ -99,22 +106,30 @@ app.main(function(ctx)
         eq(path.normalize(path.join(pr[1], path.relative(pr[1], pr[2]))), path.normalize(pr[2]), "cmp")
     end
     -- type error is raised, not coerced
-    local ok = pcall(function() return path.normalize(42) end)
-    eq(b(ok), "F", "typeerr")
+    eq(b(pcall(function() return path.normalize(42) end)), "F", "typeerr")
 
     if #fails > 0 then
         ctx.stderr:write("LUA FAIL:\n" .. table.concat(fails, "\n") .. "\n"); return 1
     end
-    -- fingerprint: a stable transform of a shared matrix (cross-runtime compare)
+
+    -- COMPREHENSIVE fingerprint: every op over a shared matrix.
+    local FP_PATHS = { "a/b/../c", "/x//y/./z/..", "../p/q", "f.tar.gz", "/", ".gitignore", "foo/", "/a/../../b", "" }
+    local FP_JOIN = { { "a", "/b" }, { "/a", "/b" }, { "foo/", "bar" }, { "src", "p", "f.lua" }, { "x", ".", "y" } }
+    local FP_REL = { { "/a/b", "/a/c/x" }, { "src", "src/p/f" }, { "/a", "/a" } }
+    local FP_WITHIN = { { ".", "../x" }, { "..", "../x" }, { "/a", "/a/b" }, { "/a", "/ab" } }
     local fp = {}
-    for _, x in ipairs({ "a/b/../c", "/x//y/./z/..", "../p/q", "f.tar.gz", "/" }) do
-        fp[#fp + 1] = path.normalize(x) .. ":" .. path.basename(x) .. ":" .. path.extension(x)
+    for _, x in ipairs(FP_PATHS) do
+        fp[#fp + 1] = table.concat({ path.normalize(x), path.basename(x), path.dirname(x),
+            path.extension(x), path.stem(x), b(path.is_absolute(x)) }, ":")
     end
+    for _, j in ipairs(FP_JOIN) do fp[#fp + 1] = path.join(table.unpack(j)) end
+    for _, r in ipairs(FP_REL) do fp[#fp + 1] = path.relative(r[1], r[2]) end
+    for _, w in ipairs(FP_WITHIN) do fp[#fp + 1] = b(path.is_within(w[1], w[2])) end
     ctx.stdout:write(table.concat(fp, "|") .. "\n"); return 0
 end)
 LUA
 
-# ── JS app: identical semantics + fingerprint (camelCase for the two names) ────
+# ── JS app (identical semantics; camelCase for the two multi-word names) ───────
 cat > "$WD/p.js" <<'JS'
 import { app } from "hull:app";
 import { path } from "hull:path";
@@ -144,6 +159,9 @@ app.main((ctx) => {
     eq(path.join("src", "plugins", "foo.lua"), "src/plugins/foo.lua", "j4");
     eq(path.join(), ".", "j5");
     eq(path.join("", "foo", ""), "foo", "j6");
+    eq(path.join("a", "/b"), "/b", "j7");
+    eq(path.join("/a", "/b"), "/b", "j8");
+    eq(path.join("a", "b/", "/c/d"), "/c/d", "j9");
     eq(path.dirname("/foo/bar.txt"), "/foo", "d1");
     eq(path.dirname("/foo"), "/", "d2");
     eq(path.dirname("foo"), ".", "d3");
@@ -174,6 +192,10 @@ app.main((ctx) => {
     eq(b(path.isWithin("/workspace", "/workspace/a/../../etc")), "F", "w6");
     eq(b(path.isWithin("a", "a/b")), "T", "w7");
     eq(b(path.isWithin("a", "../a")), "F", "w8");
+    eq(b(path.isWithin(".", "../x")), "F", "w9");
+    eq(b(path.isWithin("", "../../x")), "F", "w10");
+    eq(b(path.isWithin(".", "x")), "T", "w11");
+    eq(b(path.isWithin("..", "../x")), "T", "w12");
     for (const x of ["foo/./bar", "/a/../../b", "../../foo", "foo//bar/", "./x", "/a/b/../c"]) {
         eq(path.normalize(path.normalize(x)), path.normalize(x), "idem " + x);
     }
@@ -185,33 +207,40 @@ app.main((ctx) => {
     eq(b(threw), "T", "typeerr");
 
     if (fails.length > 0) { ctx.stderr.write("JS FAIL:\n" + fails.join("\n") + "\n"); return 1; }
+
+    const FP_PATHS = ["a/b/../c", "/x//y/./z/..", "../p/q", "f.tar.gz", "/", ".gitignore", "foo/", "/a/../../b", ""];
+    const FP_JOIN = [["a", "/b"], ["/a", "/b"], ["foo/", "bar"], ["src", "p", "f.lua"], ["x", ".", "y"]];
+    const FP_REL = [["/a/b", "/a/c/x"], ["src", "src/p/f"], ["/a", "/a"]];
+    const FP_WITHIN = [[".", "../x"], ["..", "../x"], ["/a", "/a/b"], ["/a", "/ab"]];
     const fp = [];
-    for (const x of ["a/b/../c", "/x//y/./z/..", "../p/q", "f.tar.gz", "/"]) {
-        fp.push(path.normalize(x) + ":" + path.basename(x) + ":" + path.extension(x));
+    for (const x of FP_PATHS) {
+        fp.push([path.normalize(x), path.basename(x), path.dirname(x),
+            path.extension(x), path.stem(x), b(path.isAbsolute(x))].join(":"));
     }
+    for (const j of FP_JOIN) fp.push(path.join(...j));
+    for (const r of FP_REL) fp.push(path.relative(r[0], r[1]));
+    for (const w of FP_WITHIN) fp.push(b(path.isWithin(w[0], w[1])));
     ctx.stdout.write(fp.join("|") + "\n"); return 0;
 });
 JS
 
-echo "== hull.path: Lua self-check + fingerprint =="
+echo "== hull.path: Lua self-check + comprehensive fingerprint =="
 LUA_OUT=$("$HULL" "$WD/p.lua") || { echo "LUA app FAILED"; exit 1; }
 echo "  lua fp: $LUA_OUT"
-echo "== hull.path: JS self-check + fingerprint =="
+echo "== hull.path: JS self-check + comprehensive fingerprint =="
 JS_OUT=$("$HULL" "$WD/p.js") || { echo "JS app FAILED"; exit 1; }
 echo "  js  fp: $JS_OUT"
 
 if [ "$LUA_OUT" != "$JS_OUT" ]; then
     echo "PARITY FAIL: Lua and JS hull.path fingerprints differ"
-    echo "  lua: $LUA_OUT"
-    echo "  js : $JS_OUT"
     exit 1
 fi
-# correctness anchor for the fingerprint (matches the lexical algorithm)
-EXPECT="a/c:c:|/x/y:y:|../p/q:q:|f.tar.gz:f.tar.gz:.gz|/:/:"
+# golden: the exact lexical algorithm over every op (see the comment above).
+EXPECT="a/c:c:a::c:F|/x/y:y:/x::y:T|../p/q:q:../p::q:F|f.tar.gz:f.tar.gz:.:.gz:f.tar:F|/:/:/::/:T|.gitignore:.gitignore:.::.gitignore:F|foo:foo:.::foo:F|/b:b:/::b:T|.:.:.::.:F|/b|/b|foo/bar|src/p/f.lua|x/y|../c/x|p/f|.|F|T|T|F"
 if [ "$LUA_OUT" != "$EXPECT" ]; then
     echo "GOLDEN FAIL: fingerprint != expected"
     echo "  got:  $LUA_OUT"
     echo "  want: $EXPECT"
     exit 1
 fi
-echo "hull.path parity + semantics OK (Lua == JS == golden)"
+echo "hull.path parity + semantics OK (Lua == JS == golden; all 9 ops in the fingerprint)"


### PR DESCRIPTION
Follow-up to #392 (hull.path). Fixes two correctness bugs and hardens the parity test.

## Bugs fixed (identical in Lua + JS)

**1. `join()` did not reset on an absolute component.** The documented contract
("if a component is absolute it resets the accumulated path") was not honored —
it concatenated instead.

| call | before | after |
|---|---|---|
| `join("a", "/b")` | `a/b` | `/b` |
| `join("/a", "/b")` | `/a/b` | `/b` |
| `join("a", "b/", "/c/d")` | `a/b/c/d` | `/c/d` |

**2. `is_within()` accepted a leading-`..` escape.** A zero-component base
(`"."` / `""`, which normalize to no components) matched every relative
candidate, including one that escapes above the base.

| call | before | after |
|---|---|---|
| `is_within(".", "../x")` | `true` | `false` |
| `is_within("", "../../x")` | `true` | `false` |
| `is_within(".", "x")` | `true` | `true` |
| `is_within("..", "../x")` | `true` | `true` |

The fix rejects any candidate whose first component past the base prefix is `..`
(only reachable for relative paths, where `normalize` deliberately keeps leading
`..`).

## Parity hardening

- `tests/e2e_path_parity.sh` now emits a fingerprint covering **every** operation
  over a shared matrix (was: normalize/basename/extension only), so the
  `Lua == JS == golden` assertion proves parity across all nine ops. Explicit
  self-check asserts for the fixed bug cases are added to both runtime apps.
- `AGENTS.md`: `hull.path` added to the public stdlib module table.

## Boundary unchanged

`hull.path` remains pure lexical name manipulation with no filesystem authority;
`is_within` is explicitly NOT an authorization check (a lexically-contained path
may still traverse a symlink out — real containment belongs to `hull.fs` against
the resolved object).

## Validation

Rebuilt; both runtime apps produce `Lua == JS == golden` across all ops locally
(via `--no-sandbox`, since the managed Seatbelt sandbox blocks the normal
`make e2e-path-parity` here). CI's `make e2e-path-parity` step is the
authoritative execution proof. `luacheck` clean.