### PR TITLE
fix(cosmo): force-link the strong per-runtime HTTP bridge in produced apps (0.13.1 PR#1)

### DIFF
--- a/.github/workflows/cosmocc-windows-e2e.yml
+++ b/.github/workflows/cosmocc-windows-e2e.yml
@@ -212,3 +212,70 @@ jobs:
           Write-Host "above for where the cosmocc reroute broke (resolve / compile /"
           Write-Host "apelink)."
           exit 1
+
+      # 0.13.1 PR#1 acceptance: the app.main control above proves BUILD + EXIT,
+      # but the field failure was a produced HTTP app that BUILDS + RUNS yet
+      # never serves (the fat cosmo platform archive's weak http_weakstub.o
+      # shadowed the strong per-runtime hl_<rt>_wire_routes_server, so serve
+      # aborted on the -1 no-op). This step builds two-line Lua + JS /ping apps
+      # with the SAME branch cosmo hull + bundled cosmocc and asserts each
+      # actually answers 'pong' - the coverage the app.main-only control missed.
+      - name: hull build HTTP apps -> APE and assert they SERVE (PR#1)
+        shell: pwsh
+        run: |
+          $fail = 0
+          function Build-And-Serve($dir, $ext, $src, [string]$bin, [int]$port) {
+            New-Item -ItemType Directory -Force -Path $dir | Out-Null
+            Set-Content -NoNewline "$dir\app.$ext" -Value $src -Encoding ascii
+            $bout = .\hull-cosmo.exe build $dir -o $bin --no-verify-platform 2>&1 | Out-String
+            Write-Host $bout
+            if (-not (Test-Path $bin)) { Write-Host "FAIL $dir did not build"; $script:fail = 1; return }
+            $p = Start-Process -FilePath ".\$bin" -ArgumentList @('-p', "$port") -PassThru `
+                     -RedirectStandardOutput "$dir.out" -RedirectStandardError "$dir.err" -WindowStyle Hidden
+            $resp = ''
+            for ($i = 0; $i -lt 20; $i++) {
+              Start-Sleep -Milliseconds 400
+              try { $resp = (Invoke-WebRequest "http://127.0.0.1:$port/ping" -UseBasicParsing -TimeoutSec 3).Content; break } catch {}
+              if ($p.HasExited) { break }
+            }
+            if (-not $p.HasExited) { Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue }
+            if ($resp -eq 'pong') { Write-Host "PASS $dir served pong" }
+            else { Write-Host "FAIL $dir did not serve (resp='$resp'); stderr:"; Get-Content "$dir.err" -ErrorAction SilentlyContinue | Write-Host; $script:fail = 1 }
+          }
+          $lua = "app.manifest({ modules = { `"hull/http-server@1`" } })`napp.get(`"/ping`", function(req, res) res:text(`"pong`") end)"
+          $js  = "import { app } from `"hull:app`";`napp.manifest({ modules: [`"hull/http-server@1`"] });`napp.get(`"/ping`", (req, res) => res.text(`"pong`"));"
+          Build-And-Serve "httplua" "lua" $lua "lua_windows.com" 39310
+          Build-And-Serve "httpjs"  "js"  $js  "js_windows.com"  39311
+          # Stage the produced APEs (+ the app.main control) for the macOS
+          # second-host portability leg.
+          New-Item -ItemType Directory -Force -Path apes | Out-Null
+          Copy-Item lua_windows.com apes\ -Force
+          Copy-Item js_windows.com  apes\ -Force
+          if (Test-Path app.exe) { Copy-Item app.exe apes\main_windows.com -Force }
+          if ($fail -ne 0) { Write-Host "PR#1 ACCEPTANCE FAIL: a produced cosmo HTTP app did not serve"; exit 1 }
+          Write-Host "PR#1 ACCEPTANCE PASS: produced cosmo Lua+JS HTTP apps serve pong on Windows"
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        if: always()
+        with:
+          name: cosmo-http-apes
+          path: apes/*.com
+          if-no-files-found: warn
+          retention-days: 7
+
+  macos-serve:
+    name: macOS - second-host portability (produced APEs serve)
+    runs-on: macos-latest
+    needs: [windows-e2e]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: cosmo-http-apes
+          path: apes
+      # The Windows-produced cosmo APEs must serve on a second, independent APE
+      # host too (proves the fix is a portable produced-binary property, not a
+      # Windows-run quirk). download-artifact strips the exec bit; the script
+      # chmods before running.
+      - name: Run produced APEs on macOS and assert serve
+        run: APES_DIR=apes sh tests/cosmo_http_serve_run.sh

--- a/include/hull/http_feature.h
+++ b/include/hull/http_feature.h
@@ -47,6 +47,25 @@ int  hl_js_register_http_modules(void *js_ctx, void *hl_js);
 /* 1 iff an HTTP subsystem is composed (strong override present), else 0. */
 int hl_http_feature_present(void);
 
+/* Cosmo HTTP-bridge force-link anchors (0.13.1 PR#1).
+ *
+ * These are unique STRONG symbols that exist ONLY in the per-runtime HTTP bridge
+ * objects (routes.o carries hl_<rt>_http_bridge_anchor; http_register.o carries
+ * hl_<rt>_http_register_anchor), with NO weak counterpart in http_weakstub.o /
+ * http_feature.o. On the native SLIM base the bridge is whole-archived, so these
+ * are unused there. On cosmo the bridge lives as MEMBERS of the fat platform
+ * archive alongside the weak stubs; a produced cosmo app resolves serve.o's
+ * undefined hl_<rt>_wire_routes_server against the weak no-op (which returns -1
+ * and aborts serving) and never pulls the strong member. `hull build` emits a
+ * reference to the selected runtime's anchors so the linker force-pulls the
+ * strong bridge members, overriding the weak stubs. Because an anchor has no
+ * weak twin, referencing one is a hard link error if the bridge is absent
+ * (fail closed). Defined under HL_ENABLE_HTTP_SERVER in the matching TU. */
+extern int hl_lua_http_bridge_anchor;
+extern int hl_lua_http_register_anchor;
+extern int hl_js_http_bridge_anchor;
+extern int hl_js_http_register_anchor;
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/hull/runtime/js/http_register.c
+++ b/src/hull/runtime/js/http_register.c
@@ -17,6 +17,12 @@
 
 #if defined(HL_ENABLE_HTTP_SERVER) || defined(HL_ENABLE_HTTP_CLIENT)
 
+/* Cosmo HTTP-bridge force-link anchor (0.13.1 PR#1) - see hull/http_feature.h.
+ * Co-resident with the strong hl_js_register_http_modules so a produced cosmo
+ * app force-pulls the require-able HTTP modules over the weak http_feature.o
+ * no-op. */
+int hl_js_http_register_anchor = 0;
+
 int hl_js_register_http_modules(void *js_ctx, void *hl_js)
 {
     JSContext *ctx = (JSContext *)js_ctx;

--- a/src/hull/runtime/js/routes.c
+++ b/src/hull/runtime/js/routes.c
@@ -319,6 +319,12 @@ static KlBodyReader *hl_js_multipart_factory(KlAllocator *alloc,
     return hl_cap_multipart_factory(alloc, req, route->multipart_config);
 }
 
+/* Cosmo HTTP-bridge force-link anchor (0.13.1 PR#1) - see hull/http_feature.h.
+ * Unique strong symbol, co-resident with the strong hl_js_wire_routes_server;
+ * a produced cosmo app references it to force-pull this member over the weak
+ * http_weakstub.o stub. */
+int hl_js_http_bridge_anchor = 0;
+
 int hl_js_wire_routes_server(HlJS *js, KlServer *server,
                               void *(*alloc_fn)(size_t))
 {

--- a/src/hull/runtime/lua/http_register.c
+++ b/src/hull/runtime/lua/http_register.c
@@ -19,6 +19,12 @@
 
 #if defined(HL_ENABLE_HTTP_SERVER) || defined(HL_ENABLE_HTTP_CLIENT)
 
+/* Cosmo HTTP-bridge force-link anchor (0.13.1 PR#1) - see hull/http_feature.h.
+ * Co-resident with the strong hl_lua_register_http_modules so a produced cosmo
+ * app force-pulls the require-able HTTP modules over the weak http_feature.o
+ * no-op. */
+int hl_lua_http_register_anchor = 0;
+
 /* Local copy of the modules.c helper: requiref into _LOADED, drop the value so
  * the module is import-only (not a global). */
 static void register_native_module(lua_State *L, const char *name,

--- a/src/hull/runtime/lua/routes.c
+++ b/src/hull/runtime/lua/routes.c
@@ -295,6 +295,12 @@ static KlBodyReader *hl_lua_multipart_factory(KlAllocator *alloc,
     return hl_cap_multipart_factory(alloc, req, route->multipart_config);
 }
 
+/* Cosmo HTTP-bridge force-link anchor (0.13.1 PR#1) - see hull/http_feature.h.
+ * A unique strong symbol with no weak twin, co-resident in this object with the
+ * strong hl_lua_wire_routes_server below; a produced cosmo app references it to
+ * force-pull this member over the weak http_weakstub.o stub. */
+int hl_lua_http_bridge_anchor = 0;
+
 int hl_lua_wire_routes_server(HlLua *lua, KlServer *server,
                                void *(*alloc_fn)(size_t))
 {

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1119,8 +1119,51 @@ local function compose_features(opts, tmpdir, platform_lib, is_cosmo, compute_fi
             -- Whole-archiving the base instead is WRONG: it force-pulls the
             -- selectively-linked WASM caps whose worker symbols aren't in the
             -- base, breaking the link.
-            write_file(tmpdir .. "/app_stdlib_registry.c",
-                       fcompose.gen_app_registry_c(app_rt, { factory = false }))
+            local reg_src = fcompose.gen_app_registry_c(app_rt, { factory = false })
+            -- Cosmo HTTP-bridge force-link (0.13.1 PR#1). The per-runtime HTTP
+            -- bridge (routes.o's hl_<rt>_wire_routes_server, http_register.o's
+            -- hl_<rt>_register_http_modules) lives as MEMBERS of the fat cosmo
+            -- platform archive, alongside the weak no-op stubs (http_weakstub.o /
+            -- http_feature.o). On-demand archive resolution satisfies serve.o's
+            -- undefined hl_<rt>_wire_routes_server against the WEAK stub (which
+            -- returns -1 and aborts serving) and never pulls the strong member,
+            -- so a produced cosmo web app exits without listening. Same
+            -- weak-shadow class as the stdlib-registry override above. Fix:
+            -- reference the selected runtime's unique bridge anchors (no weak
+            -- twin) from this already-kept object so the linker force-pulls the
+            -- strong members, overriding the weak stubs. A missing bridge/anchor
+            -- is then a hard link error (fail closed). Only the SELECTED
+            -- runtime's anchors are referenced (never both; never another
+            -- serve.o or the full platform archive). Native is unaffected: it
+            -- whole-archives libhull_feature-http-<rt>.a instead.
+            -- needs_http: the same resolver signal the native branch composes
+            -- on (default true so we never under-compose serving; flipped false
+            -- for a pure app.main / compute app).
+            local needs_http = true
+            do
+                local mf = fcompose.extract_manifest(opts.app_dir)
+                if mf then
+                    local r = tool.modules_resolve(mf, opts.flavor,
+                                                   with_feature_list(opts))
+                    if r and r.ok and r.needs_http ~= nil then
+                        needs_http = r.needs_http
+                    end
+                end
+            end
+            if needs_http then
+                reg_src = reg_src .. string.format([[
+
+/* Cosmo HTTP-bridge force-link (0.13.1 PR#1) - see hull/http_feature.h. */
+extern int hl_%s_http_bridge_anchor;
+extern int hl_%s_http_register_anchor;
+__attribute__((used))
+void *const hull_cosmo_http_bridge_force[] = {
+    &hl_%s_http_bridge_anchor,
+    &hl_%s_http_register_anchor,
+};
+]], app_rt, app_rt, app_rt, app_rt)
+            end
+            write_file(tmpdir .. "/app_stdlib_registry.c", reg_src)
             if not tool.compiler.compile(tmpdir .. "/app_stdlib_registry.c",
                                          tmpdir .. "/app_stdlib_registry.o", nil) then
                 tool.stderr("hull build: compilation failed (app_stdlib_registry.c)\n")
@@ -2120,6 +2163,63 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
     end
 
     print("hull build: wrote " .. opts.output)
+
+    -- Post-link verification (0.13.1 PR#1, defense in depth). The force-link
+    -- anchor emitted in compose_features is the HARD guarantee (a missing bridge
+    -- fails the link). This is a belt-and-suspenders symbol check that a produced
+    -- cosmo web app got the STRONG per-runtime route wiring, not the weak no-op
+    -- stub. It can never false-fail a good build: nm on the APE output usually
+    -- can't parse it, so it prefers the x86_64 .dbg ELF sidecar, and it only
+    -- fails the build when nm DEFINITIVELY shows a weak-only wire_routes_server;
+    -- an unreadable/absent nm just skips the check.
+    if is_cosmo then
+        local vrt = fcompose.detect_app_rt(opts.app_dir)
+        local vneeds_http = false
+        if vrt then
+            local mf = fcompose.extract_manifest(opts.app_dir)
+            if mf then
+                local r = tool.modules_resolve(mf, opts.flavor,
+                                               with_feature_list(opts))
+                vneeds_http = not (r and r.ok and r.needs_http == false)
+            end
+        end
+        if vrt and vneeds_http then
+            local dbg = opts.output .. ".dbg"
+            local target = file_exists(dbg) and dbg or opts.output
+            local nm_out = tool.spawn_read({ "nm", target })
+            if nm_out and #nm_out > 0 then
+                local function sym_state(name)  -- "strong" | "weak" | "absent"
+                    local st = "absent"
+                    for line in nm_out:gmatch("[^\n]+") do
+                        local typ = line:match("^%x* ?(%a) " .. name .. "$")
+                        if typ == "T" or typ == "t" then return "strong" end
+                        if typ == "W" or typ == "w" then st = "weak" end
+                    end
+                    return st
+                end
+                local wr = "hl_" .. vrt .. "_wire_routes_server"
+                if sym_state(wr) == "weak" then
+                    tool.stderr("hull build: FATAL - produced cosmo app linked the "
+                        .. "WEAK no-op " .. wr .. " (HTTP route wiring); it would "
+                        .. "start but never serve. The HTTP bridge failed to "
+                        .. "force-link.\n")
+                    tool.rmdir(tmpdir); tool.exit(1)
+                end
+                if sym_state("hull_serve") == "weak" then
+                    tool.stderr("hull build: FATAL - produced app linked the weak "
+                        .. "hull_serve (no server loop).\n")
+                    tool.rmdir(tmpdir); tool.exit(1)
+                end
+                local other = (vrt == "lua") and "js" or "lua"
+                if sym_state("hl_" .. other .. "_wire_routes_server") == "strong" then
+                    tool.stderr("hull build: warning - the opposite-runtime HTTP "
+                        .. "bridge (hl_" .. other .. "_wire_routes_server) was also "
+                        .. "pulled into a single-runtime app\n")
+                end
+                print("hull build: verified strong " .. vrt .. " HTTP route wiring")
+            end
+        end
+    end
 
     -- Sign if requested
     if opts.sign then

--- a/tests/cosmo_http_serve_run.sh
+++ b/tests/cosmo_http_serve_run.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# cosmo_http_serve_run.sh - ACCEPTANCE TEST second-host leg (0.13.1 PR#1).
+# Runs the Windows-produced cosmo APEs ($APES_DIR/{lua,js,main}_windows.com) on
+# THIS host (a second, independent APE host - macOS) and ASSERTS: the Lua and JS
+# apps serve 'pong'; the app.main control exits without a listener. Proves the
+# fixed produced binary is portable, not Windows-run-specific. Exits non-zero on
+# any assertion failure. download-artifact strips the exec bit, so chmod first.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -u
+APES="${APES_DIR:-apes}"
+fail=0
+
+serves() {  # <bin> <port> -> echoes the /ping body
+    bin="$1"; port="$2"
+    [ -f "$bin" ] || { echo ""; return; }
+    chmod +x "$bin" 2>/dev/null || true
+    "$bin" -p "$port" >/dev/null 2>&1 &
+    pid=$!
+    resp=""
+    i=0; while [ $i -lt 20 ]; do
+        sleep 0.4
+        resp=$(curl -fsS "http://127.0.0.1:$port/ping" 2>/dev/null) && break
+        kill -0 "$pid" 2>/dev/null || break
+        i=$((i + 1))
+    done
+    kill "$pid" 2>/dev/null; wait "$pid" 2>/dev/null
+    echo "$resp"
+}
+
+echo "== second-host run: $(uname -s -m) =="
+if [ "$(serves "$APES/lua_windows.com" 39320)" = "pong" ]; then
+    echo "PASS lua serves pong"; else echo "FAIL lua did not serve"; fail=1; fi
+if [ "$(serves "$APES/js_windows.com" 39321)" = "pong" ]; then
+    echo "PASS js serves pong"; else echo "FAIL js did not serve"; fail=1; fi
+if [ "$(serves "$APES/main_windows.com" 39322)" = "pong" ]; then
+    echo "FAIL app.main control unexpectedly served"; fail=1
+else echo "PASS app.main control did not serve"; fi
+
+[ $fail -eq 0 ] || { echo "cosmo_http_serve_run: acceptance FAILED"; exit 1; }
+echo "cosmo_http_serve_run: ALL PASS"


### PR DESCRIPTION
## 0.13.1 Windows stabilization, PR #1 (server blocker)

### Defect (precise: missing strong per-runtime HTTP bridge)
A `hull build`-produced **cosmo** app never serves HTTP: it runs through manifest extraction and sandbox, then **exits without a listener**. This is **static-archive weak-shadowing**, not "cosmo composes no server" — the strong server entry (`hull_serve`, T) and Keel backend are present.

The fat cosmo `libhull_platform.a` carries **both** the strong per-runtime bridge members (`runtime/<rt>/routes.o` → `hl_<rt>_wire_routes_server`, `http_register.o` → `hl_<rt>_register_http_modules`) **and** the weak no-op stubs (`http_weakstub.o`, `cap/http_feature.o`). On-demand archive selection resolves `serve.o`'s undefined `hl_<rt>_wire_routes_server` against the **weak** stub (returns `-1` → `serve.c:1730` error path → aborts before listening) and never pulls the strong member. The dev hull serves because it links `routes.o` directly; a produced app pulls from the archive, so the weak def wins. Native avoids this by whole-archiving `libhull_feature-http-<rt>.a`; cosmo builds **no** feature archive (`ifndef COSMO`), so nothing forces the strong member.

### Evidence (symbol + runtime, three hosts)
| binary | `hl_<rt>_wire_routes_server` | result |
|---|---|---|
| produced cosmo APE (Win + macOS, identical) | **W** (weak no-op) | exits, no listener |
| native-produced app | **T** (strong) | serves `pong` |
| dev cosmo hull (non-produced) | linked directly | serves (Linux + Win) |

### Fix (smallest composition correction)
- Unique per-runtime **link anchor** with no weak twin, co-resident in each strong bridge TU: `hl_<rt>_http_bridge_anchor` (`routes.c`), `hl_<rt>_http_register_anchor` (`http_register.c`); declared in `include/hull/http_feature.h`.
- The **`is_cosmo`** compose step (`build.lua`) references **exactly the selected runtime's** anchors from the already-kept `app_stdlib_registry.o` (needs_http-gated) → linker force-pulls the strong bridge over the weak stubs. Never both runtimes, never another `serve.o`, never the full platform archive.
- A missing bridge/anchor is a **hard link error** (fail closed).
- **Post-link `nm` verification** (defense in depth): selected `wire_routes_server` + `hull_serve` must be strong; warns if the opposite bridge leaked in; never false-fails.
- **Native unchanged** (still whole-archives `libhull_feature-http-<rt>.a`).

### Acceptance
`cosmocc-windows-e2e.yml` previously built only an **exiting `app.main` control** — the exact gap that let this ship. It now also builds two-line **Lua + JS `/ping`** apps with the branch cosmo hull and asserts each answers `pong` on **Windows**, plus a **macOS** second-host leg running the produced APEs (`tests/cosmo_http_serve_run.sh`).

### Verified locally
Native build + full test suite green; anchors present in `libhull_feature-http-lua.a`; native `/ping` still serves; cosmo verify path inert on native.

BuildContext remains frozen until 0.13.1 ships.