### PR TITLE
fs: path-authorization policy core - compile + select (checkpoint 3, Slice A)

### DIFF
--- a/docs/api/lua.md
+++ b/docs/api/lua.md
@@ -102,8 +102,8 @@ route is registered.
 
 | Field          | Type                                  | Description |
 |----------------|---------------------------------------|-------------|
-| `fs.read`      | `string[]`                            | Allowed read paths (relative, glob-ish). |
-| `fs.write`     | `string[]`                            | Allowed write paths. |
+| `fs.read`      | `string[]`                            | Read grants: a directory, an exact file, or a single-`*` component pattern. See [Filesystem grants](#filesystem-grants). |
+| `fs.write`     | `string[]`                            | Write grants (may create missing parents + the target). Same forms as `fs.read`. |
 | `hosts`        | `string[]`                            | Outbound HTTP host allowlist for `http.*` / `ws.connect`. Supports `*.domain.com`. |
 | `env`          | `string[]`                            | Env var names that `env.get` is permitted to read. Max 32 entries. |
 | `gpu`          | `boolean` or `table{ devices = … }`   | Enable `gpu.*` global. `false` (default) hides it. |
@@ -125,6 +125,35 @@ app.manifest({
     gpu = true,
 })
 ```
+
+#### Filesystem grants
+
+Each `fs.read` / `fs.write` entry is one of four forms, resolved relative to the
+app root and confined to it (a symlink target that points outside the root is
+re-rooted or clamped, never followed out):
+
+| Grant | Example | Authorizes |
+|-------|---------|------------|
+| Directory | `data/` or `data` | that directory and any descendant; in-root symlinks under it are followed, contained |
+| Exact file | `config.json` | only that file; siblings are not reachable; a symlink at that name is refused |
+| Write target (absent) | `out/result.bin` | creates the missing parent dirs and the file (`fs.write` only) |
+| Pattern | `data/*.csv` | files whose name matches, **per component** |
+
+**Pattern rules (v1):** `*` matches zero or more bytes **within a single path
+component** and never crosses `/`. Only `*` is supported; `?`, `[`, `]`, `{`, `}`,
+`\`, and `**` are rejected with a manifest error. So `data/*.csv` allows
+`data/a.csv` and `data/.csv`, but denies `data/a.txt`, `data/sub/a.csv` (the `*`
+does not cross `/`), and `data/a.csv/x`. Multiple patterned components are allowed
+(`logs/*/*.txt`). A pattern grant refuses symlinks in its matched portion (a
+`data/link.csv` symlink is denied even if it matches), so a matching name cannot
+alias a non-matching target.
+
+**Security note:** the pattern is **enforced per file**. Before this, a
+`data/*.csv` grant exposed the *entire* `data/` directory (only the kernel sandbox
+enforced the grant, coarsely, at directory granularity). An app that was relying on
+reading non-matching files under such a directory must now widen its manifest
+(add the directory or the specific files); that access was unintended
+over-authority, not a supported contract.
 
 ---
 

--- a/include/hull/cap/fs_policy.h
+++ b/include/hull/cap/fs_policy.h
@@ -63,12 +63,13 @@ typedef struct HlAllocator HlAllocator;   /* Hull's tracked allocator (utils/all
 /*
  * The four entry kinds (sec. 6 + PATTERN). The kind fixes both the anchor and the
  * per-kind symlink rule enforced later by the resolver (Slice B):
- *   - SUBTREE: anchor is the granted directory itself, reached at COMPILE by an
- *     O_NOFOLLOW descriptor walk (a symlink IN the grant's own path is refused -
- *     a narrow, documented change from the old realpath grant resolution that pins
- *     the anchor to a real directory). Any descendant is permitted; at RUNTIME
- *     descendant symlinks are FOLLOWED with virtual-root confinement (clamp within
- *     the subtree, cannot escape it).
+ *   - SUBTREE: anchor is the granted directory. Per the approved design (sec. 6),
+ *     a SUBTREE FOLLOWS in-root symlinks with virtual-root confinement, so the
+ *     anchor is obtained at COMPILE by a CONTAINED-FOLLOW resolution
+ *     (HL_FS_OPEN_DIR: each component O_NOFOLLOW + a contained readlink splice), so
+ *     a symlinked grant directory still loads and its target cannot escape the
+ *     root. Any descendant is permitted; at RUNTIME descendant symlinks are
+ *     likewise FOLLOWED, clamped within the subtree.
  *   - EXACT:   anchor is the granted file's PARENT dir; ONLY the one literal leaf
  *     name is permitted (siblings unreachable); a symlink (intermediate or
  *     terminal) is REFUSED ("symlink_denied"), never followed.
@@ -250,16 +251,19 @@ void hl_fs_grant_free(HlFsGrant *grant);
  * cannot be inferred from the grants).
  *
  * `base_dir` is the app root, opened via hl_fs_open_base() - the trusted root is
- * followed ONCE (checkpoint-1 semantics), NOT O_NOFOLLOW. Every grant then reaches
- * its anchor by a UNIFORM descriptor-bound walk of the EXISTING literal components
- * from base_fd, never reconstructing a host path: each component
- * openat(O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC) + fstat-confirm a directory, with a
- * classify/open swap re-classified within a bound. A symlink in the grant's own
- * literal path is REFUSED ("symlink_denied") for ALL kinds - a narrow documented
- * compatibility change from realpath-based grant resolution that pins every anchor
- * to a real directory. (SUBTREE runtime DESCENDANTS still follow in-root symlinks
- * contained via the Slice-B resolver; EXACT/CREATE/PATTERN also refuse symlinks in
- * their constrained portion at runtime.)
+ * followed ONCE (checkpoint-1 semantics), NOT O_NOFOLLOW. Grants are classified by
+ * a descriptor-bound walk from base_fd, never reconstructing a host path, with
+ * PER-KIND symlink semantics (design sec. 6):
+ *   - SUBTREE: the grant directory is resolved with a CONTAINED-FOLLOW
+ *     (HL_FS_OPEN_DIR) - in-root symlinks in the grant path are followed and
+ *     clamped within the root, so a symlinked grant directory still loads (this
+ *     preserves the pre-checkpoint-3 behavior; the target cannot escape the root
+ *     and the held fd pins the inode).
+ *   - EXACT / CREATE / PATTERN: the existing literal prefix is walked
+ *     openat(O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC) + fstat-confirm a directory (a
+ *     classify/open swap re-classified within a bound); ANY symlink in that path
+ *     is REFUSED ("symlink_denied"), never followed - so a symlink cannot alias an
+ *     exact/pattern/create target.
  * Classification:
  *   all literal comps exist, terminal is a dir      -> SUBTREE (or PATTERN if the
  *                                                      grant carries patterns)

--- a/include/hull/cap/fs_policy.h
+++ b/include/hull/cap/fs_policy.h
@@ -1,0 +1,328 @@
+/*
+ * fs_policy.h - compiled path-authorization policy for hull.fs (checkpoint 3).
+ *
+ * Checkpoint 3 of the hull.fs design (docs/hull_fs_design.md sec. 6). Separates the
+ * TWO authorities the older cap layer conflated:
+ *
+ *   (a) ROOT CONFINEMENT - every op stays under a root. Provided entirely by the
+ *       checkpoint-1/2 descriptor resolver (fs_resolve.h, virtual-root). NO
+ *       manifest input.
+ *   (b) PATH AUTHORIZATION - WHICH paths an app may read vs write. THIS file.
+ *
+ * A manifest `fs.read` / `fs.write` grant is compiled once (at cap-wiring time)
+ * into an AUTHORIZATION ENTRY = a HELD anchor directory fd (ALWAYS an existing
+ * directory, reached by a descriptor-bound walk from base_fd - never a
+ * reconstructed host path) + a CONSTRAINT. `fs.read` and `fs.write` compile to
+ * two INDEPENDENT entry sets: a read/mmap/stat/list op selects from the READ
+ * set, a write op from the WRITE set (sec. 6). This object is the explicit policy;
+ * the kernel sandbox stays as defense-in-depth BENEATH it. An app with no grants
+ * authorizes nothing (fails closed).
+ *
+ * Slice A (this header + fs_policy.c + test_fs_policy.c) is the policy CORE:
+ * parse grants, compile grants -> entries (descriptor-bound), and deterministic
+ * most-specific selection. It does NOT wire into hl_cap_fs read/write/mmap
+ * (Slice B) and does NOT add stat/list (Slice C).
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#ifndef HULL_CAP_FS_POLICY_H
+#define HULL_CAP_FS_POLICY_H
+
+#include <stddef.h>
+#include "hull/cap/fs_resolve.h"   /* HlFsOpenMode, HL_FS_MAX_DEPTH */
+
+typedef struct HlAllocator HlAllocator;   /* Hull's tracked allocator (utils/alloc.h) */
+
+/* -- Grant glob syntax (v1, deliberately minimal) -----------------------------
+ * A grant component MAY contain the wildcard '*' - "zero or more bytes WITHIN one
+ * path component". '*' never crosses '/'. v1 supports ONLY '*': the metacharacters
+ * '?', '[', ']', '{', '}', '\\' and the sequence "**" are REJECTED at parse with a
+ * clear manifest error (unsupported in v1; no character classes, brace expansion,
+ * escaping, locale, or platform-dependent matching). Matching is deterministic,
+ * byte-exact, and bounded (an O(len*patlen) dynamic-programming matcher - never a
+ * recursive exponential backtracker). The matcher runs on ONE component at a time
+ * against a FIXED internal DP row of NAME_MAX+1 bytes: NO VLA, NO heap allocation,
+ * NO recursion, and NO use of the caller's residual scratch. hl_fs_grant_parse
+ * rejects any component (grant OR, at select time, caller) longer than NAME_MAX -
+ * the resolver's per-component limit ("invalid_path") - so the fixed row always
+ * suffices and select() allocates nothing. A wildcard grant NEVER passes its
+ * wildcard text to filesystem resolution: the literal prefix before the first
+ * patterned component is compiled into a held directory anchor, and the caller's
+ * LITERAL bytes (not the pattern) form the residual the resolver opens.
+ *
+ * Security correction (documented, intentional): prior Hull versions exposed the
+ * WHOLE containing directory for a wildcard grant (e.g. read of `data` slash
+ * `*.csv`), because only the kernel sandbox enforced the grant (which strips the
+ * glob tail to the directory) and the cap layer checked no per-path pattern. From
+ * checkpoint 3 the pattern is ENFORCED: `data/a.csv` is allowed, `data/a.txt` is
+ * denied (component-scoped). Apps relying on the
+ * old whole-directory access must widen their manifest; that reliance was
+ * unintended over-authority, not a compatibility contract. docs/api/lua.md is
+ * corrected to describe the enforced semantics. */
+
+/*
+ * The four entry kinds (sec. 6 + PATTERN). The kind fixes both the anchor and the
+ * per-kind symlink rule enforced later by the resolver (Slice B):
+ *   - SUBTREE: anchor is the granted directory itself, reached at COMPILE by an
+ *     O_NOFOLLOW descriptor walk (a symlink IN the grant's own path is refused -
+ *     a narrow, documented change from the old realpath grant resolution that pins
+ *     the anchor to a real directory). Any descendant is permitted; at RUNTIME
+ *     descendant symlinks are FOLLOWED with virtual-root confinement (clamp within
+ *     the subtree, cannot escape it).
+ *   - EXACT:   anchor is the granted file's PARENT dir; ONLY the one literal leaf
+ *     name is permitted (siblings unreachable); a symlink (intermediate or
+ *     terminal) is REFUSED ("symlink_denied"), never followed.
+ *   - CREATE:  a not-yet-existing target; anchor is the NEAREST EXISTING ANCESTOR;
+ *     ONLY the constrained missing components may be mkdirat'd and the terminal
+ *     created; a symlink component is REFUSED, never followed.
+ *   - PATTERN: anchor is the NEAREST EXISTING literal-prefix directory (the
+ *     components before the first patterned one; the anchor may be SHALLOWER than
+ *     that prefix when it is partly absent - the missing literal components are
+ *     exact-constrained, created only under a WRITE, resolved not_found under a
+ *     READ). The terminal component(s) are matched by the parsed patterns. The
+ *     missing-literal AND pattern-constrained portions REFUSE symlinks (like
+ *     EXACT/CREATE) so a matching symlink name cannot smuggle access to a
+ *     non-matching target (authority follows the resolved target). Symlinks in the
+ *     EXISTING literal prefix are refused during COMPILE (O_NOFOLLOW per component).
+ *     A trailing-slash pattern grant is rejected at parse (no v1 descendant sense).
+ *
+ *     Multi-component PATTERN WRITE creation (e.g. grant `logs`+`*`+`*.txt`,
+ *     caller `logs/2026/a.txt`): a WRITE may create the missing literal-prefix
+ *     components AND the NONTERMINAL matched pattern components (the caller's
+ *     literal `2026`, made a directory), then create/truncate the TERMINAL matched
+ *     component (`a.txt`) as a file. Only the caller's LITERAL matched names are
+ *     passed to mkdirat, each classify-before-open and symlink-refused (a symlink
+ *     found where a patterned intermediate directory is expected fails
+ *     "symlink_denied", never followed). A READ creates nothing and returns
+ *     not_found when any required component is absent. (Creation is a Slice-B
+ *     runtime behavior; this defines the model the entry carries.)
+ */
+typedef enum {
+    HL_FS_ENTRY_SUBTREE = 0,
+    HL_FS_ENTRY_EXACT,
+    HL_FS_ENTRY_CREATE,
+    HL_FS_ENTRY_PATTERN,
+} HlFsEntryKind;
+
+/* The terminal shape of a CREATE grant: exact file (only that leaf may be
+ * created) vs subtree (descendants may be created). Taken from the grant's
+ * `directory_intent` bit (captured pre-normalization - NOT from a trailing slash
+ * after normalization, which strips it). Unused for SUBTREE/EXACT/PATTERN. */
+typedef enum {
+    HL_FS_TERMINAL_FILE = 0,   /* out/result.bin - only that terminal leaf */
+    HL_FS_TERMINAL_SUBTREE,    /* out/ (absent)  - any descendant beneath it */
+} HlFsTerminalKind;
+
+/*
+ * A PARSED grant (pure string product of hl_fs_grant_parse - NO filesystem
+ * access). `comp` are the normalized path components (no "..", no trailing slash,
+ * no NUL). Components in [0, first_pattern) are guaranteed LITERAL; components in
+ * [first_pattern, n) may contain '*' (patterns; a literal-looking tail component
+ * matches exactly). `directory_intent` records whether the RAW grant ended in a
+ * trailing slash (terminal subtree) - captured BEFORE normalization so it does
+ * not depend on a formatting detail that normalization would strip; it is ignored
+ * when first_pattern < n (a pattern is always terminal). `comp`/its strings are
+ * owned by the grant's allocator; free with hl_fs_grant_free.
+ */
+typedef struct {
+    char        **comp;
+    size_t        n;
+    size_t        first_pattern;    /* index of first patterned component; == n if pure literal */
+    int           directory_intent; /* raw grant had a trailing slash (terminal subtree).
+                                     * REJECTED at parse when first_pattern < n: a
+                                     * trailing-slash pattern grant (`data/` + `*` + `/`)
+                                     * has no defined descendant semantics in v1. */
+    HlAllocator  *alloc;            /* allocator that owns comp[]/strings (for _free) */
+} HlFsGrant;
+
+#define HL_FS_GRANT_INIT ((HlFsGrant){ .comp = NULL, .n = 0, .first_pattern = 0, \
+                                       .directory_intent = 0, .alloc = NULL })
+
+/*
+ * One compiled authorization entry. `anchor_fd` is a HELD, always-existing
+ * directory fd (reached by a descriptor-bound walk from base_fd - SUBTREE follows
+ * in-root symlinks contained, EXACT/CREATE/PATTERN refuse symlinks - and
+ * fstat-confirmed a directory) that the op's terminal syscall is issued relative
+ * to, so selection + confinement are race-free with no separate resolved-path
+ * re-check (sec. 6). `grant` is the grant's components (literal + pattern text),
+ * retained for deterministic most-specific selection and pattern matching;
+ * component-aware ("data" never matches "database"). Components in
+ * [first_pattern, grant_n) are the parsed patterns matched against the caller's
+ * terminal components. Never holds a reconstructed absolute host path.
+ */
+typedef struct {
+    HlFsEntryKind    kind;
+    int              anchor_fd;       /* held existing-directory fd (>=0 always: the
+                                       * NEAREST EXISTING literal ancestor - never -1) */
+    char           **grant;           /* grant components relative to base_dir (owned) */
+    size_t           grant_n;
+    /* The grant components split into THREE ranges by anchor_depth and
+     * first_pattern (anchor_depth <= first_pattern <= grant_n):
+     *   [0, anchor_depth)          reached by anchor_fd (existing dirs, held).
+     *   [anchor_depth, first_pattern)  MISSING literal components - exact-constrained
+     *                              dirs: a READ resolves not_found until they exist;
+     *                              a WRITE may mkdirat ONLY these; symlinks refused.
+     *   [first_pattern, grant_n)   PATTERN components (byte-matched, within-component,
+     *                              symlinks refused). Empty (== grant_n) for non-pattern.
+     * Per kind: SUBTREE anchor_depth==first_pattern==grant_n (anchor IS the dir);
+     * EXACT anchor_depth==grant_n-1==first_pattern-... (parent held; grant[grant_n-1]
+     * is the existing exact leaf); CREATE first_pattern==grant_n with a missing tail;
+     * PATTERN first_pattern<grant_n (optionally a missing literal middle too). */
+    size_t           anchor_depth;    /* existing-ancestor depth reached by anchor_fd */
+    size_t           first_pattern;   /* index of first pattern component (== grant_n if none) */
+    HlFsTerminalKind terminal;        /* CREATE / PATTERN terminal shape (FILE in v1) */
+    /* Specificity for deterministic most-specific selection (sec. 6): primary =
+     * literal_components (fully-literal, wildcard-free component count) DESC,
+     * secondary = literal_bytes (non-'*' byte count) DESC. Entries are stored
+     * pre-sorted by (specificity DESC, grant-text ASC) so selection scans in
+     * priority order and any residual tie is broken lexicographically - total and
+     * deterministic. Identical grants are deduplicated and same-component grants
+     * with conflicting intent are REJECTED at compile (never order-dependent). */
+    size_t           literal_components;
+    size_t           literal_bytes;
+} HlFsAuthEntry;
+
+/*
+ * The compiled policy: two INDEPENDENT entry sets plus the owning allocator and
+ * the app-root fd. `base_fd` is retained only for compiling CREATE anchors and
+ * for teardown; it is NOT a catch-all grant (no match -> "permission" denial).
+ *
+ * Zero-initialization is NOT a valid state (base_fd 0 is a real fd - stdin).
+ * ALWAYS initialize with HL_FS_POLICY_INIT, which sets base_fd = -1 so
+ * hl_fs_policy_free never closes a fd it does not own. hl_fs_policy_free is safe
+ * on an HL_FS_POLICY_INIT-initialized policy and idempotent on a compiled one
+ * (it -1's every fd it closes and NULLs the arrays it frees).
+ */
+typedef struct {
+    HlAllocator    *alloc;
+    int             base_fd;          /* app-root dirfd, or -1 when uninitialized/freed */
+    HlFsAuthEntry  *read;             /* READ set (read/mmap/stat/list select here) */
+    size_t          read_n;
+    HlFsAuthEntry  *write;            /* WRITE set (write selects here) */
+    size_t          write_n;
+} HlFsPolicy;
+
+#define HL_FS_POLICY_INIT ((HlFsPolicy){ .alloc = NULL, .base_fd = -1, \
+                                         .read = NULL, .read_n = 0,     \
+                                         .write = NULL, .write_n = 0 })
+
+/*
+ * The result of selecting an entry for a caller path. `residual` is written INTO
+ * the caller-provided `scratch` (the selected entry's literal caller components
+ * joined with '/', relative to entry->anchor_fd) - it is OWNED BY SCRATCH, valid
+ * until scratch is reused, and is "." (never "") when the caller path IS the
+ * grant root, because the resolver rejects an empty path. A NULL entry means
+ * DENIED, with `err` a stable token.
+ */
+typedef struct {
+    const HlFsAuthEntry *entry;       /* selected entry, or NULL == denied */
+    const char          *residual;    /* into scratch; path relative to entry->anchor_fd */
+    const char          *err;         /* when entry==NULL: "permission" / "invalid_path" */
+} HlFsSelection;
+
+/*
+ * Parse ONE raw manifest grant into a HlFsGrant (pure - no filesystem access).
+ * LENGTH-BEARING: `raw`/`raw_len` are the exact grant bytes, so an EMBEDDED NUL
+ * ("data\0/secret") is detected and REJECTED here rather than silently truncated.
+ * Captures directory_intent from a trailing slash BEFORE normalization, splits
+ * into components, and locates the first patterned component. Rejects an absolute
+ * path, any ".." component, an embedded NUL, an empty grant, an over-deep path
+ * (> HL_FS_MAX_DEPTH components), a trailing-slash PATTERN grant, and any
+ * unsupported metacharacter ('?', '[', ']', '{', '}', '\\', or "**") with a
+ * stable *err ("invalid_path" / "unsupported_pattern"). On success writes *out
+ * (an owning value; free with hl_fs_grant_free) and returns 0; on failure returns
+ * -1 with *err set, and *out is left HL_FS_GRANT_INIT (nothing to free).
+ *
+ * `out` MUST be HL_FS_GRANT_INIT on entry. hl_fs_grant_free is idempotent on an
+ * HL_FS_GRANT_INIT grant and resets a freed grant back to HL_FS_GRANT_INIT.
+ */
+int hl_fs_grant_parse(const char *raw, size_t raw_len, HlAllocator *alloc,
+                      HlFsGrant *out, const char **err);
+
+void hl_fs_grant_free(HlFsGrant *grant);
+
+/*
+ * Compile parsed grants into a policy. `alloc` owns every allocation in the
+ * result (entry arrays + deep-copied grant components); it is stored on the
+ * policy for hl_fs_policy_free. Compilation DEEP-COPIES all grant data it needs,
+ * so the caller MAY free the parsed `read`/`write` grants immediately after this
+ * returns. `alloc` MUST be non-NULL (a grant list may be empty, so the allocator
+ * cannot be inferred from the grants).
+ *
+ * `base_dir` is the app root, opened via hl_fs_open_base() - the trusted root is
+ * followed ONCE (checkpoint-1 semantics), NOT O_NOFOLLOW. Every grant then reaches
+ * its anchor by a UNIFORM descriptor-bound walk of the EXISTING literal components
+ * from base_fd, never reconstructing a host path: each component
+ * openat(O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC) + fstat-confirm a directory, with a
+ * classify/open swap re-classified within a bound. A symlink in the grant's own
+ * literal path is REFUSED ("symlink_denied") for ALL kinds - a narrow documented
+ * compatibility change from realpath-based grant resolution that pins every anchor
+ * to a real directory. (SUBTREE runtime DESCENDANTS still follow in-root symlinks
+ * contained via the Slice-B resolver; EXACT/CREATE/PATTERN also refuse symlinks in
+ * their constrained portion at runtime.)
+ * Classification:
+ *   all literal comps exist, terminal is a dir      -> SUBTREE (or PATTERN if the
+ *                                                      grant carries patterns)
+ *   all literal comps exist, terminal is a non-dir  -> EXACT (no patterns)
+ *   some literal comps missing (nearest existing
+ *     ancestor is the anchor; missing tail retained -> CREATE, or PATTERN when the
+ *     as exact-constrained comps)                      grant carries patterns
+ *
+ * Within EACH set, identical grants are DEDUPLICATED and two grants with the SAME
+ * components but CONFLICTING terminal intent (`data` file vs `data/` dir) are
+ * REJECTED (deterministic, not input-order-dependent). The READ and WRITE sets
+ * are INDEPENDENT: a grant present in both is retained in BOTH (they express
+ * different authority - readable need not be writable). Entries within a set are
+ * stored pre-sorted by specificity (literal_components DESC, then literal_bytes
+ * DESC, then grant-text ASC) so selection is deterministic.
+ *
+ * *out MUST be HL_FS_POLICY_INIT on entry. On success returns 0 (free with
+ * hl_fs_policy_free). On failure returns -1 with *err set and *out left as
+ * HL_FS_POLICY_INIT (no partial policy, no leaked fds).
+ */
+int hl_fs_policy_compile(const char *base_dir, HlAllocator *alloc,
+                         const HlFsGrant *read,  size_t read_n,
+                         const HlFsGrant *write, size_t write_n,
+                         HlFsPolicy *out, const char **err);
+
+/*
+ * Select the authorizing entry for `caller_path` (relative, no "..", no trailing
+ * slash - the hl_fs_open_at lexical contract) in the set for `mode` (READ set for
+ * HL_FS_OPEN_READ, WRITE set for HL_FS_OPEN_WRITE; any other mode value FAILS
+ * CLOSED -> denied). Deterministic: entries are scanned in stored priority order
+ * and the first match wins (most literal components, then most literal bytes,
+ * then lexicographic grant text). A SUBTREE match permits any descendant; EXACT
+ * requires exact component equality; CREATE permits the constrained terminal
+ * (and, for a subtree terminal, descendants); PATTERN requires the caller to have
+ * exactly grant_n components whose literal prefix matches exactly and whose
+ * terminal components match the parsed patterns (byte-exact, within-component).
+ *
+ * MOST-SPECIFIC-WINS SHADOWING (deliberate, documented): a narrower grant
+ * intentionally SHADOWS a broader overlapping one. With both `data/` (SUBTREE)
+ * and `data` + `*.csv` (PATTERN), a caller `data/link.csv` selects the PATTERN
+ * entry (higher specificity) and is therefore DENIED (`symlink_denied`, PATTERN
+ * refuses symlinks) even though the SUBTREE grant alone would have followed it.
+ * This is most-specific-policy-wins, NOT union-of-grants. (Selecting the most
+ * specific entry that CAN authorize the RESOLVED op is deferred to a later slice;
+ * v1 is pure and does not open anything to decide selection.) A dedicated test
+ * locks this.
+ *
+ * Errors (stable tokens, all fail closed): no match -> entry == NULL,
+ * err = "permission"; a lexically invalid caller path (absolute / ".." / trailing
+ * slash) -> "invalid_path"; a `mode` that is neither READ nor WRITE -> "permission"
+ * (denied); a `scratch` shorter than strlen(caller_path)+2 -> "invalid_args". On a
+ * match, `residual` is written into `scratch` as the LITERAL caller components
+ * relative to entry->anchor_fd ("." for the grant root). Pure: NO filesystem
+ * access - selection never opens, stats, or reads anything.
+ */
+HlFsSelection hl_fs_policy_select(const HlFsPolicy *policy, const char *caller_path,
+                                  HlFsOpenMode mode, char *scratch, size_t scratch_len);
+
+/*
+ * Close every owned anchor/base fd and free the entry arrays via policy->alloc.
+ * Safe on an HL_FS_POLICY_INIT policy and idempotent (post-call the policy is
+ * HL_FS_POLICY_INIT again). NEVER call on a {0}-initialized policy.
+ */
+void hl_fs_policy_free(HlFsPolicy *policy);
+
+#endif /* HULL_CAP_FS_POLICY_H */

--- a/include/hull/cap/fs_resolve.h
+++ b/include/hull/cap/fs_resolve.h
@@ -54,16 +54,22 @@ int hl_fs_open_base(const char *base_dir, const char **err);
 /*
  * Resolve+open `relpath` under `root_fd` with virtual-root semantics.
  *
- *   HL_FS_OPEN_READ  -> returns an O_RDONLY fd to the leaf.
+ *   HL_FS_OPEN_READ  -> returns an O_RDONLY fd to the leaf (a file).
  *   HL_FS_OPEN_WRITE -> creates missing parent dirs (contained, mkdirat) and
- *                       returns an O_WRONLY|O_CREAT|O_TRUNC fd to the leaf.
+ *                       returns an O_WRONLY|O_CREAT|O_TRUNC fd to the leaf (a file).
+ *   HL_FS_OPEN_DIR   -> returns an O_RDONLY|O_DIRECTORY fd to an existing
+ *                       DIRECTORY; a non-directory target -> "not_a_directory".
+ *                       Never creates. (Used to resolve a SUBTREE grant anchor and,
+ *                       later, stat/list.)
  *
- * `relpath` MUST be relative, MUST NOT contain ".." components, MUST NOT end in a
- * trailing slash (directory-shaped; these are leaf-file modes), and MUST have at
+ * `relpath` MUST be relative, MUST NOT contain ".." components, and MUST have at
  * most HL_FS_MAX_DEPTH components (the caller-path lexical pre-check; violations
- * return "invalid_path" / "path_too_deep"). Symlink targets ENCOUNTERED on disk
- * MAY be absolute or contain "..": those are virtual-rooted (re-root / clamp at
- * `root_fd`), never an escape.
+ * return "invalid_path" / "path_too_deep"). It MUST NOT end in a trailing slash for
+ * ANY mode - READ/WRITE are leaf-file modes, and although DIR opens a directory it
+ * ALSO rejects a trailing slash in v1 (the lexical pre-check is mode-independent);
+ * future stat/list work must not assume a trailing slash is accepted here. Symlink
+ * targets ENCOUNTERED on disk MAY be absolute or contain "..": those are
+ * virtual-rooted (re-root / clamp at `root_fd`), never an escape.
  *
  * Returns an open fd (caller closes) or -1 with *err set to a stable token:
  * "invalid_path", "path_too_deep", "not_found", "permission", "not_a_directory",

--- a/include/hull/cap/fs_resolve.h
+++ b/include/hull/cap/fs_resolve.h
@@ -37,6 +37,10 @@
 typedef enum {
     HL_FS_OPEN_READ,  /* open an existing leaf O_RDONLY (symlinks followed, contained) */
     HL_FS_OPEN_WRITE, /* mkdir-p parents (contained) + open leaf O_WRONLY|O_CREAT|O_TRUNC */
+    HL_FS_OPEN_DIR,   /* open an existing DIRECTORY O_RDONLY|O_DIRECTORY (symlinks
+                       * followed, contained); a non-directory target -> not_a_directory.
+                       * Never creates. Used to resolve a SUBTREE grant anchor
+                       * (fs_policy) and, later, stat/list. */
 } HlFsOpenMode;
 
 /*

--- a/src/hull/cap/fs_policy.c
+++ b/src/hull/cap/fs_policy.c
@@ -257,7 +257,7 @@ static void entry_free(HlAllocator *a, HlFsAuthEntry *e)
 static int compile_one(int base_fd, HlAllocator *alloc, const HlFsGrant *g,
                        HlFsAuthEntry *out, const char **err)
 {
-    const char *e = "io_error";
+    const char *e;                          /* every `goto fail` sets this before use */
     size_t lit = g->first_pattern;          /* literal prefix length */
 
     /* A pure-literal grant that resolves to a DIRECTORY is a SUBTREE. Per the
@@ -538,8 +538,12 @@ static int entry_matches(const HlFsAuthEntry *e, const char **ccomp, const size_
         for (size_t i = 0; i < e->grant_n; i++) if (!LIT_EQ(i, i)) return 0;
         return 1;
     }
-    /* PATTERN: exactly grant_n comps; literal prefix exact; pattern tail matched */
+    /* PATTERN: exactly grant_n comps; literal prefix exact; pattern tail matched.
+     * first_pattern <= grant_n == cn always (parse invariant); assert it so the
+     * analyzer can prove ccomp[i]/clen[i] below stay within the caller components
+     * split_caller filled ([0, cn)). */
     if ((size_t)cn != e->grant_n) return 0;
+    if (e->first_pattern > (size_t)cn) return 0;
     for (size_t i = 0; i < e->first_pattern; i++) if (!LIT_EQ(i, i)) return 0;
     for (size_t i = e->first_pattern; i < e->grant_n; i++)
         if (!pat_match(e->grant[i], strlen(e->grant[i]), ccomp[i], clen[i])) return 0;

--- a/src/hull/cap/fs_policy.c
+++ b/src/hull/cap/fs_policy.c
@@ -1,0 +1,528 @@
+/*
+ * fs_policy.c - compiled path-authorization policy for hull.fs (checkpoint 3,
+ * Slice A). Parse manifest grants, compile them into two independent
+ * authorization-entry sets by a descriptor-bound walk, and select deterministically
+ * by most-specific match. See include/hull/cap/fs_policy.h and
+ * docs/hull_fs_design.md sec. 6.
+ *
+ * This slice is the policy CORE: it does NOT wire into hl_cap_fs read/write/mmap
+ * (Slice B) and does NOT add stat/list (Slice C).
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#include "hull/cap/fs_policy.h"
+#include "hull/cap/fs_resolve.h"
+#include "hull/utils/alloc.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#ifndef NAME_MAX
+#define NAME_MAX 255
+#endif
+#define ANCHOR_RECLASS_MAX 64   /* bound the classify<->open swap retries (compile) */
+
+/* ── small allocation helpers (sizes recovered for the tracked free) ─────────── */
+
+static char *dup_bytes(HlAllocator *a, const char *s, size_t len)
+{
+    char *p = (char *)hl_alloc_malloc(a, len + 1);
+    if (!p) return NULL;
+    memcpy(p, s, len);
+    p[len] = '\0';
+    return p;
+}
+
+static void free_str(HlAllocator *a, char *s)
+{
+    if (s) hl_alloc_free(a, s, strlen(s) + 1);
+}
+
+static void free_comps(HlAllocator *a, char **comp, size_t n)
+{
+    if (!comp) return;
+    for (size_t i = 0; i < n; i++) free_str(a, comp[i]);
+    hl_alloc_free(a, comp, n * sizeof(char *));
+}
+
+static char **dup_comps(HlAllocator *a, char *const *src, size_t n)
+{
+    char **out = (char **)hl_alloc_calloc(a, n ? n : 1, sizeof(char *));
+    if (!out) return NULL;
+    for (size_t i = 0; i < n; i++) {
+        out[i] = dup_bytes(a, src[i], strlen(src[i]));
+        if (!out[i]) { free_comps(a, out, i); return NULL; }
+    }
+    return out;
+}
+
+/* ── component pattern metacharacter validation ──────────────────────────────── */
+
+/* Returns 0 if `seg` (len bytes) is an acceptable v1 component: only '*' is a
+ * wildcard; '?', '[', ']', '{', '}', '\\' and the adjacent sequence "**" are
+ * unsupported. Sets *has_star. Returns -1 (with *err) on an unsupported char. */
+static int scan_component(const char *seg, size_t len, int *has_star, const char **err)
+{
+    *has_star = 0;
+    int prev_star = 0;
+    for (size_t i = 0; i < len; i++) {
+        char c = seg[i];
+        switch (c) {
+        case '*':
+            if (prev_star) { *err = "unsupported_pattern"; return -1; }  /* "**" */
+            *has_star = 1; prev_star = 1;
+            continue;
+        case '?': case '[': case ']': case '{': case '}': case '\\':
+            *err = "unsupported_pattern"; return -1;
+        default:
+            prev_star = 0;
+        }
+    }
+    return 0;
+}
+
+/* ── single-component wildcard matcher (bounded DP, fixed rows, no recursion) ─── */
+
+/* Match pattern `pat` (pn bytes, may contain '*') against literal `s` (sn bytes),
+ * within one path component. '*' matches zero or more bytes. O(pn*sn), two fixed
+ * NAME_MAX+2 rows on the stack: no VLA, no heap, no recursion. */
+static int pat_match(const char *pat, size_t pn, const char *s, size_t sn)
+{
+    if (pn > NAME_MAX || sn > NAME_MAX) return 0;   /* rejected earlier; defensive */
+    unsigned char prev[NAME_MAX + 2], cur[NAME_MAX + 2];
+    prev[0] = 1;                                     /* empty pattern matches empty text */
+    for (size_t j = 0; j < pn; j++)
+        prev[j + 1] = (unsigned char)(prev[j] && pat[j] == '*');
+    for (size_t i = 0; i < sn; i++) {
+        cur[0] = 0;                                  /* non-empty text vs empty pattern */
+        for (size_t j = 0; j < pn; j++) {
+            if (pat[j] == '*')
+                cur[j + 1] = (unsigned char)(cur[j] || prev[j + 1]);
+            else
+                cur[j + 1] = (unsigned char)(prev[j] && (unsigned char)pat[j] == (unsigned char)s[i]);
+        }
+        memcpy(prev, cur, pn + 1);
+    }
+    return prev[pn];
+}
+
+/* ── grant parse ─────────────────────────────────────────────────────────────── */
+
+int hl_fs_grant_parse(const char *raw, size_t raw_len, HlAllocator *alloc,
+                      HlFsGrant *out, const char **err)
+{
+    const char *e = "invalid_path";
+    if (!raw || !out) { if (err) *err = "invalid_args"; return -1; }
+    if (raw_len == 0) { if (err) *err = "invalid_path"; return -1; }
+    if (raw[0] == '/' || raw[0] == '\\') { if (err) *err = "invalid_path"; return -1; }
+    if (memchr(raw, '\0', raw_len)) { if (err) *err = "invalid_path"; return -1; }
+
+    int directory_intent = (raw[raw_len - 1] == '/');
+
+    char *tmp[HL_FS_MAX_DEPTH];
+    size_t n = 0;
+    size_t first_pattern = (size_t)-1;
+
+    size_t i = 0;
+    while (i < raw_len) {
+        while (i < raw_len && raw[i] == '/') i++;      /* skip separators */
+        if (i >= raw_len) break;
+        size_t start = i;
+        while (i < raw_len && raw[i] != '/') i++;
+        size_t seglen = i - start;
+        const char *seg = raw + start;
+
+        if (seglen == 1 && seg[0] == '.') continue;    /* "." adds no depth */
+        if (seglen == 2 && seg[0] == '.' && seg[1] == '.') { e = "invalid_path"; goto fail; }
+        if (seglen > NAME_MAX) { e = "invalid_path"; goto fail; }
+
+        int has_star = 0;
+        if (scan_component(seg, seglen, &has_star, &e) != 0) goto fail;
+        if (has_star && first_pattern == (size_t)-1) first_pattern = n;
+
+        if (n >= HL_FS_MAX_DEPTH) { e = "invalid_path"; goto fail; }
+        tmp[n] = dup_bytes(alloc, seg, seglen);
+        if (!tmp[n]) { e = "io_error"; goto fail; }
+        n++;
+    }
+
+    if (n == 0) { e = "invalid_path"; goto fail; }     /* empty grant ("." / "/") */
+    if (first_pattern == (size_t)-1) first_pattern = n;
+    if (directory_intent && first_pattern < n) {       /* trailing-slash pattern grant */
+        e = "unsupported_pattern"; goto fail;
+    }
+
+    char **comp = (char **)hl_alloc_calloc(alloc, n, sizeof(char *));
+    if (!comp) { e = "io_error"; goto fail; }
+    memcpy(comp, tmp, n * sizeof(char *));
+
+    out->comp = comp;
+    out->n = n;
+    out->first_pattern = first_pattern;
+    out->directory_intent = directory_intent;
+    out->alloc = alloc;
+    return 0;
+
+fail:
+    for (size_t k = 0; k < n; k++) free_str(alloc, tmp[k]);
+    if (err) *err = e;
+    return -1;
+}
+
+void hl_fs_grant_free(HlFsGrant *grant)
+{
+    if (!grant || !grant->comp) { if (grant) *grant = HL_FS_GRANT_INIT; return; }
+    free_comps(grant->alloc, grant->comp, grant->n);
+    *grant = HL_FS_GRANT_INIT;
+}
+
+/* ── grant identity + specificity ────────────────────────────────────────────── */
+
+/* Component-wise byte comparison of two grants' components: <0 / 0 / >0. */
+static int comps_cmp(char *const *a, size_t an, char *const *b, size_t bn)
+{
+    size_t m = an < bn ? an : bn;
+    for (size_t i = 0; i < m; i++) {
+        int c = strcmp(a[i], b[i]);
+        if (c) return c;
+    }
+    if (an != bn) return an < bn ? -1 : 1;
+    return 0;
+}
+
+/* Two grants are "the same path" iff component-identical. */
+static int grants_same_path(const HlFsGrant *a, const HlFsGrant *b)
+{
+    return a->n == b->n && comps_cmp(a->comp, a->n, b->comp, b->n) == 0;
+}
+
+static void specificity(char *const *comp, size_t n,
+                        size_t *literal_components, size_t *literal_bytes)
+{
+    size_t lc = 0, lb = 0;
+    for (size_t i = 0; i < n; i++) {
+        int has_star = 0;
+        for (const char *p = comp[i]; *p; p++) {
+            if (*p == '*') has_star = 1; else lb++;
+        }
+        if (!has_star) lc++;
+    }
+    *literal_components = lc;
+    *literal_bytes = lb;
+}
+
+/* ── descriptor-bound compile of ONE grant into an entry ─────────────────────── */
+
+static void entry_free(HlAllocator *a, HlFsAuthEntry *e)
+{
+    if (e->anchor_fd >= 0) { close(e->anchor_fd); e->anchor_fd = -1; }
+    free_comps(a, e->grant, e->grant_n);
+    e->grant = NULL; e->grant_n = 0;
+}
+
+/* Walk the existing literal prefix of `g` from base_fd, O_NOFOLLOW per component
+ * (refusing symlinks), and classify. Fills `out` (deep-copying grant comps). */
+static int compile_one(int base_fd, HlAllocator *alloc, const HlFsGrant *g,
+                       HlFsAuthEntry *out, const char **err)
+{
+    const char *e = "io_error";
+    size_t lit = g->first_pattern;          /* literal prefix length */
+    int cur = dup(base_fd);
+    if (cur < 0) { *err = "io_error"; return -1; }
+
+    size_t depth = 0;                        /* existing literal components held by `cur` */
+    int is_exact = 0;                        /* last literal component is an existing file */
+
+    for (size_t i = 0; i < lit; i++) {
+        int reclass = 0;
+        for (;;) {
+            struct stat st;
+            if (fstatat(cur, g->comp[i], &st, AT_SYMLINK_NOFOLLOW) != 0) {
+                if (errno == ENOENT) goto done_walk;         /* missing from component i */
+                e = (errno == EACCES || errno == EPERM) ? "permission" : "io_error";
+                goto fail;
+            }
+            if (S_ISLNK(st.st_mode)) { e = "symlink_denied"; goto fail; }
+            if (!S_ISDIR(st.st_mode)) {
+                /* a non-directory literal component */
+                if (i == lit - 1 && lit == g->n && !g->directory_intent) {
+                    is_exact = 1; goto done_walk;             /* EXACT: existing file leaf */
+                }
+                e = "not_a_directory"; goto fail;             /* non-dir mid-path or dir-intent */
+            }
+            int nf = openat(cur, g->comp[i], O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+            if (nf < 0) {
+                if ((errno == ELOOP || errno == EMLINK) ) { e = "symlink_denied"; goto fail; }
+                if ((errno == ENOTDIR || errno == ENOENT) && ++reclass <= ANCHOR_RECLASS_MAX)
+                    continue;                                 /* classify/open swap: retry */
+                e = (errno == EACCES || errno == EPERM) ? "permission" : "io_error";
+                goto fail;
+            }
+            close(cur); cur = nf; depth = i + 1;
+            break;
+        }
+    }
+
+done_walk:;
+    HlFsEntryKind kind;
+    HlFsTerminalKind term = HL_FS_TERMINAL_FILE;
+
+    if (is_exact) {
+        kind = HL_FS_ENTRY_EXACT;                 /* anchor = parent (depth == g->n - 1) */
+    } else if (depth == lit) {
+        if (g->first_pattern < g->n) kind = HL_FS_ENTRY_PATTERN;   /* prefix all dirs + patterns */
+        else                          kind = HL_FS_ENTRY_SUBTREE;   /* grant dir exists */
+    } else {
+        /* some literal component missing (depth < lit) */
+        if (g->first_pattern < g->n) {
+            kind = HL_FS_ENTRY_PATTERN;           /* missing literal middle + patterns */
+        } else {
+            kind = HL_FS_ENTRY_CREATE;
+            term = g->directory_intent ? HL_FS_TERMINAL_SUBTREE : HL_FS_TERMINAL_FILE;
+        }
+    }
+
+    char **grant = dup_comps(alloc, g->comp, g->n);
+    if (!grant) { e = "io_error"; goto fail; }
+
+    out->kind = kind;
+    out->anchor_fd = cur;
+    out->grant = grant;
+    out->grant_n = g->n;
+    out->anchor_depth = depth;
+    out->first_pattern = g->first_pattern;
+    out->terminal = term;
+    specificity(g->comp, g->n, &out->literal_components, &out->literal_bytes);
+    return 0;
+
+fail:
+    if (cur >= 0) close(cur);
+    if (err) *err = e;
+    return -1;
+}
+
+/* ── set compile: dedup, conflict-reject, compile, sort ──────────────────────── */
+
+static int entry_priority_cmp(const void *pa, const void *pb)
+{
+    const HlFsAuthEntry *a = (const HlFsAuthEntry *)pa;
+    const HlFsAuthEntry *b = (const HlFsAuthEntry *)pb;
+    if (a->literal_components != b->literal_components)
+        return a->literal_components > b->literal_components ? -1 : 1;   /* DESC */
+    if (a->literal_bytes != b->literal_bytes)
+        return a->literal_bytes > b->literal_bytes ? -1 : 1;            /* DESC */
+    return comps_cmp(a->grant, a->grant_n, b->grant, b->grant_n);        /* grant-text ASC */
+}
+
+static int compile_set(int base_fd, HlAllocator *alloc,
+                       const HlFsGrant *grants, size_t n,
+                       HlFsAuthEntry **out, size_t *out_n, const char **err)
+{
+    *out = NULL; *out_n = 0;
+    if (n == 0) return 0;
+
+    /* Pass 1: mark survivors (dedup identical grants within the set) and reject a
+     * same-path conflicting-intent pair. Comparing only against KEPT grants is
+     * complete: a conflict with a skipped duplicate is also a conflict with the
+     * kept original (same path). The mask lets pass 2 allocate EXACTLY the
+     * survivor count, so the free size always matches the alloc size. */
+    unsigned char *keep = (unsigned char *)hl_alloc_calloc(alloc, n, 1);
+    if (!keep) { if (err) *err = "io_error"; return -1; }
+    size_t m = 0;
+    for (size_t i = 0; i < n; i++) {
+        int dup = 0;
+        for (size_t j = 0; j < i; j++) {
+            if (!keep[j]) continue;
+            if (grants_same_path(&grants[i], &grants[j])) {
+                if (grants[i].directory_intent != grants[j].directory_intent) {
+                    if (err) *err = "conflicting_grant";
+                    hl_alloc_free(alloc, keep, n);
+                    return -1;
+                }
+                dup = 1; break;
+            }
+        }
+        if (!dup) { keep[i] = 1; m++; }
+    }
+
+    /* Pass 2: compile the survivors into an exactly-m-sized array. */
+    HlFsAuthEntry *entries = (HlFsAuthEntry *)hl_alloc_calloc(alloc, m, sizeof(HlFsAuthEntry));
+    if (!entries) { hl_alloc_free(alloc, keep, n); if (err) *err = "io_error"; return -1; }
+    size_t w = 0;
+    for (size_t i = 0; i < n; i++) {
+        if (!keep[i]) continue;
+        if (compile_one(base_fd, alloc, &grants[i], &entries[w], err) != 0) {
+            for (size_t k = 0; k < w; k++) entry_free(alloc, &entries[k]);
+            hl_alloc_free(alloc, entries, m * sizeof(HlFsAuthEntry));
+            hl_alloc_free(alloc, keep, n);
+            return -1;
+        }
+        w++;
+    }
+    hl_alloc_free(alloc, keep, n);
+
+    if (m > 1)
+        qsort(entries, m, sizeof(HlFsAuthEntry), entry_priority_cmp);
+
+    *out = entries;
+    *out_n = m;
+    return 0;
+}
+
+/* ── public compile / free ───────────────────────────────────────────────────── */
+
+int hl_fs_policy_compile(const char *base_dir, HlAllocator *alloc,
+                         const HlFsGrant *read, size_t read_n,
+                         const HlFsGrant *write, size_t write_n,
+                         HlFsPolicy *out, const char **err)
+{
+    const char *e = "io_error";
+    if (!base_dir || !alloc || !out) { if (err) *err = "invalid_args"; return -1; }
+
+    HlFsPolicy p = HL_FS_POLICY_INIT;
+    p.alloc = alloc;
+    p.base_fd = hl_fs_open_base(base_dir, &e);
+    if (p.base_fd < 0) { if (err) *err = e; return -1; }
+
+    if (compile_set(p.base_fd, alloc, read, read_n, &p.read, &p.read_n, &e) != 0) goto fail;
+    if (compile_set(p.base_fd, alloc, write, write_n, &p.write, &p.write_n, &e) != 0) goto fail;
+
+    *out = p;
+    return 0;
+
+fail:
+    hl_fs_policy_free(&p);
+    if (err) *err = e;
+    return -1;
+}
+
+void hl_fs_policy_free(HlFsPolicy *policy)
+{
+    if (!policy) return;
+    HlAllocator *a = policy->alloc;
+    for (size_t i = 0; i < policy->read_n; i++) entry_free(a, &policy->read[i]);
+    for (size_t i = 0; i < policy->write_n; i++) entry_free(a, &policy->write[i]);
+    if (policy->read)  hl_alloc_free(a, policy->read,  policy->read_n  * sizeof(HlFsAuthEntry));
+    if (policy->write) hl_alloc_free(a, policy->write, policy->write_n * sizeof(HlFsAuthEntry));
+    if (policy->base_fd >= 0) close(policy->base_fd);
+    *policy = HL_FS_POLICY_INIT;
+}
+
+/* ── selection (pure: no filesystem access) ──────────────────────────────────── */
+
+/* Split a validated caller path into components (skipping "."). Returns component
+ * count, or -1 with *err on a lexical violation (absolute / ".." / trailing slash
+ * / empty / over-deep / over-long component). `comp`/`len` index into `path`. */
+static long split_caller(const char *path, const char **comp, size_t *len,
+                         const char **err)
+{
+    if (!path || path[0] == '\0') { *err = "invalid_path"; return -1; }
+    if (path[0] == '/' || path[0] == '\\') { *err = "invalid_path"; return -1; }
+    size_t plen = strlen(path);
+    if (path[plen - 1] == '/') { *err = "invalid_path"; return -1; }   /* trailing slash */
+
+    long n = 0;
+    size_t i = 0;
+    while (path[i]) {
+        while (path[i] == '/') i++;
+        if (!path[i]) break;
+        size_t start = i;
+        while (path[i] && path[i] != '/') i++;
+        size_t l = i - start;
+        const char *s = path + start;
+        if (l == 1 && s[0] == '.') continue;
+        if (l == 2 && s[0] == '.' && s[1] == '.') { *err = "invalid_path"; return -1; }
+        if (l > NAME_MAX) { *err = "invalid_path"; return -1; }
+        if (n >= HL_FS_MAX_DEPTH) { *err = "invalid_path"; return -1; }
+        comp[n] = s; len[n] = l; n++;
+    }
+    if (n == 0) { *err = "invalid_path"; return -1; }
+    return n;
+}
+
+/* Does the entry authorize caller components ccomp[0..cn)? */
+static int entry_matches(const HlFsAuthEntry *e, const char **ccomp, const size_t *clen, long cn)
+{
+    /* literal comparison of a caller component against a grant component (byte-exact) */
+    #define LIT_EQ(gi, ci) (strlen(e->grant[gi]) == clen[ci] && \
+                            memcmp(e->grant[gi], ccomp[ci], clen[ci]) == 0)
+
+    if (e->kind == HL_FS_ENTRY_SUBTREE) {
+        if ((size_t)cn < e->grant_n) return 0;             /* must be at/under the grant dir */
+        for (size_t i = 0; i < e->grant_n; i++) if (!LIT_EQ(i, i)) return 0;
+        return 1;
+    }
+    if (e->kind == HL_FS_ENTRY_EXACT) {
+        if ((size_t)cn != e->grant_n) return 0;
+        for (size_t i = 0; i < e->grant_n; i++) if (!LIT_EQ(i, i)) return 0;
+        return 1;
+    }
+    if (e->kind == HL_FS_ENTRY_CREATE) {
+        if (e->terminal == HL_FS_TERMINAL_SUBTREE) {
+            if ((size_t)cn < e->grant_n) return 0;
+        } else {
+            if ((size_t)cn != e->grant_n) return 0;        /* terminal file: exact */
+        }
+        for (size_t i = 0; i < e->grant_n; i++) if (!LIT_EQ(i, i)) return 0;
+        return 1;
+    }
+    /* PATTERN: exactly grant_n comps; literal prefix exact; pattern tail matched */
+    if ((size_t)cn != e->grant_n) return 0;
+    for (size_t i = 0; i < e->first_pattern; i++) if (!LIT_EQ(i, i)) return 0;
+    for (size_t i = e->first_pattern; i < e->grant_n; i++)
+        if (!pat_match(e->grant[i], strlen(e->grant[i]), ccomp[i], clen[i])) return 0;
+    return 1;
+    #undef LIT_EQ
+}
+
+HlFsSelection hl_fs_policy_select(const HlFsPolicy *policy, const char *caller_path,
+                                  HlFsOpenMode mode, char *scratch, size_t scratch_len)
+{
+    HlFsSelection sel = { NULL, NULL, "permission" };
+    if (!policy || !scratch || scratch_len == 0) { sel.err = "invalid_args"; return sel; }
+
+    const HlFsAuthEntry *set;
+    size_t set_n;
+    if (mode == HL_FS_OPEN_READ)       { set = policy->read;  set_n = policy->read_n; }
+    else if (mode == HL_FS_OPEN_WRITE) { set = policy->write; set_n = policy->write_n; }
+    else { sel.err = "permission"; return sel; }          /* invalid mode: fail closed */
+
+    const char *ccomp[HL_FS_MAX_DEPTH];
+    size_t clen[HL_FS_MAX_DEPTH];
+    const char *e = NULL;
+    long cn = split_caller(caller_path, ccomp, clen, &e);
+    if (cn < 0) { sel.err = e; return sel; }
+
+    for (size_t i = 0; i < set_n; i++) {                  /* pre-sorted: first match wins */
+        const HlFsAuthEntry *ent = &set[i];
+        if (!entry_matches(ent, ccomp, clen, cn)) continue;
+
+        /* residual = caller components [anchor_depth, cn) joined by '/', or "." */
+        size_t pos = 0;
+        for (size_t k = ent->anchor_depth; k < (size_t)cn; k++) {
+            size_t need = clen[k] + (pos ? 1 : 0);
+            if (pos + need + 1 > scratch_len) { sel.err = "invalid_args"; return sel; }
+            if (pos) scratch[pos++] = '/';
+            memcpy(scratch + pos, ccomp[k], clen[k]);
+            pos += clen[k];
+        }
+        if (pos == 0) {
+            if (scratch_len < 2) { sel.err = "invalid_args"; return sel; }
+            scratch[pos++] = '.';                          /* grant root: "." not "" */
+        }
+        scratch[pos] = '\0';
+
+        sel.entry = ent;
+        sel.residual = scratch;
+        sel.err = NULL;
+        return sel;
+    }
+
+    sel.err = "permission";
+    return sel;
+}

--- a/src/hull/cap/fs_policy.c
+++ b/src/hull/cap/fs_policy.c
@@ -25,6 +25,9 @@
 #ifndef NAME_MAX
 #define NAME_MAX 255
 #endif
+#ifndef HL_FS_PATH_MAX
+#define HL_FS_PATH_MAX 4096     /* buffer for the SUBTREE contained-follow probe path */
+#endif
 #define ANCHOR_RECLASS_MAX 64   /* bound the classify<->open swap retries (compile) */
 
 /* ── small allocation helpers (sizes recovered for the tracked free) ─────────── */
@@ -52,13 +55,37 @@ static void free_comps(HlAllocator *a, char **comp, size_t n)
 
 static char **dup_comps(HlAllocator *a, char *const *src, size_t n)
 {
-    char **out = (char **)hl_alloc_calloc(a, n ? n : 1, sizeof(char *));
+    size_t cap = n ? n : 1;                       /* actual array capacity allocated */
+    char **out = (char **)hl_alloc_calloc(a, cap, sizeof(char *));
     if (!out) return NULL;
     for (size_t i = 0; i < n; i++) {
         out[i] = dup_bytes(a, src[i], strlen(src[i]));
-        if (!out[i]) { free_comps(a, out, i); return NULL; }
+        if (!out[i]) {
+            /* free the strings built so far, then the array at its ALLOCATED
+             * capacity (cap), not the partial count i - otherwise the tracked
+             * allocator keeps (cap - i) pointers of `used` and can later false-OOM. */
+            for (size_t k = 0; k < i; k++) free_str(a, out[k]);
+            hl_alloc_free(a, out, cap * sizeof(char *));
+            return NULL;
+        }
     }
     return out;
+}
+
+/* Join components with '/' into buf (for the SUBTREE contained-follow probe).
+ * Returns 0, or -1 if the joined path does not fit. */
+static int join_path(char *const *comp, size_t n, char *buf, size_t bufsz)
+{
+    size_t pos = 0;
+    for (size_t i = 0; i < n; i++) {
+        size_t l = strlen(comp[i]);
+        if (pos + l + (pos ? 1 : 0) + 1 > bufsz) return -1;
+        if (pos) buf[pos++] = '/';
+        memcpy(buf + pos, comp[i], l);
+        pos += l;
+    }
+    buf[pos] = '\0';
+    return 0;
 }
 
 /* ── component pattern metacharacter validation ──────────────────────────────── */
@@ -232,7 +259,47 @@ static int compile_one(int base_fd, HlAllocator *alloc, const HlFsGrant *g,
 {
     const char *e = "io_error";
     size_t lit = g->first_pattern;          /* literal prefix length */
-    int cur = dup(base_fd);
+
+    /* A pure-literal grant that resolves to a DIRECTORY is a SUBTREE. Per the
+     * approved design (sec. 6), a SUBTREE FOLLOWS in-root symlinks with virtual-root
+     * confinement, so its anchor is obtained by a CONTAINED-FOLLOW resolution (the
+     * HL_FS_OPEN_DIR resolver mode: each component O_NOFOLLOW + a contained readlink
+     * splice, so a symlinked grant directory still loads and cannot escape the
+     * root). If it instead resolves to a non-directory (EXACT) or is missing
+     * (CREATE), fall through to the O_NOFOLLOW refuse walk below, which REFUSES any
+     * symlink for EXACT/CREATE. PATTERN grants (first_pattern < n) skip this probe
+     * and always refuse symlinks. */
+    if (g->first_pattern == g->n) {
+        char path[HL_FS_PATH_MAX];
+        if (join_path(g->comp, g->n, path, sizeof(path)) == 0) {
+            const char *de = "io_error";
+            int dfd = hl_fs_open_at(base_fd, path, HL_FS_OPEN_DIR, 0, &de);
+            if (dfd >= 0) {
+                char **grant = dup_comps(alloc, g->comp, g->n);
+                if (!grant) { close(dfd); *err = "io_error"; return -1; }
+                out->kind = HL_FS_ENTRY_SUBTREE;
+                out->anchor_fd = dfd;
+                out->grant = grant;
+                out->grant_n = g->n;
+                out->anchor_depth = g->n;
+                out->first_pattern = g->first_pattern;
+                out->terminal = HL_FS_TERMINAL_FILE;
+                specificity(g->comp, g->n, &out->literal_components, &out->literal_bytes);
+                return 0;
+            }
+            /* not_a_directory (a file -> EXACT) or not_found (-> CREATE) continue to
+             * the refuse walk; any other token (symlink_loop, permission, ...) is
+             * terminal. */
+            if (strcmp(de, "not_a_directory") != 0 && strcmp(de, "not_found") != 0) {
+                *err = de; return -1;
+            }
+        }
+    }
+
+    /* F_DUPFD_CLOEXEC, not dup(): a plain dup() clears FD_CLOEXEC, and this fd is
+     * RETAINED as the anchor when the grant anchors at base (root-level
+     * EXACT/CREATE/PATTERN) - it must not leak across exec. */
+    int cur = fcntl(base_fd, F_DUPFD_CLOEXEC, 0);
     if (cur < 0) { *err = "io_error"; return -1; }
 
     size_t depth = 0;                        /* existing literal components held by `cur` */

--- a/src/hull/cap/fs_resolve.c
+++ b/src/hull/cap/fs_resolve.c
@@ -174,9 +174,10 @@ static int resolve_manual(int root_fd, const char *relpath, HlFsOpenMode mode,
         while (*cur == '/') cur++;
         if (*cur == '\0') {
             /* Consumed everything without a terminal leaf (path was "." etc.).
-             * READ opens the current directory; WRITE has no leaf to create. */
-            if (mode == HL_FS_OPEN_READ) {
-                result_fd = openat(stack[depth - 1], ".", O_RDONLY | O_CLOEXEC);
+             * READ/DIR open the current directory; WRITE has no leaf to create. */
+            if (mode == HL_FS_OPEN_READ || mode == HL_FS_OPEN_DIR) {
+                int of = O_RDONLY | O_CLOEXEC | (mode == HL_FS_OPEN_DIR ? O_DIRECTORY : 0);
+                result_fd = openat(stack[depth - 1], ".", of);
                 if (result_fd < 0) { map_errno(errno, err); goto fail; }
                 goto done;
             }
@@ -264,8 +265,29 @@ static int resolve_manual(int root_fd, const char *relpath, HlFsOpenMode mode,
             }
             cur = rest;
             continue;
+        } else if (mode == HL_FS_OPEN_DIR) {
+            /* Terminal in DIR mode: this component IS the result but must be a
+             * directory, following a symlink (contained). CLASSIFY first (like an
+             * interior component): a terminal FIFO opened O_RDONLY would block, and
+             * O_DIRECTORY|O_NOFOLLOW on a symlink returns ENOTDIR on macOS (not
+             * ELOOP), which would misread a symlinked dir as not_a_directory. */
+            struct stat lst;
+            if (fstatat(stack[depth - 1], comp, &lst, AT_SYMLINK_NOFOLLOW) != 0) {
+                map_errno(errno, err); goto fail;
+            }
+            if (S_ISLNK(lst.st_mode)) goto symlink;                 /* follow the symlink */
+            if (!S_ISDIR(lst.st_mode)) { *err = "not_a_directory"; goto fail; }
+            int fd = openat(stack[depth - 1], comp,
+                            O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+            if (fd < 0) {
+                if (errno == ELOOP || errno == EMLINK) goto symlink;   /* swapped to a symlink */
+                if (errno == ENOTDIR) { *err = "not_a_directory"; goto fail; }
+                map_errno(errno, err); goto fail;
+            }
+            result_fd = fd;
+            goto done;
         } else {
-            /* terminal component */
+            /* terminal component (READ / WRITE leaf) */
             int flags = (mode == HL_FS_OPEN_READ)
                           ? (O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
                           : (O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_CLOEXEC);
@@ -330,10 +352,11 @@ int hl_fs_open_at(int root_fd, const char *relpath, HlFsOpenMode mode,
 
 #if defined(__linux__) && !defined(__COSMOPOLITAN__)
     /* openat2 does not create intermediate dirs, so WRITE always uses the manual
-     * walk (which does the contained mkdir-p). READ takes the one-call fast path,
-     * unless HL_FS_FORCE_MANUAL is set (parity testing). */
-    if (mode == HL_FS_OPEN_READ && !force_manual()) {
-        int fd = try_openat2(root_fd, relpath, O_RDONLY | O_CLOEXEC, 0, &e);
+     * walk (which does the contained mkdir-p). READ and DIR take the one-call fast
+     * path, unless HL_FS_FORCE_MANUAL is set (parity testing). */
+    if ((mode == HL_FS_OPEN_READ || mode == HL_FS_OPEN_DIR) && !force_manual()) {
+        int of = O_RDONLY | O_CLOEXEC | (mode == HL_FS_OPEN_DIR ? O_DIRECTORY : 0);
+        int fd = try_openat2(root_fd, relpath, of, 0, &e);
         if (fd >= 0) return fd;
         if (fd == -1) { if (err) *err = e; return -1; }
         /* fd == -2: openat2 unavailable -> manual walk */

--- a/tests/hull/cap/test_fs_policy.c
+++ b/tests/hull/cap/test_fs_policy.c
@@ -364,4 +364,77 @@ UTEST(fs_policy, error_paths_and_free_idempotent)
     teardown();
 }
 
+/* ── SUBTREE via a symlinked directory grant is FOLLOWED (contained), not refused ─
+ * The ratified design (sec. 6): a SUBTREE follows in-root symlinks. `linkdir` is a
+ * symlink to the real `data` dir, so the grant loads and anchors at the target. */
+UTEST(fs_policy, subtree_via_symlink_dir)
+{
+    setup(); build_tree();      /* linkdir -> data (a real dir) */
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "linkdir" };
+    ASSERT_EQ(0, build_policy(&a, rd, 1, NULL, 0, &p, &err));
+    ASSERT_EQ((size_t)1, p.read_n);
+    ASSERT_EQ((int)HL_FS_ENTRY_SUBTREE, (int)p.read[0].kind);   /* followed to a dir */
+
+    char sc[256];
+    HlFsSelection s = hl_fs_policy_select(&p, "linkdir/a.csv", HL_FS_OPEN_READ, sc, sizeof(sc));
+    ASSERT_TRUE(s.entry != NULL); ASSERT_STREQ("a.csv", s.residual);
+
+    hl_fs_policy_free(&p);
+    ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── every RETAINED policy fd is close-on-exec (base + all anchors) ──────────── */
+UTEST(fs_policy, retained_fds_cloexec)
+{
+    setup(); build_tree();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    /* "data.bin" is a root-level EXACT -> its anchor IS the dup'd base fd (the
+     * F_DUPFD_CLOEXEC path); include SUBTREE / PATTERN / CREATE too. */
+    const char *rd[] = { "data.bin", "data", "data/*.csv" };
+    const char *wr[] = { "out/result.bin" };
+    ASSERT_EQ(0, build_policy(&a, rd, 3, wr, 1, &p, &err));
+
+    ASSERT_TRUE((fcntl(p.base_fd, F_GETFD) & FD_CLOEXEC) != 0);
+    for (size_t i = 0; i < p.read_n; i++)
+        ASSERT_TRUE((fcntl(p.read[i].anchor_fd, F_GETFD) & FD_CLOEXEC) != 0);
+    for (size_t i = 0; i < p.write_n; i++)
+        ASSERT_TRUE((fcntl(p.write[i].anchor_fd, F_GETFD) & FD_CLOEXEC) != 0);
+
+    hl_fs_policy_free(&p);
+    ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── allocation-failure injection: every capped-alloc failure leaks nothing ──── */
+UTEST(fs_policy, alloc_failure_no_leak)
+{
+    setup(); build_tree();
+    const char *rd[] = { "x/y/z/w.bin" };   /* CREATE: 4 components deep-copied */
+    const char *err = NULL;
+
+    /* full footprint (uncapped) */
+    HlAllocator a0; hl_alloc_init(&a0, 0);
+    HlFsPolicy p0 = HL_FS_POLICY_INIT;
+    ASSERT_EQ(0, build_policy(&a0, rd, 1, NULL, 0, &p0, &err));
+    size_t peak = hl_alloc_peak(&a0);
+    hl_fs_policy_free(&p0);
+    ASSERT_EQ((size_t)0, hl_alloc_used(&a0));
+
+    /* Sweep every cap below the footprint: alloc fails at each position in turn
+     * (entries array, grant array, and every component string). Each MUST either
+     * succeed and free cleanly or fail with zero bytes retained. */
+    for (size_t lim = 1; lim <= peak + 16; lim++) {
+        HlAllocator a; hl_alloc_init(&a, lim);
+        HlFsPolicy p = HL_FS_POLICY_INIT;
+        int rc = build_policy(&a, rd, 1, NULL, 0, &p, &err);
+        if (rc == 0) hl_fs_policy_free(&p);
+        ASSERT_EQ_MSG((size_t)0, hl_alloc_used(&a), "capped-alloc failure leaked bytes");
+    }
+    teardown();
+}
+
 UTEST_MAIN();

--- a/tests/hull/cap/test_fs_policy.c
+++ b/tests/hull/cap/test_fs_policy.c
@@ -1,0 +1,367 @@
+/*
+ * test_fs_policy.c - hull.fs path-authorization policy core (checkpoint 3, Slice A).
+ *
+ * Pure compile + select over a real fixture tree: grant parse (incl. rejections),
+ * the four entry kinds (SUBTREE/EXACT/CREATE/PATTERN), deterministic most-specific
+ * selection + shadowing, dedup/conflict, compile-time symlink refusal, the
+ * PATTERN acceptance matrix, INIT/idempotent free, and allocator-leak accounting.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#if defined(__linux__) && !defined(_XOPEN_SOURCE)
+# define _XOPEN_SOURCE 700
+#endif
+
+#include "utest.h"
+#include "hull/cap/fs_policy.h"
+#include "hull/utils/alloc.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <ftw.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+static char base[256];
+
+static void setup(void) { snprintf(base, sizeof(base), "/tmp/hull_pol_%d", (int)getpid()); mkdir(base, 0755); }
+static int rm_entry(const char *p, const struct stat *sb, int t, struct FTW *f)
+{ (void)sb; (void)t; (void)f; return remove(p); }
+static void teardown(void) { if (nftw(base, rm_entry, 16, FTW_DEPTH | FTW_PHYS) != 0 && errno != ENOENT) {} }
+
+static void mk_dir(const char *rel)  { char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel); mkdir(p, 0755); }
+static void mk_file(const char *rel) { char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel);
+    FILE *f = fopen(p, "wb"); if (f) { fputs("x", f); fclose(f); } }
+static void mk_link(const char *target, const char *rel)
+{ char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel); unlink(p); symlink(target, p); }
+
+static void build_tree(void)
+{
+    mk_file("data.bin"); mk_file("sibling.bin"); mk_file("secret.txt");
+    mk_dir("data"); mk_dir("data/private"); mk_dir("data/sub"); mk_dir("database");
+    mk_file("data/a.csv"); mk_file("data/a.txt"); mk_file("data/.csv");
+    mk_file("data/sub/a.csv"); mk_file("data/private/p.txt");
+    mk_dir("logs"); mk_dir("logs/2026"); mk_file("logs/2026/a.txt");
+    mk_link("data", "linkdir");            /* symlink -> real dir (compile-refusal case) */
+    mk_link("secret.txt", "data/link.csv");/* pattern-matching symlink (runtime-refusal, Slice B) */
+}
+
+/* Compile a policy from raw grant-string arrays; grants are freed here (compile
+ * deep-copies). Returns compile rc; on success caller frees *out. */
+static int build_policy(HlAllocator *a, const char **rd, size_t rn,
+                        const char **wr, size_t wn, HlFsPolicy *out, const char **err)
+{
+    HlFsGrant rg[16], wg[16];
+    size_t ri = 0, wi = 0;
+    int rc = -1;
+    const char *e = "?";
+    for (; ri < rn; ri++) if (hl_fs_grant_parse(rd[ri], strlen(rd[ri]), a, &rg[ri], &e) != 0) goto cleanup;
+    for (; wi < wn; wi++) if (hl_fs_grant_parse(wr[wi], strlen(wr[wi]), a, &wg[wi], &e) != 0) goto cleanup;
+    rc = hl_fs_policy_compile(base, a, rg, rn, wg, wn, out, &e);
+cleanup:
+    for (size_t i = 0; i < ri; i++) hl_fs_grant_free(&rg[i]);
+    for (size_t i = 0; i < wi; i++) hl_fs_grant_free(&wg[i]);
+    if (err) *err = e;
+    return rc;
+}
+
+/* ── grant parse: acceptance + rejections ────────────────────────────────────── */
+UTEST(fs_policy, parse_ok_and_rejections)
+{
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsGrant g = HL_FS_GRANT_INIT; const char *err = NULL;
+
+    ASSERT_EQ(0, hl_fs_grant_parse("data/a.csv", 10, &a, &g, &err));
+    ASSERT_EQ((size_t)2, g.n); ASSERT_EQ((size_t)2, g.first_pattern);   /* pure literal */
+    ASSERT_EQ(0, g.directory_intent);
+    hl_fs_grant_free(&g);
+
+    ASSERT_EQ(0, hl_fs_grant_parse("uploads/", 8, &a, &g, &err));
+    ASSERT_EQ((size_t)1, g.n); ASSERT_EQ(1, g.directory_intent);        /* trailing slash */
+    hl_fs_grant_free(&g);
+
+    ASSERT_EQ(0, hl_fs_grant_parse("data/*.csv", 10, &a, &g, &err));
+    ASSERT_EQ((size_t)2, g.n); ASSERT_EQ((size_t)1, g.first_pattern);   /* pattern tail */
+    hl_fs_grant_free(&g);
+
+    /* rejections */
+    ASSERT_EQ(-1, hl_fs_grant_parse("/etc/passwd", 11, &a, &g, &err)); ASSERT_STREQ("invalid_path", err);
+    ASSERT_EQ(-1, hl_fs_grant_parse("a/../b", 6, &a, &g, &err));       ASSERT_STREQ("invalid_path", err);
+    ASSERT_EQ(-1, hl_fs_grant_parse("", 0, &a, &g, &err));             ASSERT_STREQ("invalid_path", err);
+    ASSERT_EQ(-1, hl_fs_grant_parse("data\0/x", 7, &a, &g, &err));     ASSERT_STREQ("invalid_path", err); /* embedded NUL */
+    ASSERT_EQ(-1, hl_fs_grant_parse("a/b?c", 5, &a, &g, &err));        ASSERT_STREQ("unsupported_pattern", err);
+    ASSERT_EQ(-1, hl_fs_grant_parse("a/**/b", 6, &a, &g, &err));       ASSERT_STREQ("unsupported_pattern", err);
+    ASSERT_EQ(-1, hl_fs_grant_parse("data/*/", 7, &a, &g, &err));      ASSERT_STREQ("unsupported_pattern", err); /* trailing-slash pattern */
+
+    ASSERT_EQ((size_t)0, hl_alloc_used(&a));   /* every parsed grant freed */
+}
+
+/* ── EXACT: file allowed, sibling denied ─────────────────────────────────────── */
+UTEST(fs_policy, exact_allows_file_denies_sibling)
+{
+    setup(); build_tree();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "data.bin" };
+    ASSERT_EQ(0, build_policy(&a, rd, 1, NULL, 0, &p, &err));
+    ASSERT_EQ((size_t)1, p.read_n);
+    ASSERT_EQ((int)HL_FS_ENTRY_EXACT, (int)p.read[0].kind);
+
+    char sc[256];
+    HlFsSelection s = hl_fs_policy_select(&p, "data.bin", HL_FS_OPEN_READ, sc, sizeof(sc));
+    ASSERT_TRUE(s.entry != NULL); ASSERT_STREQ("data.bin", s.residual);  /* residual under parent anchor */
+
+    s = hl_fs_policy_select(&p, "sibling.bin", HL_FS_OPEN_READ, sc, sizeof(sc));
+    ASSERT_TRUE(s.entry == NULL); ASSERT_STREQ("permission", s.err);
+
+    hl_fs_policy_free(&p);
+    ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── SUBTREE: descendants; component-aware ("data" != "database") ────────────── */
+UTEST(fs_policy, subtree_descendants_component_aware)
+{
+    setup(); build_tree();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "data" };
+    ASSERT_EQ(0, build_policy(&a, rd, 1, NULL, 0, &p, &err));
+    ASSERT_EQ((int)HL_FS_ENTRY_SUBTREE, (int)p.read[0].kind);
+
+    char sc[256];
+    HlFsSelection s = hl_fs_policy_select(&p, "data/sub/a.csv", HL_FS_OPEN_READ, sc, sizeof(sc));
+    ASSERT_TRUE(s.entry != NULL); ASSERT_STREQ("sub/a.csv", s.residual);
+    s = hl_fs_policy_select(&p, "data", HL_FS_OPEN_READ, sc, sizeof(sc));   /* grant root */
+    ASSERT_TRUE(s.entry != NULL); ASSERT_STREQ(".", s.residual);
+    s = hl_fs_policy_select(&p, "database/x", HL_FS_OPEN_READ, sc, sizeof(sc)); /* NOT under data */
+    ASSERT_TRUE(s.entry == NULL); ASSERT_STREQ("permission", s.err);
+
+    hl_fs_policy_free(&p);
+    ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── most-specific: data/ + data/private/ selects the deeper grant ───────────── */
+UTEST(fs_policy, most_specific_wins)
+{
+    setup(); build_tree();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "data", "data/private" };
+    ASSERT_EQ(0, build_policy(&a, rd, 2, NULL, 0, &p, &err));
+    ASSERT_EQ((size_t)2, p.read_n);
+
+    char sc[256];
+    /* a path under data/private selects the deeper (2-component) grant: residual is
+     * relative to the data/private anchor, so just the leaf. */
+    HlFsSelection s = hl_fs_policy_select(&p, "data/private/p.txt", HL_FS_OPEN_READ, sc, sizeof(sc));
+    ASSERT_TRUE(s.entry != NULL);
+    ASSERT_EQ((size_t)2, s.entry->grant_n);        /* the data/private entry */
+    ASSERT_STREQ("p.txt", s.residual);
+    /* a path only under data selects data (residual keeps the deeper components) */
+    s = hl_fs_policy_select(&p, "data/a.csv", HL_FS_OPEN_READ, sc, sizeof(sc));
+    ASSERT_TRUE(s.entry != NULL); ASSERT_EQ((size_t)1, s.entry->grant_n); ASSERT_STREQ("a.csv", s.residual);
+
+    hl_fs_policy_free(&p);
+    ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── CREATE (write): out/result.bin, out absent -> anchor at base, deny sibling ─ */
+UTEST(fs_policy, create_write_terminal_file)
+{
+    setup(); build_tree();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *wr[] = { "out/result.bin" };       /* out/ absent */
+    ASSERT_EQ(0, build_policy(&a, NULL, 0, wr, 1, &p, &err));
+    ASSERT_EQ((size_t)1, p.write_n);
+    ASSERT_EQ((int)HL_FS_ENTRY_CREATE, (int)p.write[0].kind);
+    ASSERT_EQ((size_t)0, p.write[0].anchor_depth);  /* nearest existing ancestor = base */
+
+    char sc[256];
+    HlFsSelection s = hl_fs_policy_select(&p, "out/result.bin", HL_FS_OPEN_WRITE, sc, sizeof(sc));
+    ASSERT_TRUE(s.entry != NULL); ASSERT_STREQ("out/result.bin", s.residual);
+    s = hl_fs_policy_select(&p, "out/other.bin", HL_FS_OPEN_WRITE, sc, sizeof(sc));
+    ASSERT_TRUE(s.entry == NULL); ASSERT_STREQ("permission", s.err);
+    /* write grant is NOT selectable for read (independent sets) */
+    s = hl_fs_policy_select(&p, "out/result.bin", HL_FS_OPEN_READ, sc, sizeof(sc));
+    ASSERT_TRUE(s.entry == NULL); ASSERT_STREQ("permission", s.err);
+
+    hl_fs_policy_free(&p);
+    ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── empty policy denies everything (fails closed) ───────────────────────────── */
+UTEST(fs_policy, empty_policy_denies_all)
+{
+    setup();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    ASSERT_EQ(0, build_policy(&a, NULL, 0, NULL, 0, &p, &err));
+    char sc[256];
+    HlFsSelection s = hl_fs_policy_select(&p, "anything", HL_FS_OPEN_READ, sc, sizeof(sc));
+    ASSERT_TRUE(s.entry == NULL); ASSERT_STREQ("permission", s.err);
+    hl_fs_policy_free(&p);
+    ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── PATTERN acceptance matrix (data + *.csv) ────────────────────────────────── */
+UTEST(fs_policy, pattern_acceptance_matrix)
+{
+    setup(); build_tree();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "data/*.csv" };
+    ASSERT_EQ(0, build_policy(&a, rd, 1, NULL, 0, &p, &err));
+    ASSERT_EQ((int)HL_FS_ENTRY_PATTERN, (int)p.read[0].kind);
+
+    char sc[256];
+    #define SEL(path) hl_fs_policy_select(&p, path, HL_FS_OPEN_READ, sc, sizeof(sc))
+    ASSERT_TRUE(SEL("data/a.csv").entry != NULL);          /* allowed */
+    ASSERT_STREQ("a.csv", SEL("data/a.csv").residual);      /* residual = literal caller name */
+    ASSERT_TRUE(SEL("data/.csv").entry != NULL);           /* '*' matches zero bytes */
+    ASSERT_TRUE(SEL("data/a.txt").entry == NULL);          /* denied: extension mismatch */
+    ASSERT_TRUE(SEL("data/sub/a.csv").entry == NULL);      /* denied: '*' never crosses '/' */
+    ASSERT_TRUE(SEL("data/a.csv/x").entry == NULL);        /* denied: pattern is terminal */
+    /* a symlink NAME matching the pattern still SELECTS at this pure layer; the
+     * symlink REFUSAL is enforced when Slice B opens the residual O_NOFOLLOW. */
+    ASSERT_TRUE(SEL("data/link.csv").entry != NULL);
+    ASSERT_STREQ("link.csv", SEL("data/link.csv").residual);
+    #undef SEL
+
+    hl_fs_policy_free(&p);
+    ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── shadowing: narrower PATTERN outranks the broader SUBTREE ─────────────────── */
+UTEST(fs_policy, pattern_shadows_subtree)
+{
+    setup(); build_tree();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "data", "data/*.csv" };
+    ASSERT_EQ(0, build_policy(&a, rd, 2, NULL, 0, &p, &err));
+    ASSERT_EQ((size_t)2, p.read_n);
+
+    char sc[256];
+    /* data/a.csv matches both; the PATTERN entry (more literal bytes) shadows the
+     * SUBTREE - most-specific-wins, not union. */
+    HlFsSelection s = hl_fs_policy_select(&p, "data/a.csv", HL_FS_OPEN_READ, sc, sizeof(sc));
+    ASSERT_TRUE(s.entry != NULL); ASSERT_EQ((int)HL_FS_ENTRY_PATTERN, (int)s.entry->kind);
+    /* data/a.txt matches only the SUBTREE -> allowed via SUBTREE */
+    s = hl_fs_policy_select(&p, "data/a.txt", HL_FS_OPEN_READ, sc, sizeof(sc));
+    ASSERT_TRUE(s.entry != NULL); ASSERT_EQ((int)HL_FS_ENTRY_SUBTREE, (int)s.entry->kind);
+
+    hl_fs_policy_free(&p);
+    ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── multi-component PATTERN selection (existing + missing intermediate) ──────── */
+UTEST(fs_policy, multi_component_pattern)
+{
+    setup(); build_tree();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "logs/*/*.txt" };
+    ASSERT_EQ(0, build_policy(&a, rd, 1, NULL, 0, &p, &err));
+    ASSERT_EQ((int)HL_FS_ENTRY_PATTERN, (int)p.read[0].kind);
+    ASSERT_EQ((size_t)1, p.read[0].first_pattern);   /* "logs" literal, then two patterns */
+    ASSERT_EQ((size_t)1, p.read[0].anchor_depth);    /* logs/ exists */
+
+    char sc[256];
+    HlFsSelection s = hl_fs_policy_select(&p, "logs/2026/a.txt", HL_FS_OPEN_READ, sc, sizeof(sc));
+    ASSERT_TRUE(s.entry != NULL); ASSERT_STREQ("2026/a.txt", s.residual);  /* literal residual */
+    s = hl_fs_policy_select(&p, "logs/2026/a.csv", HL_FS_OPEN_READ, sc, sizeof(sc));
+    ASSERT_TRUE(s.entry == NULL);                    /* .csv != *.txt */
+
+    /* missing intermediate: write grant whose whole pattern-prefix dir is absent */
+    HlFsPolicy p2 = HL_FS_POLICY_INIT;
+    const char *wr[] = { "arch/*/*.txt" };            /* arch/ absent */
+    ASSERT_EQ(0, build_policy(&a, NULL, 0, wr, 1, &p2, &err));
+    ASSERT_EQ((int)HL_FS_ENTRY_PATTERN, (int)p2.write[0].kind);
+    ASSERT_EQ((size_t)0, p2.write[0].anchor_depth);  /* anchor falls back to base */
+    s = hl_fs_policy_select(&p2, "arch/x/y.txt", HL_FS_OPEN_WRITE, sc, sizeof(sc));
+    ASSERT_TRUE(s.entry != NULL); ASSERT_STREQ("arch/x/y.txt", s.residual);
+    hl_fs_policy_free(&p2);
+
+    hl_fs_policy_free(&p);
+    ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── dedup + conflict rejection ──────────────────────────────────────────────── */
+UTEST(fs_policy, dedup_and_conflict)
+{
+    setup(); build_tree();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+
+    /* identical grants deduplicate to one entry */
+    const char *rd[] = { "data", "data" };
+    ASSERT_EQ(0, build_policy(&a, rd, 2, NULL, 0, &p, &err));
+    ASSERT_EQ((size_t)1, p.read_n);
+    hl_fs_policy_free(&p);
+
+    /* same components, conflicting terminal intent (file vs dir) -> rejected */
+    const char *rd2[] = { "conf", "conf/" };
+    ASSERT_EQ(-1, build_policy(&a, rd2, 2, NULL, 0, &p, &err));
+    ASSERT_STREQ("conflicting_grant", err);
+
+    ASSERT_EQ((size_t)0, hl_alloc_used(&a));   /* failed compile leaks nothing */
+    teardown();
+}
+
+/* ── compile-time symlink refusal (EXACT/PATTERN literal prefix is a symlink) ─── */
+UTEST(fs_policy, compile_refuses_symlink_prefix)
+{
+    setup(); build_tree();      /* linkdir -> data (a symlink) */
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+
+    const char *rd[] = { "linkdir/x.bin" };            /* EXACT/CREATE via a symlink prefix */
+    ASSERT_EQ(-1, build_policy(&a, rd, 1, NULL, 0, &p, &err));
+    ASSERT_STREQ("symlink_denied", err);
+
+    const char *rd2[] = { "linkdir/*.csv" };           /* PATTERN via a symlink prefix */
+    ASSERT_EQ(-1, build_policy(&a, rd2, 1, NULL, 0, &p, &err));
+    ASSERT_STREQ("symlink_denied", err);
+
+    ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── invalid mode / scratch too small / INIT + idempotent free ───────────────── */
+UTEST(fs_policy, error_paths_and_free_idempotent)
+{
+    setup(); build_tree();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "data" };
+    ASSERT_EQ(0, build_policy(&a, rd, 1, NULL, 0, &p, &err));
+
+    char sc[256];
+    HlFsSelection s = hl_fs_policy_select(&p, "data/x", (HlFsOpenMode)999, sc, sizeof(sc));
+    ASSERT_TRUE(s.entry == NULL); ASSERT_STREQ("permission", s.err);           /* invalid mode */
+    char tiny[2];
+    s = hl_fs_policy_select(&p, "data/averylongname", HL_FS_OPEN_READ, tiny, sizeof(tiny));
+    ASSERT_TRUE(s.entry == NULL); ASSERT_STREQ("invalid_args", s.err);         /* scratch too small */
+    s = hl_fs_policy_select(&p, "../escape", HL_FS_OPEN_READ, sc, sizeof(sc));
+    ASSERT_TRUE(s.entry == NULL); ASSERT_STREQ("invalid_path", s.err);         /* lexical */
+
+    hl_fs_policy_free(&p);
+    hl_fs_policy_free(&p);                    /* idempotent double free */
+    HlFsPolicy z = HL_FS_POLICY_INIT;
+    hl_fs_policy_free(&z);                     /* free on INIT is safe */
+    ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+UTEST_MAIN();

--- a/tests/hull/cap/test_fs_resolve.c
+++ b/tests/hull/cap/test_fs_resolve.c
@@ -448,4 +448,36 @@ UTEST(fs_resolve, interior_regular_file_rejected)
     close(root); teardown();
 }
 
+/* ── HL_FS_OPEN_DIR: resolve a directory, follow a symlinked dir contained, and
+ * reject a non-directory target with not_a_directory (both impls). ───────────── */
+UTEST(fs_resolve, open_dir_mode)
+{
+    setup();
+    mkdirp_host("adir"); wfile("adir/leaf", "x");
+    mkdirp_host("realdir2"); symln("realdir2", "dsym2");   /* symlink -> a real dir */
+    wfile("plainfile", "y");
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    ASSERT_GE(root, 0);
+    for (int pass = 0; pass < 2; pass++) {
+        select_path(pass);
+        err = NULL;
+        int fd = hl_fs_open_at(root, "adir", HL_FS_OPEN_DIR, 0, &err);
+        ASSERT_GE(fd, 0);
+        struct stat st; ASSERT_EQ(0, fstat(fd, &st)); ASSERT_TRUE(S_ISDIR(st.st_mode));
+        close(fd);
+
+        err = NULL;
+        fd = hl_fs_open_at(root, "dsym2", HL_FS_OPEN_DIR, 0, &err);
+        ASSERT_GE(fd, 0);                       /* follows the symlinked dir, contained */
+        close(fd);
+
+        err = NULL;
+        fd = hl_fs_open_at(root, "plainfile", HL_FS_OPEN_DIR, 0, &err);
+        ASSERT_EQ(fd, -1); ASSERT_STREQ("not_a_directory", err);  /* a file is refused */
+    }
+    unsetenv("HL_FS_FORCE_MANUAL");
+    close(root); teardown();
+}
+
 UTEST_MAIN();


### PR DESCRIPTION
Checkpoint 3 of the hull.fs design (docs/hull_fs_design.md sec. 6), **Slice A**: the
path-authorization policy CORE. Parses manifest grants, compiles them into two
independent authorization-entry sets by a descriptor-bound walk, and selects
deterministically by most-specific match. Does NOT yet wire into read/write/mmap
(Slice B) and does NOT add stat/list (Slice C).

Four entry kinds: SUBTREE (dir + descendants, follows in-root symlinks contained),
EXACT (one literal file, symlinks refused), CREATE (not-yet-existing target),
PATTERN (single-`*`-per-component, bounded DP matcher, symlinks refused).

Review blockers resolved in this branch:
- Retained anchor fds are close-on-exec (F_DUPFD_CLOEXEC, not dup()); regression
  asserts FD_CLOEXEC on base_fd + every anchor.
- Partial dup_comps() failure frees the array at its allocated capacity (no
  tracked-allocator leak); a capped-limit sweep asserts used==0 on every failure.
- SUBTREE reconciled to the ratified contained-follow (new HL_FS_OPEN_DIR resolver
  mode) so a symlinked directory grant still loads and cannot escape the root;
  EXACT/CREATE/PATTERN still refuse symlinks.

Tests: test_fs_policy (15) + test_fs_resolve (22, incl. open_dir_mode) +
test_fs (37). Allocator used==0 leak accounting on every policy path.
docs/api/lua.md corrected for the enforced per-file pattern semantics.

Held at the Slice-A boundary for review; Slice B (wire into read/write/mmap) and
Slice C (stat/list) follow.