### PR TITLE
fix(validate): cap pattern input at 8192 UTF-8 bytes (audit M1)

### DIFF
--- a/stdlib/js/hull/validate.js
+++ b/stdlib/js/hull/validate.js
@@ -34,6 +34,34 @@ function emailOk(s) {
     return true;
 }
 
+// Pattern-validation input cap: 8192 UTF-8 BYTES. Shared contract with the Lua
+// sibling (stdlib/lua/hull/validate.lua), where `#value` is a byte count. Values
+// over the cap are rejected BEFORE regex evaluation, and the FULL value is
+// tested (never a truncated prefix), so an anchored allowlist rule cannot be
+// bypassed by appending a payload past the cap and the accept/reject decision is
+// byte-identical across runtimes. Guarded by tests/e2e_validate_parity.sh.
+const PATTERN_MAX_INPUT_BYTES = 8192;
+
+// True iff the UTF-8 encoding of `s` exceeds `cap` bytes. Counts with an early
+// exit and never materializes an encoded copy (no TextEncoder allocation), so a
+// huge input costs at most cap+3 bytes of scanning to be rejected rather than a
+// full proportional encode.
+function utf8ByteLenExceeds(s, cap) {
+    let n = 0;
+    for (let i = 0; i < s.length; i++) {
+        const c = s.charCodeAt(i);
+        if (c < 0x80) n += 1;
+        else if (c < 0x800) n += 2;
+        else if (c >= 0xD800 && c <= 0xDBFF && i + 1 < s.length) {
+            const c2 = s.charCodeAt(i + 1);
+            if (c2 >= 0xDC00 && c2 <= 0xDFFF) { n += 4; i++; }  // surrogate pair -> 4 bytes
+            else n += 3;                                        // lone high surrogate -> U+FFFD
+        } else n += 3;                                          // BMP >= 0x800, or lone surrogate
+        if (n > cap) return true;
+    }
+    return false;
+}
+
 /**
  * Validate a data object against a schema.
  *
@@ -134,11 +162,11 @@ function check(data, schema) {
 
         if (err) { setError(); continue; }
 
-        // 6. pattern. Bound both the pattern (≤ 1024 chars) and the value
-        // (≤ 8192 chars) to make a ReDoS attack via crafted pattern + input
-        // require a very persistent attacker. We don't accept pre-compiled
-        // RegExp objects: their source could contain known-bad backtracking
-        // patterns the string check would catch.
+        // 6. pattern. Bound the pattern (<= 1024 chars) and the value
+        // (<= PATTERN_MAX_INPUT_BYTES UTF-8 bytes) so a ReDoS attack via a
+        // crafted pattern + input requires a very persistent attacker. We don't
+        // accept pre-compiled RegExp objects: their source could contain
+        // known-bad backtracking patterns the string check would catch.
         if (rules.pattern !== undefined && rules.pattern !== null) {
             if (rules.pattern instanceof RegExp)
                 throw new Error("validate: pass pattern as a string, not a RegExp");
@@ -149,7 +177,12 @@ function check(data, schema) {
             let re;
             try { re = new RegExp(rules.pattern); }
             catch (e) { throw new Error("validate: invalid pattern: " + e.message); }
-            if (typeof value !== "string" || !re.test(String(value).substring(0, 8192)))
+            // Reject an over-cap value BEFORE regex evaluation and test the FULL
+            // value (never a truncated prefix), so an anchored rule can't be
+            // bypassed with a payload appended past the cap.
+            if (typeof value !== "string"
+                || utf8ByteLenExceeds(value, PATTERN_MAX_INPUT_BYTES)
+                || !re.test(value))
                 err = customMsg || "does not match the required pattern";
         }
 

--- a/stdlib/lua/hull/validate.lua
+++ b/stdlib/lua/hull/validate.lua
@@ -14,6 +14,15 @@
 
 local validate = {}
 
+-- Pattern-validation input cap: 8192 bytes. Shared contract with the JS sibling
+-- (stdlib/js/hull/validate.js). Lua strings are byte strings, so `#value` is the
+-- byte count directly. Values over the cap are rejected BEFORE the pattern runs
+-- (never a truncated match), so the accept/reject decision is byte-identical
+-- across runtimes and an anchored rule can't be bypassed with a payload past the
+-- cap. Lua patterns don't backtrack catastrophically like JS regex, but the cap
+-- is enforced anyway for exact parity. Guarded by tests/e2e_validate_parity.sh.
+local PATTERN_MAX_INPUT_BYTES = 8192
+
 -- Email validation: practical RFC-5322 subset suitable for form-input
 -- screening. Catches obvious garbage (a..b@x, @foo, user@, foo) without
 -- aiming for full compliance - apps wanting stricter checks should layer
@@ -152,9 +161,11 @@ function validate.check(data, schema)
 
         if err then goto set_error end
 
-        -- 6. pattern
+        -- 6. pattern. Reject an over-cap value before matching (parity with the
+        -- JS byte cap); `#value` is a byte count.
         if rules.pattern then
-            if type(value) ~= "string" or not value:match(rules.pattern) then
+            if type(value) ~= "string" or #value > PATTERN_MAX_INPUT_BYTES
+               or not value:match(rules.pattern) then
                 err = custom_msg or "does not match the required pattern"
             end
         end

--- a/tests/e2e_validate_parity.sh
+++ b/tests/e2e_validate_parity.sh
@@ -9,6 +9,18 @@
 # BOTH runtimes and asserts the pass/fail vector is exact and identical, so the
 # validators can't silently diverge again.
 #
+# It also guards the `pattern` rule's shared input-size contract: pattern
+# validation caps the input at 8192 UTF-8 BYTES, rejects over-cap values BEFORE
+# matching, and tests the FULL value (never a truncated prefix). JS previously
+# matched only value.substring(0, 8192) - an anchored allowlist rule (^...$)
+# could be bypassed by appending a payload past 8192 chars, and it diverged from
+# Lua (which matched the whole value). The pattern matrix below proves: the
+# 8192-byte boundary accepts, 8193 rejects, a clean 8192-byte prefix + tail
+# rejects (no truncated-prefix test), anchored and unanchored patterns both
+# honor the cap, the cap is BYTE-based not char-based (multibyte UTF-8 boundary),
+# and existing short-value behavior is unchanged - byte-identically across both
+# runtimes.
+#
 # SPDX-License-Identifier: AGPL-3.0-or-later
 set -eu
 
@@ -21,6 +33,9 @@ cat > "$WD/v.lua" <<'LUA'
 local validate = require("hull.validate")
 app.manifest({ modules = { "hull/validate@1" } })
 local function b(v) return v and "T" or "F" end
+local function chk(value, pat)
+    return b(validate.check({ s = value }, { s = { pattern = pat } }))
+end
 app.main(function(ctx)
     local emails = {
         "a@b.co", "bad", "a..b@x.co", ".x@y.co", "x@.y.co",
@@ -35,6 +50,18 @@ app.main(function(ctx)
     out[#out + 1] = b(validate.check({ n = 20 }, { n = { type = "integer", min = 1, max = 10 } }))
     out[#out + 1] = b(validate.check({ s = "hi" }, { s = { oneof = { "hi", "yo" } } }))
     out[#out + 1] = b(validate.check({ s = "no" }, { s = { oneof = { "hi", "yo" } } }))
+
+    -- pattern input-size contract (8192 UTF-8 bytes, full-value match)
+    out[#out + 1] = chk(string.rep("a", 8192), "^[a-z]+$")        -- P1 at limit, matches -> T
+    out[#out + 1] = chk(string.rep("a", 8193), "^[a-z]+$")        -- P2 over limit -> F
+    out[#out + 1] = chk(string.rep("a", 8192) .. "1", "^[a-z]+$") -- P3 clean prefix + tail -> F
+    out[#out + 1] = chk(string.rep("a", 8193), "a")               -- P4 unanchored, over limit -> F
+    out[#out + 1] = chk("cat", "a")                               -- P5 short unanchored match -> T
+    out[#out + 1] = chk("hello", "^[a-z]+$")                      -- P6 short anchored match -> T
+    out[#out + 1] = chk("Hello", "^[a-z]+$")                      -- P7 short anchored non-match -> F
+    out[#out + 1] = chk(string.rep("a", 8190) .. "é", "^a")       -- P8 8192 bytes (multibyte) -> T
+    out[#out + 1] = chk(string.rep("a", 8191) .. "é", "^a")       -- P9 8193 bytes (multibyte) -> F
+
     ctx.stdout:write(table.concat(out, "") .. "\n"); return 0
 end)
 LUA
@@ -44,6 +71,7 @@ import { app } from "hull:app";
 import { validate } from "hull:validate";
 app.manifest({ modules: ["hull/validate@1"] });
 const b = (v) => v ? "T" : "F";
+const chk = (value, pat) => b(validate.check({ s: value }, { s: { pattern: pat } })[0]);
 app.main((ctx) => {
     const emails = [
         "a@b.co", "bad", "a..b@x.co", ".x@y.co", "x@.y.co",
@@ -58,6 +86,18 @@ app.main((ctx) => {
     out += b(validate.check({ n: 20 }, { n: { type: "integer", min: 1, max: 10 } })[0]);
     out += b(validate.check({ s: "hi" }, { s: { oneof: ["hi", "yo"] } })[0]);
     out += b(validate.check({ s: "no" }, { s: { oneof: ["hi", "yo"] } })[0]);
+
+    // pattern input-size contract (8192 UTF-8 bytes, full-value match)
+    out += chk("a".repeat(8192), "^[a-z]+$");        // P1 at limit, matches -> T
+    out += chk("a".repeat(8193), "^[a-z]+$");        // P2 over limit -> F
+    out += chk("a".repeat(8192) + "1", "^[a-z]+$");  // P3 clean prefix + tail -> F
+    out += chk("a".repeat(8193), "a");               // P4 unanchored, over limit -> F
+    out += chk("cat", "a");                          // P5 short unanchored match -> T
+    out += chk("hello", "^[a-z]+$");                 // P6 short anchored match -> T
+    out += chk("Hello", "^[a-z]+$");                 // P7 short anchored non-match -> F
+    out += chk("a".repeat(8190) + "é", "^a");        // P8 8192 bytes (multibyte) -> T
+    out += chk("a".repeat(8191) + "é", "^a");        // P9 8193 bytes (multibyte) -> F
+
     ctx.stdout.write(out + "\n"); return 0;
 });
 JS
@@ -65,9 +105,13 @@ JS
 lua_out="$("$HULL" "$WD/v.lua" 2>/dev/null | tail -1)"
 js_out="$("$HULL" "$WD/v.js"  2>/dev/null | tail -1)"
 
-# valid / invalid / dbl-dot / leading-dot / dot-at / digit-TLD / short-TLD /
-# uppercase-valid / too-long ; then int-in-range / int-out / oneof-hit / oneof-miss
-expect="TFFFFFFTFTFTF"
+# email:  valid / invalid / dbl-dot / leading-dot / dot-at / digit-TLD /
+#         short-TLD / uppercase-valid / too-long ; then int-in-range / int-out /
+#         oneof-hit / oneof-miss
+# pattern: P1 at-limit-match / P2 over / P3 clean-prefix+tail / P4 unanchored-over
+#          / P5 short-match / P6 short-anchored-match / P7 short-non-match /
+#          P8 8192B-multibyte / P9 8193B-multibyte
+expect="TFFFFFFTFTFTF""TFFFTTFTF"
 
 if [ "$lua_out" = "$expect" ] && [ "$lua_out" = "$js_out" ]; then
     echo "PASS: hull.validate is byte-identical across Lua and JS"


### PR DESCRIPTION
## Audit finding M1 (security-correctness)

`hull.validate`'s `pattern` rule diverged between runtimes and was bypassable in JS.

**Before:** `validate.js` tested only `value.substring(0, 8192)` against the regex. An anchored allowlist rule (`^...$`) therefore **passed** on an over-length input whose first 8192 chars matched — the `$` anchored to the truncation point, not the real end — so a payload appended past the cap slipped through. The Lua twin matched the **full** value, so the same schema accepted input in JS that Lua rejected: a real allowlist bypass **and** a security-relevant JS↔Lua parity split in a documented input-gate primitive.

## One shared contract for both runtimes

- Pattern validation caps input at **8192 UTF-8 bytes**.
- An over-cap value is rejected **before** pattern/regex evaluation.
- The **full** value is matched (JS never tests a truncated prefix).
- Lua enforces the same byte cap (`#value`), even though Lua patterns don't backtrack catastrophically like JS regex — for exact parity.

JS counts UTF-8 bytes with a bounded early-exit scan (`utf8ByteLenExceeds`) that never materializes an encoded copy (no `TextEncoder` allocation), so a huge input costs at most `cap+3` bytes of scanning to be rejected. Lua uses `#value` directly.

## Tests (golden Lua/JS parity, already in CI at `e2e-validate-parity`)

The parity matrix now runs a `pattern` segment byte-identically through **both** runtimes:

- 8192-byte matching value **accepted**;
- 8193-byte value **rejected**;
- clean 8192-byte prefix + malicious tail **rejected** (proves no truncated-prefix test);
- anchored **and** unanchored patterns;
- multibyte UTF-8 boundary (proves the cap is **byte**-based, not char-based);
- unchanged short-value behavior;
- one explicit Lua/JS golden parity assertion (`expect` compared to both outputs).

## Verification

- `make lint` exit 0 (S5 em-dash / milestone gates pass on the new comments)
- `make test` — 91/91
- `make e2e-validate-parity` — PASS

## Scope

M1 only. GPU `output:false` divergences and the `SIZE_MAX/2` guard-consistency pass from the same audit are **recorded but deferred**, as is the terminal FIFO/device READ-leaf behavior (its own future resolver-hardening review, not mixed into validation).