### PR TITLE
fs: wire path-authorization policy into read/write/mmap (checkpoint 3, Slice B)

### DIFF
--- a/bench/wasm/bench_mapped_span.c
+++ b/bench/wasm/bench_mapped_span.c
@@ -24,6 +24,8 @@
 #include <stdint.h>
 #include "hull/cap/wasm.h"
 #include "hull/cap/fs.h"
+#include "hull/cap/fs_policy.h"
+#include "hull/utils/alloc.h"
 #include "hull/limits/wasm.h"
 #include "hull/vfs.h"
 #include "hull/entry.h"
@@ -554,6 +556,18 @@ int main(int argc, char **argv)
 
     HlFsConfig cfg; memset(&cfg, 0, sizeof(cfg));
     cfg.base_dir = dir; cfg.base_len = strlen(dir);
+    /* checkpoint 3: mmap is policy-gated. This bench mmaps data.bin (read) under
+     * `dir`, so grant the whole dir with a base-root "." read grant. */
+    HlAllocator fs_alloc; hl_alloc_init(&fs_alloc, 0);
+    HlFsPolicy fs_policy = HL_FS_POLICY_INIT;
+    const char *rd_grant[] = { "." };
+    const char *fperr = NULL;
+    if (hl_fs_policy_compile_manifest(dir, &fs_alloc, rd_grant, 1, NULL, 0,
+                                      &fs_policy, &fperr) != 0) {
+        fprintf(stderr, "fs policy compile failed: %s\n", fperr ? fperr : "?");
+        return 1;
+    }
+    cfg.policy = &fs_policy;
     HlWasmCache cache; HlVfs vfs;
     /* VFS entries MUST be sorted by name (binary search). "...aot..." < "...wasm..."
      * (a < w), so the AOT entry precedes the .wasm entry when both are present. */

--- a/docs/api/lua.md
+++ b/docs/api/lua.md
@@ -134,10 +134,15 @@ re-rooted or clamped, never followed out):
 
 | Grant | Example | Authorizes |
 |-------|---------|------------|
+| Base root | `.` or `./` | the **entire app directory and every descendant** (the broadest grant; use only when the app genuinely needs whole-dir access). Shadowed by any more specific grant. |
 | Directory | `data/` or `data` | that directory and any descendant; in-root symlinks under it are followed, contained |
 | Exact file | `config.json` | only that file; siblings are not reachable; a symlink at that name is refused |
 | Write target (absent) | `out/result.bin` | creates the missing parent dirs and the file (`fs.write` only) |
 | Pattern | `data/*.csv` | files whose name matches, **per component** |
+
+All grant paths are **relative to the app root** and confined to it; an absolute
+path (e.g. `/tmp/x` or `/etc/passwd`) is **rejected** at load — read/write an
+external file by placing it under the app directory (or a bind mount) instead.
 
 **Pattern rules (v1):** `*` matches zero or more bytes **within a single path
 component** and never crosses `/`. Only `*` is supported; `?`, `[`, `]`, `{`, `}`,

--- a/examples/embed_c/main.c
+++ b/examples/embed_c/main.c
@@ -53,7 +53,9 @@ int main(void)
     /* ── 1. phase-1 sandbox (pledge) ──────────────────────────────── */
     check(hl_embed_sandbox_phase1(e) == 0, "phase-1 sandbox applied");
 
-    /* ── 2. build policy in C (app_dir-relative, like a manifest) ──── */
+    /* ── 2. build policy in C (app_dir-relative, like a manifest) ────
+     * "." is the base-root grant: read/write the whole app dir + descendants
+     * (checkpoint 3, sec. 6). Base-relative, never absolute. */
     check(hl_embed_allow_read(e, ".") == 0,  "allow_read(\".\")");
     check(hl_embed_allow_write(e, ".") == 0, "allow_write(\".\")");
     hl_embed_allow_network(e, 0, 0);

--- a/examples/embed_rust/src/main.rs
+++ b/examples/embed_rust/src/main.rs
@@ -84,7 +84,7 @@ fn main() {
         // 2. phase-1 sandbox
         check(hl_embed_sandbox_phase1(e) == 0, "phase-1 sandbox applied");
 
-        // 3. policy (app_dir-relative, like a manifest)
+        // 3. policy ("." = base-root grant: the whole app dir + descendants)
         let dot = cstr(".");
         check(hl_embed_allow_read(e, dot.as_ptr()) == 0, "allow_read(\".\")");
         check(hl_embed_allow_write(e, dot.as_ptr()) == 0, "allow_write(\".\")");

--- a/examples/embed_zig/main.zig
+++ b/examples/embed_zig/main.zig
@@ -43,7 +43,7 @@ pub fn main() u8 {
     // 2. phase-1 sandbox
     check(c.hl_embed_sandbox_phase1(e) == 0, "phase-1 sandbox applied");
 
-    // 3. policy (app_dir-relative, like a manifest)
+    // 3. policy ("." = base-root grant: the whole app dir + descendants)
     check(c.hl_embed_allow_read(e, ".") == 0, "allow_read(\".\")");
     check(c.hl_embed_allow_write(e, ".") == 0, "allow_write(\".\")");
     c.hl_embed_allow_network(e, 0, 0);

--- a/examples/tui_log_tailer/app.lua
+++ b/examples/tui_log_tailer/app.lua
@@ -6,21 +6,23 @@
 -- the main loop awaits keystrokes — same async-yield property the
 -- async_proof demo validates.
 --
--- Run:
---   echo "first line" > /tmp/hull-tail.log
+-- Run (from the app directory):
+--   echo "first line" > watched.log
 --   hull run app.lua
---   # in another terminal:
---   echo "second" >> /tmp/hull-tail.log
+--   # in another terminal, from the same directory:
+--   echo "second" >> watched.log
 --
 -- Keys: q/esc quits.
 --
--- The watched file is hard-coded to /tmp/hull-tail.log so the
--- manifest's fs.read allowlist stays minimal. Adjust to taste.
+-- The watched file is an IN-ROOT relative path (relative to the app
+-- directory) so it matches the manifest's fs.read grant: hull.fs grants
+-- and reads are always relative to the app root, never absolute. Adjust
+-- the name to taste (keep it a relative in-root path).
 
 local tui = require("hull.tui")
 local fs  = require("hull.fs")
 
-local LOG_FILE = "/tmp/hull-tail.log"
+local LOG_FILE = "watched.log"
 
 app.manifest({
     tui = true,

--- a/include/hull/cap/fs.h
+++ b/include/hull/cap/fs.h
@@ -21,6 +21,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include "hull/cap/fs_policy.h"   /* HlFsPolicy - path-authorization policy (checkpoint 3) */
 
 /* Forward declaration */
 typedef struct HlAllocator HlAllocator;
@@ -31,10 +32,17 @@ typedef struct HlAllocator HlAllocator;
  * Hull-allocated; the caller owns the lifetime. `base_dir` is the
  * app's working directory. All paths are validated to resolve to a
  * descendant of `base_dir`.
+ *
+ * `policy` is the compiled path-authorization policy (checkpoint 3, sec. 6):
+ * read/mmap select from its READ set, write from its WRITE set, and the op opens
+ * the residual under the selected entry's held anchor fd. When `policy` is NULL
+ * the fs capability is DENIED (fail closed) - the config is only wired when the
+ * app declares fs.read/fs.write grants, so a no-grant app never reaches here.
  */
 typedef struct HlFsConfig {
-    const char *base_dir;   /**< Absolute path of the app's root directory. */
-    size_t      base_len;   /**< `strlen(base_dir)` cached for hot-path prefix checks. */
+    const char        *base_dir;   /**< Absolute path of the app's root directory. */
+    size_t             base_len;   /**< `strlen(base_dir)` cached for hot-path prefix checks. */
+    const HlFsPolicy  *policy;     /**< Compiled read/write authorization policy (may be NULL). */
 } HlFsConfig;
 
 /**

--- a/include/hull/cap/fs_policy.h
+++ b/include/hull/cap/fs_policy.h
@@ -290,6 +290,19 @@ int hl_fs_policy_compile(const char *base_dir, HlAllocator *alloc,
                          HlFsPolicy *out, const char **err);
 
 /*
+ * Convenience: parse RAW manifest grant strings (fs.read / fs.write) and compile
+ * them into a policy in one call. Each raw string is parsed with hl_fs_grant_parse
+ * (NUL-terminated, so its length is strlen) and the grants are freed before
+ * returning (hl_fs_policy_compile deep-copies). A parse or compile failure returns
+ * -1 with *err set and *out left HL_FS_POLICY_INIT. *out MUST be HL_FS_POLICY_INIT
+ * on entry; free the result with hl_fs_policy_free.
+ */
+int hl_fs_policy_compile_manifest(const char *base_dir, HlAllocator *alloc,
+                                  const char *const *read,  size_t read_n,
+                                  const char *const *write, size_t write_n,
+                                  HlFsPolicy *out, const char **err);
+
+/*
  * Select the authorizing entry for `caller_path` (relative, no "..", no trailing
  * slash - the hl_fs_open_at lexical contract) in the set for `mode` (READ set for
  * HL_FS_OPEN_READ, WRITE set for HL_FS_OPEN_WRITE; any other mode value FAILS

--- a/include/hull/cap/fs_policy.h
+++ b/include/hull/cap/fs_policy.h
@@ -226,11 +226,14 @@ typedef struct {
  * LENGTH-BEARING: `raw`/`raw_len` are the exact grant bytes, so an EMBEDDED NUL
  * ("data\0/secret") is detected and REJECTED here rather than silently truncated.
  * Captures directory_intent from a trailing slash BEFORE normalization, splits
- * into components, and locates the first patterned component. Rejects an absolute
- * path, any ".." component, an embedded NUL, an empty grant, an over-deep path
- * (> HL_FS_MAX_DEPTH components), a trailing-slash PATTERN grant, and any
- * unsupported metacharacter ('?', '[', ']', '{', '}', '\\', or "**") with a
- * stable *err ("invalid_path" / "unsupported_pattern"). On success writes *out
+ * into components, and locates the first patterned component. A grant that
+ * normalizes to ZERO components ("." / "./" / "././") is the BASE-ROOT grant: it
+ * authorizes the whole app dir and every descendant (compiled to a 0-component
+ * SUBTREE at base_fd, the least-specific entry). Rejects an absolute path, any
+ * ".." component, an embedded NUL, an over-deep path (> HL_FS_MAX_DEPTH
+ * components), a trailing-slash PATTERN grant, and any unsupported metacharacter
+ * ('?', '[', ']', '{', '}', '\\', or "**") with a stable *err ("invalid_path" /
+ * "unsupported_pattern"). On success writes *out
  * (an owning value; free with hl_fs_grant_free) and returns 0; on failure returns
  * -1 with *err set, and *out is left HL_FS_GRANT_INIT (nothing to free).
  *

--- a/include/hull/cap/fs_resolve.h
+++ b/include/hull/cap/fs_resolve.h
@@ -44,6 +44,20 @@ typedef enum {
 } HlFsOpenMode;
 
 /*
+ * Symlink policy for a resolution. Independent of the open mode.
+ *   HL_FS_SYMLINK_FOLLOW - follow in-root symlinks, virtual-root contained
+ *     (re-root / clamp at root_fd). The default and back-compatible behavior;
+ *     used for a SUBTREE grant (descendants follow symlinks within the anchor).
+ *   HL_FS_SYMLINK_REFUSE - ANY symlink component (intermediate or terminal) is
+ *     REFUSED with "symlink_denied", never followed. Used for EXACT/CREATE/PATTERN
+ *     grants so a symlink cannot alias a non-authorized target.
+ */
+typedef enum {
+    HL_FS_SYMLINK_FOLLOW = 0,
+    HL_FS_SYMLINK_REFUSE,
+} HlFsSymlink;
+
+/*
  * Open `base_dir` as a directory fd suitable for hl_fs_open_at(). Returns the fd
  * (caller closes with close()) or -1 with *err set. base_dir is the trusted app
  * root; it is opened O_DIRECTORY|O_CLOEXEC (a symlinked app root is followed once
@@ -73,9 +87,19 @@ int hl_fs_open_base(const char *base_dir, const char **err);
  *
  * Returns an open fd (caller closes) or -1 with *err set to a stable token:
  * "invalid_path", "path_too_deep", "not_found", "permission", "not_a_directory",
- * "is_a_directory", "symlink_loop", "io_error".
+ * "is_a_directory", "symlink_loop", "symlink_denied", "io_error". ("symlink_denied"
+ * only under HL_FS_SYMLINK_REFUSE; see hl_fs_open_at_ex.)
  */
 int hl_fs_open_at(int root_fd, const char *relpath, HlFsOpenMode mode,
                   mode_t create_mode, const char **err);
+
+/*
+ * As hl_fs_open_at, plus an explicit symlink policy. hl_fs_open_at is exactly
+ * hl_fs_open_at_ex(..., HL_FS_SYMLINK_FOLLOW, ...). Under HL_FS_SYMLINK_REFUSE any
+ * symlink component (intermediate or terminal) fails "symlink_denied" and is never
+ * followed - used to open an EXACT/CREATE/PATTERN residual under its grant anchor.
+ */
+int hl_fs_open_at_ex(int root_fd, const char *relpath, HlFsOpenMode mode,
+                     HlFsSymlink symlink, mode_t create_mode, const char **err);
 
 #endif /* HULL_CAP_FS_RESOLVE_H */

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -860,10 +860,11 @@ fuzz/fuzz_span_sdk: fuzz/fuzz_span_sdk.c
 
 # Mapped-WINDOW geometry math (hl_cap_fs_mmap_window_geometry): page-align + EOF
 # clamp + overflow-safe rounding. The fuzzed function is a pure arithmetic leaf,
-# but cap/fs.c as a whole pulls alloc + audit (sh_json) and now the descriptor-
-# relative resolver (cap/fs_resolve.c, since read/write/mmap resolve through it);
-# link that small chain so the fuzzer resolves without dragging in Keel.
-fuzz/fuzz_span_window: fuzz/fuzz_span_window.c $(SRCDIR)/hull/cap/fs.c $(SRCDIR)/hull/cap/fs_resolve.c $(SRCDIR)/hull/cap/audit.c $(SRCDIR)/hull/utils/alloc.c $(SH_JSON_DIR)/sh_json.c $(SH_ARENA_DIR)/sh_arena.c
+# but cap/fs.c as a whole pulls alloc + audit (sh_json), the descriptor-relative
+# resolver (cap/fs_resolve.c) and the authorization policy (cap/fs_policy.c, since
+# read/write/mmap select through it); link that small chain so the fuzzer resolves
+# without dragging in Keel.
+fuzz/fuzz_span_window: fuzz/fuzz_span_window.c $(SRCDIR)/hull/cap/fs.c $(SRCDIR)/hull/cap/fs_resolve.c $(SRCDIR)/hull/cap/fs_policy.c $(SRCDIR)/hull/cap/audit.c $(SRCDIR)/hull/utils/alloc.c $(SH_JSON_DIR)/sh_json.c $(SH_ARENA_DIR)/sh_arena.c
 	$(CC) $(FUZZ_CFLAGS) -Ivendor/keel/include -o $@ $^
 
 # hull.source.lua parser: adversarial bytes -> lua.parse() over a bounded lua_State.

--- a/src/hull/app_context.c
+++ b/src/hull/app_context.c
@@ -17,6 +17,7 @@
 
 #include "hull/cap/fs.h"          /* HlFsConfig — test/agent fs sandbox wiring
                                    * (unconditional: fs_cfg is not DB-gated) */
+#include "hull/utils/alloc.h"     /* HlAllocator + hl_alloc_init for the fs policy */
 
 #ifdef HL_ENABLE_DB
 #include "hull/cap/db.h"
@@ -69,6 +70,7 @@ struct HlAppContext {
      * allowlist is the kernel sandbox, which the test harness runs without. */
     HlFsConfig     fs_cfg_storage;
     HlFsPolicy     fs_policy_storage; /* compiled fs authorization policy (checkpoint 3) */
+    HlAllocator    fs_alloc;          /* owns the policy's memory (opts->alloc may be NULL) */
 
     /* Resolved module set (opt-in via opts.gate_modules). Lives here so
      * its lifetime matches the runtime — rt->module_set borrows. */
@@ -183,6 +185,7 @@ int hl_app_context_init(HlAppContext **out, const HlAppContextOpts *opts)
     /* fds default -1 so hl_app_context_free never close(0)s stdin on a policy
      * that was never compiled (calloc gives base_fd == 0, a live fd). */
     ctx->fs_policy_storage = HL_FS_POLICY_INIT;
+    hl_alloc_init(&ctx->fs_alloc, 0);   /* the policy needs a non-NULL allocator */
 
     /* Own a stable copy of app_dir for fs_cfg.base_dir (see struct comment). */
     ctx->app_dir_copy = strdup(opts->app_dir);
@@ -347,7 +350,7 @@ int hl_app_context_init(HlAppContext **out, const HlAppContextOpts *opts)
                      * denied. */
                     const char *perr = NULL;
                     if (hl_fs_policy_compile_manifest(
-                            ctx->app_dir_copy, opts->alloc,
+                            ctx->app_dir_copy, &ctx->fs_alloc,
                             m.fs_read,  (size_t)m.fs_read_count,
                             m.fs_write, (size_t)m.fs_write_count,
                             &ctx->fs_policy_storage, &perr) != 0) {

--- a/src/hull/app_context.c
+++ b/src/hull/app_context.c
@@ -68,6 +68,7 @@ struct HlAppContext {
      * cap layer sandboxes to base_dir + rejects traversal; the per-path
      * allowlist is the kernel sandbox, which the test harness runs without. */
     HlFsConfig     fs_cfg_storage;
+    HlFsPolicy     fs_policy_storage; /* compiled fs authorization policy (checkpoint 3) */
 
     /* Resolved module set (opt-in via opts.gate_modules). Lives here so
      * its lifetime matches the runtime — rt->module_set borrows. */
@@ -179,6 +180,9 @@ int hl_app_context_init(HlAppContext **out, const HlAppContextOpts *opts)
 
     HlAppContext *ctx = calloc(1, sizeof(*ctx));
     if (!ctx) return -1;
+    /* fds default -1 so hl_app_context_free never close(0)s stdin on a policy
+     * that was never compiled (calloc gives base_fd == 0, a live fd). */
+    ctx->fs_policy_storage = HL_FS_POLICY_INIT;
 
     /* Own a stable copy of app_dir for fs_cfg.base_dir (see struct comment). */
     ctx->app_dir_copy = strdup(opts->app_dir);
@@ -334,8 +338,28 @@ int hl_app_context_init(HlAppContext **out, const HlAppContextOpts *opts)
                  * sandbox). Keyed on the app declaring fs.read OR fs.write, same
                  * condition as serve. Safe to read m before the free below. */
                 if (m.fs_read_count > 0 || m.fs_write_count > 0) {
+                    /* Compile the fs.read/fs.write grants into the authorization
+                     * policy (checkpoint 3), mirroring serve.c. Must happen BEFORE
+                     * hl_manifest_free(&m) below (compile deep-copies the grant
+                     * strings). The cap layer now enforces the grants here even
+                     * under `hull test`/`hull agent` (which run without the kernel
+                     * sandbox), so a test that reads outside its declared grants is
+                     * denied. */
+                    const char *perr = NULL;
+                    if (hl_fs_policy_compile_manifest(
+                            ctx->app_dir_copy, opts->alloc,
+                            m.fs_read,  (size_t)m.fs_read_count,
+                            m.fs_write, (size_t)m.fs_write_count,
+                            &ctx->fs_policy_storage, &perr) != 0) {
+                        fprintf(stderr, "[app-context] fs policy: %s\n",
+                                perr ? perr : "compile failed");
+                        hl_manifest_free(&m);
+                        hl_app_context_free(ctx);
+                        return -1;
+                    }
                     ctx->fs_cfg_storage.base_dir = ctx->app_dir_copy;
                     ctx->fs_cfg_storage.base_len = strlen(ctx->app_dir_copy);
+                    ctx->fs_cfg_storage.policy   = &ctx->fs_policy_storage;
                     ctx->rt->fs_cfg = &ctx->fs_cfg_storage;
                 }
                 hl_manifest_free(&m);
@@ -426,6 +450,9 @@ void hl_app_context_free(HlAppContext *ctx)
     ctx->platform_vfs_owned = NULL;
     /* rt->fs_cfg borrowed &ctx->fs_cfg_storage, whose base_dir borrowed this;
      * the runtime is already destroyed above, so no live borrow remains. */
+    /* Free the fs authorization policy (closes its held anchor fds; idempotent).
+     * The runtime that borrowed rt->fs_cfg->policy is destroyed above. */
+    hl_fs_policy_free(&ctx->fs_policy_storage);
     free(ctx->app_dir_copy);
     ctx->app_dir_copy = NULL;
     free(ctx);

--- a/src/hull/cap/fs.c
+++ b/src/hull/cap/fs.c
@@ -133,19 +133,25 @@ static int build_path(const HlFsConfig *cfg, const char *path,
     return 0;
 }
 
-/* ── Descriptor-relative resolution (checkpoint 1) ──────────────────────
- * read/write/mmap resolve through the virtual-root resolver (fs_resolve.c)
- * instead of realpath->check->open (docs/hull_fs_design.md §3). base_dir-anchored:
- * open base_dir as a dirfd, resolve `path` under it (symlinks followed but
- * confined), and return the leaf fd. No resolve-then-open window.
+#ifndef HL_FS_PATH_MAX
+#define HL_FS_PATH_MAX 4096   /* residual scratch for policy selection */
+#endif
+
+/* ── Descriptor-relative resolution + path authorization (checkpoint 1 + 3) ──
+ * read/write/mmap resolve through the virtual-root resolver (fs_resolve.c) AND
+ * the compiled path-authorization policy (fs_policy.c, docs/hull_fs_design.md
+ * sec. 6). The op SELECTS an authorization entry from the policy for (path, mode)
+ * - read/mmap from the READ set, write from the WRITE set - then opens the
+ * LITERAL residual under the selected entry's HELD anchor fd (never a
+ * reconstructed host path), with a per-kind symlink policy: a SUBTREE follows
+ * in-root symlinks (contained within its anchor), while EXACT/CREATE/PATTERN
+ * REFUSE any symlink so a symlink cannot alias a non-authorized target. No
+ * matching grant -> "permission" (fail closed).
  *
- * SCOPE (checkpoint 1): only read/write/mmap resolve through fs_resolve_fd().
- * hl_cap_fs_exists, hl_cap_fs_delete, and any direct hl_cap_fs_validate consumer
- * still use the OLD build_path()/realpath -> operation path and remain
- * TOCTOU-susceptible. The cap layer is therefore NOT fully TOCTOU-free yet; those
- * consumers migrate to a descriptor-relative resolver mode in a later checkpoint
- * (they need a parent-fd + leaf-name result shape the current READ/WRITE fd modes
- * don't provide). Tracked follow-up. */
+ * SCOPE (checkpoint 3, Slice B): read/write/mmap route through the policy.
+ * hl_cap_fs_exists / hl_cap_fs_delete and any direct hl_cap_fs_validate consumer
+ * still use the OLD build_path()/realpath path and are NOT policy-gated (they
+ * remain base_dir-confined + sandbox-gated). Tracked follow-up. */
 static int fs_resolve_fd(const HlFsConfig *cfg, const char *path,
                          HlFsOpenMode mode, mode_t cmode, const char **err_msg)
 {
@@ -153,14 +159,28 @@ static int fs_resolve_fd(const HlFsConfig *cfg, const char *path,
         if (err_msg) *err_msg = "invalid_args";
         return -1;
     }
-    const char *e = NULL;
-    int root = hl_fs_open_base(cfg->base_dir, &e);
-    if (root < 0) {
-        if (err_msg) *err_msg = e ? e : "open_failed";
+    /* No policy -> deny (fail closed). The config is only wired when the app
+     * declares fs grants, so a no-grant app never gets here with a live cfg. */
+    if (!cfg->policy) {
+        if (err_msg) *err_msg = "permission";
         return -1;
     }
-    int fd = hl_fs_open_at(root, path, mode, cmode, &e);
-    close(root);
+
+    char scratch[HL_FS_PATH_MAX];
+    HlFsSelection sel = hl_fs_policy_select(cfg->policy, path, mode,
+                                            scratch, sizeof(scratch));
+    if (!sel.entry) {
+        if (err_msg) *err_msg = sel.err ? sel.err : "permission";
+        return -1;
+    }
+
+    /* SUBTREE follows in-root symlinks (contained within its anchor);
+     * EXACT/CREATE/PATTERN refuse every symlink. */
+    HlFsSymlink sym = (sel.entry->kind == HL_FS_ENTRY_SUBTREE)
+                          ? HL_FS_SYMLINK_FOLLOW : HL_FS_SYMLINK_REFUSE;
+    const char *e = NULL;
+    int fd = hl_fs_open_at_ex(sel.entry->anchor_fd, sel.residual, mode,
+                              sym, cmode, &e);
     if (fd < 0 && err_msg) *err_msg = e ? e : "open_failed";
     return fd;
 }

--- a/src/hull/cap/fs_policy.c
+++ b/src/hull/cap/fs_policy.c
@@ -468,6 +468,50 @@ fail:
     return -1;
 }
 
+int hl_fs_policy_compile_manifest(const char *base_dir, HlAllocator *alloc,
+                                  const char *const *read, size_t read_n,
+                                  const char *const *write, size_t write_n,
+                                  HlFsPolicy *out, const char **err)
+{
+    const char *e = "io_error";
+    HlFsGrant *rg = NULL, *wg = NULL;
+    size_t rk = 0, wk = 0;   /* count of PARSEABLE grants kept */
+    int rc = -1;
+
+    if (read_n) {
+        rg = (HlFsGrant *)hl_alloc_calloc(alloc, read_n, sizeof(HlFsGrant));
+        if (!rg) { e = "io_error"; goto done; }
+    }
+    if (write_n) {
+        wg = (HlFsGrant *)hl_alloc_calloc(alloc, write_n, sizeof(HlFsGrant));
+        if (!wg) { e = "io_error"; goto done; }
+    }
+    /* SKIP a grant that fails to PARSE (an absolute path or an unsupported
+     * pattern is not a base-relative policy grant - it feeds only the kernel
+     * sandbox). Skipping preserves app load (the old wiring never validated grant
+     * content) and fails CLOSED: the skipped path is simply not authorized by the
+     * cap-layer policy. A genuine COMPILE error (conflicting intent, a symlink
+     * anchor) below is still a hard failure. */
+    for (size_t i = 0; i < read_n; i++) {
+        const char *pe = NULL;
+        if (hl_fs_grant_parse(read[i], strlen(read[i]), alloc, &rg[rk], &pe) == 0) rk++;
+    }
+    for (size_t i = 0; i < write_n; i++) {
+        const char *pe = NULL;
+        if (hl_fs_grant_parse(write[i], strlen(write[i]), alloc, &wg[wk], &pe) == 0) wk++;
+    }
+
+    rc = hl_fs_policy_compile(base_dir, alloc, rg, rk, wg, wk, out, &e);
+
+done:
+    for (size_t i = 0; i < rk; i++) hl_fs_grant_free(&rg[i]);
+    for (size_t i = 0; i < wk; i++) hl_fs_grant_free(&wg[i]);
+    if (rg) hl_alloc_free(alloc, rg, read_n * sizeof(HlFsGrant));
+    if (wg) hl_alloc_free(alloc, wg, write_n * sizeof(HlFsGrant));
+    if (err) *err = e;
+    return rc;
+}
+
 void hl_fs_policy_free(HlFsPolicy *policy)
 {
     if (!policy) return;

--- a/src/hull/cap/fs_policy.c
+++ b/src/hull/cap/fs_policy.c
@@ -178,20 +178,27 @@ int hl_fs_grant_parse(const char *raw, size_t raw_len, HlAllocator *alloc,
         n++;
     }
 
-    if (n == 0) { e = "invalid_path"; goto fail; }     /* empty grant ("." / "/") */
+    /* n == 0 is the BASE-ROOT grant ("." / "./" / a bare "/" is rejected earlier as
+     * absolute): it authorizes the app root and every descendant (a SUBTREE at
+     * base_fd). It compiles to a grant with 0 components - the least-specific
+     * entry, shadowed by any narrower grant. directory_intent is meaningless for
+     * the root (always a directory), so it is normalized to 0. */
     if (first_pattern == (size_t)-1) first_pattern = n;
     if (directory_intent && first_pattern < n) {       /* trailing-slash pattern grant */
         e = "unsupported_pattern"; goto fail;
     }
 
-    char **comp = (char **)hl_alloc_calloc(alloc, n, sizeof(char *));
-    if (!comp) { e = "io_error"; goto fail; }
-    memcpy(comp, tmp, n * sizeof(char *));
+    char **comp = NULL;
+    if (n > 0) {
+        comp = (char **)hl_alloc_calloc(alloc, n, sizeof(char *));
+        if (!comp) { e = "io_error"; goto fail; }
+        memcpy(comp, tmp, n * sizeof(char *));
+    }
 
     out->comp = comp;
     out->n = n;
     out->first_pattern = first_pattern;
-    out->directory_intent = directory_intent;
+    out->directory_intent = (n == 0) ? 0 : directory_intent;
     out->alloc = alloc;
     return 0;
 
@@ -259,6 +266,23 @@ static int compile_one(int base_fd, HlAllocator *alloc, const HlFsGrant *g,
 {
     const char *e;                          /* every `goto fail` sets this before use */
     size_t lit = g->first_pattern;          /* literal prefix length */
+
+    /* BASE-ROOT grant (0 components, "."): a SUBTREE anchored at base_fd itself,
+     * matching every caller path. anchor is base (F_DUPFD_CLOEXEC); no walk. */
+    if (g->n == 0) {
+        int afd = fcntl(base_fd, F_DUPFD_CLOEXEC, 0);
+        if (afd < 0) { *err = "io_error"; return -1; }
+        out->kind = HL_FS_ENTRY_SUBTREE;
+        out->anchor_fd = afd;
+        out->grant = NULL;                  /* 0 components; entry_free handles NULL */
+        out->grant_n = 0;
+        out->anchor_depth = 0;
+        out->first_pattern = 0;
+        out->terminal = HL_FS_TERMINAL_FILE;
+        out->literal_components = 0;
+        out->literal_bytes = 0;
+        return 0;
+    }
 
     /* A pure-literal grant that resolves to a DIRECTORY is a SUBTREE. Per the
      * approved design (sec. 6), a SUBTREE FOLLOWS in-root symlinks with virtual-root
@@ -475,7 +499,7 @@ int hl_fs_policy_compile_manifest(const char *base_dir, HlAllocator *alloc,
 {
     const char *e = "io_error";
     HlFsGrant *rg = NULL, *wg = NULL;
-    size_t rk = 0, wk = 0;   /* count of PARSEABLE grants kept */
+    size_t ri = 0, wi = 0;
     int rc = -1;
 
     if (read_n) {
@@ -486,26 +510,21 @@ int hl_fs_policy_compile_manifest(const char *base_dir, HlAllocator *alloc,
         wg = (HlFsGrant *)hl_alloc_calloc(alloc, write_n, sizeof(HlFsGrant));
         if (!wg) { e = "io_error"; goto done; }
     }
-    /* SKIP a grant that fails to PARSE (an absolute path or an unsupported
-     * pattern is not a base-relative policy grant - it feeds only the kernel
-     * sandbox). Skipping preserves app load (the old wiring never validated grant
-     * content) and fails CLOSED: the skipped path is simply not authorized by the
-     * cap-layer policy. A genuine COMPILE error (conflicting intent, a symlink
-     * anchor) below is still a hard failure. */
-    for (size_t i = 0; i < read_n; i++) {
-        const char *pe = NULL;
-        if (hl_fs_grant_parse(read[i], strlen(read[i]), alloc, &rg[rk], &pe) == 0) rk++;
-    }
-    for (size_t i = 0; i < write_n; i++) {
-        const char *pe = NULL;
-        if (hl_fs_grant_parse(write[i], strlen(write[i]), alloc, &wg[wk], &pe) == 0) wk++;
-    }
+    /* A grant that fails to PARSE (absolute, "..", unsupported pattern, malformed,
+     * or an allocation failure) FAILS compilation with its precise token - a
+     * declared capability must not silently become unusable (contract in
+     * fs_policy.h). Absolute / external-root grants are not base-relative policy
+     * grants and are rejected here; an app must use an in-root relative path. */
+    for (ri = 0; ri < read_n; ri++)
+        if (hl_fs_grant_parse(read[ri], strlen(read[ri]), alloc, &rg[ri], &e) != 0) goto done;
+    for (wi = 0; wi < write_n; wi++)
+        if (hl_fs_grant_parse(write[wi], strlen(write[wi]), alloc, &wg[wi], &e) != 0) goto done;
 
-    rc = hl_fs_policy_compile(base_dir, alloc, rg, rk, wg, wk, out, &e);
+    rc = hl_fs_policy_compile(base_dir, alloc, rg, read_n, wg, write_n, out, &e);
 
 done:
-    for (size_t i = 0; i < rk; i++) hl_fs_grant_free(&rg[i]);
-    for (size_t i = 0; i < wk; i++) hl_fs_grant_free(&wg[i]);
+    for (size_t i = 0; i < ri; i++) hl_fs_grant_free(&rg[i]);
+    for (size_t i = 0; i < wi; i++) hl_fs_grant_free(&wg[i]);
     if (rg) hl_alloc_free(alloc, rg, read_n * sizeof(HlFsGrant));
     if (wg) hl_alloc_free(alloc, wg, write_n * sizeof(HlFsGrant));
     if (err) *err = e;

--- a/src/hull/cap/fs_resolve.c
+++ b/src/hull/cap/fs_resolve.c
@@ -114,25 +114,31 @@ static int force_manual(void)
 #define RESOLVE_IN_ROOT       0x10
 struct open_how { uint64_t flags; uint64_t mode; uint64_t resolve; };
 #endif
+#ifndef RESOLVE_NO_SYMLINKS
+#define RESOLVE_NO_SYMLINKS   0x04
+#endif
 #ifndef __NR_openat2
 #define __NR_openat2 437
 #endif
 
 /* Returns fd, or -1 with *err set, or -2 meaning "openat2 unavailable, fall
- * back to the manual walk". */
+ * back to the manual walk". Under HL_FS_SYMLINK_REFUSE the kernel refuses every
+ * symlink (RESOLVE_NO_SYMLINKS) and an ELOOP is mapped to "symlink_denied". */
 static int try_openat2(int root_fd, const char *relpath, int flags,
-                       mode_t mode, const char **err)
+                       HlFsSymlink sympol, mode_t mode, const char **err)
 {
     struct open_how how;
     memset(&how, 0, sizeof(how));
     how.flags = (uint64_t)flags;
     how.mode = (flags & O_CREAT) ? (uint64_t)mode : 0;
-    how.resolve = RESOLVE_IN_ROOT | RESOLVE_NO_MAGICLINKS;
+    how.resolve = RESOLVE_IN_ROOT | RESOLVE_NO_MAGICLINKS
+                | (sympol == HL_FS_SYMLINK_REFUSE ? RESOLVE_NO_SYMLINKS : 0);
 
     long r = syscall(__NR_openat2, root_fd, relpath, &how, sizeof(how));
     if (r >= 0) return (int)r;
     if (errno == ENOSYS || errno == EPERM /* seccomp may block it */)
         return -2;
+    if (sympol == HL_FS_SYMLINK_REFUSE && errno == ELOOP) { *err = "symlink_denied"; return -1; }
     map_errno(errno, err);
     return -1;
 }
@@ -155,7 +161,7 @@ static int splice_link(const char *link, const char *rest,
 }
 
 static int resolve_manual(int root_fd, const char *relpath, HlFsOpenMode mode,
-                          mode_t cmode, const char **err)
+                          HlFsSymlink sympol, mode_t cmode, const char **err)
 {
     int stack[HL_FS_MAX_DEPTH];
     int depth = 0;
@@ -299,6 +305,9 @@ static int resolve_manual(int root_fd, const char *relpath, HlFsOpenMode mode,
         }
 
     symlink:
+        /* Every symlink-encounter site jumps here, so one gate enforces the policy:
+         * under REFUSE, any symlink (intermediate or terminal) is denied outright. */
+        if (sympol == HL_FS_SYMLINK_REFUSE) { *err = "symlink_denied"; goto fail; }
         if (++symlinks > HL_FS_SYMLINK_MAX) { *err = "symlink_loop"; goto fail; }
         {
             char link[HL_FS_PATH_MAX];
@@ -339,6 +348,13 @@ int hl_fs_open_base(const char *base_dir, const char **err)
 int hl_fs_open_at(int root_fd, const char *relpath, HlFsOpenMode mode,
                   mode_t create_mode, const char **err)
 {
+    return hl_fs_open_at_ex(root_fd, relpath, mode, HL_FS_SYMLINK_FOLLOW,
+                            create_mode, err);
+}
+
+int hl_fs_open_at_ex(int root_fd, const char *relpath, HlFsOpenMode mode,
+                     HlFsSymlink sympol, mode_t create_mode, const char **err)
+{
     const char *e = "io_error";
     if (root_fd < 0 || !relpath) { if (err) *err = "invalid_args"; return -1; }
     if (!caller_path_ok(relpath)) { if (err) *err = "invalid_path"; return -1; }
@@ -356,14 +372,14 @@ int hl_fs_open_at(int root_fd, const char *relpath, HlFsOpenMode mode,
      * path, unless HL_FS_FORCE_MANUAL is set (parity testing). */
     if ((mode == HL_FS_OPEN_READ || mode == HL_FS_OPEN_DIR) && !force_manual()) {
         int of = O_RDONLY | O_CLOEXEC | (mode == HL_FS_OPEN_DIR ? O_DIRECTORY : 0);
-        int fd = try_openat2(root_fd, relpath, of, 0, &e);
+        int fd = try_openat2(root_fd, relpath, of, sympol, 0, &e);
         if (fd >= 0) return fd;
         if (fd == -1) { if (err) *err = e; return -1; }
         /* fd == -2: openat2 unavailable -> manual walk */
     }
 #endif
 
-    int fd = resolve_manual(root_fd, relpath, mode, create_mode, &e);
+    int fd = resolve_manual(root_fd, relpath, mode, sympol, create_mode, &e);
     if (fd < 0 && err) *err = e;
     return fd;
 }

--- a/src/hull/embed.c
+++ b/src/hull/embed.c
@@ -24,6 +24,7 @@
 #include "hull/sandbox.h"
 #include "hull/manifest.h"
 #include "hull/cap/fs.h"
+#include "hull/utils/alloc.h"
 #include "hull/cap/crypto.h"
 #include "hull/module_registry.h"
 #include "hull/release_io.h"
@@ -41,6 +42,8 @@ enum { HL_EMBED_NEW = 0, HL_EMBED_SEALED = 1 };
 struct HlEmbed {
     char       *app_dir;                          /* owned pre-seal; NULLed after seal */
     HlFsConfig  fs;                               /* base_dir: app_dir pre-seal, sealed copy post-seal */
+    HlFsPolicy  fs_policy;                         /* compiled fs authorization policy (checkpoint 3) */
+    HlAllocator fs_alloc;                          /* owns the compiled policy's memory */
 
     char       *reads[HL_MANIFEST_MAX_PATHS];     /* owned dups; freed at seal or free */
     int         nreads;
@@ -78,6 +81,8 @@ HlEmbed *hl_embed_new(const char *app_dir)
     }
     e->fs.base_dir = e->app_dir;
     e->fs.base_len = strlen(e->app_dir);
+    e->fs_policy = HL_FS_POLICY_INIT;   /* fds -1 so hl_embed_free never closes stdin */
+    hl_alloc_init(&e->fs_alloc, 0);     /* tracking only, no cap */
     e->state = HL_EMBED_NEW;
     return e;
 }
@@ -95,6 +100,10 @@ static void embed_free_heap_policy(HlEmbed *e)
 void hl_embed_free(HlEmbed *e)
 {
     if (!e) return;
+    /* Close the fs policy's held anchor fds (idempotent; INIT if never sealed).
+     * It does not alias the arena (its own raw-malloc storage), so order vs the
+     * arena is free - do it first. */
+    hl_fs_policy_free(&e->fs_policy);
     /* Free heap-owned policy strings first, then destroy the sealed arena
      * LAST — fs.base_dir may alias into it (c-audit §5b: arena destroyed
      * after every consumer). No capability call can run during teardown. */
@@ -208,6 +217,24 @@ int hl_embed_seal(HlEmbed *e, const char *db_path)
     policy.tui              = e->tui;
     policy.wx_enforced      = 1;   /* no runtime dynamic code */
     /* allow_dynamic_code / allow_dynamic_libraries stay 0 (zeroed above). */
+
+    /* 2b. Compile the fs authorization policy (checkpoint 3) from the SAME grants,
+     *     BEFORE the kernel sandbox restricts fs opens (the compile opens each
+     *     grant anchor). A bad grant fails the seal here, before the
+     *     macOS-irreversible sandbox is applied. Raw allocator (NULL); the policy
+     *     deep-copies the grant strings, so the later embed_free_heap_policy is
+     *     safe. Freed in hl_embed_free. */
+    {
+        const char *perr = NULL;
+        if (hl_fs_policy_compile_manifest(
+                e->fs.base_dir, &e->fs_alloc,
+                (const char *const *)e->reads,  (size_t)e->nreads,
+                (const char *const *)e->writes, (size_t)e->nwrites,
+                &e->fs_policy, &perr) != 0) {
+            return -1;             /* fail closed: leave state NEW (fds -1) */
+        }
+        e->fs.policy = &e->fs_policy;
+    }
 
     /* 3. Apply the kernel sandbox against the sealed base_dir. */
     int rc = hl_sandbox_apply(&policy, e->fs.base_dir, db_path,

--- a/src/hull/serve.c
+++ b/src/hull/serve.c
@@ -689,6 +689,7 @@ typedef struct {
     int                  manifest_sealed; /* 1 after successful seal */
     HlResolvedModuleSet  module_set; /* frozen after resolver; consulted by gating */
     HlFsConfig           fs_cfg_storage;
+    HlFsPolicy           fs_policy_storage; /* compiled fs authorization policy (checkpoint 3) */
     HlEnvConfig          env_cfg_storage;
     HlHttpConfig         http_cfg_storage;
     HlSmtpConfig         smtp_cfg_storage;
@@ -1449,11 +1450,25 @@ static int hl_serve_wire_caps(HlServerState *s)
     }
 
     /* Wire fs_cfg from manifest (if app declares fs.read OR fs.write
-     * paths — both blob.* and fs.mmap need the cfg). */
+     * paths — both blob.* and fs.mmap need the cfg). The fs.read/fs.write grants
+     * are COMPILED into the path-authorization policy (checkpoint 3, sec. 6): the
+     * cap layer selects from it per op and opens under a held anchor. A no-grant
+     * app leaves rt->fs_cfg NULL -> fs denied (unchanged fail-closed behavior). */
     memset(&s->fs_cfg_storage, 0, sizeof(s->fs_cfg_storage));
+    s->fs_policy_storage = HL_FS_POLICY_INIT;
     if (s->manifest.fs_read_count > 0 || s->manifest.fs_write_count > 0) {
+        const char *perr = NULL;
+        if (hl_fs_policy_compile_manifest(
+                s->app_dir, &s->alloc,
+                s->manifest.fs_read,  (size_t)s->manifest.fs_read_count,
+                s->manifest.fs_write, (size_t)s->manifest.fs_write_count,
+                &s->fs_policy_storage, &perr) != 0) {
+            log_error("[hull:c] fs policy compile failed: %s", perr ? perr : "unknown");
+            return -1;
+        }
         s->fs_cfg_storage.base_dir = s->app_dir;
         s->fs_cfg_storage.base_len = strlen(s->app_dir);
+        s->fs_cfg_storage.policy   = &s->fs_policy_storage;
         rt->fs_cfg = &s->fs_cfg_storage;
     }
 
@@ -1559,6 +1574,9 @@ static int hl_serve_wire_caps(HlServerState *s)
 /* Cleanup if a phase fails after wire_caps has succeeded. */
 static void hl_serve_undo_caps(HlServerState *s)
 {
+    /* Close the fs policy's held anchor fds + free its entries (idempotent;
+     * resets to HL_FS_POLICY_INIT). Uses &s->alloc, still live here. */
+    hl_fs_policy_free(&s->fs_policy_storage);
     /* hl_manifest_free is a safe no-op on a sealed manifest (the
      * `sealed` flag short-circuits the per-string free walk). */
     hl_manifest_free(&s->manifest);
@@ -1793,6 +1811,11 @@ static void hl_serve_teardown_after_serve(HlServerState *s)
      * WASM/GPU static caches are external — freed separately below. */
     hl_app_context_free(s->app);
     s->app = NULL;
+
+    /* Free the fs authorization policy AFTER the runtime is gone: the cap layer
+     * (rt->fs_cfg->policy) may touch it during runtime shutdown, so it must
+     * outlive the runtime. Closes the held anchor fds; idempotent. */
+    hl_fs_policy_free(&s->fs_policy_storage);
 
     /* Now unwrap the async-backend wrap — borrowed, doesn't destroy
      * KlServer's KlEventCtx (server's own free does that). */
@@ -2071,6 +2094,9 @@ int hull_serve(int argc, char **argv)
 {
     HlServerState s;
     memset(&s, 0, sizeof(s));
+    /* fds default -1 so a teardown before the policy is compiled never close(0)s
+     * stdin (HL_FS_POLICY_INIT, not the memset's all-zero base_fd == 0). */
+    s.fs_policy_storage = HL_FS_POLICY_INIT;
 
     /* Phase 1: parse CLI args */
     int rc = hl_serve_parse_args(&s, argc, argv);

--- a/src/hull/serve_cli.c
+++ b/src/hull/serve_cli.c
@@ -260,17 +260,12 @@ int hull_serve(int argc, char **argv)
         log_warn("[hull:cli] manifest extraction failed; running without policy");
     }
 
-    /* Wire per-capability configs from the manifest. serve.c does this
-     * in `wire_caps` for the server build; in CLI mode we do the same
-     * dance inline so capabilities that gate on manifest declarations
-     * (fs.read paths, env allowlist, http hosts + TLS) work out of
-     * app.main. */
-    HlFsConfig fs_cfg = {0};
-    if (manifest.fs_read_count > 0 || manifest.fs_write_count > 0) {
-        fs_cfg.base_dir = app_dir;
-        fs_cfg.base_len = strlen(app_dir);
-        rt->fs_cfg = &fs_cfg;
-    }
+    /* Wire per-capability configs from the manifest. serve.c does this in
+     * `wire_caps` for the server build; in CLI mode we do the same dance inline
+     * for env allowlist + http hosts/TLS below. The FS capability (fs.read/write
+     * grants -> the compiled authorization policy, checkpoint 3) is already wired
+     * onto rt->fs_cfg by hl_app_context_load, so we do NOT overwrite it here (a
+     * base_dir-only HlFsConfig would clobber the policy and deny every op). */
 
     HlEnvConfig env_cfg = {0};
     if (manifest.env_count > 0) {

--- a/tests/e2e_cli.sh
+++ b/tests/e2e_cli.sh
@@ -119,6 +119,47 @@ JS
 run_udf_teardown "lua" "lua"
 run_udf_teardown "js"  "js"
 
+# ── fs round-trip through app.main (checkpoint 3, Slice B) ────────────────────
+# The path-authorization policy is compiled from the manifest's fs grants and
+# wired onto the CLI runtime. A grant of "." authorizes the whole app dir, so a
+# write + read-back must round-trip (before Slice B's wiring fix the CLI denied
+# every fs op). Exit 0 = round-trip OK.
+run_fs_roundtrip() {
+    runtime="$1"; ext="$2"
+    echo "--- fs round-trip via app.main (${runtime}) ---"
+    d=$(mktemp -d)
+    if [ "$ext" = "lua" ]; then
+        cat > "${d}/app.lua" <<'LUA'
+app.manifest({ modules = { "hull/fs@1" }, fs = { read = { "." }, write = { "." } } })
+app.main(function()
+  local fs = require("hull.fs")
+  local wok = fs.write("cli.txt", "cli-roundtrip")
+  local rok, data = pcall(fs.read, "cli.txt")
+  return (wok and rok and data == "cli-roundtrip") and 0 or 3
+end)
+LUA
+    else
+        cat > "${d}/app.js" <<'JS'
+import { app } from "hull:app";
+import { fs } from "hull:fs";
+app.manifest({ modules: ["hull/fs@1"], fs: { read: ["."], write: ["."] } });
+app.main(() => {
+  fs.write("cli.txt", "cli-roundtrip");
+  const buf = fs.read("cli.txt");
+  const len = (buf && buf.byteLength !== undefined) ? buf.byteLength : (buf ? buf.length : 0);
+  return (len === 13) ? 0 : 3;   // "cli-roundtrip" is 13 bytes
+});
+JS
+    fi
+    "${HULL_BIN}" "${d}/app.${ext}" >/dev/null 2>&1
+    rc=$?
+    expect_eq "${runtime} fs round-trip via app.main" "0" "${rc}"
+    rm -rf "${d}"
+}
+
+run_fs_roundtrip "lua" "lua"
+run_fs_roundtrip "js"  "js"
+
 echo
 echo "${PASS}/$((PASS + FAIL)) CLI e2e tests passed"
 [ "${FAIL}" -eq 0 ]

--- a/tests/e2e_sandbox.sh
+++ b/tests/e2e_sandbox.sh
@@ -130,7 +130,7 @@ echo "=== Test 1: Hull with manifest — sandbox log ==="
 cat > "$WORKDIR/app.lua" << 'EOF'
 app.manifest({
     modules = {"hull/http-server@1"},
-    fs = { read = {"/tmp"}, write = {"/tmp"} },
+    fs = { read = {"data"}, write = {"logs"} },
     env = {"PORT"},
     hosts = {"example.com"},
 })
@@ -226,7 +226,7 @@ echo "=== Test 3: Manifest without hosts — no dns promise ==="
 cat > "$WORKDIR/nohosts.lua" << 'EOF'
 app.manifest({
     modules = {"hull/http-server@1"},
-    fs = { read = {"/tmp"} },
+    fs = { read = {"data"} },
     env = {"PORT"},
 })
 
@@ -272,7 +272,7 @@ import { app } from 'hull:app';
 
 app.manifest({
     modules: ["hull/http-server@1"],
-    fs: { read: ["/tmp"], write: ["/tmp"] },
+    fs: { read: ["data"], write: ["logs"] },
     env: ["PORT"],
     hosts: ["example.com"],
 });

--- a/tests/hull/cap/test_fs.c
+++ b/tests/hull/cap/test_fs.c
@@ -19,6 +19,8 @@
 
 #include "utest.h"
 #include "hull/cap/fs.h"
+#include "hull/cap/fs_policy.h"
+#include "hull/utils/alloc.h"
 #include <errno.h>
 #include <fcntl.h>
 #include <ftw.h>
@@ -30,7 +32,20 @@
 #include <unistd.h>
 
 static char test_dir[256];
-static HlFsConfig test_cfg;
+static HlFsConfig  test_cfg;
+static HlFsPolicy  test_policy = HL_FS_POLICY_INIT;
+static HlAllocator test_alloc;
+
+/* Checkpoint 3: read/write/mmap are policy-gated. These tests exercise the
+ * read/write/mmap MECHANICS, so setup grants exactly the paths they touch (both
+ * read and write sets); the traversal/absolute cases stay denied by the lexical
+ * pre-check. Policy authorization itself is covered by test_fs_policy.c. */
+static const char *const test_grants[] = {
+    "a/b/c/file.txt", "del.txt", "gone.txt", "here.txt", "huge.bin",
+    "mmap_borrow.txt", "mmap_rel.txt", "mmap_test.txt", "no_such_file.txt",
+    "nope.txt", "size.txt", "test.txt", "whole.txt",
+    "win_borrow.bin", "win_cross.bin", "win_eof.bin", "win_rej.bin", "win_zero.bin",
+};
 
 static void setup_fs(void)
 {
@@ -38,6 +53,18 @@ static void setup_fs(void)
     mkdir(test_dir, 0755);
     test_cfg.base_dir = test_dir;
     test_cfg.base_len = strlen(test_dir);
+
+    hl_alloc_init(&test_alloc, 0);
+    test_policy = HL_FS_POLICY_INIT;
+    size_t n = sizeof(test_grants) / sizeof(test_grants[0]);
+    const char *perr = NULL;
+    if (hl_fs_policy_compile_manifest(test_dir, &test_alloc,
+                                      test_grants, n, test_grants, n,
+                                      &test_policy, &perr) != 0) {
+        fprintf(stderr, "test_fs setup: policy compile failed: %s\n",
+                perr ? perr : "?");
+    }
+    test_cfg.policy = &test_policy;
 }
 
 static int teardown_rm_entry(const char *path, const struct stat *sb,
@@ -49,6 +76,8 @@ static int teardown_rm_entry(const char *path, const struct stat *sb,
 
 static void teardown_fs(void)
 {
+    hl_fs_policy_free(&test_policy);   /* close held anchor fds; idempotent */
+    test_cfg.policy = NULL;
     /* In-process recursive delete via nftw(FTW_DEPTH). Cosmopolitan's
      * toybox rm rejects `-r` ("rm: illegal option -- r"), and
      * `system("rm -rf ...")` leaves the next test hitting EEXIST on

--- a/tests/hull/cap/test_fs_authz.c
+++ b/tests/hull/cap/test_fs_authz.c
@@ -210,24 +210,44 @@ UTEST(fs_authz, no_policy_denies)
     teardown();
 }
 
-/* ── manifest compile SKIPS unparseable grants (absolute etc.), keeps valid ───── */
-UTEST(fs_authz, manifest_skips_unparseable_grants)
+/* ── manifest compile REJECTS a bad grant with its precise token (no silent skip,
+ * no leak) - a declared capability must not silently become unusable. ─────────── */
+UTEST(fs_authz, manifest_rejects_bad_grants)
 {
     setup(); build_tree();
     HlAllocator a; hl_alloc_init(&a, 0);
     HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
-    /* an absolute grant (a kernel-sandbox path, e.g. tui_log_tailer's LOG_FILE) is
-     * SKIPPED so app load never fails; the valid relative grant is kept. */
-    const char *rd[] = { "/tmp/hull-tail.log", "r.txt" };
-    ASSERT_EQ(0, hl_fs_policy_compile_manifest(base, &a, rd, 2, NULL, 0, &p, &err));
-    ASSERT_EQ((size_t)1, p.read_n);            /* only r.txt kept */
+
+    const char *abs_g[] = { "/tmp/hull-tail.log", "r.txt" };   /* absolute -> reject */
+    ASSERT_EQ(-1, hl_fs_policy_compile_manifest(base, &a, abs_g, 2, NULL, 0, &p, &err));
+    ASSERT_STREQ("invalid_path", err);
+
+    const char *pat_g[] = { "data/**", "r.txt" };              /* unsupported pattern -> reject */
+    err = NULL;
+    ASSERT_EQ(-1, hl_fs_policy_compile_manifest(base, &a, pat_g, 2, NULL, 0, &p, &err));
+    ASSERT_STREQ("unsupported_pattern", err);
+
+    ASSERT_EQ((size_t)0, hl_alloc_used(&a));                   /* no leak on the failure path */
+    teardown();
+}
+
+/* ── base-root "." grant authorizes the whole app dir (least-specific SUBTREE) ─── */
+UTEST(fs_authz, base_root_grant)
+{
+    setup(); build_tree();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *g[] = { "." };                 /* the whole app dir + descendants */
+    ASSERT_EQ(0, build_policy(&a, g, 1, g, 1, &p, &err));
+    ASSERT_EQ((size_t)1, p.read_n);
+    ASSERT_EQ((int)HL_FS_ENTRY_SUBTREE, (int)p.read[0].kind);
+    ASSERT_EQ((size_t)0, p.read[0].grant_n);   /* 0 components == base root */
 
     HlFsConfig c = cfg_with(&p);
-    char buf[8];
-    ASSERT_EQ((int64_t)1, hl_cap_fs_read(&c, "r.txt", buf, sizeof(buf), &err)); /* kept grant works */
-    err = NULL;
-    ASSERT_EQ((int64_t)-1, hl_cap_fs_read(&c, "secret.txt", buf, sizeof(buf), &err)); /* ungranted */
-    ASSERT_STREQ("permission", err);
+    char buf[64];
+    ASSERT_EQ((int64_t)1, hl_cap_fs_read(&c, "r.txt", buf, sizeof(buf), &err));          /* any path */
+    ASSERT_EQ((int64_t)4, hl_cap_fs_read(&c, "data/real.txt", buf, sizeof(buf), &err));  /* nested */
+    ASSERT_EQ(0, hl_cap_fs_write(&c, "created.txt", "N", 1, &err));                       /* create */
 
     hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&a));
     teardown();

--- a/tests/hull/cap/test_fs_authz.c
+++ b/tests/hull/cap/test_fs_authz.c
@@ -1,0 +1,236 @@
+/*
+ * test_fs_authz.c - hull.fs path authorization THROUGH the cap layer (checkpoint 3,
+ * Slice B). Unlike test_fs_policy.c (pure compile/select), these drive
+ * hl_cap_fs_read / _write / _mmap with a compiled policy and verify the runtime
+ * per-kind symlink enforcement, CREATE/PATTERN creation, O_TRUNC, independent
+ * read/write sets, and no-grant denial - the Slice-B acceptance boundary.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#if defined(__linux__) && !defined(_XOPEN_SOURCE)
+# define _XOPEN_SOURCE 700
+#endif
+
+#include "utest.h"
+#include "hull/cap/fs.h"
+#include "hull/cap/fs_policy.h"
+#include "hull/utils/alloc.h"
+#include <errno.h>
+#include <ftw.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+static char base[256];
+
+static void setup(void) { snprintf(base, sizeof(base), "/tmp/hull_authz_%d", (int)getpid()); mkdir(base, 0755); }
+static int rm_e(const char *p, const struct stat *s, int t, struct FTW *f)
+{ (void)s; (void)t; (void)f; return remove(p); }
+static void teardown(void) { if (nftw(base, rm_e, 16, FTW_DEPTH | FTW_PHYS) != 0 && errno != ENOENT) {} }
+
+static void mk_dir(const char *rel)  { char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel); mkdir(p, 0755); }
+static void mk_file(const char *rel, const char *data)
+{ char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel);
+  FILE *f = fopen(p, "wb"); if (f) { fputs(data, f); fclose(f); } }
+static void mk_link(const char *target, const char *rel)
+{ char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel); unlink(p); symlink(target, p); }
+
+static void build_tree(void)
+{
+    mk_file("r.txt", "R");
+    mk_file("secret.txt", "SECRET");
+    mk_dir("data"); mk_file("data/real.txt", "REAL");
+    mk_link("real.txt", "data/link");        /* in-subtree symlink -> data/real.txt */
+    mk_link("/etc/hostname", "data/esc");     /* escaping symlink (absolute) */
+    mk_link("r.txt", "exlink.txt");           /* a symlink used as an EXACT grant */
+}
+
+/* Compile a policy from raw read/write grant arrays (grants freed here). */
+static int build_policy(HlAllocator *a, const char **rd, size_t rn,
+                        const char **wr, size_t wn, HlFsPolicy *out, const char **err)
+{
+    HlFsGrant rg[8], wg[8]; size_t ri = 0, wi = 0; int rc = -1; const char *e = "?";
+    for (; ri < rn; ri++) if (hl_fs_grant_parse(rd[ri], strlen(rd[ri]), a, &rg[ri], &e) != 0) goto done;
+    for (; wi < wn; wi++) if (hl_fs_grant_parse(wr[wi], strlen(wr[wi]), a, &wg[wi], &e) != 0) goto done;
+    rc = hl_fs_policy_compile(base, a, rg, rn, wg, wn, out, &e);
+done:
+    for (size_t i = 0; i < ri; i++) hl_fs_grant_free(&rg[i]);
+    for (size_t i = 0; i < wi; i++) hl_fs_grant_free(&wg[i]);
+    if (err) *err = e; return rc;
+}
+
+static HlFsConfig cfg_with(HlFsPolicy *p)
+{ HlFsConfig c; memset(&c, 0, sizeof c); c.base_dir = base; c.base_len = strlen(base); c.policy = p; return c; }
+
+/* ── independent read/write sets + no-grant denial ───────────────────────────── */
+UTEST(fs_authz, independent_sets_and_deny)
+{
+    setup(); build_tree();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "r.txt" };            /* readable only */
+    const char *wr[] = { "w.txt" };            /* writable only (absent -> CREATE) */
+    ASSERT_EQ(0, build_policy(&a, rd, 1, wr, 1, &p, &err));
+    HlFsConfig c = cfg_with(&p);
+
+    char buf[64];
+    ASSERT_EQ((int64_t)1, hl_cap_fs_read(&c, "r.txt", buf, sizeof(buf), &err)); /* read OK */
+    err = NULL;
+    ASSERT_EQ(-1, hl_cap_fs_write(&c, "r.txt", "x", 1, &err));                  /* not writable */
+    ASSERT_STREQ("permission", err);
+    ASSERT_EQ(0, hl_cap_fs_write(&c, "w.txt", "hi", 2, &err));                  /* write OK (create) */
+    err = NULL;
+    ASSERT_EQ((int64_t)-1, hl_cap_fs_read(&c, "w.txt", buf, sizeof(buf), &err));/* not readable */
+    ASSERT_STREQ("permission", err);
+    err = NULL;
+    ASSERT_EQ((int64_t)-1, hl_cap_fs_read(&c, "nope.txt", buf, sizeof(buf), &err)); /* ungranted */
+    ASSERT_STREQ("permission", err);
+
+    hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── SUBTREE follows in-subtree symlinks but stays confined to its anchor ─────── */
+UTEST(fs_authz, subtree_follows_but_confined)
+{
+    setup(); build_tree();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "data" };
+    ASSERT_EQ(0, build_policy(&a, rd, 1, NULL, 0, &p, &err));
+    HlFsConfig c = cfg_with(&p);
+
+    char buf[64];
+    int64_t n = hl_cap_fs_read(&c, "data/real.txt", buf, sizeof(buf), &err);
+    ASSERT_EQ((int64_t)4, n); ASSERT_EQ(0, memcmp(buf, "REAL", 4));
+    /* in-subtree symlink is FOLLOWED */
+    n = hl_cap_fs_read(&c, "data/link", buf, sizeof(buf), &err);
+    ASSERT_EQ((int64_t)4, n); ASSERT_EQ(0, memcmp(buf, "REAL", 4));
+    /* escaping absolute symlink is CLAMPED to base -> base/etc/hostname (absent),
+     * NEVER the host /etc/hostname */
+    err = NULL;
+    ASSERT_EQ((int64_t)-1, hl_cap_fs_read(&c, "data/esc", buf, sizeof(buf), &err));
+    ASSERT_STREQ("not_found", err);
+
+    hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── EXACT refuses a symlink (no aliasing a non-authorized target) ────────────── */
+UTEST(fs_authz, exact_refuses_symlink)
+{
+    setup(); build_tree();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    /* exlink.txt is a symlink -> compile refuses it at the anchor walk (its parent
+     * is base, the leaf itself is the symlink; EXACT refuses). */
+    const char *rd[] = { "exlink.txt" };
+    /* the grant compiles (leaf recorded); the OPEN refuses the symlink */
+    int rc = build_policy(&a, rd, 1, NULL, 0, &p, &err);
+    char buf[64];
+    if (rc == 0) {
+        HlFsConfig c = cfg_with(&p);
+        err = NULL;
+        ASSERT_EQ((int64_t)-1, hl_cap_fs_read(&c, "exlink.txt", buf, sizeof(buf), &err));
+        ASSERT_STREQ("symlink_denied", err);
+        hl_fs_policy_free(&p);
+    } else {
+        /* or it is refused at compile - either way the symlink is never followed */
+        ASSERT_STREQ("symlink_denied", err);
+    }
+    ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── CREATE: only constrained components; O_TRUNC preserved ───────────────────── */
+UTEST(fs_authz, create_constrained_and_trunc)
+{
+    setup(); build_tree();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *g[] = { "out/result.bin" };    /* out/ absent -> CREATE, in both sets */
+    ASSERT_EQ(0, build_policy(&a, g, 1, g, 1, &p, &err));
+    HlFsConfig c = cfg_with(&p);
+
+    ASSERT_EQ(0, hl_cap_fs_write(&c, "out/result.bin", "AAAAAA", 6, &err));  /* creates out/ + file */
+    struct stat st; char dp[512]; snprintf(dp, sizeof(dp), "%s/out", base);
+    ASSERT_EQ(0, stat(dp, &st)); ASSERT_TRUE(S_ISDIR(st.st_mode));           /* out/ created */
+    err = NULL;
+    ASSERT_EQ(-1, hl_cap_fs_write(&c, "out/other.bin", "x", 1, &err));       /* sibling denied */
+    ASSERT_STREQ("permission", err);
+    ASSERT_EQ(0, hl_cap_fs_write(&c, "out/result.bin", "BB", 2, &err));      /* O_TRUNC */
+    char buf[64];
+    ASSERT_EQ((int64_t)2, hl_cap_fs_read(&c, "out/result.bin", buf, sizeof(buf), &err));
+    ASSERT_EQ(0, memcmp(buf, "BB", 2));                                       /* NOT "BBAAAA" */
+
+    hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── PATTERN write: creates only matched nonterminal dirs + the terminal file ─── */
+UTEST(fs_authz, pattern_write_creates_matched)
+{
+    setup(); build_tree();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *g[] = { "logs/*/*.txt" };      /* logs/ absent; in both sets */
+    ASSERT_EQ(0, build_policy(&a, g, 1, g, 1, &p, &err));
+    HlFsConfig c = cfg_with(&p);
+
+    ASSERT_EQ(0, hl_cap_fs_write(&c, "logs/2026/a.txt", "L", 1, &err));      /* creates logs/2026 + a.txt */
+    struct stat st; char dp[512]; snprintf(dp, sizeof(dp), "%s/logs/2026", base);
+    ASSERT_EQ(0, stat(dp, &st)); ASSERT_TRUE(S_ISDIR(st.st_mode));
+    char buf[8];
+    ASSERT_EQ((int64_t)1, hl_cap_fs_read(&c, "logs/2026/a.txt", buf, sizeof(buf), &err));
+    err = NULL;
+    ASSERT_EQ(-1, hl_cap_fs_write(&c, "logs/2026/a.csv", "x", 1, &err));     /* .csv not matched */
+    ASSERT_STREQ("permission", err);
+    err = NULL;
+    ASSERT_EQ(-1, hl_cap_fs_write(&c, "logs/2026/sub/a.txt", "x", 1, &err)); /* '*' never crosses '/' */
+    ASSERT_STREQ("permission", err);
+
+    hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── no policy on the cfg -> denied (the no-grant migration) ──────────────────── */
+UTEST(fs_authz, no_policy_denies)
+{
+    setup(); build_tree();
+    HlFsConfig c; memset(&c, 0, sizeof c);
+    c.base_dir = base; c.base_len = strlen(base); c.policy = NULL;
+    char buf[64]; const char *err = NULL;
+    ASSERT_EQ((int64_t)-1, hl_cap_fs_read(&c, "r.txt", buf, sizeof(buf), &err));
+    ASSERT_STREQ("permission", err);
+    err = NULL;
+    ASSERT_EQ(-1, hl_cap_fs_write(&c, "r.txt", "x", 1, &err));
+    ASSERT_STREQ("permission", err);
+    teardown();
+}
+
+/* ── manifest compile SKIPS unparseable grants (absolute etc.), keeps valid ───── */
+UTEST(fs_authz, manifest_skips_unparseable_grants)
+{
+    setup(); build_tree();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    /* an absolute grant (a kernel-sandbox path, e.g. tui_log_tailer's LOG_FILE) is
+     * SKIPPED so app load never fails; the valid relative grant is kept. */
+    const char *rd[] = { "/tmp/hull-tail.log", "r.txt" };
+    ASSERT_EQ(0, hl_fs_policy_compile_manifest(base, &a, rd, 2, NULL, 0, &p, &err));
+    ASSERT_EQ((size_t)1, p.read_n);            /* only r.txt kept */
+
+    HlFsConfig c = cfg_with(&p);
+    char buf[8];
+    ASSERT_EQ((int64_t)1, hl_cap_fs_read(&c, "r.txt", buf, sizeof(buf), &err)); /* kept grant works */
+    err = NULL;
+    ASSERT_EQ((int64_t)-1, hl_cap_fs_read(&c, "secret.txt", buf, sizeof(buf), &err)); /* ungranted */
+    ASSERT_STREQ("permission", err);
+
+    hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+UTEST_MAIN();

--- a/tests/hull/cap/test_fs_resolve.c
+++ b/tests/hull/cap/test_fs_resolve.c
@@ -480,4 +480,37 @@ UTEST(fs_resolve, open_dir_mode)
     close(root); teardown();
 }
 
+/* ── HL_FS_SYMLINK_REFUSE: FOLLOW resolves symlinks, REFUSE denies them
+ * (intermediate + terminal), on both openat2 and the forced-manual walk. ─────── */
+UTEST(fs_resolve, symlink_refuse_mode)
+{
+    setup();
+    mkdirp_host("rd"); wfile("rd/f", "x");
+    symln("rd", "dl");            /* symlink -> dir (interior component) */
+    symln("rd/f", "fl");          /* symlink -> file (terminal component) */
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    ASSERT_GE(root, 0);
+    for (int pass = 0; pass < 2; pass++) {
+        select_path(pass);
+        /* FOLLOW (the default) resolves both symlinks */
+        err = NULL;
+        int fd = hl_fs_open_at_ex(root, "dl/f", HL_FS_OPEN_READ, HL_FS_SYMLINK_FOLLOW, 0, &err);
+        ASSERT_GE(fd, 0); close(fd);
+        err = NULL;
+        fd = hl_fs_open_at_ex(root, "fl", HL_FS_OPEN_READ, HL_FS_SYMLINK_FOLLOW, 0, &err);
+        ASSERT_GE(fd, 0); close(fd);
+        /* REFUSE denies an interior symlink... */
+        err = NULL;
+        fd = hl_fs_open_at_ex(root, "dl/f", HL_FS_OPEN_READ, HL_FS_SYMLINK_REFUSE, 0, &err);
+        ASSERT_EQ(fd, -1); ASSERT_STREQ("symlink_denied", err);
+        /* ...and a terminal symlink */
+        err = NULL;
+        fd = hl_fs_open_at_ex(root, "fl", HL_FS_OPEN_READ, HL_FS_SYMLINK_REFUSE, 0, &err);
+        ASSERT_EQ(fd, -1); ASSERT_STREQ("symlink_denied", err);
+    }
+    unsetenv("HL_FS_FORCE_MANUAL");
+    close(root); teardown();
+}
+
 UTEST_MAIN();

--- a/tests/hull/cap/test_wasm_spans.c
+++ b/tests/hull/cap/test_wasm_spans.c
@@ -32,6 +32,7 @@
 #include "hull/cap/wasm_data.h"
 #include "hull/worker_wasm.h"
 #include "hull/cap/fs.h"
+#include "hull/cap/fs_policy.h"
 #include "hull/vfs.h"
 #include "hull/utils/alloc.h"
 #include "wasm_export.h"
@@ -53,7 +54,9 @@
 UTEST_MAIN();
 
 static char test_dir[256];
-static HlFsConfig cfg;
+static HlFsConfig  cfg;
+static HlFsPolicy  cfg_policy = HL_FS_POLICY_INIT;
+static HlAllocator cfg_alloc;
 
 static void setup(void)
 {
@@ -61,9 +64,23 @@ static void setup(void)
     mkdir(test_dir, 0755);
     cfg.base_dir = test_dir;
     cfg.base_len = strlen(test_dir);
+
+    /* checkpoint 3: fs read/write/mmap are policy-gated. These tests write files
+     * under test_dir then mmap them, so grant the whole dir (base-root ".") in
+     * BOTH the read and write sets. */
+    hl_alloc_init(&cfg_alloc, 0);
+    cfg_policy = HL_FS_POLICY_INIT;
+    const char *g[] = { "." };
+    const char *perr = NULL;
+    if (hl_fs_policy_compile_manifest(test_dir, &cfg_alloc, g, 1, g, 1,
+                                      &cfg_policy, &perr) != 0)
+        fprintf(stderr, "test_wasm_spans setup: policy: %s\n", perr ? perr : "?");
+    cfg.policy = &cfg_policy;
 }
 static void teardown_dir(void)
 {
+    hl_fs_policy_free(&cfg_policy);   /* close held anchor fds; idempotent */
+    cfg.policy = NULL;
     /* best-effort: unlink the files we create + rmdir. */
     char p[512];
     const char *names[] = { "a.bin", "b.bin", "c.bin", "big.bin", "big2.bin" };


### PR DESCRIPTION
Slice B of the hull.fs design (docs/hull_fs_design.md sec. 6): read/write/mmap now
resolve through the compiled authorization policy (Slice A, #403) + the virtual-root
resolver. An op selects an entry for (path, mode) - read/mmap from the READ set,
write from the WRITE set - then opens the LITERAL residual under the selected
entry's HELD anchor fd (never a reconstructed host path), with a per-kind symlink
policy: SUBTREE follows in-root symlinks (contained within its anchor);
EXACT/CREATE/PATTERN REFUSE any symlink so it cannot alias a non-authorized target.
No matching grant -> permission (fail closed). stat/list stay out (Slice C).

Acceptance boundary (test_fs_authz.c, through the cap layer):
- read/mmap select only from fs.read; write only from fs.write
- no matching grant -> permission
- SUBTREE follows symlinks but stays confined to its held anchor (an escaping
  absolute symlink is clamped to base, never the host file)
- EXACT/CREATE/PATTERN refuse intermediate + terminal symlinks
- CREATE permits only the constrained components and preserves O_TRUNC
- PATTERN writes create only matched nonterminal dirs + the terminal file
- selection/opening use the literal residual, no host-path reconstruction
- no-grant migration: cfg wired only when grants exist -> no-grant app denied;
  manifest compile SKIPS unparseable (absolute) grants so app load never fails
- read/mmap/windowed-mmap/write remain green (test_fs migrated to a policy)

New resolver mode HL_FS_SYMLINK_REFUSE (hl_fs_open_at_ex) tested on both openat2
and the forced-manual walk. blob is unaffected (base_dir + raw fds under the kernel
sandbox, not the policy).

Local: fs suite green (resolve 23, fs 37, authz 7, policy 15), test_lua 172,
test_js 154; static analyzer clean. Held at the Slice-B boundary; Slice C
(stat + deterministic list) follows.