### PR TITLE
docs(fs): application hull.fs design (design-only)

### DIFF
--- a/docs/hull_fs_design.md
+++ b/docs/hull_fs_design.md
@@ -12,8 +12,9 @@ NAMES lexically; `hull.fs` exercises AUTHORITY.** `hull.fs` is where real
 filesystem containment is enforced against the RESOLVED object - never by lexical
 checks alone.
 
-Two DECISIONS-FOR-REVIEW are flagged inline (§5, §9). They are the load-bearing
-choices; the review is their decision forum. Everything else is a recommendation
+Symlink policy (§5) has been DECIDED during review: **in-sandbox symlinks are
+followed, with `base_dir` a hard containment ceiling.** One DECISION-FOR-REVIEW
+remains (§9, resolver-migration sequencing). Everything else is a recommendation
 with rationale.
 
 ## 1. Inventory - the CURRENT application `hull.fs` (verified, not assumed)
@@ -63,7 +64,8 @@ swapped (a directory replaced by a symlink), so the check does not bind the
    opened.
 2. **Deterministic enumeration + metadata** - add `list` and `stat`, the minimum
    an app (or later a build) needs to discover and describe files.
-3. **Explicit, safe symlink policy** (DECISION, §5).
+3. **Follow in-sandbox symlinks, contained race-free** - `base_dir` is a hard
+   ceiling (§5, DECIDED).
 4. **Keep the surface deliberately SMALL** - Hull's convention is to reach for
    stdlib / composition before widening a C capability. Conveniences
    (copy/rename/mkdir/atomic-write/tempfile) are enumerated as candidates in §4.3
@@ -75,35 +77,51 @@ swapped (a directory replaced by a symlink), so the check does not bind the
    only the resolution MECHANISM hardens and the symlink behavior tightens (§5),
    both documented.
 
-## 3. Resolution model (the shared foundation)
+## 3. Resolution model (the shared foundation) - follow within base, contained
 
-A single descriptor-relative resolver underpins every `hull.fs` op AND (later)
-BuildContext:
+A single resolver underpins every `hull.fs` op AND (later) BuildContext. It
+**follows symlinks that resolve within `base_dir`** and **refuses any resolution
+that would escape it** (via `..` chains or an out-of-base target), with NO
+resolve-then-open (TOCTOU) window. `base_dir` is a hard ceiling - the sandbox root
+IS the root for resolution purposes.
 
-- Lexically pre-validate the caller's path with `hull.path` (reject absolute,
-  reject any `..`) BEFORE touching the disk. This is a fast fail, NOT the
-  authority.
-- Open the configured `base_dir` once as a directory fd (`O_DIRECTORY |
-  O_NOFOLLOW | O_CLOEXEC`).
-- Walk the relative path ONE COMPONENT at a time: interior components with
-  `openat(dfd, comp, O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)`; the leaf with
-  `openat(dfd, leaf, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)` (or
-  `O_WRONLY | O_CREAT | O_NOFOLLOW` for writes). Because each step is relative to
-  a fd itself opened `O_NOFOLLOW`, containment is enforced against the object
-  actually opened - there is no resolve-then-open window, and a swapped or
-  symlinked component is REFUSED, not silently followed.
-- The manifest `fs.read` / `fs.write` allowlist is still enforced, now against the
-  lexically-normalized relative path (which the descriptor walk proves is the real
-  target), not a pre-open `realpath` string.
+- **Lexical pre-check** with `hull.path` (reject an absolute caller path, reject
+  `..` in the CALLER-supplied path) - a fast fail, NOT the authority. (Symlink
+  targets encountered DURING resolution are handled below, not by this check.)
+- **Linux >= 5.6:** `openat2(base_dfd, relpath, { flags, resolve: RESOLVE_IN_ROOT
+  | RESOLVE_NO_MAGICLINKS })`. `RESOLVE_IN_ROOT` makes `base_dfd` the root for the
+  ENTIRE resolution: interior and leaf symlinks - even absolute ones, even ones
+  containing `..` - are followed but can NEVER escape `base_dir`; the kernel
+  enforces containment race-free in one syscall, and the returned fd IS the opened
+  object (no separate check to race). `RESOLVE_NO_MAGICLINKS` blocks
+  `/proc`-style magic-symlink escapes.
+- **Platforms without `openat2` (macOS, older Linux, cosmo where unavailable):** a
+  manual component-wise walk that REPRODUCES `RESOLVE_IN_ROOT`. Hold a STACK of
+  directory fds rooted at `base_dfd`; for each component `openat(top, comp,
+  O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)`; when a component is a symlink (detected
+  via `O_NOFOLLOW`'s `ELOOP` or an `fstatat` probe), `readlinkat` its target and
+  SPLICE the target's components into the walk (an ABSOLUTE target restarts at
+  `base_dfd` = re-root; a RELATIVE target continues from the current dir). A `..`
+  component POPS the fd stack and is CLAMPED at `base_dfd` - it is never passed to
+  the kernel as `openat(dfd, "..")`, so the walk can never ascend above the base.
+  Bound total symlink expansions (e.g. 40, matching the kernel `ELOOP` limit) to
+  stop loops. Because every step is relative to a HELD fd (never a re-resolved
+  path string), there is no TOCTOU window and containment is structural.
+- The manifest `fs.read` / `fs.write` allowlist is still enforced, against the
+  lexically-normalized relative caller path.
+- **Fail closed** where a platform offers neither primitive - never downgrade to
+  `realpath`.
 
-**Platform notes** (resolve at implementation, same as the audit): `openat` /
-`O_NOFOLLOW` / `O_DIRECTORY` are POSIX (Linux, macOS, Cosmopolitan shim). macOS
-`O_NOFOLLOW` fails only on a TRAILING symlink - the component-wise walk makes
-every component a trailing check, so the guarantee holds uniformly. A native
-Windows target (not today's cosmo APE) needs the reparse-point-aware equivalent;
-scope that when such a target exists. Where a platform cannot offer a
-race-resistant primitive, the op **fails closed** - it must never downgrade to
-`realpath`.
+This is the userspace equivalent of what container runtimes settled on
+(`RESOLVE_IN_ROOT` / Go's `securejoin`): symlinks are followed, but the sandbox
+root is a hard ceiling.
+
+**Platform notes** (resolve at implementation): `openat2` is Linux-only (>= 5.6);
+confirm whether the Cosmopolitan target exposes it (raw syscall) or must use the
+manual walk on its Linux host. `openat` / `O_NOFOLLOW` / `readlinkat` / `fstatat`
+are POSIX (Linux, macOS, cosmo shim). A native Windows target (not today's cosmo
+APE) needs the reparse-point-aware equivalent; scope that when such a target
+exists.
 
 ## 4. Operations
 
@@ -152,28 +170,32 @@ without a second cap surface that could disagree with `stat` about symlinks.
 The through-line: `hull.fs` gets read-side hardening + discovery (stat/list); the
 WRITE-side transactional machinery stays in BuildContext.
 
-## 5. DECISION-FOR-REVIEW #1: symlink policy on the APP surface
+## 5. DECIDED: in-sandbox symlinks are FOLLOWED (contained), not refused
 
-Today's `realpath`-based validate **follows** symlinks and then checks the
-resolved target is under `base_dir` - so an in-sandbox symlink pointing to
-another in-sandbox file is transparently followed. The §3 descriptor walk
-(`O_NOFOLLOW` every component) **refuses any symlink anywhere in the path**. That
-is a behavior change for existing apps.
+**Decision (owner: user, during review): the app surface MUST follow symlinks
+that resolve within `base_dir`.** Real apps rely on in-sandbox symlinks -
+atomic-deploy `current -> releases/N`, asset trees, config indirection - so
+refusing them would break legitimate layouts. The prior draft's deny-all
+recommendation is REJECTED. Preserving today's follow-within-base BEHAVIOR while
+fixing the TOCTOU (via §3, not `realpath`) is the chosen path.
 
-- **Recommended: deny-all (tighten).** Refuse a symlink at any component;
-  `stat`/`list` report symlinks by type without following. Rationale: it makes
-  the app surface and the plugin BuildContext share ONE symlink rule, it is the
-  strictly safer default, and it removes an entire class of confused-deputy /
-  swap-during-resolution risk. Document it as an intentional tightening; add an
-  explicit opt-in follow ONLY if a concrete app need surfaces (default deny).
-- **Alternative: preserve follow-within-base.** Keep today's "follow, then
-  require the resolved object under `base_dir`" semantics, but implement it
-  race-resistantly (resolve each symlink target via a fresh descriptor walk and
-  re-verify containment at each hop). More code, keeps back-compat, weaker
-  invariant.
+Semantics (the `RESOLVE_IN_ROOT` model of §3):
+- A symlink whose recursively-resolved target stays under `base_dir` is FOLLOWED
+  transparently, for `read` / `write` / `mmap`.
+- An ABSOLUTE symlink target is RE-ROOTED at `base_dir` (the sandbox root is the
+  resolution root), so `foo -> /bar` resolves to `base_dir/bar` - followed, still
+  contained.
+- Any resolution that would ESCAPE `base_dir` (a `..` chain or an out-of-base
+  target) is REFUSED with `outside_root`. The ceiling is hard and kernel-enforced
+  (Linux) / structurally enforced (manual walk).
+- `stat` / `list` report a symlink's OWN type WITHOUT following (`lstat`
+  semantics), so an app can enumerate links as links; only path RESOLUTION for
+  read/write/mmap follows.
+- Guarantee vs today: SAME "follow within base" behavior, now enforced race-free
+  (no `realpath -> check -> open` window).
 
-This is the review's call because it trades a (likely small) back-compat surface
-for a materially simpler and safer model.
+Still NOT a lexical check - `hull.path` never authorizes; the `openat2` /
+descriptor walk is the authority.
 
 ## 6. Capability + manifest integration
 
@@ -184,7 +206,8 @@ allowlist. New ops require `fs.read` authority over their target (`stat` and
 **Error model (proposed, stable tokens).** Uniform `(nil, err)` (Lua) / `throw`
 (JS) with a small closed set of tokens so app code can branch:
 `"not_found"`, `"permission"` (allowlist / mode), `"not_a_directory"`,
-`"is_a_directory"`, `"symlink_refused"`, `"outside_root"`, `"too_large"`,
+`"is_a_directory"`, `"outside_root"` (a symlink or `..` chain that would escape
+`base_dir`), `"symlink_loop"` (expansion bound exceeded), `"too_large"`,
 `"io_error"`. (The exact tokens are confirmed at implementation; today's messages
 are not a stable contract.)
 
@@ -194,11 +217,12 @@ Every application op has both bindings, mirrored semantics, snake_case (Lua) /
 camelCase (JS) only. `read`/`write`/`mmap` already parity; `stat`/`list` land in
 both at once. A parity E2E (the `tests/e2e_path_parity.sh` model, but over a real
 fixture tree because fs needs files) asserts Lua == JS for: `list` ordering +
-per-entry metadata, `stat` fields + symlink typing, `symlink_refused` on a
-symlinked component, and `outside_root` on an escaping path. Where a
-swapped-component TOCTOU is testable deterministically it is asserted; where it is
-inherently racy it is covered by construction (the `O_NOFOLLOW` walk) plus a
-unit test on the resolver.
+per-entry metadata, `stat` fields + symlink typing, an in-base symlink FOLLOWED
+identically for `read`, an absolute in-base symlink target re-rooted the same way,
+and `outside_root` on a symlink (or `..` chain) whose target escapes `base_dir`.
+Where a swapped-component TOCTOU is testable deterministically it is asserted;
+where it is inherently racy it is covered by construction (`openat2
+RESOLVE_IN_ROOT` / the held-fd walk) plus a unit test on the resolver.
 
 ## 8. Relationship to BuildContext (#393)
 
@@ -215,7 +239,7 @@ RECORDING + content hashing, and drops write. BuildContext.outputs adds the
 staging + atomic-publish (`rename`/`fsync`) that app `hull.fs` deliberately does
 NOT expose (§4.3). A build plugin never receives the general `hull.fs`.
 
-## 9. DECISION-FOR-REVIEW #2: resolver-migration sequencing
+## 9. DECISION-FOR-REVIEW (sole remaining): resolver-migration sequencing
 
 The audit (§6) said the app-`hull.fs` migration to the descriptor-relative
 resolver is a follow-up sequenced AFTER BuildContext proves the primitive.
@@ -235,8 +259,9 @@ Designing `hull.fs` first inverts that emphasis:
 Design only. No code, no binding changes, no resolver, no `stat`/`list`, no
 BuildContext, no plugin loader, no Query IR.
 
-1. **This design + the BuildContext audit (#393)** - STOP for review (resolve
-   DECISIONS #1 and #2).
+1. **This design + the BuildContext audit (#393)** - STOP for review. Symlink
+   policy (§5) is DECIDED (follow within base, contained); the sole remaining
+   decision is resolver-migration sequencing (§9).
 2. Implement the descriptor-relative resolver + harden `read`/`write`/`mmap` + add
    `stat`/`list`, with Lua/JS parity tests - STOP.
 3. `BuildContext.inputs` (declared reads + dependency hashing) - STOP.

--- a/docs/hull_fs_design.md
+++ b/docs/hull_fs_design.md
@@ -18,10 +18,19 @@ excess `..` clamped, `base_dir` a hard ceiling - NO "escape" error, because a
 virtual root makes escape impossible, not rejected); sequencing (§9) =
 **resolver-first** (fix the existing `realpath` TOCTOU + migrate the current
 surface before any plugin work). Everything else is a recommendation with
-rationale. This revision also corrects four review findings: the
-`RESOLVE_IN_ROOT`/`outside_root` contradiction (§3, §5, §6), the over-stated
-allowlist claim (§1.3, §6), the `write` implicit-parent-creation back-compat (§1.4,
-§4.1), and under-specified resolver result shapes (§3 mode table).
+rationale.
+
+This revision corrects SEVEN review findings across two rounds. Round 1: the
+`RESOLVE_IN_ROOT`/`outside_root` contradiction (§3/§5/§6), the over-stated
+allowlist claim (§1.3/§6), the `write` implicit-parent-creation back-compat
+(§1.4/§4.1), and under-specified resolver result shapes (§3 mode table). Round 2:
+(1) `WRITE` must also `O_TRUNC` to match today's truncating `fopen("wb")` (§3/§4.1,
+tested §7); (2) virtual-root is NOT behavior-preserving for ABSOLUTE symlink
+targets - now documented as an intentional compatibility change with a migration
+note (§2/§5/§9), not "unchanged behavior"; (3) path authorization must follow the
+RESOLVED path, not the caller path (`allowed/link -> ../secret`) - realized by
+rooting resolution at each authorized root so confinement IS authorization,
+race-free (§3/§6, tested §7).
 
 ## 1. Inventory - the CURRENT application `hull.fs` (verified, not assumed)
 
@@ -95,10 +104,14 @@ FUTURE API change (§4.3), not part of this prerequisite.
    not app `hull.fs`.
 5. **Lua/JS parity** across the whole app surface (the `hull.path` bar: mirrored
    semantics, snake_case vs camelCase only).
-6. **Backward-compatible semantics** - `read`/`write`/`mmap` keep their contracts
-   AND their observable behavior (symlink follow-within-base preserved, §5; `write`
-   still creates parent dirs, §4.1). Only the resolution MECHANISM hardens
-   (descriptor-relative instead of `realpath`).
+6. **Backward-compatible where it can be, with ONE documented exception.**
+   `read`/`write`/`mmap` keep their signatures; regular paths and RELATIVE
+   in-sandbox symlinks resolve exactly as today, and `write` still creates parent
+   dirs (§4.1). The ONE intentional compatibility change: ABSOLUTE symlink targets
+   are re-interpreted under the virtual root (§5) instead of as host-absolute paths
+   - `link -> /app/releases/1` no longer means the host path `/app/releases/1`. This
+   is called out as an intentional change (not "unchanged behavior") with a
+   migration note in §5; it affects only symlinks whose stored target is absolute.
 7. **Two distinct authorities** - ROOT CONFINEMENT (descriptor resolver keeps every
    op under `base_dir`) is separate from OPERATION/PATH AUTHORIZATION (which paths
    an app may read/write). The resolver provides the first; the second is an
@@ -137,16 +150,25 @@ and each mode's terminal syscall is issued relative to a held fd:
 | mode | terminal op | result | leaf symlink |
 |---|---|---|---|
 | `READ` / `MMAP` | open leaf `O_RDONLY` | leaf fd | FOLLOWED (contained) |
-| `WRITE` | mkdir-p parents (contained) + open leaf `O_WRONLY\|O_CREAT` | leaf fd | FOLLOWED (contained) |
+| `WRITE` | mkdir-p parents (contained) + open leaf `O_WRONLY\|O_CREAT\|O_TRUNC` | leaf fd | FOLLOWED (contained) |
 | `STAT` | `fstatat(parent_fd, leaf, AT_SYMLINK_NOFOLLOW)` | stat record | NOT followed (link-own) |
 | `LIST` | open dir `O_DIRECTORY` | dir fd | FOLLOWED (contained) |
 
 For `WRITE` and `STAT` the resolver walks to the leaf's PARENT fd (contained) and
 issues the create/stat relative to that held fd - the final component is never
-re-resolved from a path string, so there is no leaf race.
+re-resolved from a path string, so there is no leaf race. `WRITE` carries
+`O_TRUNC` because today's `fopen("wb")` truncates: overwriting `abcdef` with `xy`
+must yield `xy`, not `xycdef` (a shorter-replacement test is mandatory, §7).
+
+**The resolver is rooted at the AUTHORIZED ROOT, not always `base_dir`.** The root
+dirfd (`root_dfd` below) is the authorized `fs.read` / `fs.write` root that the
+caller path falls under (§6); when the app declares no granular roots, the
+authorized root IS `base_dir` (= today's confinement). Rooting resolution at the
+authorized root is what makes authorization race-free (§6): a symlink can only
+ever reach targets WITHIN the same root.
 
 **Implementations:**
-- **Linux >= 5.6:** `openat2(base_dfd, relpath, { flags, resolve: RESOLVE_IN_ROOT
+- **Linux >= 5.6:** `openat2(root_dfd, subpath, { flags, resolve: RESOLVE_IN_ROOT
   | RESOLVE_NO_MAGICLINKS })` for `READ`/`WRITE`/`LIST` leaf/dir opens (one
   race-free syscall; the returned fd IS the object). `WRITE` first mkdir-p's the
   parents (each `mkdirat` relative to a held, contained fd); `STAT` uses the
@@ -154,11 +176,11 @@ re-resolved from a path string, so there is no leaf race.
   blocks `/proc` magic-symlink escapes.
 - **Platforms without `openat2` (macOS, older Linux, cosmo where unavailable):** a
   manual walk reproducing `RESOLVE_IN_ROOT` EXACTLY. Hold a STACK of directory fds
-  rooted at `base_dfd`; each component `openat(top, comp, O_NOFOLLOW | O_DIRECTORY
+  rooted at `root_dfd`; each component `openat(top, comp, O_NOFOLLOW | O_DIRECTORY
   | O_CLOEXEC)`; when a component is a symlink (`ELOOP` / `fstatat` probe),
   `readlinkat` and SPLICE its target into the walk (ABSOLUTE target restarts at
-  `base_dfd` = re-root; RELATIVE continues from the current dir); a `..` component
-  POPS the fd stack, CLAMPED at `base_dfd` (never `openat(dfd, "..")`). Bound total
+  `root_dfd` = re-root; RELATIVE continues from the current dir); a `..` component
+  POPS the fd stack, CLAMPED at `root_dfd` (never `openat(dfd, "..")`). Bound total
   symlink expansions (e.g. 40, the kernel `ELOOP` limit) -> `symlink_loop`. Every
   step is relative to a HELD fd, so containment is structural and there is no
   TOCTOU window. The leaf is just the terminal component, handled per the mode
@@ -170,9 +192,13 @@ This is the userspace equivalent of what container runtimes settled on
 (`RESOLVE_IN_ROOT` / Go's `securejoin`): a hard virtual root, symlinks followed
 inside it.
 
-**Root confinement is NOT operation authorization.** The resolver guarantees only
-that every op stays under `base_dir`. WHICH paths an app may read/write is a
-separate policy (§6) - the resolver does not consult the manifest allowlist.
+**Confinement and authorization are UNIFIED by the root choice.** The resolver
+guarantees every op stays under `root_dfd`. By setting `root_dfd` to the
+applicable AUTHORIZED root (§6), that single guarantee delivers BOTH root
+confinement (the authorized root is always within `base_dir`) AND path
+authorization (the resolved object cannot leave the authorized root) - race-free,
+with no separate resolved-path re-check. The outer `base_dir` remains the ceiling
+for the no-granular-roots case.
 
 **Platform notes** (resolve at implementation): `openat2` is Linux-only (>= 5.6);
 confirm whether the Cosmopolitan target exposes it (raw syscall) or must use the
@@ -240,8 +266,10 @@ transactional staging + atomic-publication machinery stays in BuildContext.
 that resolve within `base_dir`.** Real apps rely on in-sandbox symlinks -
 atomic-deploy `current -> releases/N`, asset trees, config indirection - so
 refusing them would break legitimate layouts. The prior draft's deny-all
-recommendation is REJECTED. Preserving today's follow-within-base BEHAVIOR while
-fixing the TOCTOU (via §3, not `realpath`) is the chosen path.
+recommendation is REJECTED. The chosen path follows in-sandbox symlinks while
+fixing the TOCTOU (via §3, not `realpath`) - which preserves RELATIVE-symlink
+behavior exactly but INTENTIONALLY changes ABSOLUTE-symlink behavior (see the
+compatibility note below).
 
 Semantics = the **true virtual-root** model of §3 (chosen deliberately over a
 reject-escapes / `RESOLVE_BENEATH` model, which would conflict with re-rooting
@@ -262,11 +290,30 @@ absolute targets and could not use the one-call `RESOLVE_IN_ROOT` implementation
 - `stat` / `list` report a symlink's OWN type WITHOUT following (`lstat`
   semantics), so an app can enumerate links as links; only path RESOLUTION for
   `read`/`write`/`mmap` follows.
-- Guarantee vs today: SAME "follow within base" behavior, now enforced race-free
-  (no `realpath -> check -> open` window).
-
 Still NOT a lexical authorization - `hull.path` never authorizes; the `openat2` /
 descriptor walk is the confinement authority.
+
+**COMPATIBILITY CHANGE (intentional, not "unchanged behavior").** Virtual-root is
+behavior-preserving for regular paths and RELATIVE symlinks, but it CHANGES what an
+ABSOLUTE symlink target means. With `base_dir = /app`:
+
+| symlink target | today (`realpath`) | virtual-root (new) |
+|---|---|---|
+| `link -> releases/1` (relative) | `/app/releases/1` | `/app/releases/1` (same) |
+| `link -> /app/releases/1` (absolute, in base) | `/app/releases/1` (resolves) | `/app/app/releases/1` (re-rooted -> usually `not_found`) |
+| `link -> /outside/x` (absolute, out of base) | REJECTED | `/app/outside/x` (re-rooted, no longer an error) |
+
+So an absolute in-sandbox symlink that happened to include the `base_dir` prefix
+BREAKS, and an absolute symlink pointing outside is silently redirected inside
+rather than refused. This is an accepted consequence of the virtual-root decision,
+documented here rather than hidden.
+
+**Migration note.** In-root symlinks should use **sandbox-root-relative** targets
+(`/releases/1`, which under the virtual root means `base_dir/releases/1`) or
+**relative** targets (`releases/1`), NOT host-absolute targets that embed
+`base_dir` (`/app/releases/1`). Checkpoint 1 includes an audit for absolute
+symlink targets inside app trees + this migration guidance in the release notes.
+Affected surface is narrow: only symlinks whose STORED target string is absolute.
 
 ## 6. Two authorities: root confinement vs path authorization
 
@@ -280,20 +327,38 @@ No manifest input.
 **(b) Operation / path authorization** - WHICH paths an app may read vs write.
 Today this is materialized by the KERNEL SANDBOX (unveil / seatbelt) from the
 manifest `fs.read` / `fs.write` roots; `HlFsConfig` / `hl_cap_fs_validate` do NOT
-carry or check per-path lists (§1.3). Two design implications:
+carry or check per-path lists (§1.3).
 
-- **`stat` / `list` must respect the READ roots, not merely `base_dir`.** A file
-  inside `base_dir` but OUTSIDE the declared `fs.read` roots must not have its
-  metadata or directory entries exposed - otherwise the new ops leak more than
-  `read` does. Since the cap layer has no path policy today, this design must add
-  an EXPLICIT policy object (the resolved `fs.read` / `fs.write` root sets) that
-  `stat`/`list`/`read`/`write` consult at the cap layer, layered ON TOP of root
-  confinement. Whether the policy lives in an extended `HlFsConfig` or a separate
-  `HlFsPolicy` is an implementation detail resolved at checkpoint 2; the design
-  REQUIREMENT is that path authorization is an explicit, cap-layer-checked policy,
-  not an accident of what the kernel sandbox happens to block.
-- Kernel-sandbox enforcement remains as defense-in-depth beneath the explicit
-  policy, not the sole gate for the new read-side surface.
+**The rule (chosen): authority follows the RESOLVED path, enforced by
+CONFINEMENT.** A lexical check on the CALLER path is insufficient - consider
+`allowed/link -> ../secret` where `allowed/` is a declared read root and `secret`
+is not: authorizing on the caller path `allowed/link` would grant an object
+OUTSIDE the read root. So authorization must bind the RESOLVED target, race-free.
+The design achieves that WITHOUT a separate (racy) resolved-path re-check by
+**modelling each authorized root as a resolver root** (§3): open each declared
+`fs.read` / `fs.write` root once as a held `root_dfd` at config time, and resolve
+an op's caller path WITHIN the root it falls under. Then virtual-root confinement
+makes the resolved object structurally unable to leave that root -
+`allowed/link -> ../secret` CLAMPS to `allowed/secret` (never `secret`), so the
+symlink cannot smuggle authority out. Selecting WHICH root a caller path falls
+under is a lexical prefix match (that only picks the root; the resolution then
+enforces it); a path under no authorized root -> `permission`.
+
+This is the user-recommended option (authority-follows-resolved-path) realized via
+the one-call `openat2(root_dfd, ...)` / rooted manual walk - the resolver root IS
+the policy evidence, so the cap layer has INDEPENDENT, race-free authorization.
+Consequences:
+- **`stat` / `list` respect the READ roots, not merely `base_dir`** - they resolve
+  within a read root like `read` does, so metadata / directory entries inside
+  `base_dir` but outside the declared read roots are never exposed.
+- The explicit policy object is the SET OF ROOT DIRFDS (an extended `HlFsConfig`
+  or a separate `HlFsPolicy`; implementation detail at checkpoint 2), NOT a list of
+  path strings re-checked per call.
+- The KERNEL SANDBOX remains as defense-in-depth BENEATH this, but is no longer the
+  sole authorization gate for the new surface.
+- The rejected alternative - "a symlink under an authorized root conveys authority
+  to its contained target" - is NOT adopted: authority is bound to the root, and a
+  link that would resolve outside it is clamped, not honored.
 
 **Error model (proposed, stable tokens).** Uniform `(nil, err)` (Lua) / `throw`
 (JS): `"invalid_path"` (caller path absolute or containing `..` - lexical
@@ -313,11 +378,14 @@ per-entry metadata, `stat` fields + symlink typing (link reported as link), an
 in-base symlink FOLLOWED identically for `read`, an absolute symlink target
 RE-ROOTED at `base_dir` the same way, a `foo -> ../../../x` target CLAMPED to
 `base_dir/x` the same way (NOT an error, per §5), `invalid_path` on a caller path
-with `..`, and a `symlink_loop` cycle bounded identically. A dedicated resolver
-unit test proves virtual-root parity between the `openat2` and manual-walk paths
-on the same fixture tree (Linux runs BOTH to catch drift), and covers a
-swapped-component TOCTOU by construction (held-fd walk) with a deterministic case
-where testable.
+with `..`, a `symlink_loop` cycle bounded identically, a WRITE that OVERWRITES
+longer content with shorter (`abcdef` -> `xy` yields `xy`, proving `O_TRUNC`,
+correction 1), and the authorization case `allowed/link -> ../secret` resolving to
+`allowed/secret` / `not_found` rather than reaching an unauthorized `secret`
+(correction 3). A dedicated resolver unit test proves virtual-root parity between
+the `openat2` and manual-walk paths on the same fixture tree (Linux runs BOTH to
+catch drift), and covers a swapped-component TOCTOU by construction (held-fd walk)
+with a deterministic case where testable.
 
 ## 8. Relationship to BuildContext (#393)
 
@@ -346,8 +414,10 @@ most-used surface rather than proving it first on a new, less-exercised one.
 Ratified ordering:
 1. **Land the resolver and migrate existing `read`/`write`/`mmap` first** - onto
    the §3 virtual-root resolver (write keeps implicit parent creation, now
-   `mkdirat`-based). No new app ops yet; this is purely the TOCTOU fix +
-   behavior-preserving migration.
+   `mkdirat`-based, and `O_TRUNC`). No new app ops yet; this is the TOCTOU fix +
+   migration, behavior-preserving EXCEPT the intentional absolute-symlink
+   re-rooting (§5), which ships with the migration note + an absolute-symlink
+   audit.
 2. **STOP and prove** platform parity (`openat2` path == manual walk) AND
    race-resistant symlink behavior (virtual-root follow, re-root, clamp, loop
    bound) on the fixture tree + resolver unit tests.
@@ -366,8 +436,9 @@ Checkpoints mirror the §9 ratified ordering; every arrow is a STOP-for-review:
 0. **This design + the BuildContext audit (#393)** - STOP for review. Both
    decisions are now settled: symlink policy = virtual-root follow (§5),
    sequencing = resolver-first (§9). Nothing else is open.
-1. Land the resolver + migrate `read`/`write`/`mmap` (TOCTOU fix, behavior
-   preserved) - STOP.
+1. Land the resolver + migrate `read`/`write`/`mmap` (TOCTOU fix; `O_TRUNC` +
+   implicit parents preserved; the one intentional change = absolute-symlink
+   re-rooting, §5, shipped with a migration note) - STOP.
 2. Prove platform parity + race-resistant symlink behavior - STOP.
 3. Add `stat`/`list` + the path-authorization policy (§6), Lua/JS parity - STOP.
 4. `BuildContext.inputs` then `BuildContext.outputs` - STOP. Then Build Plugin /

--- a/docs/hull_fs_design.md
+++ b/docs/hull_fs_design.md
@@ -1,0 +1,244 @@
+# hull.fs application design (design-only)
+
+Status: **DESIGN (awaiting review). NOTHING implemented.** This is the dedicated
+design of the APPLICATION-facing `hull.fs` capability - the general filesystem
+surface an app author uses. It is a peer of, and a PREREQUISITE for, the
+BuildContext audit ([hull_fs_buildcontext_audit.md](hull_fs_buildcontext_audit.md),
+PR #393): BuildContext is the narrower, Hull-owned plugin surface built ON the
+hardened primitives designed here - so `hull.fs` is designed first.
+
+Design rule carried in from `hull.path` (#392, #394): **`hull.path` manipulates
+NAMES lexically; `hull.fs` exercises AUTHORITY.** `hull.fs` is where real
+filesystem containment is enforced against the RESOLVED object - never by lexical
+checks alone.
+
+Two DECISIONS-FOR-REVIEW are flagged inline (§5, §9). They are the load-bearing
+choices; the review is their decision forum. Everything else is a recommendation
+with rationale.
+
+## 1. Inventory - the CURRENT application `hull.fs` (verified, not assumed)
+
+### 1.1 What app code can actually call today
+
+Both runtimes expose EXACTLY three operations plus the mapped-buffer methods:
+
+| app op | Lua | JS | backing cap |
+|---|---|---|---|
+| read a file | `fs.read(path)` | `fs.read(path)` | `hl_cap_fs_read` |
+| write a file | `fs.write(path, bytes)` | `fs.write(path, bytes)` | `hl_cap_fs_write` |
+| memory-map (zero-copy RO window) | `fs.mmap(path[, {offset,length}])` | `fs.mmap(path[, {offset,length}])` | `hl_cap_fs_mmap` / `_mmap_window` |
+| mapped-buffer size / release | `buf:len()` / `buf:close()` | `buf.len()` / `buf.close()` | `_munmap` / `_borrow` / `_release` |
+
+Bindings: `src/hull/runtime/lua/mod_fs.c` (the `luaL_Reg` is `read`/`write`/`mmap`
++ `len`/`close`), `src/hull/runtime/js/mod_fs.c` (`read`/`write`/`mmap`).
+
+### 1.2 Correction to the BuildContext audit's inventory
+
+The audit (§1.2) listed the app surface as "read, write, exists, delete, mmap."
+That is the **cap layer**, not the app surface. `hl_cap_fs_exists` and
+`hl_cap_fs_delete` DO exist in `include/hull/cap/fs.h`, but **neither is exposed
+as an app binding** in either runtime today. So the real application surface is
+even smaller: **read / write / mmap only.** There is NO enumeration, NO
+stat/metadata, NO exists probe, NO delete, NO rename/copy/mkdir at the app level.
+
+### 1.3 Authority model (unchanged, still correct)
+
+Two independent gates: a build-time module gate (`hull/fs@1`) and a per-call
+capability gate. `hl_cap_fs_validate` enforces the manifest `fs.read` / `fs.write`
+allowlists + containment under `base_dir`.
+
+### 1.4 The load-bearing finding (same as the audit): resolution is TOCTOU-susceptible
+
+`hl_cap_fs_validate` resolves with **`realpath()`** (three call sites in
+`src/hull/cap/fs.c`) and the actual `open`/`read`/`write` happens later:
+`realpath -> check -> open`. Between the check and the open a path component can be
+swapped (a directory replaced by a symlink), so the check does not bind the
+`open` target. In-tree precedent for the fix already exists:
+`src/hull/shared/blob_store.c` opens with `O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC`.
+
+## 2. Design goals
+
+1. **Race-resistant resolution** - replace `realpath -> check -> open` with a
+   descriptor-relative walk so the authority check binds the object actually
+   opened.
+2. **Deterministic enumeration + metadata** - add `list` and `stat`, the minimum
+   an app (or later a build) needs to discover and describe files.
+3. **Explicit, safe symlink policy** (DECISION, §5).
+4. **Keep the surface deliberately SMALL** - Hull's convention is to reach for
+   stdlib / composition before widening a C capability. Conveniences
+   (copy/rename/mkdir/atomic-write/tempfile) are enumerated as candidates in §4.3
+   but are NOT added by default; several belong to the Hull-owned BuildContext,
+   not app `hull.fs`.
+5. **Lua/JS parity** across the whole app surface (the `hull.path` bar: mirrored
+   semantics, snake_case vs camelCase only).
+6. **Backward-compatible semantics** - `read`/`write`/`mmap` keep their contracts;
+   only the resolution MECHANISM hardens and the symlink behavior tightens (§5),
+   both documented.
+
+## 3. Resolution model (the shared foundation)
+
+A single descriptor-relative resolver underpins every `hull.fs` op AND (later)
+BuildContext:
+
+- Lexically pre-validate the caller's path with `hull.path` (reject absolute,
+  reject any `..`) BEFORE touching the disk. This is a fast fail, NOT the
+  authority.
+- Open the configured `base_dir` once as a directory fd (`O_DIRECTORY |
+  O_NOFOLLOW | O_CLOEXEC`).
+- Walk the relative path ONE COMPONENT at a time: interior components with
+  `openat(dfd, comp, O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)`; the leaf with
+  `openat(dfd, leaf, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)` (or
+  `O_WRONLY | O_CREAT | O_NOFOLLOW` for writes). Because each step is relative to
+  a fd itself opened `O_NOFOLLOW`, containment is enforced against the object
+  actually opened - there is no resolve-then-open window, and a swapped or
+  symlinked component is REFUSED, not silently followed.
+- The manifest `fs.read` / `fs.write` allowlist is still enforced, now against the
+  lexically-normalized relative path (which the descriptor walk proves is the real
+  target), not a pre-open `realpath` string.
+
+**Platform notes** (resolve at implementation, same as the audit): `openat` /
+`O_NOFOLLOW` / `O_DIRECTORY` are POSIX (Linux, macOS, Cosmopolitan shim). macOS
+`O_NOFOLLOW` fails only on a TRAILING symlink - the component-wise walk makes
+every component a trailing check, so the guarantee holds uniformly. A native
+Windows target (not today's cosmo APE) needs the reparse-point-aware equivalent;
+scope that when such a target exists. Where a platform cannot offer a
+race-resistant primitive, the op **fails closed** - it must never downgrade to
+`realpath`.
+
+## 4. Operations
+
+### 4.1 Existing, hardened (no signature change)
+- `fs.read(path)` -> bytes | (nil,err) / throw. Now resolved per §3; `fs.read`
+  authority.
+- `fs.write(path, bytes)` -> true | (nil,err) / throw. Resolved per §3; `fs.write`
+  authority. (Parent-dir creation is NOT implicit - see §4.3 `mkdir`.)
+- `fs.mmap(path[, window])` -> MappedBuffer. Resolved per §3 for the initial open;
+  the mapping's lifetime semantics are unchanged (refcounted borrow, `close`
+  defers `munmap` while a borrower is alive).
+
+### 4.2 New (the minimal additions this design proposes)
+
+**`fs.stat(path)` -> metadata | nil**
+- Returns `{ type, size, mode, mtime }` where `type` is one of `"file"`,
+  `"dir"`, `"symlink"`, `"other"`. `mode` is the permission bits; `mtime` is
+  exposed but carries a policy note: reproducible builds MUST NOT key on it (that
+  is the BuildContext content-hash policy, audit §3.4). Returns `nil` (Lua) /
+  `null` (JS) for a non-existent path - so `stat(p) ~= nil` SUBSUMES a separate
+  `exists` probe.
+- Implemented with `fstatat(parent_dfd, leaf, AT_SYMLINK_NOFOLLOW)` off the §3
+  walk, so it reports a symlink AS a symlink WITHOUT following it (`lstat`
+  semantics). Requires `fs.read` authority over the target.
+
+**`fs.list(dir)` -> entries**
+- Returns a **deterministically ordered** (byte-wise sort of `name`) array of
+  `{ name, type, size }`. `.` and `..` are omitted; no entry escapes `dir`.
+  `fdopendir` on a `dirfd` opened per §3. **Non-recursive** by design - an app
+  composes recursion with `hull.path.join` + `fs.list`; a recursive walker is
+  stdlib/BuildContext territory, not a C primitive. Requires `fs.read` authority
+  over `dir`.
+
+`exists` is deliberately NOT added as a distinct op - `stat(p) ~= nil` covers it
+without a second cap surface that could disagree with `stat` about symlinks.
+
+### 4.3 Candidates DEFERRED (enumerated, with rationale - none added in v1)
+
+| candidate | why deferred |
+|---|---|
+| `delete` | Exists at the cap layer, unexposed today. A mutation with real blast radius; add only when a concrete app need appears, and gate on `fs.write`. Not needed for enumeration/hardening. |
+| `mkdir` | App authors rarely need directory creation; when they do it is usually part of a WRITE that BuildContext should own transactionally. Keep `write` non-implicit-mkdir for now. |
+| `copy` / `rename` / `move` | `rename` is the ATOMIC-PUBLISH primitive - it belongs to the Hull-owned BuildContext.outputs (audit §3.5), NOT general app `hull.fs`, precisely so staging/publication authority stays separate. |
+| `atomic write` / `tempfile` | Same: transactional staging + atomic publication is a BuildContext concern by the audit's HARD boundary; exposing it on app `hull.fs` would blur the two authorities. |
+
+The through-line: `hull.fs` gets read-side hardening + discovery (stat/list); the
+WRITE-side transactional machinery stays in BuildContext.
+
+## 5. DECISION-FOR-REVIEW #1: symlink policy on the APP surface
+
+Today's `realpath`-based validate **follows** symlinks and then checks the
+resolved target is under `base_dir` - so an in-sandbox symlink pointing to
+another in-sandbox file is transparently followed. The §3 descriptor walk
+(`O_NOFOLLOW` every component) **refuses any symlink anywhere in the path**. That
+is a behavior change for existing apps.
+
+- **Recommended: deny-all (tighten).** Refuse a symlink at any component;
+  `stat`/`list` report symlinks by type without following. Rationale: it makes
+  the app surface and the plugin BuildContext share ONE symlink rule, it is the
+  strictly safer default, and it removes an entire class of confused-deputy /
+  swap-during-resolution risk. Document it as an intentional tightening; add an
+  explicit opt-in follow ONLY if a concrete app need surfaces (default deny).
+- **Alternative: preserve follow-within-base.** Keep today's "follow, then
+  require the resolved object under `base_dir`" semantics, but implement it
+  race-resistantly (resolve each symlink target via a fresh descriptor walk and
+  re-verify containment at each hop). More code, keeps back-compat, weaker
+  invariant.
+
+This is the review's call because it trades a (likely small) back-compat surface
+for a materially simpler and safer model.
+
+## 6. Capability + manifest integration
+
+Gates unchanged in shape: build-time `hull/fs@1` module gate + per-call
+allowlist. New ops require `fs.read` authority over their target (`stat` and
+`list` are reads of metadata / directory contents). No new manifest section.
+
+**Error model (proposed, stable tokens).** Uniform `(nil, err)` (Lua) / `throw`
+(JS) with a small closed set of tokens so app code can branch:
+`"not_found"`, `"permission"` (allowlist / mode), `"not_a_directory"`,
+`"is_a_directory"`, `"symlink_refused"`, `"outside_root"`, `"too_large"`,
+`"io_error"`. (The exact tokens are confirmed at implementation; today's messages
+are not a stable contract.)
+
+## 7. Lua/JS parity
+
+Every application op has both bindings, mirrored semantics, snake_case (Lua) /
+camelCase (JS) only. `read`/`write`/`mmap` already parity; `stat`/`list` land in
+both at once. A parity E2E (the `tests/e2e_path_parity.sh` model, but over a real
+fixture tree because fs needs files) asserts Lua == JS for: `list` ordering +
+per-entry metadata, `stat` fields + symlink typing, `symlink_refused` on a
+symlinked component, and `outside_root` on an escaping path. Where a
+swapped-component TOCTOU is testable deterministically it is asserted; where it is
+inherently racy it is covered by construction (the `O_NOFOLLOW` walk) plus a
+unit test on the resolver.
+
+## 8. Relationship to BuildContext (#393)
+
+Same descriptor-relative resolver + `stat`/`list` primitives underpin both
+surfaces; this design PROVIDES them.
+
+| surface | who | authority | ops |
+|---|---|---|---|
+| **application `hull.fs`** | app code | manifest `fs.read`/`fs.write` + `base_dir` | read / write / mmap / stat / list |
+| **plugin `BuildContext`** | Hull-owned, handed to a plugin | declared input roots + a private staging root; NARROWER | inputs: read / stat / list (recorded + hashed); outputs: staged write + atomic publish |
+
+BuildContext.inputs reuses this design's resolver + `stat`/`list`, adds read
+RECORDING + content hashing, and drops write. BuildContext.outputs adds the
+staging + atomic-publish (`rename`/`fsync`) that app `hull.fs` deliberately does
+NOT expose (§4.3). A build plugin never receives the general `hull.fs`.
+
+## 9. DECISION-FOR-REVIEW #2: resolver-migration sequencing
+
+The audit (§6) said the app-`hull.fs` migration to the descriptor-relative
+resolver is a follow-up sequenced AFTER BuildContext proves the primitive.
+Designing `hull.fs` first inverts that emphasis:
+
+- **Recommended: resolver lands as the app-fs foundation FIRST.** Harden
+  `read`/`write`/`mmap` + add `stat`/`list` on the descriptor-relative resolver as
+  checkpoint 1; BuildContext (checkpoints 3-4) then builds on a primitive already
+  proven in production by the app surface. This SUPERSEDES the audit's ordering.
+- **Alternative: keep the audit's order.** Implement the resolver inside
+  BuildContext first, migrate app `hull.fs` afterward. Keeps the app surface
+  untouched longer, but ships the same TOCTOU one release longer and duplicates
+  validation.
+
+## 10. Non-scope + checkpoints
+
+Design only. No code, no binding changes, no resolver, no `stat`/`list`, no
+BuildContext, no plugin loader, no Query IR.
+
+1. **This design + the BuildContext audit (#393)** - STOP for review (resolve
+   DECISIONS #1 and #2).
+2. Implement the descriptor-relative resolver + harden `read`/`write`/`mmap` + add
+   `stat`/`list`, with Lua/JS parity tests - STOP.
+3. `BuildContext.inputs` (declared reads + dependency hashing) - STOP.
+4. `BuildContext.outputs` (transactional staging + atomic publish) - STOP. Then
+   Build Plugin / BuildArtifact. **Not Query IR yet.**

--- a/docs/hull_fs_design.md
+++ b/docs/hull_fs_design.md
@@ -29,8 +29,13 @@ tested §7); (2) virtual-root is NOT behavior-preserving for ABSOLUTE symlink
 targets - now documented as an intentional compatibility change with a migration
 note (§2/§5/§9), not "unchanged behavior"; (3) path authorization must follow the
 RESOLVED path, not the caller path (`allowed/link -> ../secret`) - realized by
-rooting resolution at each authorized root so confinement IS authorization,
-race-free (§3/§6, tested §7).
+rooting resolution at the authorized grant so confinement IS authorization,
+race-free (§3/§6, tested §7). Round 3: a manifest grant is not necessarily an
+existing directory (Hull grants exact files and not-yet-existing write targets),
+so §6 now compiles grants into AUTHORIZATION ENTRIES (held anchor dir fd + a
+`SUBTREE`/`EXACT`/`CREATE` constraint), with deterministic most-specific selection,
+independent read/write sets, and an explicit symlink rule so an exact-file grant
+never becomes sibling-directory authority.
 
 ## 1. Inventory - the CURRENT application `hull.fs` (verified, not assumed)
 
@@ -160,12 +165,15 @@ re-resolved from a path string, so there is no leaf race. `WRITE` carries
 `O_TRUNC` because today's `fopen("wb")` truncates: overwriting `abcdef` with `xy`
 must yield `xy`, not `xycdef` (a shorter-replacement test is mandatory, §7).
 
-**The resolver is rooted at the AUTHORIZED ROOT, not always `base_dir`.** The root
-dirfd (`root_dfd` below) is the authorized `fs.read` / `fs.write` root that the
-caller path falls under (§6); when the app declares no granular roots, the
-authorized root IS `base_dir` (= today's confinement). Rooting resolution at the
-authorized root is what makes authorization race-free (§6): a symlink can only
-ever reach targets WITHIN the same root.
+**The resolver is rooted at the SELECTED grant's anchor, not always `base_dir`.**
+`root_dfd` below is the held ANCHOR fd of the compiled authorization entry the
+caller path selects (§6) - an existing-directory grant's own fd (`SUBTREE`), an
+exact-file grant's PARENT fd (`EXACT`, terminal-name-constrained), or a
+not-yet-existing target's nearest-existing-ancestor fd (`CREATE`, component-
+constrained). When the app declares no granular grants, the anchor IS `base_dir`
+(= today's confinement). Rooting resolution at the anchor + applying the entry's
+constraint is what makes authorization race-free (§6). The mode table below
+describes the terminal op; §6 defines which anchor/constraint applies.
 
 **Implementations:**
 - **Linux >= 5.6:** `openat2(root_dfd, subpath, { flags, resolve: RESOLVE_IN_ROOT
@@ -330,35 +338,65 @@ manifest `fs.read` / `fs.write` roots; `HlFsConfig` / `hl_cap_fs_validate` do NO
 carry or check per-path lists (§1.3).
 
 **The rule (chosen): authority follows the RESOLVED path, enforced by
-CONFINEMENT.** A lexical check on the CALLER path is insufficient - consider
-`allowed/link -> ../secret` where `allowed/` is a declared read root and `secret`
-is not: authorizing on the caller path `allowed/link` would grant an object
-OUTSIDE the read root. So authorization must bind the RESOLVED target, race-free.
-The design achieves that WITHOUT a separate (racy) resolved-path re-check by
-**modelling each authorized root as a resolver root** (§3): open each declared
-`fs.read` / `fs.write` root once as a held `root_dfd` at config time, and resolve
-an op's caller path WITHIN the root it falls under. Then virtual-root confinement
-makes the resolved object structurally unable to leave that root -
-`allowed/link -> ../secret` CLAMPS to `allowed/secret` (never `secret`), so the
-symlink cannot smuggle authority out. Selecting WHICH root a caller path falls
-under is a lexical prefix match (that only picks the root; the resolution then
-enforces it); a path under no authorized root -> `permission`.
+CONFINEMENT** - but a manifest grant is NOT necessarily an existing directory, so
+"each authorized root is a dirfd" is too narrow. Hull grants exact files
+(`fs.read = {"data.bin"}`, `{"huge.bin"}`) and write targets that do not exist yet
+(`fs.write` may name `out/result.bin` with `out/` absent, which `write` must
+create). Each grant is therefore COMPILED at config time into an
+**authorization entry** = a HELD anchor dir fd (always an EXISTING directory) plus
+a CONSTRAINT. Three entry kinds:
 
-This is the user-recommended option (authority-follows-resolved-path) realized via
-the one-call `openat2(root_dfd, ...)` / rooted manual walk - the resolver root IS
-the policy evidence, so the cap layer has INDEPENDENT, race-free authorization.
-Consequences:
-- **`stat` / `list` respect the READ roots, not merely `base_dir`** - they resolve
-  within a read root like `read` does, so metadata / directory entries inside
-  `base_dir` but outside the declared read roots are never exposed.
-- The explicit policy object is the SET OF ROOT DIRFDS (an extended `HlFsConfig`
-  or a separate `HlFsPolicy`; implementation detail at checkpoint 2), NOT a list of
-  path strings re-checked per call.
-- The KERNEL SANDBOX remains as defense-in-depth BENEATH this, but is no longer the
+| grant | compiled entry | permits |
+|---|---|---|
+| **existing directory** (`data/`) | `anchor_fd = open(data, O_DIRECTORY\|O_NOFOLLOW)`; constraint = `SUBTREE` | virtual-root resolution rooted at `anchor_fd`; any descendant. Symlinks clamp WITHIN the subtree (§3/§5), so they cannot leave it. |
+| **exact file** (`data.bin`) | `anchor_fd = open(dirname, O_DIRECTORY)`; constraint = `EXACT("data.bin")` | ONLY `openat(anchor_fd, "data.bin", ...)` - the one leaf. Siblings are unreachable (no subtree traversal is granted; the exact leaf name is a literal). |
+| **not-yet-existing target** (`out/result.bin`, `out/` absent) | anchor at the NEAREST EXISTING ANCESTOR (`open(".", O_DIRECTORY)`) + constraint = `CREATE(["out","result.bin"], kind)` where kind is exact-file or subtree | `mkdirat` ONLY the constrained intermediate components (`out`) relative to `anchor_fd`, then create the terminal (`result.bin`, `O_TRUNC`). `out/other.bin` is denied (terminal is exactly `result.bin`). |
+
+**Selection is deterministic and component-aware.** `fs.read` and `fs.write`
+compile to two INDEPENDENT entry sets (a readable path need not be writable, and
+vice versa) - a `read`/`mmap`/`stat`/`list` op selects from the READ set, a
+`write` op from the WRITE set. When a caller path matches several entries, the
+MOST SPECIFIC (deepest component-prefix) wins - grants `data/` and `data/private/`
+select `data/private/` for a path beneath it. Matching is component-aware
+(`data` never matches `database`). A caller path matching NO entry in the relevant
+set -> `permission`. Because the terminal syscall is issued relative to the held
+anchor fd (§3 mode table), selection + confinement are race-free with no separate
+resolved-path re-check.
+
+**Symlinks never widen a non-subtree grant.** Under an `EXACT` (or `CREATE`) entry
+there is no granted subtree to clamp within, so a symlink at the exact target does
+NOT inherit that entry's authority: its resolved target is RE-EVALUATED against the
+full policy and permitted only if it independently matches some grant (resolved
+within THAT grant). `link.bin -> secret.bin` under an exact grant for `link.bin`
+CANNOT reach `secret.bin` unless `secret.bin` is itself granted - an exact-file
+grant never becomes sibling-directory authority. (Under a `SUBTREE` entry the
+symlink instead clamps within the subtree per §5, which already cannot escape.)
+
+**Acceptance cases (must pass, checkpoint 2):**
+```
+read grant  data.bin:            data.bin -> allowed;  sibling.bin -> denied
+write grant out/result.bin (out/ absent):
+                                 out/ created;  result.bin created+truncated;
+                                 out/other.bin -> denied
+grants      data/ and data/private/:   most-specific (data/private/) selected
+exact grant link.bin -> secret.bin:    secret.bin unreachable unless independently granted
+```
+
+This is the user-recommended option (authority-follows-resolved-path) generalized
+to Hull's real manifest contract. Consequences:
+- **`stat` / `list` respect the READ set, not merely `base_dir`** - they select +
+  resolve within a read entry like `read` does, so metadata / directory entries
+  inside `base_dir` but outside the granted read paths are never exposed.
+- The explicit policy object is the two SETS OF COMPILED ENTRIES (anchor fd +
+  constraint), held on an extended `HlFsConfig` or a separate `HlFsPolicy`
+  (implementation detail, checkpoint 2) - NOT a list of path strings re-checked per
+  call, and NOT an assumption that grants are directories.
+- The KERNEL SANDBOX remains defense-in-depth BENEATH this, but is no longer the
   sole authorization gate for the new surface.
-- The rejected alternative - "a symlink under an authorized root conveys authority
-  to its contained target" - is NOT adopted: authority is bound to the root, and a
-  link that would resolve outside it is clamped, not honored.
+- **Anchoring edge cases** (checkpoint 2): a `CREATE` anchor whose nearest existing
+  ancestor is removed/replaced between config and op fails closed; an intermediate
+  component that exists but is a non-directory or an unexpected symlink under a
+  `CREATE`/`EXACT` entry is refused, never traversed.
 
 **Error model (proposed, stable tokens).** Uniform `(nil, err)` (Lua) / `throw`
 (JS): `"invalid_path"` (caller path absolute or containing `..` - lexical
@@ -382,7 +420,12 @@ with `..`, a `symlink_loop` cycle bounded identically, a WRITE that OVERWRITES
 longer content with shorter (`abcdef` -> `xy` yields `xy`, proving `O_TRUNC`,
 correction 1), and the authorization case `allowed/link -> ../secret` resolving to
 `allowed/secret` / `not_found` rather than reaching an unauthorized `secret`
-(correction 3). A dedicated resolver unit test proves virtual-root parity between
+(correction 3), and the §6 authorization-entry acceptance cases (exact-file grant
+allows the file but denies a sibling; a `CREATE` write grant creates `out/` +
+truncates `result.bin` but denies `out/other.bin`; overlapping `data/` +
+`data/private/` select most-specific; an exact grant `link.bin -> secret.bin`
+cannot reach `secret.bin` unless independently granted). A dedicated resolver unit
+test proves virtual-root parity between
 the `openat2` and manual-walk paths on the same fixture tree (Linux runs BOTH to
 catch drift), and covers a swapped-component TOCTOU by construction (held-fd walk)
 with a deterministic case where testable.
@@ -413,16 +456,21 @@ most-used surface rather than proving it first on a new, less-exercised one.
 
 Ratified ordering:
 1. **Land the resolver and migrate existing `read`/`write`/`mmap` first** - onto
-   the §3 virtual-root resolver (write keeps implicit parent creation, now
-   `mkdirat`-based, and `O_TRUNC`). No new app ops yet; this is the TOCTOU fix +
+   the §3 virtual-root resolver, anchored at `base_dir` (the no-granular-grants
+   case), so today's authorization model (base_dir confinement + kernel sandbox) is
+   PRESERVED. Write keeps implicit parent creation (now `mkdirat`-based) and
+   `O_TRUNC`. No new app ops, no compiled-entry policy yet; this is the TOCTOU fix +
    migration, behavior-preserving EXCEPT the intentional absolute-symlink
-   re-rooting (§5), which ships with the migration note + an absolute-symlink
-   audit.
+   re-rooting (§5), which ships with the migration note + an absolute-symlink audit.
 2. **STOP and prove** platform parity (`openat2` path == manual walk) AND
    race-resistant symlink behavior (virtual-root follow, re-root, clamp, loop
    bound) on the fixture tree + resolver unit tests.
-3. **Add application `stat` / `list`** (with the §6 path-authorization policy so
-   they respect READ roots, not merely `base_dir`) - Lua/JS parity - STOP.
+3. **Add the §6 compiled-entry authorization policy + application `stat` / `list`.**
+   The policy (SUBTREE/EXACT/CREATE entries, independent read/write sets,
+   most-specific selection, exact-file symlink rule) lands HERE, because `stat`/
+   `list` are the new metadata-leak surface that requires it; `read`/`write`/`mmap`
+   adopt the same per-grant anchoring at this point. Lua/JS parity; the §6
+   acceptance cases pass - STOP.
 4. **Then `BuildContext.inputs` and `BuildContext.outputs`** on the proven
    primitive. Then Build Plugin / BuildArtifact. **Not Query IR yet.**
 
@@ -440,6 +488,8 @@ Checkpoints mirror the §9 ratified ordering; every arrow is a STOP-for-review:
    implicit parents preserved; the one intentional change = absolute-symlink
    re-rooting, §5, shipped with a migration note) - STOP.
 2. Prove platform parity + race-resistant symlink behavior - STOP.
-3. Add `stat`/`list` + the path-authorization policy (§6), Lua/JS parity - STOP.
+3. Add the §6 compiled-entry authorization policy (SUBTREE/EXACT/CREATE,
+   independent read/write sets, most-specific selection, exact-file symlink rule)
+   + `stat`/`list`, Lua/JS parity, §6 acceptance cases pass - STOP.
 4. `BuildContext.inputs` then `BuildContext.outputs` - STOP. Then Build Plugin /
    BuildArtifact. **Not Query IR yet.**

--- a/docs/hull_fs_design.md
+++ b/docs/hull_fs_design.md
@@ -34,8 +34,11 @@ race-free (§3/§6, tested §7). Round 3: a manifest grant is not necessarily an
 existing directory (Hull grants exact files and not-yet-existing write targets),
 so §6 now compiles grants into AUTHORIZATION ENTRIES (held anchor dir fd + a
 `SUBTREE`/`EXACT`/`CREATE` constraint), with deterministic most-specific selection,
-independent read/write sets, and an explicit symlink rule so an exact-file grant
-never becomes sibling-directory authority.
+independent read/write sets, and a per-kind symlink rule: `SUBTREE` follows
+symlinks (virtual-root confined), `EXACT`/`CREATE` REFUSE any symlink
+(`symlink_denied`) - so an exact-file grant never becomes sibling-directory
+authority and needs no race-prone cross-policy symlink resolution. An independently
+granted target is reached via its own grant, not through an exact-file alias.
 
 ## 1. Inventory - the CURRENT application `hull.fs` (verified, not assumed)
 
@@ -158,6 +161,10 @@ and each mode's terminal syscall is issued relative to a held fd:
 | `WRITE` | mkdir-p parents (contained) + open leaf `O_WRONLY\|O_CREAT\|O_TRUNC` | leaf fd | FOLLOWED (contained) |
 | `STAT` | `fstatat(parent_fd, leaf, AT_SYMLINK_NOFOLLOW)` | stat record | NOT followed (link-own) |
 | `LIST` | open dir `O_DIRECTORY` | dir fd | FOLLOWED (contained) |
+
+The "leaf symlink FOLLOWED" column applies under a `SUBTREE` grant (§6). Under an
+`EXACT` or `CREATE` grant, an intermediate or terminal symlink is REFUSED
+(`symlink_denied`), never followed - see §6.
 
 For `WRITE` and `STAT` the resolver walks to the leaf's PARENT fd (contained) and
 issues the create/stat relative to that held fd - the final component is never
@@ -363,14 +370,24 @@ set -> `permission`. Because the terminal syscall is issued relative to the held
 anchor fd (§3 mode table), selection + confinement are race-free with no separate
 resolved-path re-check.
 
-**Symlinks never widen a non-subtree grant.** Under an `EXACT` (or `CREATE`) entry
-there is no granted subtree to clamp within, so a symlink at the exact target does
-NOT inherit that entry's authority: its resolved target is RE-EVALUATED against the
-full policy and permitted only if it independently matches some grant (resolved
-within THAT grant). `link.bin -> secret.bin` under an exact grant for `link.bin`
-CANNOT reach `secret.bin` unless `secret.bin` is itself granted - an exact-file
-grant never becomes sibling-directory authority. (Under a `SUBTREE` entry the
-symlink instead clamps within the subtree per §5, which already cannot escape.)
+**Symlink rule per entry kind (definitive):**
+- **`SUBTREE`**: symlinks are FOLLOWED with virtual-root confinement (§3/§5) - they
+  clamp within the granted subtree and cannot escape it.
+- **`EXACT` and `CREATE`**: an intermediate OR terminal symlink is **REFUSED**
+  (`symlink_denied`), never followed. There is no granted subtree to clamp within,
+  and following the leaf would require re-selecting another grant AFTER the leaf is
+  opened - which the one-call `openat2` cannot do (it resolves the leaf inside the
+  exact entry's parent first), and which a manual `readlinkat` + reselect cannot do
+  race-free (component-replacement race) without a stable symlink handle the
+  platform does not provide. So an exact/create grant follows NO symlink at all.
+  This keeps authorization race-free with the documented resolver (no cross-policy
+  symlink-resolution protocol).
+- An INDEPENDENTLY authorized target stays reachable through ITS OWN granted path,
+  NOT through an exact-file alias: `link.bin -> secret.bin` under an exact grant for
+  `link.bin` is DENIED (the symlink is refused) even if `secret.bin` is separately
+  granted - read `secret.bin` via its own grant instead. An exact-file grant never
+  becomes sibling-directory authority. (Following exact-file aliases could be a
+  later, explicitly-designed extension if a real need appears; it is NOT v1.)
 
 **Acceptance cases (must pass, checkpoint 2):**
 ```
@@ -379,7 +396,9 @@ write grant out/result.bin (out/ absent):
                                  out/ created;  result.bin created+truncated;
                                  out/other.bin -> denied
 grants      data/ and data/private/:   most-specific (data/private/) selected
-exact grant link.bin -> secret.bin:    secret.bin unreachable unless independently granted
+exact grant link.bin -> secret.bin:    DENIED through link.bin (symlink refused under EXACT),
+                                       even if secret.bin is separately granted; reach
+                                       secret.bin only via its own grant
 ```
 
 This is the user-recommended option (authority-follows-resolved-path) generalized
@@ -395,15 +414,18 @@ to Hull's real manifest contract. Consequences:
   sole authorization gate for the new surface.
 - **Anchoring edge cases** (checkpoint 2): a `CREATE` anchor whose nearest existing
   ancestor is removed/replaced between config and op fails closed; an intermediate
-  component that exists but is a non-directory or an unexpected symlink under a
-  `CREATE`/`EXACT` entry is refused, never traversed.
+  component that exists but is a non-directory is refused; any symlink component
+  under a `CREATE`/`EXACT` entry is refused (`symlink_denied`), never traversed -
+  consistent with the per-kind symlink rule above.
 
 **Error model (proposed, stable tokens).** Uniform `(nil, err)` (Lua) / `throw`
 (JS): `"invalid_path"` (caller path absolute or containing `..` - lexical
 pre-check), `"not_found"`, `"permission"` (path-authorization policy or file
 mode), `"not_a_directory"`, `"is_a_directory"`, `"symlink_loop"` (expansion bound
-exceeded), `"too_large"`, `"io_error"`. **No `outside_root` token** - resolution
-cannot escape (§5, virtual-root); an escape is impossible, not an error. (Exact
+exceeded), `"symlink_denied"` (a symlink under an `EXACT`/`CREATE` entry, which
+never follows symlinks - §6), `"too_large"`, `"io_error"`. **No `outside_root`
+token** - resolution cannot escape (§5, virtual-root); an escape is impossible, not
+an error. (Exact
 tokens confirmed at implementation; today's messages are not a stable contract.)
 
 ## 7. Lua/JS parity
@@ -423,8 +445,9 @@ correction 1), and the authorization case `allowed/link -> ../secret` resolving 
 (correction 3), and the §6 authorization-entry acceptance cases (exact-file grant
 allows the file but denies a sibling; a `CREATE` write grant creates `out/` +
 truncates `result.bin` but denies `out/other.bin`; overlapping `data/` +
-`data/private/` select most-specific; an exact grant `link.bin -> secret.bin`
-cannot reach `secret.bin` unless independently granted). A dedicated resolver unit
+`data/private/` select most-specific; an exact grant `link.bin -> secret.bin` is
+DENIED through `link.bin` with `symlink_denied` even when `secret.bin` is separately
+granted - `secret.bin` reachable only via its own grant). A dedicated resolver unit
 test proves virtual-root parity between
 the `openat2` and manual-walk paths on the same fixture tree (Linux runs BOTH to
 catch drift), and covers a swapped-component TOCTOU by construction (held-fd walk)

--- a/docs/hull_fs_design.md
+++ b/docs/hull_fs_design.md
@@ -12,10 +12,16 @@ NAMES lexically; `hull.fs` exercises AUTHORITY.** `hull.fs` is where real
 filesystem containment is enforced against the RESOLVED object - never by lexical
 checks alone.
 
-Symlink policy (§5) has been DECIDED during review: **in-sandbox symlinks are
-followed, with `base_dir` a hard containment ceiling.** One DECISION-FOR-REVIEW
-remains (§9, resolver-migration sequencing). Everything else is a recommendation
-with rationale.
+Both load-bearing decisions are SETTLED during review: symlink policy (§5) =
+**virtual-root follow** (in-sandbox symlinks followed; absolute targets re-rooted,
+excess `..` clamped, `base_dir` a hard ceiling - NO "escape" error, because a
+virtual root makes escape impossible, not rejected); sequencing (§9) =
+**resolver-first** (fix the existing `realpath` TOCTOU + migrate the current
+surface before any plugin work). Everything else is a recommendation with
+rationale. This revision also corrects four review findings: the
+`RESOLVE_IN_ROOT`/`outside_root` contradiction (§3, §5, §6), the over-stated
+allowlist claim (§1.3, §6), the `write` implicit-parent-creation back-compat (§1.4,
+§4.1), and under-specified resolver result shapes (§3 mode table).
 
 ## 1. Inventory - the CURRENT application `hull.fs` (verified, not assumed)
 
@@ -42,20 +48,36 @@ as an app binding** in either runtime today. So the real application surface is
 even smaller: **read / write / mmap only.** There is NO enumeration, NO
 stat/metadata, NO exists probe, NO delete, NO rename/copy/mkdir at the app level.
 
-### 1.3 Authority model (unchanged, still correct)
+### 1.3 Authority model (corrected - the cap layer confines, it does not authorize paths)
 
-Two independent gates: a build-time module gate (`hull/fs@1`) and a per-call
-capability gate. `hl_cap_fs_validate` enforces the manifest `fs.read` / `fs.write`
-allowlists + containment under `base_dir`.
+Gates: a build-time module gate (`hull/fs@1`) and a per-call capability gate. But
+the per-call gate is NARROWER than the audit implied. `HlFsConfig`
+(`include/hull/cap/fs.h`) carries ONLY `base_dir` + `base_len` - it does NOT carry
+the manifest's individual `fs.read` / `fs.write` path lists, and
+`hl_cap_fs_validate` checks ONLY containment under `base_dir` (via `realpath`
+prefix), NOT a per-path allowlist. The manifest's read/write path restrictions are
+materialized primarily by the KERNEL SANDBOX (unveil / seatbelt), not by the cap
+layer. So today there are effectively two separable things already: ROOT
+CONFINEMENT (cap layer, `base_dir`) and PATH AUTHORIZATION (kernel sandbox). §6
+makes that split explicit for the new resolver + `stat`/`list`.
 
-### 1.4 The load-bearing finding (same as the audit): resolution is TOCTOU-susceptible
+### 1.4 The load-bearing findings
 
-`hl_cap_fs_validate` resolves with **`realpath()`** (three call sites in
-`src/hull/cap/fs.c`) and the actual `open`/`read`/`write` happens later:
-`realpath -> check -> open`. Between the check and the open a path component can be
-swapped (a directory replaced by a symlink), so the check does not bind the
-`open` target. In-tree precedent for the fix already exists:
+**(a) Resolution is TOCTOU-susceptible.** `hl_cap_fs_validate` resolves with
+**`realpath()`** (three call sites in `src/hull/cap/fs.c`) and the actual
+`open`/`read`/`write` happens later: `realpath -> check -> open`. Between the check
+and the open a path component can be swapped (a directory replaced by a symlink),
+so the check does not bind the `open` target. In-tree precedent for the fix:
 `src/hull/shared/blob_store.c` opens with `O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC`.
+
+**(b) `write` creates parent directories** - `hl_cap_fs_write` mkdir-p's the
+leaf's parents (a `mkdir()` loop over reconstructed absolute path prefixes). This
+is EXISTING behavior the design must preserve (§4.1), and the absolute-path
+`mkdir()` is itself part of the TOCTOU surface to move descriptor-relative.
+
+**(c) `write` is NOT atomic** - it `fopen(full, "wb")` + `fwrite`, truncating in
+place. Any header/comment implying atomicity is stale. Atomic write is a possible
+FUTURE API change (§4.3), not part of this prerequisite.
 
 ## 2. Design goals
 
@@ -73,63 +95,104 @@ swapped (a directory replaced by a symlink), so the check does not bind the
    not app `hull.fs`.
 5. **Lua/JS parity** across the whole app surface (the `hull.path` bar: mirrored
    semantics, snake_case vs camelCase only).
-6. **Backward-compatible semantics** - `read`/`write`/`mmap` keep their contracts;
-   only the resolution MECHANISM hardens and the symlink behavior tightens (§5),
-   both documented.
+6. **Backward-compatible semantics** - `read`/`write`/`mmap` keep their contracts
+   AND their observable behavior (symlink follow-within-base preserved, §5; `write`
+   still creates parent dirs, §4.1). Only the resolution MECHANISM hardens
+   (descriptor-relative instead of `realpath`).
+7. **Two distinct authorities** - ROOT CONFINEMENT (descriptor resolver keeps every
+   op under `base_dir`) is separate from OPERATION/PATH AUTHORIZATION (which paths
+   an app may read/write). The resolver provides the first; the second is an
+   explicit policy + the kernel sandbox (§6). Conflating them is the current gap
+   this design must not repeat.
 
-## 3. Resolution model (the shared foundation) - follow within base, contained
+## 3. Resolution model (the shared foundation) - virtual-root, contained
 
-A single resolver underpins every `hull.fs` op AND (later) BuildContext. It
-**follows symlinks that resolve within `base_dir`** and **refuses any resolution
-that would escape it** (via `..` chains or an out-of-base target), with NO
-resolve-then-open (TOCTOU) window. `base_dir` is a hard ceiling - the sandbox root
-IS the root for resolution purposes.
+A single resolver underpins every `hull.fs` op AND (later) BuildContext. Its
+contract is **true virtual-root (chroot-like) semantics**: `base_dir` is the
+resolution ROOT, symlinks are followed, and NOTHING can escape - with NO
+resolve-then-open (TOCTOU) window.
 
-- **Lexical pre-check** with `hull.path` (reject an absolute caller path, reject
-  `..` in the CALLER-supplied path) - a fast fail, NOT the authority. (Symlink
-  targets encountered DURING resolution are handled below, not by this check.)
+**Semantic contract (this is the whole point of §5's decision).** Within
+resolution:
+- an ABSOLUTE symlink target is RE-ROOTED at `base_dir` (`foo -> /etc/x` resolves
+  to `base_dir/etc/x`);
+- excess `..` is CLAMPED at `base_dir` (`foo -> ../../../x` resolves to
+  `base_dir/x`);
+- these are NOT errors - a virtual root does not "reject escapes," it makes escape
+  impossible by construction. There is therefore **no `outside_root` outcome for
+  symlink targets or `..` encountered during resolution** (this is the correction
+  to the earlier draft: `RESOLVE_IN_ROOT` clamps, it does not reject, and the
+  manual fallback clamps identically - so the two cannot disagree).
+
+The only rejection is a LEXICAL pre-check on the CALLER-supplied path (reject an
+absolute path, reject `..` components) via `hull.path` - an API input contract
+(`invalid_path`), distinct from resolution. The caller declares clean relative
+paths; symlink DATA discovered on disk is virtual-rooted, not errored.
+
+**The resolver performs the TERMINAL operation itself (no returned re-openable
+path).** A single "opened object fd" is insufficient and would let the manual
+fallback reintroduce a final-component race, so the resolver is MODE-parameterized
+and each mode's terminal syscall is issued relative to a held fd:
+
+| mode | terminal op | result | leaf symlink |
+|---|---|---|---|
+| `READ` / `MMAP` | open leaf `O_RDONLY` | leaf fd | FOLLOWED (contained) |
+| `WRITE` | mkdir-p parents (contained) + open leaf `O_WRONLY\|O_CREAT` | leaf fd | FOLLOWED (contained) |
+| `STAT` | `fstatat(parent_fd, leaf, AT_SYMLINK_NOFOLLOW)` | stat record | NOT followed (link-own) |
+| `LIST` | open dir `O_DIRECTORY` | dir fd | FOLLOWED (contained) |
+
+For `WRITE` and `STAT` the resolver walks to the leaf's PARENT fd (contained) and
+issues the create/stat relative to that held fd - the final component is never
+re-resolved from a path string, so there is no leaf race.
+
+**Implementations:**
 - **Linux >= 5.6:** `openat2(base_dfd, relpath, { flags, resolve: RESOLVE_IN_ROOT
-  | RESOLVE_NO_MAGICLINKS })`. `RESOLVE_IN_ROOT` makes `base_dfd` the root for the
-  ENTIRE resolution: interior and leaf symlinks - even absolute ones, even ones
-  containing `..` - are followed but can NEVER escape `base_dir`; the kernel
-  enforces containment race-free in one syscall, and the returned fd IS the opened
-  object (no separate check to race). `RESOLVE_NO_MAGICLINKS` blocks
-  `/proc`-style magic-symlink escapes.
+  | RESOLVE_NO_MAGICLINKS })` for `READ`/`WRITE`/`LIST` leaf/dir opens (one
+  race-free syscall; the returned fd IS the object). `WRITE` first mkdir-p's the
+  parents (each `mkdirat` relative to a held, contained fd); `STAT` uses the
+  contained parent fd + `fstatat(...AT_SYMLINK_NOFOLLOW)`. `RESOLVE_NO_MAGICLINKS`
+  blocks `/proc` magic-symlink escapes.
 - **Platforms without `openat2` (macOS, older Linux, cosmo where unavailable):** a
-  manual component-wise walk that REPRODUCES `RESOLVE_IN_ROOT`. Hold a STACK of
-  directory fds rooted at `base_dfd`; for each component `openat(top, comp,
-  O_NOFOLLOW | O_DIRECTORY | O_CLOEXEC)`; when a component is a symlink (detected
-  via `O_NOFOLLOW`'s `ELOOP` or an `fstatat` probe), `readlinkat` its target and
-  SPLICE the target's components into the walk (an ABSOLUTE target restarts at
-  `base_dfd` = re-root; a RELATIVE target continues from the current dir). A `..`
-  component POPS the fd stack and is CLAMPED at `base_dfd` - it is never passed to
-  the kernel as `openat(dfd, "..")`, so the walk can never ascend above the base.
-  Bound total symlink expansions (e.g. 40, matching the kernel `ELOOP` limit) to
-  stop loops. Because every step is relative to a HELD fd (never a re-resolved
-  path string), there is no TOCTOU window and containment is structural.
-- The manifest `fs.read` / `fs.write` allowlist is still enforced, against the
-  lexically-normalized relative caller path.
+  manual walk reproducing `RESOLVE_IN_ROOT` EXACTLY. Hold a STACK of directory fds
+  rooted at `base_dfd`; each component `openat(top, comp, O_NOFOLLOW | O_DIRECTORY
+  | O_CLOEXEC)`; when a component is a symlink (`ELOOP` / `fstatat` probe),
+  `readlinkat` and SPLICE its target into the walk (ABSOLUTE target restarts at
+  `base_dfd` = re-root; RELATIVE continues from the current dir); a `..` component
+  POPS the fd stack, CLAMPED at `base_dfd` (never `openat(dfd, "..")`). Bound total
+  symlink expansions (e.g. 40, the kernel `ELOOP` limit) -> `symlink_loop`. Every
+  step is relative to a HELD fd, so containment is structural and there is no
+  TOCTOU window. The leaf is just the terminal component, handled per the mode
+  table above.
 - **Fail closed** where a platform offers neither primitive - never downgrade to
   `realpath`.
 
 This is the userspace equivalent of what container runtimes settled on
-(`RESOLVE_IN_ROOT` / Go's `securejoin`): symlinks are followed, but the sandbox
-root is a hard ceiling.
+(`RESOLVE_IN_ROOT` / Go's `securejoin`): a hard virtual root, symlinks followed
+inside it.
+
+**Root confinement is NOT operation authorization.** The resolver guarantees only
+that every op stays under `base_dir`. WHICH paths an app may read/write is a
+separate policy (§6) - the resolver does not consult the manifest allowlist.
 
 **Platform notes** (resolve at implementation): `openat2` is Linux-only (>= 5.6);
 confirm whether the Cosmopolitan target exposes it (raw syscall) or must use the
-manual walk on its Linux host. `openat` / `O_NOFOLLOW` / `readlinkat` / `fstatat`
-are POSIX (Linux, macOS, cosmo shim). A native Windows target (not today's cosmo
-APE) needs the reparse-point-aware equivalent; scope that when such a target
-exists.
+manual walk on its Linux host. `openat` / `O_NOFOLLOW` / `readlinkat` / `fstatat` /
+`mkdirat` are POSIX (Linux, macOS, cosmo shim). A native Windows target (not
+today's cosmo APE) needs the reparse-point-aware equivalent; scope that when such a
+target exists.
 
 ## 4. Operations
 
 ### 4.1 Existing, hardened (no signature change)
 - `fs.read(path)` -> bytes | (nil,err) / throw. Now resolved per §3; `fs.read`
   authority.
-- `fs.write(path, bytes)` -> true | (nil,err) / throw. Resolved per §3; `fs.write`
-  authority. (Parent-dir creation is NOT implicit - see §4.3 `mkdir`.)
+- `fs.write(path, bytes)` -> true | (nil,err) / throw. Resolved per §3 (`WRITE`
+  mode); `fs.write` authority. **Preserves today's implicit parent-directory
+  creation** (the current `hl_cap_fs_write` mkdir-p's parents) - now done
+  descriptor-relatively with `mkdirat` under the contained walk instead of
+  `mkdir()` on reconstructed absolute paths. Behavior unchanged; only the
+  mechanism hardens. Whether writes should become ATOMIC (they are NOT today -
+  see §1.4) is a SEPARATE API decision, out of this prerequisite scope.
 - `fs.mmap(path[, window])` -> MappedBuffer. Resolved per §3 for the initial open;
   the mapping's lifetime semantics are unchanged (refcounted borrow, `close`
   defers `munmap` while a borrower is alive).
@@ -163,12 +226,13 @@ without a second cap surface that could disagree with `stat` about symlinks.
 | candidate | why deferred |
 |---|---|
 | `delete` | Exists at the cap layer, unexposed today. A mutation with real blast radius; add only when a concrete app need appears, and gate on `fs.write`. Not needed for enumeration/hardening. |
-| `mkdir` | App authors rarely need directory creation; when they do it is usually part of a WRITE that BuildContext should own transactionally. Keep `write` non-implicit-mkdir for now. |
+| explicit `mkdir` | `write` ALREADY creates parents implicitly (§1.4b, §4.1) and that is preserved; a STANDALONE `mkdir(path)` op (create an empty dir with no write) is rarely needed and deferred until a concrete case appears. |
 | `copy` / `rename` / `move` | `rename` is the ATOMIC-PUBLISH primitive - it belongs to the Hull-owned BuildContext.outputs (audit §3.5), NOT general app `hull.fs`, precisely so staging/publication authority stays separate. |
-| `atomic write` / `tempfile` | Same: transactional staging + atomic publication is a BuildContext concern by the audit's HARD boundary; exposing it on app `hull.fs` would blur the two authorities. |
+| ATOMIC `write` / `tempfile` | Today's `write` is non-atomic truncate-in-place (§1.4c); making it atomic (tmp + `rename`) is a SEPARATE API decision. The transactional staging + atomic PUBLICATION machinery specifically is a BuildContext.outputs concern by the audit's HARD boundary; exposing it on app `hull.fs` would blur the two authorities. |
 
-The through-line: `hull.fs` gets read-side hardening + discovery (stat/list); the
-WRITE-side transactional machinery stays in BuildContext.
+The through-line: `hull.fs` gets its EXISTING contracts hardened
+(`read`/`write`-with-implicit-parents/`mmap`) + discovery (`stat`/`list`); the
+transactional staging + atomic-publication machinery stays in BuildContext.
 
 ## 5. DECIDED: in-sandbox symlinks are FOLLOWED (contained), not refused
 
@@ -179,37 +243,65 @@ refusing them would break legitimate layouts. The prior draft's deny-all
 recommendation is REJECTED. Preserving today's follow-within-base BEHAVIOR while
 fixing the TOCTOU (via §3, not `realpath`) is the chosen path.
 
-Semantics (the `RESOLVE_IN_ROOT` model of §3):
-- A symlink whose recursively-resolved target stays under `base_dir` is FOLLOWED
-  transparently, for `read` / `write` / `mmap`.
-- An ABSOLUTE symlink target is RE-ROOTED at `base_dir` (the sandbox root is the
-  resolution root), so `foo -> /bar` resolves to `base_dir/bar` - followed, still
-  contained.
-- Any resolution that would ESCAPE `base_dir` (a `..` chain or an out-of-base
-  target) is REFUSED with `outside_root`. The ceiling is hard and kernel-enforced
-  (Linux) / structurally enforced (manual walk).
+Semantics = the **true virtual-root** model of §3 (chosen deliberately over a
+reject-escapes / `RESOLVE_BENEATH` model, which would conflict with re-rooting
+absolute targets and could not use the one-call `RESOLVE_IN_ROOT` implementation):
+- A symlink whose target resolves within `base_dir` is FOLLOWED transparently for
+  `read` / `write` / `mmap`.
+- An ABSOLUTE symlink target is RE-ROOTED at `base_dir` (`foo -> /bar` ->
+  `base_dir/bar`); excess `..` in a target is CLAMPED at `base_dir`.
+- Re-rooting and clamping are **not errors** - a virtual root makes escape
+  impossible by construction, so there is **no `outside_root` outcome** for a
+  symlink target or `..` met during resolution. (This is the correction to the
+  earlier draft, which wrongly promised both re-rooting AND `outside_root`:
+  `RESOLVE_IN_ROOT` clamps rather than rejects, and the manual fallback clamps
+  identically, so the contract is virtual-root, single and consistent.)
+- The only rejection is the LEXICAL caller-path pre-check (absolute path or `..`
+  in the app-supplied path -> `invalid_path`), an input contract, NOT a resolution
+  outcome.
 - `stat` / `list` report a symlink's OWN type WITHOUT following (`lstat`
   semantics), so an app can enumerate links as links; only path RESOLUTION for
-  read/write/mmap follows.
+  `read`/`write`/`mmap` follows.
 - Guarantee vs today: SAME "follow within base" behavior, now enforced race-free
   (no `realpath -> check -> open` window).
 
-Still NOT a lexical check - `hull.path` never authorizes; the `openat2` /
-descriptor walk is the authority.
+Still NOT a lexical authorization - `hull.path` never authorizes; the `openat2` /
+descriptor walk is the confinement authority.
 
-## 6. Capability + manifest integration
+## 6. Two authorities: root confinement vs path authorization
 
-Gates unchanged in shape: build-time `hull/fs@1` module gate + per-call
-allowlist. New ops require `fs.read` authority over their target (`stat` and
-`list` are reads of metadata / directory contents). No new manifest section.
+The audit and the earlier draft conflated these; they are separate and this
+design keeps them separate (goal §2.7).
+
+**(a) Root confinement** - every op stays under `base_dir`. Provided entirely by
+the §3 descriptor resolver (virtual-root), for every op including `stat`/`list`.
+No manifest input.
+
+**(b) Operation / path authorization** - WHICH paths an app may read vs write.
+Today this is materialized by the KERNEL SANDBOX (unveil / seatbelt) from the
+manifest `fs.read` / `fs.write` roots; `HlFsConfig` / `hl_cap_fs_validate` do NOT
+carry or check per-path lists (§1.3). Two design implications:
+
+- **`stat` / `list` must respect the READ roots, not merely `base_dir`.** A file
+  inside `base_dir` but OUTSIDE the declared `fs.read` roots must not have its
+  metadata or directory entries exposed - otherwise the new ops leak more than
+  `read` does. Since the cap layer has no path policy today, this design must add
+  an EXPLICIT policy object (the resolved `fs.read` / `fs.write` root sets) that
+  `stat`/`list`/`read`/`write` consult at the cap layer, layered ON TOP of root
+  confinement. Whether the policy lives in an extended `HlFsConfig` or a separate
+  `HlFsPolicy` is an implementation detail resolved at checkpoint 2; the design
+  REQUIREMENT is that path authorization is an explicit, cap-layer-checked policy,
+  not an accident of what the kernel sandbox happens to block.
+- Kernel-sandbox enforcement remains as defense-in-depth beneath the explicit
+  policy, not the sole gate for the new read-side surface.
 
 **Error model (proposed, stable tokens).** Uniform `(nil, err)` (Lua) / `throw`
-(JS) with a small closed set of tokens so app code can branch:
-`"not_found"`, `"permission"` (allowlist / mode), `"not_a_directory"`,
-`"is_a_directory"`, `"outside_root"` (a symlink or `..` chain that would escape
-`base_dir`), `"symlink_loop"` (expansion bound exceeded), `"too_large"`,
-`"io_error"`. (The exact tokens are confirmed at implementation; today's messages
-are not a stable contract.)
+(JS): `"invalid_path"` (caller path absolute or containing `..` - lexical
+pre-check), `"not_found"`, `"permission"` (path-authorization policy or file
+mode), `"not_a_directory"`, `"is_a_directory"`, `"symlink_loop"` (expansion bound
+exceeded), `"too_large"`, `"io_error"`. **No `outside_root` token** - resolution
+cannot escape (§5, virtual-root); an escape is impossible, not an error. (Exact
+tokens confirmed at implementation; today's messages are not a stable contract.)
 
 ## 7. Lua/JS parity
 
@@ -217,12 +309,15 @@ Every application op has both bindings, mirrored semantics, snake_case (Lua) /
 camelCase (JS) only. `read`/`write`/`mmap` already parity; `stat`/`list` land in
 both at once. A parity E2E (the `tests/e2e_path_parity.sh` model, but over a real
 fixture tree because fs needs files) asserts Lua == JS for: `list` ordering +
-per-entry metadata, `stat` fields + symlink typing, an in-base symlink FOLLOWED
-identically for `read`, an absolute in-base symlink target re-rooted the same way,
-and `outside_root` on a symlink (or `..` chain) whose target escapes `base_dir`.
-Where a swapped-component TOCTOU is testable deterministically it is asserted;
-where it is inherently racy it is covered by construction (`openat2
-RESOLVE_IN_ROOT` / the held-fd walk) plus a unit test on the resolver.
+per-entry metadata, `stat` fields + symlink typing (link reported as link), an
+in-base symlink FOLLOWED identically for `read`, an absolute symlink target
+RE-ROOTED at `base_dir` the same way, a `foo -> ../../../x` target CLAMPED to
+`base_dir/x` the same way (NOT an error, per §5), `invalid_path` on a caller path
+with `..`, and a `symlink_loop` cycle bounded identically. A dedicated resolver
+unit test proves virtual-root parity between the `openat2` and manual-walk paths
+on the same fixture tree (Linux runs BOTH to catch drift), and covers a
+swapped-component TOCTOU by construction (held-fd walk) with a deterministic case
+where testable.
 
 ## 8. Relationship to BuildContext (#393)
 
@@ -231,7 +326,7 @@ surfaces; this design PROVIDES them.
 
 | surface | who | authority | ops |
 |---|---|---|---|
-| **application `hull.fs`** | app code | manifest `fs.read`/`fs.write` + `base_dir` | read / write / mmap / stat / list |
+| **application `hull.fs`** | app code | root confinement (`base_dir`, resolver) + path-authorization policy (`fs.read`/`fs.write` roots, §6) + kernel sandbox | read / write / mmap / stat / list |
 | **plugin `BuildContext`** | Hull-owned, handed to a plugin | declared input roots + a private staging root; NARROWER | inputs: read / stat / list (recorded + hashed); outputs: staged write + atomic publish |
 
 BuildContext.inputs reuses this design's resolver + `stat`/`list`, adds read
@@ -239,31 +334,41 @@ RECORDING + content hashing, and drops write. BuildContext.outputs adds the
 staging + atomic-publish (`rename`/`fsync`) that app `hull.fs` deliberately does
 NOT expose (§4.3). A build plugin never receives the general `hull.fs`.
 
-## 9. DECISION-FOR-REVIEW (sole remaining): resolver-migration sequencing
+## 9. DECIDED: resolver-first (migrate the existing surface before building plugins)
 
-The audit (§6) said the app-`hull.fs` migration to the descriptor-relative
-resolver is a follow-up sequenced AFTER BuildContext proves the primitive.
-Designing `hull.fs` first inverts that emphasis:
+**Decision (owner: user, during review): resolver-FIRST.** The audit (§6) had the
+app-`hull.fs` migration sequenced AFTER BuildContext; that is REVERSED. Rationale:
+it fixes the EXISTING security defect (the `realpath` TOCTOU, §1.4a) before any
+plugin work, and it validates the foundational resolver through the primary,
+most-used surface rather than proving it first on a new, less-exercised one.
+`RESOLVE_BENEATH` / reject-escape is also rejected in favor of virtual-root (§5).
 
-- **Recommended: resolver lands as the app-fs foundation FIRST.** Harden
-  `read`/`write`/`mmap` + add `stat`/`list` on the descriptor-relative resolver as
-  checkpoint 1; BuildContext (checkpoints 3-4) then builds on a primitive already
-  proven in production by the app surface. This SUPERSEDES the audit's ordering.
-- **Alternative: keep the audit's order.** Implement the resolver inside
-  BuildContext first, migrate app `hull.fs` afterward. Keeps the app surface
-  untouched longer, but ships the same TOCTOU one release longer and duplicates
-  validation.
+Ratified ordering:
+1. **Land the resolver and migrate existing `read`/`write`/`mmap` first** - onto
+   the §3 virtual-root resolver (write keeps implicit parent creation, now
+   `mkdirat`-based). No new app ops yet; this is purely the TOCTOU fix +
+   behavior-preserving migration.
+2. **STOP and prove** platform parity (`openat2` path == manual walk) AND
+   race-resistant symlink behavior (virtual-root follow, re-root, clamp, loop
+   bound) on the fixture tree + resolver unit tests.
+3. **Add application `stat` / `list`** (with the §6 path-authorization policy so
+   they respect READ roots, not merely `base_dir`) - Lua/JS parity - STOP.
+4. **Then `BuildContext.inputs` and `BuildContext.outputs`** on the proven
+   primitive. Then Build Plugin / BuildArtifact. **Not Query IR yet.**
 
 ## 10. Non-scope + checkpoints
 
 Design only. No code, no binding changes, no resolver, no `stat`/`list`, no
 BuildContext, no plugin loader, no Query IR.
 
-1. **This design + the BuildContext audit (#393)** - STOP for review. Symlink
-   policy (§5) is DECIDED (follow within base, contained); the sole remaining
-   decision is resolver-migration sequencing (§9).
-2. Implement the descriptor-relative resolver + harden `read`/`write`/`mmap` + add
-   `stat`/`list`, with Lua/JS parity tests - STOP.
-3. `BuildContext.inputs` (declared reads + dependency hashing) - STOP.
-4. `BuildContext.outputs` (transactional staging + atomic publish) - STOP. Then
-   Build Plugin / BuildArtifact. **Not Query IR yet.**
+Checkpoints mirror the §9 ratified ordering; every arrow is a STOP-for-review:
+
+0. **This design + the BuildContext audit (#393)** - STOP for review. Both
+   decisions are now settled: symlink policy = virtual-root follow (§5),
+   sequencing = resolver-first (§9). Nothing else is open.
+1. Land the resolver + migrate `read`/`write`/`mmap` (TOCTOU fix, behavior
+   preserved) - STOP.
+2. Prove platform parity + race-resistant symlink behavior - STOP.
+3. Add `stat`/`list` + the path-authorization policy (§6), Lua/JS parity - STOP.
+4. `BuildContext.inputs` then `BuildContext.outputs` - STOP. Then Build Plugin /
+   BuildArtifact. **Not Query IR yet.**


### PR DESCRIPTION
Dedicated design of the **application-facing `hull.fs`** capability — the general filesystem surface app authors use. It is the prerequisite for and peer of the BuildContext audit (**#393**): BuildContext is the narrower, Hull-owned plugin surface built *on* these primitives, so `hull.fs` is designed first.

**Design only. Nothing implemented.** Own checkpoint; stop after review.

## Highlights
- **Honest inventory (corrects the #393 audit):** the actual app surface today is **`read` / `write` / `mmap` only**. `exists`/`delete` exist at the cap layer but are **not** exposed to app code in either runtime. There is no enumeration, stat, or metadata.
- **One shared resolver:** a descriptor-relative walk (`openat` + `O_NOFOLLOW` component-wise from a base dirfd) replaces the `realpath → check → open` TOCTOU in `hl_cap_fs_validate` for *every* op. `blob_store.c` is the in-tree precedent; fail-closed where a platform lacks the primitive.
- **Minimal additions:** deterministic `list` + `stat`/metadata (`exists` is subsumed by `stat`). The write-side transactional machinery (`delete`/`mkdir`/`rename`/atomic-write) is **deferred** — several pieces belong to the Hull-owned `BuildContext`, not app `hull.fs`, keeping the two authorities distinct.
- **Lua/JS parity** across the whole app surface; a stable error-token model.

## Two DECISIONS-FOR-REVIEW (the load-bearing choices)
1. **Symlink policy on the app surface** — deny-all (recommended: matches the plugin rule, strictly safer, one model) vs. preserve today's follow-within-base. `O_NOFOLLOW`-every-component is a behavior change for existing apps.
2. **Resolver-migration sequencing** — land the descriptor-relative resolver as the app-fs foundation **first** (recommended; supersedes the audit's "BuildContext first" ordering) vs. keep the audit's order.

Pairs with #393. No implementation begins until both are reviewed.