### PR TITLE
fs: type-gate READ/WRITE leaves to regular files, non-blocking (special-file guard)

### DIFF
--- a/docs/api/lua.md
+++ b/docs/api/lua.md
@@ -421,6 +421,13 @@ and `..` are rejected. See [Filesystem grants](#filesystem-grants).
 creates missing parents + the file and returns `true` (or `nil, err`); `mmap`
 returns a read-only `MappedBuffer` (optionally a page-aligned window).
 
+The leaf **must be a regular file.** A FIFO, socket, character/block device, or
+directory target is rejected `nil, "not_a_regular_file"` and never blocks (a
+special-file `open` cannot hang the runtime). This is a deliberate confinement of
+the sandboxed filesystem capability to ordinary files; a non-regular leaf is not
+readable/writable/mmap-able. (`fs.stat` still reports such a node as `"other"` /
+`"symlink"` - only `read`/`write`/`mmap` require a regular file.)
+
 #### `fs.stat(path)`
 
 Return a metadata table, or `nil` when the path does not exist (so `fs.stat(p) ~=

--- a/docs/hull_fs_design.md
+++ b/docs/hull_fs_design.md
@@ -342,6 +342,40 @@ documented here rather than hidden.
 symlink targets inside app trees + this migration guidance in the release notes.
 Affected surface is narrow: only symlinks whose STORED target string is absolute.
 
+## 5a. DECIDED: a READ/WRITE/MMAP leaf must be a REGULAR file
+
+`fs.read`, `fs.write`, and `fs.mmap` resolve to a terminal FILE leaf. The resolver
+opens that leaf **non-blocking** (`O_NONBLOCK`) and then **type-gates** it: only a
+regular file is accepted. A FIFO, socket, character/block device, or directory is
+rejected with the single stable token **`not_a_regular_file`**; the `O_NONBLOCK` is
+cleared on the accepted regular fd so ordinary blocking read/write semantics are
+preserved. (`HL_FS_OPEN_DIR`, used by `list` and to resolve a `SUBTREE` grant
+anchor, keeps its own `S_ISDIR` contract and is unaffected - a directory never
+blocks on open.)
+
+**Why.** A special-file leaf is both a correctness and an availability hazard.
+`open(O_RDONLY)` on a FIFO with no writer, or `open(O_WRONLY)` on a FIFO with no
+reader, **blocks indefinitely** - on Hull that would hang the event-loop thread (a
+self-DoS), and for a build plugin's declared inputs a stray `mkfifo` in a workspace
+would hang the whole pipeline. Character devices can carry open-time side effects,
+and reading a directory as a file is meaningless. The interior components of a path
+and the `DIR`-mode terminal were already classify-before-open protected against the
+FIFO hang; this extends the same guarantee to the READ/WRITE **leaf**, which was
+the one remaining path that could block. The two implementations (Linux `openat2`
+fast path and the portable manual walk) apply identical behavior.
+
+**Intentional tightening (migration note).** An authorized special-file leaf that
+was previously readable/writable is now rejected. In practice `fs.read`/`fs.write`
+targets are regular files; an app that legitimately needs to read a FIFO/device is
+out of scope for the sandboxed filesystem capability. The token surfaces to app
+code (Lua `nil, "not_a_regular_file"` / JS throw) exactly like the other stable
+resolver tokens. Enforcement lives in `src/hull/cap/fs_resolve.c`
+(`finalize_regular_leaf` + `leaf_type_errno`); covered by the special-file suite in
+`tests/hull/cap/test_fs_resolve.c` (FIFO/socket/device/directory under READ and
+WRITE, each under a no-hang watchdog, on both implementations, with fd-leak guards)
+and the concurrent regular<->special leaf-swap case in
+`tests/hull/cap/test_fs_resolve_parity.c`.
+
 ## 6. Two authorities: root confinement vs path authorization
 
 The audit and the earlier draft conflated these; they are separate and this

--- a/include/hull/cap/fs_resolve.h
+++ b/include/hull/cap/fs_resolve.h
@@ -36,8 +36,14 @@
 #define HL_FS_MAX_DEPTH 256
 
 typedef enum {
-    HL_FS_OPEN_READ,  /* open an existing leaf O_RDONLY (symlinks followed, contained) */
-    HL_FS_OPEN_WRITE, /* mkdir-p parents (contained) + open leaf O_WRONLY|O_CREAT|O_TRUNC */
+    HL_FS_OPEN_READ,  /* open an existing REGULAR-FILE leaf O_RDONLY (symlinks
+                       * followed, contained). The leaf is opened O_NONBLOCK so a
+                       * special-file target can never block the open, then type-gated
+                       * to a regular file: a FIFO / socket / character-or-block device
+                       * / directory is rejected "not_a_regular_file" (§5a). */
+    HL_FS_OPEN_WRITE, /* mkdir-p parents (contained) + open leaf O_WRONLY|O_CREAT|O_TRUNC,
+                       * O_NONBLOCK + regular-file type gate as for READ (a special-file
+                       * or directory target -> "not_a_regular_file"). */
     HL_FS_OPEN_DIR,   /* open an existing DIRECTORY O_RDONLY|O_DIRECTORY (symlinks
                        * followed, contained); a non-directory target -> not_a_directory.
                        * Never creates. Used to resolve a SUBTREE grant anchor
@@ -88,8 +94,11 @@ int hl_fs_open_base(const char *base_dir, const char **err);
  *
  * Returns an open fd (caller closes) or -1 with *err set to a stable token:
  * "invalid_path", "path_too_deep", "not_found", "permission", "not_a_directory",
- * "is_a_directory", "symlink_loop", "symlink_denied", "io_error". ("symlink_denied"
- * only under HL_FS_SYMLINK_REFUSE; see hl_fs_open_at_ex.)
+ * "is_a_directory", "not_a_regular_file", "symlink_loop", "symlink_denied",
+ * "io_error". "not_a_regular_file" is the single token for a READ/WRITE leaf that
+ * resolves to a FIFO, socket, character/block device, or directory (§5a intentional
+ * tightening). "symlink_denied" only under HL_FS_SYMLINK_REFUSE; see
+ * hl_fs_open_at_ex.
  */
 int hl_fs_open_at(int root_fd, const char *relpath, HlFsOpenMode mode,
                   mode_t create_mode, const char **err);

--- a/src/hull/cap/fs_resolve.c
+++ b/src/hull/cap/fs_resolve.c
@@ -44,6 +44,45 @@ static void map_errno(int e, const char **err)
     }
 }
 
+/* An open() errno from a terminal READ/WRITE leaf that means the target is a
+ * non-regular special file (or, under WRITE, a directory) rather than a transient
+ * failure: a socket special file fails ENXIO (Linux) / EOPNOTSUPP (macOS), a FIFO
+ * opened for WRITE with no reader fails ENXIO, and a directory opened O_WRONLY
+ * fails EISDIR. These collapse to the single stable "not_a_regular_file" token so
+ * every special-file / directory rejection reads identically, whether it surfaces
+ * at open() (this helper) or at the post-open type gate (finalize_regular_leaf). */
+static int leaf_type_errno(int e)
+{
+    if (e == EISDIR || e == ENXIO) return 1;
+#ifdef EOPNOTSUPP
+    if (e == EOPNOTSUPP) return 1;
+#endif
+#if defined(ENOTSUP) && (!defined(EOPNOTSUPP) || ENOTSUP != EOPNOTSUPP)
+    if (e == ENOTSUP) return 1;
+#endif
+    return 0;
+}
+
+/* Type gate for a terminal READ/WRITE LEAF: accept ONLY a regular file. A FIFO,
+ * socket, character/block device, or directory is rejected with the single stable
+ * "not_a_regular_file" token. The leaf is opened O_NONBLOCK (so a special-file leaf
+ * can never BLOCK the open - a FIFO/device open returns immediately instead of
+ * waiting on a peer); O_NONBLOCK is then cleared on the accepted regular fd so the
+ * returned descriptor has ordinary blocking read/write semantics. On rejection or
+ * fstat failure the fd is closed and -1 returned with *err set. INTENTIONAL
+ * tightening: an authorized special-file leaf is no longer readable/writable/
+ * mmap-able (docs/hull_fs_design.md §5a). Applied to READ and WRITE only; DIR keeps
+ * its own S_ISDIR contract (a directory never blocks on open). */
+static int finalize_regular_leaf(int fd, const char **err)
+{
+    struct stat st;
+    if (fstat(fd, &st) != 0) { map_errno(errno, err); close(fd); return -1; }
+    if (!S_ISREG(st.st_mode)) { *err = "not_a_regular_file"; close(fd); return -1; }
+    int fl = fcntl(fd, F_GETFL);
+    if (fl >= 0) (void)fcntl(fd, F_SETFL, fl & ~O_NONBLOCK);
+    return fd;
+}
+
 /* ── caller-path lexical pre-check (docs §3/§5) ────────────────────────────────
  * Relative, no "..", and no TRAILING slash. The trailing-slash rejection is a
  * cross-platform PARITY guard: a directory-shaped path like "file/" must not open
@@ -139,6 +178,12 @@ static int try_openat2(int root_fd, const char *relpath, int flags,
     if (errno == ENOSYS || errno == EPERM /* seccomp may block it */)
         return -2;
     if (sympol == HL_FS_SYMLINK_REFUSE && errno == ELOOP) { *err = "symlink_denied"; return -1; }
+    /* A READ leaf (no O_DIRECTORY) that is a socket special file fails ENXIO here;
+     * map it to the same token the post-open type gate uses. O_DIRECTORY opens (DIR
+     * mode) keep their ENOTDIR-> not_a_directory mapping. */
+    if (!(flags & O_DIRECTORY) && leaf_type_errno(errno)) {
+        *err = "not_a_regular_file"; return -1;
+    }
     map_errno(errno, err);
     return -1;
 }
@@ -179,12 +224,21 @@ static int resolve_manual(int root_fd, const char *relpath, HlFsOpenMode mode,
     for (;;) {
         while (*cur == '/') cur++;
         if (*cur == '\0') {
-            /* Consumed everything without a terminal leaf (path was "." etc.).
-             * READ/DIR open the current directory; WRITE has no leaf to create. */
+            /* Consumed everything without a terminal leaf: the path IS a directory
+             * (a grant root reached via residual ".", or a path that clamped to root
+             * via ".."). DIR opens it. READ resolves to a DIRECTORY, which is not a
+             * regular file, so it is type-gated exactly like a special-file leaf and
+             * rejected "not_a_regular_file" (the O_NONBLOCK is harmless on a dir but
+             * kept for one uniform finalize path). WRITE has no leaf to create. */
             if (mode == HL_FS_OPEN_READ || mode == HL_FS_OPEN_DIR) {
-                int of = O_RDONLY | O_CLOEXEC | (mode == HL_FS_OPEN_DIR ? O_DIRECTORY : 0);
+                int of = O_RDONLY | O_CLOEXEC
+                         | (mode == HL_FS_OPEN_DIR ? O_DIRECTORY : O_NONBLOCK);
                 result_fd = openat(stack[depth - 1], ".", of);
                 if (result_fd < 0) { map_errno(errno, err); goto fail; }
+                if (mode == HL_FS_OPEN_READ) {
+                    result_fd = finalize_regular_leaf(result_fd, err);
+                    if (result_fd < 0) goto fail;   /* directory -> not_a_regular_file */
+                }
                 goto done;
             }
             *err = "invalid_path";
@@ -293,13 +347,24 @@ static int resolve_manual(int root_fd, const char *relpath, HlFsOpenMode mode,
             result_fd = fd;
             goto done;
         } else {
-            /* terminal component (READ / WRITE leaf) */
+            /* terminal component (READ / WRITE leaf). O_NONBLOCK guarantees a
+             * special-file leaf (FIFO / device / socket) can never BLOCK the open;
+             * the opened fd is then type-gated to a regular file
+             * (finalize_regular_leaf). WRITE keeps O_CREAT|O_TRUNC (creation +
+             * truncate) plus the contained mkdir-p already done for interior
+             * components. A symlink leaf still returns ELOOP (O_NOFOLLOW) and is
+             * handled by the symlink policy below, unchanged. */
             int flags = (mode == HL_FS_OPEN_READ)
-                          ? (O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
-                          : (O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_CLOEXEC);
+                          ? (O_RDONLY | O_NOFOLLOW | O_NONBLOCK | O_CLOEXEC)
+                          : (O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_NONBLOCK | O_CLOEXEC);
             int fd = openat(stack[depth - 1], comp, flags, cmode);
-            if (fd >= 0) { result_fd = fd; goto done; }
+            if (fd >= 0) {
+                result_fd = finalize_regular_leaf(fd, err);  /* closes fd + sets *err on reject */
+                if (result_fd < 0) goto fail;                /* *err already set */
+                goto done;
+            }
             if (errno == ELOOP || errno == EMLINK) goto symlink;
+            if (leaf_type_errno(errno)) { *err = "not_a_regular_file"; goto fail; }
             map_errno(errno, err);
             goto fail;
         }
@@ -371,9 +436,19 @@ int hl_fs_open_at_ex(int root_fd, const char *relpath, HlFsOpenMode mode,
      * walk (which does the contained mkdir-p). READ and DIR take the one-call fast
      * path, unless HL_FS_FORCE_MANUAL is set (parity testing). */
     if ((mode == HL_FS_OPEN_READ || mode == HL_FS_OPEN_DIR) && !force_manual()) {
-        int of = O_RDONLY | O_CLOEXEC | (mode == HL_FS_OPEN_DIR ? O_DIRECTORY : 0);
+        /* A READ leaf opens O_NONBLOCK so a special-file target can never block the
+         * open; it is then type-gated to a regular file. DIR keeps O_DIRECTORY (its
+         * own S_ISDIR contract; a directory open never blocks). */
+        int of = O_RDONLY | O_CLOEXEC
+                 | (mode == HL_FS_OPEN_DIR ? O_DIRECTORY : O_NONBLOCK);
         int fd = try_openat2(root_fd, relpath, of, sympol, 0, &e);
-        if (fd >= 0) return fd;
+        if (fd >= 0) {
+            if (mode == HL_FS_OPEN_READ) {
+                fd = finalize_regular_leaf(fd, &e);
+                if (fd < 0) { if (err) *err = e; return -1; }
+            }
+            return fd;
+        }
         if (fd == -1) { if (err) *err = e; return -1; }
         /* fd == -2: openat2 unavailable -> manual walk */
     }

--- a/tests/hull/cap/test_fs_resolve.c
+++ b/tests/hull/cap/test_fs_resolve.c
@@ -18,12 +18,15 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <ftw.h>
+#include <setjmp.h>
 #include <signal.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
+#include <sys/un.h>
 
 static char base[256];
 
@@ -576,6 +579,205 @@ UTEST(fs_resolve, parent_refuses_symlink_intermediate)
     close(pr.parent_fd);
 
     close(root); teardown();
+}
+
+/* ── special-file leaf rejection (O_NONBLOCK + regular-file type gate, §5a) ─────
+ * A terminal READ/WRITE leaf that is a FIFO, socket, character/block device, or
+ * directory is rejected with the single stable token "not_a_regular_file" and NEVER
+ * blocks the open (O_NONBLOCK). Each case runs under a watchdog (proving no hang),
+ * on BOTH the openat2 fast path and the forced-manual walk (Linux; macOS/cosmo are
+ * always manual), and asserts no fd is leaked on the failure path. */
+
+/* Lowest free fd number: a proxy for "no descriptor leaked" - stable across a
+ * failing resolve iff every fd the resolver opened was closed. */
+static int probe_lowest_fd(void)
+{
+    int fd = open("/dev/null", O_RDONLY | O_CLOEXEC);
+    if (fd < 0) return -1;
+    close(fd);
+    return fd;
+}
+
+/* Watchdog: run hl_fs_open_at under a wall-clock alarm. If the open ever BLOCKS
+ * (a regression - a special-file leaf without O_NONBLOCK), SIGALRM fires and
+ * siglongjmps back with *hung=1 so the test fails loudly instead of hanging CI. */
+static sigjmp_buf g_wd_jmp;
+static void wd_alarm(int s) { (void)s; siglongjmp(g_wd_jmp, 1); }
+static int open_watchdog(int root, const char *rel, HlFsOpenMode mode,
+                         mode_t cm, const char **err, int *hung)
+{
+    struct sigaction sa, old;
+    memset(&sa, 0, sizeof sa); sa.sa_handler = wd_alarm;
+    sigaction(SIGALRM, &sa, &old);
+    *hung = 0;
+    int fd = -1;
+    if (sigsetjmp(g_wd_jmp, 1) == 0) {
+        alarm(5);
+        fd = hl_fs_open_at(root, rel, mode, cm, err);
+        alarm(0);
+    } else {
+        *hung = 1;
+    }
+    sigaction(SIGALRM, &old, NULL);
+    return fd;
+}
+
+/* Check that resolving `rel` in `mode` is rejected "not_a_regular_file" without
+ * blocking and without leaking an fd, on BOTH implementations. Returns NULL on
+ * success, or a static message naming the first failure (utest ASSERT_* macros
+ * only work inside a UTEST body, so a plain helper reports via a message the caller
+ * asserts on). */
+static const char *check_special_rejected(const char *rel, HlFsOpenMode mode, mode_t cm)
+{
+    for (int m = 0; m < 2; m++) {
+        if (m) setenv("HL_FS_FORCE_MANUAL", "1", 1); else unsetenv("HL_FS_FORCE_MANUAL");
+        const char *err = NULL;
+        int root = hl_fs_open_base(base, &err);
+        if (root < 0) { unsetenv("HL_FS_FORCE_MANUAL"); return "open_base failed"; }
+        int before = probe_lowest_fd();
+        int hung = 0;
+        err = NULL;
+        int fd = open_watchdog(root, rel, mode, cm, &err, &hung);
+        int after = probe_lowest_fd();
+        close(root);
+        unsetenv("HL_FS_FORCE_MANUAL");
+        if (hung) return "resolve BLOCKED on a special-file leaf (hang)";
+        if (fd != -1) { close(fd); return "expected rejection, got an open fd"; }
+        if (!err || strcmp(err, "not_a_regular_file") != 0)
+            return "wrong error token (expected not_a_regular_file)";
+        if (before != after) return "fd leaked on the failure path";
+    }
+    return NULL;
+}
+/* Surface the helper's message through a utest assertion: NULL -> "OK" == "OK". */
+#define ASSERT_REJECTED(r) do { const char *rr_ = (r); ASSERT_STREQ("OK", rr_ ? rr_ : "OK"); } while (0)
+
+#if !defined(__COSMOPOLITAN__)
+static int mkfifo_host(const char *rel)
+{ char p[512]; snprintf(p, sizeof p, "%s/%s", base, rel); unlink(p); return mkfifo(p, 0644); }
+
+UTEST(fs_resolve, read_fifo_rejected_no_hang)
+{
+    setup();
+    ASSERT_EQ(0, mkfifo_host("pipe"));                   /* no writer: O_RDONLY would block */
+    ASSERT_REJECTED(check_special_rejected("pipe", HL_FS_OPEN_READ, 0));
+    teardown();
+}
+
+UTEST(fs_resolve, write_fifo_rejected_no_hang)
+{
+    setup();
+    ASSERT_EQ(0, mkfifo_host("pipe"));                   /* no reader: O_WRONLY would block */
+    ASSERT_REJECTED(check_special_rejected("pipe", HL_FS_OPEN_WRITE, 0644));
+    teardown();
+}
+#endif /* !__COSMOPOLITAN__ */
+
+/* AF_UNIX socket special file: open() fails ENXIO (Linux) / EOPNOTSUPP (macOS),
+ * mapped to the same token as the fstat-gated types. */
+static int mksocket_host(const char *rel)
+{
+    char p[512]; snprintf(p, sizeof p, "%s/%s", base, rel);
+    int s = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (s < 0) return -1;
+    struct sockaddr_un un;
+    memset(&un, 0, sizeof un); un.sun_family = AF_UNIX;
+    snprintf(un.sun_path, sizeof un.sun_path, "%s", p);
+    unlink(p);
+    int r = bind(s, (struct sockaddr *)&un, sizeof un);  /* creates the fs node */
+    close(s);                                            /* node persists after close */
+    return r;
+}
+
+UTEST(fs_resolve, read_socket_rejected)
+{
+    setup();
+    if (mksocket_host("sk") != 0) { teardown(); return; } /* skip if unsupported */
+    ASSERT_REJECTED(check_special_rejected("sk", HL_FS_OPEN_READ, 0));
+    teardown();
+}
+
+UTEST(fs_resolve, write_socket_rejected)
+{
+    setup();
+    if (mksocket_host("sk") != 0) { teardown(); return; }
+    ASSERT_REJECTED(check_special_rejected("sk", HL_FS_OPEN_WRITE, 0644));
+    teardown();
+}
+
+/* A directory as a READ/WRITE LEAF is not a regular file -> same token. The READ
+ * case also covers the residual-"." path (reading a directory that IS the resolved
+ * root); WRITE-to-an-existing-directory-leaf surfaces EISDIR at open(). */
+UTEST(fs_resolve, read_directory_leaf_rejected)
+{
+    setup();
+    mkdirp_host("d");
+    ASSERT_REJECTED(check_special_rejected("d", HL_FS_OPEN_READ, 0));
+    teardown();
+}
+
+UTEST(fs_resolve, read_dot_directory_rejected)
+{
+    setup();
+    for (int m = 0; m < 2; m++) {
+        if (m) setenv("HL_FS_FORCE_MANUAL", "1", 1); else unsetenv("HL_FS_FORCE_MANUAL");
+        const char *err = NULL;
+        int root = hl_fs_open_base(base, &err); ASSERT_GE(root, 0);
+        int before = probe_lowest_fd(), hung = 0;
+        err = NULL;
+        int fd = open_watchdog(root, ".", HL_FS_OPEN_READ, 0, &err, &hung);
+        ASSERT_FALSE(hung);
+        ASSERT_EQ(-1, fd);
+        ASSERT_STREQ("not_a_regular_file", err);         /* reading the root dir as a file */
+        ASSERT_EQ(before, probe_lowest_fd());
+        close(root);
+    }
+    unsetenv("HL_FS_FORCE_MANUAL");
+    teardown();
+}
+
+UTEST(fs_resolve, write_directory_leaf_rejected)
+{
+    setup();
+    mkdirp_host("d");
+    ASSERT_REJECTED(check_special_rejected("d", HL_FS_OPEN_WRITE, 0644));
+    teardown();
+}
+
+/* Character device where creatable (needs privilege): the same S_ISREG gate. Skips
+ * cleanly when a device node cannot be made without privilege. */
+#if !defined(__COSMOPOLITAN__)
+UTEST(fs_resolve, read_chardev_rejected_if_creatable)
+{
+    setup();
+    char p[512]; snprintf(p, sizeof p, "%s/cdev", base);
+    if (mknod(p, S_IFCHR | 0644, 0) != 0) { teardown(); return; } /* skip w/o privilege */
+    ASSERT_REJECTED(check_special_rejected("cdev", HL_FS_OPEN_READ, 0));
+    teardown();
+}
+#endif
+
+/* Regression: a REGULAR leaf still resolves, and the returned fd has O_NONBLOCK
+ * CLEARED (ordinary blocking read/write semantics), on both implementations. */
+UTEST(fs_resolve, regular_leaf_fd_is_blocking)
+{
+    setup();
+    wfile("r.txt", "data");
+    for (int m = 0; m < 2; m++) {
+        if (m) setenv("HL_FS_FORCE_MANUAL", "1", 1); else unsetenv("HL_FS_FORCE_MANUAL");
+        const char *err = NULL;
+        int root = hl_fs_open_base(base, &err); ASSERT_GE(root, 0);
+        err = NULL;
+        int fd = hl_fs_open_at(root, "r.txt", HL_FS_OPEN_READ, 0, &err);
+        ASSERT_GE(fd, 0);
+        int fl = fcntl(fd, F_GETFL);
+        ASSERT_GE(fl, 0);
+        ASSERT_EQ(0, fl & O_NONBLOCK);                   /* cleared on the accepted fd */
+        char b[16]; ASSERT_STREQ("data", slurp(fd, b, sizeof b));
+        close(fd); close(root);
+    }
+    unsetenv("HL_FS_FORCE_MANUAL");
+    teardown();
 }
 
 UTEST_MAIN();

--- a/tests/hull/cap/test_fs_resolve_parity.c
+++ b/tests/hull/cap/test_fs_resolve_parity.c
@@ -23,6 +23,8 @@
 #include <fcntl.h>
 #include <ftw.h>
 #include <pthread.h>
+#include <setjmp.h>
+#include <signal.h>
 #include <stdatomic.h>
 #include <stdint.h>
 #include <string.h>
@@ -381,5 +383,105 @@ UTEST(fs_resolve_parity, component_swap_race_stays_contained)
     rm_tree(g_ext_dir);
     teardown();
 }
+
+/* ── leaf regular<->special swap: containment + no-hang under concurrent flip ───
+ * A LEAF "leaf" is flipped between a regular file and a FIFO by a background thread.
+ * Resolving it READ, repeatedly, through BOTH implementations, must ALWAYS resolve
+ * to a REGULAR fd, or fail "not_a_regular_file" (the FIFO), or "not_found" (the
+ * brief unlink gap) - never BLOCK (O_NONBLOCK), never hand back a non-regular fd,
+ * never a different token - and leak no fd. This is the concurrent analogue of the
+ * single-shot special-file rejection: the regular<->special TOCTOU can never turn a
+ * regular open into a blocking / mistyped special-file open. */
+#if !defined(__COSMOPOLITAN__)
+static atomic_int g_leaf_stop;
+static char g_leaf_path[512];
+
+static void *leaf_swapper(void *arg)
+{
+    (void)arg;
+    unsigned seed = 0x5EEDu;
+    while (!atomic_load_explicit(&g_leaf_stop, memory_order_relaxed)) {
+        unlink(g_leaf_path);
+        if (lcg_next(&seed) & 1) {
+            int fd = open(g_leaf_path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+            if (fd >= 0) { ssize_t w = write(fd, "reg", 3); (void)w; close(fd); }
+        } else {
+            mkfifo(g_leaf_path, 0644);
+        }
+    }
+    return NULL;
+}
+
+/* per-call alarm watchdog: a blocked open (regression) trips SIGALRM -> siglongjmp. */
+static sigjmp_buf g_leaf_wd;
+static void leaf_wd_alarm(int s) { (void)s; siglongjmp(g_leaf_wd, 1); }
+
+UTEST(fs_resolve_parity, leaf_regular_special_swap_stays_contained)
+{
+    setup();
+    const char *err = NULL;
+    int root = hl_fs_open_base(base, &err);
+    ASSERT_GE(root, 0);
+    snprintf(g_leaf_path, sizeof g_leaf_path, "%s/leaf", base);
+
+    struct sigaction sa, old;
+    memset(&sa, 0, sizeof sa); sa.sa_handler = leaf_wd_alarm;
+    sigaction(SIGALRM, &sa, &old);
+
+    int fds_before = count_open_fds();
+    atomic_store(&g_leaf_stop, 0);
+    pthread_t th;
+    ASSERT_EQ(0, pthread_create(&th, NULL, leaf_swapper, NULL));
+
+    const int ITERS = 8000;
+    const long CAP_SEC = 60;
+    time_t start = time(NULL);
+    int reg = 0, rejected = 0, bad = 0, hung = 0, done = 0;
+    char firstbad[96] = {0};
+    for (int i = 0; i < ITERS && !done; i++) {
+        if (time(NULL) - start > CAP_SEC) break;
+        for (int manual = 0; manual < 2 && !done; manual++) {
+            const char *tok = NULL;
+            int fd = -1;
+            if (sigsetjmp(g_leaf_wd, 1) == 0) {
+                alarm(5);
+                fd = resolve_via(root, "leaf", HL_FS_OPEN_READ, manual, &tok);
+                alarm(0);
+            } else { hung = 1; done = 1; break; }
+            if (fd >= 0) {
+                struct stat st;                          /* MUST be a regular file */
+                if (fstat(fd, &st) == 0 && S_ISREG(st.st_mode)) reg++;
+                else { if (!firstbad[0]) snprintf(firstbad, sizeof firstbad,
+                            "opened a NON-regular fd (mode=%o)", (unsigned)st.st_mode);
+                       bad++; done = 1; }
+                close(fd);
+            } else if (tok && strcmp(tok, "not_a_regular_file") == 0) {
+                rejected++;                              /* the FIFO, correctly refused */
+            } else if (tok && strcmp(tok, "not_found") == 0) {
+                /* brief unlink gap - contained */
+            } else {
+                if (!firstbad[0]) snprintf(firstbad, sizeof firstbad, "tok=%.40s", tok ? tok : "?");
+                bad++; done = 1;
+            }
+        }
+    }
+    atomic_store(&g_leaf_stop, 1);
+    pthread_join(th, NULL);
+    alarm(0);
+    sigaction(SIGALRM, &old, NULL);
+
+    ASSERT_EQ_MSG(0, hung, "resolve BLOCKED on a FIFO leaf during the swap");
+    ASSERT_EQ_MSG(0, bad, firstbad);
+    ASSERT_GT(reg, 0);            /* the regular file resolved sometimes */
+    ASSERT_GT(rejected, 0);      /* the FIFO was rejected sometimes */
+
+    unlink(g_leaf_path);
+    int fds_after = count_open_fds();
+    char fdctx[64]; snprintf(fdctx, sizeof fdctx, "before=%d after=%d", fds_before, fds_after);
+    ASSERT_GE_MSG(fds_before, fds_after, fdctx);   /* no fd leaked */
+    close(root);
+    teardown();
+}
+#endif /* !__COSMOPOLITAN__ */
 
 UTEST_MAIN();


### PR DESCRIPTION
## BuildContext preflight blocker (resolved separately, before checkpoint 1)

The descriptor-relative resolver already defended **interior** components and the **DIR-mode terminal** against a special-file open hang (classify-then-`O_DIRECTORY|O_NOFOLLOW`), but the terminal **READ/WRITE leaf** opened `O_RDONLY` / `O_WRONLY|O_CREAT|O_TRUNC` with **no `O_NONBLOCK` and no type gate** (`fs_resolve.c:295`). A FIFO or blocking device as a leaf therefore blocked `openat()` **indefinitely** — a self-DoS for app `hull.fs`, and a hard blocker for `BuildContext.inputs` (a stray `mkfifo` in a workspace would hang the whole build pipeline).

## The guard (identical on both implementations)

Applied on the `openat2` fast path **and** the portable manual walk:

- open the terminal leaf **`O_NONBLOCK`** so a special-file open can never block;
- **`fstat`** the opened fd and accept **only a regular file** for READ / MMAP / WRITE;
- reject FIFO, socket, character/block device, and directory with **one stable token `not_a_regular_file`** — whether it surfaces at the post-open type gate (`finalize_regular_leaf`) or at `open()` itself (`leaf_type_errno` maps socket `ENXIO`/`EOPNOTSUPP`, write-on-dir `EISDIR`, writer-FIFO-no-reader `ENXIO`);
- **clear `O_NONBLOCK`** on the accepted regular fd (ordinary blocking read/write);
- also guard the residual-`"."` branch (reading a path that resolves to a directory).

Preserves: virtual-root symlink behavior (`O_NOFOLLOW` → `ELOOP` still routes to the symlink policy), `EXACT`/`CREATE`/`PATTERN` refusal, WRITE creation + implicit parents + `O_TRUNC`. DIR mode keeps its own `S_ISDIR` contract.

**Intentional tightening:** an authorized special-file leaf is no longer readable/writable/mmap-able. Documented in `docs/hull_fs_design.md` §5a and `docs/api/lua.md`. This also closes the deferred audit Low (terminal-leaf blocking-open).

## Acceptance boundary (all met)

- ✅ `O_NONBLOCK` before any terminal leaf can block; `fstat` accepts regular only for READ/MMAP/WRITE.
- ✅ FIFO / socket / char+block device / directory rejected with one documented token (`not_a_regular_file`).
- ✅ Virtual-root symlink + `EXACT`/`CREATE`/`PATTERN` refusal preserved; WRITE creation + implicit parents + `O_TRUNC` preserved.
- ✅ Identical behavior on `openat2` and forced-manual (`HL_FS_FORCE_MANUAL`).
- ✅ No-hang proven with bounded SIGALRM watchdog tests for READ and WRITE.
- ✅ Exercises FIFO + socket; char device where creatable (skips cleanly without privilege).
- ✅ Concurrent regular↔special leaf-swap containment/no-hang coverage.
- ✅ No fd growth asserted on every failure path.
- ✅ Documented the tightening.

## Verification

- `make test` — 91/91.
- fs suites (`test_fs_resolve` 34, `test_fs_resolve_parity` 4, `test_fs` 37, `test_fs_statlist` 13, `test_fs_policy` 15) green under **ASan+UBSan** (`test_fs_resolve_parity` is in the TSan set for CI).
- `check-no-emdash` + `check-no-milestone-narration` pass.
- cosmo runs the same manual-walk path macOS validated; the Cosmopolitan APE + Linux/aarch64 + MSan/TSan matrix on CI is authoritative.