### PR TITLE
fix(tools): non-admin Windows cosmocc extraction — prefer validated hardlinks (0.13.1)

### DIFF
--- a/scripts/build_cosmocc_bundle.sh
+++ b/scripts/build_cosmocc_bundle.sh
@@ -147,6 +147,18 @@ find "$work/tree" -path '*/lib/*' -type f \( \
         -name 'ape*' \) >> "$keep"
 sort -u "$keep" -o "$keep"
 
+# Keep every symlink's TARGET so the trace-closure trim never leaves a DANGLING
+# link. hl_tar_extract fails closed on a dangling link (a non-admin Windows box
+# materializes links from their target instead of creating a symlink), so a
+# bundle with a dangling arch-cc -> cosmocc stub would be unextractable there.
+# Resolve each link (following chains) to its real file and add it to the keep
+# set BEFORE the deletion below. Symlinks themselves are never deleted.
+find "$work/tree" -type l | while IFS= read -r link; do
+    tgt=$(realpath -m "$link" 2>/dev/null) || continue
+    case "$tgt" in "$work/tree"/*) [ -f "$tgt" ] && printf '%s\n' "$tgt" ;; esac
+done >> "$keep"
+sort -u "$keep" -o "$keep"
+
 # Delete every regular file NOT in the keep set (symlinks + dirs untouched),
 # then prune the directories left empty.
 find "$work/tree" -type f | sort -u > "$work/all.txt"
@@ -160,6 +172,17 @@ for v in dbg optlinux tiny; do
 done
 find "$work/tree" -depth -type d -empty -delete 2>/dev/null || true
 rm -rf "$probe"
+
+# Belt-and-suspenders: no dangling symlink may survive the trim. The extractor
+# rejects one (fail closed), so a dangling link here would ship an unextractable
+# bundle to non-admin Windows users. Fail the build with the offenders listed.
+dangling=$(find "$work/tree" -type l ! -exec test -e {} \; -print 2>/dev/null || true)
+if [ -n "$dangling" ]; then
+    echo "build_cosmocc_bundle: FATAL - dangling symlink(s) after trim (would be" >&2
+    echo "  unextractable on a non-admin Windows box):" >&2
+    printf '  %s\n' $dangling | sed "s#$work/tree/##" >&2
+    exit 1
+fi
 
 after=$(du -sm "$work/tree" | cut -f1)
 echo "build_cosmocc_bundle: trimmed ${before} MB -> ${after} MB"

--- a/src/hull/cap/tar.c
+++ b/src/hull/cap/tar.c
@@ -268,11 +268,19 @@ static int extract_symlink_cb(const HlTarEntry *e, void *vctx)
 
     if (extract_make_parents(path) != 0) return -1;
     (void)unlink(path);                          /* idempotent re-extract */
-    if (symlink(e->linkname, path) == 0) return 0;
 
-    /* Fallback where symlinks are unavailable (e.g. Windows without the
-     * privilege): copy the target file. The target is relative to the link's
-     * OWN directory; pass 1 already wrote it, so it is on disk. */
+    /* A real symlink is best where the platform allows it. HL_TAR_NO_SYMLINK
+     * skips the attempt so the Windows non-admin fallback (below) can be
+     * exercised on any host - the CI runners are elevated with Developer Mode
+     * on, where symlink() would otherwise succeed and hide the fallback. */
+    if (!getenv("HL_TAR_NO_SYMLINK") && symlink(e->linkname, path) == 0)
+        return 0;
+
+    /* Symlinks unavailable (Windows without SeCreateSymbolicLinkPrivilege and
+     * Developer Mode off). Materialize the link from its target. The target is
+     * the linkname resolved against the link's OWN directory; pass 1 already
+     * wrote it, and tar_safe_linkname confined it to the extraction root at
+     * parse time. */
     char target[PATH_MAX];
     char *last = strrchr(path, '/');
     int tn = last
@@ -280,6 +288,23 @@ static int extract_symlink_cb(const HlTarEntry *e, void *vctx)
                    (int)(last - path), path, e->linkname)
         : snprintf(target, sizeof(target), "%s/%s", c->dest, e->linkname);
     if (tn < 0 || (size_t)tn >= sizeof(target)) return -1;
+
+    /* The materialized source MUST be an existing REGULAR file inside the
+     * extraction root. A missing target is a DANGLING link in the (trimmed)
+     * bundle: FAIL rather than silently produce an incomplete toolchain. A
+     * non-regular target (directory / device / fifo) is likewise refused.
+     * (Containment is already guaranteed by tar_safe_linkname; this adds the
+     * verified-regular-target requirement.) */
+    struct stat st;
+    if (stat(target, &st) != 0 || !S_ISREG(st.st_mode))
+        return -1;
+
+    /* Prefer a hardlink for archive links: no data copy, and no privilege on
+     * Windows (CreateHardLink works for a non-elevated user). Fall back to a
+     * byte copy across filesystems or where hardlinks are unavailable. */
+    if (link(target, path) == 0)
+        return 0;
+    (void)unlink(path);   /* a failed link() may have left a stub */
     return extract_copy(target, path, e->mode ? e->mode : 0755);
 }
 

--- a/src/hull/cap/tar.c
+++ b/src/hull/cap/tar.c
@@ -259,44 +259,83 @@ static int extract_copy(const char *src, const char *dst, unsigned mode)
     return rc;
 }
 
-static int extract_symlink_cb(const HlTarEntry *e, void *vctx)
+/* A collected symlink member. The parser's linkname is a transient stack
+ * buffer, so name + linkname are copied for the deferred-resolution passes. */
+struct sym_ent { char *name; char *linkname; unsigned mode; int done; };
+struct sym_collect { struct sym_ent *v; size_t n, cap; int oom; };
+
+static char *dup_str(const char *s)
 {
-    struct extract_ctx *c = (struct extract_ctx *)vctx;
+    size_t n = strlen(s) + 1;
+    char *p = (char *)malloc(n);
+    if (p) memcpy(p, s, n);
+    return p;
+}
+
+static int collect_symlink_cb(const HlTarEntry *e, void *vctx)
+{
+    struct sym_collect *s = (struct sym_collect *)vctx;
+    if (s->n == s->cap) {
+        size_t nc = s->cap ? s->cap * 2 : 16;
+        struct sym_ent *nv = (struct sym_ent *)realloc(s->v, nc * sizeof *nv);
+        if (!nv) { s->oom = 1; return -1; }
+        s->v = nv; s->cap = nc;
+    }
+    struct sym_ent *se = &s->v[s->n];
+    se->name = dup_str(e->name);
+    se->linkname = dup_str(e->linkname);
+    se->mode = e->mode;
+    se->done = 0;
+    if (!se->name || !se->linkname) { s->oom = 1; return -1; }
+    s->n++;
+    return 0;
+}
+
+static void sym_collect_free(struct sym_collect *s)
+{
+    for (size_t i = 0; i < s->n; i++) { free(s->v[i].name); free(s->v[i].linkname); }
+    free(s->v);
+}
+
+/* Materialize one collected link under @p dest. Returns 0 = done, 1 = DEFERRED
+ * (target not yet on disk - retry after other links materialize), -1 = hard
+ * error. */
+static int materialize_link(const char *dest, struct sym_ent *se)
+{
     char path[PATH_MAX];
-    int pn = snprintf(path, sizeof(path), "%s/%s", c->dest, e->name);
+    int pn = snprintf(path, sizeof(path), "%s/%s", dest, se->name);
     if (pn < 0 || (size_t)pn >= sizeof(path)) return -1;
 
     if (extract_make_parents(path) != 0) return -1;
     (void)unlink(path);                          /* idempotent re-extract */
 
-    /* A real symlink is best where the platform allows it. HL_TAR_NO_SYMLINK
-     * skips the attempt so the Windows non-admin fallback (below) can be
+    /* A real symlink is best where the platform allows it (and needs no target
+     * on disk). HL_TAR_NO_SYMLINK skips it so the Windows non-admin fallback is
      * exercised on any host - the CI runners are elevated with Developer Mode
      * on, where symlink() would otherwise succeed and hide the fallback. */
-    if (!getenv("HL_TAR_NO_SYMLINK") && symlink(e->linkname, path) == 0)
+    if (!getenv("HL_TAR_NO_SYMLINK") && symlink(se->linkname, path) == 0)
         return 0;
 
     /* Symlinks unavailable (Windows without SeCreateSymbolicLinkPrivilege and
      * Developer Mode off). Materialize the link from its target. The target is
-     * the linkname resolved against the link's OWN directory; pass 1 already
-     * wrote it, and tar_safe_linkname confined it to the extraction root at
-     * parse time. */
+     * the linkname resolved against the link's OWN directory; tar_safe_linkname
+     * confined it to the extraction root at parse time. */
     char target[PATH_MAX];
     char *last = strrchr(path, '/');
     int tn = last
         ? snprintf(target, sizeof(target), "%.*s/%s",
-                   (int)(last - path), path, e->linkname)
-        : snprintf(target, sizeof(target), "%s/%s", c->dest, e->linkname);
+                   (int)(last - path), path, se->linkname)
+        : snprintf(target, sizeof(target), "%s/%s", dest, se->linkname);
     if (tn < 0 || (size_t)tn >= sizeof(target)) return -1;
 
-    /* The materialized source MUST be an existing REGULAR file inside the
-     * extraction root. A missing target is a DANGLING link in the (trimmed)
-     * bundle: FAIL rather than silently produce an incomplete toolchain. A
-     * non-regular target (directory / device / fifo) is likewise refused.
-     * (Containment is already guaranteed by tar_safe_linkname; this adds the
-     * verified-regular-target requirement.) */
+    /* Target must be an existing REGULAR file. If it is MISSING it may be
+     * another link this run materializes later (a symlink -> symlink chain, in
+     * any archive order): DEFER rather than fail, so the retry loop resolves it.
+     * A non-regular target (dir / device / fifo) is refused outright. */
     struct stat st;
-    if (stat(target, &st) != 0 || !S_ISREG(st.st_mode))
+    if (stat(target, &st) != 0)
+        return 1;                                /* deferred */
+    if (!S_ISREG(st.st_mode))
         return -1;
 
     /* Prefer a hardlink for archive links: no data copy, and no privilege on
@@ -305,7 +344,7 @@ static int extract_symlink_cb(const HlTarEntry *e, void *vctx)
     if (link(target, path) == 0)
         return 0;
     (void)unlink(path);   /* a failed link() may have left a stub */
-    return extract_copy(target, path, e->mode ? e->mode : 0755);
+    return extract_copy(target, path, se->mode ? se->mode : 0755);
 }
 
 int hl_tar_extract(const unsigned char *tar, size_t tar_len, const char *dest_dir)
@@ -316,11 +355,36 @@ int hl_tar_extract(const unsigned char *tar, size_t tar_len, const char *dest_di
      * ~/.hull/tools/<name>/ before anything else created ~/.hull/tools. */
     if (hl_mkdir_p(dest_dir, 0755) != 0) return -1;
     struct extract_ctx c = { dest_dir };
-    /* Two passes: files + dirs first, THEN symlinks, so a link's target is
-     * already on disk for the copy-fallback (and symlink ordering is moot). */
+    /* Pass 1: files + dirs, so every REGULAR-file link target is on disk. */
     int rc = tar_iter(tar, tar_len, extract_file_cb, &c, 1, 0);
     if (rc) return rc;
-    return tar_iter(tar, tar_len, extract_symlink_cb, &c, 0, 1);
+
+    /* Pass 2: symlinks. In the materialize-from-target fallback a link's target
+     * may itself be a link created later this run, so resolution is order-
+     * dependent. Collect all links and resolve to a FIXPOINT: repeat while any
+     * link resolves; a link whose target is still missing DEFERS to the next
+     * round. Only after a round makes NO progress do the survivors (a genuinely
+     * dangling target, or a cycle) FAIL closed. (Where real symlinks work the
+     * first round creates them all - no target needed - so the loop is one
+     * pass.) */
+    struct sym_collect sc = { 0 };
+    rc = tar_iter(tar, tar_len, collect_symlink_cb, &sc, 0, 1);
+    if (rc || sc.oom) { sym_collect_free(&sc); return -1; }
+
+    size_t remaining = sc.n;
+    int progress = 1;
+    while (remaining > 0 && progress) {
+        progress = 0;
+        for (size_t i = 0; i < sc.n; i++) {
+            if (sc.v[i].done) continue;
+            int r = materialize_link(dest_dir, &sc.v[i]);
+            if (r == 0) { sc.v[i].done = 1; remaining--; progress = 1; }
+            else if (r < 0) { sym_collect_free(&sc); return -1; }
+            /* r == 1: deferred - retry next round. */
+        }
+    }
+    sym_collect_free(&sc);
+    return remaining == 0 ? 0 : -1;   /* survivors = dangling / cycle -> closed */
 }
 
 /* ── Creation ──────────────────────────────────────────────────────── */

--- a/tests/hull/cap/test_tar.c
+++ b/tests/hull/cap/test_tar.c
@@ -391,6 +391,64 @@ UTEST_F(tar_fixture, extract_symlink_in_root_dotdot_ok) {
     free(buf);
 }
 
+/* Windows non-admin (no SeCreateSymbolicLinkPrivilege, Developer Mode off):
+ * symlink() fails, so an archive link is materialized from its target - PREFER
+ * a hardlink (no data copy, no privilege), never left as a symlink. Forced with
+ * HL_TAR_NO_SYMLINK so the fallback runs on this POSIX host too. This is the
+ * cosmocc arch-cc -> cosmocc case on a locked-down Windows box. */
+UTEST_F(tar_fixture, extract_symlink_fallback_prefers_hardlink) {
+    setenv("HL_TAR_NO_SYMLINK", "1", 1);
+    unsigned char *buf = calloc(1, 8192);
+    ASSERT_NE(buf, NULL);
+    size_t off = 0;
+    tar_add_file(buf, &off, "bin/cosmocc", "DRIVER-BYTES", 12);
+    tar_add_symlink(buf, &off, "bin/x86_64-cc", "cosmocc");  /* same-dir target */
+    off += 512;
+
+    char dest[PATH_MAX];
+    snprintf(dest, sizeof(dest), "%s/cc", utest_fixture->tmpdir);
+    ASSERT_EQ(hl_tar_extract(buf, off, dest), 0);
+
+    char p[PATH_MAX], tp[PATH_MAX], rd[64];
+    snprintf(p, sizeof(p), "%s/bin/x86_64-cc", dest);
+    snprintf(tp, sizeof(tp), "%s/bin/cosmocc", dest);
+
+    /* NOT a symlink - a materialized regular file resolving to target bytes. */
+    struct stat st, ts;
+    ASSERT_EQ(lstat(p, &st), 0);
+    ASSERT_FALSE(S_ISLNK(st.st_mode));
+    ASSERT_TRUE(S_ISREG(st.st_mode));
+    FILE *f = fopen(p, "rb"); ASSERT_NE(f, NULL);
+    size_t n = fread(rd, 1, sizeof(rd), f); fclose(f);
+    ASSERT_EQ(n, (size_t)12);
+    ASSERT_EQ(memcmp(rd, "DRIVER-BYTES", 12), 0);
+
+    /* Preferred a HARDLINK: same inode as the target (a copy would differ). */
+    ASSERT_EQ(stat(tp, &ts), 0);
+    ASSERT_EQ(st.st_ino, ts.st_ino);
+
+    unsetenv("HL_TAR_NO_SYMLINK");
+    free(buf);
+}
+
+/* A DANGLING archive link (target absent from the trimmed bundle) must FAIL the
+ * non-admin fallback rather than silently producing an incomplete toolchain. */
+UTEST_F(tar_fixture, extract_symlink_dangling_fails_in_fallback) {
+    setenv("HL_TAR_NO_SYMLINK", "1", 1);
+    unsigned char *buf = calloc(1, 8192);
+    ASSERT_NE(buf, NULL);
+    size_t off = 0;
+    tar_add_symlink(buf, &off, "bin/x86_64-cc", "cosmocc"); /* no bin/cosmocc */
+    off += 512;
+
+    char dest[PATH_MAX];
+    snprintf(dest, sizeof(dest), "%s/cc", utest_fixture->tmpdir);
+    ASSERT_EQ(hl_tar_extract(buf, off, dest), -1);   /* dangling -> fail closed */
+
+    unsetenv("HL_TAR_NO_SYMLINK");
+    free(buf);
+}
+
 /* A symlink whose target is absolute or escapes via ".." is rejected (a
  * malformed archive), so it can never become a write-through primitive. */
 UTEST_F(tar_fixture, extract_rejects_unsafe_symlink_target) {

--- a/tests/hull/cap/test_tar.c
+++ b/tests/hull/cap/test_tar.c
@@ -449,6 +449,45 @@ UTEST_F(tar_fixture, extract_symlink_dangling_fails_in_fallback) {
     free(buf);
 }
 
+/* Deferred (fixpoint) resolution: a link whose TARGET IS ANOTHER LINK
+ * materialized later this run must still resolve in the non-admin fallback,
+ * regardless of archive order. arch2 -> arch1 -> cosmocc, with arch2 emitted
+ * BEFORE arch1 (target-after-link), forces the retry loop: round 1 defers arch2
+ * (arch1 not on disk yet) and materializes arch1 from cosmocc; round 2
+ * materializes arch2 from the now-regular arch1. Proves ordering cannot break
+ * the fallback. */
+UTEST_F(tar_fixture, extract_symlink_chain_target_after_link_resolves) {
+    setenv("HL_TAR_NO_SYMLINK", "1", 1);
+    unsigned char *buf = calloc(1, 8192);
+    ASSERT_NE(buf, NULL);
+    size_t off = 0;
+    tar_add_file(buf, &off, "bin/cosmocc", "DRIVER-BYTES", 12);
+    tar_add_symlink(buf, &off, "bin/arch2", "arch1");   /* link BEFORE its target */
+    tar_add_symlink(buf, &off, "bin/arch1", "cosmocc"); /* arch2's target, later */
+    off += 512;
+
+    char dest[PATH_MAX];
+    snprintf(dest, sizeof(dest), "%s/cc", utest_fixture->tmpdir);
+    ASSERT_EQ(hl_tar_extract(buf, off, dest), 0);
+
+    /* BOTH links resolve to the driver bytes despite the reversed order, and
+     * both are materialized regular files (not symlinks). */
+    for (int k = 0; k < 2; k++) {
+        char p[PATH_MAX], rd[64];
+        snprintf(p, sizeof(p), "%s/bin/%s", dest, k ? "arch1" : "arch2");
+        struct stat st;
+        ASSERT_EQ(lstat(p, &st), 0);
+        ASSERT_TRUE(S_ISREG(st.st_mode));
+        FILE *f = fopen(p, "rb"); ASSERT_NE(f, NULL);
+        size_t n = fread(rd, 1, sizeof(rd), f); fclose(f);
+        ASSERT_EQ(n, (size_t)12);
+        ASSERT_EQ(memcmp(rd, "DRIVER-BYTES", 12), 0);
+    }
+
+    unsetenv("HL_TAR_NO_SYMLINK");
+    free(buf);
+}
+
 /* A symlink whose target is absolute or escapes via ".." is rejected (a
  * malformed archive), so it can never become a write-through primitive. */
 UTEST_F(tar_fixture, extract_rejects_unsafe_symlink_target) {


### PR DESCRIPTION
## 0.13.1 Windows stabilization, fix #4 (non-admin cosmocc extraction)

### Defect
`hull tools install cosmocc` extracts the cosmocc tree via `hl_tar_extract`; the arch compilers (`x86_64-unknown-cosmo-cc`, … → `cosmocc`) are **symlinks**. On a **non-elevated Windows box with Developer Mode off**, `symlink()` needs `SeCreateSymbolicLinkPrivilege` and **fails**, so those links must be materialized from their target — otherwise the toolchain is broken for non-admin users.

### Fix
**Extraction (`cap/tar.c` `extract_symlink_cb`):** on symlink-creation failure, **prefer a hardlink** to the target (no data copy; `CreateHardLink` needs no privilege on Windows), falling back to a byte copy. The materialized source is verified to be an existing **regular file** — a missing target is a **dangling** link → **fail closed** (never a silently incomplete toolchain); a non-regular target is refused. Containment was already guaranteed by `tar_safe_linkname` at parse time. `HL_TAR_NO_SYMLINK` skips the symlink attempt so the fallback runs on any host (CI runners are elevated + Dev-Mode-on).

**Producer (`build_cosmocc_bundle.sh`):** the trace-closure trim kept every symlink but only trace-touched regular files, so a link whose target went untraced would **dangle** — unextractable under the fail-closed rule. Now every symlink's resolved **target** is added to the keep set **before** the trim, plus a **post-trim guard** that fails the bundle build on any surviving dangling symlink.

### Tests (`test_tar.c`)
- `extract_symlink_fallback_prefers_hardlink` — materializes a regular file, **same inode** as the target (hardlink, not copy).
- `extract_symlink_dangling_fails_in_fallback` — dangling → `rc=-1`.

Both run cross-platform **including as a cosmo APE** under `make test CC=cosmocc` (the same binary that runs on Windows). Native suite 0 failures.

### Coverage note (honest limitation)
GitHub's `windows-latest` runner is **elevated with Developer Mode on**, and a branch-built hull can't `hull tools install` (strict `HL_VERSION` coupling, never `latest`), so a Windows-**runtime** run of the fixed extractor isn't naturally CI-able. `HL_TAR_NO_SYMLINK` in the unit test exercises exactly the non-elevated/Dev-Mode-off code path; the cosmo-APE test run covers the same binary Windows uses.

BuildContext remains frozen. The JS extraction-fatality parity gap stays release-blocking for 0.13.1.