### PR TITLE
chore(H0): add SECURITY.md + self-testing docs-integrity gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2339,6 +2339,12 @@ jobs:
       - name: Compute-SDK header check self-test (negative) (#331)
         run: make check-sdk-headers-selftest
 
+      - name: Documentation-integrity gate
+        run: make check-docs-integrity
+
+      - name: Documentation-integrity self-test (negative)
+        run: make check-docs-integrity-selftest
+
   htmx-browser:
     needs: [classify]
     if: needs.classify.outputs.run_web == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,13 +119,24 @@ employer step is needed.
 make            # build clean, zero non-vendor warnings
 make test       # 35+ unit suites
 make e2e        # 22+ end-to-end tests
-make lint-lua   # Lua stdlib lint
-make lint-js    # JS stdlib lint
+make lint       # Lua + JS lint, SDK-header + docs-integrity gates
 make cppcheck   # static analysis
 ```
 
+`make lint` includes `check-docs-integrity` — it verifies that every
+`docs/*.md` is catalogued in `docs/README.md`, that Markdown links resolve,
+that archived docs are not presented as active specs, and that moved historical
+paths cannot silently reappear. If you add or move a doc, update
+`docs/README.md` (and, for a historical doc, `docs/archive/README.md`) or this
+check will fail.
+
 CI runs all of these (plus ASan, MSan, scan-build, and the Cosmopolitan
 build). A green CI run is required to merge.
+
+## Reporting a security vulnerability
+
+Do **not** open a public issue or PR for a security vulnerability. Follow the
+private disclosure process in [SECURITY.md](SECURITY.md).
 
 ## Sign-off mechanics
 

--- a/Makefile
+++ b/Makefile
@@ -2000,7 +2000,7 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
 
 # ── Targets ─────────────────────────────────────────────────────────
 
-.PHONY: all clean test debug msan tsan tsan-shared-heap fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-valkey e2e-feature-valkey e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-stream-meta e2e-compute-async-trap e2e-sync-spans e2e-compute-aot-shared-heap e2e-compute-memory64 e2e-compute-headers e2e-spans-example e2e-spans-multi e2e-spans-hugefile e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-linker-zig e2e-cross-build e2e-musl e2e-musl-cross floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-test-harness e2e-jobs e2e-hypermedia-photos-upload e2e-jwt-asym e2e-path-parity hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-mapped-span bench-gpu bench-bytecode-cache wamrc wamrc-configure coverage lint-lua lint-js lint check-sdk-headers check-sdk-headers-selftest check-wamr-msan-annotation platform platform-cosmo hardening check-hardening
+.PHONY: all clean test debug msan tsan tsan-shared-heap fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-valkey e2e-feature-valkey e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-stream-meta e2e-compute-async-trap e2e-sync-spans e2e-compute-aot-shared-heap e2e-compute-memory64 e2e-compute-headers e2e-spans-example e2e-spans-multi e2e-spans-hugefile e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-linker-zig e2e-cross-build e2e-musl e2e-musl-cross floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-test-harness e2e-jobs e2e-hypermedia-photos-upload e2e-jwt-asym e2e-path-parity hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-mapped-span bench-gpu bench-bytecode-cache wamrc wamrc-configure coverage lint-lua lint-js lint check-sdk-headers check-sdk-headers-selftest check-wamr-msan-annotation check-docs-integrity check-docs-integrity-selftest platform platform-cosmo hardening check-hardening
 
 all: $(BUILDDIR)/hull
 
@@ -3246,7 +3246,17 @@ check-sdk-headers-selftest:
 check-wamr-msan-annotation:
 	sh tests/check_wamr_msan_annotation.sh
 
-lint: lint-lua lint-js check-sdk-headers
+# Documentation-integrity gate: catalogued docs, resolving Markdown links,
+# inventoried archive, resolving first-party docs/ refs, no resurrected historical
+# paths. See tests/check_docs_integrity.sh.
+check-docs-integrity:
+	sh tests/check_docs_integrity.sh
+
+# Deterministic negative test: prove the docs gate bites on each violation class.
+check-docs-integrity-selftest:
+	sh tests/check_docs_integrity_selftest.sh
+
+lint: lint-lua lint-js check-sdk-headers check-docs-integrity
 
 # ── API documentation (two-tier: source comments + generated HTML) ──
 #

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ hull init --profile htmx
 
 This wires up HTMX 2 + Pico CSS, CSRF + per-request CSP nonce, session-backed
 flash messages, pagination, and an idempotency-aware POST cache. See
-[`examples/hypermedia_todo/`](examples/hypermedia_todo/) for the reference
+[`examples/hypermedia_photos/`](examples/hypermedia_photos/) for the reference
 app and [docs/htmx.md](docs/htmx.md) for the integration guide.
 
 ### Shell completions
@@ -1118,7 +1118,7 @@ Example apps in both Lua and JavaScript:
 | [webhooks](examples/webhooks/) | Webhook delivery with HMAC-SHA256 signatures |
 | [templates](examples/templates/) | Template engine: inheritance, includes, filters |
 | [todo](examples/todo/) | Full CRUD todo app with HTML frontend and migrations |
-| [hypermedia_todo](examples/hypermedia_todo/) | HTMX hypermedia todo: search, inline edit, flash, pagination, idempotency-cached POST |
+| [hypermedia_photos](examples/hypermedia_photos/) | HTMX hypermedia app (Pico CSS) scaffolded by `hull init --profile htmx` |
 | [bench_db](examples/bench_db/) | SQLite performance benchmarks with migrations |
 | [async_http](examples/async_http/) | Non-blocking HTTP requests via event loop |
 | [timers](examples/timers/) | Background timers with `app.every()` and self-cancellation |
@@ -1160,8 +1160,11 @@ Full index with start-here guidance by role lives in [`docs/README.md`](docs/REA
 | [docs/known_limitations.md](docs/known_limitations.md) | Compile-time limit constants, override knobs |
 | [docs/benchmark.md](docs/benchmark.md) | Performance methodology and measured numbers |
 | [docs/release_signing.md](docs/release_signing.md) | Three-layer signature flow + release-key handling |
-| [docs/api_review.md](docs/api_review.md) | Pre-v0.1.0 API surface review |
+| [docs/archive/api_review.md](docs/archive/api_review.md) | Pre-v0.1.0 API surface review (archived) |
 | [docs/roadmap.md](docs/roadmap.md) · [docs/roadmap_next.md](docs/roadmap_next.md) | What's built; what's next |
+
+The full, categorized index (active architecture / invariants / historical) is
+[`docs/README.md`](docs/README.md).
 
 **Subsystem deep-dives:**
 
@@ -1169,17 +1172,19 @@ Full index with start-here guidance by role lives in [`docs/README.md`](docs/REA
 |---|---|
 | [docs/wamr_architecture.md](docs/wamr_architecture.md) | WASM compute design. WAMR integration, ABI, pooling, segments, streaming, AOT, Memory64 |
 
-**Audits (current state of record):**
+**Security audits (historical, all findings closed):**
 
 | Document | Scope |
 |---|---|
-| [docs/audit_2026_05_15.md](docs/audit_2026_05_15.md) | Main audit. Phase 5 surface, 49 findings, all closed |
-| [docs/audit_2026_05_15_phase6.md](docs/audit_2026_05_15_phase6.md) | Phase 6 (extended `hull agent` + MCP). 21 findings, all closed |
-| [docs/audit_2026_05_15_phase6_reaudit.md](docs/audit_2026_05_15_phase6_reaudit.md) | Re-audit of the Phase 6 fixes. 3 follow-ups, all closed |
+| [docs/archive/audits/audit_2026_05_15.md](docs/archive/audits/audit_2026_05_15.md) | Main audit. Phase 5 surface, 49 findings, all closed |
+| [docs/archive/audits/audit_2026_05_15_phase6.md](docs/archive/audits/audit_2026_05_15_phase6.md) | Phase 6 (extended `hull agent` + MCP). 21 findings, all closed |
+| [docs/archive/audits/audit_2026_05_15_phase6_reaudit.md](docs/archive/audits/audit_2026_05_15_phase6_reaudit.md) | Re-audit of the Phase 6 fixes. 3 follow-ups, all closed |
+
+To report a vulnerability, see [SECURITY.md](SECURITY.md).
 
 **Strategic / positioning (non-developer audience):**
 
-[docs/MANIFESTO.md](docs/MANIFESTO.md) · [docs/ASSESSMENT.md](docs/ASSESSMENT.md) · [docs/INVESTORS.md](docs/INVESTORS.md) · [docs/PERSONAS.md](docs/PERSONAS.md)
+[docs/MANIFESTO.md](docs/MANIFESTO.md) · [docs/archive/ASSESSMENT.md](docs/archive/ASSESSMENT.md) · [docs/INVESTORS.md](docs/INVESTORS.md) · [docs/PERSONAS.md](docs/PERSONAS.md)
 
 **Archive:** historical audits and completed roadmaps (architecture A–L refactor, db-vtable, WASM-improvement, v0-to-v1) live in [`docs/archive/`](docs/archive/). Preserved for reproducibility, not current state.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,99 @@
+# Security Policy
+
+Hull is a capability-secure application runtime: its security model (the
+capability layer, the kernel sandbox, the signature/attestation chain) is the
+product, not an afterthought. We take vulnerability reports seriously and want to
+make responsible disclosure easy.
+
+This file is the **vulnerability-reporting** policy. For the security
+*architecture* (threat model, sandbox phases, capability-enforcement invariants,
+the three-layer signature system) see [`docs/security.md`](docs/security.md).
+
+## Supported versions
+
+Hull is pre-1.0. Security fixes are made against the **latest released version**
+and the `main` branch. Older tagged releases are not maintained — if you are on an
+older `0.x`, upgrade to the latest release rather than expecting a backport.
+
+| Version | Supported |
+|---|---|
+| Latest release (current `0.x`) | ✅ Security fixes |
+| `main` | ✅ Security fixes |
+| Any older tagged release | ❌ Upgrade to latest |
+
+`hull update` moves an installed binary to the latest signed release; see
+[`docs/release_signing.md`](docs/release_signing.md).
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue, pull request, or discussion for a security
+vulnerability.** Public disclosure before a fix is available puts every Hull user
+at risk.
+
+Report privately, using either channel:
+
+1. **GitHub private vulnerability reporting (preferred).** On this repository, go
+   to the **Security** tab → **Report a vulnerability** ("Advisories" →
+   "Report a vulnerability"). This opens a private advisory visible only to you
+   and the maintainers.
+2. **Email.** If you cannot use GitHub's private reporting, email
+   **security@artalis.io**. Encrypt if you can; if you need a key first, send a
+   short unencrypted note asking for one (no vulnerability details).
+
+Please include, to the extent you can:
+
+- the affected component (capability layer, sandbox, signature/attestation,
+  a specific `hull.*` / `hull_cap_*` surface, the build/release pipeline, …);
+- Hull version (`hull version`) and platform (Linux / macOS / cosmo APE);
+- a minimal reproduction (an `app.lua` / `app.js`, a manifest, and the exact
+  commands), or a proof-of-concept;
+- the impact you believe it has (sandbox escape, capability bypass, signature
+  forgery, memory-safety defect, DoS, information disclosure, …).
+
+You do **not** need a complete exploit to report — a credible description of a
+weakness is enough to start.
+
+## What to expect
+
+| Stage | Target |
+|---|---|
+| Acknowledgement of your report | within **3 business days** |
+| Initial triage + severity assessment | within **7 days** |
+| Fix + coordinated disclosure | negotiated with you; typically within **90 days**, faster for actively-exploited or critical issues |
+
+We will keep you updated as we triage and fix, tell you when a fix ships and in
+which release, and — unless you prefer to stay anonymous — credit you in the
+advisory and the release notes. We practice coordinated disclosure: please give
+us a reasonable window to ship a fix before any public write-up.
+
+## Scope
+
+**In scope** — anything that breaks a security boundary Hull promises:
+
+- **Capability escape / bypass** — reaching a resource (fs, db, network, env,
+  compute) not granted by the app manifest, or defeating a `hull_cap_*` check
+  (path traversal / authorization bypass, SQL injection past the parameterized
+  layer, host-allowlist bypass, env-allowlist bypass).
+- **Sandbox escape** — escaping the kernel sandbox (pledge/unveil/seatbelt) or
+  the Lua/QuickJS interpreter sandbox (`eval`, `io`/`os`, `load*` reachability).
+- **Signature / attestation forgery** — defeating the release, platform, or app
+  signature layers, or the composed-feature attestation.
+- **Memory-safety defects** in the trusted C core (`src/hull/**`, the public
+  headers) reachable from app input.
+- **Build / release supply-chain** defects that let unverified code into a
+  produced binary.
+
+**Out of scope** (report upstream, or not a Hull vulnerability):
+
+- Bugs in vendored dependencies (WAMR, QuickJS, Lua, SQLite, mbedTLS, Keel) that
+  do not change Hull's security posture — report to that project (Keel lives at
+  [github.com/artalis-io/keel](https://github.com/artalis-io/keel)).
+- Findings that require `--no-sandbox`, `--no-ca-bundle`, or an already-compromised
+  host / build machine.
+- Missing hardening that is documented as a deliberate trade-off (see
+  `docs/security.md` and `docs/known_limitations.md`).
+- Vulnerabilities in example apps (`examples/`) that do not reflect a runtime
+  defect.
+
+When in doubt, report it privately and let us classify — we would rather triage a
+non-issue than miss a real one.

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -760,7 +760,7 @@ timer.
 
 `HL_ENABLE_DB=1` (default) embeds SQLite. `HL_ENABLE_DB=0` produces a
 compute-only build (~1.4 MB smaller). See [§14](#14-build) and
-[`docs/audit_2026_05_15.md`](audit_2026_05_15.md) for the full list of
+[`docs/archive/audits/audit_2026_05_15.md`](archive/audits/audit_2026_05_15.md) for the full list of
 modules that require DB.
 
 ### Querying
@@ -1146,7 +1146,7 @@ global branch).
 
 ### Run `/c-audit`, `/js-audit`, `/lua-audit`
 
-Periodic audits live in [`docs/audit_2026_05_15.md`](audit_2026_05_15.md).
+Periodic audits live in [`docs/archive/audits/audit_2026_05_15.md`](archive/audits/audit_2026_05_15.md).
 The audit skills in `.claude/skills/` produce the same reports. Rerun on
 significant changes.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1168,7 +1168,7 @@ Outputs:
 | ETag support | **Done** | `hull.web.middleware.etag`. Compute + compare + 304 Not Modified |
 | PostgreSQL support | Shipped | Pure-C wire client behind the `HlDbBackend` vtable; `postgres://` DSN selects it. Handles-only API (`db.default()` / `db.connect(name)`) |
 | Database encryption at rest | Planned | SQLite SEE or custom VFS |
-| HTTP/2 full support | [Plan](http2_plan.md) | Currently h2c upgrade only |
+| HTTP/2 full support | Planned | Currently h2c upgrade only |
 | PDF document builder | Planned | Report generation |
 | Module/package ecosystem | Planned | `hull add <package>` for sharing middleware and compute plugins |
 

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -152,7 +152,7 @@ We reserve the right to:
 
 ## Resolved before v0.1.0 (no longer experimental)
 
-The pre-v0.1.0 API review landed these decisions (see `docs/api_review.md`):
+The pre-v0.1.0 API review landed these decisions (see `docs/archive/api_review.md`):
 
 - **Async error convention**. All `*.async.*` APIs throw on error (uniform with sync). `db.async.query`/`db.async.exec`/`compute.async.call` no longer return `{error}` objects.
 - **HTTP route methods**. `app.delete` is canonical; `app.del` is a deprecated alias kept for one release cycle.

--- a/tests/check_docs_integrity.sh
+++ b/tests/check_docs_integrity.sh
@@ -1,0 +1,202 @@
+#!/bin/sh
+# tests/check_docs_integrity.sh — permanent documentation-integrity gate.
+#
+# Protects the docs/ reorganization (active / invariants / historical) from
+# silent rot. Five checks, each fatal:
+#
+#   1. CATALOG      every top-level docs/*.md is catalogued in docs/README.md
+#   2. LINKS        every relative Markdown link (in docs/** + the root
+#                   README/CONTRIBUTING/SECURITY) resolves to an existing file
+#   3. ARCHIVE      every file under docs/archive/ is inventoried by
+#                   docs/archive/README.md (archived docs are classified as
+#                   historical, never floating as pseudo-active specs)
+#   4. SOURCE-REFS  every first-party `docs/....md` reference in code / docs /
+#                   instructions resolves (illustrative examples allowlisted)
+#   5. RESURRECTION moved/archived historical docs cannot silently reappear at
+#                   their old top-level docs/ path
+#
+# POSIX sh. Run from anywhere; it locates the repo root from its own path.
+# Wired into `make lint` (target: check-docs-integrity); the negative self-test
+# tests/check_docs_integrity_selftest.sh proves it bites.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -u
+
+# Repo root = parent of this script's tests/ dir.
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$ROOT" || exit 2
+
+FAIL=0
+err() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; FAIL=$((FAIL + 1)); }
+ok()  { printf '  \033[32mok\033[0m   %s\n' "$1"; }
+
+# Illustrative / synthetic docs paths used as literals in code (CI classifier
+# tests, path-normalization examples) — NOT real doc links. Keep this list tight.
+is_allowlisted_ref() {
+    case "$1" in
+        # synthetic inputs in CI-classifier / path tests
+        docs/x.md|docs/a.md|docs/b.md|docs/moved.md|docs/new.md|docs/only.md) return 0 ;;
+        # the literal pattern "docs/....md" appears in prose describing this gate
+        docs/....md) return 0 ;;
+        # planned (not-yet-written) artifact named in the DEFERRED reporting-IR design
+        docs/reporting.md) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Historical docs that were physically relocated. Old top-level path must stay
+# gone; the value is where it now lives (for the message).
+MOVED_PATHS="
+docs/cachelib_spike.md>docs/archive/design_records/cachelib_spike.md
+docs/kvmem_design.md>docs/archive/design_records/kvmem_design.md
+docs/kvmem_negative_result.md>docs/archive/design_records/kvmem_negative_result.md
+docs/memstore_lru_plan.md>docs/archive/design_records/memstore_lru_plan.md
+docs/jobs_wasm_replay_spike.md>docs/archive/design_records/jobs_wasm_replay_spike.md
+docs/api_review.md>docs/archive/api_review.md
+docs/ASSESSMENT.md>docs/archive/ASSESSMENT.md
+docs/audit_2026_05_15.md>docs/archive/audits/audit_2026_05_15.md
+docs/audit_2026_05_15_phase6.md>docs/archive/audits/audit_2026_05_15_phase6.md
+docs/audit_2026_05_15_phase6_reaudit.md>docs/archive/audits/audit_2026_05_15_phase6_reaudit.md
+"
+
+# ── 1. CATALOG: every top-level docs/*.md is linked from docs/README.md ────────
+check_catalog() {
+    linked=$(grep -oE '\]\([^)]+\)' docs/README.md \
+             | sed -E 's/\]\(([^)#]+)(#[^)]*)?\)/\1/' \
+             | while IFS= read -r t; do basename "$t"; done | sort -u)
+    for f in docs/*.md; do
+        b=$(basename "$f")
+        [ "$b" = "README.md" ] && continue
+        if printf '%s\n' "$linked" | grep -qxF "$b"; then :; else
+            err "1/CATALOG: docs/$b is not catalogued in docs/README.md"
+        fi
+    done
+    [ "$FAIL" -eq 0 ] && ok "1/CATALOG: every top-level docs/*.md is in docs/README.md"
+}
+
+# ── 2. LINKS: every relative Markdown link resolves ───────────────────────────
+# Scope: ACTIVE docs (top-level docs/*.md) + every index README (incl. archive
+# indexes) + the root policy/readme files. Frozen archived RECORD bodies under
+# docs/archive/*/ are NOT deep-link-audited - they are historical snapshots whose
+# cross-references reflect the state at the time, not the present tree.
+check_links() {
+    before=$FAIL
+    files=$( { ls docs/*.md 2>/dev/null; find docs -name 'README.md';
+               printf '%s\n' README.md CONTRIBUTING.md SECURITY.md; } | sort -u)
+    printf '%s\n' "$files" | while IFS= read -r src; do
+        [ -f "$src" ] || continue
+        dir=$(dirname "$src")
+        grep -oE '\]\([^)]+\)' "$src" \
+        | sed -E 's/\]\(([^)]+)\)/\1/' \
+        | while IFS= read -r target; do
+            case "$target" in
+                http://*|https://*|mailto:*|'#'*|'') continue ;;
+            esac
+            # strip a #anchor suffix
+            path=${target%%#*}
+            [ -z "$path" ] && continue
+            # resolve relative to the source file's directory (handles ../)
+            if ( cd "$dir" 2>/dev/null && [ -e "$path" ] ); then :; else
+                printf 'BROKEN %s -> %s\n' "$src" "$target"
+            fi
+          done
+    done > /tmp/hull_docs_links.$$ 2>/dev/null || true
+    if [ -s /tmp/hull_docs_links.$$ ]; then
+        while IFS= read -r line; do err "2/LINKS: ${line#BROKEN }"; done < /tmp/hull_docs_links.$$
+    fi
+    rm -f /tmp/hull_docs_links.$$
+    [ "$FAIL" -eq "$before" ] && ok "2/LINKS: all relative Markdown links resolve"
+}
+
+# ── 3. ARCHIVE: every archived doc is inventoried by docs/archive/README.md ────
+check_archive() {
+    before=$FAIL
+    [ -f docs/archive/README.md ] || { err "3/ARCHIVE: docs/archive/README.md missing"; return; }
+    inv=docs/archive/README.md
+    find docs/archive -name '*.md' | while IFS= read -r f; do
+        b=$(basename "$f")
+        [ "$b" = "README.md" ] && continue
+        # the inventory must mention the file basename somewhere
+        if grep -qF "$b" "$inv"; then :; else
+            printf 'UNLISTED %s\n' "$f"
+        fi
+    done > /tmp/hull_docs_arch.$$ 2>/dev/null || true
+    if [ -s /tmp/hull_docs_arch.$$ ]; then
+        while IFS= read -r line; do
+            err "3/ARCHIVE: ${line#UNLISTED } not inventoried in docs/archive/README.md"
+        done < /tmp/hull_docs_arch.$$
+    fi
+    rm -f /tmp/hull_docs_arch.$$
+    [ "$FAIL" -eq "$before" ] && ok "3/ARCHIVE: every archived doc is inventoried"
+}
+
+# ── 4. SOURCE-REFS: first-party docs/....md references resolve ─────────────────
+check_source_refs() {
+    before=$FAIL
+    # First-party trees only; exclude vendored / generated / build dirs and this
+    # gate's own scripts (their MOVED_PATHS / allowlist literals are not doc links).
+    # docs/archive/ record BODIES are frozen historical snapshots - their prose
+    # `docs/X.md` mentions reflect the state at the time, so they are excluded from
+    # the ACTIVE source-reference check (mirrors the LINKS scope).
+    refs=$(grep -rhoE 'docs/[A-Za-z0-9_./-]+\.md' \
+             --exclude-dir=.playwright --exclude-dir=node_modules \
+             --exclude-dir=vendor --exclude-dir=build --exclude-dir=.git \
+             --exclude-dir=archive \
+             --exclude=check_docs_integrity.sh \
+             --exclude=check_docs_integrity_selftest.sh \
+             src include tests scripts CLAUDE.md AGENTS.md README.md \
+             CONTRIBUTING.md SECURITY.md docs 2>/dev/null \
+           | sed 's#docs//#docs/#' | sort -u)
+    printf '%s\n' "$refs" | while IFS= read -r ref; do
+        [ -z "$ref" ] && continue
+        is_allowlisted_ref "$ref" && continue
+        [ -f "$ref" ] || printf 'DANGLING %s\n' "$ref"
+    done > /tmp/hull_docs_refs.$$ 2>/dev/null || true
+    if [ -s /tmp/hull_docs_refs.$$ ]; then
+        while IFS= read -r line; do
+            err "4/SOURCE-REFS: ${line#DANGLING } referenced in code/docs but does not exist"
+        done < /tmp/hull_docs_refs.$$
+    fi
+    rm -f /tmp/hull_docs_refs.$$
+    [ "$FAIL" -eq "$before" ] && ok "4/SOURCE-REFS: every first-party docs/*.md reference resolves"
+}
+
+# ── 5. RESURRECTION: moved historical docs stay gone from docs/ top level ──────
+check_resurrection() {
+    before=$FAIL
+    printf '%s\n' "$MOVED_PATHS" | while IFS= read -r pair; do
+        [ -z "$pair" ] && continue
+        old=${pair%%>*}; new=${pair#*>}
+        if [ -e "$old" ]; then
+            printf 'REAPPEARED %s (belongs at %s)\n' "$old" "$new"
+        elif [ ! -e "$new" ]; then
+            printf 'MISSINGNEW %s (moved target %s not found)\n' "$old" "$new"
+        fi
+    done > /tmp/hull_docs_res.$$ 2>/dev/null || true
+    if [ -s /tmp/hull_docs_res.$$ ]; then
+        while IFS= read -r line; do
+            case "$line" in
+                REAPPEARED*) err "5/RESURRECTION: ${line#REAPPEARED }" ;;
+                MISSINGNEW*) err "5/RESURRECTION: ${line#MISSINGNEW }" ;;
+            esac
+        done < /tmp/hull_docs_res.$$
+    fi
+    rm -f /tmp/hull_docs_res.$$
+    [ "$FAIL" -eq "$before" ] && ok "5/RESURRECTION: moved historical docs have not reappeared"
+}
+
+echo "docs-integrity gate:"
+check_catalog
+check_links
+check_archive
+check_source_refs
+check_resurrection
+
+if [ "$FAIL" -ne 0 ]; then
+    printf '\n\033[31m%d documentation-integrity violation(s).\033[0m\n' "$FAIL"
+    printf 'Fix the doc/link, or update docs/README.md / docs/archive/README.md.\n'
+    exit 1
+fi
+printf '\n\033[32mAll documentation-integrity checks passed.\033[0m\n'
+exit 0

--- a/tests/check_docs_integrity_selftest.sh
+++ b/tests/check_docs_integrity_selftest.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# tests/check_docs_integrity_selftest.sh — deterministic NEGATIVE test.
+#
+# Proves check_docs_integrity.sh is not a no-op: for each of its five checks it
+# injects a single representative violation, asserts the gate exits non-zero AND
+# reports that specific check, then removes the injection. Ends by confirming the
+# tree is clean again. Mirrors tests/check_sdk_headers_selftest.sh.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -u
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$ROOT" || exit 2
+
+GATE="sh tests/check_docs_integrity.sh"
+FAILED=0
+BAK="/tmp/hull_readme_bak.$$"
+pass() { printf '  \033[32mok\033[0m   %s\n' "$1"; }
+bad()  { printf '  \033[31mFAIL\033[0m %s\n' "$1"; FAILED=$((FAILED + 1)); }
+
+cleanup() {
+    rm -f docs/__selftest_c1.md docs/archive/__selftest_a.md \
+          tests/__selftest_ref_probe.sh docs/kvmem_design.md
+    [ -f "$BAK" ] && cp "$BAK" docs/README.md && rm -f "$BAK"
+}
+trap cleanup EXIT INT TERM
+
+# expect_bite <check-id-substring> <label>: run the gate, require non-zero exit
+# AND that the named check appears in the output.
+expect_bite() {
+    id=$1; label=$2
+    out=$($GATE 2>&1); rc=$?
+    if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "$id"; then
+        pass "$label -> gate bites ($id)"
+    else
+        bad "$label -> gate did NOT bite (expected $id; rc=$rc)"
+    fi
+}
+
+echo "docs-integrity self-test:"
+
+# Baseline: the real tree must pass.
+if $GATE >/dev/null 2>&1; then pass "baseline: clean tree passes"
+else bad "baseline: clean tree should pass but did not"; fi
+
+# 1. CATALOG — an uncatalogued top-level doc.
+: > docs/__selftest_c1.md
+expect_bite "1/CATALOG" "uncatalogued top-level doc"
+rm -f docs/__selftest_c1.md
+
+# 2. LINKS — a broken relative Markdown link in an active index.
+cp docs/README.md "$BAK"
+printf '\n[selftest](__selftest_nope_%s.md)\n' "$$" >> docs/README.md
+expect_bite "2/LINKS" "broken markdown link"
+cp "$BAK" docs/README.md; rm -f "$BAK"
+
+# 3. ARCHIVE — an archived doc missing from the archive inventory.
+: > docs/archive/__selftest_a.md
+expect_bite "3/ARCHIVE" "uninventoried archived doc"
+rm -f docs/archive/__selftest_a.md
+
+# 4. SOURCE-REFS — a dangling docs/ reference in first-party code.
+printf '# probe references docs/__selftest_ref_missing_%s.md\n' "$$" > tests/__selftest_ref_probe.sh
+expect_bite "4/SOURCE-REFS" "dangling docs ref in code"
+rm -f tests/__selftest_ref_probe.sh
+
+# 5. RESURRECTION — a moved historical doc reappears at its old path.
+: > docs/kvmem_design.md
+expect_bite "5/RESURRECTION" "resurrected moved doc"
+rm -f docs/kvmem_design.md
+
+# Final: the tree is clean again (cleanup worked, no leftover injections).
+if $GATE >/dev/null 2>&1; then pass "tree clean again after self-test"
+else bad "tree not clean after self-test (leftover injection?)"; fi
+
+if [ "$FAILED" -eq 0 ]; then
+    printf '\n\033[32mdocs-integrity self-test passed: all 5 checks bite.\033[0m\n'
+    exit 0
+fi
+printf '\n\033[31mdocs-integrity self-test FAILED (%d).\033[0m\n' "$FAILED"
+exit 1


### PR DESCRIPTION
Housekeeping **H0** — the two repository-governance gaps worth closing before BuildContext (Checkpoint 4). Tightly bounded; the larger items (operations/testing/fuzzing consolidation, source-comment archaeology, dependabot/CodeQL/Scorecard, BuildContext-boundary gates) are explicitly deferred as separate stories.

## 1. Root `SECURITY.md`
A real responsible-disclosure policy (Hull had only `docs/security.md`, which is *architecture*, not vulnerability reporting):
- **Supported versions** (pre-1.0: latest release + `main`).
- **Private reporting channel** — GitHub private vulnerability reporting (preferred) + a security email.
- **Explicit "do not open a public issue/PR"** for vulnerabilities.
- **Acknowledgement / triage / remediation timeline** (3 business days / 7 days / coordinated, typically ≤90 days).
- **Scope** oriented to Hull's actual boundaries: capability escape, sandbox escape, signature/attestation forgery, trusted-core memory safety, supply-chain.
- Linked from `README.md` and `CONTRIBUTING.md`.

## 2. Self-testing docs-integrity gate
`tests/check_docs_integrity.sh`, wired into `make lint` and the CI **Lint** job (mirrors the `check-sdk-headers` + `-selftest` pattern). Five fatal checks:
1. **CATALOG** — every top-level `docs/*.md` is catalogued in `docs/README.md`.
2. **LINKS** — relative Markdown links in active docs + index READMEs + root policy files resolve.
3. **ARCHIVE** — every archived doc is inventoried by `docs/archive/README.md` (archived ≠ pseudo-active).
4. **SOURCE-REFS** — first-party `docs/*.md` references in code/docs resolve (vendored trees + illustrative literals excluded).
5. **RESURRECTION** — moved historical docs cannot silently reappear at their old path.

Frozen archive **record bodies** are deliberately not deep-audited (they're historical snapshots). `tests/check_docs_integrity_selftest.sh` injects one violation per class and proves each check bites — so the gate can't silently rot into a no-op.

## Rot the gate already caught (fixed here)
Introducing the gate surfaced real pre-existing breakage: README's `api_review` / `ASSESSMENT` / `audit_2026_05_15*` links (now under `archive/`), a `hypermedia_todo` example that no longer exists (→ `hypermedia_photos`), `agent_guide`'s moved-audit links, `stability.md`'s `api_review` reference, and `roadmap.md`'s dead `http2_plan` link.

## Verification
- `make check-docs-integrity` → all 5 checks pass on the tree.
- `make check-docs-integrity-selftest` → all 5 checks bite; no leftover artifacts.

Sequence: this is H0. On merge, Checkpoint 4 (BuildContext) begins — design-first, with its own review gate.