### PR TITLE
docs(H1/S1): dead-code evidence audit - result: retain, no deletion

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -96,6 +96,7 @@ specific signature, parameter list, or return value.
 | [`hull_fs_resolver_parity.md`](hull_fs_resolver_parity.md) | Checkpoint 2 ratification record: `openat2` vs the manual walk parity + the ratified depth divergence. |
 | [`hull_fs_buildcontext_audit.md`](hull_fs_buildcontext_audit.md) | The BuildContext / app-vs-plugin authority-split audit that feeds checkpoint 4. |
 | [`h1_cleanup_inventory.md`](h1_cleanup_inventory.md) | Design-only inventory + freeze for the H1 code-housekeeping cleanup (dead code, redundancy, comment archaeology, em-dashes) that precedes BuildContext. |
+| [`h1_s1_deadcode_audit.md`](h1_s1_deadcode_audit.md) | H1 slice S1: recorded source/build + fixture closure proofs and the `cap.h` disposition. Result: retain as-is, no deletion. |
 | [`reporting_ir_design.md`](reporting_ir_design.md) | Proposed reporting IR — **deferred** (over-scoped as the immediate next feature). |
 | [`sidecar_design.md`](sidecar_design.md) | Native sidecars — design only (Phase 0), not yet scheduled. |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,7 +96,7 @@ specific signature, parameter list, or return value.
 | [`hull_fs_resolver_parity.md`](hull_fs_resolver_parity.md) | Checkpoint 2 ratification record: `openat2` vs the manual walk parity + the ratified depth divergence. |
 | [`hull_fs_buildcontext_audit.md`](hull_fs_buildcontext_audit.md) | The BuildContext / app-vs-plugin authority-split audit that feeds checkpoint 4. |
 | [`h1_cleanup_inventory.md`](h1_cleanup_inventory.md) | Design-only inventory + freeze for the H1 code-housekeeping cleanup (dead code, redundancy, comment archaeology, em-dashes) that precedes BuildContext. |
-| [`h1_s1_deadcode_audit.md`](h1_s1_deadcode_audit.md) | H1 slice S1: recorded source/build + fixture closure proofs and the `cap.h` disposition. Result: retain as-is, no deletion. |
+| [`h1_s1_deadcode_audit.md`](h1_s1_deadcode_audit.md) | H1 slice S1: recorded build-system + fixture reference-coverage evidence and the `cap.h` disposition. Result: retain as-is, no deletion. |
 | [`reporting_ir_design.md`](reporting_ir_design.md) | Proposed reporting IR — **deferred** (over-scoped as the immediate next feature). |
 | [`sidecar_design.md`](sidecar_design.md) | Native sidecars — design only (Phase 0), not yet scheduled. |
 

--- a/docs/h1_s1_deadcode_audit.md
+++ b/docs/h1_s1_deadcode_audit.md
@@ -1,52 +1,85 @@
 # H1 / S1 - dead-code evidence audit (result: no deletion)
 
 Status: **AUDIT COMPLETE. ZERO CODE CHANGE.** S1 of the ratified
-[H1 cleanup freeze](h1_cleanup_inventory.md). It proves the freeze's 1.1 survey
-observations with recorded, reproducible commands, and settles the
-`include/hull/cap.h` disposition. **Outcome: retain as-is - there is nothing safe
-to delete in the dead-code dimension.** ("Finding no safe cleanup is a valid
-result.")
+[H1 cleanup freeze](h1_cleanup_inventory.md). It records reproducible evidence for
+the freeze's 1.1 survey observations and settles the `include/hull/cap.h`
+disposition. **Outcome: retain as-is - there is nothing safe to delete in the
+dead-code dimension.** ("Finding no safe cleanup is a valid result.")
 
-## 1. Source / build closure - COMPLETE (no orphan `.c`)
+**What this evidence does and does not prove (per review).** The two commands below
+establish REFERENCE COVERAGE - that the build system and the test/build harness
+mention every source and every fixture - NOT the prerequisite CLOSURE of a specific
+linked target. That is sufficient for the audit's purpose (there is no orphan file
+and nothing to delete); a per-composition prerequisite-closure proof is only needed
+if a deletion were ever proposed, and none is.
 
-Claim (freeze 1.1): every `src/hull/**/*.c` is part of the build under some
-configuration. Proven by diffing the full source set against every `.c` make
-resolves across the default build plus every feature flag:
+## 1. Build-system reference coverage - COMPLETE (every `.c` is referenced)
+
+Claim (freeze 1.1): no orphan `.c`. Evidence: every `src/hull/**/*.c` is referenced
+by the build system across the main build (all feature flags) AND the feature-
+archive targets (`make feature-<name>`). Fail-closed (the loop aborts if any
+`make -pn` errors, so a partial database is never silently accepted):
 
 ```sh
-{ make -pn 2>/dev/null
-  make -pn HL_ENABLE_GPU=1 HL_ENABLE_DUCKDB=1 HL_ENABLE_POSTGRES=1 \
-           HL_ENABLE_MYSQL=1 HL_ENABLE_TUI=1 HL_ENABLE_VALKEY=1 2>/dev/null
-} | grep -oE 'src/hull/[A-Za-z0-9_/.-]+\.c' | sort -u > /tmp/make_known
-find src/hull -name '*.c' | sort -u > /tmp/all_c
-comm -23 /tmp/all_c /tmp/make_known   # -> empty
+set -eu
+cov=$(mktemp)
+for goal in "" "HL_ENABLE_GPU=1 HL_ENABLE_DUCKDB=1 HL_ENABLE_POSTGRES=1 HL_ENABLE_MYSQL=1 HL_ENABLE_TUI=1 HL_ENABLE_VALKEY=1"; do
+  make -pn $goal >/dev/null   # fail closed: non-zero aborts under `set -e`
+  make -pn $goal 2>/dev/null | grep -oE 'src/hull/[A-Za-z0-9_/.-]+\.c'
+done > "$cov"
+for t in feature-duckdb feature-mysql feature-postgres feature-gpu feature-valkey; do
+  make -pn "$t" 2>/dev/null | grep -oE 'src/hull/[A-Za-z0-9_/.-]+\.c' >> "$cov"
+done
+comm -23 <(find src/hull -name '*.c' | sort -u) <(sort -u "$cov")   # -> empty
 ```
 
-Result: **275 source files, 275 build-referenced, 0 orphans.** One file
-(`cap/valkey_register.c`) is referenced ONLY under `HL_ENABLE_VALKEY=1` - it is
-feature-gated, not dead (this is exactly the "optional composition" case the freeze
-flagged: a default-only oracle would have mis-reported it). `make -pn` expands the
-`$(wildcard …)` globs and feature `ifeq` blocks, so the oracle is the build system's
-own resolved source set, not a basename grep.
+Result: **275 / 275 referenced, 0 orphans.** 270 are referenced by the main build
+(default + feature flags); the remaining **5 are feature-BACKEND sources built by
+the feature-archive targets, not the main hull link** - `cap/db_duckdb.c`,
+`cap/db_mysql.c`, `cap/db_postgres.c` (`make feature-<db>`, 8 refs each),
+`cap/gpu_wgpu.c` (`feature-gpu`, 8 refs), `cap/valkey_register.c`
+(`feature-valkey`). This is exactly the "optional composition" case the freeze
+flagged: a main-build-only oracle mis-reports them, which is why the feature targets
+are included. `make -pn` expands the `$(wildcard …)` globs and feature `ifeq`
+blocks, so the oracle is the build's own resolved reference set - not a basename grep.
 
-## 2. Fixture-reference closure - COMPLETE (no stale fixtures)
+**Corroboration (actual compilation, not just reference).** The generated
+`build/*.d` prerequisite files record what was ACTUALLY compiled in the
+currently-built configuration: `grep -hoE 'src/hull/[^ ]+\.c' build/*.d | sort -u`
+lists 253 `.c` for the default+test build present at audit time. This is stronger
+than reference coverage but composition-specific; extending it to a full
+per-composition compile+link closure is the strengthening step S1 would run IF a
+deletion were proposed.
 
-Claim (freeze 1.1): every `tests/fixtures/*` is used. Proven repo-wide (the search
-MUST include the Makefile / mk / scripts, not just `tests/` - the first pass missed
-two because it was `tests/`-scoped):
+## 2. Fixture-name reference coverage - COMPLETE (every fixture has a validated consumer)
+
+Claim (freeze 1.1): no stale `tests/fixtures/*`. Evidence: a path-exact
+fixture->consumer table over **executable test/build wiring only** (Make / mk /
+shell / test `.c`), with DOCUMENTATION references excluded (a `CLAUDE.md` mention is
+not test use - the earlier draft's inclusion of it, and its bare-basename substring
+match, overstated the claim):
 
 ```sh
 for fx in tests/fixtures/*; do b=$(basename "$fx")
-  grep -rq "$b" Makefile mk scripts tests CLAUDE.md \
-    --exclude-dir="$(basename "$fx")" 2>/dev/null \
-    || echo "UNREFERENCED $fx"
-done   # -> no output
+  grep -rn "tests/fixtures/$b\b" Makefile mk scripts tests \
+    --include='*.mk' --include='*.sh' --include='*.c' --include='Makefile' \
+    | grep -v "^tests/fixtures/$b/" || echo "NO PATH-EXACT CONSUMER $b"
+done
 ```
 
-Result: **every fixture is referenced.** The two the `tests/`-only pass flagged are
-driven from the Makefile: `tests/fixtures/selfbuild_app` (self-build e2e,
-`Makefile:3008`) and `tests/fixtures/null_app` (compiler-free / null-app e2e,
-`Makefile:3036,3038`).
+Result: **every fixture has an executable consumer**, each manually confirmed to be
+real test/build wiring (not a doc mention). The path-exact table maps e.g.
+`auth_flows_*` -> `e2e_auth_flows*.sh`, `oauth_*` -> `e2e_oauth.sh`, `mime` ->
+`tests/hull/cap/test_mime.c`, `null_app` / `selfbuild_app` -> `Makefile`
+(compiler-free / self-build e2e), `test262` / `lua54-tests` -> `scripts/fetch_*.sh`.
+The only two the path-exact pass flagged - `valkey_kv_lua` / `valkey_kv_js` - are
+consumed by `tests/e2e_valkey.sh:104-105` via a variable-prefixed path
+(`"$FIX/valkey_kv_lua/app.lua"`), which a literal-path grep cannot see;
+manually validated as executable wiring.
+
+Caveat: this is fixture-NAME reference coverage over the enumerated wiring, plus a
+manual check that each hit is executable - not a mechanical proof that every
+referenced fixture is exercised on every CI run.
 
 ## 3. `include/hull/cap.h` - disposition: RETAIN
 
@@ -74,10 +107,16 @@ audit finds no reason to do even that now.
 ## 4. Conclusion
 
 The dead-code dimension of H1 has **nothing to delete**:
-- source/build closure: complete (0 orphans);
-- fixture-reference closure: complete (0 stale);
+- build-system reference coverage: complete (275/275 referenced; 0 orphans),
+  corroborated by the `build/*.d` actual-compile set for the built configuration;
+- fixture-name reference coverage: complete (every fixture has a manually-validated
+  executable consumer; 0 stale);
 - `cap.h`: retained public surface, not dead code.
 
-**No code was changed in S1.** The commands above are reproducible and could seed a
-future closure gate if desired. Next slice: S2a (consolidate only the verbatim
+Each result states exactly what its command proves - reference coverage (+ a compile
+corroboration and a manual wiring check), NOT the prerequisite closure of a linked
+target; the latter is only warranted if a deletion is proposed, and none is.
+
+**No code was changed in S1.** The commands are reproducible and could seed a future
+coverage gate if desired. Next slice: S2a (consolidate only the verbatim
 `feature.c` / `flavor.c` checksum comparison).

--- a/docs/h1_s1_deadcode_audit.md
+++ b/docs/h1_s1_deadcode_audit.md
@@ -1,0 +1,83 @@
+# H1 / S1 - dead-code evidence audit (result: no deletion)
+
+Status: **AUDIT COMPLETE. ZERO CODE CHANGE.** S1 of the ratified
+[H1 cleanup freeze](h1_cleanup_inventory.md). It proves the freeze's 1.1 survey
+observations with recorded, reproducible commands, and settles the
+`include/hull/cap.h` disposition. **Outcome: retain as-is - there is nothing safe
+to delete in the dead-code dimension.** ("Finding no safe cleanup is a valid
+result.")
+
+## 1. Source / build closure - COMPLETE (no orphan `.c`)
+
+Claim (freeze 1.1): every `src/hull/**/*.c` is part of the build under some
+configuration. Proven by diffing the full source set against every `.c` make
+resolves across the default build plus every feature flag:
+
+```sh
+{ make -pn 2>/dev/null
+  make -pn HL_ENABLE_GPU=1 HL_ENABLE_DUCKDB=1 HL_ENABLE_POSTGRES=1 \
+           HL_ENABLE_MYSQL=1 HL_ENABLE_TUI=1 HL_ENABLE_VALKEY=1 2>/dev/null
+} | grep -oE 'src/hull/[A-Za-z0-9_/.-]+\.c' | sort -u > /tmp/make_known
+find src/hull -name '*.c' | sort -u > /tmp/all_c
+comm -23 /tmp/all_c /tmp/make_known   # -> empty
+```
+
+Result: **275 source files, 275 build-referenced, 0 orphans.** One file
+(`cap/valkey_register.c`) is referenced ONLY under `HL_ENABLE_VALKEY=1` - it is
+feature-gated, not dead (this is exactly the "optional composition" case the freeze
+flagged: a default-only oracle would have mis-reported it). `make -pn` expands the
+`$(wildcard …)` globs and feature `ifeq` blocks, so the oracle is the build system's
+own resolved source set, not a basename grep.
+
+## 2. Fixture-reference closure - COMPLETE (no stale fixtures)
+
+Claim (freeze 1.1): every `tests/fixtures/*` is used. Proven repo-wide (the search
+MUST include the Makefile / mk / scripts, not just `tests/` - the first pass missed
+two because it was `tests/`-scoped):
+
+```sh
+for fx in tests/fixtures/*; do b=$(basename "$fx")
+  grep -rq "$b" Makefile mk scripts tests CLAUDE.md \
+    --exclude-dir="$(basename "$fx")" 2>/dev/null \
+    || echo "UNREFERENCED $fx"
+done   # -> no output
+```
+
+Result: **every fixture is referenced.** The two the `tests/`-only pass flagged are
+driven from the Makefile: `tests/fixtures/selfbuild_app` (self-build e2e,
+`Makefile:3008`) and `tests/fixtures/null_app` (compiler-free / null-app e2e,
+`Makefile:3036,3038`).
+
+## 3. `include/hull/cap.h` - disposition: RETAIN
+
+Evidence:
+- **Content:** a pure umbrella - 9 `#include "hull/cap/*.h"` lines plus the
+  `HL_CAP_H` guard. It defines no symbols of its own.
+- **In-repo use:** zero (every Hull TU includes the individual `cap/*.h`).
+- **Public surface:** `include/hull/**` IS Hull's public C-header tree, shipped to
+  native embedders (see [`libhull_flavor.md`](libhull_flavor.md); embedders compile
+  against `hull/embed.h` and the header tree). `cap.h` has been present since an
+  early commit and is a valid `#include <hull/cap.h>` an external embedder could use
+  to pull in every capability header at once.
+- **Not** named in [`stability.md`](stability.md) tiers or any packaging / install
+  manifest - so it is neither an explicitly-committed nor an explicitly-excluded
+  surface.
+
+Disposition: **RETAIN.** Zero in-repo use does NOT prove external embedders don't
+depend on it; deleting a long-present public header is a source-compatibility risk
+with no offsetting benefit (a 9-line umbrella costs nothing to keep). It is
+correctly classified as "internally-unused public surface", not dead code. If the
+project later decides to slim the public surface, the path is **deprecate-first** (a
+documented deprecation note + one release cycle), never a silent delete - but this
+audit finds no reason to do even that now.
+
+## 4. Conclusion
+
+The dead-code dimension of H1 has **nothing to delete**:
+- source/build closure: complete (0 orphans);
+- fixture-reference closure: complete (0 stale);
+- `cap.h`: retained public surface, not dead code.
+
+**No code was changed in S1.** The commands above are reproducible and could seed a
+future closure gate if desired. Next slice: S2a (consolidate only the verbatim
+`feature.c` / `flavor.c` checksum comparison).

--- a/docs/h1_s1_deadcode_audit.md
+++ b/docs/h1_s1_deadcode_audit.md
@@ -28,6 +28,7 @@ for goal in "" "HL_ENABLE_GPU=1 HL_ENABLE_DUCKDB=1 HL_ENABLE_POSTGRES=1 HL_ENABL
   make -pn $goal 2>/dev/null | grep -oE 'src/hull/[A-Za-z0-9_/.-]+\.c'
 done > "$cov"
 for t in feature-duckdb feature-mysql feature-postgres feature-gpu feature-valkey; do
+  make -pn "$t" >/dev/null   # fail closed: same preflight as the runs above
   make -pn "$t" 2>/dev/null | grep -oE 'src/hull/[A-Za-z0-9_/.-]+\.c' >> "$cov"
 done
 comm -23 <(find src/hull -name '*.c' | sort -u) <(sort -u "$cov")   # -> empty


### PR DESCRIPTION
**H1 slice S1 — evidence audit only. Zero code change; zero deletion.** Proves the freeze's 1.1 survey observations with recorded, reproducible commands and settles the `cap.h` disposition. Outcome: **retain as-is — nothing safe to delete in the dead-code dimension** (a valid result).

## 1. Source/build closure — COMPLETE (0 orphans)
Diffed all `src/hull/**/*.c` against every `.c` make resolves across the default build **plus every feature flag** (`make -pn` expands `$(wildcard)` + feature `ifeq`, so the oracle is the build's own resolved source set — not a basename grep). **275 files, 275 build-referenced, 0 orphans.** The lone default-build outlier, `cap/valkey_register.c`, is `HL_ENABLE_VALKEY`-gated — feature, not dead (exactly the "optional composition" case the freeze warned about).

## 2. Fixture-reference closure — COMPLETE (0 stale)
Every `tests/fixtures/*` is referenced. The two a `tests/`-only pass flagged (`null_app`, `selfbuild_app`) are driven from Makefile e2e targets — the recorded command searches `Makefile`/`mk`/`scripts` too.

## 3. `include/hull/cap.h` — RETAIN
Pure umbrella (9 `cap/*.h` includes + guard), zero in-repo use, but in the **public embedder header tree** (`include/hull/` ships to embedders) and long-present. Zero in-repo use doesn't prove external embedders don't use it; deleting long-present public surface is a source-compat risk with no benefit. Classified "internally-unused public surface," not dead code. Deprecate-first if ever slimmed — but this audit finds no reason to do even that now.

## Verification
Docs-only change (the recorded audit + its catalog entry); docs-integrity gate green; `git status` confirms **no source file touched**.

Next slice after review: **S2a** — consolidate only the verbatim `feature.c`/`flavor.c` checksum comparison.