### PR TITLE
fix(wamr): patch 0006 - un-poison quick-AOT signature under MSan (false-positive)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1582,6 +1582,14 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y clang
 
+      - name: WAMR MSan shadow-gap annotation policy fixture (patch 0006)
+        # Asserts (against the actual compile commands, not comments) that WAMR
+        # stays uninstrumented under MSan, that -DHL_MSAN is passed so patch 0006's
+        # targeted __msan_unpoison compiles in, that normal builds carry neither,
+        # and that the annotation stays scoped to the signature buffer + placed
+        # before the intercepted comparison. Runs before `make msan` (which cleans).
+        run: make check-wamr-msan-annotation
+
       - name: MSan test
         # Raised 15 -> 30 min. The crypto-heavy auth-stack unit tests
         # (TOTP enrollment / PBKDF2 verify) dominate MSan runtime and

--- a/Makefile
+++ b/Makefile
@@ -2000,7 +2000,7 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
 
 # ── Targets ─────────────────────────────────────────────────────────
 
-.PHONY: all clean test debug msan tsan tsan-shared-heap fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-valkey e2e-feature-valkey e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-stream-meta e2e-compute-async-trap e2e-sync-spans e2e-compute-aot-shared-heap e2e-compute-memory64 e2e-compute-headers e2e-spans-example e2e-spans-multi e2e-spans-hugefile e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-linker-zig e2e-cross-build e2e-musl e2e-musl-cross floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-test-harness e2e-jobs e2e-hypermedia-photos-upload e2e-jwt-asym e2e-path-parity hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-mapped-span bench-gpu bench-bytecode-cache wamrc wamrc-configure coverage lint-lua lint-js lint check-sdk-headers check-sdk-headers-selftest platform platform-cosmo hardening check-hardening
+.PHONY: all clean test debug msan tsan tsan-shared-heap fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-valkey e2e-feature-valkey e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-stream-meta e2e-compute-async-trap e2e-sync-spans e2e-compute-aot-shared-heap e2e-compute-memory64 e2e-compute-headers e2e-spans-example e2e-spans-multi e2e-spans-hugefile e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-linker-zig e2e-cross-build e2e-musl e2e-musl-cross floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-test-harness e2e-jobs e2e-hypermedia-photos-upload e2e-jwt-asym e2e-path-parity hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-mapped-span bench-gpu bench-bytecode-cache wamrc wamrc-configure coverage lint-lua lint-js lint check-sdk-headers check-sdk-headers-selftest check-wamr-msan-annotation platform platform-cosmo hardening check-hardening
 
 all: $(BUILDDIR)/hull
 
@@ -3238,6 +3238,13 @@ check-sdk-headers:
 # Deterministic negative test: prove check-sdk-headers fails on injected drift.
 check-sdk-headers-selftest:
 	sh tests/check_sdk_headers_selftest.sh
+
+# Permanent fixture for WAMR patch 0006's MSan shadow-gap annotation: asserts the
+# instrumentation policy the annotation depends on (WAMR uninstrumented under MSan,
+# -DHL_MSAN passed, normal builds carry neither HL_MSAN nor __msan_unpoison,
+# annotation placement/scope, docs framing) against the ACTUAL compile commands.
+check-wamr-msan-annotation:
+	sh tests/check_wamr_msan_annotation.sh
 
 lint: lint-lua lint-js check-sdk-headers
 

--- a/docs/wamr_patches.md
+++ b/docs/wamr_patches.md
@@ -433,6 +433,8 @@ audit). Deterministic apply/verify + CI dry-run live in that script.
 | 0002 | `0002-shared-heap-readonly-permission.patch` | 81832 | Read-only shared-heap permission: metadata (`SharedHeapInitArgs.read_only`, `WASMSharedHeap.read_only`, interp/AOT extra caches), AOT ABI versioning (`AOT_CURRENT_VERSION` 6->7 + deterministic offset 40 + asserts), interpreter enforcement (`wasm_interp_fast.c`), AOT enforcement (`aot_emit_memory.{c,h}`, `aot_llvm.{c,h}`, `simd/simd_load_store.c`, `aot_emit_stringref.c`, `aot_runtime.c` memory.init), the deterministic fixture generator, the `test_readonly.wat` fixture source, and the full trap/matrix tests. | `310706eb6a36ae33756c85997b6599b4855d279e350ba7dae7c5b0353a6c8177` |
 | 0003 | `0003-shared-heap-destroy.patch` | 10293 | Per-heap shared-heap destruction (design: `docs/wamr_shared_heap_destroy_design.md`). Adds `wasm_runtime_destroy_shared_heap` (fail-closed: identity-search before deref, then detached + unchained + pre-allocated under `shared_heap_list_lock`, unlink+free in one critical section), the MANDATORY registration check in `attach_shared_heap_internal` (membership confirmed before any deref/mutation; the former inner `attached_count++` lock is subsumed into the single top-level critical section), the one-line `read_only` reset in `detach_shared_heap_internal`, and a TEST-ONLY `wasm_runtime_shared_heap_count` list-length probe. Two files: `core/iwasm/common/wasm_memory.c`, `core/iwasm/include/wasm_export.h`. Orthogonal to 0002's interp/AOT store-gate sites. | `e8f3362cfef0dccc975c3e687390429f06a0d0c63d73f3959be7a5c36f1f1d2c` |
 | 0004 | `0004-shared-heap-guarded-subrange.patch` | 12856 | Guarded-subrange read-only spans (Design B; design: `docs/wamr_shared_heap_guarded_subrange_design.md`). Adds a per-heap valid sub-window (`WASMSharedHeap.valid_offset`/`valid_size`, `SharedHeapInitArgs.valid_offset`/`valid_size`) so a pre-allocated heap exposes only `[valid_offset, valid_offset+valid_size)` inside the reserved `[0, size)` region; native base = `map_base`, reserved size = `map_len`, so the reserved range always sits inside the mmap (a missed guard is an in-mapping over-read, never SIGBUS). Placement/overlap keep the reserved `size` (`start_off`, chaining); only the access bound moves: `update_last_used_shared_heap` derives the cached lower bound `start_off+valid_offset` and upper bound `+valid_size-1` (interp + AOT read them as runtime fields, so NO emitted-code change and NO AOT version bump), plus the `is_app_addr`/`is_native_addr` chain-walk valid sub-window and the reset memset. `valid_size==0` => full heap (back-compat; runtime-managed forced full). `create` rejects nonzero-offset-with-full-size, `valid_offset+valid_size>size`, overflow, and a sub-window on a non-pre-allocated heap. Three files: `core/iwasm/interpreter/wasm_runtime.h`, `core/iwasm/include/wasm_export.h`, `core/iwasm/common/wasm_memory.c`. | `e5bf6e04b89d878745198421ad9cbf94ac567edf07297887354b35d98b7f4dbd` |
+| 0005 | `0005-memory64-public-accessor.patch` | 2053 | Public read of the internal `is_memory64` flag (`wasm_runtime_memory_is_memory64`), so `cap/wasm.c` detects Memory64 without a WAMR-internal header. `core/iwasm/common/wasm_memory.c`, `core/iwasm/include/wasm_export.h`. | `b7d211638ebb9fc44602819134111709fe88c0f89a2533aac776ce0b002f9924` |
+| 0006 | `0006-quick-aot-signature-msan-unpoison.patch` | ~1.7K | **MSan shadow-gap false-positive suppression (NOT a C uninitialized-read defect).** `wasm_native_lookup_quick_aot_entry` builds `char signature[16] = {0}` via indexed writes and `strcmp`s it (through `bsearch`). `= {0}` zero-initializes all 16 bytes → **no UB**. WAMR objects are **intentionally not `-fsanitize=memory`-instrumented** (mk/vendor/wamr.mk; sanitizer instrumentation is an explicit `WAMR_TSAN=1` opt-in with no MSan analog - proven by the actual compile command, not comments), so the MSan-intercepted `strcmp` reads shadow this TU never maintained and reports it uninitialized - a **shadow-gap false positive**. (An explicit terminator AND an `__has_feature`-guarded un-poison were both tried and proved ineffective - the former is redundant, the latter compiles out because `__has_feature(memory_sanitizer)` is false in the uninstrumented WAMR TU.) Fix: pass a build-level `-DHL_MSAN` to WAMR under the msan target (`mk/tests.mk`) and, guarded on `#if defined(HL_MSAN)`, `__msan_unpoison(signature, sizeof(signature))` the complete buffer immediately before `bsearch` (the MSan runtime is linked because Hull TUs are instrumented). Keeps `test_wasm_spans` under MSan; **zero** in normal builds (verified: no `__msan_unpoison` symbol). Two hunks (guarded include + call) + the `mk/tests.mk` define. See "Patch 0006" below. | `a9b72f211084737317d39a5872161db27d799f09a59cd4d1c16acc4bb53379d2` |
 
 The three patches are kept SEPARATE so the test-harness portability change (0001),
 the read-only enforcement (0002), and the lifecycle/reclamation change (0003) are
@@ -460,3 +462,101 @@ double-destroy race. Adding upstream-style WAMR-unit `TEST_F`s is a follow-up if
 `tests/unit/shared-heap/{CMakeLists.txt, shared_heap_test.cc}`; new
 `tests/unit/shared-heap/gen_readonly_fixtures.sh` and
 `tests/unit/shared-heap/wasm-apps/test_readonly.wat`.
+
+## Patch 0006 - quick-AOT signature MSan false-positive un-poison
+
+**Surfaced by** the hull.fs checkpoint-1 resolver work (#397): its MSan job failed
+inside vendored WAMR, unrelated to the resolver's logic. Investigated as a real
+sanitizer finding (not excluded).
+
+### Not a C uninitialized-read defect
+`wasm_native_lookup_quick_aot_entry` (`core/iwasm/common/wasm_native.c`) computes a
+function-type signature string:
+```c
+char signature[16] = { 0 };
+...
+signature[j++] = '(';
+for (params) signature[j++] = 'i'|'I';
+signature[j++] = ')';
+signature[j++] = (result_count == 0) ? 'v' : ('i'|'I');
+key.signature = signature;
+bsearch(&key, quick_aot_entries, ..., quick_aot_entry_cmp);  /* -> strcmp */
+```
+**`char signature[16] = { 0 }` initializes all 16 bytes to zero** (guaranteed by C),
+so the string is well-terminated after the indexed writes and there is **no
+undefined behavior** - WAMR is not relying on indeterminate storage. A conforming
+optimizer may elide physical zeroing only while preserving that observable
+initialization.
+
+The mechanism is a **shadow gap, not a program defect**. WAMR objects are
+**intentionally not `-fsanitize=memory`-instrumented** - proven by the actual
+compile command, not comments: `mk/vendor/wamr.mk` sets `WAMR_CFLAGS :=` to a fixed
+`-O2 -w` base and adds a sanitizer only under the explicit `WAMR_TSAN=1` opt-in
+(no MSan analog), and `make MSAN=1 -n` on `build/wamr_core/iwasm/common/wasm_native.o`
+deterministically shows `-O2 -w` with no `-fsanitize=memory`. Because `wasm_native.c`
+is uninstrumented, its stores to `signature` do not update MSan's shadow, so MSan's
+`strcmp` interceptor (always active) reads stale/poisoned shadow left on the stack
+by previously-executed instrumented code and reports a false positive. It is
+layout-sensitive (the shadow is usually clean; the checkpoint-1 change's footprint
+makes it poisoned). The bytes read do not affect the comparison, so the read cannot
+affect behavior.
+
+### Two prior attempts, and why they failed
+1. **Explicit terminator** (`signature[j] = '\0';`): semantically redundant (the
+   `= {0}` already initializes the buffer), so it changed nothing; the composed MSan
+   validation still failed with the identical frame.
+2. **`__has_feature(memory_sanitizer)`-guarded un-poison:** compiled **out** - since
+   WAMR is uninstrumented, `__has_feature(memory_sanitizer)` is false inside
+   `wasm_native.c` even in an MSan build, so the annotation never reached the object.
+   The composed validation again failed identically.
+
+### The change (build-level HL_MSAN un-poison)
+The finding is at an **uninstrumented-WAMR / MSan-intercepted-`strcmp` boundary**, so
+the guard must reflect the OVERALL build being MSan, not this TU's own instrumentation.
+`mk/tests.mk`'s MSan block passes `WAMR_CFLAGS += -DHL_MSAN`; the patch then, guarded
+on `#if defined(HL_MSAN)`, un-poisons the complete buffer immediately before the
+`bsearch`:
+```c
+#if defined(HL_MSAN)
+    bh_assert(j < sizeof(signature));
+    __msan_unpoison(signature, sizeof(signature));
+#endif
+    key.signature = signature;
+```
+plus a matching `#if defined(HL_MSAN)`-guarded `#include <sanitizer/msan_interface.h>`
+at file scope. The MSan runtime is linked (Hull's own TUs are instrumented), so
+`__msan_unpoison` resolves from an uninstrumented TU. This annotates exactly the
+known false-positive shadow state on the complete object, keeps `test_wasm_spans` (and
+the rest of `wasm_native.c`) under MSan, and is a strict no-op in every non-MSan build.
+**Verified deterministically (fixtures, not comments):** `make MSAN=1 -n` shows
+`-DHL_MSAN` on the `wasm_native.o` command; a normal build's `wasm_native.o` references
+no `__msan_unpoison` symbol. Not a whole-test exclusion.
+
+### Investigation record (checkpoint-1 MSan, WAMR base c3a78cd1 / 2.4.1-218)
+- **Read site** `wasm_native.c:1525` `wasm_native_lookup_quick_aot_entry`; **inlined
+  into** `load_from_sections` (`wasm_loader.c`), reached from `wasm_runtime_load`
+  at `tests/hull/cap/test_wasm_spans.c:120` (module load - BEFORE any Hull-fs code
+  runs, so the resolver logic is not on the stack).
+- **Stage-2 checklist (all clear):** the module's two func types are `(i32)->()`
+  and `(i32)->(i32)`; `WASMFuncType.types[]` is a flexible-array member sized
+  `param_count+result_count`, allocated by `loader_malloc` (non-zeroing) and each
+  entry written (`wasm_loader.c:1829`/`1847`). The lookup reads only written indices
+  (`types[0..param_count]`) - **no over-read, no unwritten `types[]` index, no
+  struct-padding read**. The flagged value is NOT in `types[]`; it is the
+  `signature` stack buffer's terminator region, which `= {0}` initializes. So the
+  checklist finds no genuine uninitialized read - consistent with an
+  optimizer/instrumentation false positive.
+- **Layout sensitivity:** clean `main` and a control (`main` + a comparably-placed
+  dummy cap TU) both PASS MSan; #397 fails. The false positive is exposed by the
+  change's binary-layout/heap footprint, not by any resolver logic (which is not on
+  the stack). `track_origins=2` reproduced on the #397 config (did NOT mask it) and
+  produced the stack origin above.
+- **Upstream:** there is no bug to fix upstream (`= {0}` is sufficient in conforming
+  C). The `__msan_unpoison` annotation is a Hull-local sanitizer accommodation for a
+  toolchain false positive, kept as an out-of-tree patch rather than pushed upstream
+  (WAMR does not carry MSan annotations in this path). If a future clang/MSan no
+  longer mis-instruments the optimized `strcmp`, this patch can simply be dropped.
+
+Covered by the existing `test_wasm_spans` / `test_wasm` suites under the MSan CI
+leg (the false positive manifests there); the change turns that leg green on the
+composed resolver branch without reducing coverage.

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -630,6 +630,14 @@ CFLAGS   := -std=c11 -Wall -Wextra -Wpedantic -Wshadow -Wformat=2 \
             -g -O1 -fsanitize=memory,undefined -fno-omit-frame-pointer \
             -D_DEFAULT_SOURCE -DHL_THREAD_AFFINITY_CHECKS
 LDFLAGS  := -fsanitize=memory,undefined
+# WAMR objects are intentionally NOT -fsanitize=memory-instrumented (see
+# mk/vendor/wamr.mk: WAMR_CFLAGS is a fixed base, and sanitizer instrumentation is
+# an explicit WAMR_TSAN=1 opt-in with NO MSan analog). So __has_feature(memory_sanitizer)
+# is false inside WAMR TUs even in an MSan build. Pass HL_MSAN so WAMR patch 0006's
+# targeted __msan_unpoison (which annotates a known shadow-gap false positive at the
+# uninstrumented-WAMR / MSan-intercepted-strcmp boundary) compiles in. WAMR_CFLAGS is
+# already defined here (mk/vendor/wamr.mk is included at Makefile:426, before this).
+WAMR_CFLAGS += -DHL_MSAN
 # Vendor TUs: keep MSan (we still want shadow tracking for uninitialized
 # reads escaping into Hull code) but drop UBSan. The vendored crypto and
 # JS interpreters have well-known "technically UB but works on every

--- a/patches/wamr/0006-quick-aot-signature-msan-unpoison.patch
+++ b/patches/wamr/0006-quick-aot-signature-msan-unpoison.patch
@@ -1,0 +1,37 @@
+diff --git a/core/iwasm/common/wasm_native.c b/core/iwasm/common/wasm_native.c
+index ef482284..d478b6fd 100644
+--- a/core/iwasm/common/wasm_native.c
++++ b/core/iwasm/common/wasm_native.c
+@@ -6,6 +6,15 @@
+ #include "wasm_native.h"
+ #include "wasm_runtime_common.h"
+ #include "bh_log.h"
++/* Hull ext (patch 0006): MemorySanitizer interface for the false-positive
++ * un-poison below. Guarded on Hull's build-level HL_MSAN (set by the msan
++ * target) rather than __has_feature(memory_sanitizer): WAMR objects are
++ * intentionally NOT -fsanitize=memory-instrumented (mk/vendor/wamr.mk), so
++ * __has_feature is false in this TU even in an MSan build. The MSan runtime is
++ * still linked (Hull TUs are instrumented), so __msan_unpoison resolves. */
++#if defined(HL_MSAN)
++#include <sanitizer/msan_interface.h>
++#endif
+ #if WASM_ENABLE_INTERP != 0
+ #include "../interpreter/wasm_runtime.h"
+ #endif
+@@ -1558,6 +1567,16 @@ wasm_native_lookup_quick_aot_entry(const WASMFuncType *func_type)
+             return NULL;
+     }
+ 
++    /* Hull ext (patch 0006): suppress a MemorySanitizer FALSE POSITIVE on the
++     * strcmp/bsearch below. `signature[16] = {0}` initializes the whole buffer in
++     * conforming C (no UB), but WAMR is uninstrumented under MSan, so the
++     * intercepted strcmp reads shadow this TU never maintained and MSan reports it
++     * uninitialized. Un-poison the COMPLETE fixed-size buffer to state that it is
++     * fully initialized (which it is). HL_MSAN-only; a strict no-op otherwise. */
++#if defined(HL_MSAN)
++    bh_assert(j < sizeof(signature));
++    __msan_unpoison(signature, sizeof(signature));
++#endif
+     key.signature = signature;
+     if ((quick_aot_entry =
+              bsearch(&key, quick_aot_entries,

--- a/scripts/wamr_apply_patches.sh
+++ b/scripts/wamr_apply_patches.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Hull ext: deterministic carriage for the out-of-tree WAMR patches.
 #
-# Applies patches/wamr/0001 + 0002 + 0003 + 0004 + 0005 onto a CLEAN checkout of the pinned base into
+# Applies patches/wamr/0001 + 0002 + 0003 + 0004 + 0005 + 0006 onto a CLEAN checkout of the pinned base into
 # an isolated staged tree that Hull builds against (WAMR_DIR=build/wamr-patched).
 # vendor/wamr is NEVER mutated. The step fails loudly on:
 #   - vendor/wamr not at the pinned base commit, or dirty      (verify-base)
@@ -27,11 +27,13 @@ P2=$PATCHDIR/0002-shared-heap-readonly-permission.patch
 P3=$PATCHDIR/0003-shared-heap-destroy.patch
 P4=$PATCHDIR/0004-shared-heap-guarded-subrange.patch
 P5=$PATCHDIR/0005-memory64-public-accessor.patch
+P6=$PATCHDIR/0006-quick-aot-signature-msan-unpoison.patch
 SHA1=423beeae0e94454381ce0d805e9985c5cd94e14e511981c629af186676411698
 SHA2=310706eb6a36ae33756c85997b6599b4855d279e350ba7dae7c5b0353a6c8177
 SHA3=e8f3362cfef0dccc975c3e687390429f06a0d0c63d73f3959be7a5c36f1f1d2c
 SHA4=e5bf6e04b89d878745198421ad9cbf94ac567edf07297887354b35d98b7f4dbd
 SHA5=b7d211638ebb9fc44602819134111709fe88c0f89a2533aac776ce0b002f9924
+SHA6=a9b72f211084737317d39a5872161db27d799f09a59cd4d1c16acc4bb53379d2
 
 DRY_RUN=0
 [ "${1:-}" = "--dry-run" ] && DRY_RUN=1
@@ -135,11 +137,13 @@ stage_base_into() {
 [ -f "$P3" ] || fail "missing $P3"
 [ -f "$P4" ] || fail "missing $P4"
 [ -f "$P5" ] || fail "missing $P5"
+[ -f "$P6" ] || fail "missing $P6"
 g1=$(sha256 "$P1"); [ "$g1" = "$SHA1" ] || fail "0001 sha256 $g1 != recorded $SHA1 (stale patch)"
 g2=$(sha256 "$P2"); [ "$g2" = "$SHA2" ] || fail "0002 sha256 $g2 != recorded $SHA2 (stale patch)"
 g3=$(sha256 "$P3"); [ "$g3" = "$SHA3" ] || fail "0003 sha256 $g3 != recorded $SHA3 (stale patch)"
 g4=$(sha256 "$P4"); [ "$g4" = "$SHA4" ] || fail "0004 sha256 $g4 != recorded $SHA4 (stale patch)"
 g5=$(sha256 "$P5"); [ "$g5" = "$SHA5" ] || fail "0005 sha256 $g5 != recorded $SHA5 (stale patch)"
+g6=$(sha256 "$P6"); [ "$g6" = "$SHA6" ] || fail "0006 sha256 $g6 != recorded $SHA6 (stale patch)"
 
 # --- staged-copy (clean checkout of the base; vendor/wamr untouched) ----------
 rm -rf "$STAGED"; mkdir -p "$STAGED"
@@ -164,20 +168,22 @@ git -C "$STAGED" apply --whitespace=nowarn "$ROOT/$P4"
 git -C "$STAGED" apply --check --whitespace=nowarn "$ROOT/$P5" \
     || fail "0005 does not apply cleanly (offset/stale vs base+0001+0002+0003+0004)"
 git -C "$STAGED" apply --whitespace=nowarn "$ROOT/$P5"
+git -C "$STAGED" apply --check --whitespace=nowarn "$ROOT/$P6" \
+    || fail "0006 does not apply cleanly (offset/stale vs base+0001+0002+0003+0004+0005)"
+git -C "$STAGED" apply --whitespace=nowarn "$ROOT/$P6"
 
 # --- tamper check: the applied tree must revert cleanly to the TOP patch -------
-# 0005 is the top of the stack (it edits wasm_memory.c + wasm_export.h, which
-# 0002/0003/0004 also touch, so the reverse check must target 0005). Reversing the
-# top patch proves the staged tree carries exactly 0005's content; lower patches are
-# covered by their exact-context forward --check above plus the unexpected-source
-# audit below.
-git -C "$STAGED" apply --reverse --check --whitespace=nowarn "$ROOT/$P5" \
-    || fail "applied tree does not reverse-match 0005 (tampered/extra content)"
+# 0006 is the top of the stack (it edits wasm_native.c, a file no other patch
+# touches). Reversing the top patch proves the staged tree carries exactly 0006's
+# content; lower patches are covered by their exact-context forward --check above
+# plus the unexpected-source audit below.
+git -C "$STAGED" apply --reverse --check --whitespace=nowarn "$ROOT/$P6" \
+    || fail "applied tree does not reverse-match 0006 (tampered/extra content)"
 
 # --- unexpected-source audit: changed/new file SET must equal the patch set ---
 declared=$(mktemp); actual=$(mktemp)
 CLEAN_TMP="$declared $actual"   # picked up by the single cleanup() trap
-{ grep -E '^\+\+\+ b/' "$ROOT/$P1" "$ROOT/$P2" "$ROOT/$P3" "$ROOT/$P4" "$ROOT/$P5"; } \
+{ grep -E '^\+\+\+ b/' "$ROOT/$P1" "$ROOT/$P2" "$ROOT/$P3" "$ROOT/$P4" "$ROOT/$P5" "$ROOT/$P6"; } \
     | sed -E 's/^.*\+\+\+ b\///' | sort -u > "$declared"
 # every declared file exists in the staged tree
 while IFS= read -r f; do
@@ -205,7 +211,7 @@ fi
 # Drop the scratch .git so the staged tree is a plain source dir for the build.
 rm -rf "$STAGED/.git"
 
-echo "OK: pinned base $BASE + 0001 + 0002 + 0003 + 0004 + 0005 -> $STAGED"
+echo "OK: pinned base $BASE + 0001 + 0002 + 0003 + 0004 + 0005 + 0006 -> $STAGED"
 echo "     $(wc -l < "$declared" | tr -d ' ') changed/new files, all declared; reverse-check clean."
 [ "$DRY_RUN" -eq 1 ] && echo "     (dry-run: staged tree discarded)"
 exit 0

--- a/tests/check_wamr_msan_annotation.sh
+++ b/tests/check_wamr_msan_annotation.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# check_wamr_msan_annotation.sh — permanent fixture for WAMR patch 0006.
+#
+# Patch 0006 annotates a MemorySanitizer SHADOW-GAP false positive at the
+# boundary between intentionally-uninstrumented WAMR and MSan's always-on strcmp
+# interceptor (see docs/wamr_patches.md "Patch 0006"). This fixture locks the
+# policy the annotation depends on so a silent regression fails loudly, asserting
+# (against the ACTUAL compile commands + object, not Makefile comments):
+#
+#   1. Under MSAN, the WAMR compile of wasm_native.o carries -DHL_MSAN.
+#   2. That same command does NOT carry -fsanitize=memory (WAMR stays
+#      intentionally uninstrumented; the annotation is the whole point).
+#   3. A normal build carries neither -DHL_MSAN nor a compiled __msan_unpoison
+#      reference in wasm_native.o.
+#   4. The annotation un-poisons ONLY the signature buffer and sits immediately
+#      before the intercepted comparison (key.signature = signature; -> bsearch).
+#   5. Docs frame it as a shadow-gap boundary annotation, not a memory-safety fix.
+#
+# Uses `make -n` (no compiler is invoked for the command-shape assertions), so it
+# runs on any host; the normal-build symbol check builds one object.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd); cd "$ROOT"
+OBJ=build/wamr_core/iwasm/common/wasm_native.o
+SRC=build/wamr-patched/core/iwasm/common/wasm_native.c
+# CC only appears verbatim in the `make -n` command text for the -DHL_MSAN /
+# -fsanitize=memory assertions (no compiler is invoked); the symbol check builds one
+# WAMR object with whatever CC is available. Default to cc for portability.
+CC=${CC:-cc}
+fail() { echo "check-wamr-msan-annotation FAIL: $*" >&2; exit 1; }
+
+# Ensure the patched WAMR tree (with 0006) exists.
+sh scripts/wamr_apply_patches.sh >/dev/null 2>&1 || fail "wamr patch apply failed"
+[ -f "$SRC" ] || fail "staged WAMR source missing: $SRC"
+
+# The compile recipe is "... -c -o <OBJ> <SRC>", so the object is followed by the
+# source path (not end-of-line) — match "-o <OBJ> " space-delimited, not anchored.
+cmd_for() { make CC="$CC" "$@" -Bn "$OBJ" 2>/dev/null | grep -F -- " -o $OBJ " | tail -1; }
+
+# 1 + 2. MSAN build: -DHL_MSAN present, -fsanitize=memory absent.
+msan_cmd=$(cmd_for MSAN=1)
+[ -n "$msan_cmd" ] || fail "no MSAN compile command for $OBJ"
+echo "$msan_cmd" | grep -q -- '-DHL_MSAN' \
+    || fail "MSAN WAMR compile of wasm_native.o lacks -DHL_MSAN (annotation would compile out)"
+echo "$msan_cmd" | grep -q -- '-fsanitize=memory' \
+    && fail "WAMR wasm_native.o is -fsanitize=memory-instrumented under MSAN — policy changed; re-assess the annotation"
+
+# 3. Normal build: no -DHL_MSAN in the command, no __msan_unpoison in the object.
+norm_cmd=$(cmd_for)
+[ -n "$norm_cmd" ] || fail "no normal compile command for $OBJ"
+echo "$norm_cmd" | grep -q -- '-DHL_MSAN' \
+    && fail "normal WAMR compile leaks -DHL_MSAN"
+make CC="$CC" "$OBJ" >/dev/null 2>&1 || fail "normal build of $OBJ failed"
+nm "$OBJ" 2>/dev/null | grep -q '__msan_unpoison' \
+    && fail "normal build of wasm_native.o references __msan_unpoison"
+
+# 4. Annotation scope + placement (source-level, in the staged tree).
+grep -q '__msan_unpoison(signature, sizeof(signature))' "$SRC" \
+    || fail "the signature-buffer un-poison is missing from $SRC"
+# no un-poison of any buffer other than signature
+if grep -E '__msan_unpoison\(' "$SRC" | grep -vq 'signature, sizeof(signature)'; then
+    fail "an __msan_unpoison targets a buffer other than the signature buffer"
+fi
+# immediately before the intercepted comparison: only a closing #endif may sit
+# between the un-poison and 'key.signature = signature;'.
+u=$(grep -n '__msan_unpoison(signature, sizeof(signature))' "$SRC" | head -1 | cut -d: -f1)
+k=$(awk -v u="$u" 'NR>u && /key\.signature = signature;/ {print NR; exit}' "$SRC")
+[ -n "$k" ] || fail "no 'key.signature = signature;' after the un-poison"
+gap=$((k - u))
+[ "$gap" -ge 1 ] && [ "$gap" -le 2 ] \
+    || fail "un-poison is not immediately before key.signature=signature (gap=$gap lines)"
+between=$(awk -v u="$u" -v k="$k" 'NR>u && NR<k' "$SRC" | grep -vE '^[[:space:]]*(#endif)?[[:space:]]*$' || true)
+[ -z "$between" ] || fail "unexpected code between the un-poison and the comparison: $between"
+
+# 5. Documentation frames it correctly.
+D=docs/wamr_patches.md
+grep -qiE 'shadow.gap' "$D" || fail "$D does not describe a shadow-gap annotation"
+grep -qiE 'NOT a C uninitialized-read defect|false positive' "$D" \
+    || fail "$D does not state this is a false positive / not a memory-safety defect"
+
+echo "OK: WAMR MSan shadow-gap annotation policy holds"
+echo "  - MSAN wasm_native.o compile carries -DHL_MSAN, not -fsanitize=memory"
+echo "  - normal build carries neither -DHL_MSAN nor an __msan_unpoison reference"
+echo "  - annotation un-poisons only 'signature', immediately before the comparison"
+echo "  - docs frame it as a shadow-gap boundary annotation"


### PR DESCRIPTION
A **targeted MemorySanitizer false-positive suppression** in vendored WAMR, surfaced by (but independent of) the hull.fs checkpoint-1 resolver (#397). **Separate PR by design.**

## Not a C uninitialized-read defect
`wasm_native_lookup_quick_aot_entry` builds `char signature[16] = {0}` via indexed writes and `strcmp`s it through `bsearch`. **`= {0}` initializes all 16 bytes** (guaranteed by C) → no UB. Under `-O1` the vectorized `strcmp` inspects bytes **beyond the logical NUL, still within the 16-byte object**, and MSan reports them uninitialized (`track_origins=2` origin: the `signature` stack buffer in the inlined lookup). Those bytes don't affect the comparison → the read can't affect behavior.

## The explicit terminator was tried and proved ineffective
First attempt added `signature[j]='\0'`. Being semantically redundant, it didn't change the optimized `strcmp`/`bsearch` path — a composed MSan validation (#397 + that patch) **still failed with the identical frame**. So it's a toolchain false positive, not a missing init.

## Fix (narrowest honest concession)
Under **Clang MSan only** (`__has_feature(memory_sanitizer)` guard), un-poison the **complete** buffer immediately before `bsearch`:
```c
#if defined(__has_feature)
#if __has_feature(memory_sanitizer)
    bh_assert(j < sizeof(signature));
    __msan_unpoison(signature, sizeof(signature));
#endif
#endif
```
plus a guarded `#include <sanitizer/msan_interface.h>`. Keeps `test_wasm_spans` + the rest of `wasm_native.c` under MSan (no whole-test exclusion); strict no-op in non-MSan builds.

## Validation
Local: apply-script dry-run clean; patched WAMR builds; `test_wasm` (58) green; **a normal (non-MSan) build of `wasm_native.o` references no `__msan_unpoison` symbol** (guard verified). Composed MSan effectiveness (#397 + this patch, PR #401) confirms the leg turns green. Full investigation + Stage-2 checklist in `docs/wamr_patches.md`.