### PR TITLE
docs: refresh JS ProjectDiscovery + hull.fs surface, drop rollout-era Phase headings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,7 +270,7 @@ Analyze deployment readiness. Manifest, directory structure, existing configs.
 }
 ```
 
-### Extended introspection (Phase 6, 2026-05-15; auth-stack additions v0.3.0)
+### Extended introspection
 
 Eighteen additional subcommands close the iterative-edit loop. All JSON to stdout.
 
@@ -280,12 +280,12 @@ One-shot snapshot. Composes manifest + modules + capabilities + routes + compute
 
 #### `hull agent inspect [app_dir]`
 
-The **project source-discovery** model as versioned JSON: a static analysis of the app's Lua source (parsed by the pure-Lua `hull.source.*` layer, **without executing app code**) that reports the **annotated declarations** - `---@name` annotations attached to `local` / `local function` / `function` declarations - with exact ranges, deterministic IDs, and `by_annotation` / `by_source` / `by_language` / `by_id` indexes.
+The **project source-discovery** model as versioned JSON: a static analysis of the app's source (**without executing app code**) that reports the **annotated declarations** - `---@name` (Lua) / `@name` (JS) annotations attached to `local` / `local function` / `function` (and the JS equivalents) declarations - with exact ranges, deterministic IDs, and `by_annotation` / `by_source` / `by_language` / `by_id` indexes. Lua is parsed by the pure-Lua `hull.source.*` layer; JavaScript by a bundled QuickJS frontend session.
 
 - Top-level fields: `schema_version`, `generation`, `source` (`"standalone"` | `"dev"`), `project_root`, `valid` (no source rejected/failed), `complete` (every application source had an analyzable frontend), `sources[]`, `frontends[]`, `declarations[]` (annotated-only), `diagnostics[]`, `summary`, `indexes`.
 - Runs **standalone**, or - when a live `hull dev --agent` session has published a generation - serves that live `.hull/discovery.json` generation (same schema; `source: "dev"`, `generation >= 1`).
 - Exit 0 whenever a discovery is produced (validity is data: read `valid` / `complete`); exit 2 only on a usage error (e.g. a second positional root).
-- JavaScript is a reserved-but-not-yet-analyzable frontend: an application `.js` is reported `status: "unsupported"` and sets `complete: false`, and is **never parsed as Lua**; `static/*.js` browser assets are pruned.
+- JavaScript is a first-class analyzable frontend on a default (`RUNTIME=all`) build: an application `.js` is analyzed end-to-end via the bundled QuickJS frontend, with parity to Lua (declarations, annotations, scope). It is reported `status: "unsupported"` (and sets `complete: false`) **only** on a `RUNTIME=lua` build with no JS frontend compiled in; a `.js` is never parsed as Lua, and `static/*.js` browser assets are always pruned.
 - CLI-only (not exposed via `hull mcp`). Foundation for a future codegen step (Query/Compute IR). Design: [docs/project_discovery_design.md](docs/project_discovery_design.md).
 
 ```json
@@ -692,7 +692,7 @@ Every module except the intrinsic core must be listed in `manifest.modules`. The
 | `crypto` | `local crypto = require("hull.crypto")` | `import { crypto } from "hull:crypto"` | `"hull/crypto@1"` | Hashing, signing, random |
 | `time` | `local time = require("hull.time")` | `import { time } from "hull:time"` | `"hull/time@1"` | Timestamps |
 | `env` | `local env = require("hull.env")` | `import { env } from "hull:env"` | `"hull/env@1"` | Environment vars (also needs `env` allowlist) |
-| `fs` | `local fs = require("hull.fs")` | `import { fs } from "hull:fs"` | `"hull/fs@1"` | Sandboxed FS (also needs `fs_read`/`fs_write`) |
+| `fs` | `local fs = require("hull.fs")` | `import { fs } from "hull:fs"` | `"hull/fs@1"` | Sandboxed FS: `read` / `write` / `stat` / `list` / `mmap` (policy-backed; also needs `fs_read`/`fs_write`). Leaves must be regular files (`not_a_regular_file`); `exists`/`delete` are not app-exposed |
 | `http_client` | `local http_client = require("hull.http-client")` | `import { httpClient } from "hull:http-client"` | `"hull/http-client@1"` | Outbound HTTP/HTTPS (`http.fetch` etc.); needs `hosts` allowlist |
 | `http_server` | `local http_server = require("hull.http-server")` | `import { httpServer } from "hull:http-server"` | `"hull/http-server@1"` | Decorates `app` with `get/post/use/router`; also exposes `server.stats()` |
 | `ws_server` | `local ws_server = require("hull.web.ws-server")` | `import { wsServer } from "hull:web:ws-server"` | `"hull/web/ws-server@1"` | Decorates `app.ws`; also exposes `wsServer.broadcast`, `wsServer.connections` |
@@ -887,7 +887,7 @@ Example audit output (one JSON object per line on stderr):
 {"ts":"2026-08-05T14:23:04Z","cap":"tool.spawn","cmd":"cc","exit_code":0}
 ```
 
-Every capability module is instrumented: `db.query`, `db.exec`, `fs.read`, `fs.write`, `fs.delete`, `http.request`, `env.get`, `tool.spawn`, `smtp.send`. SQL queries are truncated to 512 bytes. Passwords and secrets are never logged.
+Every capability module is instrumented: `db.query`, `db.exec`, `fs.read`, `fs.write`, `http.request`, `env.get`, `tool.spawn`, `smtp.send`. SQL queries are truncated to 512 bytes. Passwords and secrets are never logged.
 
 **Use cases for agents:**
 - **Debugging failed requests:** See exactly which DB queries ran, what files were accessed, which HTTP calls were made

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -899,7 +899,7 @@ All system access is mediated by C capability functions. Neither runtime touches
 | Module | File | Key Functions |
 |--------|------|---------------|
 | Database | `cap/db.c` | `hl_cap_db_query()`, `hl_cap_db_exec()`, `hl_cap_db_begin/commit/rollback()` |
-| Filesystem | `cap/fs.c` | `hl_cap_fs_read()`, `hl_cap_fs_write()`, `hl_cap_fs_exists()`, `hl_cap_fs_delete()` |
+| Filesystem | `cap/fs.c`, `cap/fs_resolve.c`, `cap/fs_policy.c` | `hl_cap_fs_read()`, `hl_cap_fs_write()`, `hl_cap_fs_mmap()`, `hl_cap_fs_stat()`, `hl_cap_fs_list()`, all through the descriptor-relative virtual-root resolver + compiled `fs.read`/`fs.write` authorization policy; READ/WRITE/MMAP leaves must be regular files (`not_a_regular_file`). `hl_cap_fs_exists()`/`hl_cap_fs_delete()` exist at the cap layer but are NOT app-exposed |
 | Crypto | `cap/crypto.c` | SHA-256/512, HMAC, PBKDF2, Ed25519, secretbox, box, random |
 | HTTP client | `cap/http.c` | `hl_cap_http_request()` with host allowlist |
 | Environment | `cap/env.c` | `hl_cap_env_get()` with manifest allowlist |
@@ -1179,10 +1179,11 @@ The naming pattern is `HULL_NO_<KIND>_CACHE` where `<KIND>` is the registry's `e
 
 ### Project source discovery (`hull.source.*` + `hull.project.*`)
 
-Hull statically analyzes an app's **Lua source WITHOUT executing it**, producing a canonical
+Hull statically analyzes an app's **source WITHOUT executing it**, producing a canonical
 representation of annotated declarations that a future codegen step (Query/Compute IR) can
-consume. Two layers, both **pure Lua in the sandboxed tool VM** (the whole analysis brain is
-zero C):
+consume. Both frontends ship: the Lua analysis brain is pure Lua in the sandboxed tool VM;
+the JavaScript frontend runs in a bundled QuickJS tooling session (it never executes app JS).
+Two layers:
 
 - **`hull.source.*`** (`stdlib/cli/lua/hull/source/`) - the language-analysis layer: a
   pure-Lua recursive-descent Lua 5.4 lexer/parser (NEVER `load()`), half-open byte ranges,
@@ -1193,9 +1194,12 @@ zero C):
   exclude-dirs pruned during traversal, canonical containment, deterministic/regular/no-symlink)
   - the ONE recursive source walker in Hull. Design: [docs/lua_source_analysis_design.md](docs/lua_source_analysis_design.md), [docs/hull_analyze_design.md](docs/hull_analyze_design.md).
 - **`hull.project.*`** (`stdlib/cli/lua/hull/project/`) - the frontend-neutral project layer
-  on top: `registry` (extension → frontend map; Lua analyzable, `js/mjs/cjs` reserved +
-  `analyzable=false`, never parsed as Lua), `frontend_lua` (the ONLY module that knows Lua AST
-  layouts), `model` (the `ProjectDiscovery` - deterministic textual IDs, per-name facts sharing
+  on top: `registry` (extension → frontend map; `lua` and `js`/`mjs`/`cjs` are both analyzable
+  frontends, `analyzable` computed per build from `tool.frontend_available(engine)` - JS is on
+  by default and reported unsupported only on a `RUNTIME=lua` build; a `.js` is never parsed as
+  Lua), `frontend_lua` (knows Lua AST layouts) + the JS frontend (`stdlib/cli/js/hull/source/`,
+  run in a QuickJS tool session via `HL_FRONTEND_JS`), `model` (the `ProjectDiscovery` -
+  deterministic textual IDs, per-name facts sharing
   a `group_id` with each annotation carrying `target_group_id` + `frontend`, annotated-only
   public `declarations[]`, independent `valid` / `complete` axes, `by_annotation`/`by_source`/
   `by_language`/`by_id`/`annotated` indexes), `analyze` (the single canonical host analyzer:
@@ -1212,7 +1216,8 @@ schema either way (`source: "dev"` vs `"standalone"`). The build seam is documen
 but **abstraction-only**: `build.lua` is unchanged and does no per-build parse; a future
 lowering consumer calls `hull.project.analyze(app_dir)` in `main()` (after `parse_args()`,
 before `discover()`). ~180 lines of hardened C (in `agent.c` + `dev.c`) handle only the
-live-read/sidecar/publish glue; all source parsing stays in Lua. Tests:
+live-read/sidecar/publish glue; Lua source parsing stays in Lua and JavaScript parses in the
+bundled QuickJS tool session (never the app runtime), not in C. Tests:
 `stdlib/cli/lua/hull/project/tests/test_project.lua` (UTEST leg `project_discovery`) +
 `tests/e2e_project_discovery.sh` (`make e2e-project-discovery`, incl. a live backgrounded
 `hull dev --agent`).

--- a/README.md
+++ b/README.md
@@ -1203,7 +1203,7 @@ any product spec - fully app-agnostic.
 Hull provides structured JSON interfaces for AI coding agents via the `hull agent` command. The same interfaces work for any automation (CI scripts, service orchestrators, or human developers who prefer structured output. **Twenty-eight machine-readable subcommands** cover routes, database schema, test results, server status, HTTP responses, deployment readiness, capability analysis, request preview, one-shot eval, the analyzed project model, and more) no screen-scraping or log parsing required.
 
 ```
-# Core introspection (Phase 1–5)
+# Core introspection
 hull agent routes [app_dir]              # routes + middleware as JSON
 hull agent db schema [app_dir] [-d path] # database tables and columns
 hull agent db query "SQL" [app_dir]      # read-only SQL → rows as JSON
@@ -1215,7 +1215,7 @@ hull agent context --task=T [--level=L]  # task-relevant documentation
 hull agent migrate [app_dir] [-d path]   # migration status
 hull agent deploy [app_dir]              # deployment readiness analysis
 
-# Extended introspection (Phase 6)
+# Extended introspection
 hull agent manifest [app_dir]            # effective manifest JSON
 hull agent endpoint METHOD PATH [dir]    # request preview (no execution)
 hull agent middleware METHOD PATH [dir]  # middleware stack for path
@@ -1239,7 +1239,7 @@ hull agent sql named <qname> [--params J] [dir]  # named query from queries.json
 
 Combined with `hull dev --agent` (which writes `.hull/dev.json`, `.hull/last_error.json`, and a per-reload `.hull/discovery.json` generation as sidecar files), agents get a complete feedback loop: edit code, check for errors, run tests, inspect the database, make HTTP requests, validate manifest coverage. All structured.
 
-`hull agent inspect` surfaces Hull's **project source-discovery** model: a static, host-owned analysis of the app's Lua source (via the pure-Lua `hull.source.*` layer, without executing app code) that reports the annotated declarations - `---@` annotations attached to `local` / `local function` / `function` declarations, with exact ranges, deterministic IDs, and by-annotation indexes. It runs standalone, or serves the live generation a running `hull dev --agent` session has published. JavaScript is a reserved-but-not-yet-analyzable frontend (honestly reported, never parsed as Lua). This is the foundation a future codegen step (e.g. Query/Compute IR) consumes.
+`hull agent inspect` surfaces Hull's **project source-discovery** model: a static, host-owned analysis of the app's source (Lua via the pure-Lua `hull.source.*` layer, JavaScript via a bundled QuickJS frontend session, without executing app code) that reports the annotated declarations - annotations attached to declarations, with exact ranges, deterministic IDs, and by-annotation indexes. It runs standalone, or serves the live generation a running `hull dev --agent` session has published. JavaScript is a first-class analyzable frontend on a default build (analyzed via a bundled QuickJS frontend session with parity to Lua; reported unsupported only on a `RUNTIME=lua` build, never parsed as Lua). This is the foundation a future codegen step (e.g. Query/Compute IR) consumes.
 
 ### Agent Development Workflow
 

--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -415,7 +415,7 @@ SQLite / FS / network / crypto
 | Module | Source | Key functions |
 |---|---|---|
 | Database | `cap/db.c`, `cap/db_sqlite.c` | `hl_cap_db_query/exec/begin/commit/rollback` |
-| Filesystem | `cap/fs.c` | `hl_cap_fs_read/write/exists/delete/validate` |
+| Filesystem | `cap/fs.c`, `cap/fs_resolve.c`, `cap/fs_policy.c` | `hl_cap_fs_read/write/mmap/stat/list` (descriptor-relative virtual-root resolver + compiled `fs.read`/`fs.write` policy; regular-file leaves only) |
 | Crypto | `cap/crypto.c` | SHA-256/512, HMAC, PBKDF2, Ed25519, NaCl secretbox/box, random |
 | HTTP client | `cap/http.c`, `cap/http_async.c` | `hl_cap_http_request` (host allowlist) |
 | Environment | `cap/env.c` | `hl_cap_env_get` (allowlist) |
@@ -679,7 +679,7 @@ app.use_post("POST", "/api/*", idempotency.middleware())
 |---|---|---|
 | `db` | Database (requires `HL_ENABLE_DB=1`) | `query`, `exec`, `batch`, `udf.register`, `async.query`, `async.exec` |
 | `http` | HTTP client | `fetch`, `get`, `post`, `async.fetch`, `async.get`, `async.post` |
-| `fs` | Filesystem (manifest allowlist) | `read`, `write`, `exists`, `delete`, `mmap`, `list_dir` |
+| `fs` | Filesystem (manifest allowlist) | `read`, `write`, `stat`, `list`, `mmap` (policy-backed; regular-file leaves only, else `not_a_regular_file`). `exists`/`delete` are not app-exposed |
 | `crypto` | Crypto primitives | `sha256`, `sha512`, `hmac_sha256`, `pbkdf2`, `ed25519_*`, `secretbox_*`, `random`, `hash_password`, `verify_password`, `base64url_*` |
 | `env` | Env vars (manifest allowlist) | `get(name)` → string or nil |
 | `time` | Time | `now`, `now_ms`, `clock`, `date`, `datetime` |
@@ -1457,7 +1457,7 @@ Tools exposed: `hull_routes`, `hull_db_schema`, `hull_db_query`, `hull_request`,
 The MCP server keeps a warm `HlAppContext` between calls so requests don't
 re-init the runtime each time.
 
-### Extended introspection subcommands (Phase 6, 2026-05-15)
+### Extended introspection subcommands
 
 Sixteen additional subcommands close common agent productivity gaps:
 
@@ -1730,7 +1730,7 @@ templates/                     Build templates (app_main.c, entry.h)
 
 ---
 
-## Agent gap analysis. Closed (Phase 6, 2026-05-15)
+## Agent gap analysis (closed)
 
 All sixteen identified gaps have been implemented. See § Extended
 introspection above for the full subcommand reference. Implementation
@@ -1753,7 +1753,7 @@ notes per command:
 | `sql named` | `src/hull/agent/sql.c` | Loads `app_dir/queries.json`, binds named params from `--params JSON`. |
 
 All buffer sizes named in `src/hull/agent/limits.h` (no magic constants).
-Total Phase 6 surface: ~1,500 lines of new C + ~150 lines of CLI glue in
+Total extended-introspection surface: ~1,500 lines of C + ~150 lines of CLI glue in
 `commands/agent.c`. CI-gated and smoke-tested against `examples/hello`.
 
 ---

--- a/docs/api/js.md
+++ b/docs/api/js.md
@@ -180,6 +180,41 @@ import { log } from "hull:log";
 Modules are loaded on first import; subsequent imports return the same
 binding.
 
+### `fs` - Filesystem
+
+Sandboxed, manifest-authorized filesystem. Every path resolves under the app root
+through a descriptor-relative, virtual-root resolver (in-sandbox symlinks followed
+and contained) gated by the compiled `fs.read` / `fs.write` authorization policy.
+This mirrors the Lua `hull.fs` surface exactly (see `docs/api/lua.md` for the full
+semantics).
+
+```javascript
+import { fs } from "hull:fs";
+
+const bytes   = fs.read("config.json");              // ArrayBuffer (throws on error)
+fs.write("uploads/out.bin", bytes);                  // creates parents + truncates; true
+const meta    = fs.stat("data.csv");                 // { type, size, mode, mtime } | null
+const entries = fs.list("uploads");                  // [{ name, type, size }, ...] (ordered)
+const buf     = fs.mmap("big.bin", { offset, length }); // read-only MappedBuffer (optional window)
+```
+
+- `fs.read(path)` -> `ArrayBuffer` (throws on error).
+- `fs.write(path, bytes)` -> `true`; creates missing parents and truncates.
+- `fs.stat(path)` -> `{ type, size, mode, mtime }`, or `null` when the path does not
+  exist (so `fs.stat(p) !== null` subsumes an existence check). `type` is `"file"` /
+  `"dir"` / `"symlink"` / `"other"`; a terminal symlink is reported as a link (lstat),
+  never followed.
+- `fs.list(dir)` -> deterministically-ordered `Array<{ name, type, size }>`
+  (non-recursive; `.` / `..` omitted), gated by `fs.read`. Ordering is unsigned-byte
+  lexicographic, identical on every platform.
+- `fs.mmap(path[, { offset, length }])` -> a read-only `MappedBuffer` (optionally a
+  page-aligned window) for zero-copy input to `compute.*` / `gpu.*`.
+
+`read` / `write` / `mmap` require a **regular-file** leaf: a FIFO, socket,
+character/block device, or directory target throws `not_a_regular_file` and never
+blocks. `exists` and `delete` are NOT part of the app surface. Error tokens match
+Lua (thrown with the token in the message).
+
 ### `db` - Database
 
 Requires `HL_ENABLE_DB=1`. The import fails to resolve in compute-only


### PR DESCRIPTION
Bounded, docs-only correctness refresh of operational guidance (per review), after the JS source-analysis frontend shipped (#367) and the `hull.fs` surface reached read/write/mmap/stat/list + the regular-file-leaf rule (#405, #420). No BuildContext work; the design stays described as next work; the marketing site is untouched.

## JavaScript ProjectDiscovery (was stale)

It is **shipped and on by default** — a bundled QuickJS frontend session with parity to Lua declarations/annotations/scope; reported `unsupported` only on a `RUNTIME=lua` build (never parsed as Lua). Fixed:
- `README.md`, `AGENTS.md`: no longer "reserved-but-not-yet-analyzable" / always-`unsupported`.
- `CLAUDE.md`: discovery no longer described as "pure-Lua / zero-C with JS reserved (`analyzable=false`)"; the registry note reflects the per-build `analyzable` flag (`tool.frontend_available`, `HL_FRONTEND_JS`) and the QuickJS frontend under `stdlib/cli/js/hull/source/`.

## hull.fs surface (was stale)

App-callable surface is **`{ read, write, stat, list, mmap }`** (both runtimes, policy-backed through the descriptor-relative resolver + compiled `fs.read`/`fs.write` policy); READ/WRITE/MMAP leaves must be regular files (`not_a_regular_file`); **`exists`/`delete` are cap-layer only, not app-exposed**. Fixed the stale `exists`/`delete`/`list_dir` listings in `CLAUDE.md`, `AGENTS.md`, `docs/agent_guide.md`, and dropped the non-exposed `fs.delete` from the audit-instrumented list.

## JS API parity

`docs/api/js.md` now documents the mirrored `fs.read`/`write`/`stat`/`list`/`mmap` surface explicitly (it previously deferred `fs` to a "representative slice").

## Rollout-era headings

Removed `Phase 6, 2026-05-15` headings from `README.md`, `AGENTS.md`, `docs/agent_guide.md` operational guidance (recast to present-tense descriptive headings). **Unchanged** (architectural / accurate): the two-phase `sandbox phase 1/2`, `Phase 4.3` (flavors), and the `docs/archive/audits/…phase6…` reference links.

## Verification

- `check-no-emdash` + `check-no-milestone-narration` pass; zero em-dashes added.
- Docs-only (5 files); no code, no build, no behavior change.