### PR TITLE
ci(wamrc): runner image build-number is provenance, not a hard identity gate

### DIFF
--- a/docs/ci_architecture_design.md
+++ b/docs/ci_architecture_design.md
@@ -1449,9 +1449,16 @@ inputs AND same-run provenance. The consumer recomputes/inspects every field and
 refuses the artifact on any mismatch (D.1.3).
 
 **Reuse-identity inputs** (a change to any yields a different key -> no reuse):
-1. **OS + arch + runner image** - not just `ubuntu-24.04`: the concrete runner
-   image identity AND version (`ImageOS` / `ImageVersion` from the runner
-   environment, e.g. `ubuntu24`/`<image-version>`), plus `uname -m`.
+1. **OS family + arch** - the concrete OS family (`ImageOS`, e.g. `ubuntu24`) and
+   `uname -m`. Both are HARD: a different OS family or architecture rejects the
+   artifact. The runner **image build number** (`ImageVersion`, e.g.
+   `20260816.277.1`) is recorded as provenance and present/hollow-checked, but a
+   producer/consumer difference in it is a **warning, not a rejection**: GitHub
+   rolls the image build number across its fleet mid-workflow, so a producer and a
+   consumer of the same run can legitimately land on different build numbers while
+   every substantive toolchain input below is byte-identical. Gating on the build
+   number turned the compute matrix red during image rollouts for no safety gain;
+   the OS family + toolchain are what determine wamrc equivalence.
 2. **Actual CMake compilers** - the resolved C and C++ compiler **paths** and
    **versions** that cmake used to build wamrc (from `CMakeCache.txt`
    `CMAKE_C_COMPILER` / `CMAKE_CXX_COMPILER` + each `--version`), not a generic

--- a/scripts/ci/test_wamrc_artifact.py
+++ b/scripts/ci/test_wamrc_artifact.py
@@ -28,7 +28,7 @@ def check(name, cond):
 
 # A complete, self-consistent set of gathered fields.
 GOOD = {
-    "runner_image": "ubuntu24-20260801.1", "arch": "x86_64",
+    "image_os": "ubuntu24", "image_version": "20260801.1", "arch": "x86_64",
     "cc_path": "/usr/bin/cc", "cc_version": "cc (Ubuntu) 13.2.0",
     "cxx_path": "/usr/bin/c++", "cxx_version": "c++ (Ubuntu) 13.2.0",
     "llvm_version": "18.1.3", "wamr_rev": "c3a78cd159e59c86ac4543308bd676ff78d30a93",
@@ -45,6 +45,15 @@ def local(**overrides):
     return d
 
 
+# verify() returns (problems, warnings); most fixtures assert on the problems.
+def problems(manifest, loc):
+    return wa.verify(manifest, loc)[0]
+
+
+def warnings(manifest, loc):
+    return wa.verify(manifest, loc)[1]
+
+
 # -- build_manifest --
 m = wa.build_manifest(GOOD)
 check("manifest carries schema_version", m["schema_version"] == wa.SCHEMA_VERSION)
@@ -57,49 +66,50 @@ except ValueError:
     check("build_manifest rejects missing fields", True)
 
 # -- verify: the happy path --
-check("matching artifact verifies (no problems)", wa.verify(m, local()) == [])
+check("matching artifact verifies (no problems)", problems(m, local()) == [])
 
 # -- verify: identity mismatches -> rejected --
 for field, bad in [("llvm_version", "17.0.0"), ("wamr_rev", "f" * 40),
                    ("patch_hash", "0" * 64), ("wamrc_flags", "-DLLVM_DIR=/other"),
                    ("build_script_hash", "9" * 64), ("cc_version", "cc 12.0.0"),
-                   ("cc_path", "/usr/local/bin/cc"), ("runner_image", "ubuntu24-OTHER"),
+                   ("cc_path", "/usr/local/bin/cc"), ("image_os", "ubuntu-OTHER"),
                    ("arch", "aarch64")]:
     check("identity mismatch rejected: %s" % field,
-          len(wa.verify(m, local(**{field: bad}))) >= 1)
+          len(problems(m, local(**{field: bad}))) >= 1)
 
 # -- verify: provenance mismatches (different run/attempt/commit) -> rejected --
 for field, bad in [("commit_sha", "beefdead" * 5), ("run_id", "99999"),
                    ("run_attempt", "2"), ("producer_job", "some-other-job")]:
     check("provenance mismatch rejected: %s" % field,
-          len(wa.verify(m, local(**{field: bad}))) >= 1)
+          len(problems(m, local(**{field: bad}))) >= 1)
 
 # -- verify: checksum mismatch (corruption) -> rejected --
 check("checksum mismatch (corruption) rejected",
-      len(wa.verify(m, local(artifact_sha256="d" * 64))) >= 1)
+      len(problems(m, local(artifact_sha256="d" * 64))) >= 1)
 check("MISSING artifact (download failed) rejected",
-      len(wa.verify(m, local(artifact_sha256="MISSING"))) >= 1)
+      len(problems(m, local(artifact_sha256="MISSING"))) >= 1)
 
 # -- verify: unknown / malformed schema -> rejected outright --
-check("unknown schema_version rejected", len(wa.verify({**m, "schema_version": 99}, local())) >= 1)
-check("no schema_version rejected", len(wa.verify({k: v for k, v in m.items() if k != "schema_version"}, local())) >= 1)
-check("non-dict manifest rejected", len(wa.verify([], local())) >= 1)
-check("non-dict manifest rejected (str)", len(wa.verify("nope", local())) >= 1)
+check("unknown schema_version rejected", len(problems({**m, "schema_version": 99}, local())) >= 1)
+check("no schema_version rejected", len(problems({k: v for k, v in m.items() if k != "schema_version"}, local())) >= 1)
+check("non-dict manifest rejected", len(problems([], local())) >= 1)
+check("non-dict manifest rejected (str)", len(problems("nope", local())) >= 1)
 
 # -- verify: a manifest missing a field -> rejected --
 check("manifest missing a field rejected",
-      len(wa.verify({k: v for k, v in m.items() if k != "wamr_rev"}, local())) >= 1)
+      len(problems({k: v for k, v in m.items() if k != "wamr_rev"}, local())) >= 1)
 # -- verify: local missing a field -> rejected --
 _partial = dict(GOOD)
 del _partial["llvm_version"]
-check("local missing a field rejected", len(wa.verify(m, _partial)) >= 1)
+check("local missing a field rejected", len(problems(m, _partial)) >= 1)
 
 # -- hardening: build_manifest rejects hollow / unavailable / empty fields --
 for field, bad in [("cc_path", "unknown"), ("cxx_path", "MISSING"),
                    ("cc_version", "unknown"), ("llvm_version", "MISSING"),
                    ("patch_hash", "MISSING"), ("build_script_hash", "MISSING"),
                    ("wamr_rev", "unknown"), ("artifact_sha256", "MISSING"),
-                   ("wamrc_flags", ""), ("runner_image", "unknown")]:
+                   ("wamrc_flags", ""), ("image_os", "unknown"),
+                   ("image_version", "unknown")]:
     try:
         wa.build_manifest(local(**{field: bad}))
         check("build_manifest rejects hollow %s=%r" % (field, bad), False)
@@ -115,11 +125,49 @@ except ValueError:
 # -- hardening: verify rejects a HOLLOW LOCAL field (a cold consumer that
 #    verified WITHOUT first configuring the wamrc toolchain -> cc_path unknown) --
 check("verify rejects local cc_path=unknown (cold, no configure)",
-      any("cc_path" in p for p in wa.verify(m, local(cc_path="unknown"))))
+      any("cc_path" in p for p in problems(m, local(cc_path="unknown"))))
 check("verify rejects local llvm_version=MISSING",
-      len(wa.verify(m, local(llvm_version="MISSING"))) >= 1)
+      len(problems(m, local(llvm_version="MISSING"))) >= 1)
 check("verify rejects local wamrc_flags='' (empty)",
-      len(wa.verify(m, local(wamrc_flags=""))) >= 1)
+      len(problems(m, local(wamrc_flags=""))) >= 1)
+
+# -- image_version WARN model (the GitHub runner-image rollout fix) ----------
+# Same OS family, DIFFERENT image build number (the EXACT observed rollout pair:
+# 20260816.277.1 -> 20260823.283.1). This must VERIFY (no problems) but surface a
+# visible WARNING, not reject: the build number is not a toolchain-identity input.
+_m_obs = wa.build_manifest(local(image_version="20260816.277.1"))
+_obs_probs, _obs_warns = wa.verify(_m_obs, local(image_version="20260823.283.1"))
+check("same OS, different image_version -> VERIFIES (no problems)", _obs_probs == [])
+check("same OS, different image_version -> emits a WARNING", len(_obs_warns) >= 1)
+check("the warning names image_version + both observed build numbers",
+      any("image_version" in w and "20260816.277.1" in w and "20260823.283.1" in w
+          for w in _obs_warns))
+check("identical image_version -> NO warning", warnings(m, local()) == [])
+
+# Different OS FAMILY stays a HARD reject (and is a problem, not merely a warning).
+_os_probs, _os_warns = wa.verify(m, local(image_os="ubuntu22"))
+check("different image_os (OS family) -> REJECTED as a problem, not a warning",
+      len(_os_probs) >= 1 and _os_warns == [])
+check("different image_os names image_os in the problem",
+      any("image_os" in p for p in _os_probs))
+
+# image_version drift must NOT rescue an otherwise-broken artifact: a checksum
+# corruption alongside a drifted image_version is STILL REJECTED.
+check("image_version drift + checksum corruption -> still REJECTED",
+      any("artifact_sha256" in p
+          for p in problems(m, local(image_version="20260823.283.1",
+                                     artifact_sha256="d" * 64))))
+
+# Producer / consumer failure remains gate-fatal:
+#  - CONSUMER: any problem -> non-empty problems list -> main() returns exit 1
+#    (gate-fatal). Proven by every reject fixture above.
+#  - PRODUCER: a producer that cannot fully describe its identity FAILS at
+#    build_manifest (hollow / None -> ValueError) rather than ship a hollow
+#    manifest; a missing/undownloaded artifact (producer/upload-failure surrogate)
+#    is a MISSING checksum -> hard reject. Both proven above. The producer JOB
+#    failing outright stays gate-fatal via ci.yml `needs:` (the consumer is skipped
+#    and the applicability-aware gate treats a non-success producer as failure) -
+#    a workflow guarantee this fix does not touch.
 
 # -- cold-verify seam: cmake_compiler_paths reads a CONFIGURE-ONLY cache (no
 #    compiled wamrc), proving a consumer can reproduce the producer's compiler

--- a/scripts/ci/wamrc_artifact.py
+++ b/scripts/ci/wamrc_artifact.py
@@ -23,11 +23,14 @@ import re
 import subprocess
 import sys
 
-SCHEMA_VERSION = 1
+# v2: runner_image split into image_os (hard) + image_version (warn-only). See
+# the WARN_FIELDS note below and docs/ci_architecture_design.md Appendix D.
+SCHEMA_VERSION = 2
 
 # The reuse-identity inputs (a change to any -> a different key -> no reuse).
+# These are HARD: a mismatch REJECTS the artifact and fails the job.
 IDENTITY_FIELDS = [
-    "runner_image",        # ImageOS-ImageVersion (not just "ubuntu-24.04")
+    "image_os",            # ImageOS (e.g. "ubuntu24") - the OS family, HARD
     "arch",                # uname -m
     "cc_path", "cc_version",     # the actual CMake C compiler path + version
     "cxx_path", "cxx_version",   # the actual CMake C++ compiler path + version
@@ -37,12 +40,26 @@ IDENTITY_FIELDS = [
     "wamrc_flags",         # WAMRC_CMAKE_FLAGS
     "build_script_hash",   # sha256 of the wamrc make rule region + ci_ensure_wamrc.sh
 ]
-# Same-run provenance (proves the artifact belongs to THIS run).
+# Same-run provenance (proves the artifact belongs to THIS run). HARD.
 PROVENANCE_FIELDS = ["commit_sha", "run_id", "run_attempt", "producer_job"]
-# The artifact digest (checksum integrity).
+# Recorded for provenance and present/hollow-checked like every other field, but a
+# MISMATCH is a WARNING, not a rejection. GitHub rolls the runner ImageVersion
+# (the image build number, e.g. 20260816.277.1 -> 20260823.283.1) across its fleet
+# mid-workflow, so a producer and a consumer of the SAME run can legitimately land
+# on different image build numbers while every substantive identity input (OS
+# family, arch, compiler path+version, LLVM, WAMR rev, patches, flags, build-script
+# hash) is byte-identical. Gating on the build number rejected good artifacts and
+# turned the whole compute matrix red during rollouts. The build number is not a
+# toolchain-identity input, so it is retained as provenance and warned-on, never
+# used as a compatibility rejection.
+WARN_FIELDS = ["image_version"]
+# The artifact digest (checksum integrity). HARD.
 CHECKSUM_FIELD = "artifact_sha256"
 
-ALL_FIELDS = IDENTITY_FIELDS + PROVENANCE_FIELDS + [CHECKSUM_FIELD]
+# Every field is present- and hollow-checked (build_manifest + verify). Only
+# HARD_FIELDS are equality-GATED; WARN_FIELDS differences produce a warning.
+ALL_FIELDS = IDENTITY_FIELDS + PROVENANCE_FIELDS + WARN_FIELDS + [CHECKSUM_FIELD]
+HARD_FIELDS = IDENTITY_FIELDS + PROVENANCE_FIELDS + [CHECKSUM_FIELD]
 
 # Sentinels a probe emits when a value could not be determined. In this CI profile
 # EVERY field must be concrete: a manifest carrying any of these (or an empty
@@ -77,17 +94,23 @@ def build_manifest(fields):
 
 
 def verify(manifest, local):
-    """Return a list of problems (empty => the artifact is trusted). `manifest` is
-    the producer's recorded metadata; `local` is the consumer's freshly-recomputed
-    identity/provenance (including the sha256 of the DOWNLOADED wamrc). An unknown
-    schema, a missing field, or ANY field mismatch is a problem -> the caller fails
-    the job. Fail closed: a non-dict manifest, or a schema it does not understand,
-    is rejected outright."""
+    """Return (problems, warnings). `problems` empty => the artifact is trusted (the
+    caller exits 0, though it still prints any warnings). `manifest` is the
+    producer's recorded metadata; `local` is the consumer's freshly-recomputed
+    identity/provenance (including the sha256 of the DOWNLOADED wamrc).
+
+    A problem (REJECT) is: an unknown/absent schema, a missing field on either
+    side, a hollow local field, or a mismatch in any HARD field (identity +
+    provenance + checksum). A warning (still trusted) is a mismatch in a WARN field
+    (image_version): GitHub's runner image build number rolls across the fleet
+    mid-run, so producer/consumer can differ there with an identical toolchain.
+    Fail closed: a non-dict manifest, or a schema it does not understand, is
+    rejected outright."""
     if not isinstance(manifest, dict):
-        return ["manifest is not a JSON object"]
+        return (["manifest is not a JSON object"], [])
     if manifest.get("schema_version") != SCHEMA_VERSION:
-        return ["unknown manifest schema_version %r (expected %d)"
-                % (manifest.get("schema_version"), SCHEMA_VERSION)]
+        return (["unknown manifest schema_version %r (expected %d)"
+                 % (manifest.get("schema_version"), SCHEMA_VERSION)], [])
     problems = []
     for k in ALL_FIELDS:
         if k not in manifest:
@@ -96,14 +119,25 @@ def verify(manifest, local):
             problems.append("local missing field %s" % k)
     # The consumer's OWN identity must be fully determined; a hollow local field
     # (e.g. `cc_path=unknown` because a cold consumer verified WITHOUT first
-    # configuring the wamrc toolchain) is a verification failure, not a silent
-    # mismatch.
+    # configuring the wamrc toolchain, or an absent ImageVersion) is a verification
+    # failure, not a silent mismatch. This applies to EVERY field, WARN ones too.
     for k in _invalid_fields(local):
         problems.append("local field %s is unavailable/invalid: %r" % (k, local.get(k)))
-    for k in ALL_FIELDS:
+    # HARD equality gate: identity + provenance + checksum.
+    for k in HARD_FIELDS:
         if k in manifest and k in local and str(manifest[k]) != str(local[k]):
             problems.append("%s mismatch: manifest=%r local=%r" % (k, manifest[k], local[k]))
-    return problems
+    # WARN downgrade: image build-number drift is expected during GitHub image
+    # rollouts and is NOT a compatibility rejection (the OS family + toolchain are
+    # equality-gated above). Surface it visibly for provenance.
+    warnings = []
+    for k in WARN_FIELDS:
+        if k in manifest and k in local and str(manifest[k]) != str(local[k]):
+            warnings.append("%s differs: manifest=%r local=%r (GitHub runner image "
+                            "rolled mid-workflow; OS family + toolchain identity "
+                            "unchanged, so the artifact is still trusted)"
+                            % (k, manifest[k], local[k]))
+    return (problems, warnings)
 
 
 # -- environment probing (impure; kept thin) ---------------------------------
@@ -161,7 +195,6 @@ def gather_local(wamrc_path, producer_job, root):
     (an absent patch set, an unmatched Makefile rule, a missing script, an empty
     WAMRC_CMAKE_FLAGS, or a compiler the CMakeCache did not record)."""
     env = os.environ
-    runner_image = "%s-%s" % (env.get("ImageOS", "unknown"), env.get("ImageVersion", "unknown"))
 
     ph = hashlib.sha256()
     patches = sorted(glob.glob(os.path.join(root, "patches", "wamr", "*.patch")))
@@ -199,7 +232,8 @@ def gather_local(wamrc_path, producer_job, root):
     cxx_version = _first_line([cxx_path, "--version"]) if cxx_path not in INVALID_VALUES else None
 
     return {
-        "runner_image": runner_image,
+        "image_os": env.get("ImageOS", "unknown"),          # OS family - HARD
+        "image_version": env.get("ImageVersion", "unknown"),  # build number - WARN
         "arch": _run(["uname", "-m"]) or "unknown",
         "cc_path": cc_path, "cc_version": cc_version or "unknown",
         "cxx_path": cxx_path, "cxx_version": cxx_version or "unknown",
@@ -246,14 +280,20 @@ def main(argv):
         print("wamrc-verify: cannot read manifest (%s) -> FAIL" % e)
         return 1
     local = gather_local(args.wamrc, args.producer, root)
-    problems = verify(manifest, local)
+    problems, warnings = verify(manifest, local)
+    # Warnings print whether or not there are problems, and are visible in the CI
+    # log AND as a GitHub annotation. They never fail the job on their own.
+    for w in warnings:
+        print("::warning title=wamrc runner-image drift::%s" % w)
+        print("  WARN:", w)
     if problems:
         for p in problems:
             print("  FAIL:", p)
         print("wamrc-verify: artifact REJECTED (%d problem(s)); NOT rebuilding - failing the job."
               % len(problems))
         return 1
-    print("wamrc-verify: artifact identity + provenance + checksum verified.")
+    print("wamrc-verify: artifact identity + provenance + checksum verified%s."
+          % (" (with runner-image-version drift warnings)" if warnings else ""))
     return 0
 
 


### PR DESCRIPTION
## Problem

The wamrc producer/consumer artifact verifier (`scripts/ci/wamrc_artifact.py`) folds the runner image into a single **hard** identity field `runner_image = ImageOS-ImageVersion` and rejects any mismatch. GitHub is **rolling its Ubuntu runner image build number** (`ubuntu24-20260816.277.1` → `ubuntu24-20260823.283.1`) across the fleet mid-workflow, so the **producer** job and a **consumer** AOT job of the *same run* land on different build numbers and the consumer rejects a perfectly good artifact:

```
FAIL: runner_image mismatch: manifest='ubuntu24-20260816.277.1' local='ubuntu24-20260823.283.1'
```

This turned the whole compute-AOT matrix red on **`main` itself** and every open PR (observed on the S2b/S3 merge runs). It's an infra flake — the build number is not a toolchain-identity input.

## Compatibility model (exactly as specified)

- **Split** `runner_image` → `image_os` (HARD) + `image_version` (provenance).
- **`image_os` stays exact** — a different OS family still rejects.
- **`image_version` is retained in provenance** and present/hollow-checked like every field, but a producer/consumer **mismatch is a visible warning** (`::warning::` annotation + log line), **never** a compatibility rejection.
- **Every substantive hard check is byte-identical:** arch, compiler path+version, LLVM version, WAMR rev, patch hash, wamrc flags, build-script hash, run-scoped provenance (commit/run/attempt/producer), artifact checksum. The **fresh-build equivalence canary** and the `ldd` / executable-usability / target-compat steps in `ci.yml` are untouched.
- **Artifacts stay run-scoped** — no cross-run cache or release trust introduced.
- `verify()` now returns `(problems, warnings)`; schema bumped `1 → 2`.

## Fixtures (`scripts/ci/test_wamrc_artifact.py`, 52 pass)

Proves:
- **same ImageOS, different ImageVersion** — using the **exact observed pair** `20260816.277.1 → 20260823.283.1` — VERIFIES with a WARNING (no problems);
- **different ImageOS** → REJECT (a problem, not a warning);
- version drift does **not** rescue a checksum corruption;
- all existing **identity / checksum / linkage / corruption / hollow-field / schema** failures still REJECT;
- **producer or consumer failure remains gate-fatal** (`build_manifest` ValueError on hollow, exit 1 on any problem, `ci.yml needs:` on producer).

## Live proof

This PR's own CI exercises the real producer→consumer AOT flow. If GitHub's fleet is still mixed, the wamrc/AOT jobs will pass **with a visible image-version-drift warning**; if homogenized, they pass cleanly. Either way the broad matrix must go green.

Merge this first; then #415 (H1/S4) reruns against the corrected `main`.