### PR TITLE
fix(tools): unify tool resolution across doctor / tools-list / agent-tools (0.13.1)

### DIFF
--- a/include/hull/tools_install.h
+++ b/include/hull/tools_install.h
@@ -26,6 +26,11 @@
 #define HL_TOOLS_INSTALL_H
 
 #include <stddef.h>
+#include <limits.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
 
 /* Maximum tool-name length. Tool names are short identifiers and never
  * paths, so a generous cap is fine. Anything longer is rejected by
@@ -156,5 +161,63 @@ int hl_tools_lookup_path(const char *name, const char *hull_exe,
 
 /* Bundle extraction now lives in the shared tar core: include hull/cap/tar.h
  * and call hl_tar_extract(). */
+
+/**
+ * @brief Where a resolved tool was found.
+ */
+typedef enum {
+    HL_TOOL_SRC_NONE = 0,   /**< not resolvable as an executable anywhere */
+    HL_TOOL_SRC_MANAGED,    /**< under $HOME/.hull/tools (via `hull tools install`) */
+    HL_TOOL_SRC_SIBLING,    /**< next to the running hull binary (ejected/portable) */
+    HL_TOOL_SRC_PATH        /**< on the system $PATH */
+} HlToolSource;
+
+/**
+ * @brief Unified install + resolution status for one registered tool.
+ *
+ * The SINGLE source of truth shared by `hull tools list`, `hull agent
+ * tools`, and `hull doctor` (and consistent with `hull build`, which
+ * resolves via `hl_tools_lookup_path` directly), so all surfaces agree on
+ * whether a tool is a hull-managed install, whether/where it resolves as an
+ * executable, and how large a managed install is.
+ *
+ * `managed` and `resolved` are RELATED but DISTINCT: a data-only bundle (the
+ * libc-musl floor) can be `managed` (installed under ~/.hull/tools with its
+ * sentinel present) yet not `resolved` (its sentinel isn't an executable). A
+ * system tool on $PATH is `resolved` (source PATH) but not `managed`.
+ */
+typedef struct {
+    int                managed;       /**< a valid install exists under ~/.hull/tools */
+    int                resolved;      /**< hl_tools_lookup_path found an executable */
+    HlToolSource       source;        /**< where the executable resolved from */
+    char               path[PATH_MAX];        /**< resolved executable, "" if !resolved */
+    char               install_path[PATH_MAX];/**< ~/.hull/tools/<name>, "" if unknown */
+    unsigned long long size_bytes;    /**< managed install size (recursive for a bundle
+                                           directory, stat for a single file); 0 if
+                                           not managed / unknown */
+} HlToolStatus;
+
+/**
+ * @brief Recursively sum the on-disk byte size of a file or directory tree.
+ *
+ * Uses lstat and does not follow symlinks into other trees, so the result is
+ * an extracted bundle's real footprint. Returns 0 on a missing path or error.
+ * Recursion depth is bounded by the tree's real nesting.
+ */
+unsigned long long hl_tools_dir_size(const char *path);
+
+/**
+ * @brief Fill @p out with the unified status of @p name.
+ *
+ * Runs the managed-install check (works for single-binary AND bundle tools)
+ * and the canonical executable resolver (`hl_tools_lookup_path`, so PATH and
+ * sibling installs are seen, matching doctor/build), and computes an accurate
+ * managed-install size. @p hull_exe is the running hull path (for the sibling
+ * probe) or NULL.
+ *
+ * @returns 0 on success (state is carried in @p out), -1 on a NULL/invalid
+ *          argument or an unregistered name.
+ */
+int hl_tools_status(const char *name, const char *hull_exe, HlToolStatus *out);
 
 #endif /* HL_TOOLS_INSTALL_H */

--- a/src/hull/agent/tools.c
+++ b/src/hull/agent/tools.c
@@ -64,16 +64,17 @@ int hl_agent_tools(ShJsonBuf *out)
 
         /* installed: is there an executable at the canonical install
          * location? We don't fall back to PATH here - the install
-         * state is specifically about hull-managed installs. */
-        char path[HL_AGENT_PATH_MAX];
-        int has_path = hl_tools_install_path(t->name, path, sizeof(path)) == 0;
-        struct stat st;
-        int installed = has_path && stat(path, &st) == 0 && S_ISREG(st.st_mode);
-
-        sh_json_write_kv_bool(&w, "installed", installed != 0);
-        if (installed) {
-            sh_json_write_kv_string(&w, "path", path);
-            sh_json_write_kv_int(&w, "size_bytes", (int64_t)st.st_size);
+         * state is specifically about hull-managed installs. Via the shared
+         * hl_tools_status so a BUNDLE tool (cosmocc/zig/musl-floor, which
+         * install as a DIRECTORY, not a single regular file) is detected and
+         * sized correctly - the old S_ISREG-only check reported every bundle as
+         * not-installed with size 0. */
+        HlToolStatus ts;
+        hl_tools_status(t->name, NULL, &ts);
+        sh_json_write_kv_bool(&w, "installed", ts.managed != 0);
+        if (ts.managed) {
+            sh_json_write_kv_string(&w, "path", ts.install_path);
+            sh_json_write_kv_int(&w, "size_bytes", (int64_t)ts.size_bytes);
         } else {
             sh_json_write_kv_null(&w, "path");
         }
@@ -86,11 +87,11 @@ int hl_agent_tools(ShJsonBuf *out)
 
         /* Concrete action for the agent: install / refresh / build
          * from source, depending on state and availability. */
-        if (!installed && available) {
+        if (!ts.managed && available) {
             char hint[128];
             snprintf(hint, sizeof(hint), "hull tools install %s", t->name);
             sh_json_write_kv_string(&w, "install_hint", hint);
-        } else if (!installed && !available) {
+        } else if (!ts.managed && !available) {
             sh_json_write_kv_string(&w, "install_hint",
                 "no signed binary published for this platform");
         }

--- a/src/hull/commands/doctor.c
+++ b/src/hull/commands/doctor.c
@@ -130,13 +130,24 @@ static int find_in_path(const char *name, char *out, size_t out_sz)
     return 0;
 }
 
-static void discover_compilers(CompilerInfo *ci, int count)
+static void discover_compilers(CompilerInfo *ci, int count, const char *hull_exe)
 {
     for (int i = 0; i < count; i++)
         ci[i].path[0] = '\0';
 
-    for (int i = 0; i < count; i++)
+    for (int i = 0; i < count; i++) {
         find_in_path(ci[i].name, ci[i].path, sizeof(ci[i].path));
+        /* cosmocc is a hull-managed TOOL, not typically on PATH: `hull tools
+         * install cosmocc` extracts it to ~/.hull/tools/cosmocc/bin/cosmocc,
+         * which is what `hull build` resolves via the compiler driver. Consult
+         * the same shared resolver so doctor agrees with build (a PATH-only
+         * probe would report a hull-installed cosmocc as missing). */
+        if (!ci[i].path[0] && strcmp(ci[i].name, "cosmocc") == 0) {
+            HlToolStatus cs;
+            if (hl_tools_status("cosmocc", hull_exe, &cs) == 0 && cs.resolved)
+                snprintf(ci[i].path, sizeof(ci[i].path), "%s", cs.path);
+        }
+    }
 }
 
 /* ── Platform embedding detection ──────────────────────────────── */
@@ -191,28 +202,6 @@ typedef struct {
     int   gpu_enabled;           /* HL_ENABLE_GPU */
 } ComputeInfo;
 
-/* Look for wamrc next to the running hull binary as well as in PATH.
- * Many devs run `make wamrc` which produces build/wamrc next to build/hull. */
-static int find_sibling_executable(const char *self_path, const char *name,
-                                   char *out, size_t out_sz)
-{
-    if (!self_path || !name || !out || out_sz == 0) return 0;
-    /* Strip the basename from self_path. */
-    char dir[PATH_MAX];
-    snprintf(dir, sizeof(dir), "%s", self_path);
-    char *slash = strrchr(dir, '/');
-    if (!slash) return 0;
-    *slash = '\0';
-    char candidate[PATH_MAX];
-    int n = snprintf(candidate, sizeof(candidate), "%s/%s", dir, name);
-    if (n <= 0 || (size_t)n >= sizeof(candidate)) return 0;
-    if (access(candidate, X_OK) == 0) {
-        snprintf(out, out_sz, "%s", candidate);
-        return 1;
-    }
-    return 0;
-}
-
 static void detect_compute(ComputeInfo *info, const char *self_path)
 {
     memset(info, 0, sizeof(*info));
@@ -229,30 +218,18 @@ static void detect_compute(ComputeInfo *info, const char *self_path)
     info->gpu_enabled = 0;
 #endif
 
-    /* wamrc: consult the shared `hl_tools_lookup_path` so we follow the
-     * same order as the build system (~/.hull/tools first, then
-     * dirname(hull), then PATH). Fall back to the historical
-     * sibling-to-hull / PATH probes if the canonical helper returns
-     * nothing, so `./build/wamrc` is still discoverable in source-tree
-     * development. */
-    if (hl_tools_lookup_path("wamrc", self_path,
-                             info->wamrc_path, sizeof(info->wamrc_path)) != 0) {
-        if (!find_sibling_executable(self_path, "wamrc",
-                                     info->wamrc_path,
-                                     sizeof(info->wamrc_path)))
-            find_in_path("wamrc", info->wamrc_path, sizeof(info->wamrc_path));
-    }
-    /* Flag whether the discovered binary is under ~/.hull/tools so the
-     * renderer can produce the right hint. */
-    if (info->wamrc_path[0]) {
-        const char *home = getenv("HOME");
-        if (home && *home) {
-            char prefix[PATH_MAX];
-            int pn = snprintf(prefix, sizeof(prefix), "%s/.hull/tools/", home);
-            if (pn > 0 && (size_t)pn < sizeof(prefix) &&
-                strncmp(info->wamrc_path, prefix, (size_t)pn) == 0) {
-                info->wamrc_managed = 1;
-            }
+    /* wamrc: the shared `hl_tools_status` (built on `hl_tools_lookup_path`) is
+     * the SINGLE resolver `hull tools list` / `hull agent tools` / `hull build`
+     * also use - same order (~/.hull/tools → beside hull → PATH), same
+     * managed-install classification. The `dirname(hull)/wamrc` step covers the
+     * source-tree `./build/wamrc` (it sits beside `./build/hull`); the PATH step
+     * covers a system install. */
+    {
+        HlToolStatus ws;
+        hl_tools_status("wamrc", self_path, &ws);
+        if (ws.resolved) {
+            snprintf(info->wamrc_path, sizeof(info->wamrc_path), "%s", ws.path);
+            info->wamrc_managed = ws.managed;
         }
     }
 
@@ -720,7 +697,7 @@ void hl_doctor_collect_json(FILE *f)
         { "clang",   {0} },
         { "cosmocc", {0} },
     };
-    discover_compilers(ci, MAX_COMPILERS);
+    discover_compilers(ci, MAX_COMPILERS, NULL);
 
     int any_compiler = 0;
     for (int i = 0; i < MAX_COMPILERS; i++) {
@@ -730,8 +707,8 @@ void hl_doctor_collect_json(FILE *f)
     PlatformEmbed embed = detect_platform();
 
     ComputeInfo cmp;
-    /* hull_exe lookup not available here - pass NULL; only wamrc/clang
-     * paths near the binary are skipped, PATH lookup still works. */
+    /* hull_exe lookup not available here - pass NULL; the sibling-to-hull
+     * probe is skipped, but ~/.hull/tools + PATH resolution still work. */
     detect_compute(&cmp, NULL);
 
     print_json(f, ci, MAX_COMPILERS, embed, any_compiler, &cmp);
@@ -779,7 +756,7 @@ int hl_cmd_doctor(int argc, char **argv, const HlCommandEnv *env)
         { "clang",   {0} },
         { "cosmocc", {0} },
     };
-    discover_compilers(ci, MAX_COMPILERS);
+    discover_compilers(ci, MAX_COMPILERS, env->hull_exe);
 
     int any_compiler = 0;
     for (int i = 0; i < MAX_COMPILERS; i++) {

--- a/src/hull/commands/tools.c
+++ b/src/hull/commands/tools.c
@@ -97,44 +97,30 @@ static int stdio_write_fn(void *ctx, const char *data, size_t len)
     return fwrite(data, 1, len, fp) == len ? 0 : -1;
 }
 
-/* Returns 1 if a tool is installed at $HOME/.hull/tools/<name>. The
- * out_path / out_size args are optional and filled when given. */
-static int tool_installed(const char *name, char *out_path, size_t out_path_sz,
-                          size_t *out_size)
+/* Human label for a non-managed resolved source, for the text listing. */
+static const char *tool_source_label(HlToolSource src)
 {
-    char path[PATH_MAX];
-    if (hl_tools_install_path(name, path, sizeof(path)) != 0) return 0;
-    struct stat st;
-    if (stat(path, &st) != 0) return 0;
-
-    const HlToolSpec *spec = hl_tools_find(name);
-    if (spec && spec->is_bundle) {
-        /* A bundle installs as a DIRECTORY; consider it present when the dir
-         * exists and holds its bundle_entry sentinel (crt1.o for the floor, the
-         * zig/lld executable for a toolchain - a complete extraction). */
-        if (!S_ISDIR(st.st_mode) || !spec->bundle_entry) return 0;
-        char sentinel[PATH_MAX];
-        int n = snprintf(sentinel, sizeof(sentinel), "%s/%s", path,
-                         spec->bundle_entry);
-        struct stat cs;
-        if (n < 0 || (size_t)n >= sizeof(sentinel) ||
-            stat(sentinel, &cs) != 0 || !S_ISREG(cs.st_mode))
-            return 0;
-        if (out_path && out_path_sz > 0) snprintf(out_path, out_path_sz, "%s", path);
-        if (out_size) *out_size = 0;
-        return 1;
+    switch (src) {
+        case HL_TOOL_SRC_SIBLING: return "beside hull";
+        case HL_TOOL_SRC_PATH:    return "on PATH";
+        default:                  return "";
     }
+}
 
-    if (!S_ISREG(st.st_mode)) return 0;
-    if (out_path && out_path_sz > 0)
-        snprintf(out_path, out_path_sz, "%s", path);
-    if (out_size) *out_size = (size_t)st.st_size;
-    return 1;
+/* Machine label for the JSON `source` field. */
+static const char *tool_source_json(HlToolSource src)
+{
+    switch (src) {
+        case HL_TOOL_SRC_MANAGED: return "managed";
+        case HL_TOOL_SRC_SIBLING: return "sibling";
+        case HL_TOOL_SRC_PATH:    return "path";
+        default:                  return "none";
+    }
 }
 
 /* ── `hull tools list` ───────────────────────────────────────────── */
 
-static int print_list_text(const char *platform)
+static int print_list_text(const char *platform, const char *hull_exe)
 {
     const char *version = HL_VERSION;
     if (version[0] == 'v') version++;
@@ -145,17 +131,21 @@ static int print_list_text(const char *platform)
     for (const HlToolSpec *t = hl_tools_registry(); t->name; t++) {
         any = 1;
         int published = hl_tools_published_for(t, platform);
-        char inst_path[PATH_MAX];
-        size_t inst_size = 0;
-        int installed = tool_installed(t->name,
-                                       inst_path, sizeof(inst_path),
-                                       &inst_size);
+        HlToolStatus st;
+        hl_tools_status(t->name, hull_exe, &st);
 
-        if (installed) {
+        if (st.managed) {
+            /* Managed install (uninstallable). Accurate size, recursive for a
+             * bundle directory. */
             char sz_buf[32];
-            format_size(inst_size, sz_buf, sizeof(sz_buf));
+            format_size((size_t)st.size_bytes, sz_buf, sizeof(sz_buf));
             fprintf(stdout, "  %-10s [installed]  %s at %s\n",
-                    t->name, sz_buf, inst_path);
+                    t->name, sz_buf, st.install_path);
+        } else if (st.resolved) {
+            /* Usable but not hull-managed (a system/sibling install) - the same
+             * binary doctor + `hull build` resolve. */
+            fprintf(stdout, "  %-10s [found %s]  %s\n",
+                    t->name, tool_source_label(st.source), st.path);
         } else if (published) {
             fprintf(stdout, "  %-10s [available]  hint: `hull tools install %s`\n",
                     t->name, t->name);
@@ -172,7 +162,7 @@ static int print_list_text(const char *platform)
     return 0;
 }
 
-static int print_list_json(const char *platform)
+static int print_list_json(const char *platform, const char *hull_exe)
 {
     const char *version = HL_VERSION;
     if (version[0] == 'v') version++;
@@ -193,16 +183,18 @@ static int print_list_json(const char *platform)
         int published = hl_tools_published_for(t, platform);
         sh_json_write_kv_bool(&w, "available", published != 0);
 
-        char inst_path[PATH_MAX];
-        size_t inst_size = 0;
-        int installed = tool_installed(t->name,
-                                       inst_path, sizeof(inst_path),
-                                       &inst_size);
-        sh_json_write_kv_bool(&w, "installed", installed != 0);
-        if (installed) {
-            sh_json_write_kv_string(&w, "path",       inst_path);
-            sh_json_write_kv_int   (&w, "size_bytes", (int64_t)inst_size);
-        }
+        HlToolStatus st;
+        hl_tools_status(t->name, hull_exe, &st);
+        /* `installed` = hull-managed (what `uninstall` acts on); `resolved` =
+         * usable as an executable anywhere doctor/build would look. */
+        sh_json_write_kv_bool  (&w, "installed", st.managed != 0);
+        sh_json_write_kv_bool  (&w, "resolved",  st.resolved != 0);
+        sh_json_write_kv_string(&w, "source",    tool_source_json(st.source));
+        if (st.managed || st.resolved)
+            sh_json_write_kv_string(&w, "path",
+                                    st.resolved ? st.path : st.install_path);
+        if (st.managed)
+            sh_json_write_kv_int(&w, "size_bytes", (int64_t)st.size_bytes);
         if (published) {
             char asset[128];
             hl_tools_asset_name(t, platform, asset, sizeof(asset));
@@ -224,19 +216,35 @@ static int print_list_json(const char *platform)
  *   hl_release_io_fetch_verified_manifest(repo, tag, alloc, tls,
  *                                         "hull-tools", &manifest, &len). */
 
+/* Explain why a tool can't be installed on this platform, with a tool-specific
+ * next step. Shared by the pre-flight check (before any network round-trip) and
+ * install_one's defensive re-check. */
+static void print_unpublished(const HlToolSpec *spec, const char *platform)
+{
+    fprintf(stderr,
+            "hull tools: no %s binary published for %s on this hull release.\n",
+            spec->name, platform);
+    if (strcmp(platform, "cosmo") == 0 && strcmp(spec->name, "wamrc") == 0) {
+        fprintf(stderr,
+                "             cosmo users build wamrc from source: `make wamrc`.\n");
+    }
+    if (strcmp(spec->name, "cosmocc") == 0 && strcmp(platform, "cosmo") != 0) {
+        fprintf(stderr,
+                "             cosmocc is the toolchain for cosmo/APE app builds "
+                "(e.g. on Windows).\n"
+                "             Install it from the cosmo `hull` (the APE download); "
+                "a native hull\n"
+                "             builds with cc/gcc/clang and does not use it.\n");
+    }
+}
+
 static int install_one(const HlToolSpec *spec, const char *platform,
                        const char *repo, const char *tag,
                        KlAllocator *alloc, KlTlsCtx *tls,
                        const char *manifest, size_t manifest_len)
 {
     if (!hl_tools_published_for(spec, platform)) {
-        fprintf(stderr,
-                "hull tools: no %s binary published for %s on this hull release.\n",
-                spec->name, platform);
-        if (strcmp(platform, "cosmo") == 0 && strcmp(spec->name, "wamrc") == 0) {
-            fprintf(stderr,
-                    "             cosmo users build wamrc from source: `make wamrc`.\n");
-        }
+        print_unpublished(spec, platform);
         return -1;
     }
 
@@ -439,7 +447,8 @@ static int cmd_install(int argc, char **argv, const char *repo)
 
     /* Fail fast on unknown names - don't make a network round-trip for
      * something that's not in the registry. */
-    if (!install_all && !hl_tools_find(name)) {
+    const HlToolSpec *named = install_all ? NULL : hl_tools_find(name);
+    if (!install_all && !named) {
         fprintf(stderr,
                 "hull tools: unknown tool '%s'. Run `hull tools list` for the registry.\n",
                 name);
@@ -447,6 +456,15 @@ static int cmd_install(int argc, char **argv, const char *repo)
     }
 
     const char *platform = hl_release_io_platform();
+
+    /* Fail fast on a tool that isn't published for THIS platform too - and
+     * surface the tool-specific hint (e.g. cosmocc is cosmo-only) BEFORE the
+     * network round-trip / TLS setup, so the guidance shows even when the
+     * manifest fetch would fail. */
+    if (named && !hl_tools_published_for(named, platform)) {
+        print_unpublished(named, platform);
+        return 1;
+    }
 
     /* Set up TLS once for all installs in this invocation. */
     KlAllocator alloc = kl_allocator_default();
@@ -608,7 +626,7 @@ static void usage(void)
 
 int hl_cmd_tools(int argc, char **argv, const HlCommandEnv *env)
 {
-    (void)env;
+    const char *hull_exe = env ? env->hull_exe : NULL;
     if (argc < 2) {
         usage();
         return 2;
@@ -632,7 +650,8 @@ int hl_cmd_tools(int argc, char **argv, const HlCommandEnv *env)
             if (strcmp(argv[i], "--json") == 0) json = 1;
         }
         const char *platform = hl_release_io_platform();
-        return json ? print_list_json(platform) : print_list_text(platform);
+        return json ? print_list_json(platform, hull_exe)
+                    : print_list_text(platform, hull_exe);
     }
 
     if (strcmp(verb, "install") == 0) {

--- a/src/hull/tools_install.c
+++ b/src/hull/tools_install.c
@@ -23,6 +23,7 @@
 #include "hull/tools_install.h"
 #include "hull/shared/fs_util.h"
 
+#include <dirent.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdio.h>
@@ -428,4 +429,91 @@ int hl_tools_lookup_path(const char *name, const char *hull_exe,
     }
 
     return -1;
+}
+
+/* ── Unified status (parity across tools-list / agent-tools / doctor) ──── */
+
+unsigned long long hl_tools_dir_size(const char *path)
+{
+    struct stat st;
+    if (!path || lstat(path, &st) != 0) return 0;
+    if (S_ISREG(st.st_mode)) return (unsigned long long)st.st_size;
+    if (!S_ISDIR(st.st_mode)) return 0;   /* symlink / special: don't follow */
+
+    DIR *d = opendir(path);
+    if (!d) return 0;
+    unsigned long long total = 0;
+    struct dirent *e;
+    while ((e = readdir(d)) != NULL) {
+        if (strcmp(e->d_name, ".") == 0 || strcmp(e->d_name, "..") == 0) continue;
+        char child[PATH_MAX];
+        int n = snprintf(child, sizeof(child), "%s/%s", path, e->d_name);
+        if (n < 0 || (size_t)n >= sizeof(child)) continue;
+        total += hl_tools_dir_size(child);
+    }
+    closedir(d);
+    return total;
+}
+
+int hl_tools_status(const char *name, const char *hull_exe, HlToolStatus *out)
+{
+    if (!name || !out) return -1;
+    memset(out, 0, sizeof(*out));
+    const HlToolSpec *spec = hl_tools_find(name);
+    if (!spec) return -1;
+
+    /* Managed-install check - works for a single-binary tool (a symlink to the
+     * CAS blob, stat() follows it -> regular file) AND a bundle (a directory
+     * whose bundle_entry sentinel is present). This is the "installed via
+     * `hull tools install`, uninstallable" concept, independent of executable
+     * resolution below (a data-only floor is managed but not resolvable). */
+    if (hl_tools_install_path(name, out->install_path,
+                              sizeof(out->install_path)) == 0) {
+        struct stat st;
+        if (stat(out->install_path, &st) == 0) {
+            if (spec->is_bundle) {
+                if (S_ISDIR(st.st_mode) && spec->bundle_entry) {
+                    char sentinel[PATH_MAX];
+                    int n = snprintf(sentinel, sizeof(sentinel), "%s/%s",
+                                     out->install_path, spec->bundle_entry);
+                    struct stat cs;
+                    if (n > 0 && (size_t)n < sizeof(sentinel) &&
+                        stat(sentinel, &cs) == 0 && S_ISREG(cs.st_mode)) {
+                        out->managed    = 1;
+                        out->size_bytes = hl_tools_dir_size(out->install_path);
+                    }
+                }
+            } else if (S_ISREG(st.st_mode)) {
+                out->managed    = 1;
+                out->size_bytes = (unsigned long long)st.st_size;
+            }
+        }
+    }
+
+    /* Executable resolution - the SAME order doctor + build use. Classify the
+     * source so callers can distinguish a hull-managed install from a
+     * sibling/PATH one. Managed installs are probed first by the resolver, so a
+     * present managed executable always classifies as MANAGED. */
+    if (hl_tools_lookup_path(name, hull_exe, out->path, sizeof(out->path)) == 0) {
+        out->resolved = 1;
+        size_t ilen = strlen(out->install_path);
+        if (ilen && strncmp(out->path, out->install_path, ilen) == 0 &&
+            (out->path[ilen] == '\0' || out->path[ilen] == '/')) {
+            out->source = HL_TOOL_SRC_MANAGED;
+        } else if (hull_exe && *hull_exe) {
+            char dir[PATH_MAX];
+            char sib[PATH_MAX];
+            int n;
+            if (strip_basename(hull_exe, dir, sizeof(dir)) == 0 &&
+                (n = snprintf(sib, sizeof(sib), "%s/%s", dir, name)) > 0 &&
+                (size_t)n < sizeof(sib) && strcmp(out->path, sib) == 0) {
+                out->source = HL_TOOL_SRC_SIBLING;
+            } else {
+                out->source = HL_TOOL_SRC_PATH;
+            }
+        } else {
+            out->source = HL_TOOL_SRC_PATH;
+        }
+    }
+    return 0;
 }

--- a/tests/hull/test_tools_install.c
+++ b/tests/hull/test_tools_install.c
@@ -536,4 +536,137 @@ UTEST(tools_cosmocc, asset_name_is_arch_free_tar) {
                                   "linux-x86_64", asset, sizeof(asset)), -1);
 }
 
+/* Write a file of `n` bytes (mkdir -p its parent), 0644 (non-exec) unless
+ * `exec`. Returns 0 on success. */
+static int write_data(const char *path, size_t n, int exec)
+{
+    if (touch_exec(path) != 0) return -1;   /* reuse its mkdir -p + create */
+    FILE *f = fopen(path, "w");
+    if (!f) return -1;
+    for (size_t i = 0; i < n; i++) fputc('x', f);
+    fclose(f);
+    return chmod(path, exec ? 0755 : 0644);
+}
+
+/* ── hl_tools_dir_size ──────────────────────────────────────────── */
+
+UTEST_F(tools_fixture, dir_size_of_regular_file) {
+    char p[PATH_MAX];
+    snprintf(p, sizeof(p), "%s/f", utest_fixture->tmpdir);
+    ASSERT_EQ(write_data(p, 1234, 0), 0);
+    ASSERT_EQ(hl_tools_dir_size(p), 1234ULL);
+}
+
+UTEST_F(tools_fixture, dir_size_recurses) {
+    char base[PATH_MAX];
+    snprintf(base, sizeof(base), "%s/tree", utest_fixture->tmpdir);
+    char p[PATH_MAX];
+    snprintf(p, sizeof(p), "%s/a", base);         ASSERT_EQ(write_data(p, 100, 0), 0);
+    snprintf(p, sizeof(p), "%s/sub/b", base);     ASSERT_EQ(write_data(p, 200, 0), 0);
+    snprintf(p, sizeof(p), "%s/sub/c/d", base);   ASSERT_EQ(write_data(p, 300, 1), 0);
+    ASSERT_EQ(hl_tools_dir_size(base), 600ULL);
+}
+
+UTEST_F(tools_fixture, dir_size_missing_is_zero) {
+    char p[PATH_MAX];
+    snprintf(p, sizeof(p), "%s/nope", utest_fixture->tmpdir);
+    ASSERT_EQ(hl_tools_dir_size(p), 0ULL);
+}
+
+/* ── hl_tools_status ────────────────────────────────────────────── */
+
+UTEST_F(tools_fixture, status_none_when_absent) {
+    HlToolStatus st;
+    ASSERT_EQ(hl_tools_status("wamrc", NULL, &st), 0);
+    ASSERT_FALSE(st.managed);
+    ASSERT_FALSE(st.resolved);
+    ASSERT_EQ(st.source, HL_TOOL_SRC_NONE);
+    ASSERT_EQ(st.size_bytes, 0ULL);
+}
+
+UTEST_F(tools_fixture, status_unknown_tool_errors) {
+    HlToolStatus st;
+    ASSERT_EQ(hl_tools_status("definitely-not-a-tool", NULL, &st), -1);
+}
+
+UTEST_F(tools_fixture, status_managed_single_binary) {
+    /* A single-binary managed install: ~/.hull/tools/wamrc, sized by stat. */
+    char dir[PATH_MAX];
+    ASSERT_EQ(hl_tools_dir(dir, sizeof(dir)), 0);
+    char target[PATH_MAX];
+    snprintf(target, sizeof(target), "%swamrc", dir);
+    ASSERT_EQ(write_data(target, 4096, 1), 0);
+
+    HlToolStatus st;
+    ASSERT_EQ(hl_tools_status("wamrc", NULL, &st), 0);
+    ASSERT_TRUE(st.managed);
+    ASSERT_TRUE(st.resolved);
+    ASSERT_EQ(st.source, HL_TOOL_SRC_MANAGED);
+    ASSERT_STREQ(st.path, target);
+    ASSERT_EQ(st.size_bytes, 4096ULL);
+}
+
+UTEST_F(tools_fixture, status_managed_executable_bundle) {
+    /* cosmocc is a bundle (bundle_entry "bin/cosmocc", executable): managed via
+     * the sentinel, resolved to the entry, sized RECURSIVELY over the dir. */
+    char dir[PATH_MAX];
+    ASSERT_EQ(hl_tools_dir(dir, sizeof(dir)), 0);
+    char entry[PATH_MAX], extra[PATH_MAX], root[PATH_MAX];
+    snprintf(root,  sizeof(root),  "%scosmocc", dir);
+    snprintf(entry, sizeof(entry), "%scosmocc/bin/cosmocc", dir);
+    snprintf(extra, sizeof(extra), "%scosmocc/lib/x.a", dir);
+    ASSERT_EQ(write_data(entry, 3000, 1), 0);
+    ASSERT_EQ(write_data(extra, 2000, 0), 0);
+
+    HlToolStatus st;
+    ASSERT_EQ(hl_tools_status("cosmocc", NULL, &st), 0);
+    ASSERT_TRUE(st.managed);
+    ASSERT_TRUE(st.resolved);
+    ASSERT_EQ(st.source, HL_TOOL_SRC_MANAGED);
+    ASSERT_STREQ(st.path, entry);
+    ASSERT_STREQ(st.install_path, root);
+    ASSERT_EQ(st.size_bytes, 5000ULL);   /* the old S_ISREG check reported 0 */
+}
+
+UTEST_F(tools_fixture, status_managed_data_only_bundle) {
+    /* A data-only floor bundle: its bundle_entry (libhull_platform.a) is NOT
+     * executable, so hl_tools_lookup_path's bundle-entry probe misses; but its
+     * install DIRECTORY is searchable (X_OK on a dir), so the resolver returns
+     * the dir - the documented behavior build.lua relies on. So it is `managed`
+     * (installed, accurately sized) and `resolved` to its directory (source
+     * MANAGED), never to an executable. `installed`-based surfaces (list, agent)
+     * key off `managed`, which is what matters here. */
+    char dir[PATH_MAX];
+    ASSERT_EQ(hl_tools_dir(dir, sizeof(dir)), 0);
+    char root[PATH_MAX], sentinel[PATH_MAX];
+    snprintf(root,     sizeof(root),     "%splatform-musl-x86_64", dir);
+    snprintf(sentinel, sizeof(sentinel), "%s/libhull_platform.a", root);
+    ASSERT_EQ(write_data(sentinel, 8192, 0), 0);
+
+    HlToolStatus st;
+    ASSERT_EQ(hl_tools_status("platform-musl-x86_64", NULL, &st), 0);
+    ASSERT_TRUE(st.managed);
+    ASSERT_EQ(st.source, HL_TOOL_SRC_MANAGED);
+    ASSERT_STREQ(st.path, root);         /* the searchable install dir */
+    ASSERT_EQ(st.size_bytes, 8192ULL);
+}
+
+UTEST_F(tools_fixture, status_sibling_source) {
+    /* No managed install; a wamrc beside the hull binary resolves as SIBLING. */
+    char hull_dir[PATH_MAX], hull_path[PATH_MAX], tool_path[PATH_MAX];
+    snprintf(hull_dir,  sizeof(hull_dir),  "%s/bin", utest_fixture->tmpdir);
+    ASSERT_EQ(mkdir(hull_dir, 0755), 0);
+    snprintf(hull_path, sizeof(hull_path), "%s/hull",  hull_dir);
+    snprintf(tool_path, sizeof(tool_path), "%s/wamrc", hull_dir);
+    ASSERT_EQ(touch_exec(hull_path), 0);
+    ASSERT_EQ(touch_exec(tool_path), 0);
+
+    HlToolStatus st;
+    ASSERT_EQ(hl_tools_status("wamrc", hull_path, &st), 0);
+    ASSERT_FALSE(st.managed);
+    ASSERT_TRUE(st.resolved);
+    ASSERT_EQ(st.source, HL_TOOL_SRC_SIBLING);
+    ASSERT_STREQ(st.path, tool_path);
+}
+
 UTEST_MAIN()


### PR DESCRIPTION
Item #5 of the 0.13.1 Windows stabilization sequence: **doctor / tool-resolver parity**.

## Problem

`hull doctor`, `hull tools list`, `hull agent tools`, and `hull build` each decided "is tool X installed / where is it" with different logic, so they disagreed — and two carried real bugs:

- **`hull tools list` / `hull agent tools`** checked only `~/.hull/tools` (never PATH / sibling), so a tool that `hull doctor` and `hull build` resolve looked absent.
- **Bundle size was always `0`** — `tools list` unconditionally, and `agent tools` reported every **bundle** tool (`cosmocc`, `zig`, the musl floors — which install as *directories*) as `installed:false`, because it only accepted a single regular file (`S_ISREG`).
- **`hull doctor`** probed `cosmocc` on `$PATH` only, so a hull-managed `~/.hull/tools/cosmocc/bin/cosmocc` — exactly what `hull build` drives — showed as missing.

## Fix

One shared source of truth, `hl_tools_status` (built on the canonical `hl_tools_lookup_path`), returning `managed` / `resolved` + `source` (managed / sibling / PATH) / resolved path / accurate managed-install size (via the new recursive `hl_tools_dir_size`). `doctor`, `tools list`, and `agent tools` all consume it, so they agree; `build` already used the resolver core.

- `tools list` shows a system/sibling install as `[found on PATH]` and reports accurate (recursive) bundle sizes.
- `agent tools` bundle-installed + size bug fixed.
- `doctor` resolves a hull-managed `cosmocc`.
- `installed` semantics (managed, uninstallable) are preserved; JSON gains `resolved` / `source` and keeps `installed`.

## Windows cosmocc hint

`hull tools install cosmocc` on a native hull now fails **fast** (before any network round-trip) with a clear message that cosmocc is the cosmo/APE toolchain for Windows app builds, installed from the cosmo `hull`.

## Tests

`test_tools_install` gains `hl_tools_dir_size` (file / recursive / missing) and `hl_tools_status` (absent / unknown / managed single-binary / managed executable bundle with recursive size / data-only floor bundle / sibling source) — 39 pass. Verified end to end that all four surfaces agree on a fake managed single-binary + directory bundle with an accurate recursive size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)