### PR TITLE
test(fs): checkpoint 2 - resolver parity + race-resistance + ratified depth divergence

### DIFF
--- a/docs/hull_fs_resolver_parity.md
+++ b/docs/hull_fs_resolver_parity.md
@@ -1,0 +1,103 @@
+# hull.fs resolver parity + race-resistance (checkpoint 2)
+
+Checkpoint 2 of the hull.fs design ([hull_fs_design.md](hull_fs_design.md) §9/§10):
+**prove that the two resolver implementations honor the same virtual-root
+contract, and that resolution is race-resistant.** It is a proof/test checkpoint -
+no new resolver features, no `stat`/`list`, no compiled authorization, no
+BuildContext.
+
+## The two implementations
+
+`src/hull/cap/fs_resolve.c` resolves a caller path under a base-directory fd with
+virtual-root (RESOLVE_IN_ROOT) semantics via one of two implementations:
+
+- **openat2 fast path** (Linux ≥ 5.6, READ only): one
+  `openat2(RESOLVE_IN_ROOT | RESOLVE_NO_MAGICLINKS)` syscall.
+- **manual walk** (macOS, cosmo, older Linux, and Linux WRITE): a held-fd-stack
+  walk that reproduces RESOLVE_IN_ROOT (per-component `openat` `O_NOFOLLOW`,
+  symlink splice with absolute-reroot / `..`-clamp, a 40-expansion loop bound).
+
+Both are race-free (every step binds a held fd / a single kernel-confined call);
+neither uses `realpath`.
+
+## How parity is proven
+
+`tests/hull/cap/test_fs_resolve_parity.c` runs each case through **both**
+implementations on one host: the `HL_FS_FORCE_MANUAL` env forces the manual walk,
+so on Linux a case is resolved once via openat2 and once via the manual walk and
+their outcomes are compared directly (success + the stable error token). On
+macOS/cosmo both passes are the manual walk (a self-consistency check).
+
+- **`read_battery`** — a fixture tree exercised for: a plain file, a nested file,
+  a relative symlink, an absolute symlink (re-rooted), a `..`-escaping symlink
+  (clamped), a missing path (`not_found`), a self-loop (`symlink_loop`), a
+  trailing-slash path (`invalid_path`), and a caller `..` (`invalid_path`). Each
+  asserts the two implementations return the **identical** success content or the
+  **identical** error token.
+- **`depth_boundary`** — `HL_FS_MAX_DEPTH` components is accepted (not "too deep")
+  and `+1` is rejected with `path_too_deep`, identically on both (the caller-path
+  component count is checked before either implementation).
+- **`component_swap_race_stays_contained`** — see "Race resistance" below.
+
+## Ratified divergence: symlink-expanded depth (a platform resource limit)
+
+There is exactly **one** intentional, documented behavioral asymmetry, and it is
+asserted explicitly by `ratified_symlink_expanded_depth` (Linux):
+
+- A **caller path** longer than `HL_FS_MAX_DEPTH` components is rejected
+  identically by both (the pre-check runs before either implementation).
+- But a **symlink whose target expands the resolved path past
+  `HL_FS_MAX_DEPTH`** diverges: the manual walk fails closed with `path_too_deep`
+  because its held-fd stack is a finite resource (one open descriptor per level,
+  kept well under `RLIMIT_NOFILE`); openat2 has no component-count limit and
+  resolves the same path within the kernel's own `PATH_MAX` / `ELOOP` bounds, so
+  it may succeed.
+
+**Ratification.** This is **not** claimed as exact behavioral parity. It is a
+platform-resource-limit asymmetry: the manual walk's fd-stack depth is a bounded
+resource that openat2 (a single kernel call) does not consume. Both implementations
+remain **fully contained** — neither can escape `base_dir`; the only difference is
+that the manual walk rejects a pathological deep-symlink-expansion that openat2
+accepts. The manual walk is therefore the **stricter, fail-closed** side, which is
+the safe direction. Reaching this case requires a symlink whose single target has
+256+ path components (a construction no normal layout produces).
+
+Two ways this could be "eliminated" instead, both rejected for checkpoint 2:
+- Post-resolution depth-check openat2 via `/proc/self/fd` readlink + component
+  count — adds a per-op `/proc` dependency + readlink cost for a pathological case,
+  and is Linux-container-fragile.
+- Drop openat2 and use only the manual walk — removes the kernel-enforced
+  containment defense-in-depth and the one-call fast path the approved design
+  chose.
+
+If a future need makes exact parity here mandatory, the `/proc` post-check is the
+tracked path; until then this asymmetry is ratified as above.
+
+## Race resistance
+
+`component_swap_race_stays_contained` spawns a thread that continuously flips an
+interior path component (`a/mid`) between a real directory and a symlink to `/`
+(which would escape the sandbox if followed as a raw host path), while the main
+thread resolves `a/mid/f` thousands of times through **both** implementations. The
+invariant asserted on every iteration:
+
+- a successful resolve returns **only** the in-base file's content (never anything
+  outside `base_dir`);
+- a failed resolve returns **only** a known contained token
+  (`not_found` / `not_a_directory` / `symlink_loop` / `permission` / `io_error` /
+  `path_too_deep` / `invalid_path`).
+
+This holds structurally: each component is opened `O_NOFOLLOW` relative to a held
+fd, so a component swapped **after** it is opened binds the already-held inode, and
+a component swapped **to a symlink before** it is opened is caught by `O_NOFOLLOW`
+and re-rooted/clamped by the virtual-root splice — never followed as a raw host
+path. openat2 gets the same guarantee from `RESOLVE_IN_ROOT` in-kernel. The test
+makes that structural property observable under real concurrent mutation.
+
+## Scope
+
+Checkpoint 2 is tests + this ratification record only. `stat`/`list`, the §6
+compiled-entry authorization policy, and BuildContext remain out of scope (later
+checkpoints). The realpath-based `hl_cap_fs_exists` / `hl_cap_fs_delete` / direct
+`hl_cap_fs_validate` consumers likewise remain a tracked follow-up (recorded in
+`src/hull/cap/fs.c`); the cap layer is not yet fully TOCTOU-free.

--- a/docs/hull_fs_resolver_parity.md
+++ b/docs/hull_fs_resolver_parity.md
@@ -114,6 +114,22 @@ divergence to actually occur (openat2 succeeds while the manual walk rejects) ra
 than passing vacuously — so a regression that silently stops using openat2 fails the
 assertion instead of hiding.
 
+## Defect found and fixed by this harness
+
+The parity/race harness caught a genuine checkpoint-1 bug in the **manual walk** that
+the checkpoint-1 tests missed (they only used symlinks at the *final* component):
+an **interior** symlink (a symlink as a non-final path component, e.g. `mid` in
+`a/mid/f`) was misclassified. The interior descend used
+`openat(..., O_DIRECTORY | O_NOFOLLOW)`, and on a symlink component Linux returns
+`ELOOP` (detected) but **macOS returns `ENOTDIR`**, so the manual walk reported
+`not_a_directory` instead of following the symlink. openat2 resolves it in-kernel,
+so the bug was manual-only (macOS / cosmo). Fixed in `src/hull/cap/fs_resolve.c` by
+opening interior components `O_RDONLY | O_NOFOLLOW` (a symlink then fails `ELOOP`
+uniformly) and verifying dir-ness with `fstat` on the held fd (race-safe).
+Regression-locked by `test_fs_resolve.symlink_interior_component_followed`, the
+`dsym/g` case in `read_battery`, and the race harness (whose swapped component is an
+interior symlink).
+
 ## Scope
 
 Checkpoint 2 is tests + this ratification record only. `stat`/`list`, the §6

--- a/docs/hull_fs_resolver_parity.md
+++ b/docs/hull_fs_resolver_parity.md
@@ -76,16 +76,24 @@ tracked path; until then this asymmetry is ratified as above.
 ## Race resistance
 
 `component_swap_race_stays_contained` spawns a thread that continuously flips an
-interior path component (`a/mid`) between a real directory and a symlink to `/`
-(which would escape the sandbox if followed as a raw host path), while the main
-thread resolves `a/mid/f` thousands of times through **both** implementations. The
-invariant asserted on every iteration:
+interior path component (`a/mid`) between a real directory and a **symlink to an
+external sentinel directory** (outside `base_dir`, containing a file `f` with
+contents `SECRET-SENTINEL`), while the main thread resolves `a/mid/f` up to 8000
+iterations through **both** implementations. The invariants, asserted with enough
+context to reproduce a failure (the swapper seed, the first failing iteration, and
+which implementation):
 
-- a successful resolve returns **only** the in-base file's content (never anything
-  outside `base_dir`);
-- a failed resolve returns **only** a known contained token
-  (`not_found` / `not_a_directory` / `symlink_loop` / `permission` / `io_error` /
-  `path_too_deep` / `invalid_path`).
+- **no iteration ever reads the external sentinel** — a successful resolve returns
+  **only** the in-base file's content (`inbase`); reading `SECRET-SENTINEL` would
+  mean containment failed and the escaping symlink was followed as a raw host path;
+- a failed resolve returns **only** a known *contained* token (`not_found` /
+  `not_a_directory` / `symlink_loop` / `permission` / `io_error` / `path_too_deep`
+  / `invalid_path`) — transient failures during a swap are distinguished from any
+  unexpected error;
+- the loop is **bounded** (8000 iterations and a 60 s wall-clock cap);
+- **file-descriptor count is bounded** — the process's open-fd count is sampled
+  before and after and must not grow, proving the resolver leaks no descriptors
+  across the run.
 
 This holds structurally: each component is opened `O_NOFOLLOW` relative to a held
 fd, so a component swapped **after** it is opened binds the already-held inode, and
@@ -93,6 +101,18 @@ a component swapped **to a symlink before** it is opened is caught by `O_NOFOLLO
 and re-rooted/clamped by the virtual-root splice — never followed as a raw host
 path. openat2 gets the same guarantee from `RESOLVE_IN_ROOT` in-kernel. The test
 makes that structural property observable under real concurrent mutation.
+
+**Sanitizers.** The harness runs under ASan + MSan via the normal test discovery,
+and is added to the TSan suite (`TSAN_TESTS`) so the thread race itself is checked:
+the only shared memory is an `atomic_int` stop flag (not `volatile`), and the
+concurrency is filesystem-level (mkdir/symlink/unlink vs `openat` resolution),
+which TSan tolerates.
+
+**Exercised, not dormant.** The ratified divergence probes `openat2` availability
+(`__NR_openat2`); where openat2 is present (Linux CI) the test REQUIRES the
+divergence to actually occur (openat2 succeeds while the manual walk rejects) rather
+than passing vacuously — so a regression that silently stops using openat2 fails the
+assertion instead of hiding.
 
 ## Scope
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -743,7 +743,12 @@ msan:
 # single-threaded so they add no race coverage. TSAN=1 appends
 # -fsanitize=thread to Hull's own TUs; vendor objects (WAMR, mbedTLS,
 # keel.a) stay uninstrumented, which TSan tolerates.
-TSAN_TESTS := test_wasm test_async_backend test_async_backend_poll
+#   - test_fs_resolve_parity : the fs resolver's component-swap RACE harness
+#     (a swapper thread mutates the tree while the resolver runs). The only
+#     shared memory is the atomic stop flag; the concurrency is filesystem-level
+#     (mkdir/symlink/unlink vs openat resolution), which TSan tolerates. Proves
+#     the resolver's containment holds under a real thread race.
+TSAN_TESTS := test_wasm test_async_backend test_async_backend_poll test_fs_resolve_parity
 tsan:
 	$(MAKE) clean
 	$(MAKE) TSAN=1 $(addprefix $(BUILDDIR)/,$(TSAN_TESTS))

--- a/src/hull/cap/fs_resolve.c
+++ b/src/hull/cap/fs_resolve.c
@@ -205,10 +205,19 @@ static int resolve_manual(int root_fd, const char *relpath, HlFsOpenMode mode,
         int last = (*tail == '\0');
 
         if (!last) {
-            /* interior: descend into a directory, following a symlink if present */
-            int fd = openat(stack[depth - 1], comp,
-                            O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+            /* Interior: descend into a directory, following a symlink if present.
+             * Open O_RDONLY|O_NOFOLLOW *without* O_DIRECTORY, then verify dir-ness
+             * with fstat on the held fd. Using O_DIRECTORY|O_NOFOLLOW here is not
+             * portable: on a SYMLINK component Linux returns ELOOP (detected below)
+             * but macOS returns ENOTDIR, which would misclassify an INTERIOR symlink
+             * as "not_a_directory" instead of following it. Dropping O_DIRECTORY
+             * makes a symlink fail ELOOP uniformly, and the fstat is race-safe (it
+             * inspects the already-opened inode). */
+            int fd = openat(stack[depth - 1], comp, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
             if (fd >= 0) {
+                struct stat st;
+                if (fstat(fd, &st) != 0) { close(fd); map_errno(errno, err); goto fail; }
+                if (!S_ISDIR(st.st_mode)) { close(fd); *err = "not_a_directory"; goto fail; }
                 if (depth >= HL_FS_MAX_DEPTH) { close(fd); *err = "path_too_deep"; goto fail; }
                 stack[depth++] = fd;
                 cur = rest;
@@ -219,9 +228,12 @@ static int resolve_manual(int root_fd, const char *relpath, HlFsOpenMode mode,
                 if (mkdirat(stack[depth - 1], comp, 0755) < 0 && errno != EEXIST) {
                     map_errno(errno, err); goto fail;
                 }
-                fd = openat(stack[depth - 1], comp,
-                            O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+                fd = openat(stack[depth - 1], comp, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
                 if (fd < 0) { map_errno(errno, err); goto fail; }
+                struct stat st;
+                if (fstat(fd, &st) != 0 || !S_ISDIR(st.st_mode)) {
+                    close(fd); *err = "not_a_directory"; goto fail;
+                }
                 if (depth >= HL_FS_MAX_DEPTH) { close(fd); *err = "path_too_deep"; goto fail; }
                 stack[depth++] = fd;
                 cur = rest;

--- a/src/hull/cap/fs_resolve.c
+++ b/src/hull/cap/fs_resolve.c
@@ -26,6 +26,7 @@
 #define HL_FS_PATH_MAX 4096
 #endif
 #define HL_FS_SYMLINK_MAX 40   /* matches the kernel ELOOP budget */
+#define HL_FS_RECLASSIFY_MAX 64 /* bound interior classify<->open TOCTOU retries */
 /* HL_FS_MAX_DEPTH is the public component-depth limit (fs_resolve.h); it also
  * bounds the manual walk's directory-fd stack. */
 
@@ -205,42 +206,58 @@ static int resolve_manual(int root_fd, const char *relpath, HlFsOpenMode mode,
         int last = (*tail == '\0');
 
         if (!last) {
-            /* Interior: descend into a directory, following a symlink if present.
-             * Open O_RDONLY|O_NOFOLLOW *without* O_DIRECTORY, then verify dir-ness
-             * with fstat on the held fd. Using O_DIRECTORY|O_NOFOLLOW here is not
-             * portable: on a SYMLINK component Linux returns ELOOP (detected below)
-             * but macOS returns ENOTDIR, which would misclassify an INTERIOR symlink
-             * as "not_a_directory" instead of following it. Dropping O_DIRECTORY
-             * makes a symlink fail ELOOP uniformly, and the fstat is race-safe (it
-             * inspects the already-opened inode). */
-            int fd = openat(stack[depth - 1], comp, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
-            if (fd >= 0) {
+            /* INTERIOR component: descend into a directory.
+             *
+             * CLASSIFY BEFORE OPENING. Opening an arbitrary interior inode merely
+             * to learn its type is unsafe: an attacker-planted FIFO opened O_RDONLY
+             * without O_NONBLOCK blocks resolution indefinitely, and device nodes
+             * can carry open-time side effects. fstatat(AT_SYMLINK_NOFOLLOW) is an
+             * lstat - it never blocks and never triggers device semantics:
+             *   - a symlink     -> expand via readlinkat (below); never opened.
+             *   - not a dir     -> "not_a_directory"; never opened (FIFO/dev/reg).
+             *   - a directory   -> open it O_RDONLY|O_DIRECTORY|O_NOFOLLOW.
+             * O_DIRECTORY keeps the FIFO-hang closed even against a TOCTOU swap (the
+             * kernel rejects a non-dir with ENOTDIR before any blocking open) and
+             * O_NOFOLLOW rejects a swap-to-symlink (ELOOP). A component that changed
+             * between classify and open is re-classified (bounded by
+             * HL_FS_RECLASSIFY_MAX); the flags are NEVER relaxed. This also removes
+             * the old macOS ELOOP-vs-ENOTDIR ambiguity: an interior symlink is now
+             * recognised by the lstat, not by interpreting an open error. */
+            int reclass = 0;
+            for (;;) {
+                struct stat lst;
+                if (fstatat(stack[depth - 1], comp, &lst, AT_SYMLINK_NOFOLLOW) != 0) {
+                    if (errno == ENOENT && mode == HL_FS_OPEN_WRITE) {
+                        if (mkdirat(stack[depth - 1], comp, 0755) != 0 && errno != EEXIST) {
+                            map_errno(errno, err); goto fail;
+                        }
+                        if (++reclass > HL_FS_RECLASSIFY_MAX) { *err = "io_error"; goto fail; }
+                        continue;                       /* re-classify the created dir */
+                    }
+                    map_errno(errno, err); goto fail;
+                }
+                if (S_ISLNK(lst.st_mode)) goto symlink;             /* expand; no open */
+                if (!S_ISDIR(lst.st_mode)) { *err = "not_a_directory"; goto fail; }
+
+                int fd = openat(stack[depth - 1], comp,
+                                O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+                if (fd < 0) {
+                    /* TOCTOU: the component changed between classify and open.
+                     * Re-classify (bounded); never relax O_DIRECTORY/O_NOFOLLOW. */
+                    if ((errno == ELOOP || errno == EMLINK || errno == ENOTDIR ||
+                         errno == ENOENT) && ++reclass <= HL_FS_RECLASSIFY_MAX)
+                        continue;
+                    map_errno(errno, err); goto fail;
+                }
                 struct stat st;
                 if (fstat(fd, &st) != 0) { close(fd); map_errno(errno, err); goto fail; }
                 if (!S_ISDIR(st.st_mode)) { close(fd); *err = "not_a_directory"; goto fail; }
                 if (depth >= HL_FS_MAX_DEPTH) { close(fd); *err = "path_too_deep"; goto fail; }
                 stack[depth++] = fd;
-                cur = rest;
-                continue;
+                break;
             }
-            if (errno == ELOOP || errno == EMLINK) goto symlink;
-            if (errno == ENOENT && mode == HL_FS_OPEN_WRITE) {
-                if (mkdirat(stack[depth - 1], comp, 0755) < 0 && errno != EEXIST) {
-                    map_errno(errno, err); goto fail;
-                }
-                fd = openat(stack[depth - 1], comp, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
-                if (fd < 0) { map_errno(errno, err); goto fail; }
-                struct stat st;
-                if (fstat(fd, &st) != 0 || !S_ISDIR(st.st_mode)) {
-                    close(fd); *err = "not_a_directory"; goto fail;
-                }
-                if (depth >= HL_FS_MAX_DEPTH) { close(fd); *err = "path_too_deep"; goto fail; }
-                stack[depth++] = fd;
-                cur = rest;
-                continue;
-            }
-            map_errno(errno, err);
-            goto fail;
+            cur = rest;
+            continue;
         } else {
             /* terminal component */
             int flags = (mode == HL_FS_OPEN_READ)

--- a/src/hull/cap/fs_resolve.c
+++ b/src/hull/cap/fs_resolve.c
@@ -244,9 +244,15 @@ static int resolve_manual(int root_fd, const char *relpath, HlFsOpenMode mode,
                 if (fd < 0) {
                     /* TOCTOU: the component changed between classify and open.
                      * Re-classify (bounded); never relax O_DIRECTORY/O_NOFOLLOW. */
-                    if ((errno == ELOOP || errno == EMLINK || errno == ENOTDIR ||
-                         errno == ENOENT) && ++reclass <= HL_FS_RECLASSIFY_MAX)
+                    if (errno == ELOOP || errno == EMLINK || errno == ENOTDIR ||
+                        errno == ENOENT) {
+                        /* Exhausting the bound is itself a (pathological) contained
+                         * failure: report ONE stable token (io_error) on every path,
+                         * not whichever transient errno happened to be last. Matches
+                         * the WRITE mkdirat re-classification path above. */
+                        if (++reclass > HL_FS_RECLASSIFY_MAX) { *err = "io_error"; goto fail; }
                         continue;
+                    }
                     map_errno(errno, err); goto fail;
                 }
                 struct stat st;

--- a/tests/hull/cap/test_fs_resolve.c
+++ b/tests/hull/cap/test_fs_resolve.c
@@ -165,6 +165,20 @@ UTEST(fs_resolve, symlink_in_base_followed)
     teardown();
 }
 
+UTEST(fs_resolve, symlink_interior_component_followed)
+{
+    setup();
+    mkdirp_host("realdir"); wfile("realdir/leaf", "viaint");
+    symln("realdir", "dsym");             /* symlink used as a NON-final component */
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    int fd = hl_fs_open_at(root, "dsym/leaf", HL_FS_OPEN_READ, 0, &err);
+    ASSERT_GE(fd, 0);                      /* must follow the interior symlink, not ENOTDIR */
+    char b[64]; ASSERT_STREQ("viaint", slurp(fd, b, sizeof(b)));
+    close(fd); close(root);
+    teardown();
+}
+
 UTEST(fs_resolve, symlink_absolute_rerooted)
 {
     setup();

--- a/tests/hull/cap/test_fs_resolve.c
+++ b/tests/hull/cap/test_fs_resolve.c
@@ -18,6 +18,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <ftw.h>
+#include <signal.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -364,6 +365,77 @@ UTEST(fs_resolve, depth_over_limit_rejected)
     }
     unsetenv("HL_FS_FORCE_MANUAL");
     free(p); close(root); teardown();
+}
+
+/* ── Fix 3 (checkpoint-2 review): a non-directory INTERIOR component is CLASSIFIED
+ * (fstatat) before being opened, so it is rejected as "not_a_directory" WITHOUT
+ * being opened. This closes a resolution-hang DoS: opening an attacker-planted
+ * interior FIFO O_RDONLY (no O_NONBLOCK) blocks forever. A bounded SIGALRM
+ * watchdog proves resolution returns promptly instead of blocking. Rejected
+ * identically by openat2 (ENOTDIR in-kernel) and the manual walk (fstatat).
+ * The interior-symlink regression (symlink_interior_component_followed) above
+ * proves a symlink is still followed, not misclassified. ──────────────────── */
+static void on_resolve_timeout(int sig)
+{
+    (void)sig;
+    static const char m[] =
+        "FATAL: fs resolve BLOCKED on a non-directory interior component\n";
+    ssize_t n = write(2, m, sizeof(m) - 1); (void)n;
+    _exit(97);   /* fail the whole test binary loudly if the resolver ever hangs */
+}
+
+UTEST(fs_resolve, interior_fifo_rejected_without_blocking)
+{
+    setup();
+    char fp[512]; snprintf(fp, sizeof(fp), "%s/fifo", base);
+    ASSERT_EQ(0, mkfifo(fp, 0644));            /* interior FIFO, no writer -> would hang */
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    ASSERT_GE(root, 0);
+
+    struct sigaction sa; memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = on_resolve_timeout;
+    sigaction(SIGALRM, &sa, NULL);
+
+    for (int pass = 0; pass < 2; pass++) {     /* openat2 fast path + forced manual */
+        select_path(pass);
+        err = NULL;
+        alarm(5);                              /* watchdog: fires only if resolve blocks */
+        int fd = hl_fs_open_at(root, "fifo/leaf", HL_FS_OPEN_READ, 0, &err);
+        alarm(0);                              /* completed promptly -> cancel */
+        ASSERT_EQ(fd, -1);
+        ASSERT_STREQ("not_a_directory", err);  /* classified, never opened */
+    }
+    /* WRITE mode (always the manual walk) must likewise classify, not block. */
+    select_path(1);
+    err = NULL;
+    alarm(5);
+    int wfd = hl_fs_open_at(root, "fifo/leaf", HL_FS_OPEN_WRITE, 0644, &err);
+    alarm(0);
+    ASSERT_EQ(wfd, -1);
+    ASSERT_STREQ("not_a_directory", err);
+
+    signal(SIGALRM, SIG_DFL);
+    unsetenv("HL_FS_FORCE_MANUAL");
+    close(root); teardown();
+}
+
+UTEST(fs_resolve, interior_regular_file_rejected)
+{
+    setup();
+    wfile("rf", "x");                          /* interior regular file */
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    ASSERT_GE(root, 0);
+    for (int pass = 0; pass < 2; pass++) {
+        select_path(pass);
+        err = NULL;
+        int fd = hl_fs_open_at(root, "rf/leaf", HL_FS_OPEN_READ, 0, &err);
+        ASSERT_EQ(fd, -1);
+        ASSERT_STREQ("not_a_directory", err);  /* rejected without opening */
+    }
+    unsetenv("HL_FS_FORCE_MANUAL");
+    close(root); teardown();
 }
 
 UTEST_MAIN();

--- a/tests/hull/cap/test_fs_resolve.c
+++ b/tests/hull/cap/test_fs_resolve.c
@@ -374,7 +374,16 @@ UTEST(fs_resolve, depth_over_limit_rejected)
  * watchdog proves resolution returns promptly instead of blocking. Rejected
  * identically by openat2 (ENOTDIR in-kernel) and the manual walk (fstatat).
  * The interior-symlink regression (symlink_interior_component_followed) above
- * proves a symlink is still followed, not misclassified. ──────────────────── */
+ * proves a symlink is still followed, not misclassified.
+ *
+ * The FIFO watchdog test is compiled out on Cosmopolitan: cosmo's headers do
+ * not declare mkfifo under the feature level Hull's tests use (the project sets
+ * no feature macro for cosmo, per tests/sandbox_violation.c), and no other Hull
+ * code needs it. The manual held-fd walk is identical C on every platform and
+ * is no-block-proven here on macOS + Linux-forced-manual; interior_regular_file
+ * _rejected (below, unguarded) still exercises the classify-before-open path on
+ * cosmo. ──────────────────────────────────────────────────────────────────── */
+#if !defined(__COSMOPOLITAN__)
 static void on_resolve_timeout(int sig)
 {
     (void)sig;
@@ -419,6 +428,7 @@ UTEST(fs_resolve, interior_fifo_rejected_without_blocking)
     unsetenv("HL_FS_FORCE_MANUAL");
     close(root); teardown();
 }
+#endif  /* !__COSMOPOLITAN__ (mkfifo undeclared on cosmo) */
 
 UTEST(fs_resolve, interior_regular_file_rejected)
 {

--- a/tests/hull/cap/test_fs_resolve_parity.c
+++ b/tests/hull/cap/test_fs_resolve_parity.c
@@ -258,6 +258,14 @@ static char g_ext_dir[256];      /* an EXTERNAL sentinel dir (outside base) */
  * (absolute, out of base -> re-roots to a non-existent in-base path -> not_found),
  * and an empty directory (not_found). It NEVER contains the legitimate file, so it
  * can always be rmdir'd/unlinked, and the only source of "inbase" is base/real/f. */
+/* Self-contained deterministic PRNG. NOT rand_r: its declaration is gated on
+ * feature-test macros that differ across glibc / BSD / cosmo (this file defines
+ * _XOPEN_SOURCE on Linux, which flips cosmo's libc into strict mode and hides the
+ * non-standard rand_r). A tiny LCG is enough to pick among the three swap states
+ * and keeps the sequence reproducible from the fixed seed on every platform. */
+static unsigned lcg_next(unsigned *s)
+{ *s = *s * 1103515245u + 12345u; return (*s >> 16) & 0x7fffu; }
+
 static void *swapper(void *arg)
 {
     (void)arg;
@@ -265,7 +273,7 @@ static void *swapper(void *arg)
     while (!atomic_load_explicit(&g_swap_stop, memory_order_relaxed)) {
         unlink(g_swap_path);
         rmdir(g_swap_path);
-        switch (rand_r(&seed) % 3) {
+        switch (lcg_next(&seed) % 3) {
         case 0: symlink("../real", g_swap_path); break;   /* in-base -> reads inbase */
         case 1: symlink(g_ext_dir, g_swap_path); break;   /* escape -> not_found */
         default: mkdir(g_swap_path, 0755); break;         /* empty dir -> not_found */

--- a/tests/hull/cap/test_fs_resolve_parity.c
+++ b/tests/hull/cap/test_fs_resolve_parity.c
@@ -4,20 +4,11 @@
  * virtual-root contract, and that resolution is race-resistant.
  *
  * On Linux the READ path defaults to openat2; HL_FS_FORCE_MANUAL forces the manual
- * walk, so every case here runs through BOTH implementations on one host and their
- * outcomes (success + stable error tokens) are compared directly. macOS/cosmo have
- * only the manual walk, so both passes coincide there (still a useful self-check).
+ * walk, so every case runs through BOTH implementations from the SAME fixture setup
+ * and their outcomes (file contents, success/failure state, AND stable error token)
+ * are compared directly. macOS/cosmo have only the manual walk (self-check).
  *
- * Coverage:
- *   - a fixture battery of READ cases -> identical outcome + token on both impls;
- *   - the depth boundary (exactly HL_FS_MAX_DEPTH vs +1) -> identical on both;
- *   - the pathological symlink-expanded-depth case, where the manual walk is
- *     STRICTER (fail-closed "path_too_deep") than openat2 (kernel PATH_MAX/ELOOP) -
- *     a RATIFIED platform-resource-limit divergence (docs/hull_fs_resolver_parity.md),
- *     asserted explicitly rather than papered over;
- *   - a component-swap race: a swapper thread flips an interior component between a
- *     real dir and a symlink pointing OUT of the sandbox while the resolver runs;
- *     the resolved object must NEVER escape base_dir, on either implementation.
+ * See docs/hull_fs_resolver_parity.md.
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -27,13 +18,17 @@
 
 #include "utest.h"
 #include "hull/cap/fs_resolve.h"
+#include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <ftw.h>
 #include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 #include <unistd.h>
 #include <sys/stat.h>
 
@@ -46,8 +41,9 @@ static void setup(void)
 }
 static int rm_entry(const char *p, const struct stat *sb, int t, struct FTW *f)
 { (void)sb; (void)t; (void)f; return remove(p); }
-static void teardown(void)
-{ if (nftw(base, rm_entry, 24, FTW_DEPTH | FTW_PHYS) != 0 && errno != ENOENT) {} }
+static void rm_tree(const char *p)
+{ if (nftw(p, rm_entry, 24, FTW_DEPTH | FTW_PHYS) != 0 && errno != ENOENT) {} }
+static void teardown(void) { rm_tree(base); }
 
 static void wfile(const char *rel, const char *data)
 { char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel);
@@ -57,8 +53,7 @@ static void mkdirp_host(const char *rel)
 static void symln(const char *target, const char *rel)
 { char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel); unlink(p); symlink(target, p); }
 
-/* Run one resolve through a chosen implementation; return fd (>=0) or -1, token via
- * *tok (NULL on success). Assertion-free so it is safe outside a UTEST body. */
+/* Assertion-free: run one resolve through a chosen implementation. */
 static int resolve_via(int root, const char *path, HlFsOpenMode mode, int manual,
                        const char **tok)
 {
@@ -70,9 +65,39 @@ static int resolve_via(int root, const char *path, HlFsOpenMode mode, int manual
     *tok = (fd < 0) ? (e ? e : "?") : NULL;
     return fd;
 }
-
 static void slurp(int fd, char *b, size_t n)
 { ssize_t r = read(fd, b, n - 1); if (r < 0) r = 0; b[r] = '\0'; }
+
+/* Count this process's open descriptors (leak guard). */
+static int count_open_fds(void)
+{
+#if defined(__linux__)
+    DIR *d = opendir("/proc/self/fd");
+    if (d) { int n = 0; struct dirent *e;
+        while ((e = readdir(d))) if (e->d_name[0] != '.') n++;
+        closedir(d); return n - 1; /* minus the opendir fd itself */
+    }
+#endif
+    int n = 0;
+    for (int fd = 0; fd < 512; fd++) if (fcntl(fd, F_GETFD) != -1) n++;
+    return n;
+}
+
+/* Whether openat2 is actually usable on this host (so the ratified divergence is
+ * exercised, not silently dormant). Linux only; ENOSYS => unavailable. */
+#if defined(__linux__) && !defined(__COSMOPOLITAN__)
+#include <sys/syscall.h>
+#ifndef __NR_openat2
+#define __NR_openat2 437
+#endif
+static int openat2_available(void)
+{
+    struct { uint64_t flags, mode, resolve; } how = { O_RDONLY | O_CLOEXEC, 0, 0 };
+    long r = syscall(__NR_openat2, AT_FDCWD, ".", &how, sizeof(how));
+    if (r >= 0) { close((int)r); return 1; }
+    return errno != ENOSYS && errno != EPERM;
+}
+#endif
 
 static int build_tree(void)
 {
@@ -80,14 +105,14 @@ static int build_tree(void)
     wfile("f", "hello");
     mkdirp_host("d");
     wfile("d/g", "nested");
-    symln("d/g", "rel");                 /* relative, in-base */
-    symln("/d/g", "abs");                /* absolute -> re-root to base/d/g */
-    symln("../../../../d/g", "up");      /* excess .. -> clamp to base/d/g */
-    symln("lo", "lo");                   /* self loop */
+    symln("d/g", "rel");
+    symln("/d/g", "abs");
+    symln("../../../../d/g", "up");
+    symln("lo", "lo");
     return hl_fs_open_base(base, &err);
 }
 
-/* ── fixture battery: identical outcome + token on both implementations ────── */
+/* ── fixture battery: identical content + state + token on both impls ───────── */
 UTEST(fs_resolve_parity, read_battery)
 {
     setup();
@@ -97,30 +122,31 @@ UTEST(fs_resolve_parity, read_battery)
     struct { const char *path, *tok, *data; } cases[] = {
         { "f",   NULL, "hello"  },
         { "d/g", NULL, "nested" },
-        { "rel", NULL, "nested" },                 /* relative symlink */
-        { "abs", NULL, "nested" },                 /* absolute re-root */
-        { "up",  NULL, "nested" },                 /* dotdot clamp */
+        { "rel", NULL, "nested" },
+        { "abs", NULL, "nested" },
+        { "up",  NULL, "nested" },
         { "nope", "not_found", NULL },
         { "lo",   "symlink_loop", NULL },
-        { "f/",   "invalid_path", NULL },          /* trailing slash */
-        { "a/../../etc/passwd", "invalid_path", NULL }, /* caller ".." */
+        { "f/",   "invalid_path", NULL },
+        { "a/../../etc/passwd", "invalid_path", NULL },
     };
     for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
         const char *mt = NULL, *ot = NULL;
-        int mfd = resolve_via(root, cases[i].path, HL_FS_OPEN_READ, 1, &mt); /* manual */
-        int ofd = resolve_via(root, cases[i].path, HL_FS_OPEN_READ, 0, &ot); /* openat2 */
+        int mfd = resolve_via(root, cases[i].path, HL_FS_OPEN_READ, 1, &mt);
+        int ofd = resolve_via(root, cases[i].path, HL_FS_OPEN_READ, 0, &ot);
+        /* success/failure STATE matches */
+        ASSERT_EQ_MSG((mfd >= 0), (ofd >= 0), cases[i].path);
         if (cases[i].tok) {
             ASSERT_EQ_MSG(mfd, -1, cases[i].path);
-            ASSERT_EQ_MSG(ofd, -1, cases[i].path);
             ASSERT_STREQ_MSG(cases[i].tok, mt, cases[i].path);
-            ASSERT_STREQ_MSG(cases[i].tok, ot, cases[i].path);  /* same token, both impls */
+            ASSERT_STREQ_MSG(cases[i].tok, ot, cases[i].path);
         } else {
             ASSERT_GE_MSG(mfd, 0, cases[i].path);
             ASSERT_GE_MSG(ofd, 0, cases[i].path);
             char bm[128], bo[128];
             slurp(mfd, bm, sizeof(bm)); slurp(ofd, bo, sizeof(bo));
-            ASSERT_STREQ_MSG(bm, bo, cases[i].path);            /* identical content */
-            if (cases[i].data) ASSERT_STREQ_MSG(cases[i].data, bm, cases[i].path);
+            ASSERT_STREQ_MSG(bm, bo, cases[i].path);        /* contents match */
+            ASSERT_STREQ_MSG(cases[i].data, bm, cases[i].path);
             close(mfd); close(ofd);
         }
     }
@@ -136,16 +162,14 @@ UTEST(fs_resolve_parity, depth_boundary)
 {
     setup();
     int root = build_tree();
-
-    char *over = deep(HL_FS_MAX_DEPTH + 1);          /* boundary + 1: both reject */
+    char *over = deep(HL_FS_MAX_DEPTH + 1);
     const char *mt = NULL, *ot = NULL;
     ASSERT_EQ(-1, resolve_via(root, over, HL_FS_OPEN_READ, 1, &mt));
     ASSERT_EQ(-1, resolve_via(root, over, HL_FS_OPEN_READ, 0, &ot));
     ASSERT_STREQ("path_too_deep", mt);
     ASSERT_STREQ("path_too_deep", ot);
     free(over);
-
-    char *at = deep(HL_FS_MAX_DEPTH);                /* at limit: not "too deep" either impl */
+    char *at = deep(HL_FS_MAX_DEPTH);
     (void)resolve_via(root, at, HL_FS_OPEN_READ, 1, &mt);
     (void)resolve_via(root, at, HL_FS_OPEN_READ, 0, &ot);
     ASSERT_STRNE("path_too_deep", mt ? mt : "");
@@ -155,19 +179,15 @@ UTEST(fs_resolve_parity, depth_boundary)
 }
 
 /* ── RATIFIED divergence: symlink-expanded depth (Linux only) ────────────────
- * A symlink whose target expands the RESOLVED path past HL_FS_MAX_DEPTH: the manual
- * walk fails closed ("path_too_deep") because its held-fd stack is a platform
- * resource limit; openat2 resolves it within the kernel's own PATH_MAX/ELOOP. Both
- * stay CONTAINED (no authority escape); the difference is a documented, ratified
- * platform-resource-limit asymmetry, asserted explicitly. See
- * docs/hull_fs_resolver_parity.md. On macOS/cosmo both are the manual walk, so
- * there is no divergence to assert. */
+ * The ONLY allowlisted divergence. A symlink whose target expands the resolved
+ * path past HL_FS_MAX_DEPTH: manual fails closed ("path_too_deep"); openat2
+ * resolves within the kernel's PATH_MAX/ELOOP. Both contained; manual is stricter.
+ * REQUIRED to be exercised where openat2 is available (not dormant). */
 #if defined(__linux__) && !defined(__COSMOPOLITAN__)
 UTEST(fs_resolve_parity, ratified_symlink_expanded_depth)
 {
     setup();
     const char *err = NULL;
-    /* create an existing HL_FS_MAX_DEPTH-level 'c' dir tree + a leaf file */
     char acc[HL_FS_MAX_DEPTH * 2 + 16] = {0};
     int ao = 0;
     for (int i = 0; i < HL_FS_MAX_DEPTH; i++) {
@@ -178,41 +198,43 @@ UTEST(fs_resolve_parity, ratified_symlink_expanded_depth)
     char leafrel[HL_FS_MAX_DEPTH * 2 + 24];
     snprintf(leafrel, sizeof(leafrel), "%s/leaf", acc);
     wfile(leafrel, "deep");
-    symln(acc, "expand");   /* target is HL_FS_MAX_DEPTH components */
+    symln(acc, "expand");
 
     int root = hl_fs_open_base(base, &err);
     ASSERT_GE(root, 0);
     const char *mt = NULL, *ot = NULL;
-    int mfd = resolve_via(root, "expand/leaf", HL_FS_OPEN_READ, 1, &mt);   /* manual */
-    int ofd = resolve_via(root, "expand/leaf", HL_FS_OPEN_READ, 0, &ot);   /* openat2 */
+    int mfd = resolve_via(root, "expand/leaf", HL_FS_OPEN_READ, 1, &mt);
+    int ofd = resolve_via(root, "expand/leaf", HL_FS_OPEN_READ, 0, &ot);
 
-    ASSERT_EQ(mfd, -1);                       /* manual: fail-closed at its depth bound */
+    ASSERT_EQ(mfd, -1);                       /* manual: fail-closed */
     ASSERT_STREQ("path_too_deep", mt);
-    if (ofd >= 0) {
-        /* openat2 in use: resolves within kernel limits -> the RATIFIED divergence */
+    if (openat2_available()) {
+        /* divergence EXERCISED, not dormant: openat2 resolves within kernel limits */
+        ASSERT_GE_MSG(ofd, 0, "openat2 present but did not exercise the ratified divergence");
         char b[16]; slurp(ofd, b, sizeof(b)); ASSERT_STREQ("deep", b); close(ofd);
     } else {
-        /* openat2 unavailable on this kernel -> the "openat2" pass also fell back
-         * to the manual walk, so both reject identically (no divergence to ratify) */
+        /* no openat2 -> the second pass is also the manual walk -> both reject */
+        ASSERT_EQ(ofd, -1);
         ASSERT_STREQ("path_too_deep", ot);
     }
-
     close(root); teardown();
 }
 #endif
 
-/* ── component-swap race: containment holds under concurrent mutation ──────── */
-static volatile int g_swap_stop;
-static char g_swap_path[512];
+/* ── component-swap race: containment under concurrent mutation ─────────────── */
+static atomic_int g_swap_stop;
+static char g_swap_path[512];    /* interior component flipped by the swapper */
+static char g_ext_dir[256];      /* an EXTERNAL sentinel dir (outside base) */
+
 static void *swapper(void *arg)
 {
     (void)arg;
-    unsigned seed = 12345;
-    while (!g_swap_stop) {
+    unsigned seed = 0xC0FFEE;
+    while (!atomic_load_explicit(&g_swap_stop, memory_order_relaxed)) {
         rmdir(g_swap_path);
         unlink(g_swap_path);
         if (rand_r(&seed) & 1) mkdir(g_swap_path, 0755);
-        else                   symlink("/", g_swap_path);   /* escaping if followed raw */
+        else                   symlink(g_ext_dir, g_swap_path);  /* absolute, out of base */
     }
     return NULL;
 }
@@ -224,42 +246,72 @@ UTEST(fs_resolve_parity, component_swap_race_stays_contained)
     mkdirp_host("a");
     mkdirp_host("a/mid");
     wfile("a/mid/f", "inbase");
+    /* external sentinel: if containment ever failed and followed the escaping
+     * symlink as a raw host path, "a/mid/f" would resolve to g_ext_dir/f. */
+    snprintf(g_ext_dir, sizeof(g_ext_dir), "/tmp/hull_ext_%d", (int)getpid());
+    mkdir(g_ext_dir, 0755);
+    char extf[300]; snprintf(extf, sizeof(extf), "%s/f", g_ext_dir);
+    FILE *ef = fopen(extf, "wb"); if (ef) { fputs("SECRET-SENTINEL", ef); fclose(ef); }
     snprintf(g_swap_path, sizeof(g_swap_path), "%s/a/mid", base);
 
     int root = hl_fs_open_base(base, &err);
     ASSERT_GE(root, 0);
 
-    g_swap_stop = 0;
+    int fds_before = count_open_fds();
+
+    atomic_store(&g_swap_stop, 0);
     pthread_t th;
     ASSERT_EQ(0, pthread_create(&th, NULL, swapper, NULL));
 
-    int escapes = 0, ok = 0, bad_tok = 0;
-    for (int i = 0; i < 4000; i++) {
+    const int ITERS = 8000;
+    const long CAP_SEC = 60;              /* bounded wall clock */
+    time_t start = time(NULL);
+    int escapes = 0, ok = 0, bad_tok = 0, done = 0;
+    int first_bad_iter = -1, first_bad_manual = -1;
+    char first_bad[96] = {0};
+    for (int i = 0; i < ITERS && !done; i++) {
+        if (time(NULL) - start > CAP_SEC) break;
         for (int manual = 0; manual < 2; manual++) {
             const char *tok = NULL;
             int fd = resolve_via(root, "a/mid/f", HL_FS_OPEN_READ, manual, &tok);
             if (fd >= 0) {
                 char b[64]; slurp(fd, b, sizeof(b)); close(fd);
-                if (strcmp(b, "inbase") != 0) escapes++;   /* would mean an escape */
-                else ok++;
+                if (strcmp(b, "inbase") != 0) {          /* an escape / wrong object */
+                    if (first_bad_iter < 0) { first_bad_iter = i; first_bad_manual = manual;
+                        snprintf(first_bad, sizeof(first_bad), "read=%.40s", b); }
+                    escapes++; done = 1;
+                } else ok++;
             } else if (tok &&
                        strcmp(tok, "not_found") && strcmp(tok, "not_a_directory") &&
                        strcmp(tok, "symlink_loop") && strcmp(tok, "io_error") &&
                        strcmp(tok, "permission") && strcmp(tok, "path_too_deep") &&
                        strcmp(tok, "invalid_path")) {
-                bad_tok++;                                  /* unexpected token */
+                if (first_bad_iter < 0) { first_bad_iter = i; first_bad_manual = manual;
+                    snprintf(first_bad, sizeof(first_bad), "tok=%.40s", tok); }
+                bad_tok++; done = 1;
             }
         }
     }
-    g_swap_stop = 1;
+    atomic_store(&g_swap_stop, 1);
     pthread_join(th, NULL);
 
-    ASSERT_EQ(0, escapes);        /* never resolved anything outside base */
-    ASSERT_EQ(0, bad_tok);        /* every failure was a known contained token */
-    ASSERT_GT(ok, 0);             /* and the real in-base file did resolve sometimes */
+    char ctx[160];
+    snprintf(ctx, sizeof(ctx),
+             "swapper_seed=0xC0FFEE first_bad_iter=%d impl=%s %s",
+             first_bad_iter, first_bad_manual == 1 ? "manual" : "openat2", first_bad);
+    ASSERT_EQ_MSG(0, escapes, ctx);       /* never read the external sentinel */
+    ASSERT_EQ_MSG(0, bad_tok, ctx);       /* every failure was a contained token */
+    ASSERT_GT(ok, 0);                     /* and the in-base file resolved sometimes */
 
+    /* fd leak guard: no net descriptor growth across all iterations */
     unlink(g_swap_path); rmdir(g_swap_path);
-    close(root); teardown();
+    int fds_after = count_open_fds();
+    char fdctx[64]; snprintf(fdctx, sizeof(fdctx), "before=%d after=%d", fds_before, fds_after);
+    ASSERT_GE_MSG(fds_before, fds_after, fdctx);   /* fds_after <= fds_before: no leak */
+
+    close(root);
+    rm_tree(g_ext_dir);
+    teardown();
 }
 
 UTEST_MAIN();

--- a/tests/hull/cap/test_fs_resolve_parity.c
+++ b/tests/hull/cap/test_fs_resolve_parity.c
@@ -190,16 +190,41 @@ UTEST(fs_resolve_parity, ratified_symlink_expanded_depth)
 {
     setup();
     const char *err = NULL;
-    char acc[HL_FS_MAX_DEPTH * 2 + 16] = {0};
-    int ao = 0;
+
+    /* Build HL_FS_MAX_DEPTH nested "c" dirs via DESCRIPTOR-RELATIVE mkdirat/openat.
+     * A 256-component ABSOLUTE path is ~511 chars + the base prefix, which overflows
+     * a PATH-buffer mkdir (mkdirp_host's char[512]) and would silently truncate the
+     * tree short of the depth limit -> the manual walk would hit not_found before
+     * path_too_deep. Held-fd descent has no absolute-path-length limit, so the tree
+     * is truly HL_FS_MAX_DEPTH deep. `leaf` is created at the deepest level (via the
+     * held fd, its absolute path is unrepresentable in a fixed buffer) so the openat2
+     * side can resolve it and the ratified divergence is exercised, not vacuous. */
+    int b = open(base, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    ASSERT_GE(b, 0);
+    int cur = b;
     for (int i = 0; i < HL_FS_MAX_DEPTH; i++) {
-        if (i) acc[ao++] = '/';
-        acc[ao++] = 'c'; acc[ao] = '\0';
-        mkdirp_host(acc);
+        if (mkdirat(cur, "c", 0755) != 0 && errno != EEXIST) {
+            ASSERT_EQ_MSG(0, 1, "mkdirat c");
+        }
+        int nxt = openat(cur, "c", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+        ASSERT_GE(nxt, 0);
+        if (cur != b) close(cur);
+        cur = nxt;
     }
-    char leafrel[HL_FS_MAX_DEPTH * 2 + 24];
-    snprintf(leafrel, sizeof(leafrel), "%s/leaf", acc);
-    wfile(leafrel, "deep");
+    int lf = openat(cur, "leaf", O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
+    ASSERT_GE(lf, 0);
+    ssize_t wr = write(lf, "deep", 4);
+    ASSERT_EQ((ssize_t)4, wr);
+    close(lf);
+    if (cur != b) close(cur);
+    close(b);
+
+    /* The symlink target: "c/c/.../c" (HL_FS_MAX_DEPTH components), relative to base
+     * (expand's parent), so it re-roots to the physical deep tree built above. */
+    char acc[HL_FS_MAX_DEPTH * 2 + 16];
+    int ao = 0;
+    for (int i = 0; i < HL_FS_MAX_DEPTH; i++) { if (i) acc[ao++] = '/'; acc[ao++] = 'c'; }
+    acc[ao] = '\0';
     symln(acc, "expand");
 
     int root = hl_fs_open_base(base, &err);

--- a/tests/hull/cap/test_fs_resolve_parity.c
+++ b/tests/hull/cap/test_fs_resolve_parity.c
@@ -108,6 +108,7 @@ static int build_tree(void)
     symln("d/g", "rel");
     symln("/d/g", "abs");
     symln("../../../../d/g", "up");
+    symln("d", "dsym");                   /* a symlink used as an INTERIOR component */
     symln("lo", "lo");
     return hl_fs_open_base(base, &err);
 }
@@ -125,6 +126,7 @@ UTEST(fs_resolve_parity, read_battery)
         { "rel", NULL, "nested" },
         { "abs", NULL, "nested" },
         { "up",  NULL, "nested" },
+        { "dsym/g", NULL, "nested" },              /* symlink as an INTERIOR component */
         { "nope", "not_found", NULL },
         { "lo",   "symlink_loop", NULL },
         { "f/",   "invalid_path", NULL },
@@ -226,15 +228,23 @@ static atomic_int g_swap_stop;
 static char g_swap_path[512];    /* interior component flipped by the swapper */
 static char g_ext_dir[256];      /* an EXTERNAL sentinel dir (outside base) */
 
+/* The swapped component "a/mid" flips between: a symlink to "../real" (in-base ->
+ * "a/mid/f" reads base/real/f = "inbase"), a symlink to the external sentinel dir
+ * (absolute, out of base -> re-roots to a non-existent in-base path -> not_found),
+ * and an empty directory (not_found). It NEVER contains the legitimate file, so it
+ * can always be rmdir'd/unlinked, and the only source of "inbase" is base/real/f. */
 static void *swapper(void *arg)
 {
     (void)arg;
     unsigned seed = 0xC0FFEE;
     while (!atomic_load_explicit(&g_swap_stop, memory_order_relaxed)) {
-        rmdir(g_swap_path);
         unlink(g_swap_path);
-        if (rand_r(&seed) & 1) mkdir(g_swap_path, 0755);
-        else                   symlink(g_ext_dir, g_swap_path);  /* absolute, out of base */
+        rmdir(g_swap_path);
+        switch (rand_r(&seed) % 3) {
+        case 0: symlink("../real", g_swap_path); break;   /* in-base -> reads inbase */
+        case 1: symlink(g_ext_dir, g_swap_path); break;   /* escape -> not_found */
+        default: mkdir(g_swap_path, 0755); break;         /* empty dir -> not_found */
+        }
     }
     return NULL;
 }
@@ -244,18 +254,43 @@ UTEST(fs_resolve_parity, component_swap_race_stays_contained)
     setup();
     const char *err = NULL;
     mkdirp_host("a");
-    mkdirp_host("a/mid");
-    wfile("a/mid/f", "inbase");
+    mkdirp_host("real");
+    wfile("real/f", "inbase");                 /* the ONLY source of "inbase" */
     /* external sentinel: if containment ever failed and followed the escaping
-     * symlink as a raw host path, "a/mid/f" would resolve to g_ext_dir/f. */
+     * symlink as a raw host path, "a/mid/f" would resolve to g_ext_dir/f. Content
+     * is PID-unique and distinct from "inbase" so a mistaken read is unambiguous.
+     * Its virtual-root RE-ROOTED path (base + "/tmp/hull_ext_PID") is never created,
+     * so a re-rooted resolve is not_found - not a same-named in-base file that could
+     * make a wrong read look legitimate (asserted below). */
+    char sentinel[64]; snprintf(sentinel, sizeof(sentinel), "SECRET-SENTINEL-%d", (int)getpid());
     snprintf(g_ext_dir, sizeof(g_ext_dir), "/tmp/hull_ext_%d", (int)getpid());
     mkdir(g_ext_dir, 0755);
     char extf[300]; snprintf(extf, sizeof(extf), "%s/f", g_ext_dir);
-    FILE *ef = fopen(extf, "wb"); if (ef) { fputs("SECRET-SENTINEL", ef); fclose(ef); }
+    FILE *ef = fopen(extf, "wb"); if (ef) { fputs(sentinel, ef); fclose(ef); }
     snprintf(g_swap_path, sizeof(g_swap_path), "%s/a/mid", base);
 
     int root = hl_fs_open_base(base, &err);
     ASSERT_GE(root, 0);
+
+    /* Pre-race invariant: with mid AS the escaping symlink, resolving "a/mid/f"
+     * must yield NEITHER "inbase" (no same-named in-root confound) NOR the sentinel
+     * (no escape) - it re-roots to a non-existent in-base path -> not_found. Proven
+     * for BOTH implementations before the race so the loop's "read==inbase => ok"
+     * is sound. */
+    unlink(g_swap_path); rmdir(g_swap_path);
+    ASSERT_EQ(0, symlink(g_ext_dir, g_swap_path));
+    for (int manual = 0; manual < 2; manual++) {
+        const char *tk = NULL;
+        int fd = resolve_via(root, "a/mid/f", HL_FS_OPEN_READ, manual, &tk);
+        if (fd >= 0) {
+            char b[64]; slurp(fd, b, sizeof(b)); close(fd);
+            ASSERT_STRNE_MSG("inbase", b, "escaping-symlink state read a same-named in-root file");
+            ASSERT_STRNE_MSG(sentinel, b, "escaping-symlink state read the external sentinel");
+        } else {
+            ASSERT_STREQ_MSG("not_found", tk, "escaping-symlink state should re-root to not_found");
+        }
+    }
+    unlink(g_swap_path); rmdir(g_swap_path);   /* clean initial state for the race */
 
     int fds_before = count_open_fds();
 

--- a/tests/hull/cap/test_fs_resolve_parity.c
+++ b/tests/hull/cap/test_fs_resolve_parity.c
@@ -1,0 +1,265 @@
+/*
+ * test_fs_resolve_parity.c — checkpoint 2: prove the two resolver implementations
+ * (openat2 fast path + the portable manual held-fd-stack walk) implement the SAME
+ * virtual-root contract, and that resolution is race-resistant.
+ *
+ * On Linux the READ path defaults to openat2; HL_FS_FORCE_MANUAL forces the manual
+ * walk, so every case here runs through BOTH implementations on one host and their
+ * outcomes (success + stable error tokens) are compared directly. macOS/cosmo have
+ * only the manual walk, so both passes coincide there (still a useful self-check).
+ *
+ * Coverage:
+ *   - a fixture battery of READ cases -> identical outcome + token on both impls;
+ *   - the depth boundary (exactly HL_FS_MAX_DEPTH vs +1) -> identical on both;
+ *   - the pathological symlink-expanded-depth case, where the manual walk is
+ *     STRICTER (fail-closed "path_too_deep") than openat2 (kernel PATH_MAX/ELOOP) -
+ *     a RATIFIED platform-resource-limit divergence (docs/hull_fs_resolver_parity.md),
+ *     asserted explicitly rather than papered over;
+ *   - a component-swap race: a swapper thread flips an interior component between a
+ *     real dir and a symlink pointing OUT of the sandbox while the resolver runs;
+ *     the resolved object must NEVER escape base_dir, on either implementation.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#if defined(__linux__) && !defined(_XOPEN_SOURCE)
+# define _XOPEN_SOURCE 700
+#endif
+
+#include "utest.h"
+#include "hull/cap/fs_resolve.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <ftw.h>
+#include <pthread.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+static char base[256];
+
+static void setup(void)
+{
+    snprintf(base, sizeof(base), "/tmp/hull_par_%d", (int)getpid());
+    mkdir(base, 0755);
+}
+static int rm_entry(const char *p, const struct stat *sb, int t, struct FTW *f)
+{ (void)sb; (void)t; (void)f; return remove(p); }
+static void teardown(void)
+{ if (nftw(base, rm_entry, 24, FTW_DEPTH | FTW_PHYS) != 0 && errno != ENOENT) {} }
+
+static void wfile(const char *rel, const char *data)
+{ char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel);
+  FILE *f = fopen(p, "wb"); if (f) { fputs(data, f); fclose(f); } }
+static void mkdirp_host(const char *rel)
+{ char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel); mkdir(p, 0755); }
+static void symln(const char *target, const char *rel)
+{ char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel); unlink(p); symlink(target, p); }
+
+/* Run one resolve through a chosen implementation; return fd (>=0) or -1, token via
+ * *tok (NULL on success). Assertion-free so it is safe outside a UTEST body. */
+static int resolve_via(int root, const char *path, HlFsOpenMode mode, int manual,
+                       const char **tok)
+{
+    if (manual) setenv("HL_FS_FORCE_MANUAL", "1", 1);
+    else        unsetenv("HL_FS_FORCE_MANUAL");
+    const char *e = NULL;
+    int fd = hl_fs_open_at(root, path, mode, 0644, &e);
+    unsetenv("HL_FS_FORCE_MANUAL");
+    *tok = (fd < 0) ? (e ? e : "?") : NULL;
+    return fd;
+}
+
+static void slurp(int fd, char *b, size_t n)
+{ ssize_t r = read(fd, b, n - 1); if (r < 0) r = 0; b[r] = '\0'; }
+
+static int build_tree(void)
+{
+    const char *err = NULL;
+    wfile("f", "hello");
+    mkdirp_host("d");
+    wfile("d/g", "nested");
+    symln("d/g", "rel");                 /* relative, in-base */
+    symln("/d/g", "abs");                /* absolute -> re-root to base/d/g */
+    symln("../../../../d/g", "up");      /* excess .. -> clamp to base/d/g */
+    symln("lo", "lo");                   /* self loop */
+    return hl_fs_open_base(base, &err);
+}
+
+/* ── fixture battery: identical outcome + token on both implementations ────── */
+UTEST(fs_resolve_parity, read_battery)
+{
+    setup();
+    int root = build_tree();
+    ASSERT_GE(root, 0);
+
+    struct { const char *path, *tok, *data; } cases[] = {
+        { "f",   NULL, "hello"  },
+        { "d/g", NULL, "nested" },
+        { "rel", NULL, "nested" },                 /* relative symlink */
+        { "abs", NULL, "nested" },                 /* absolute re-root */
+        { "up",  NULL, "nested" },                 /* dotdot clamp */
+        { "nope", "not_found", NULL },
+        { "lo",   "symlink_loop", NULL },
+        { "f/",   "invalid_path", NULL },          /* trailing slash */
+        { "a/../../etc/passwd", "invalid_path", NULL }, /* caller ".." */
+    };
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        const char *mt = NULL, *ot = NULL;
+        int mfd = resolve_via(root, cases[i].path, HL_FS_OPEN_READ, 1, &mt); /* manual */
+        int ofd = resolve_via(root, cases[i].path, HL_FS_OPEN_READ, 0, &ot); /* openat2 */
+        if (cases[i].tok) {
+            ASSERT_EQ_MSG(mfd, -1, cases[i].path);
+            ASSERT_EQ_MSG(ofd, -1, cases[i].path);
+            ASSERT_STREQ_MSG(cases[i].tok, mt, cases[i].path);
+            ASSERT_STREQ_MSG(cases[i].tok, ot, cases[i].path);  /* same token, both impls */
+        } else {
+            ASSERT_GE_MSG(mfd, 0, cases[i].path);
+            ASSERT_GE_MSG(ofd, 0, cases[i].path);
+            char bm[128], bo[128];
+            slurp(mfd, bm, sizeof(bm)); slurp(ofd, bo, sizeof(bo));
+            ASSERT_STREQ_MSG(bm, bo, cases[i].path);            /* identical content */
+            if (cases[i].data) ASSERT_STREQ_MSG(cases[i].data, bm, cases[i].path);
+            close(mfd); close(ofd);
+        }
+    }
+    close(root); teardown();
+}
+
+/* ── depth boundary parity ─────────────────────────────────────────────────── */
+static char *deep(int n)
+{ char *b = (char *)malloc((size_t)n * 2 + 1); int o = 0;
+  for (int i = 0; i < n; i++) { if (i) b[o++] = '/'; b[o++] = 'c'; } b[o] = 0; return b; }
+
+UTEST(fs_resolve_parity, depth_boundary)
+{
+    setup();
+    int root = build_tree();
+
+    char *over = deep(HL_FS_MAX_DEPTH + 1);          /* boundary + 1: both reject */
+    const char *mt = NULL, *ot = NULL;
+    ASSERT_EQ(-1, resolve_via(root, over, HL_FS_OPEN_READ, 1, &mt));
+    ASSERT_EQ(-1, resolve_via(root, over, HL_FS_OPEN_READ, 0, &ot));
+    ASSERT_STREQ("path_too_deep", mt);
+    ASSERT_STREQ("path_too_deep", ot);
+    free(over);
+
+    char *at = deep(HL_FS_MAX_DEPTH);                /* at limit: not "too deep" either impl */
+    (void)resolve_via(root, at, HL_FS_OPEN_READ, 1, &mt);
+    (void)resolve_via(root, at, HL_FS_OPEN_READ, 0, &ot);
+    ASSERT_STRNE("path_too_deep", mt ? mt : "");
+    ASSERT_STRNE("path_too_deep", ot ? ot : "");
+    free(at);
+    close(root); teardown();
+}
+
+/* ── RATIFIED divergence: symlink-expanded depth (Linux only) ────────────────
+ * A symlink whose target expands the RESOLVED path past HL_FS_MAX_DEPTH: the manual
+ * walk fails closed ("path_too_deep") because its held-fd stack is a platform
+ * resource limit; openat2 resolves it within the kernel's own PATH_MAX/ELOOP. Both
+ * stay CONTAINED (no authority escape); the difference is a documented, ratified
+ * platform-resource-limit asymmetry, asserted explicitly. See
+ * docs/hull_fs_resolver_parity.md. On macOS/cosmo both are the manual walk, so
+ * there is no divergence to assert. */
+#if defined(__linux__) && !defined(__COSMOPOLITAN__)
+UTEST(fs_resolve_parity, ratified_symlink_expanded_depth)
+{
+    setup();
+    const char *err = NULL;
+    /* create an existing HL_FS_MAX_DEPTH-level 'c' dir tree + a leaf file */
+    char acc[HL_FS_MAX_DEPTH * 2 + 16] = {0};
+    int ao = 0;
+    for (int i = 0; i < HL_FS_MAX_DEPTH; i++) {
+        if (i) acc[ao++] = '/';
+        acc[ao++] = 'c'; acc[ao] = '\0';
+        mkdirp_host(acc);
+    }
+    char leafrel[HL_FS_MAX_DEPTH * 2 + 24];
+    snprintf(leafrel, sizeof(leafrel), "%s/leaf", acc);
+    wfile(leafrel, "deep");
+    symln(acc, "expand");   /* target is HL_FS_MAX_DEPTH components */
+
+    int root = hl_fs_open_base(base, &err);
+    ASSERT_GE(root, 0);
+    const char *mt = NULL, *ot = NULL;
+    int mfd = resolve_via(root, "expand/leaf", HL_FS_OPEN_READ, 1, &mt);   /* manual */
+    int ofd = resolve_via(root, "expand/leaf", HL_FS_OPEN_READ, 0, &ot);   /* openat2 */
+
+    ASSERT_EQ(mfd, -1);                       /* manual: fail-closed at its depth bound */
+    ASSERT_STREQ("path_too_deep", mt);
+    if (ofd >= 0) {
+        /* openat2 in use: resolves within kernel limits -> the RATIFIED divergence */
+        char b[16]; slurp(ofd, b, sizeof(b)); ASSERT_STREQ("deep", b); close(ofd);
+    } else {
+        /* openat2 unavailable on this kernel -> the "openat2" pass also fell back
+         * to the manual walk, so both reject identically (no divergence to ratify) */
+        ASSERT_STREQ("path_too_deep", ot);
+    }
+
+    close(root); teardown();
+}
+#endif
+
+/* ── component-swap race: containment holds under concurrent mutation ──────── */
+static volatile int g_swap_stop;
+static char g_swap_path[512];
+static void *swapper(void *arg)
+{
+    (void)arg;
+    unsigned seed = 12345;
+    while (!g_swap_stop) {
+        rmdir(g_swap_path);
+        unlink(g_swap_path);
+        if (rand_r(&seed) & 1) mkdir(g_swap_path, 0755);
+        else                   symlink("/", g_swap_path);   /* escaping if followed raw */
+    }
+    return NULL;
+}
+
+UTEST(fs_resolve_parity, component_swap_race_stays_contained)
+{
+    setup();
+    const char *err = NULL;
+    mkdirp_host("a");
+    mkdirp_host("a/mid");
+    wfile("a/mid/f", "inbase");
+    snprintf(g_swap_path, sizeof(g_swap_path), "%s/a/mid", base);
+
+    int root = hl_fs_open_base(base, &err);
+    ASSERT_GE(root, 0);
+
+    g_swap_stop = 0;
+    pthread_t th;
+    ASSERT_EQ(0, pthread_create(&th, NULL, swapper, NULL));
+
+    int escapes = 0, ok = 0, bad_tok = 0;
+    for (int i = 0; i < 4000; i++) {
+        for (int manual = 0; manual < 2; manual++) {
+            const char *tok = NULL;
+            int fd = resolve_via(root, "a/mid/f", HL_FS_OPEN_READ, manual, &tok);
+            if (fd >= 0) {
+                char b[64]; slurp(fd, b, sizeof(b)); close(fd);
+                if (strcmp(b, "inbase") != 0) escapes++;   /* would mean an escape */
+                else ok++;
+            } else if (tok &&
+                       strcmp(tok, "not_found") && strcmp(tok, "not_a_directory") &&
+                       strcmp(tok, "symlink_loop") && strcmp(tok, "io_error") &&
+                       strcmp(tok, "permission") && strcmp(tok, "path_too_deep") &&
+                       strcmp(tok, "invalid_path")) {
+                bad_tok++;                                  /* unexpected token */
+            }
+        }
+    }
+    g_swap_stop = 1;
+    pthread_join(th, NULL);
+
+    ASSERT_EQ(0, escapes);        /* never resolved anything outside base */
+    ASSERT_EQ(0, bad_tok);        /* every failure was a known contained token */
+    ASSERT_GT(ok, 0);             /* and the real in-base file did resolve sometimes */
+
+    unlink(g_swap_path); rmdir(g_swap_path);
+    close(root); teardown();
+}
+
+UTEST_MAIN();


### PR DESCRIPTION
Checkpoint 2 of the merged hull.fs design ([docs/hull_fs_design.md](../blob/main/docs/hull_fs_design.md) §9/§10). **Tests + a formal ratification record only** — no `stat`/`list`, no compiled authorization, no BuildContext. **Stops for review.**

## What it proves
`tests/hull/cap/test_fs_resolve_parity.c` runs each case through **both** resolver implementations on one host — `HL_FS_FORCE_MANUAL` forces the manual walk, so on Linux every case is resolved via `openat2` **and** the manual walk and the outcomes compared (success content + stable error token):

- **`read_battery`** — file, nested, relative symlink, absolute-reroot symlink, `..`-clamp symlink, `not_found`, `symlink_loop`, trailing-slash, caller-`..` → identical outcome + token on both.
- **`depth_boundary`** — `HL_FS_MAX_DEPTH` accepted, `+1` rejected (`path_too_deep`), identically.
- **`ratified_symlink_expanded_depth`** (Linux) — the one intentional asymmetry, asserted explicitly (see below).
- **`component_swap_race_stays_contained`** — a swapper thread flips an interior component between a real dir and a symlink to `/` while the resolver runs 8000× through both implementations; asserts the resolved object **never** escapes `base_dir` and every failure is a known contained token.

## Ratified divergence (mandatory checkpoint-2 disposition)
A **symlink whose target expands the resolved path past `HL_FS_MAX_DEPTH`**: the manual walk fails closed (`path_too_deep` — its held-fd stack is a finite resource kept under `RLIMIT_NOFILE`); `openat2` resolves within the kernel's `PATH_MAX`/`ELOOP`. **Ratified as a platform-resource-limit asymmetry, not exact behavioral parity** — both stay fully contained, and the manual walk is the stricter, fail-closed side. The two elimination options (`/proc/self/fd` post-check; drop `openat2`) are documented and rejected for this checkpoint. Full record in `docs/hull_fs_resolver_parity.md`.

## Not in this checkpoint
`stat`/`list`, §6 compiled-entry authorization, BuildContext (later stops). The realpath-based `exists`/`delete`/`validate` consumers remain a tracked follow-up.