### PR TITLE
H1/S2b execution: consolidate byte->hex encoders onto a private utils/hex leaf (Option A)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -934,6 +934,14 @@ CAP_OBJS := $(patsubst $(SRCDIR)/hull/cap/%.c,$(BUILDDIR)/cap_%.o,$(CAP_SRCS))
 # where unreferenced (flavors with no db and no http).
 HOST_MATCH_OBJ := $(BUILDDIR)/host_match.o
 CAP_OBJS += $(HOST_MATCH_OBJ)
+# hex is a domain-free leaf util (src/hull/utils/hex.c): the single home for the
+# byte->hex-buffer transform (H1 / S2b, docs/h1_s2b_hex_ownership.md). Like
+# host_match it rides CAP_OBJS, so it reaches the platform lib (base + cosmo),
+# the hull binary, libhull, and every TEST_CAP_OBJS suite with one edit. Harmless
+# where unreferenced. Consumers (signature/release/sbom/blob_store/db_postgres/
+# verify_self/mod_tool) include it by relative path; it is not public API.
+HEX_OBJ := $(BUILDDIR)/hex.o
+CAP_OBJS += $(HEX_OBJ)
 CAP_TOOL_OBJ := $(BUILDDIR)/cap_tool.o
 # cap/test.c is the in-process HTTP test harness — depends on KlRouter
 # and the rest of Keel's request/response machinery. Server-only.
@@ -2926,6 +2934,9 @@ $(CSP_OBJ): $(SRCDIR)/hull/utils/csp.c $(INCDIR)/hull/utils/csp.h | $(BUILDDIR)
 
 # Host allowlist matcher (glob + CIDR), shared by db / http / smtp.
 $(HOST_MATCH_OBJ): $(SRCDIR)/hull/utils/host_match.c $(INCDIR)/hull/host_match.h | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
+
+$(HEX_OBJ): $(SRCDIR)/hull/utils/hex.c $(SRCDIR)/hull/utils/hex.h | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
 
 # QuickJS sources (relaxed warnings)

--- a/docs/h1_s2b_hex_ownership.md
+++ b/docs/h1_s2b_hex_ownership.md
@@ -16,6 +16,17 @@ only the seven verified buffer encoders (P1-P7); the cache helper, the
 `hl_release_io_sha256_hex` hash+hex composite, and the `FILE*`-stream encoder are
 left unchanged unless a later ownership audit justifies moving them.
 
+**EXECUTED:** the consolidation slice landed `src/hull/utils/hex.{c,h}` and
+routed P1-P7 onto it, one TU per commit, under section 5's acceptance. Proof of
+unchanged dependency closure: `hex.o` has zero undefined symbols, so every
+consumer's link closure grows by exactly `hl_hex_encode` and no composition
+gains a crypto/mbedtls reference (`nm` verified per consumer). No material size
+regression: the base binary is 96 bytes SMALLER (seven statics removed, one
+152-byte leaf added). Linked and validated across base (unit tests 91/91),
+pure-compute, libhull (C embedder links), and PostgreSQL; cosmo inclusion is
+structural (`PLATFORM_CAP_OBJS` is the full `CAP_OBJS` on cosmo, which carries
+`hex.o`) and CI-covered.
+
 ## 1. Why this slice is design-only
 
 The freeze deferred hex consolidation specifically because "route the generic

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -382,6 +382,9 @@ $(BUILDDIR)/test_cfi: $(TESTDIR)/hull/test_cfi.c | $(BUILDDIR)
 $(BUILDDIR)/test_csp: $(TESTDIR)/hull/test_csp.c $(CSP_OBJ) | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(CSP_OBJ)
 
+$(BUILDDIR)/test_hex: $(TESTDIR)/hull/test_hex.c $(HEX_OBJ) | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(HEX_OBJ)
+
 # Mapped-spans SDK header (templates/hull_span.h, checkpoint 3b) — native decoder
 # / name-lookup / scratch-narrow tests. Freestanding header; the only extra
 # include path is -Itemplates for hull_span.h. No deps beyond libc.

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -503,16 +503,16 @@ CRYPTO_TEST_OBJS := $(BUILDDIR)/cap_crypto.o $(BUILDDIR)/cap_crypto_hmac_mbedtls
 # atomic write). Skipped on HL_ENABLE_HTTP_CLIENT=0 builds where the
 # helper module isn't compiled in.
 ifneq ($(HL_ENABLE_HTTP_CLIENT),0)
-$(BUILDDIR)/test_release_io: $(TESTDIR)/hull/test_release_io.c $(RELEASE_IO_OBJ) $(RELEASE_OBJ) $(CACERT_OBJ) $(TLS_TRANSPORT_OBJ) $(TLS_TRANSPORT_STUB_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) | $(BUILDDIR)
-	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(RELEASE_IO_OBJ) $(RELEASE_OBJ) $(CACERT_OBJ) $(TLS_TRANSPORT_OBJ) $(TLS_TRANSPORT_STUB_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) -lm -lpthread
+$(BUILDDIR)/test_release_io: $(TESTDIR)/hull/test_release_io.c $(RELEASE_IO_OBJ) $(RELEASE_OBJ) $(HEX_OBJ) $(CACERT_OBJ) $(TLS_TRANSPORT_OBJ) $(TLS_TRANSPORT_STUB_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(RELEASE_IO_OBJ) $(RELEASE_OBJ) $(HEX_OBJ) $(CACERT_OBJ) $(TLS_TRANSPORT_OBJ) $(TLS_TRANSPORT_STUB_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) -lm -lpthread
 endif
 
 # Verify-self helpers test. Reuses release_io.{c,h} for asset-name,
 # checksum-line lookup, SHA-256, and self-path resolution. Same link
 # dependencies as test_release_io.
 ifneq ($(HL_ENABLE_HTTP_CLIENT),0)
-$(BUILDDIR)/test_verify_self: $(TESTDIR)/hull/test_verify_self.c $(RELEASE_IO_OBJ) $(RELEASE_OBJ) $(CACERT_OBJ) $(TLS_TRANSPORT_OBJ) $(TLS_TRANSPORT_STUB_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) | $(BUILDDIR)
-	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(RELEASE_IO_OBJ) $(RELEASE_OBJ) $(CACERT_OBJ) $(TLS_TRANSPORT_OBJ) $(TLS_TRANSPORT_STUB_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) -lm -lpthread
+$(BUILDDIR)/test_verify_self: $(TESTDIR)/hull/test_verify_self.c $(RELEASE_IO_OBJ) $(RELEASE_OBJ) $(HEX_OBJ) $(CACERT_OBJ) $(TLS_TRANSPORT_OBJ) $(TLS_TRANSPORT_STUB_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(RELEASE_IO_OBJ) $(RELEASE_OBJ) $(HEX_OBJ) $(CACERT_OBJ) $(TLS_TRANSPORT_OBJ) $(TLS_TRANSPORT_STUB_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) -lm -lpthread
 endif
 
 # Platform-sig helpers — reuses release.c (sign/verify) +
@@ -542,8 +542,8 @@ $(BUILDDIR)/test_obj_emit: $(TESTDIR)/hull/test_obj_emit.c $(OBJ_EMIT_OBJ) | $(B
 # embedded-blob SHA-256 cache. Links against sbom.o + cacert.o + mbedTLS;
 # nothing else. If SBOM accidentally pulls in other Hull subsystems,
 # this link line will need to grow — that's the orthogonality canary.
-$(BUILDDIR)/test_sbom: $(TESTDIR)/hull/test_sbom.c $(SBOM_OBJ) $(CACERT_OBJ) $(SH_JSON_OBJ) $(SH_ARENA_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) | $(BUILDDIR)
-	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(SBOM_OBJ) $(CACERT_OBJ) $(SH_JSON_OBJ) $(SH_ARENA_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS)
+$(BUILDDIR)/test_sbom: $(TESTDIR)/hull/test_sbom.c $(SBOM_OBJ) $(HEX_OBJ) $(CACERT_OBJ) $(SH_JSON_OBJ) $(SH_ARENA_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(SBOM_OBJ) $(HEX_OBJ) $(CACERT_OBJ) $(SH_JSON_OBJ) $(SH_ARENA_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS)
 
 # Path-normalize test — standalone, exercises hl_path_normalize directly
 # so a regression in the helper is caught here rather than only via the

--- a/src/hull/cap/db_postgres.c
+++ b/src/hull/cap/db_postgres.c
@@ -18,6 +18,7 @@
 #include "hull/cap/pg_conn.h"
 #include "hull/cap/types.h"
 #include "hull/utils/alloc.h"
+#include "../utils/hex.h"
 
 #include <limits.h>
 #include <stdint.h>
@@ -87,7 +88,6 @@ static HlPgParam *encode_params(const HlValue *params, int n, char ***scratch_ou
     char **scratch = calloc((size_t)n, sizeof *scratch);
     if (!pp || !scratch) { free(pp); free(scratch); return NULL; }
 
-    static const char hex[] = "0123456789abcdef";
     for (int i = 0; i < n; i++) {
         const HlValue *v = &params[i];
         switch (v->type) {
@@ -122,12 +122,8 @@ static HlPgParam *encode_params(const HlValue *params, int n, char ***scratch_ou
             char *b = malloc(hl + 1);
             if (!b) goto oom;
             b[0] = '\\'; b[1] = 'x';
-            const unsigned char *src = (const unsigned char *)v->s;
-            for (size_t j = 0; j < bl; j++) {
-                b[2 + j * 2]     = hex[src[j] >> 4];
-                b[2 + j * 2 + 1] = hex[src[j] & 0xf];
-            }
-            b[hl] = '\0';
+            /* hex chars fill b[2 .. 2+bl*2), NUL at b[hl]; capacity = bl*2+1. */
+            hl_hex_encode((const uint8_t *)v->s, bl, b + 2, bl * 2 + 1);
             scratch[i] = b; pp[i].text = b; pp[i].len = (int32_t)hl;
             break;
         }

--- a/src/hull/commands/verify_self.c
+++ b/src/hull/commands/verify_self.c
@@ -38,6 +38,7 @@
 #define HL_VERIFY_SELF_BINARY_MAX_BYTES (256U * 1024U * 1024U)
 
 #include "hull/cap/crypto.h"
+#include "../utils/hex.h"
 
 static void usage(FILE *fp)
 {
@@ -107,12 +108,7 @@ static int sha256_file_hex(const char *path, char hex_out[HL_SHA256_HEX_BUF])
     free(buf);
     if (rc != 0) return -1;
 
-    static const char hex[] = "0123456789abcdef";
-    for (int i = 0; i < 32; i++) {
-        hex_out[i*2]   = hex[(digest[i] >> 4) & 0xf];
-        hex_out[i*2+1] = hex[digest[i] & 0xf];
-    }
-    hex_out[64] = '\0';
+    hl_hex_encode(digest, 32, hex_out, HL_SHA256_HEX_BUF);
     return 0;
 }
 

--- a/src/hull/release.c
+++ b/src/hull/release.c
@@ -10,6 +10,7 @@
 
 #include "hull/release.h"
 #include "hull/cap/crypto.h"
+#include "utils/hex.h"
 
 #include <ctype.h>
 #include <stdio.h>
@@ -21,17 +22,9 @@
 /* hex decode goes through the canonical hl_cap_crypto_hex_decode (cap/crypto.h):
  * it returns the byte count written (out_size is a capacity), so `rc == N`
  * checks an exact N-byte decode - equivalent to the old local 0/-1 contract
- * that required hex_len == N*2. See signature.c for the rationale. */
-
-static void hex_encode(const uint8_t *data, size_t len, char *out)
-{
-    static const char digits[] = "0123456789abcdef";
-    for (size_t i = 0; i < len; i++) {
-        out[i * 2]     = digits[(data[i] >> 4) & 0xF];
-        out[i * 2 + 1] = digits[data[i] & 0xF];
-    }
-    out[len * 2] = '\0';
-}
+ * that required hex_len == N*2. See signature.c for the rationale.
+ *
+ * hex encode goes through the shared byte->hex leaf hl_hex_encode (utils/hex.h). */
 
 /* Strip trailing whitespace (\n, \r, space, tab). */
 static size_t strip_trailing_ws(const char *buf, size_t len)
@@ -117,7 +110,7 @@ int hl_release_sign_manifest(const void *manifest, size_t manifest_len,
         return -1;
     }
 
-    hex_encode(sig, sizeof(sig), out_sig_hex);
+    hl_hex_encode(sig, sizeof(sig), out_sig_hex, out_sig_hex_size);
     secure_zero(sig, sizeof(sig));
     return 0;
 }

--- a/src/hull/runtime/lua/mod_tool.c
+++ b/src/hull/runtime/lua/mod_tool.c
@@ -30,6 +30,7 @@
 #include "hull/obj_emit.h"
 #include "hull/linker.h"
 #include "hull/bundled_objs.h"
+#include "../../utils/hex.h"
 #include "hull/tools_install.h"
 #include "hull/embedded_platform_sig.h"
 #include "hull/platform_sig.h"
@@ -1554,13 +1555,8 @@ static int l_tool_sha256_file(lua_State *L)
         lua_pushstring(L, "hash failed");
         return 2;
     }
-    static const char hexd[] = "0123456789abcdef";
     char hex[65];
-    for (int i = 0; i < 32; i++) {
-        hex[i * 2]     = hexd[digest[i] >> 4];
-        hex[i * 2 + 1] = hexd[digest[i] & 0x0f];
-    }
-    hex[64] = '\0';
+    hl_hex_encode(digest, 32, hex, sizeof(hex));
     lua_pushstring(L, hex);
     return 1;
 }

--- a/src/hull/sbom.c
+++ b/src/hull/sbom.c
@@ -66,17 +66,14 @@
  * (mbedTLS is dropped there). The gate name is retained for back-compat; it
  * now just toggles whether these hashing helpers are compiled at all. */
 #include "hull/cap/crypto.h"
+#include "utils/hex.h"
 
 /* Encode raw SHA-256 bytes as lowercase hex; writes exactly
- * HL_SHA256_HEX_LEN chars plus a NUL terminator into out_hex. */
+ * HL_SHA256_HEX_LEN chars plus a NUL terminator into out_hex. Callers pass a
+ * HL_SHA256_HEX_BUF (65-byte) buffer. Routed through the shared byte->hex leaf. */
 static void hex_encode_sha256(const unsigned char *raw, char *out_hex)
 {
-    static const char hex[] = "0123456789abcdef";
-    for (unsigned i = 0; i < HL_SHA256_DIGEST_BYTES; i++) {
-        out_hex[i*2]   = hex[(raw[i] >> 4) & 0xf];
-        out_hex[i*2+1] = hex[raw[i] & 0xf];
-    }
-    out_hex[HL_SHA256_HEX_LEN] = '\0';
+    hl_hex_encode(raw, HL_SHA256_DIGEST_BYTES, out_hex, HL_SHA256_HEX_BUF);
 }
 
 /* Compute SHA-256 over an in-memory buffer; cache the hex result. */

--- a/src/hull/shared/blob_store.c
+++ b/src/hull/shared/blob_store.c
@@ -15,6 +15,7 @@
 #include "hull/shared/fs_util.h"
 #include "hull/cap/crypto.h"
 #include "hull/utils/alloc.h"
+#include "../utils/hex.h"
 
 #include <ctype.h>
 #include <dirent.h>
@@ -83,17 +84,9 @@ struct HlBlobStoreReader {
     int          fd;
 };
 
-/* ── Hex helpers ─────────────────────────────────────────────────── */
-
-static void hex_encode(const uint8_t *bytes, size_t len, char *out)
-{
-    static const char HEX[] = "0123456789abcdef";
-    for (size_t i = 0; i < len; i++) {
-        out[i * 2]     = HEX[(bytes[i] >> 4) & 0xF];
-        out[i * 2 + 1] = HEX[bytes[i] & 0xF];
-    }
-    out[len * 2] = '\0';
-}
+/* Hex encoding goes through the shared byte->hex leaf hl_hex_encode
+ * (utils/hex.h). The nibble->shard-directory-name table further down is a
+ * different shape (path construction, not buffer encoding) and stays local. */
 
 /* Validate that `id` is exactly HL_BLOB_STORE_ID_HEX_LEN lowercase
  * hex characters. */
@@ -149,7 +142,7 @@ static int make_tmp_name(char *out, size_t out_cap)
     uint8_t rand_bytes[HL_BLOB_STORE_TMP_RAND_BYTES];
     if (hl_cap_crypto_random(rand_bytes, sizeof(rand_bytes)) != 0) return -1;
     char hex[HL_BLOB_STORE_TMP_RAND_HEX + 1];
-    hex_encode(rand_bytes, sizeof(rand_bytes), hex);
+    hl_hex_encode(rand_bytes, sizeof(rand_bytes), hex, sizeof(hex));
     int n = snprintf(out, out_cap, "%s%s%s",
                      HL_BLOB_STORE_TMP_PREFIX, hex,
                      HL_BLOB_STORE_TMP_SUFFIX);
@@ -349,7 +342,7 @@ int hl_blob_store_writer_finalize(HlBlobStoreWriter *w,
         return -1;
     }
     char id[HL_BLOB_STORE_ID_BUF_SIZE];
-    hex_encode(digest, 32, id);
+    hl_hex_encode(digest, 32, id, sizeof(id));
 
     if (w->durable && fsync(w->fd) < 0) {
         close(w->fd); w->fd = -1;

--- a/src/hull/signature.c
+++ b/src/hull/signature.c
@@ -11,6 +11,7 @@
 #include "hull/signature.h"
 #include "hull/cap/crypto.h"
 #include "hull/platform_sig.h"
+#include "utils/hex.h"
 
 #include "log.h"
 
@@ -32,13 +33,9 @@
  * success check is `rc == N` where N is the expected byte count: that requires
  * hex_len/2 == N exactly (a short input returns <N; a long one returns -1 for
  * insufficient capacity), matching the exact-length fail-closed contract these
- * Ed25519 verify paths need. */
-
-static void hex_encode(const uint8_t *data, size_t len, char *out)
-{
-    for (size_t i = 0; i < len; i++)
-        snprintf(out + i * 2, 3, "%02x", data[i]);
-}
+ * Ed25519 verify paths need.
+ *
+ * hex encode goes through the shared byte->hex leaf hl_hex_encode (utils/hex.h). */
 
 /* ── Recursive JSON value serializer ─────────────────────────────── */
 
@@ -463,7 +460,7 @@ int hl_sig_verify_files_embedded(const HlSignature *sig, const HlVfs *vfs)
         if (hl_cap_crypto_sha256(data, data_len, hash) != 0) return -1;
 
         char hash_hex[65];
-        hex_encode(hash, 32, hash_hex);
+        hl_hex_encode(hash, 32, hash_hex, sizeof(hash_hex));
 
         if (strcmp(hash_hex, expected_hash) != 0) {
             log_error("[sig] hash mismatch for %s", sig_name);
@@ -530,7 +527,7 @@ int hl_sig_verify_files_fs(const HlSignature *sig, const char *app_dir)
         free(data);
 
         char hash_hex[65];
-        hex_encode(hash, 32, hash_hex);
+        hl_hex_encode(hash, 32, hash_hex, sizeof(hash_hex));
 
         if (strcmp(hash_hex, expected_hash) != 0) {
             log_error("[sig] hash mismatch: %s (expected %s, got %s)",

--- a/src/hull/utils/hex.c
+++ b/src/hull/utils/hex.c
@@ -1,0 +1,29 @@
+/*
+ * utils/hex.c - lowercase hex encoding of a byte buffer. See utils/hex.h for
+ * the bounded contract.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#include "hex.h"
+
+int hl_hex_encode(const uint8_t *in, size_t in_len, char *out, size_t out_cap)
+{
+    static const char digits[] = "0123456789abcdef";
+
+    if (!out || out_cap == 0)
+        return -1;
+    out[0] = '\0';                         /* fail-closed default */
+    if (in_len > 0 && !in)
+        return -1;
+    if (in_len > (SIZE_MAX - 1) / 2)       /* in_len*2 + 1 would overflow */
+        return -1;
+    if (out_cap < in_len * 2 + 1)
+        return -1;
+
+    for (size_t i = 0; i < in_len; i++) {
+        out[i * 2]     = digits[(in[i] >> 4) & 0xF];
+        out[i * 2 + 1] = digits[in[i] & 0xF];
+    }
+    out[in_len * 2] = '\0';
+    return 0;
+}

--- a/src/hull/utils/hex.h
+++ b/src/hull/utils/hex.h
@@ -1,0 +1,41 @@
+/*
+ * utils/hex.h - lowercase hex encoding of a byte buffer.
+ *
+ * A private, dependency-neutral leaf: no Hull-domain knowledge, no crypto, no
+ * allocation. It is the single home for the byte->hex-BUFFER transform that was
+ * previously copied verbatim across signature.c, release.c, sbom.c,
+ * blob_store.c, db_postgres.c, verify_self.c, and mod_tool.c (H1 / S2b - see
+ * docs/h1_s2b_hex_ownership.md).
+ *
+ * Deliberately NOT under include/hull/: this is an internal helper, not part of
+ * the public embedder API. Consumers include it by relative path.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#ifndef HULL_UTILS_HEX_H
+#define HULL_UTILS_HEX_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Encode `in_len` bytes from `in` as lowercase hex into `out`.
+ *
+ * Bounded contract:
+ *   - Input:  `in_len` bytes at `in`. `in` may be NULL only when `in_len == 0`.
+ *   - Output: writes exactly `in_len * 2` lowercase hex characters followed by a
+ *     single NUL terminator, i.e. `in_len * 2 + 1` bytes total.
+ *   - Capacity: `out_cap` must be at least `in_len * 2 + 1`. On insufficient
+ *     capacity the call fails and writes nothing beyond a defensive
+ *     `out[0] = '\0'` (when `out_cap > 0`), so the destination is never left
+ *     holding a partial, unterminated string.
+ *   - Encoding: lowercase (`0-9a-f`).
+ *   - Termination: the result is always NUL-terminated on success.
+ *
+ * Returns 0 on success, -1 on a NULL/zero-capacity destination, a NULL input
+ * with a non-zero length, insufficient capacity, or overflow of the
+ * `in_len * 2 + 1` size computation.
+ */
+int hl_hex_encode(const uint8_t *in, size_t in_len, char *out, size_t out_cap);
+
+#endif /* HULL_UTILS_HEX_H */

--- a/tests/hull/test_hex.c
+++ b/tests/hull/test_hex.c
@@ -1,0 +1,95 @@
+/*
+ * test_hex.c - boundary tests for the utils/hex byte->hex leaf.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#include "utest.h"
+#include "../../src/hull/utils/hex.h"
+
+#include <string.h>
+
+UTEST(hex, empty_input)
+{
+    /* Zero bytes: writes just a terminator; in may be NULL. */
+    char out[4] = { 'x', 'x', 'x', 'x' };
+    ASSERT_EQ(hl_hex_encode(NULL, 0, out, sizeof(out)), 0);
+    ASSERT_EQ(out[0], '\0');
+    ASSERT_EQ((int)strlen(out), 0);
+}
+
+UTEST(hex, empty_input_min_capacity)
+{
+    /* out_cap == 1 is exactly enough for the terminator of a 0-byte input. */
+    char out[1] = { 'x' };
+    ASSERT_EQ(hl_hex_encode(NULL, 0, out, 1), 0);
+    ASSERT_EQ(out[0], '\0');
+}
+
+UTEST(hex, one_byte)
+{
+    const uint8_t in[] = { 0xAB };
+    char out[3];
+    ASSERT_EQ(hl_hex_encode(in, 1, out, sizeof(out)), 0);
+    ASSERT_STREQ(out, "ab");            /* lowercase */
+    ASSERT_EQ(out[2], '\0');            /* terminated */
+}
+
+UTEST(hex, lowercase_full_range)
+{
+    /* Covers both nibbles across the alphabet incl. 0x00 and 0xff. */
+    const uint8_t in[] = { 0x00, 0x0f, 0xf0, 0xff, 0x12, 0x9a };
+    char out[13];
+    ASSERT_EQ(hl_hex_encode(in, sizeof(in), out, sizeof(out)), 0);
+    ASSERT_STREQ(out, "000ff0ff129a");
+}
+
+UTEST(hex, typical_digest_32_bytes)
+{
+    uint8_t in[32];
+    for (int i = 0; i < 32; i++) in[i] = (uint8_t)i;
+    char out[65];
+    ASSERT_EQ(hl_hex_encode(in, 32, out, sizeof(out)), 0);
+    ASSERT_EQ((int)strlen(out), 64);
+    ASSERT_STREQ(out,
+        "000102030405060708090a0b0c0d0e0f"
+        "101112131415161718191a1b1c1d1e1f");
+    ASSERT_EQ(out[64], '\0');
+}
+
+UTEST(hex, exact_output_capacity)
+{
+    /* out_cap == in_len*2 + 1 is the minimum that succeeds. */
+    const uint8_t in[] = { 0xDE, 0xAD };
+    char out[5];                        /* 2*2 + 1 */
+    ASSERT_EQ(hl_hex_encode(in, 2, out, 5), 0);
+    ASSERT_STREQ(out, "dead");
+    ASSERT_EQ(out[4], '\0');
+}
+
+UTEST(hex, insufficient_capacity_fails_closed)
+{
+    /* out_cap one short of the required in_len*2 + 1 must fail and leave the
+     * destination as an empty (terminated) string, never a partial digest. */
+    const uint8_t in[] = { 0xDE, 0xAD };
+    char out[5];
+    memset(out, 'Z', sizeof(out));
+    ASSERT_EQ(hl_hex_encode(in, 2, out, 4), -1);   /* need 5, given 4 */
+    ASSERT_EQ(out[0], '\0');
+}
+
+UTEST(hex, zero_capacity_and_null_out)
+{
+    const uint8_t in[] = { 0x01 };
+    char out[2];
+    ASSERT_EQ(hl_hex_encode(in, 1, out, 0), -1);   /* zero capacity */
+    ASSERT_EQ(hl_hex_encode(in, 1, NULL, 2), -1);  /* NULL destination */
+}
+
+UTEST(hex, null_input_nonzero_len_fails)
+{
+    char out[8];
+    ASSERT_EQ(hl_hex_encode(NULL, 4, out, sizeof(out)), -1);
+    ASSERT_EQ(out[0], '\0');
+}
+
+UTEST_MAIN();


### PR DESCRIPTION
## H1 / S2b execution — Option A (private, dependency-neutral hex leaf)

Executes the ratified S2b decision ([docs/h1_s2b_hex_ownership.md](../blob/main/docs/h1_s2b_hex_ownership.md), Option A). Adds one private leaf and routes the **seven verified byte→hex-buffer encoders** onto it, one TU per commit.

### What landed
- **`src/hull/utils/hex.{c,h}`** — a private (`src/hull/`, not `include/hull/`), zero-dependency leaf with a bounded contract: `in_len` bytes → exactly `in_len*2` lowercase hex chars + NUL; **fails closed** on insufficient capacity (needs `in_len*2+1`) or overflow, never leaving a partial/unterminated string. Not public API.
- **Routed (P1–P7):** `signature.c`, `release.c`, `sbom.c`, `shared/blob_store.c`, `cap/db_postgres.c` (BYTEA `\x`), `commands/verify_self.c`, `runtime/lua/mod_tool.c`.
- **Left unchanged** (per the decision): `hl_runtime_cache_hex_encode` (deliberately crypto-free cache home), `hl_release_io_sha256_hex` (hash+hex composite), the `blob_store` shard-dir `HEX[]` table and `tool.c` `FILE*` streams (different shape).
- Wiring mirrors `host_match` (`CAP_OBJS += $(HEX_OBJ)`), reaching the platform lib (base + cosmo), the hull binary, libhull, and every test suite; three custom-list test rules got `$(HEX_OBJ)` explicitly.

### Constraints honored
- Outside `include/hull/`; no public API expansion.
- Explicit bounded contract (byte count, capacity, lowercase, guaranteed terminator, fail-on-insufficient-capacity).
- Only the seven verified encoders consolidated.
- Boundary tests: empty, one byte, 32-byte digest, exact capacity, insufficient capacity (fail-closed), + NULL/zero-cap/NULL-input guards.

### Proof — unchanged dependency closure + no size regression
- **`hex.o` has zero undefined symbols** (pulls nothing), so every consumer's link closure grows by exactly `hl_hex_encode`; `nm` confirms **no consumer gained a crypto/mbedtls reference** (incl. the postgres feature TU).
- **No size regression:** base binary is **96 bytes smaller** (7 statics removed, one 152-byte leaf added).
- **Linked/validated across compositions:** base (unit tests **91/91**, e2e_build signing path), **pure-compute** (7.1 MB), **libhull** (`hex.o` in archive, C reference embedder links), **PostgreSQL** (`db_postgres` + `hex` linked). **cosmo** inclusion is structural (`PLATFORM_CAP_OBJS` is the full `CAP_OBJS` on cosmo) and CI-covered.
- `make lint` (docs-integrity gate) green.