### PR TITLE
fs: add fs.stat + deterministic fs.list (checkpoint 3, Slice C)

### DIFF
--- a/docs/api/lua.md
+++ b/docs/api/lua.md
@@ -401,9 +401,65 @@ local rows = db.query("SELECT id, hull_double(score) AS doubled FROM games")
 
 ---
 
-(Continuing through `http`, `fs`, `crypto`, `time`, `env`, `log`, then
+(Continuing through `http`, `crypto`, `time`, `env`, `log`, then
 stdlib modules and middleware. Representative slice complete for
 review.)
+
+---
+
+### `fs.*` table — Filesystem
+
+`require("hull.fs")`. Every path is relative to the app root, resolved through the
+descriptor-relative virtual-root resolver + the compiled authorization policy: an
+op selects from `fs.read` (read / stat / list / mmap) or `fs.write` (write), then
+resolves the literal path under the selected grant's held anchor. Absolute paths
+and `..` are rejected. See [Filesystem grants](#filesystem-grants).
+
+#### `fs.read(path)` / `fs.write(path, bytes)` / `fs.mmap(path[, {offset, length}])`
+
+`read` returns the whole file as a binary-safe string (or `nil, err`); `write`
+creates missing parents + the file and returns `true` (or `nil, err`); `mmap`
+returns a read-only `MappedBuffer` (optionally a page-aligned window).
+
+#### `fs.stat(path)`
+
+Return a metadata table, or `nil` when the path does not exist (so `fs.stat(p) ~=
+nil` subsumes an `exists` check). On a policy / IO error returns `nil, err`.
+**lstat semantics:** a terminal symlink is reported **as a link** (`type =
+"symlink"`), never followed — a metadata op cannot alias a symlink target.
+
+| Field   | Type      | Description |
+|---------|-----------|-------------|
+| `type`  | `string`  | `"file"`, `"dir"`, `"symlink"`, or `"other"` (FIFO / socket / device). |
+| `size`  | `integer` | Size in bytes. |
+| `mode`  | `integer` | Permission bits (`st_mode & 0o777`). |
+| `mtime` | `integer` | Modification time, epoch seconds. Reproducible builds MUST NOT key on it. |
+
+Requires `fs.read` authority over `path`.
+
+#### `fs.list(dir)`
+
+Return a **deterministically ordered** array of `{ name, type, size }` (non-recursive;
+`.` and `..` omitted), or `nil, err`. **Ordering** is unsigned-byte lexicographic,
+shorter-prefix-first — identical on every platform, independent of locale and
+`readdir` order. Each entry's `type` comes from an lstat, so a symlink child is
+reported as `"symlink"`, never followed. An empty directory yields `{}`; a missing
+directory yields `nil, "not_found"`.
+
+Selection is gated by `fs.read`: a **directory** grant lists any descendant
+directory; a single-terminal **pattern** grant (e.g. `data/*.csv`) lists its
+directory exposing **only matching names**; an **exact-file** grant is not a
+listable directory (so it can neither list its parent nor inspect siblings). When
+grants overlap, the **most specific** governs (a narrower grant shadows a broader
+one, and a governing multi-component pattern such as `logs/*/*.txt` denies
+`list("logs")` rather than falling through to a `logs/` subtree grant).
+
+**Error tokens** (Lua returns `nil, token`; JS throws with the token in the
+message): `permission`, `invalid_path`, `not_found`, `not_a_directory`,
+`symlink_denied`, `too_many_entries`, `listing_too_large`, `name_too_long`,
+`size_unrepresentable`, `io_error`. A size beyond `2^53 - 1` errors
+(`size_unrepresentable`) rather than returning a rounded number, so Lua and JS
+agree exactly.
 
 ---
 

--- a/docs/api/lua.md
+++ b/docs/api/lua.md
@@ -435,7 +435,10 @@ nil` subsumes an `exists` check). On a policy / IO error returns `nil, err`.
 | `mode`  | `integer` | Permission bits (`st_mode & 0o777`). |
 | `mtime` | `integer` | Modification time, epoch seconds. Reproducible builds MUST NOT key on it. |
 
-Requires `fs.read` authority over `path`.
+Requires `fs.read` authority over `path`. A directory is statable too, including
+the app root itself — `fs.stat(".")` returns `{ type = "dir", ... }` under a
+base-root (`.`) grant. A path that is authorized but does not exist (including a
+grant whose parent directory is still absent) returns `nil`, not an error.
 
 #### `fs.list(dir)`
 
@@ -448,11 +451,13 @@ directory yields `nil, "not_found"`.
 
 Selection is gated by `fs.read`: a **directory** grant lists any descendant
 directory; a single-terminal **pattern** grant (e.g. `data/*.csv`) lists its
-directory exposing **only matching names**; an **exact-file** grant is not a
-listable directory (so it can neither list its parent nor inspect siblings). When
-grants overlap, the **most specific** governs (a narrower grant shadows a broader
-one, and a governing multi-component pattern such as `logs/*/*.txt` denies
-`list("logs")` rather than falling through to a `logs/` subtree grant).
+directory exposing **only matching names**; an **exact-file** grant authorizes
+that path but it is not a directory, so `list` of the exact file returns
+`not_a_directory` while its **parent and siblings** (unauthorized) return
+`permission`. When grants overlap, the **most specific** governs (a narrower grant
+shadows a broader one, and a governing multi-component pattern such as
+`logs/*/*.txt` denies `list("logs")` rather than falling through to a `logs/`
+subtree grant).
 
 **Error tokens** (Lua returns `nil, token`; JS throws with the token in the
 message): `permission`, `invalid_path`, `not_found`, `not_a_directory`,

--- a/include/hull/cap/fs.h
+++ b/include/hull/cap/fs.h
@@ -129,6 +129,138 @@ int hl_cap_fs_exists(const HlFsConfig *cfg, const char *path,
 int hl_cap_fs_delete(const HlFsConfig *cfg, const char *path,
                      const char **err_msg);
 
+/* ── Metadata (stat) + enumeration (list): checkpoint 3, Slice C ─────── */
+
+/**
+ * @brief Node type in a stat / list result.
+ *
+ * Reported via `fstatat(..., AT_SYMLINK_NOFOLLOW)` - lstat semantics. A symlink is
+ * #HL_FS_NODE_SYMLINK (its OWN type, NEVER followed), so a metadata op cannot alias
+ * a symlink target. Ratified metadata contract for terminal symlinks (preserving
+ * checkpoint-3 Slice A): an EXACT grant CANNOT name an existing symlink (the policy
+ * refuses it at compile), so a reported #HL_FS_NODE_SYMLINK is only ever reached
+ * through a SUBTREE/PATTERN grant, or when an authorized regular/absent target was
+ * REPLACED by a symlink after compile (TOCTOU) - and even then stat/list only
+ * REPORT the link while read/mmap still refuse it (`symlink_denied`).
+ */
+typedef enum {
+    HL_FS_NODE_FILE = 0,
+    HL_FS_NODE_DIR,
+    HL_FS_NODE_SYMLINK,
+    HL_FS_NODE_OTHER,     /**< FIFO, socket, device, ... - reported, never opened. */
+} HlFsNodeType;
+
+/**
+ * @brief Portable numeric ceiling for a metadata size (2^53 - 1).
+ *
+ * A file whose `st_size` exceeds this makes stat / list FAIL with
+ * `"size_unrepresentable"` rather than return a rounded value, so Lua and JS agree
+ * EXACTLY (Lua could hold int64, but is capped identically for parity). 2^53 - 1 is
+ * JavaScript's exact-integer limit; no real file approaches 8 PiB, so this is a
+ * fail-closed portability guard, never a practical limit.
+ */
+#define HL_FS_SIZE_MAX ((uint64_t)((1ULL << 53) - 1))
+
+/**
+ * @name fs.list resource bounds
+ * Exceeding ANY bound FAILS the whole op (freeing everything, no partial result) -
+ * a listing is never silently truncated, and a malformed / over-long entry is never
+ * silently skipped.
+ * @{
+ */
+#define HL_FS_LIST_MAX_ENTRIES     65536u                /**< over -> "too_many_entries" */
+#define HL_FS_LIST_MAX_NAME_BYTES  255u                  /**< NAME_MAX; over -> "name_too_long" */
+#define HL_FS_LIST_MAX_TOTAL_BYTES (4u * 1024u * 1024u)  /**< sum of names; over -> "listing_too_large" */
+/** @} */
+
+/** @brief Stable metadata schema returned by @ref hl_cap_fs_stat. */
+typedef struct HlFsStatInfo {
+    HlFsNodeType type;
+    uint64_t     size;    /**< bytes (<= #HL_FS_SIZE_MAX, else the op fails). */
+    uint32_t     mode;    /**< permission bits (`st_mode & 0777`). */
+    int64_t      mtime;   /**< modification time, epoch seconds. */
+} HlFsStatInfo;
+
+/** @brief One entry in a @ref hl_cap_fs_list result. */
+typedef struct HlFsDirEntry {
+    char        *name;    /**< NUL-terminated, allocated by the list allocator. */
+    HlFsNodeType type;
+    uint64_t     size;    /**< bytes (<= #HL_FS_SIZE_MAX). */
+} HlFsDirEntry;
+
+/**
+ * @brief Stat a path's metadata (lstat semantics). Requires `fs.read` authority.
+ *
+ * Selects from the policy READ set, resolves the leaf's PARENT under the selected
+ * anchor with the per-kind symlink rule (SUBTREE follows contained; EXACT / CREATE
+ * / PATTERN refuse intermediate symlinks), then `fstatat(parent, leaf,
+ * AT_SYMLINK_NOFOLLOW)` - the leaf is NEVER opened or followed.
+ *
+ * @param cfg      Filesystem config. NULL policy (no grants) -> `-1` "permission".
+ * @param path     Relative path; selected + resolved through the policy.
+ * @param out      Non-NULL; populated only on return 0.
+ * @param err_msg  Out-parameter for a stable error token; may be NULL.
+ *
+ * @return Three-valued:
+ *   - `0`  present: `*out` fully populated.
+ *   - `1`  ABSENT: the authorized path does not exist. `*out` untouched, `*err_msg`
+ *          NULL. (Bindings map this to `nil` / `null`; `stat(p) ~= nil` thus
+ *          subsumes a separate `exists` probe.)
+ *   - `-1` ERROR: `*err_msg` set (`"permission"`, `"invalid_path"`,
+ *          `"symlink_denied"`, `"size_unrepresentable"`, `"io_error"`); `*out`
+ *          untouched.
+ */
+int hl_cap_fs_stat(const HlFsConfig *cfg, const char *path,
+                   HlFsStatInfo *out, const char **err_msg);
+
+/**
+ * @brief List a directory's immediate entries (non-recursive), deterministic order.
+ *        Requires `fs.read` authority.
+ *
+ * Selects from the policy READ set: a SUBTREE grant lists any descendant directory
+ * (all children); a single-terminal PATTERN grant lists its literal-prefix directory
+ * exposing ONLY names matching the pattern; an EXACT / CREATE grant is not a listable
+ * directory (denied). `.` and `..` are omitted. Each entry's type/size come from
+ * `fstatat(dirfd, name, AT_SYMLINK_NOFOLLOW)` - a symlink child is reported as such,
+ * never followed. One held directory fd is used throughout (O(1) open fds).
+ *
+ * ORDERING (documented, cross-platform stable): entries are sorted by `name` in
+ * UNSIGNED-BYTE lexicographic order, shorter-prefix-first (`memcmp` over the shared
+ * length; on a tie the shorter name precedes) - independent of locale and of the
+ * platform `readdir()` order, so Linux / macOS / cosmo return byte-identical lists.
+ *
+ * OWNERSHIP + RETURN CONTRACT:
+ *   - On success returns `0`, sets `*out_entries` (an array the CALLER owns, freed
+ *     with @ref hl_cap_fs_list_free) and `*out_count`. An empty directory yields
+ *     count 0 with `*out_entries == NULL`. Names + array are allocated via `alloc`
+ *     (the tracked allocator; NULL = raw malloc), so the free accounts exactly.
+ *   - On ANY failure returns `-1` with `*err_msg` set, `*out_entries == NULL`,
+ *     `*out_count == 0`. NO PARTIAL RESULT IS EVER OBSERVABLE: a failure midway
+ *     (a bound, a malformed / over-long entry, an allocation failure) frees every
+ *     name and the array before returning.
+ *   - Bounds each FAIL (never truncate): #HL_FS_LIST_MAX_ENTRIES
+ *     (`"too_many_entries"`), #HL_FS_LIST_MAX_TOTAL_BYTES (`"listing_too_large"`),
+ *     #HL_FS_LIST_MAX_NAME_BYTES (`"name_too_long"`), any `st_size` > #HL_FS_SIZE_MAX
+ *     (`"size_unrepresentable"`).
+ *
+ * @return `0` on success, `-1` on failure. Stable tokens: `"permission"`,
+ *         `"invalid_path"`, `"not_found"`, `"not_a_directory"`, `"symlink_denied"`,
+ *         `"too_many_entries"`, `"listing_too_large"`, `"name_too_long"`,
+ *         `"size_unrepresentable"`, `"io_error"`.
+ */
+int hl_cap_fs_list(const HlFsConfig *cfg, const char *path,
+                   HlFsDirEntry **out_entries, size_t *out_count,
+                   HlAllocator *alloc, const char **err_msg);
+
+/**
+ * @brief Free a list returned by @ref hl_cap_fs_list.
+ *
+ * Frees each entry's `name` then the array, via the SAME `alloc` passed to
+ * @ref hl_cap_fs_list (NULL = raw malloc/free). NULL-safe; a count of 0 / NULL
+ * array is a no-op. Discard the pointer after return.
+ */
+void hl_cap_fs_list_free(HlFsDirEntry *entries, size_t count, HlAllocator *alloc);
+
 /* ── Memory-mapped file buffer ─────────────────────────────────────── */
 
 /**

--- a/include/hull/cap/fs_policy.h
+++ b/include/hull/cap/fs_policy.h
@@ -18,10 +18,12 @@
  * the kernel sandbox stays as defense-in-depth BENEATH it. An app with no grants
  * authorizes nothing (fails closed).
  *
- * Slice A (this header + fs_policy.c + test_fs_policy.c) is the policy CORE:
- * parse grants, compile grants -> entries (descriptor-bound), and deterministic
- * most-specific selection. It does NOT wire into hl_cap_fs read/write/mmap
- * (Slice B) and does NOT add stat/list (Slice C).
+ * Slice A was the policy CORE: parse grants, compile grants -> entries
+ * (descriptor-bound), and deterministic most-specific file selection
+ * (hl_fs_policy_select). Slice B wired that into hl_cap_fs read/write/mmap. Slice C
+ * adds enumeration selection (hl_fs_policy_select_list) for fs.stat / fs.list; a
+ * SUBTREE lists any descendant directory, a single-terminal PATTERN exposes only
+ * matching names, and EXACT/CREATE are not listable directories.
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -337,6 +339,81 @@ int hl_fs_policy_compile_manifest(const char *base_dir, HlAllocator *alloc,
  */
 HlFsSelection hl_fs_policy_select(const HlFsPolicy *policy, const char *caller_path,
                                   HlFsOpenMode mode, char *scratch, size_t scratch_len);
+
+/*
+ * The result of selecting an entry to ENUMERATE a directory (fs.list, Slice C).
+ * Distinct from hl_fs_policy_select (which selects a FILE leaf for read/write/stat):
+ * listing targets a DIRECTORY, and a PATTERN grant must expose ONLY matching names.
+ *
+ *   entry    - selected entry, or NULL == denied (err set).
+ *   residual - the directory to enumerate, relative to entry->anchor_fd, written
+ *              INTO scratch ("." for the anchor itself). OWNED BY SCRATCH.
+ *   filter   - NULL for a SUBTREE entry (every child returned). For a PATTERN entry,
+ *              the single terminal pattern component (e.g. "*.csv") that each
+ *              enumerated child NAME must byte-match (component-scoped) to be
+ *              returned. Points into entry->grant (valid for the policy lifetime),
+ *              never into scratch.
+ *   sympol   - HL_FS_SYMLINK_FOLLOW for SUBTREE, HL_FS_SYMLINK_REFUSE for PATTERN,
+ *              applied to the walk that opens `residual` as a directory.
+ */
+typedef struct {
+    const HlFsAuthEntry *entry;
+    const char          *residual;
+    const char          *filter;
+    HlFsSymlink          sympol;
+    const char          *err;
+} HlFsListSelection;
+
+/*
+ * Select the entry authorizing ENUMERATION of directory `caller_path` from the READ
+ * set. Pure (NO filesystem access), deterministic, same specificity order as
+ * hl_fs_policy_select. Per kind:
+ *   - SUBTREE: the caller directory at/under the grant is listable; filter = NULL
+ *     (all children); every descendant directory is enumerable.
+ *   - EXACT / CREATE: a file (or absent) grant is NEVER a listable directory -> no
+ *     match, so a caller can list neither the grant nor its parent nor its siblings.
+ *   - PATTERN: GOVERNS listing of the grant's literal PREFIX directory (grant[0 ..
+ *     first_pattern)) when `caller_path` equals that prefix. It is LISTABLE only for
+ *     a SINGLE-TERMINAL-COMPONENT pattern (v1 restriction: first_pattern ==
+ *     grant_n - 1) -> filter = grant[first_pattern]. A governing MULTI-component
+ *     pattern (first_pattern < grant_n - 1, e.g. `logs`+`*`+`*.txt`) is NOT listable
+ *     in v1 -> "permission": depth-aware pattern enumeration would reveal intermediate
+ *     names matching an earlier '*' that contain no authorized terminal file, a
+ *     metadata-exposure widening that deserves a separate design.
+ *   - EXACT / CREATE: a file (or absent) grant NEVER governs a directory listing.
+ *
+ * MOST-SPECIFIC SHADOWING RUNS BEFORE THE LISTABILITY CHECK (deliberate, tested):
+ * selection scans in stored priority order (specificity DESC, then grant-text ASC)
+ * and the FIRST entry that GOVERNS `caller_path` is chosen; the per-kind listability
+ * decision is then made ON THAT ENTRY. A narrower governing entry therefore SHADOWS
+ * a broader overlapping one and its verdict stands - it is NOT skipped to fall
+ * through to the broader grant. With both `logs/` (SUBTREE) and `logs`+`*`+`*.txt`
+ * (PATTERN), `list("logs")` selects the more-specific multi-component PATTERN and
+ * returns "permission"; it must NOT list via the SUBTREE. Likewise multiple
+ * same-prefix terminal patterns (`data`+`*.csv` and `data`+`*.txt`) resolve to the
+ * single most-specific/lexicographic winner and apply ITS filter alone - this is
+ * deterministic policy selection, NEVER a union of filters. Dedicated tests lock
+ * both cases. (Deeper callers where only the SUBTREE governs - e.g. `list("logs/x")`
+ * - are authorized by the SUBTREE as normal; shadowing bites only at the overlap.)
+ *
+ * Errors (stable tokens, fail closed): no governing entry -> entry == NULL, err =
+ * "permission"; a governing-but-unlistable entry -> entry == NULL, err = "permission";
+ * a lexically invalid caller path (absolute / ".." / trailing slash) -> "invalid_path";
+ * a `scratch` shorter than strlen(caller_path)+2 -> "invalid_args".
+ */
+HlFsListSelection hl_fs_policy_select_list(const HlFsPolicy *policy,
+                                           const char *caller_path,
+                                           char *scratch, size_t scratch_len);
+
+/*
+ * Match ONE path component `name` (nlen bytes) against a v1 grant pattern component
+ * `pattern` (plen bytes; single-component '*' wildcard, byte-exact, bounded - the
+ * SAME matcher compile/select use). Returns 1 on match, 0 otherwise (including any
+ * component or pattern longer than NAME_MAX, or a NULL argument). fs.list uses it to
+ * filter a PATTERN grant's enumeration to the matching names (via the `filter`
+ * returned by hl_fs_policy_select_list).
+ */
+int hl_fs_pattern_match(const char *pattern, size_t plen, const char *name, size_t nlen);
 
 /*
  * Close every owned anchor/base fd and free the entry arrays via policy->alloc.

--- a/include/hull/cap/fs_policy.h
+++ b/include/hull/cap/fs_policy.h
@@ -341,6 +341,16 @@ HlFsSelection hl_fs_policy_select(const HlFsPolicy *policy, const char *caller_p
                                   HlFsOpenMode mode, char *scratch, size_t scratch_len);
 
 /*
+ * Select the entry authorizing fs.stat of `caller_path` from the READ set. Behaves
+ * exactly like hl_fs_policy_select(HL_FS_OPEN_READ) EXCEPT it also permits the app
+ * ROOT itself (a 0-component "." caller) when a base-root grant governs it - a
+ * metadata op may target a directory, including the root, whereas read/write/mmap
+ * require a named leaf and reject "." with "invalid_path". Same stable error tokens.
+ */
+HlFsSelection hl_fs_policy_select_stat(const HlFsPolicy *policy, const char *caller_path,
+                                       char *scratch, size_t scratch_len);
+
+/*
  * The result of selecting an entry to ENUMERATE a directory (fs.list, Slice C).
  * Distinct from hl_fs_policy_select (which selects a FILE leaf for read/write/stat):
  * listing targets a DIRECTORY, and a PATTERN grant must expose ONLY matching names.

--- a/include/hull/cap/fs_resolve.h
+++ b/include/hull/cap/fs_resolve.h
@@ -19,6 +19,7 @@
 #ifndef HULL_CAP_FS_RESOLVE_H
 #define HULL_CAP_FS_RESOLVE_H
 
+#include <limits.h>    /* NAME_MAX */
 #include <sys/types.h>
 
 /*
@@ -101,5 +102,39 @@ int hl_fs_open_at(int root_fd, const char *relpath, HlFsOpenMode mode,
  */
 int hl_fs_open_at_ex(int root_fd, const char *relpath, HlFsOpenMode mode,
                      HlFsSymlink symlink, mode_t create_mode, const char **err);
+
+/*
+ * Result of resolving a path to its PARENT directory fd + leaf NAME - for a
+ * METADATA op (stat) that must lstat the terminal WITHOUT opening or following it.
+ *
+ *   parent_fd - a HELD directory fd (the caller closes it with close()), or -1 on
+ *               failure. The terminal is named RELATIVE to this fd, so the caller's
+ *               fstatat(parent_fd, leaf, AT_SYMLINK_NOFOLLOW) is descriptor-relative
+ *               and race-resistant (no host path reconstructed).
+ *   leaf      - the terminal component, NUL-terminated (guaranteed <= NAME_MAX
+ *               bytes; never contains '/'), OR the empty string "" when `relpath`
+ *               is the GRANT ROOT (".") and there is no parent-plus-leaf. On "" the
+ *               caller fstat(parent_fd)s the anchor directory itself.
+ */
+typedef struct {
+    int  parent_fd;
+    char leaf[NAME_MAX + 1];
+} HlFsParent;
+
+/*
+ * Resolve `relpath` under `root_fd` to (parent_fd, leaf) for a NO-FOLLOW metadata
+ * op. Every component EXCEPT the terminal is walked with the `symlink` policy
+ * (HL_FS_SYMLINK_FOLLOW = in-root contained; HL_FS_SYMLINK_REFUSE = "symlink_denied"
+ * on ANY symlink), holding the terminal's PARENT dir fd. The TERMINAL is NEVER
+ * opened or followed - the caller lstat()s it via *out. The residual "." (grant
+ * root) yields parent_fd = a fresh O_CLOEXEC dup of root_fd and leaf = "".
+ *
+ * Same lexical contract + stable error tokens as hl_fs_open_at (relative, no "..",
+ * <= HL_FS_MAX_DEPTH components, no trailing slash). On success returns 0 with *out
+ * populated (caller closes out->parent_fd); on failure returns -1 with *err set and
+ * out->parent_fd == -1 (nothing to close).
+ */
+int hl_fs_resolve_parent(int root_fd, const char *relpath, HlFsSymlink symlink,
+                         HlFsParent *out, const char **err);
 
 #endif /* HULL_CAP_FS_RESOLVE_H */

--- a/src/hull/cap/fs.c
+++ b/src/hull/cap/fs.c
@@ -18,6 +18,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <dirent.h>
 #include <errno.h>
 #include <limits.h>
 
@@ -337,6 +338,253 @@ audit:
         hl_audit_end(&w);
     }
     return result;
+}
+
+/* ── Metadata (stat) + enumeration (list): checkpoint 3, Slice C ─────── */
+
+/* Map an lstat'd mode to the public node type (symlink reported as a link). */
+static HlFsNodeType fs_node_type(mode_t m)
+{
+    if (S_ISREG(m))  return HL_FS_NODE_FILE;
+    if (S_ISDIR(m))  return HL_FS_NODE_DIR;
+    if (S_ISLNK(m))  return HL_FS_NODE_SYMLINK;
+    return HL_FS_NODE_OTHER;   /* FIFO, socket, device, ... */
+}
+
+int hl_cap_fs_stat(const HlFsConfig *cfg, const char *path,
+                   HlFsStatInfo *out, const char **err_msg)
+{
+    int result = -1;   /* -1 error, 0 present, 1 absent */
+    if (!cfg || !path || !cfg->base_dir || !out) {
+        if (err_msg) *err_msg = "invalid_args";
+        return -1;
+    }
+    if (!cfg->policy) { if (err_msg) *err_msg = "permission"; return -1; }
+
+    char scratch[HL_FS_PATH_MAX];
+    HlFsSelection sel = hl_fs_policy_select(cfg->policy, path, HL_FS_OPEN_READ,
+                                            scratch, sizeof(scratch));
+    if (!sel.entry) { if (err_msg) *err_msg = sel.err ? sel.err : "permission"; goto audit; }
+
+    {
+        /* SUBTREE follows in-root symlinks (intermediates only); EXACT/CREATE/PATTERN
+         * refuse them. The terminal is NEVER followed - lstat reports a link. */
+        HlFsSymlink sym = (sel.entry->kind == HL_FS_ENTRY_SUBTREE)
+                              ? HL_FS_SYMLINK_FOLLOW : HL_FS_SYMLINK_REFUSE;
+        HlFsParent pr;
+        const char *e = NULL;
+        if (hl_fs_resolve_parent(sel.entry->anchor_fd, sel.residual, sym, &pr, &e) != 0) {
+            if (err_msg) *err_msg = e ? e : "io_error";
+            goto audit;
+        }
+
+        struct stat st;
+        int rc = (pr.leaf[0] == '\0')
+                     ? fstat(pr.parent_fd, &st)
+                     : fstatat(pr.parent_fd, pr.leaf, &st, AT_SYMLINK_NOFOLLOW);
+        int saved = errno;
+        close(pr.parent_fd);
+        if (rc != 0) {
+            if (saved == ENOENT) { result = 1; goto audit; }   /* ABSENT (not an error) */
+            if (err_msg)
+                *err_msg = (saved == EACCES || saved == EPERM) ? "permission" : "io_error";
+            goto audit;
+        }
+        if (st.st_size < 0 || (uint64_t)st.st_size > HL_FS_SIZE_MAX) {
+            if (err_msg) *err_msg = "size_unrepresentable";
+            goto audit;
+        }
+        out->type  = fs_node_type(st.st_mode);
+        out->size  = (uint64_t)st.st_size;
+        out->mode  = (uint32_t)(st.st_mode & 0777);
+        out->mtime = (int64_t)st.st_mtime;
+        result = 0;
+    }
+
+audit:
+    {
+        ShJsonWriter w = hl_audit_begin("fs.stat");
+        sh_json_write_kv_string(&w, "path", path);
+        sh_json_write_kv_int(&w, "result", result);
+        hl_audit_end(&w);
+    }
+    return result;
+}
+
+/* Sort comparator: unsigned-byte lexicographic, shorter-prefix-first. */
+static int fs_direntry_cmp(const void *pa, const void *pb)
+{
+    const HlFsDirEntry *a = (const HlFsDirEntry *)pa;
+    const HlFsDirEntry *b = (const HlFsDirEntry *)pb;
+    size_t la = strlen(a->name), lb = strlen(b->name);
+    size_t m = la < lb ? la : lb;
+    int c = memcmp(a->name, b->name, m);   /* memcmp = unsigned-byte comparison */
+    if (c) return c;
+    if (la != lb) return la < lb ? -1 : 1; /* shorter prefix precedes */
+    return 0;
+}
+
+int hl_cap_fs_list(const HlFsConfig *cfg, const char *path,
+                   HlFsDirEntry **out_entries, size_t *out_count,
+                   HlAllocator *alloc, const char **err_msg)
+{
+    if (out_entries) *out_entries = NULL;
+    if (out_count)   *out_count = 0;
+    if (!cfg || !path || !cfg->base_dir || !out_entries || !out_count) {
+        if (err_msg) *err_msg = "invalid_args";
+        return -1;
+    }
+    if (!cfg->policy) { if (err_msg) *err_msg = "permission"; return -1; }
+
+    int result = -1;
+    HlFsDirEntry *arr = NULL;
+    size_t count = 0, cap = 0, total_bytes = 0;
+    DIR *dirp = NULL;
+
+    char scratch[HL_FS_PATH_MAX];
+    HlFsListSelection sel = hl_fs_policy_select_list(cfg->policy, path,
+                                                     scratch, sizeof(scratch));
+    if (!sel.entry) { if (err_msg) *err_msg = sel.err ? sel.err : "permission"; goto audit; }
+
+    {
+        const char *e = NULL;
+        int dfd = hl_fs_open_at_ex(sel.entry->anchor_fd, sel.residual, HL_FS_OPEN_DIR,
+                                   sel.sympol, 0, &e);
+        if (dfd < 0) { if (err_msg) *err_msg = e ? e : "io_error"; goto audit; }
+
+        dirp = fdopendir(dfd);   /* takes ownership of dfd; closedir closes it */
+        if (!dirp) { close(dfd); if (err_msg) *err_msg = "io_error"; goto audit; }
+    }
+
+    {
+        struct dirent *de;
+        errno = 0;
+        while ((de = readdir(dirp)) != NULL) {
+            const char *name = de->d_name;
+            if (name[0] == '.' &&
+                (name[1] == '\0' || (name[1] == '.' && name[2] == '\0')))
+                continue;   /* skip "." and ".." */
+
+            size_t nlen = strlen(name);
+            /* A malformed / over-long entry FAILS the op; it is never silently
+             * skipped (contract in fs.h). */
+            if (nlen == 0 || nlen > HL_FS_LIST_MAX_NAME_BYTES) {
+                if (err_msg) *err_msg = "name_too_long";
+                goto fail_mid;
+            }
+
+            /* PATTERN filter: only the terminal-pattern matches are exposed. A
+             * non-match is filtered out (NOT a failure). */
+            if (sel.filter &&
+                !hl_fs_pattern_match(sel.filter, strlen(sel.filter), name, nlen))
+                continue;
+
+            if (count >= HL_FS_LIST_MAX_ENTRIES) {
+                if (err_msg) *err_msg = "too_many_entries";
+                goto fail_mid;
+            }
+            if (nlen > HL_FS_LIST_MAX_TOTAL_BYTES - total_bytes) {
+                if (err_msg) *err_msg = "listing_too_large";
+                goto fail_mid;
+            }
+
+            struct stat st;
+            if (fstatat(dirfd(dirp), name, &st, AT_SYMLINK_NOFOLLOW) != 0) {
+                /* An entry that vanished mid-enumeration is a hard failure, not a
+                 * silent skip - the whole list rolls back. */
+                if (err_msg) *err_msg = "io_error";
+                goto fail_mid;
+            }
+            if (st.st_size < 0 || (uint64_t)st.st_size > HL_FS_SIZE_MAX) {
+                if (err_msg) *err_msg = "size_unrepresentable";
+                goto fail_mid;
+            }
+
+            if (count == cap) {
+                size_t ncap = cap ? cap * 2 : 16;
+                HlFsDirEntry *na =
+                    (HlFsDirEntry *)hl_alloc_calloc(alloc, ncap, sizeof(HlFsDirEntry));
+                if (!na) { if (err_msg) *err_msg = "io_error"; goto fail_mid; }
+                if (arr) {
+                    memcpy(na, arr, cap * sizeof(HlFsDirEntry));
+                    hl_alloc_free(alloc, arr, cap * sizeof(HlFsDirEntry));
+                }
+                arr = na;
+                cap = ncap;
+            }
+
+            char *ncopy = (char *)hl_alloc_malloc(alloc, nlen + 1);
+            if (!ncopy) { if (err_msg) *err_msg = "io_error"; goto fail_mid; }
+            memcpy(ncopy, name, nlen);
+            ncopy[nlen] = '\0';
+            arr[count].name = ncopy;
+            arr[count].type = fs_node_type(st.st_mode);
+            arr[count].size = (uint64_t)st.st_size;
+            count++;
+            total_bytes += nlen;
+            errno = 0;
+        }
+        if (errno != 0) {   /* readdir() failure (not end-of-stream) */
+            if (err_msg) *err_msg = "io_error";
+            goto fail_mid;
+        }
+    }
+
+    closedir(dirp);   /* closes the held dir fd */
+    dirp = NULL;
+
+    if (count > 1)
+        qsort(arr, count, sizeof(HlFsDirEntry), fs_direntry_cmp);
+
+    /* Shrink the (doubling-grown) buffer to EXACTLY `count` so the caller's
+     * hl_cap_fs_list_free(entries, count, alloc) frees the exact allocated size -
+     * the tracked allocator requires matching sizes. Past this point `cap` is no
+     * longer read (success falls straight to `audit`), so it is not re-tracked. */
+    if (count > 0 && cap != count) {
+        HlFsDirEntry *shrunk =
+            (HlFsDirEntry *)hl_alloc_calloc(alloc, count, sizeof(HlFsDirEntry));
+        if (!shrunk) { if (err_msg) *err_msg = "io_error"; goto fail_mid; }
+        memcpy(shrunk, arr, count * sizeof(HlFsDirEntry));
+        hl_alloc_free(alloc, arr, cap * sizeof(HlFsDirEntry));
+        arr = shrunk;
+    } else if (count == 0 && arr) {
+        hl_alloc_free(alloc, arr, cap * sizeof(HlFsDirEntry));
+        arr = NULL;
+    }
+
+    *out_entries = arr;
+    *out_count = count;
+    result = 0;
+    goto audit;
+
+fail_mid:
+    /* Complete-result rollback: NO partial result is ever observable. */
+    for (size_t k = 0; k < count; k++)
+        hl_alloc_free(alloc, arr[k].name, strlen(arr[k].name) + 1);
+    if (arr) hl_alloc_free(alloc, arr, cap * sizeof(HlFsDirEntry));
+    if (dirp) closedir(dirp);
+    *out_entries = NULL;
+    *out_count = 0;
+    result = -1;
+
+audit:
+    {
+        ShJsonWriter w = hl_audit_begin("fs.list");
+        sh_json_write_kv_string(&w, "path", path);
+        sh_json_write_kv_int(&w, "entries", result == 0 ? (int64_t)count : -1);
+        sh_json_write_kv_int(&w, "result", result);
+        hl_audit_end(&w);
+    }
+    return result;
+}
+
+void hl_cap_fs_list_free(HlFsDirEntry *entries, size_t count, HlAllocator *alloc)
+{
+    if (!entries) return;
+    for (size_t i = 0; i < count; i++)
+        if (entries[i].name)
+            hl_alloc_free(alloc, entries[i].name, strlen(entries[i].name) + 1);
+    hl_alloc_free(alloc, entries, count * sizeof(HlFsDirEntry));
 }
 
 /* ── Memory-mapped file ────────────────────────────────────────────── */

--- a/src/hull/cap/fs.c
+++ b/src/hull/cap/fs.c
@@ -355,6 +355,10 @@ int hl_cap_fs_stat(const HlFsConfig *cfg, const char *path,
                    HlFsStatInfo *out, const char **err_msg)
 {
     int result = -1;   /* -1 error, 0 present, 1 absent */
+    /* Clear the caller's error slot up front so an ABSENT result (return 1) leaves
+     * *err_msg == NULL even when the caller reuses a pointer that held a prior
+     * token (contract: absent -> no error). */
+    if (err_msg) *err_msg = NULL;
     if (!cfg || !path || !cfg->base_dir || !out) {
         if (err_msg) *err_msg = "invalid_args";
         return -1;
@@ -362,8 +366,9 @@ int hl_cap_fs_stat(const HlFsConfig *cfg, const char *path,
     if (!cfg->policy) { if (err_msg) *err_msg = "permission"; return -1; }
 
     char scratch[HL_FS_PATH_MAX];
-    HlFsSelection sel = hl_fs_policy_select(cfg->policy, path, HL_FS_OPEN_READ,
-                                            scratch, sizeof(scratch));
+    /* stat selection also authorizes the app root itself ("."). */
+    HlFsSelection sel = hl_fs_policy_select_stat(cfg->policy, path,
+                                                 scratch, sizeof(scratch));
     if (!sel.entry) { if (err_msg) *err_msg = sel.err ? sel.err : "permission"; goto audit; }
 
     {
@@ -374,6 +379,10 @@ int hl_cap_fs_stat(const HlFsConfig *cfg, const char *path,
         HlFsParent pr;
         const char *e = NULL;
         if (hl_fs_resolve_parent(sel.entry->anchor_fd, sel.residual, sym, &pr, &e) != 0) {
+            /* A "not_found" from resolution means an intermediate (e.g. a read-set
+             * CREATE's missing ancestor) does not exist -> the authorized path is
+             * ABSENT, not an error. Any other token is a genuine failure. */
+            if (e && strcmp(e, "not_found") == 0) { result = 1; goto audit; }
             if (err_msg) *err_msg = e ? e : "io_error";
             goto audit;
         }
@@ -465,13 +474,15 @@ int hl_cap_fs_list(const HlFsConfig *cfg, const char *path,
                 (name[1] == '\0' || (name[1] == '.' && name[2] == '\0')))
                 continue;   /* skip "." and ".." */
 
-            size_t nlen = strlen(name);
-            /* A malformed / over-long entry FAILS the op; it is never silently
-             * skipped (contract in fs.h). */
-            if (nlen == 0 || nlen > HL_FS_LIST_MAX_NAME_BYTES) {
-                if (err_msg) *err_msg = "name_too_long";
-                goto fail_mid;
-            }
+            /* BOUNDED name-length check: scan at most HL_FS_LIST_MAX_NAME_BYTES + 1
+             * bytes (<= the struct-dirent d_name field on every platform) for the
+             * terminator. A name with no NUL in that window is malformed / over-long
+             * and FAILS the op - never a silent skip, and never an unbounded strlen
+             * that could read past the entry's name storage. */
+            const void *nul = memchr(name, '\0', HL_FS_LIST_MAX_NAME_BYTES + 1);
+            if (!nul) { if (err_msg) *err_msg = "name_too_long"; goto fail_mid; }
+            size_t nlen = (size_t)((const char *)nul - name);
+            if (nlen == 0) { if (err_msg) *err_msg = "io_error"; goto fail_mid; }
 
             /* PATTERN filter: only the terminal-pattern matches are exposed. A
              * non-match is filtered out (NOT a failure). */

--- a/src/hull/cap/fs_policy.c
+++ b/src/hull/cap/fs_policy.c
@@ -547,9 +547,13 @@ void hl_fs_policy_free(HlFsPolicy *policy)
 
 /* Split a validated caller path into components (skipping "."). Returns component
  * count, or -1 with *err on a lexical violation (absolute / ".." / trailing slash
- * / empty / over-deep / over-long component). `comp`/`len` index into `path`. */
+ * / empty / over-deep / over-long component). `comp`/`len` index into `path`.
+ * `allow_empty` = 1 permits a ZERO-component result ("." / "./"): valid only for an
+ * ENUMERATION target (fs.list of the anchor root itself), never for a leaf op
+ * (read/write/stat need a named terminal, so they pass 0 and a 0-component path is
+ * rejected "invalid_path"). */
 static long split_caller(const char *path, const char **comp, size_t *len,
-                         const char **err)
+                         int allow_empty, const char **err)
 {
     if (!path || path[0] == '\0') { *err = "invalid_path"; return -1; }
     if (path[0] == '/' || path[0] == '\\') { *err = "invalid_path"; return -1; }
@@ -571,8 +575,20 @@ static long split_caller(const char *path, const char **comp, size_t *len,
         if (n >= HL_FS_MAX_DEPTH) { *err = "invalid_path"; return -1; }
         comp[n] = s; len[n] = l; n++;
     }
-    if (n == 0) { *err = "invalid_path"; return -1; }
+    if (n == 0 && !allow_empty) { *err = "invalid_path"; return -1; }
     return n;
+}
+
+/* Byte-exact equality of a grant component against a caller component. */
+static int comp_lit_eq(const char *grant_comp, const char *cc, size_t cl)
+{
+    return strlen(grant_comp) == cl && memcmp(grant_comp, cc, cl) == 0;
+}
+
+int hl_fs_pattern_match(const char *pattern, size_t plen, const char *name, size_t nlen)
+{
+    if (!pattern || !name) return 0;
+    return pat_match(pattern, plen, name, nlen);
 }
 
 /* Does the entry authorize caller components ccomp[0..cn)? */
@@ -629,7 +645,7 @@ HlFsSelection hl_fs_policy_select(const HlFsPolicy *policy, const char *caller_p
     const char *ccomp[HL_FS_MAX_DEPTH];
     size_t clen[HL_FS_MAX_DEPTH];
     const char *e = NULL;
-    long cn = split_caller(caller_path, ccomp, clen, &e);
+    long cn = split_caller(caller_path, ccomp, clen, 0 /*leaf op*/, &e);
     if (cn < 0) { sel.err = e; return sel; }
 
     for (size_t i = 0; i < set_n; i++) {                  /* pre-sorted: first match wins */
@@ -653,6 +669,94 @@ HlFsSelection hl_fs_policy_select(const HlFsPolicy *policy, const char *caller_p
 
         sel.entry = ent;
         sel.residual = scratch;
+        sel.err = NULL;
+        return sel;
+    }
+
+    sel.err = "permission";
+    return sel;
+}
+
+/* ── enumeration selection (fs.list) ─────────────────────────────────────────── */
+
+HlFsListSelection hl_fs_policy_select_list(const HlFsPolicy *policy,
+                                           const char *caller_path,
+                                           char *scratch, size_t scratch_len)
+{
+    HlFsListSelection sel = { NULL, NULL, NULL, HL_FS_SYMLINK_FOLLOW, "permission" };
+    if (!policy || !scratch || scratch_len == 0) { sel.err = "invalid_args"; return sel; }
+
+    /* A list target may be the anchor root itself ("."), so 0 components is valid. */
+    const char *ccomp[HL_FS_MAX_DEPTH];
+    size_t clen[HL_FS_MAX_DEPTH];
+    const char *e = NULL;
+    long cn = split_caller(caller_path, ccomp, clen, 1 /*allow_empty*/, &e);
+    if (cn < 0) { sel.err = e; return sel; }
+
+    /* Scan in stored priority order (most-specific first). MOST-SPECIFIC SHADOWING
+     * RUNS BEFORE THE LISTABILITY CHECK: the FIRST entry that GOVERNS `caller_path`
+     * decides, even a governing-but-unlistable one (which denies) - it is never
+     * skipped to fall through to a broader grant. */
+    for (size_t i = 0; i < policy->read_n; i++) {
+        const HlFsAuthEntry *ent = &policy->read[i];
+        int governs = 0, listable = 0;
+        HlFsSymlink sym = HL_FS_SYMLINK_FOLLOW;
+        const char *filter = NULL;
+        size_t residual_end = (size_t)cn;
+
+        if (ent->kind == HL_FS_ENTRY_SUBTREE) {
+            /* Listable at/under the grant directory (all children). */
+            if ((size_t)cn >= ent->grant_n) {
+                int ok = 1;
+                for (size_t k = 0; k < ent->grant_n; k++)
+                    if (!comp_lit_eq(ent->grant[k], ccomp[k], clen[k])) { ok = 0; break; }
+                if (ok) { governs = 1; listable = 1; }   /* FOLLOW, no filter */
+            }
+        } else if (ent->kind == HL_FS_ENTRY_PATTERN) {
+            /* Governs listing ONLY at the grant's literal prefix (caller ==
+             * grant[0 .. first_pattern)). */
+            if ((size_t)cn == ent->first_pattern) {
+                int ok = 1;
+                for (size_t k = 0; k < ent->first_pattern; k++)
+                    if (!comp_lit_eq(ent->grant[k], ccomp[k], clen[k])) { ok = 0; break; }
+                if (ok) {
+                    governs = 1;
+                    /* v1: only a SINGLE terminal pattern component is listable; a
+                     * multi-component pattern governs but is NOT listable (denies). */
+                    if (ent->first_pattern == ent->grant_n - 1) {
+                        listable = 1;
+                        sym = HL_FS_SYMLINK_REFUSE;
+                        filter = ent->grant[ent->first_pattern];
+                    }
+                    residual_end = ent->first_pattern;   /* == cn here */
+                }
+            }
+        }
+        /* EXACT / CREATE never govern a directory listing. */
+
+        if (!governs) continue;
+        if (!listable) { sel.err = "permission"; return sel; }   /* shadow: no fall-through */
+
+        /* residual = caller components [anchor_depth, residual_end) joined by '/',
+         * or "." for the anchor itself. */
+        size_t pos = 0;
+        for (size_t k = ent->anchor_depth; k < residual_end; k++) {
+            size_t need = clen[k] + (pos ? 1 : 0);
+            if (pos + need + 1 > scratch_len) { sel.err = "invalid_args"; return sel; }
+            if (pos) scratch[pos++] = '/';
+            memcpy(scratch + pos, ccomp[k], clen[k]);
+            pos += clen[k];
+        }
+        if (pos == 0) {
+            if (scratch_len < 2) { sel.err = "invalid_args"; return sel; }
+            scratch[pos++] = '.';
+        }
+        scratch[pos] = '\0';
+
+        sel.entry = ent;
+        sel.residual = scratch;
+        sel.filter = filter;
+        sel.sympol = sym;
         sel.err = NULL;
         return sel;
     }

--- a/src/hull/cap/fs_policy.c
+++ b/src/hull/cap/fs_policy.c
@@ -630,11 +630,64 @@ static int entry_matches(const HlFsAuthEntry *e, const char **ccomp, const size_
     #undef LIT_EQ
 }
 
+/* Build the residual for a matched entry into scratch and return the selection.
+ * residual = caller components [anchor_depth, residual_end) joined by '/', or "."
+ * for the anchor itself. */
+static HlFsSelection make_selection(const HlFsAuthEntry *ent, const char **ccomp,
+                                    const size_t *clen, size_t residual_end,
+                                    char *scratch, size_t scratch_len)
+{
+    HlFsSelection sel = { NULL, NULL, "permission" };
+    size_t pos = 0;
+    for (size_t k = ent->anchor_depth; k < residual_end; k++) {
+        size_t need = clen[k] + (pos ? 1 : 0);
+        if (pos + need + 1 > scratch_len) { sel.err = "invalid_args"; return sel; }
+        if (pos) scratch[pos++] = '/';
+        memcpy(scratch + pos, ccomp[k], clen[k]);
+        pos += clen[k];
+    }
+    if (pos == 0) {
+        if (scratch_len < 2) { sel.err = "invalid_args"; return sel; }
+        scratch[pos++] = '.';                          /* grant root: "." not "" */
+    }
+    scratch[pos] = '\0';
+    sel.entry = ent;
+    sel.residual = scratch;
+    sel.err = NULL;
+    return sel;
+}
+
+/* Shared leaf/node selector over one entry set. `allow_empty` = 1 permits a
+ * 0-component caller ("." = the app root), which stat uses but read/write/mmap
+ * do not (they need a named leaf). Deterministic: entries are pre-sorted, first
+ * match wins. */
+static HlFsSelection select_in_set(const HlFsAuthEntry *set, size_t set_n,
+                                   const char *caller_path, int allow_empty,
+                                   char *scratch, size_t scratch_len)
+{
+    HlFsSelection sel = { NULL, NULL, "permission" };
+    if (!scratch || scratch_len == 0) { sel.err = "invalid_args"; return sel; }
+
+    const char *ccomp[HL_FS_MAX_DEPTH];
+    size_t clen[HL_FS_MAX_DEPTH];
+    const char *e = NULL;
+    long cn = split_caller(caller_path, ccomp, clen, allow_empty, &e);
+    if (cn < 0) { sel.err = e; return sel; }
+
+    for (size_t i = 0; i < set_n; i++) {                  /* pre-sorted: first match wins */
+        const HlFsAuthEntry *ent = &set[i];
+        if (!entry_matches(ent, ccomp, clen, cn)) continue;
+        return make_selection(ent, ccomp, clen, (size_t)cn, scratch, scratch_len);
+    }
+    sel.err = "permission";
+    return sel;
+}
+
 HlFsSelection hl_fs_policy_select(const HlFsPolicy *policy, const char *caller_path,
                                   HlFsOpenMode mode, char *scratch, size_t scratch_len)
 {
-    HlFsSelection sel = { NULL, NULL, "permission" };
-    if (!policy || !scratch || scratch_len == 0) { sel.err = "invalid_args"; return sel; }
+    HlFsSelection sel = { NULL, NULL, "invalid_args" };
+    if (!policy) return sel;
 
     const HlFsAuthEntry *set;
     size_t set_n;
@@ -642,39 +695,19 @@ HlFsSelection hl_fs_policy_select(const HlFsPolicy *policy, const char *caller_p
     else if (mode == HL_FS_OPEN_WRITE) { set = policy->write; set_n = policy->write_n; }
     else { sel.err = "permission"; return sel; }          /* invalid mode: fail closed */
 
-    const char *ccomp[HL_FS_MAX_DEPTH];
-    size_t clen[HL_FS_MAX_DEPTH];
-    const char *e = NULL;
-    long cn = split_caller(caller_path, ccomp, clen, 0 /*leaf op*/, &e);
-    if (cn < 0) { sel.err = e; return sel; }
+    return select_in_set(set, set_n, caller_path, 0 /*leaf op*/, scratch, scratch_len);
+}
 
-    for (size_t i = 0; i < set_n; i++) {                  /* pre-sorted: first match wins */
-        const HlFsAuthEntry *ent = &set[i];
-        if (!entry_matches(ent, ccomp, clen, cn)) continue;
-
-        /* residual = caller components [anchor_depth, cn) joined by '/', or "." */
-        size_t pos = 0;
-        for (size_t k = ent->anchor_depth; k < (size_t)cn; k++) {
-            size_t need = clen[k] + (pos ? 1 : 0);
-            if (pos + need + 1 > scratch_len) { sel.err = "invalid_args"; return sel; }
-            if (pos) scratch[pos++] = '/';
-            memcpy(scratch + pos, ccomp[k], clen[k]);
-            pos += clen[k];
-        }
-        if (pos == 0) {
-            if (scratch_len < 2) { sel.err = "invalid_args"; return sel; }
-            scratch[pos++] = '.';                          /* grant root: "." not "" */
-        }
-        scratch[pos] = '\0';
-
-        sel.entry = ent;
-        sel.residual = scratch;
-        sel.err = NULL;
-        return sel;
-    }
-
-    sel.err = "permission";
-    return sel;
+HlFsSelection hl_fs_policy_select_stat(const HlFsPolicy *policy, const char *caller_path,
+                                       char *scratch, size_t scratch_len)
+{
+    HlFsSelection sel = { NULL, NULL, "invalid_args" };
+    if (!policy) return sel;
+    /* stat authorizes the same nodes as a read but ALSO permits the app root
+     * itself (0-component "."), when a base-root grant governs it - read/write/mmap
+     * need a named leaf and reject it. */
+    return select_in_set(policy->read, policy->read_n, caller_path, 1 /*allow root*/,
+                         scratch, scratch_len);
 }
 
 /* ── enumeration selection (fs.list) ─────────────────────────────────────────── */
@@ -704,57 +737,44 @@ HlFsListSelection hl_fs_policy_select_list(const HlFsPolicy *policy,
         const char *filter = NULL;
         size_t residual_end = (size_t)cn;
 
-        if (ent->kind == HL_FS_ENTRY_SUBTREE) {
-            /* Listable at/under the grant directory (all children). */
-            if ((size_t)cn >= ent->grant_n) {
-                int ok = 1;
-                for (size_t k = 0; k < ent->grant_n; k++)
-                    if (!comp_lit_eq(ent->grant[k], ccomp[k], clen[k])) { ok = 0; break; }
-                if (ok) { governs = 1; listable = 1; }   /* FOLLOW, no filter */
-            }
-        } else if (ent->kind == HL_FS_ENTRY_PATTERN) {
-            /* Governs listing ONLY at the grant's literal prefix (caller ==
-             * grant[0 .. first_pattern)). */
-            if ((size_t)cn == ent->first_pattern) {
-                int ok = 1;
-                for (size_t k = 0; k < ent->first_pattern; k++)
-                    if (!comp_lit_eq(ent->grant[k], ccomp[k], clen[k])) { ok = 0; break; }
-                if (ok) {
-                    governs = 1;
-                    /* v1: only a SINGLE terminal pattern component is listable; a
-                     * multi-component pattern governs but is NOT listable (denies). */
-                    if (ent->first_pattern == ent->grant_n - 1) {
-                        listable = 1;
-                        sym = HL_FS_SYMLINK_REFUSE;
-                        filter = ent->grant[ent->first_pattern];
-                    }
-                    residual_end = ent->first_pattern;   /* == cn here */
+        if (ent->kind == HL_FS_ENTRY_PATTERN && (size_t)cn == ent->first_pattern) {
+            /* Listing the pattern's literal-prefix DIRECTORY: enumerate + filter. */
+            int ok = 1;
+            for (size_t k = 0; k < ent->first_pattern; k++)
+                if (!comp_lit_eq(ent->grant[k], ccomp[k], clen[k])) { ok = 0; break; }
+            if (ok) {
+                governs = 1;
+                if (ent->first_pattern == ent->grant_n - 1) {   /* single terminal: listable */
+                    listable = 1;
+                    sym = HL_FS_SYMLINK_REFUSE;
+                    filter = ent->grant[ent->first_pattern];
+                    residual_end = ent->first_pattern;          /* == cn here */
                 }
+                /* multi-component pattern: governs but is NOT listable in v1 (deny). */
             }
+        } else if (entry_matches(ent, ccomp, clen, cn)) {
+            /* The caller is an authorized NODE (not a pattern prefix). Govern it and
+             * let the DIR open decide the outcome: a directory (a SUBTREE descendant,
+             * or a created CREATE-subtree) lists; an authorized FILE (an EXACT grant,
+             * a matched PATTERN terminal, a CREATE-file) reports "not_a_directory";
+             * an absent CREATE target reports "not_found". This preserves the ratified
+             * distinction - the exact path is authorized but is not a directory - so
+             * its unauthorized parent / siblings stay "permission" while the path
+             * itself does not. */
+            governs = 1;
+            listable = 1;
+            sym = (ent->kind == HL_FS_ENTRY_SUBTREE) ? HL_FS_SYMLINK_FOLLOW
+                                                     : HL_FS_SYMLINK_REFUSE;
         }
-        /* EXACT / CREATE never govern a directory listing. */
 
         if (!governs) continue;
-        if (!listable) { sel.err = "permission"; return sel; }   /* shadow: no fall-through */
+        if (!listable) { sel.err = "permission"; return sel; }   /* multi-pattern shadow */
 
-        /* residual = caller components [anchor_depth, residual_end) joined by '/',
-         * or "." for the anchor itself. */
-        size_t pos = 0;
-        for (size_t k = ent->anchor_depth; k < residual_end; k++) {
-            size_t need = clen[k] + (pos ? 1 : 0);
-            if (pos + need + 1 > scratch_len) { sel.err = "invalid_args"; return sel; }
-            if (pos) scratch[pos++] = '/';
-            memcpy(scratch + pos, ccomp[k], clen[k]);
-            pos += clen[k];
-        }
-        if (pos == 0) {
-            if (scratch_len < 2) { sel.err = "invalid_args"; return sel; }
-            scratch[pos++] = '.';
-        }
-        scratch[pos] = '\0';
-
-        sel.entry = ent;
-        sel.residual = scratch;
+        HlFsSelection base = make_selection(ent, ccomp, clen, residual_end,
+                                            scratch, scratch_len);
+        if (!base.entry) { sel.err = base.err; return sel; }     /* scratch too small */
+        sel.entry = base.entry;
+        sel.residual = base.residual;
         sel.filter = filter;
         sel.sympol = sym;
         sel.err = NULL;

--- a/src/hull/cap/fs_resolve.c
+++ b/src/hull/cap/fs_resolve.c
@@ -420,7 +420,8 @@ int hl_fs_resolve_parent(int root_fd, const char *relpath, HlFsSymlink sympol,
     size_t leaf_len = strlen(leaf);
     if (leaf_len == 0 || leaf_len > NAME_MAX) { if (err) *err = "invalid_path"; return -1; }
     if (strcmp(leaf, ".") == 0 || strcmp(leaf, "..") == 0) {
-        if (err) *err = "invalid_path"; return -1;   /* not a nameable leaf */
+        if (err) *err = "invalid_path";              /* not a nameable leaf */
+        return -1;
     }
 
     int parent_fd;

--- a/src/hull/cap/fs_resolve.c
+++ b/src/hull/cap/fs_resolve.c
@@ -383,3 +383,64 @@ int hl_fs_open_at_ex(int root_fd, const char *relpath, HlFsOpenMode mode,
     if (fd < 0 && err) *err = e;
     return fd;
 }
+
+int hl_fs_resolve_parent(int root_fd, const char *relpath, HlFsSymlink sympol,
+                         HlFsParent *out, const char **err)
+{
+    const char *e = "io_error";
+    if (root_fd < 0 || !relpath || !out) { if (err) *err = "invalid_args"; return -1; }
+    out->parent_fd = -1;
+    out->leaf[0] = '\0';
+    if (!caller_path_ok(relpath)) { if (err) *err = "invalid_path"; return -1; }
+    if (caller_component_count(relpath) > HL_FS_MAX_DEPTH) {
+        if (err) *err = "path_too_deep";
+        return -1;
+    }
+
+    /* Grant root ".": there is no parent-plus-leaf. Hand back a CLOEXEC dup of the
+     * anchor and an EMPTY leaf; the caller fstat()s the anchor directory itself.
+     * (caller_path_ok accepted "." - a bare "." is a valid single "." segment.) */
+    if (relpath[0] == '.' && relpath[1] == '\0') {
+        int fd = fcntl(root_fd, F_DUPFD_CLOEXEC, 0);
+        if (fd < 0) { map_errno(errno, &e); if (err) *err = e; return -1; }
+        out->parent_fd = fd;
+        return 0;
+    }
+
+    /* Split the terminal component off lexically. `relpath` is a clean relative path
+     * (no "..", no trailing slash), so the bytes after the final '/' are the leaf and
+     * everything before it is the parent directory. The leaf is NEVER opened here -
+     * the caller lstat()s it - so a terminal symlink is reported, not followed. */
+    size_t len = strlen(relpath);
+    const char *slash = NULL;
+    for (size_t i = len; i-- > 0; ) {
+        if (relpath[i] == '/') { slash = relpath + i; break; }
+    }
+    const char *leaf = slash ? slash + 1 : relpath;
+    size_t leaf_len = strlen(leaf);
+    if (leaf_len == 0 || leaf_len > NAME_MAX) { if (err) *err = "invalid_path"; return -1; }
+    if (strcmp(leaf, ".") == 0 || strcmp(leaf, "..") == 0) {
+        if (err) *err = "invalid_path"; return -1;   /* not a nameable leaf */
+    }
+
+    int parent_fd;
+    if (!slash) {
+        /* Single-component residual: the parent IS the anchor. */
+        parent_fd = fcntl(root_fd, F_DUPFD_CLOEXEC, 0);
+        if (parent_fd < 0) { map_errno(errno, &e); if (err) *err = e; return -1; }
+    } else {
+        char dir[HL_FS_PATH_MAX];
+        size_t dlen = (size_t)(slash - relpath);
+        if (dlen == 0 || dlen >= sizeof(dir)) { if (err) *err = "invalid_path"; return -1; }
+        memcpy(dir, relpath, dlen);
+        dir[dlen] = '\0';
+        /* Walk the intermediates with the per-kind symlink policy; the parent must be
+         * a directory (HL_FS_OPEN_DIR). The leaf stays unopened. */
+        parent_fd = hl_fs_open_at_ex(root_fd, dir, HL_FS_OPEN_DIR, sympol, 0, &e);
+        if (parent_fd < 0) { if (err) *err = e; return -1; }
+    }
+
+    memcpy(out->leaf, leaf, leaf_len + 1);
+    out->parent_fd = parent_fd;
+    return 0;
+}

--- a/src/hull/runtime/js/mod_fs.c
+++ b/src/hull/runtime/js/mod_fs.c
@@ -132,6 +132,99 @@ static JSValue js_fs_write(JSContext *ctx, JSValueConst this_val,
     return JS_TRUE;
 }
 
+/* Map the node-type enum to its stable string label (Lua/JS parity). */
+static const char *js_fs_node_type_name(HlFsNodeType t)
+{
+    switch (t) {
+    case HL_FS_NODE_FILE:    return "file";
+    case HL_FS_NODE_DIR:     return "dir";
+    case HL_FS_NODE_SYMLINK: return "symlink";
+    default:                 return "other";
+    }
+}
+
+/* fs.stat(path) -> { type, size, mode, mtime } | null.
+ * Present -> an object; absent -> null (subsumes `exists`); error -> throw.
+ * lstat semantics: a terminal symlink is type "symlink", never followed. */
+static JSValue js_fs_stat(JSContext *ctx, JSValueConst this_val,
+                          int argc, JSValueConst *argv)
+{
+    (void)this_val;
+    HlJS *js = (HlJS *)JS_GetContextOpaque(ctx);
+    if (!js || !js->base.fs_cfg)
+        return JS_ThrowInternalError(ctx,
+            "fs.stat: not available (declare fs.read in manifest)");
+    if (argc < 1)
+        return JS_ThrowTypeError(ctx, "fs.stat requires (path)");
+
+    const char *path = JS_ToCString(ctx, argv[0]);
+    if (!path) return JS_EXCEPTION;
+
+    const char *err = NULL;
+    HlFsStatInfo info;
+    int rc = hl_cap_fs_stat(js->base.fs_cfg, path, &info, &err);
+    JS_FreeCString(ctx, path);
+    if (rc == 1) return JS_NULL;                          /* absent */
+    if (rc != 0)
+        return JS_ThrowInternalError(ctx, "fs.stat: %s", err ? err : "stat_failed");
+
+    JSValue o = JS_NewObject(ctx);
+    if (JS_IsException(o)) return o;
+    JS_SetPropertyStr(ctx, o, "type", JS_NewString(ctx, js_fs_node_type_name(info.type)));
+    JS_SetPropertyStr(ctx, o, "size", JS_NewInt64(ctx, (int64_t)info.size));
+    JS_SetPropertyStr(ctx, o, "mode", JS_NewInt32(ctx, (int32_t)info.mode));
+    JS_SetPropertyStr(ctx, o, "mtime", JS_NewInt64(ctx, (int64_t)info.mtime));
+    return o;
+}
+
+/* fs.list(dir) -> Array<{ name, type, size }>. Deterministic byte-order
+ * (unsigned-byte lexicographic, shorter first). Empty dir -> []; missing or
+ * denied dir -> throw. */
+static JSValue js_fs_list(JSContext *ctx, JSValueConst this_val,
+                          int argc, JSValueConst *argv)
+{
+    (void)this_val;
+    HlJS *js = (HlJS *)JS_GetContextOpaque(ctx);
+    if (!js || !js->base.fs_cfg)
+        return JS_ThrowInternalError(ctx,
+            "fs.list: not available (declare fs.read in manifest)");
+    if (argc < 1)
+        return JS_ThrowTypeError(ctx, "fs.list requires (path)");
+
+    const char *path = JS_ToCString(ctx, argv[0]);
+    if (!path) return JS_EXCEPTION;
+
+    const char *err = NULL;
+    HlFsDirEntry *entries = NULL;
+    size_t count = 0;
+    int rc = hl_cap_fs_list(js->base.fs_cfg, path, &entries, &count,
+                            js->base.alloc, &err);
+    JS_FreeCString(ctx, path);
+    if (rc != 0)
+        return JS_ThrowInternalError(ctx, "fs.list: %s", err ? err : "list_failed");
+
+    JSValue arr = JS_NewArray(ctx);
+    if (JS_IsException(arr)) {
+        hl_cap_fs_list_free(entries, count, js->base.alloc);
+        return arr;
+    }
+    for (size_t i = 0; i < count; i++) {
+        JSValue o = JS_NewObject(ctx);
+        if (JS_IsException(o)) {
+            JS_FreeValue(ctx, arr);
+            hl_cap_fs_list_free(entries, count, js->base.alloc);
+            return JS_EXCEPTION;
+        }
+        JS_SetPropertyStr(ctx, o, "name", JS_NewString(ctx, entries[i].name));
+        JS_SetPropertyStr(ctx, o, "type",
+                          JS_NewString(ctx, js_fs_node_type_name(entries[i].type)));
+        JS_SetPropertyStr(ctx, o, "size", JS_NewInt64(ctx, (int64_t)entries[i].size));
+        JS_SetPropertyUint32(ctx, arr, (uint32_t)i, o);
+    }
+    hl_cap_fs_list_free(entries, count, js->base.alloc);
+    return arr;
+}
+
 static JSValue js_fs_mmap(JSContext *ctx, JSValueConst this_val,
                           int argc, JSValueConst *argv)
 {
@@ -203,6 +296,10 @@ static int js_fs_module_init(JSContext *ctx, JSModuleDef *m)
                       JS_NewCFunction(ctx, js_fs_read, "read", 1));
     JS_SetPropertyStr(ctx, fs, "write",
                       JS_NewCFunction(ctx, js_fs_write, "write", 2));
+    JS_SetPropertyStr(ctx, fs, "stat",
+                      JS_NewCFunction(ctx, js_fs_stat, "stat", 1));
+    JS_SetPropertyStr(ctx, fs, "list",
+                      JS_NewCFunction(ctx, js_fs_list, "list", 1));
     JS_SetPropertyStr(ctx, fs, "mmap",
                       JS_NewCFunction(ctx, js_fs_mmap, "mmap", 2));
     JS_SetModuleExport(ctx, m, "fs", fs);

--- a/src/hull/runtime/lua/mod_fs.c
+++ b/src/hull/runtime/lua/mod_fs.c
@@ -147,6 +147,87 @@ static int lua_fs_mmap(lua_State *L)
     return 1;
 }
 
+/* Map the node-type enum to its stable string label (Lua/JS parity). */
+static const char *fs_node_type_name(HlFsNodeType t)
+{
+    switch (t) {
+    case HL_FS_NODE_FILE:    return "file";
+    case HL_FS_NODE_DIR:     return "dir";
+    case HL_FS_NODE_SYMLINK: return "symlink";
+    default:                 return "other";   /* FIFO, socket, device, ... */
+    }
+}
+
+/* fs.stat(path) -> { type, size, mode, mtime } | nil | (nil, err).
+ * Present -> a metadata table. Absent -> a single nil (subsumes `exists`).
+ * Error   -> (nil, err) with a stable token. lstat semantics: a terminal
+ * symlink is reported as type "symlink", never followed. */
+static int lua_fs_stat(lua_State *L)
+{
+    HlLua *lua = get_hl_lua(L);
+    if (!lua || !lua->base.fs_cfg) {
+        lua_pushnil(L);
+        lua_pushstring(L, "fs.stat: not available (declare fs.read in manifest)");
+        return 2;
+    }
+    const char *path = luaL_checkstring(L, 1);
+
+    const char *err = NULL;
+    HlFsStatInfo info;
+    int rc = hl_cap_fs_stat(lua->base.fs_cfg, path, &info, &err);
+    if (rc == 1) { lua_pushnil(L); return 1; }        /* absent (not an error) */
+    if (rc != 0) {
+        lua_pushnil(L);
+        lua_pushstring(L, err ? err : "stat_failed");
+        return 2;
+    }
+    lua_createtable(L, 0, 4);
+    lua_pushstring(L, fs_node_type_name(info.type)); lua_setfield(L, -2, "type");
+    lua_pushinteger(L, (lua_Integer)info.size);      lua_setfield(L, -2, "size");
+    lua_pushinteger(L, (lua_Integer)info.mode);      lua_setfield(L, -2, "mode");
+    lua_pushinteger(L, (lua_Integer)info.mtime);     lua_setfield(L, -2, "mtime");
+    return 1;
+}
+
+/* fs.list(dir) -> array of { name, type, size } | (nil, err). Deterministic
+ * byte-order (unsigned-byte lexicographic, shorter first). An empty directory
+ * yields an empty array; a missing/denied directory yields (nil, err). */
+static int lua_fs_list(lua_State *L)
+{
+    HlLua *lua = get_hl_lua(L);
+    if (!lua || !lua->base.fs_cfg) {
+        lua_pushnil(L);
+        lua_pushstring(L, "fs.list: not available (declare fs.read in manifest)");
+        return 2;
+    }
+    const char *path = luaL_checkstring(L, 1);
+
+    const char *err = NULL;
+    HlFsDirEntry *entries = NULL;
+    size_t count = 0;
+    int rc = hl_cap_fs_list(lua->base.fs_cfg, path, &entries, &count,
+                            lua->base.alloc, &err);
+    if (rc != 0) {
+        lua_pushnil(L);
+        lua_pushstring(L, err ? err : "list_failed");
+        return 2;
+    }
+    /* count is bounded by HL_FS_LIST_MAX_ENTRIES (fits int). */
+    lua_createtable(L, (int)count, 0);
+    for (size_t i = 0; i < count; i++) {
+        lua_createtable(L, 0, 3);
+        lua_pushstring(L, entries[i].name);
+        lua_setfield(L, -2, "name");
+        lua_pushstring(L, fs_node_type_name(entries[i].type));
+        lua_setfield(L, -2, "type");
+        lua_pushinteger(L, (lua_Integer)entries[i].size);
+        lua_setfield(L, -2, "size");
+        lua_rawseti(L, -2, (lua_Integer)(i + 1));
+    }
+    hl_cap_fs_list_free(entries, count, lua->base.alloc);
+    return 1;
+}
+
 static HlMappedBuffer *check_mmap(lua_State *L, int idx)
 {
     HlMappedBuffer **pp = luaL_checkudata(L, idx, HL_MMAP_MT);
@@ -225,6 +306,8 @@ static void lua_register_mmap_metatable(lua_State *L)
 static const luaL_Reg fs_funcs[] = {
     {"read",  lua_fs_read},
     {"write", lua_fs_write},
+    {"stat",  lua_fs_stat},
+    {"list",  lua_fs_list},
     {"mmap",  lua_fs_mmap},
     {NULL, NULL}
 };

--- a/tests/e2e_cli.sh
+++ b/tests/e2e_cli.sh
@@ -160,6 +160,64 @@ JS
 run_fs_roundtrip "lua" "lua"
 run_fs_roundtrip "js"  "js"
 
+# ── fs.stat + fs.list parity through app.main (checkpoint 3, Slice C) ─────────
+# Proves the Lua and JS bindings return EQUIVALENT values + error tokens for the
+# metadata (stat) and enumeration (list) surface: present -> metadata, absent ->
+# nil/null, deterministic byte-order list, and a "not_found" token on a missing
+# dir (Lua returns (nil, err); JS throws with the token in the message). The app
+# asserts every case internally and returns 0 only when all match.
+run_fs_statlist() {
+    runtime="$1"; ext="$2"
+    echo "--- fs.stat + fs.list parity via app.main (${runtime}) ---"
+    d=$(mktemp -d)
+    if [ "$ext" = "lua" ]; then
+        cat > "${d}/app.lua" <<'LUA'
+app.manifest({ modules = { "hull/fs@1" }, fs = { read = { "." }, write = { "." } } })
+app.main(function()
+  local fs = require("hull.fs")
+  fs.write("data/a.csv", "1"); fs.write("data/b.txt", "1"); fs.write("data/c.csv", "1")
+  local st = fs.stat("data/a.csv")
+  if not (st and st.type == "file" and st.size == 1) then return 2 end
+  if fs.stat("data/nope") ~= nil then return 3 end            -- absent -> nil
+  local es = fs.list("data")
+  if #es ~= 3 then return 4 end
+  if not (es[1].name == "a.csv" and es[2].name == "b.txt" and es[3].name == "c.csv") then return 5 end
+  if es[1].type ~= "file" then return 6 end                    -- deterministic order
+  local l, err = fs.list("data/missingdir")
+  if l ~= nil or err ~= "not_found" then return 7 end          -- error token
+  return 0
+end)
+LUA
+    else
+        cat > "${d}/app.js" <<'JS'
+import { app } from "hull:app";
+import { fs } from "hull:fs";
+app.manifest({ modules: ["hull/fs@1"], fs: { read: ["."], write: ["."] } });
+app.main(() => {
+  fs.write("data/a.csv", "1"); fs.write("data/b.txt", "1"); fs.write("data/c.csv", "1");
+  const st = fs.stat("data/a.csv");
+  if (!(st && st.type === "file" && st.size === 1)) return 2;
+  if (fs.stat("data/nope") !== null) return 3;                 // absent -> null
+  const es = fs.list("data");
+  if (es.length !== 3) return 4;
+  if (!(es[0].name === "a.csv" && es[1].name === "b.txt" && es[2].name === "c.csv")) return 5;
+  if (es[0].type !== "file") return 6;                          // deterministic order
+  let tok = null;
+  try { fs.list("data/missingdir"); } catch (e) { tok = String(e.message || e); }
+  if (tok === null || tok.indexOf("not_found") < 0) return 7;   // error token
+  return 0;
+});
+JS
+    fi
+    "${HULL_BIN}" "${d}/app.${ext}" >/dev/null 2>&1
+    rc=$?
+    expect_eq "${runtime} fs.stat + fs.list parity via app.main" "0" "${rc}"
+    rm -rf "${d}"
+}
+
+run_fs_statlist "lua" "lua"
+run_fs_statlist "js"  "js"
+
 echo
 echo "${PASS}/$((PASS + FAIL)) CLI e2e tests passed"
 [ "${FAIL}" -eq 0 ]

--- a/tests/hull/cap/test_fs_resolve.c
+++ b/tests/hull/cap/test_fs_resolve.c
@@ -513,4 +513,69 @@ UTEST(fs_resolve, symlink_refuse_mode)
     close(root); teardown();
 }
 
+/* ── hl_fs_resolve_parent: (parent_fd, leaf) for a NO-FOLLOW metadata op ──────── */
+UTEST(fs_resolve, parent_nested_and_root_and_leaf)
+{
+    setup();
+    mkdirp_host("a"); mkdirp_host("a/b"); wfile("a/b/c.txt", "deep");
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    ASSERT_GE(root, 0);
+
+    /* nested: parent walks a/b, leaf = "c.txt"; fstatat off parent_fd finds it. */
+    HlFsParent pr; err = NULL;
+    ASSERT_EQ(0, hl_fs_resolve_parent(root, "a/b/c.txt", HL_FS_SYMLINK_FOLLOW, &pr, &err));
+    ASSERT_GE(pr.parent_fd, 0);
+    ASSERT_STREQ("c.txt", pr.leaf);
+    struct stat st;
+    ASSERT_EQ(0, fstatat(pr.parent_fd, pr.leaf, &st, AT_SYMLINK_NOFOLLOW));
+    ASSERT_TRUE(S_ISREG(st.st_mode));
+    close(pr.parent_fd);
+
+    /* single component: parent IS the anchor (root), leaf is the whole name. */
+    wfile("top.txt", "T"); err = NULL;
+    ASSERT_EQ(0, hl_fs_resolve_parent(root, "top.txt", HL_FS_SYMLINK_FOLLOW, &pr, &err));
+    ASSERT_GE(pr.parent_fd, 0); ASSERT_STREQ("top.txt", pr.leaf);
+    ASSERT_EQ(0, fstatat(pr.parent_fd, pr.leaf, &st, AT_SYMLINK_NOFOLLOW));
+    close(pr.parent_fd);
+
+    /* grant root ".": empty leaf, parent_fd is a dup of the anchor -> fstat the dir. */
+    err = NULL;
+    ASSERT_EQ(0, hl_fs_resolve_parent(root, ".", HL_FS_SYMLINK_FOLLOW, &pr, &err));
+    ASSERT_GE(pr.parent_fd, 0); ASSERT_STREQ("", pr.leaf);
+    ASSERT_EQ(0, fstat(pr.parent_fd, &st));
+    ASSERT_TRUE(S_ISDIR(st.st_mode));
+    close(pr.parent_fd);
+
+    close(root); teardown();
+}
+
+/* ── parent resolution honours the per-kind symlink policy on the WALK, never the
+ * terminal (REFUSE denies a symlinked intermediate; the leaf is never opened) ─── */
+UTEST(fs_resolve, parent_refuses_symlink_intermediate)
+{
+    setup();
+    mkdirp_host("real"); wfile("real/leaf.txt", "L");
+    symln("real", "dl");                        /* dl -> real (dir symlink) */
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    ASSERT_GE(root, 0);
+
+    HlFsParent pr;
+    /* REFUSE: the symlinked intermediate "dl" is denied. */
+    err = NULL;
+    ASSERT_EQ(-1, hl_fs_resolve_parent(root, "dl/leaf.txt", HL_FS_SYMLINK_REFUSE, &pr, &err));
+    ASSERT_STREQ("symlink_denied", err);
+    ASSERT_EQ(-1, pr.parent_fd);
+    /* FOLLOW: the same intermediate is followed contained; leaf resolved off it. */
+    err = NULL;
+    ASSERT_EQ(0, hl_fs_resolve_parent(root, "dl/leaf.txt", HL_FS_SYMLINK_FOLLOW, &pr, &err));
+    ASSERT_GE(pr.parent_fd, 0); ASSERT_STREQ("leaf.txt", pr.leaf);
+    struct stat st;
+    ASSERT_EQ(0, fstatat(pr.parent_fd, pr.leaf, &st, AT_SYMLINK_NOFOLLOW));
+    close(pr.parent_fd);
+
+    close(root); teardown();
+}
+
 UTEST_MAIN();

--- a/tests/hull/cap/test_fs_statlist.c
+++ b/tests/hull/cap/test_fs_statlist.c
@@ -38,8 +38,12 @@ static void mk_file(const char *rel, const char *data)
   FILE *f = fopen(p, "wb"); if (f) { fputs(data, f); fclose(f); } }
 static void mk_link(const char *target, const char *rel)
 { char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel); unlink(p); symlink(target, p); }
+/* cosmo does not declare mkfifo under the feature level Hull's tests use (same as
+ * test_fs_resolve.c); the FIFO-reporting checks are compiled out there. */
+#if !defined(__COSMOPOLITAN__)
 static void mk_fifo(const char *rel)
 { char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel); unlink(p); mkfifo(p, 0644); }
+#endif
 
 /* Compile a policy from raw read/write grant arrays (grants freed here). */
 static int build_policy(HlAllocator *a, const char **rd, size_t rn,
@@ -280,7 +284,10 @@ UTEST(fs_statlist, empty_missing_and_fifo)
 {
     setup();
     mk_dir("empty");
-    mk_dir("data"); mk_file("data/f", "1"); mk_fifo("data/pipe");
+    mk_dir("data"); mk_file("data/f", "1");
+#if !defined(__COSMOPOLITAN__)
+    mk_fifo("data/pipe");
+#endif
     HlAllocator a; hl_alloc_init(&a, 0);
     HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
     const char *rd[] = { "." };                 /* base-root: everything readable */
@@ -298,6 +305,7 @@ UTEST(fs_statlist, empty_missing_and_fifo)
     ASSERT_STREQ("not_found", err);
     ASSERT_TRUE(e == NULL); ASSERT_EQ((size_t)0, n);
 
+#if !defined(__COSMOPOLITAN__)
     /* FIFO is REPORTED as "other" via lstat - never opened (would block) */
     err = NULL;
     ASSERT_EQ(0, hl_cap_fs_list(&c, "data", &e, &n, &a, &err));
@@ -309,6 +317,7 @@ UTEST(fs_statlist, empty_missing_and_fifo)
     HlFsStatInfo st; err = NULL;
     ASSERT_EQ(0, hl_cap_fs_stat(&c, "data/pipe", &st, &err));
     ASSERT_EQ((int)HL_FS_NODE_OTHER, (int)st.type);   /* stat lstat's it; no block */
+#endif
 
     hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&a));
     teardown();

--- a/tests/hull/cap/test_fs_statlist.c
+++ b/tests/hull/cap/test_fs_statlist.c
@@ -1,0 +1,413 @@
+/*
+ * test_fs_statlist.c - hull.fs metadata (stat) + enumeration (list) THROUGH the
+ * cap layer (checkpoint 3, Slice C). Proves the Slice-C acceptance boundary:
+ * READ-only selection; exact-grant cannot list a parent or inspect siblings;
+ * write-only grants leak no metadata; PATTERN enumeration exposes only matches;
+ * SUBTREE symlinks stay confined; terminal symlinks are reported as links (lstat),
+ * never followed; deterministic unsigned-byte ordering; most-specific shadowing
+ * before listability; empty / missing / FIFO cases; and resource-bound rollback.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#if defined(__linux__) && !defined(_XOPEN_SOURCE)
+# define _XOPEN_SOURCE 700
+#endif
+
+#include "utest.h"
+#include "hull/cap/fs.h"
+#include "hull/cap/fs_policy.h"
+#include "hull/utils/alloc.h"
+#include <errno.h>
+#include <ftw.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+static char base[256];
+
+static void setup(void) { snprintf(base, sizeof(base), "/tmp/hull_statlist_%d", (int)getpid()); mkdir(base, 0755); }
+static int rm_e(const char *p, const struct stat *s, int t, struct FTW *f)
+{ (void)s; (void)t; (void)f; return remove(p); }
+static void teardown(void) { if (nftw(base, rm_e, 16, FTW_DEPTH | FTW_PHYS) != 0 && errno != ENOENT) {} }
+
+static void mk_dir(const char *rel)  { char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel); mkdir(p, 0755); }
+static void mk_file(const char *rel, const char *data)
+{ char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel);
+  FILE *f = fopen(p, "wb"); if (f) { fputs(data, f); fclose(f); } }
+static void mk_link(const char *target, const char *rel)
+{ char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel); unlink(p); symlink(target, p); }
+static void mk_fifo(const char *rel)
+{ char p[512]; snprintf(p, sizeof(p), "%s/%s", base, rel); unlink(p); mkfifo(p, 0644); }
+
+/* Compile a policy from raw read/write grant arrays (grants freed here). */
+static int build_policy(HlAllocator *a, const char **rd, size_t rn,
+                        const char **wr, size_t wn, HlFsPolicy *out, const char **err)
+{
+    HlFsGrant rg[8], wg[8]; size_t ri = 0, wi = 0; int rc = -1; const char *e = "?";
+    for (; ri < rn; ri++) if (hl_fs_grant_parse(rd[ri], strlen(rd[ri]), a, &rg[ri], &e) != 0) goto done;
+    for (; wi < wn; wi++) if (hl_fs_grant_parse(wr[wi], strlen(wr[wi]), a, &wg[wi], &e) != 0) goto done;
+    rc = hl_fs_policy_compile(base, a, rg, rn, wg, wn, out, &e);
+done:
+    for (size_t i = 0; i < ri; i++) hl_fs_grant_free(&rg[i]);
+    for (size_t i = 0; i < wi; i++) hl_fs_grant_free(&wg[i]);
+    if (err) *err = e; return rc;
+}
+
+static HlFsConfig cfg_with(HlFsPolicy *p)
+{ HlFsConfig c; memset(&c, 0, sizeof c); c.base_dir = base; c.base_len = strlen(base); c.policy = p; return c; }
+
+/* Find an entry by name in a list; returns its index or -1. */
+static long find_entry(const HlFsDirEntry *e, size_t n, const char *name)
+{ for (size_t i = 0; i < n; i++) if (strcmp(e[i].name, name) == 0) return (long)i; return -1; }
+
+/* ── stat/list select ONLY from the READ set; absent vs error; write-only leaks
+ * no metadata (points 1, 3, 10) ──────────────────────────────────────────────── */
+UTEST(fs_statlist, read_only_selection_absent_and_writeonly)
+{
+    setup();
+    mk_dir("data"); mk_file("data/real.txt", "REAL");
+    mk_file("secret.txt", "S");
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "data" };          /* readable subtree */
+    const char *wr[] = { "wonly.bin" };     /* write-only (absent -> CREATE) */
+    ASSERT_EQ(0, build_policy(&a, rd, 1, wr, 1, &p, &err));
+    HlFsConfig c = cfg_with(&p);
+
+    HlFsStatInfo st;
+    /* present read-set target */
+    err = NULL;
+    ASSERT_EQ(0, hl_cap_fs_stat(&c, "data/real.txt", &st, &err));
+    ASSERT_EQ((int)HL_FS_NODE_FILE, (int)st.type);
+    ASSERT_EQ((uint64_t)4, st.size);
+    /* absent authorized path -> rc 1 (nil), NOT an error */
+    err = NULL;
+    ASSERT_EQ(1, hl_cap_fs_stat(&c, "data/none.txt", &st, &err));
+    ASSERT_TRUE(err == NULL);
+    /* write-only grant reveals no metadata through stat -> permission */
+    err = NULL;
+    ASSERT_EQ(-1, hl_cap_fs_stat(&c, "wonly.bin", &st, &err));
+    ASSERT_STREQ("permission", err);
+    /* ungranted path -> permission */
+    err = NULL;
+    ASSERT_EQ(-1, hl_cap_fs_stat(&c, "secret.txt", &st, &err));
+    ASSERT_STREQ("permission", err);
+
+    /* stat of the SUBTREE anchor itself resolves the "." residual (fstat the dir). */
+    err = NULL;
+    ASSERT_EQ(0, hl_cap_fs_stat(&c, "data", &st, &err));
+    ASSERT_EQ((int)HL_FS_NODE_DIR, (int)st.type);
+
+    hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── an EXACT-file grant cannot list its parent or inspect siblings (point 2) ─── */
+UTEST(fs_statlist, exact_grant_no_parent_no_sibling)
+{
+    setup();
+    mk_dir("data"); mk_file("data/real.txt", "REAL"); mk_file("data/other.txt", "O");
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "data/real.txt" };   /* EXACT */
+    ASSERT_EQ(0, build_policy(&a, rd, 1, NULL, 0, &p, &err));
+    HlFsConfig c = cfg_with(&p);
+
+    HlFsStatInfo st;
+    /* the exact file itself stats fine */
+    err = NULL;
+    ASSERT_EQ(0, hl_cap_fs_stat(&c, "data/real.txt", &st, &err));
+    ASSERT_EQ((int)HL_FS_NODE_FILE, (int)st.type);
+    /* the parent directory is NOT listable via an exact-file grant */
+    HlFsDirEntry *e = NULL; size_t n = 0; err = NULL;
+    ASSERT_EQ(-1, hl_cap_fs_list(&c, "data", &e, &n, &a, &err));
+    ASSERT_STREQ("permission", err);
+    ASSERT_TRUE(e == NULL); ASSERT_EQ((size_t)0, n);
+    /* the exact file itself is not a directory to list */
+    err = NULL;
+    ASSERT_EQ(-1, hl_cap_fs_list(&c, "data/real.txt", &e, &n, &a, &err));
+    ASSERT_STREQ("permission", err);   /* a file grant is not a listable directory */
+    /* a sibling cannot be stat'd */
+    err = NULL;
+    ASSERT_EQ(-1, hl_cap_fs_stat(&c, "data/other.txt", &st, &err));
+    ASSERT_STREQ("permission", err);
+
+    hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── PATTERN enumeration exposes ONLY matching entries; stat gated too (point 4) ─ */
+UTEST(fs_statlist, pattern_enumeration_only_matches)
+{
+    setup();
+    mk_dir("data");
+    mk_file("data/a.csv", "1"); mk_file("data/b.txt", "22"); mk_file("data/c.csv", "333");
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "data/*.csv" };
+    ASSERT_EQ(0, build_policy(&a, rd, 1, NULL, 0, &p, &err));
+    HlFsConfig c = cfg_with(&p);
+
+    HlFsDirEntry *e = NULL; size_t n = 0;
+    err = NULL;
+    ASSERT_EQ(0, hl_cap_fs_list(&c, "data", &e, &n, &a, &err));
+    ASSERT_EQ((size_t)2, n);                       /* only the two .csv */
+    ASSERT_STREQ("a.csv", e[0].name);              /* deterministic order */
+    ASSERT_STREQ("c.csv", e[1].name);
+    ASSERT_EQ(-1L, find_entry(e, n, "b.txt"));     /* .txt filtered out */
+    hl_cap_fs_list_free(e, n, &a);
+
+    HlFsStatInfo st;
+    err = NULL;
+    ASSERT_EQ(0, hl_cap_fs_stat(&c, "data/a.csv", &st, &err));   /* matches */
+    err = NULL;
+    ASSERT_EQ(-1, hl_cap_fs_stat(&c, "data/b.txt", &st, &err));  /* not matched */
+    ASSERT_STREQ("permission", err);
+
+    hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── SUBTREE list stays confined; terminal symlinks reported as links, escaping
+ * symlink target never leaked (points 5, 6, 10) ──────────────────────────────── */
+UTEST(fs_statlist, subtree_symlinks_reported_not_followed)
+{
+    setup();
+    mk_dir("data"); mk_file("data/real.txt", "REAL");
+    mk_link("real.txt", "data/link");          /* in-subtree symlink */
+    mk_link("/etc/hostname", "data/esc");      /* escaping absolute symlink */
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "data" };
+    ASSERT_EQ(0, build_policy(&a, rd, 1, NULL, 0, &p, &err));
+    HlFsConfig c = cfg_with(&p);
+
+    HlFsDirEntry *e = NULL; size_t n = 0;
+    err = NULL;
+    ASSERT_EQ(0, hl_cap_fs_list(&c, "data", &e, &n, &a, &err));
+    long il = find_entry(e, n, "link"), ie = find_entry(e, n, "esc"),
+         ir = find_entry(e, n, "real.txt");
+    ASSERT_TRUE(il >= 0 && ie >= 0 && ir >= 0);
+    ASSERT_EQ((int)HL_FS_NODE_SYMLINK, (int)e[il].type);   /* link reported AS a link */
+    ASSERT_EQ((int)HL_FS_NODE_SYMLINK, (int)e[ie].type);   /* escaping link too */
+    ASSERT_EQ((int)HL_FS_NODE_FILE,    (int)e[ir].type);
+    hl_cap_fs_list_free(e, n, &a);
+
+    /* stat reports the link's OWN type, NEVER following to the target - so the
+     * escaping symlink's target (/etc/hostname) leaks no metadata. */
+    HlFsStatInfo st;
+    err = NULL;
+    ASSERT_EQ(0, hl_cap_fs_stat(&c, "data/esc", &st, &err));
+    ASSERT_EQ((int)HL_FS_NODE_SYMLINK, (int)st.type);
+    err = NULL;
+    ASSERT_EQ(0, hl_cap_fs_stat(&c, "data/link", &st, &err));
+    ASSERT_EQ((int)HL_FS_NODE_SYMLINK, (int)st.type);
+
+    hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── PATTERN terminal symlink: reported as a link by stat/list, REFUSED by read
+ * (the ratified metadata contract, point 6) ──────────────────────────────────── */
+UTEST(fs_statlist, pattern_terminal_symlink_reported_read_refused)
+{
+    setup();
+    mk_dir("data"); mk_file("data/real.txt", "REAL");
+    mk_link("real.txt", "data/link.csv");      /* a symlink whose name matches *.csv */
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "data/*.csv" };
+    ASSERT_EQ(0, build_policy(&a, rd, 1, NULL, 0, &p, &err));
+    HlFsConfig c = cfg_with(&p);
+
+    /* list exposes it (matches *.csv) and reports it as a link */
+    HlFsDirEntry *e = NULL; size_t n = 0; err = NULL;
+    ASSERT_EQ(0, hl_cap_fs_list(&c, "data", &e, &n, &a, &err));
+    long i = find_entry(e, n, "link.csv");
+    ASSERT_TRUE(i >= 0);
+    ASSERT_EQ((int)HL_FS_NODE_SYMLINK, (int)e[i].type);
+    hl_cap_fs_list_free(e, n, &a);
+
+    /* stat reports the link (metadata), never following */
+    HlFsStatInfo st; err = NULL;
+    ASSERT_EQ(0, hl_cap_fs_stat(&c, "data/link.csv", &st, &err));
+    ASSERT_EQ((int)HL_FS_NODE_SYMLINK, (int)st.type);
+    /* but READ refuses the symlink (PATTERN refuses; no aliasing the target) */
+    char buf[16]; err = NULL;
+    ASSERT_EQ((int64_t)-1, hl_cap_fs_read(&c, "data/link.csv", buf, sizeof(buf), &err));
+    ASSERT_STREQ("symlink_denied", err);
+
+    hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── deterministic unsigned-byte order, shorter-prefix-first (point 7) ────────── */
+UTEST(fs_statlist, deterministic_byte_order)
+{
+    setup();
+    mk_dir("d");
+    /* creation order deliberately unsorted; includes an uppercase (0x42 < 0x61)
+     * and a prefix pair to prove shorter-first. */
+    mk_file("d/z", "1"); mk_file("d/a", "1"); mk_file("d/m", "1");
+    mk_file("d/B", "1"); mk_file("d/abc", "1"); mk_file("d/ab", "1");
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "d" };
+    ASSERT_EQ(0, build_policy(&a, rd, 1, NULL, 0, &p, &err));
+    HlFsConfig c = cfg_with(&p);
+
+    HlFsDirEntry *e = NULL; size_t n = 0; err = NULL;
+    ASSERT_EQ(0, hl_cap_fs_list(&c, "d", &e, &n, &a, &err));
+    ASSERT_EQ((size_t)6, n);
+    /* 'B'(0x42) < 'a'(0x61) < 'ab' < 'abc' < 'm' < 'z' */
+    ASSERT_STREQ("B",   e[0].name);
+    ASSERT_STREQ("a",   e[1].name);
+    ASSERT_STREQ("ab",  e[2].name);   /* shorter prefix precedes longer */
+    ASSERT_STREQ("abc", e[3].name);
+    ASSERT_STREQ("m",   e[4].name);
+    ASSERT_STREQ("z",   e[5].name);
+    hl_cap_fs_list_free(e, n, &a);
+
+    hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── empty dir -> empty list; missing dir -> not_found; FIFO reported not opened
+ * (point 10) ─────────────────────────────────────────────────────────────────── */
+UTEST(fs_statlist, empty_missing_and_fifo)
+{
+    setup();
+    mk_dir("empty");
+    mk_dir("data"); mk_file("data/f", "1"); mk_fifo("data/pipe");
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "." };                 /* base-root: everything readable */
+    ASSERT_EQ(0, build_policy(&a, rd, 1, NULL, 0, &p, &err));
+    HlFsConfig c = cfg_with(&p);
+
+    /* empty directory -> rc 0, count 0, NULL array */
+    HlFsDirEntry *e = NULL; size_t n = 99; err = NULL;
+    ASSERT_EQ(0, hl_cap_fs_list(&c, "empty", &e, &n, &a, &err));
+    ASSERT_EQ((size_t)0, n); ASSERT_TRUE(e == NULL);
+
+    /* missing directory -> error (not_found), no partial */
+    err = NULL;
+    ASSERT_EQ(-1, hl_cap_fs_list(&c, "nope", &e, &n, &a, &err));
+    ASSERT_STREQ("not_found", err);
+    ASSERT_TRUE(e == NULL); ASSERT_EQ((size_t)0, n);
+
+    /* FIFO is REPORTED as "other" via lstat - never opened (would block) */
+    err = NULL;
+    ASSERT_EQ(0, hl_cap_fs_list(&c, "data", &e, &n, &a, &err));
+    long ip = find_entry(e, n, "pipe");
+    ASSERT_TRUE(ip >= 0);
+    ASSERT_EQ((int)HL_FS_NODE_OTHER, (int)e[ip].type);
+    hl_cap_fs_list_free(e, n, &a);
+
+    HlFsStatInfo st; err = NULL;
+    ASSERT_EQ(0, hl_cap_fs_stat(&c, "data/pipe", &st, &err));
+    ASSERT_EQ((int)HL_FS_NODE_OTHER, (int)st.type);   /* stat lstat's it; no block */
+
+    hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── most-specific shadowing BEFORE listability: a governing multi-component
+ * PATTERN denies list("logs") and does NOT fall through to the SUBTREE; deeper
+ * lists that only the SUBTREE governs are allowed (reviewer requirement) ──────── */
+UTEST(fs_statlist, multi_pattern_shadows_subtree)
+{
+    setup();
+    mk_dir("logs"); mk_dir("logs/2026"); mk_file("logs/2026/x.txt", "1");
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "logs", "logs/*/*.txt" };
+    ASSERT_EQ(0, build_policy(&a, rd, 2, NULL, 0, &p, &err));
+    HlFsConfig c = cfg_with(&p);
+
+    /* the more-specific multi-component PATTERN governs list("logs") and denies it */
+    HlFsDirEntry *e = NULL; size_t n = 0; err = NULL;
+    ASSERT_EQ(-1, hl_cap_fs_list(&c, "logs", &e, &n, &a, &err));
+    ASSERT_STREQ("permission", err);       /* NOT listed via the broader SUBTREE */
+    ASSERT_TRUE(e == NULL);
+
+    /* deeper: only the SUBTREE governs -> authorized */
+    err = NULL;
+    ASSERT_EQ(0, hl_cap_fs_list(&c, "logs/2026", &e, &n, &a, &err));
+    ASSERT_EQ((size_t)1, n);
+    ASSERT_STREQ("x.txt", e[0].name);
+    hl_cap_fs_list_free(e, n, &a);
+
+    hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── multiple same-prefix terminal patterns resolve to ONE most-specific /
+ * lexicographic filter, NEVER a union (reviewer requirement) ──────────────────── */
+UTEST(fs_statlist, same_prefix_patterns_no_union)
+{
+    setup();
+    mk_dir("data");
+    mk_file("data/a.csv", "1"); mk_file("data/b.txt", "1"); mk_file("data/c.csv", "1");
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "data/*.csv", "data/*.txt" };
+    ASSERT_EQ(0, build_policy(&a, rd, 2, NULL, 0, &p, &err));
+    HlFsConfig c = cfg_with(&p);
+
+    /* grant-text ASC breaks the specificity tie: "*.csv" < "*.txt", so the csv
+     * filter wins alone - b.txt is NOT exposed (no filter union). */
+    HlFsDirEntry *e = NULL; size_t n = 0; err = NULL;
+    ASSERT_EQ(0, hl_cap_fs_list(&c, "data", &e, &n, &a, &err));
+    ASSERT_EQ((size_t)2, n);
+    ASSERT_STREQ("a.csv", e[0].name);
+    ASSERT_STREQ("c.csv", e[1].name);
+    ASSERT_EQ(-1L, find_entry(e, n, "b.txt"));
+    hl_cap_fs_list_free(e, n, &a);
+
+    hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── resource bounds: an allocation-failure mid-list rolls back COMPLETELY (no
+ * partial result, no leak); one directory fd is used (no fd leak over many calls)
+ * (point 11) ─────────────────────────────────────────────────────────────────── */
+UTEST(fs_statlist, list_rollback_and_no_fd_leak)
+{
+    setup();
+    mk_dir("data");
+    for (int i = 0; i < 40; i++) { char nm[64]; snprintf(nm, sizeof(nm), "data/f%02d", i); mk_file(nm, "x"); }
+    HlAllocator pa; hl_alloc_init(&pa, 0);        /* policy allocator (unlimited) */
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "data" };
+    ASSERT_EQ(0, build_policy(&pa, rd, 1, NULL, 0, &p, &err));
+    HlFsConfig c = cfg_with(&p);
+
+    /* A tiny-limit allocator for the LIST buffers forces a mid-enumeration alloc
+     * failure; the op must roll back completely and leak nothing. */
+    HlAllocator la; hl_alloc_init(&la, 256);      /* far below 40 names + array */
+    HlFsDirEntry *e = NULL; size_t n = 99; err = NULL;
+    ASSERT_EQ(-1, hl_cap_fs_list(&c, "data", &e, &n, &la, &err));
+    ASSERT_STREQ("io_error", err);
+    ASSERT_TRUE(e == NULL); ASSERT_EQ((size_t)0, n);
+    ASSERT_EQ((size_t)0, hl_alloc_used(&la));     /* complete rollback, no leak */
+
+    /* No directory-fd leak across many list calls: the fd number stays bounded. */
+    int f0 = dup(1); close(f0);
+    for (int i = 0; i < 200; i++) {
+        HlFsDirEntry *ee = NULL; size_t nn = 0; const char *e2 = NULL;
+        ASSERT_EQ(0, hl_cap_fs_list(&c, "data", &ee, &nn, &pa, &e2));
+        ASSERT_EQ((size_t)40, nn);
+        hl_cap_fs_list_free(ee, nn, &pa);
+    }
+    int f1 = dup(1);
+    ASSERT_TRUE(f1 <= f0 + 4);                     /* no accumulating open fds */
+    close(f1);
+
+    hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&pa));
+    teardown();
+}
+
+UTEST_MAIN();

--- a/tests/hull/cap/test_fs_statlist.c
+++ b/tests/hull/cap/test_fs_statlist.c
@@ -124,15 +124,17 @@ UTEST(fs_statlist, exact_grant_no_parent_no_sibling)
     err = NULL;
     ASSERT_EQ(0, hl_cap_fs_stat(&c, "data/real.txt", &st, &err));
     ASSERT_EQ((int)HL_FS_NODE_FILE, (int)st.type);
-    /* the parent directory is NOT listable via an exact-file grant */
+    /* the parent directory is NOT authorized via an exact-file grant -> permission */
     HlFsDirEntry *e = NULL; size_t n = 0; err = NULL;
     ASSERT_EQ(-1, hl_cap_fs_list(&c, "data", &e, &n, &a, &err));
     ASSERT_STREQ("permission", err);
     ASSERT_TRUE(e == NULL); ASSERT_EQ((size_t)0, n);
-    /* the exact file itself is not a directory to list */
+    /* the exact path IS authorized but is not a directory -> not_a_directory
+     * (the ratified distinction: authorized-but-wrong-type, not "permission"). */
     err = NULL;
     ASSERT_EQ(-1, hl_cap_fs_list(&c, "data/real.txt", &e, &n, &a, &err));
-    ASSERT_STREQ("permission", err);   /* a file grant is not a listable directory */
+    ASSERT_STREQ("not_a_directory", err);
+    ASSERT_TRUE(e == NULL); ASSERT_EQ((size_t)0, n);
     /* a sibling cannot be stat'd */
     err = NULL;
     ASSERT_EQ(-1, hl_cap_fs_stat(&c, "data/other.txt", &st, &err));
@@ -416,6 +418,91 @@ UTEST(fs_statlist, list_rollback_and_no_fd_leak)
     close(f1);
 
     hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&pa));
+    teardown();
+}
+
+/* ── a read-set CREATE whose target (or an intermediate) is absent -> stat returns
+ * ABSENT (nil), never (nil, "not_found") (issue 1) ───────────────────────────── */
+UTEST(fs_statlist, stat_read_create_absent_is_nil)
+{
+    setup();
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "out/result.bin" };   /* out/ absent -> read-set CREATE */
+    ASSERT_EQ(0, build_policy(&a, rd, 1, NULL, 0, &p, &err));
+    HlFsConfig c = cfg_with(&p);
+
+    HlFsStatInfo st;
+    /* the intermediate out/ is missing -> ABSENT, and *err is cleared (issue 2). */
+    err = "stale";
+    ASSERT_EQ(1, hl_cap_fs_stat(&c, "out/result.bin", &st, &err));
+    ASSERT_TRUE(err == NULL);
+    /* out/ exists but the file is still absent -> still ABSENT */
+    mk_dir("out"); err = "stale";
+    ASSERT_EQ(1, hl_cap_fs_stat(&c, "out/result.bin", &st, &err));
+    ASSERT_TRUE(err == NULL);
+    /* create the file -> present */
+    mk_file("out/result.bin", "R"); err = NULL;
+    ASSERT_EQ(0, hl_cap_fs_stat(&c, "out/result.bin", &st, &err));
+    ASSERT_EQ((int)HL_FS_NODE_FILE, (int)st.type);
+
+    hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── a prior error token does not leak into a later ABSENT via a reused pointer
+ * (issue 2) ──────────────────────────────────────────────────────────────────── */
+UTEST(fs_statlist, stat_error_then_absent_same_pointer)
+{
+    setup();
+    mk_dir("data"); mk_file("data/real.txt", "R"); mk_file("secret.txt", "S");
+    HlAllocator a; hl_alloc_init(&a, 0);
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "data" };
+    ASSERT_EQ(0, build_policy(&a, rd, 1, NULL, 0, &p, &err));
+    HlFsConfig c = cfg_with(&p);
+
+    HlFsStatInfo st;
+    /* a DENIED path sets the token... */
+    err = NULL;
+    ASSERT_EQ(-1, hl_cap_fs_stat(&c, "secret.txt", &st, &err));
+    ASSERT_STREQ("permission", err);
+    /* ...then the SAME pointer for an ABSENT authorized path clears it. */
+    ASSERT_EQ(1, hl_cap_fs_stat(&c, "data/none.txt", &st, &err));
+    ASSERT_TRUE(err == NULL);
+
+    hl_fs_policy_free(&p); ASSERT_EQ((size_t)0, hl_alloc_used(&a));
+    teardown();
+}
+
+/* ── stat(".") of the app root works under a base-root grant, and is denied
+ * without one (issue 3) ──────────────────────────────────────────────────────── */
+UTEST(fs_statlist, stat_root_via_base_grant)
+{
+    setup();
+    mk_file("f.txt", "1"); mk_dir("data");
+    HlAllocator a; hl_alloc_init(&a, 0);
+
+    HlFsPolicy p = HL_FS_POLICY_INIT; const char *err = NULL;
+    const char *rd[] = { "." };                 /* base-root */
+    ASSERT_EQ(0, build_policy(&a, rd, 1, NULL, 0, &p, &err));
+    HlFsConfig c = cfg_with(&p);
+    HlFsStatInfo st; err = NULL;
+    ASSERT_EQ(0, hl_cap_fs_stat(&c, ".", &st, &err));       /* the root, a directory */
+    ASSERT_EQ((int)HL_FS_NODE_DIR, (int)st.type);
+    hl_fs_policy_free(&p);
+
+    /* a non-root grant does NOT authorize stat(".") */
+    HlFsPolicy p2 = HL_FS_POLICY_INIT;
+    const char *rd2[] = { "data" };
+    ASSERT_EQ(0, build_policy(&a, rd2, 1, NULL, 0, &p2, &err));
+    HlFsConfig c2 = cfg_with(&p2);
+    err = NULL;
+    ASSERT_EQ(-1, hl_cap_fs_stat(&c2, ".", &st, &err));
+    ASSERT_STREQ("permission", err);
+    hl_fs_policy_free(&p2);
+
+    ASSERT_EQ((size_t)0, hl_alloc_used(&a));
     teardown();
 }
 


### PR DESCRIPTION
Slice C of the hull.fs path-authorization work: the metadata (`fs.stat`) and enumeration (`fs.list`) surface, gated by the READ policy set and resolved descriptor-relative through the virtual-root resolver. No BuildContext.

## Acceptance boundary (all proven)
- **stat/list select only from the READ set** — write-only grants leak no metadata.
- **exact-file grants cannot list the parent or inspect siblings** — an EXACT grant is not a listable directory.
- **CREATE/write-only grants reveal no metadata through READ.**
- **PATTERN grants expose only matching entries during enumeration** — v1 restricts listable patterns to a single terminal component; multi-component patterns are withheld (a separate metadata-exposure design).
- **SUBTREE symlinks follow only within the anchored virtual root**; the escaping symlink's target is never reached.
- **Terminal-symlink metadata contract (ratified, preserves Slice A):** stat/list report a terminal symlink as a link (lstat, never followed) under SUBTREE/PATTERN or a post-compile TOCTOU replacement; read/mmap still refuse it. An EXACT grant still cannot name an existing symlink (compile refuses).
- **Deterministic listing** — unsigned-byte lexicographic, shorter-prefix-first; locale- and readdir-order-independent. Stable `{name,type,size}` schema.
- **Descriptor-relative, race-resistant** — held dir fd + `fdopendir` + per-entry `fstatat`, no path reconstruction.
- **Lua/JS equivalent values + error tokens** — Lua `nil` / `(nil, err)`; JS `null` / throw with the same token.
- **empty / missing / replaced / symlinked / FIFO / permission-denied** covered.
- **Resource bounds** — entry count, total name bytes, name length, and `size > 2^53-1` all FAIL the op with **complete-result rollback** (no partial result); one directory fd throughout.

## Reviewer-locked details
- **Most-specific shadowing runs before the listability check.** With both `logs/` (SUBTREE) and `logs/*/*.txt` (PATTERN), `list("logs")` selects the narrower multi-component pattern and returns `permission` — it does **not** fall through to the subtree. Same-prefix terminal patterns resolve to one most-specific/lexicographic filter, **never a union**. Both cases documented and tested.
- **`size_unrepresentable` applied consistently** to stat and every listed entry, with complete-result rollback for list.
- **`HlFsParent` result struct** (`{parent_fd, leaf}`) with the explicit grant-root case (`fstat(anchor)` when the residual is `.`).
- **Result ownership contract** specified in the header before coding: caller owns the array + names, freed by `hl_cap_fs_list_free`; `not_found` (absent dir) is an error, distinct from an empty-but-present dir (count 0); failure frees everything and returns no list.

## Verification
- `test_fs_statlist.c` — 10 cap-level cases (each `used==0`); two `hl_fs_resolve_parent` cases in `test_fs_resolve.c`; Lua/JS parity leg in `e2e_cli.sh` (18/18).
- Full unit suite 90/90; `e2e_sandbox` 18/18; clang static analyzer clean on the three fs files; platform + hull build clean.

Stops at the Slice-C boundary; **no BuildContext work**.