### PR TITLE
investigate(msan): origin capture [THROWAWAY]

### DIFF
--- a/include/hull/cap/fs_resolve.h
+++ b/include/hull/cap/fs_resolve.h
@@ -1,0 +1,56 @@
+/*
+ * fs_resolve.h — descriptor-relative, virtual-root path resolver.
+ *
+ * Checkpoint 1 of the hull.fs design (docs/hull_fs_design.md). Replaces the
+ * realpath->check->open TOCTOU (docs §1.4a) with a resolution that opens a path
+ * under a base directory FILE DESCRIPTOR, following in-sandbox symlinks but
+ * confining every resolution to that root (virtual-root, RESOLVE_IN_ROOT
+ * semantics, docs §3/§5): absolute symlink targets re-root at the base, excess
+ * ".." clamps at the base, nothing escapes. There is no resolve-then-open window
+ * because every step is relative to a held fd (or one openat2 syscall).
+ *
+ * This is checkpoint 1: it is BASE_DIR-anchored (the no-granular-grants case).
+ * The compiled-entry authorization policy (SUBTREE/EXACT/CREATE) lands at
+ * checkpoint 3; here the root is always base_dir, preserving today's
+ * authorization model (base_dir confinement + kernel sandbox).
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#ifndef HULL_CAP_FS_RESOLVE_H
+#define HULL_CAP_FS_RESOLVE_H
+
+#include <sys/types.h>
+
+typedef enum {
+    HL_FS_OPEN_READ,  /* open an existing leaf O_RDONLY (symlinks followed, contained) */
+    HL_FS_OPEN_WRITE, /* mkdir-p parents (contained) + open leaf O_WRONLY|O_CREAT|O_TRUNC */
+} HlFsOpenMode;
+
+/*
+ * Open `base_dir` as a directory fd suitable for hl_fs_open_at(). Returns the fd
+ * (caller closes with close()) or -1 with *err set. base_dir is the trusted app
+ * root; it is opened O_DIRECTORY|O_CLOEXEC (a symlinked app root is followed once
+ * here - it is the ceiling, not a traversal step).
+ */
+int hl_fs_open_base(const char *base_dir, const char **err);
+
+/*
+ * Resolve+open `relpath` under `root_fd` with virtual-root semantics.
+ *
+ *   HL_FS_OPEN_READ  -> returns an O_RDONLY fd to the leaf.
+ *   HL_FS_OPEN_WRITE -> creates missing parent dirs (contained, mkdirat) and
+ *                       returns an O_WRONLY|O_CREAT|O_TRUNC fd to the leaf.
+ *
+ * `relpath` MUST be relative and MUST NOT contain ".." components (the caller
+ * performs that lexical pre-check; a violation returns "invalid_path"). Symlink
+ * targets ENCOUNTERED on disk MAY be absolute or contain "..": those are
+ * virtual-rooted (re-root / clamp at `root_fd`), never an escape.
+ *
+ * Returns an open fd (caller closes) or -1 with *err set to a stable token:
+ * "invalid_path", "not_found", "permission", "not_a_directory",
+ * "is_a_directory", "symlink_loop", "io_error".
+ */
+int hl_fs_open_at(int root_fd, const char *relpath, HlFsOpenMode mode,
+                  mode_t create_mode, const char **err);
+
+#endif /* HULL_CAP_FS_RESOLVE_H */

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -847,9 +847,10 @@ fuzz/fuzz_span_sdk: fuzz/fuzz_span_sdk.c
 
 # Mapped-WINDOW geometry math (hl_cap_fs_mmap_window_geometry): page-align + EOF
 # clamp + overflow-safe rounding. The fuzzed function is a pure arithmetic leaf,
-# but cap/fs.c as a whole pulls alloc + audit (sh_json); link that small chain so
-# the fuzzer resolves without dragging in mmap/Keel. mmap/open/realpath are libc.
-fuzz/fuzz_span_window: fuzz/fuzz_span_window.c $(SRCDIR)/hull/cap/fs.c $(SRCDIR)/hull/cap/audit.c $(SRCDIR)/hull/utils/alloc.c $(SH_JSON_DIR)/sh_json.c $(SH_ARENA_DIR)/sh_arena.c
+# but cap/fs.c as a whole pulls alloc + audit (sh_json) and now the descriptor-
+# relative resolver (cap/fs_resolve.c, since read/write/mmap resolve through it);
+# link that small chain so the fuzzer resolves without dragging in Keel.
+fuzz/fuzz_span_window: fuzz/fuzz_span_window.c $(SRCDIR)/hull/cap/fs.c $(SRCDIR)/hull/cap/fs_resolve.c $(SRCDIR)/hull/cap/audit.c $(SRCDIR)/hull/utils/alloc.c $(SH_JSON_DIR)/sh_json.c $(SH_ARENA_DIR)/sh_arena.c
 	$(CC) $(FUZZ_CFLAGS) -Ivendor/keel/include -o $@ $^
 
 # hull.source.lua parser: adversarial bytes -> lua.parse() over a bounded lua_State.

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -627,7 +627,8 @@ test: $(TEST_BINS)
 
 ifdef MSAN
 CFLAGS   := -std=c11 -Wall -Wextra -Wpedantic -Wshadow -Wformat=2 \
-            -g -O1 -fsanitize=memory,undefined -fno-omit-frame-pointer \
+            -g -O1 -fsanitize=memory,undefined -fsanitize-memory-track-origins=2 \
+            -fno-omit-frame-pointer \
             -D_DEFAULT_SOURCE -DHL_THREAD_AFFINITY_CHECKS
 LDFLAGS  := -fsanitize=memory,undefined
 # Vendor TUs: keep MSan (we still want shadow tracking for uninitialized

--- a/src/hull/cap/fs.c
+++ b/src/hull/cap/fs.c
@@ -8,6 +8,7 @@
  */
 
 #include "hull/cap/fs.h"
+#include "hull/cap/fs_resolve.h"
 #include "hull/utils/alloc.h"
 #include "hull/cap/audit.h"
 #include <stdio.h>
@@ -132,6 +133,31 @@ static int build_path(const HlFsConfig *cfg, const char *path,
     return 0;
 }
 
+/* ── Descriptor-relative resolution (checkpoint 1) ──────────────────────
+ * read/write/mmap resolve through the virtual-root resolver (fs_resolve.c)
+ * instead of realpath->check->open (docs/hull_fs_design.md §3). base_dir-anchored:
+ * open base_dir as a dirfd, resolve `path` under it (symlinks followed but
+ * confined), and return the leaf fd. No resolve-then-open window. exists/delete
+ * still use build_path() until they gain a resolver mode (a later checkpoint). */
+static int fs_resolve_fd(const HlFsConfig *cfg, const char *path,
+                         HlFsOpenMode mode, mode_t cmode, const char **err_msg)
+{
+    if (!cfg || !path || !cfg->base_dir) {
+        if (err_msg) *err_msg = "invalid_args";
+        return -1;
+    }
+    const char *e = NULL;
+    int root = hl_fs_open_base(cfg->base_dir, &e);
+    if (root < 0) {
+        if (err_msg) *err_msg = e ? e : "open_failed";
+        return -1;
+    }
+    int fd = hl_fs_open_at(root, path, mode, cmode, &e);
+    close(root);
+    if (fd < 0 && err_msg) *err_msg = e ? e : "open_failed";
+    return fd;
+}
+
 /* ── Public API ─────────────────────────────────────────────────────── */
 
 int64_t hl_cap_fs_read(const HlFsConfig *cfg, const char *path,
@@ -140,12 +166,13 @@ int64_t hl_cap_fs_read(const HlFsConfig *cfg, const char *path,
 {
     int64_t result = -1;
 
-    char full[PATH_MAX];
-    if (build_path(cfg, path, full, sizeof(full), err_msg) != 0)
+    int fd = fs_resolve_fd(cfg, path, HL_FS_OPEN_READ, 0, err_msg);
+    if (fd < 0)
         goto audit;
 
-    FILE *f = fopen(full, "rb");
+    FILE *f = fdopen(fd, "rb");
     if (!f) {
+        close(fd);
         if (err_msg) *err_msg = "open_failed";
         goto audit;
     }
@@ -210,26 +237,17 @@ int hl_cap_fs_write(const HlFsConfig *cfg, const char *path,
 {
     int result = -1;
 
-    char full[PATH_MAX];
-    if (build_path(cfg, path, full, sizeof(full), err_msg) != 0)
+    /* WRITE mode: the resolver creates missing parent dirs (contained mkdirat)
+     * and opens the leaf O_WRONLY|O_CREAT|O_TRUNC — same implicit-parents +
+     * truncate behavior as the previous mkdir-p + fopen("wb"), now race-free. */
+    int fd = fs_resolve_fd(cfg, path, HL_FS_OPEN_WRITE, 0644, err_msg);
+    if (fd < 0)
         goto audit;
 
-    /* Create parent directories if needed */
-    char tmp[PATH_MAX];
-    strncpy(tmp, full, sizeof(tmp) - 1);
-    tmp[sizeof(tmp) - 1] = '\0';
-
-    for (char *p = tmp + 1; *p; p++) {
-        if (*p == '/') {
-            *p = '\0';
-            mkdir(tmp, 0755); /* ignore errors — may already exist */
-            *p = '/';
-        }
-    }
-
     {
-        FILE *f = fopen(full, "wb");
+        FILE *f = fdopen(fd, "wb");
         if (!f) {
+            close(fd);
             if (err_msg) *err_msg = "write_failed";
             goto audit;
         }
@@ -301,15 +319,9 @@ HlMappedBuffer *hl_cap_fs_mmap(const HlFsConfig *cfg, const char *path,
 {
     HlMappedBuffer *buf = NULL;
 
-    char full[PATH_MAX];
-    if (build_path(cfg, path, full, sizeof(full), err_msg) != 0)
+    int fd = fs_resolve_fd(cfg, path, HL_FS_OPEN_READ, 0, err_msg);
+    if (fd < 0)
         goto audit;
-
-    int fd = open(full, O_RDONLY);
-    if (fd < 0) {
-        if (err_msg) *err_msg = "open_failed";
-        goto audit;
-    }
 
     struct stat st;
     if (fstat(fd, &st) != 0) {
@@ -437,15 +449,9 @@ HlMappedBuffer *hl_cap_fs_mmap_window(const HlFsConfig *cfg, const char *path,
     HlMappedBuffer *buf = NULL;
     uint64_t map_off = 0, map_len = 0, slop = 0, eff_len = 0;
 
-    char full[PATH_MAX];
-    if (build_path(cfg, path, full, sizeof(full), err_msg) != 0)
+    int fd = fs_resolve_fd(cfg, path, HL_FS_OPEN_READ, 0, err_msg);
+    if (fd < 0)
         goto audit;
-
-    int fd = open(full, O_RDONLY);
-    if (fd < 0) {
-        if (err_msg) *err_msg = "open_failed";
-        goto audit;
-    }
 
     struct stat st;
     if (fstat(fd, &st) != 0) {

--- a/src/hull/cap/fs_resolve.c
+++ b/src/hull/cap/fs_resolve.c
@@ -1,0 +1,258 @@
+/*
+ * fs_resolve.c — descriptor-relative, virtual-root path resolver.
+ *
+ * See include/hull/cap/fs_resolve.h and docs/hull_fs_design.md §3/§5.
+ *
+ * Two implementations of the SAME virtual-root contract:
+ *   - Linux >= 5.6: one openat2(RESOLVE_IN_ROOT | RESOLVE_NO_MAGICLINKS) syscall.
+ *   - Everywhere else (macOS, older Linux, cosmo): a manual held-fd-stack walk
+ *     that reproduces RESOLVE_IN_ROOT exactly. Both are race-free (every step is
+ *     relative to a held fd / a single kernel-confined call); never realpath.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "hull/cap/fs_resolve.h"
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+#include <sys/stat.h>
+
+#ifndef HL_FS_PATH_MAX
+#define HL_FS_PATH_MAX 4096
+#endif
+#define HL_FS_SYMLINK_MAX 40   /* matches the kernel ELOOP budget */
+#define HL_FS_MAX_DEPTH   256  /* directory-fd stack bound */
+
+static void map_errno(int e, const char **err)
+{
+    switch (e) {
+    case ENOENT:  *err = "not_found";       break;
+    case EACCES:
+    case EPERM:   *err = "permission";      break;
+    case ENOTDIR: *err = "not_a_directory"; break;
+    case EISDIR:  *err = "is_a_directory";  break;
+    case ELOOP:   *err = "symlink_loop";    break;
+    case ENAMETOOLONG: *err = "invalid_path"; break;
+    default:      *err = "io_error";        break;
+    }
+}
+
+/* ── caller-path lexical pre-check (docs §3/§5): relative, no ".." ─────────── */
+static int caller_path_ok(const char *p)
+{
+    if (!p || p[0] == '\0' || p[0] == '/') return 0;   /* empty or absolute */
+    const char *c = p;
+    while (*c) {
+        if (c[0] == '.' && c[1] == '.' && (c[2] == '/' || c[2] == '\0'))
+            return 0;                                   /* ".." component */
+        const char *s = strchr(c, '/');
+        if (!s) break;
+        c = s + 1;
+    }
+    return 1;
+}
+
+/* ── Linux openat2 fast-path ──────────────────────────────────────────────── */
+/* Cosmopolitan (fat APE) uses the portable manual walk, not a Linux raw syscall. */
+#if defined(__linux__) && !defined(__COSMOPOLITAN__)
+#include <sys/syscall.h>
+#include <stdint.h>
+
+/* Kernel uapi may predate openat2; define the ABI locally if absent. */
+#ifndef RESOLVE_IN_ROOT
+#define RESOLVE_NO_MAGICLINKS 0x02
+#define RESOLVE_IN_ROOT       0x10
+struct open_how { uint64_t flags; uint64_t mode; uint64_t resolve; };
+#endif
+#ifndef __NR_openat2
+#define __NR_openat2 437
+#endif
+
+/* Returns fd, or -1 with *err set, or -2 meaning "openat2 unavailable, fall
+ * back to the manual walk". */
+static int try_openat2(int root_fd, const char *relpath, int flags,
+                       mode_t mode, const char **err)
+{
+    struct open_how how;
+    memset(&how, 0, sizeof(how));
+    how.flags = (uint64_t)flags;
+    how.mode = (flags & O_CREAT) ? (uint64_t)mode : 0;
+    how.resolve = RESOLVE_IN_ROOT | RESOLVE_NO_MAGICLINKS;
+
+    long r = syscall(__NR_openat2, root_fd, relpath, &how, sizeof(how));
+    if (r >= 0) return (int)r;
+    if (errno == ENOSYS || errno == EPERM /* seccomp may block it */)
+        return -2;
+    map_errno(errno, err);
+    return -1;
+}
+#endif /* __linux__ */
+
+/* ── portable manual walk (reproduces RESOLVE_IN_ROOT) ────────────────────── */
+
+/* Prepend `link` (a symlink target) in front of `rest`, into `out`. An absolute
+ * link resets the caller's dir stack to the root (signalled via *reset). */
+static int splice_link(const char *link, const char *rest,
+                       char *out, size_t out_sz, int *reset)
+{
+    *reset = (link[0] == '/');
+    int n;
+    if (rest && rest[0] != '\0')
+        n = snprintf(out, out_sz, "%s/%s", link, rest);
+    else
+        n = snprintf(out, out_sz, "%s", link);
+    return (n < 0 || (size_t)n >= out_sz) ? -1 : 0;
+}
+
+static int resolve_manual(int root_fd, const char *relpath, HlFsOpenMode mode,
+                          mode_t cmode, const char **err)
+{
+    int stack[HL_FS_MAX_DEPTH];
+    int depth = 0;
+    stack[depth++] = dup(root_fd);            /* stack[0] = root; never popped */
+    if (stack[0] < 0) { map_errno(errno, err); return -1; }
+
+    char rem[HL_FS_PATH_MAX];
+    if (strlen(relpath) >= sizeof(rem)) { *err = "invalid_path"; goto fail; }
+    strcpy(rem, relpath);
+
+    int symlinks = 0;
+    int result_fd = -1;
+    char *cur = rem;
+
+    for (;;) {
+        while (*cur == '/') cur++;
+        if (*cur == '\0') {
+            /* Consumed everything without a terminal leaf (path was "." etc.).
+             * READ opens the current directory; WRITE has no leaf to create. */
+            if (mode == HL_FS_OPEN_READ) {
+                result_fd = openat(stack[depth - 1], ".", O_RDONLY | O_CLOEXEC);
+                if (result_fd < 0) { map_errno(errno, err); goto fail; }
+                goto done;
+            }
+            *err = "invalid_path";
+            goto fail;
+        }
+
+        /* Extract the next component. */
+        char comp[NAME_MAX + 1];
+        char *slash = strchr(cur, '/');
+        size_t clen = slash ? (size_t)(slash - cur) : strlen(cur);
+        if (clen > NAME_MAX) { *err = "invalid_path"; goto fail; }
+        memcpy(comp, cur, clen);
+        comp[clen] = '\0';
+        char *rest = slash ? slash + 1 : cur + clen;   /* what remains after comp */
+
+        if (strcmp(comp, ".") == 0) { cur = rest; continue; }
+        if (strcmp(comp, "..") == 0) {                 /* clamp at root */
+            if (depth > 1) close(stack[--depth]);
+            cur = rest;
+            continue;
+        }
+
+        /* Is this the terminal component? (nothing but slashes/empty after it) */
+        const char *tail = rest;
+        while (*tail == '/') tail++;
+        int last = (*tail == '\0');
+
+        if (!last) {
+            /* interior: descend into a directory, following a symlink if present */
+            int fd = openat(stack[depth - 1], comp,
+                            O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+            if (fd >= 0) {
+                if (depth >= HL_FS_MAX_DEPTH) { close(fd); *err = "invalid_path"; goto fail; }
+                stack[depth++] = fd;
+                cur = rest;
+                continue;
+            }
+            if (errno == ELOOP || errno == EMLINK) goto symlink;
+            if (errno == ENOENT && mode == HL_FS_OPEN_WRITE) {
+                if (mkdirat(stack[depth - 1], comp, 0755) < 0 && errno != EEXIST) {
+                    map_errno(errno, err); goto fail;
+                }
+                fd = openat(stack[depth - 1], comp,
+                            O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+                if (fd < 0) { map_errno(errno, err); goto fail; }
+                if (depth >= HL_FS_MAX_DEPTH) { close(fd); *err = "invalid_path"; goto fail; }
+                stack[depth++] = fd;
+                cur = rest;
+                continue;
+            }
+            map_errno(errno, err);
+            goto fail;
+        } else {
+            /* terminal component */
+            int flags = (mode == HL_FS_OPEN_READ)
+                          ? (O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+                          : (O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_CLOEXEC);
+            int fd = openat(stack[depth - 1], comp, flags, cmode);
+            if (fd >= 0) { result_fd = fd; goto done; }
+            if (errno == ELOOP || errno == EMLINK) goto symlink;
+            map_errno(errno, err);
+            goto fail;
+        }
+
+    symlink:
+        if (++symlinks > HL_FS_SYMLINK_MAX) { *err = "symlink_loop"; goto fail; }
+        {
+            char link[HL_FS_PATH_MAX];
+            ssize_t ln = readlinkat(stack[depth - 1], comp, link, sizeof(link) - 1);
+            if (ln < 0) { map_errno(errno, err); goto fail; }
+            link[ln] = '\0';
+            char next[HL_FS_PATH_MAX];
+            int reset = 0;
+            if (splice_link(link, rest, next, sizeof(next), &reset) != 0) {
+                *err = "invalid_path"; goto fail;
+            }
+            if (reset)                       /* absolute target: re-root */
+                while (depth > 1) close(stack[--depth]);
+            memcpy(rem, next, strlen(next) + 1);
+            cur = rem;
+            continue;
+        }
+    }
+
+done:
+    for (int i = 0; i < depth; i++) close(stack[i]);
+    return result_fd;
+fail:
+    for (int i = 0; i < depth; i++) close(stack[i]);
+    return -1;
+}
+
+/* ── public entry points ──────────────────────────────────────────────────── */
+
+int hl_fs_open_base(const char *base_dir, const char **err)
+{
+    if (!base_dir || base_dir[0] == '\0') { if (err) *err = "invalid_args"; return -1; }
+    int fd = open(base_dir, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (fd < 0) { if (err) map_errno(errno, err); return -1; }
+    return fd;
+}
+
+int hl_fs_open_at(int root_fd, const char *relpath, HlFsOpenMode mode,
+                  mode_t create_mode, const char **err)
+{
+    const char *e = "io_error";
+    if (root_fd < 0 || !relpath) { if (err) *err = "invalid_args"; return -1; }
+    if (!caller_path_ok(relpath)) { if (err) *err = "invalid_path"; return -1; }
+
+#if defined(__linux__) && !defined(__COSMOPOLITAN__)
+    /* openat2 does not create intermediate dirs, so WRITE always uses the manual
+     * walk (which does the contained mkdir-p). READ takes the one-call fast path. */
+    if (mode == HL_FS_OPEN_READ) {
+        int fd = try_openat2(root_fd, relpath, O_RDONLY | O_CLOEXEC, 0, &e);
+        if (fd >= 0) return fd;
+        if (fd == -1) { if (err) *err = e; return -1; }
+        /* fd == -2: openat2 unavailable -> manual walk */
+    }
+#endif
+
+    int fd = resolve_manual(root_fd, relpath, mode, create_mode, &e);
+    if (fd < 0 && err) *err = e;
+    return fd;
+}

--- a/tests/hull/cap/test_fs_resolve.c
+++ b/tests/hull/cap/test_fs_resolve.c
@@ -1,0 +1,225 @@
+/*
+ * test_fs_resolve.c — descriptor-relative virtual-root resolver (checkpoint 1).
+ *
+ * Exercises hl_fs_open_at / hl_fs_open_base against a real temp tree: READ,
+ * WRITE (mkdir-p + O_TRUNC), in-base symlink follow, absolute-symlink re-root,
+ * ".." clamp, symlink loop, and the caller-path lexical pre-check. On macOS this
+ * runs the manual held-fd-stack walk; on Linux it exercises the openat2 fast path
+ * for READ + the manual walk for WRITE.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#if defined(__linux__) && !defined(_XOPEN_SOURCE)
+# define _XOPEN_SOURCE 700
+#endif
+
+#include "utest.h"
+#include "hull/cap/fs_resolve.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <ftw.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+static char base[256];
+
+static void setup(void)
+{
+    snprintf(base, sizeof(base), "/tmp/hull_res_%d", (int)getpid());
+    mkdir(base, 0755);
+}
+static int rm_entry(const char *p, const struct stat *sb, int t, struct FTW *f)
+{ (void)sb; (void)t; (void)f; return remove(p); }
+static void teardown(void)
+{ if (nftw(base, rm_entry, 16, FTW_DEPTH | FTW_PHYS) != 0 && errno != ENOENT) {} }
+
+/* helpers relative to base (real host paths, for fixture construction) */
+static void wfile(const char *rel, const char *data)
+{
+    char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel);
+    FILE *f = fopen(p, "wb"); if (f) { fputs(data, f); fclose(f); }
+}
+static void mkdirp_host(const char *rel)
+{ char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel); mkdir(p, 0755); }
+static void symln(const char *target, const char *rel)
+{ char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel); unlink(p); symlink(target, p); }
+
+static char *slurp(int fd, char *buf, size_t n)
+{
+    ssize_t r = read(fd, buf, n - 1); if (r < 0) r = 0; buf[r] = '\0'; return buf;
+}
+
+/* ── READ ─────────────────────────────────────────────────────────────── */
+UTEST(fs_resolve, read_basic)
+{
+    setup();
+    wfile("hello.txt", "world");
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    ASSERT_GE(root, 0);
+    int fd = hl_fs_open_at(root, "hello.txt", HL_FS_OPEN_READ, 0, &err);
+    ASSERT_GE(fd, 0);
+    char b[64]; ASSERT_STREQ("world", slurp(fd, b, sizeof(b)));
+    close(fd); close(root);
+    teardown();
+}
+
+UTEST(fs_resolve, read_nested)
+{
+    setup();
+    mkdirp_host("a"); mkdirp_host("a/b"); wfile("a/b/c.txt", "deep");
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    int fd = hl_fs_open_at(root, "a/b/c.txt", HL_FS_OPEN_READ, 0, &err);
+    ASSERT_GE(fd, 0);
+    char b[64]; ASSERT_STREQ("deep", slurp(fd, b, sizeof(b)));
+    close(fd); close(root);
+    teardown();
+}
+
+UTEST(fs_resolve, read_not_found)
+{
+    setup();
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    int fd = hl_fs_open_at(root, "nope.txt", HL_FS_OPEN_READ, 0, &err);
+    ASSERT_EQ(fd, -1);
+    ASSERT_STREQ("not_found", err);
+    close(root);
+    teardown();
+}
+
+/* ── caller-path lexical pre-check ────────────────────────────────────── */
+UTEST(fs_resolve, caller_dotdot_rejected)
+{
+    setup();
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    int fd = hl_fs_open_at(root, "a/../../etc/passwd", HL_FS_OPEN_READ, 0, &err);
+    ASSERT_EQ(fd, -1);
+    ASSERT_STREQ("invalid_path", err);
+    close(root);
+    teardown();
+}
+UTEST(fs_resolve, caller_absolute_rejected)
+{
+    setup();
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    int fd = hl_fs_open_at(root, "/etc/passwd", HL_FS_OPEN_READ, 0, &err);
+    ASSERT_EQ(fd, -1);
+    ASSERT_STREQ("invalid_path", err);
+    close(root);
+    teardown();
+}
+
+/* ── WRITE: mkdir-p + O_TRUNC ─────────────────────────────────────────── */
+UTEST(fs_resolve, write_creates_parents)
+{
+    setup();
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    int fd = hl_fs_open_at(root, "out/deep/result.bin", HL_FS_OPEN_WRITE, 0644, &err);
+    ASSERT_GE(fd, 0);
+    ASSERT_EQ((ssize_t)5, write(fd, "abcde", 5));
+    close(fd);
+    /* verify via READ back through the resolver */
+    fd = hl_fs_open_at(root, "out/deep/result.bin", HL_FS_OPEN_READ, 0, &err);
+    ASSERT_GE(fd, 0);
+    char b[64]; ASSERT_STREQ("abcde", slurp(fd, b, sizeof(b)));
+    close(fd); close(root);
+    teardown();
+}
+
+UTEST(fs_resolve, write_truncates)
+{
+    setup();
+    wfile("f.txt", "abcdef");
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    int fd = hl_fs_open_at(root, "f.txt", HL_FS_OPEN_WRITE, 0644, &err);
+    ASSERT_GE(fd, 0);
+    ASSERT_EQ((ssize_t)2, write(fd, "xy", 2));   /* shorter replacement */
+    close(fd);
+    fd = hl_fs_open_at(root, "f.txt", HL_FS_OPEN_READ, 0, &err);
+    char b[64]; ASSERT_STREQ("xy", slurp(fd, b, sizeof(b)));  /* NOT "xycdef" */
+    close(fd); close(root);
+    teardown();
+}
+
+/* ── symlinks: virtual-root ───────────────────────────────────────────── */
+UTEST(fs_resolve, symlink_in_base_followed)
+{
+    setup();
+    mkdirp_host("real"); wfile("real/data", "payload");
+    symln("real/data", "link");           /* relative, in-base */
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    int fd = hl_fs_open_at(root, "link", HL_FS_OPEN_READ, 0, &err);
+    ASSERT_GE(fd, 0);
+    char b[64]; ASSERT_STREQ("payload", slurp(fd, b, sizeof(b)));
+    close(fd); close(root);
+    teardown();
+}
+
+UTEST(fs_resolve, symlink_absolute_rerooted)
+{
+    setup();
+    /* absolute target /etc/hostname must re-root to base/etc/hostname (absent)
+     * -> not_found, and MUST NOT read the real host /etc/hostname. */
+    symln("/etc/hostname", "abs");
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    int fd = hl_fs_open_at(root, "abs", HL_FS_OPEN_READ, 0, &err);
+    ASSERT_EQ(fd, -1);
+    ASSERT_STREQ("not_found", err);
+    close(root);
+    teardown();
+}
+
+UTEST(fs_resolve, symlink_absolute_rerooted_hits_inbase)
+{
+    setup();
+    mkdirp_host("etc"); wfile("etc/hostname", "sandboxed");
+    symln("/etc/hostname", "abs");        /* re-roots to base/etc/hostname */
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    int fd = hl_fs_open_at(root, "abs", HL_FS_OPEN_READ, 0, &err);
+    ASSERT_GE(fd, 0);
+    char b[64]; ASSERT_STREQ("sandboxed", slurp(fd, b, sizeof(b)));
+    close(fd); close(root);
+    teardown();
+}
+
+UTEST(fs_resolve, symlink_dotdot_clamped)
+{
+    setup();
+    wfile("top", "at-root");
+    mkdirp_host("d");
+    symln("../../../../top", "d/up");     /* excess .. clamps at base -> base/top */
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    int fd = hl_fs_open_at(root, "d/up", HL_FS_OPEN_READ, 0, &err);
+    ASSERT_GE(fd, 0);
+    char b[64]; ASSERT_STREQ("at-root", slurp(fd, b, sizeof(b)));
+    close(fd); close(root);
+    teardown();
+}
+
+UTEST(fs_resolve, symlink_loop_bounded)
+{
+    setup();
+    symln("b", "a"); symln("a", "b");     /* a -> b -> a ... */
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    int fd = hl_fs_open_at(root, "a", HL_FS_OPEN_READ, 0, &err);
+    ASSERT_EQ(fd, -1);
+    ASSERT_STREQ("symlink_loop", err);
+    close(root);
+    teardown();
+}
+
+UTEST_MAIN();


### PR DESCRIPTION
Throwaway. #397 + track-origins=2 to capture the WAMR uninit origin. Not for merge.