### PR TITLE
chore(H1/S2a): de-duplicate feature/flavor checksum compare (private helper)

### DIFF
--- a/src/hull/commands/asset_checksum.c
+++ b/src/hull/commands/asset_checksum.c
@@ -1,0 +1,16 @@
+/*
+ * asset_checksum.c - the fixed-64 constant-time checksum compare shared by
+ * `hull feature install` and `hull flavor install`. See asset_checksum.h for the
+ * contract and the rationale for keeping this out of the public header tree.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#include "asset_checksum.h"
+
+int hl_asset_checksum_eq(const char a[64], const char b[64])
+{
+    unsigned char diff = 0;
+    for (int i = 0; i < 64; i++)
+        diff |= (unsigned char)(a[i] ^ b[i]);
+    return diff == 0;
+}

--- a/src/hull/commands/asset_checksum.h
+++ b/src/hull/commands/asset_checksum.h
@@ -1,0 +1,26 @@
+/*
+ * asset_checksum.h - PRIVATE helper for the installer commands (`hull feature
+ * install` / `hull flavor install`).
+ *
+ * Deliberately NOT in include/hull/ (Hull's public C-header surface): the fixed
+ * 64-byte width is an installer-INTERNAL detail, not an external API contract. A
+ * public, unbounded-pointer, fixed-read primitive would let future callers violate
+ * the "both buffers are 64-byte array-backed" precondition; keeping it private
+ * confines that precondition to the two trusted callers that already satisfy it.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#ifndef HULL_COMMANDS_ASSET_CHECKSUM_H
+#define HULL_COMMANDS_ASSET_CHECKSUM_H
+
+/*
+ * Constant-time equality of two 64-char hex SHA-256 digests. The checksums are
+ * PUBLIC values (a manifest entry vs a locally-computed digest), so the
+ * constant-time form is belt-and-suspenders, matching the rest of Hull's hash
+ * compares. The caller GUARANTEES both arguments are 64-byte array-backed buffers
+ * already parsed from the release manifest / computed locally; exactly 64 bytes
+ * are compared. Returns 1 if the 64 bytes are equal, 0 otherwise.
+ */
+int hl_asset_checksum_eq(const char a[64], const char b[64]);
+
+#endif /* HULL_COMMANDS_ASSET_CHECKSUM_H */

--- a/src/hull/commands/feature.c
+++ b/src/hull/commands/feature.c
@@ -25,6 +25,7 @@
 #ifdef HL_ENABLE_HTTP_CLIENT
 
 #include "hull/release_io.h"
+#include "asset_checksum.h"   /* private installer helper (sibling, not public) */
 
 #include <keel/allocator.h>
 #include <keel/tls_mbedtls.h>
@@ -136,16 +137,6 @@ static int feature_cache_dir(char *out, size_t out_sz)
     return 0;
 }
 
-/* Constant-time compare of two 64-char hex SHA-256 strings (public values;
- * matches the rest of Hull's hash compares). */
-static int ct_hex_eq(const char *a, const char *b)
-{
-    unsigned char diff = 0;
-    for (int i = 0; i < 64; i++)
-        diff |= (unsigned char)(a[i] ^ b[i]);
-    return diff == 0;
-}
-
 static int install_asset(const char *asset, const char *repo, const char *tag,
                          KlAllocator *alloc, KlTlsCtx *tls,
                          const char *manifest, size_t manifest_len,
@@ -180,7 +171,7 @@ static int install_asset(const char *asset, const char *repo, const char *tag,
         kl_free(alloc, body, body_len);
         return -1;
     }
-    if (!ct_hex_eq(expected, actual)) {
+    if (!hl_asset_checksum_eq(expected, actual)) {
         fprintf(stderr, "hull feature: SHA-256 MISMATCH for %s\n"
                         "  expected %s\n  actual   %s\n", asset, expected, actual);
         kl_free(alloc, body, body_len);

--- a/src/hull/commands/flavor.c
+++ b/src/hull/commands/flavor.c
@@ -24,6 +24,7 @@
 
 #include "hull/release_io.h"
 #include "hull/module_resolver.h"   /* HlBuildFlavor / hl_build_flavor_* */
+#include "asset_checksum.h"         /* private installer helper (sibling, not public) */
 
 #include <keel/allocator.h>
 #include <keel/tls_mbedtls.h>
@@ -78,17 +79,6 @@ static int platform_cache_dir(char *out, size_t out_sz)
     return 0;
 }
 
-/* Constant-time compare of two 64-char hex SHA-256 strings. The values are
- * public (manifest checksum + computed digest), so a timing leak reveals
- * nothing; the constant-time form matches the rest of Hull's hash compares. */
-static int ct_hex_eq(const char *a, const char *b)
-{
-    unsigned char diff = 0;
-    for (int i = 0; i < 64; i++)
-        diff |= (unsigned char)(a[i] ^ b[i]);
-    return diff == 0;
-}
-
 /* Build the published asset names for a flavor on this platform.
  * Returns the count (1 native, 2 cosmo); names written into assets[]. */
 static int flavor_assets(const HlBuildFlavor *f, const char *plat,
@@ -140,7 +130,7 @@ static int install_asset(const char *asset, const char *repo, const char *tag,
         kl_free(alloc, body, body_len);
         return -1;
     }
-    if (!ct_hex_eq(expected, actual)) {
+    if (!hl_asset_checksum_eq(expected, actual)) {
         fprintf(stderr, "hull platform: SHA-256 MISMATCH for %s\n"
                         "  expected %s\n  actual   %s\n", asset, expected, actual);
         kl_free(alloc, body, body_len);

--- a/tests/hull/commands/test_dispatch.c
+++ b/tests/hull/commands/test_dispatch.c
@@ -45,4 +45,19 @@ UTEST(dispatch, entry_point_returns_neg1)
  * the dispatcher correctly falls through for non-command args.
  */
 
+/* The private installer checksum helper (src/hull/commands/asset_checksum.h is not
+ * on the public -Iinclude path, so forward-declare it; the symbol is in CMD_OBJS,
+ * which this test links). H1 S2a de-duplicated feature.c/flavor.c onto it. */
+int hl_asset_checksum_eq(const char a[64], const char b[64]);
+
+UTEST(asset_checksum, fixed64_equal_and_diffs)
+{
+    char a[64], b[64];
+    memset(a, 'a', 64); memset(b, 'a', 64);
+    ASSERT_EQ(hl_asset_checksum_eq(a, b), 1);   /* equal over the 64 */
+    b[0] = 'b';  ASSERT_EQ(hl_asset_checksum_eq(a, b), 0);   /* differ at index 0 */
+    b[0] = 'a';  b[63] = 'b';
+    ASSERT_EQ(hl_asset_checksum_eq(a, b), 0);   /* differ at index 63 */
+}
+
 UTEST_MAIN();


### PR DESCRIPTION
**H1 slice S2a**, revised per review. Consolidate the byte-identical `ct_hex_eq` copied verbatim in `commands/feature.c` and `commands/flavor.c` — **without expanding public surface**.

## Why this form (review correction)
The first form added `hl_release_io_ct_hex_eq()` to `include/hull/release_io.h` — Hull's **public** header tree. That was the wrong trade: a lax, unbounded-pointer, fixed-64-read primitive as public API lets future callers violate the "64-byte array-backed buffers" precondition that only the two current callers satisfy. The cleanup must **reduce** surface, not add public API.

## Change
- New **`src/hull/commands/asset_checksum.{h,c}`** — a **private** installer helper, deliberately **not** under `include/hull/`. The fixed-64 width is an installer-internal detail, confined to the two trusted callers.
- `feature.c` / `flavor.c` include the sibling header and call `hl_asset_checksum_eq`; their local statics are deleted.
- Auto-built via the `CMD_SRCS` wildcard (no Makefile change); the symbol is in `CMD_OBJS` (which `test_dispatch` links), so the test forward-declares it.

`release_io.c`'s own `local_ct_hex_eq` (stricter, length-validating — a *different* contract) is **untouched**; reconciling the families is **S3**.

## Verification
- Behavior **byte-identical** (verbatim extraction).
- Test (`test_dispatch.c::asset_checksum`): equal + differences at indices **0 and 63**. It deliberately does **not** assert "byte 64 ignored" — incidental implementation behavior, not a supported contract.
- `make test` 90/90; `test_dispatch` 5/5; `test_release_io` 19/19 (public-API form reverted); hull + static analyzer clean.
- Diff vs `main` is exactly: `asset_checksum.{h,c}` + the two callers + the test. Zero `release_io` / public-header change.

Next after review: **S2b** — hex ownership + link-closure design (no consolidation code until its dependency table is ratified).