### PR TITLE
fix(update): Windows-safe self-update via deferred rename-aside swap (0.13.1)

### DIFF
--- a/include/hull/release_io.h
+++ b/include/hull/release_io.h
@@ -154,4 +154,37 @@ int hl_release_io_atomic_write(const char *target_path,
                                const void *data, size_t len,
                                int mode);
 
+/**
+ * Replace the RUNNING hull binary at @p self_path with @p data - a
+ * self-update-safe variant of hl_release_io_atomic_write.
+ *
+ * On POSIX, `rename(2)`-ing a new file over the running executable works, so
+ * this takes the atomic path: write `<self>.new`, then rename over @p self_path.
+ *
+ * On Windows a running `.exe` is locked and cannot be overwritten/renamed-over,
+ * so when the atomic rename fails this falls back to a DEFERRED SWAP: move the
+ * running exe aside to `<self>.old` (allowed while running), rename `<self>.new`
+ * into place, then best-effort delete `<self>.old` (which stays locked until the
+ * old process exits, so it is cleaned up on the next startup - see
+ * hl_release_io_cleanup_stale_self). On any failure during the swap the original
+ * is ROLLED BACK from `<self>.old`, so a failed update never leaves hull missing.
+ *
+ * No OS detection: the atomic path is tried first and the deferred swap is used
+ * only when it fails. Setting `HULL_FORCE_DEFERRED_SWAP` forces the deferred
+ * path (for tests on POSIX).
+ *
+ * @returns 0 on success, -1 on failure (self_path left intact / restored).
+ */
+int hl_release_io_self_replace(const char *self_path,
+                               const void *data, size_t len,
+                               int mode);
+
+/**
+ * Best-effort removal of a leftover `<self>.old` from a prior deferred-swap
+ * self-update (see hl_release_io_self_replace). Safe to call on every startup:
+ * it resolves the running binary (hl_release_io_self_path, else @p argv0) and
+ * unlinks `<self>.old` if present. A no-op when nothing was left behind.
+ */
+void hl_release_io_cleanup_stale_self(const char *argv0);
+
 #endif /* HL_RELEASE_IO_H */

--- a/src/hull/commands/update.c
+++ b/src/hull/commands/update.c
@@ -263,7 +263,9 @@ int hl_cmd_update(int argc, char **argv, const HlCommandEnv *env)
         }
     }
 
-    if (hl_release_io_atomic_write(self_path, binary, binary_len, 0755) != 0) {
+    /* Self-replace: atomic rename on POSIX; deferred rename-aside swap with
+     * rollback on Windows, where a running .exe can't be overwritten in place. */
+    if (hl_release_io_self_replace(self_path, binary, binary_len, 0755) != 0) {
         kl_free(&alloc, binary, binary_len);
         return 1;
     }

--- a/src/hull/main.c
+++ b/src/hull/main.c
@@ -17,6 +17,7 @@
 #include "hull/commands/dispatch.h"
 #include "hull/commands/version.h"
 #include "hull/commands/help.h"
+#include "hull/release_io.h"
 #include "hull/serve.h"
 
 #include <string.h>
@@ -30,6 +31,12 @@
 
 int hull_main(int argc, char **argv)
 {
+    /* Sweep a leftover `<self>.old` from a prior deferred-swap self-update
+     * (Windows keeps the old exe locked until its process exits, so it's this
+     * next startup that can finally remove it). Best-effort; a no-op on native
+     * builds. */
+    hl_release_io_cleanup_stale_self(argc > 0 ? argv[0] : NULL);
+
     /* Handle -v / --version before subcommand dispatch so that
      * `hull --version` and `hull -v` work as conventional global flags. */
     if (argc >= 2 &&

--- a/src/hull/release_io.c
+++ b/src/hull/release_io.c
@@ -427,6 +427,52 @@ int hl_release_io_find_checksum(const char *manifest, size_t mlen,
 
 /* ── Atomic write ────────────────────────────────────────────────── */
 
+/* Write @p data to @p new_path (O_CREAT|O_TRUNC, @p mode), fsync, close, and
+ * re-chmod (umask defeats the open mode). Unlinks @p new_path on any failure.
+ * Shared by atomic_write and self_replace. Returns 0 on success, -1 on failure. */
+static int write_new_file(const char *new_path, const void *data, size_t len,
+                          int mode)
+{
+    int fd = open(new_path, O_WRONLY | O_CREAT | O_TRUNC, mode);
+    if (fd < 0) {
+        fprintf(stderr, "release_io: cannot create %s: %s\n",
+                new_path, strerror(errno));
+        return -1;
+    }
+    const unsigned char *p = (const unsigned char *)data;
+    size_t written = 0;
+    while (written < len) {
+        ssize_t w = write(fd, p + written, len - written);
+        if (w <= 0) {
+            fprintf(stderr, "release_io: write failed: %s\n", strerror(errno));
+            close(fd);
+            unlink(new_path);
+            return -1;
+        }
+        written += (size_t)w;
+    }
+    /* fsync before rename so a power-loss doesn't leave a half-written
+     * executable behind. ENOSPC and EIO are the realistic failures. */
+    if (fsync(fd) != 0) {
+        fprintf(stderr, "release_io: fsync failed: %s\n", strerror(errno));
+        close(fd);
+        unlink(new_path);
+        return -1;
+    }
+    /* close(2) can also surface deferred write errors (NFS, network mounts). */
+    if (close(fd) != 0) {
+        fprintf(stderr, "release_io: close failed: %s\n", strerror(errno));
+        unlink(new_path);
+        return -1;
+    }
+    if (chmod(new_path, (mode_t)mode) != 0) {
+        fprintf(stderr, "release_io: chmod failed: %s\n", strerror(errno));
+        unlink(new_path);
+        return -1;
+    }
+    return 0;
+}
+
 int hl_release_io_atomic_write(const char *target_path,
                                const void *data, size_t len,
                                int mode)
@@ -437,49 +483,7 @@ int hl_release_io_atomic_write(const char *target_path,
     int n = snprintf(new_path, sizeof(new_path), "%s.new", target_path);
     if (n < 0 || (size_t)n >= sizeof(new_path)) return -1;
 
-    int fd = open(new_path, O_WRONLY | O_CREAT | O_TRUNC, mode);
-    if (fd < 0) {
-        fprintf(stderr, "atomic_write: cannot create %s: %s\n",
-                new_path, strerror(errno));
-        return -1;
-    }
-    const unsigned char *p = (const unsigned char *)data;
-    size_t written = 0;
-    while (written < len) {
-        ssize_t w = write(fd, p + written, len - written);
-        if (w <= 0) {
-            fprintf(stderr, "atomic_write: write failed: %s\n",
-                    strerror(errno));
-            close(fd);
-            unlink(new_path);
-            return -1;
-        }
-        written += (size_t)w;
-    }
-    /* fsync before rename so a power-loss doesn't leave a half-written
-     * executable behind. ENOSPC and EIO are the realistic failures;
-     * either way, abort rather than rename a partially-flushed file. */
-    if (fsync(fd) != 0) {
-        fprintf(stderr, "atomic_write: fsync failed: %s\n", strerror(errno));
-        close(fd);
-        unlink(new_path);
-        return -1;
-    }
-    /* close(2) can also surface deferred write errors on some
-     * filesystems (NFS, network mounts) - treat the same way. */
-    if (close(fd) != 0) {
-        fprintf(stderr, "atomic_write: close failed: %s\n", strerror(errno));
-        unlink(new_path);
-        return -1;
-    }
-
-    /* chmod again - open(O_CREAT, mode) honours umask, which on most
-     * systems clears the world / group bits we asked for. */
-    if (chmod(new_path, (mode_t)mode) != 0) {
-        fprintf(stderr, "atomic_write: chmod failed: %s\n", strerror(errno));
-        unlink(new_path);
-        return -1;
-    }
+    if (write_new_file(new_path, data, len, mode) != 0) return -1;
 
     if (rename(new_path, target_path) != 0) {
         fprintf(stderr, "atomic_write: rename %s -> %s failed: %s\n",
@@ -488,4 +492,94 @@ int hl_release_io_atomic_write(const char *target_path,
         return -1;
     }
     return 0;
+}
+
+/* ── Self-update-safe replace (Windows deferred swap) ────────────────── */
+
+int hl_release_io_self_replace(const char *self_path,
+                               const void *data, size_t len,
+                               int mode)
+{
+    if (!self_path || (!data && len > 0)) return -1;
+
+    char new_path[PATH_MAX + 8];
+    char old_path[PATH_MAX + 8];
+    int n = snprintf(new_path, sizeof(new_path), "%s.new", self_path);
+    if (n < 0 || (size_t)n >= sizeof(new_path)) return -1;
+    n = snprintf(old_path, sizeof(old_path), "%s.old", self_path);
+    if (n < 0 || (size_t)n >= sizeof(old_path)) return -1;
+
+    if (write_new_file(new_path, data, len, mode) != 0) return -1;
+
+    /* Fast path: on POSIX, rename over the running exe is atomic and works.
+     * HULL_FORCE_DEFERRED_SWAP forces the fallback for tests. */
+    if (!getenv("HULL_FORCE_DEFERRED_SWAP")) {
+        if (rename(new_path, self_path) == 0)
+            return 0;
+        /* The atomic rename failed - most likely the running exe is locked
+         * (Windows). Fall through to the deferred swap rather than abort. */
+    }
+
+    /* Deferred swap. Move the running binary aside (allowed while running,
+     * even on Windows), install the new one, then best-effort remove the old
+     * (it stays locked until this process exits; cleaned up on next startup). */
+    (void)unlink(old_path);                          /* clear any stale .old */
+    if (rename(self_path, old_path) != 0) {
+        fprintf(stderr,
+                "self_replace: cannot move %s aside: %s (update aborted, "
+                "binary intact)\n", self_path, strerror(errno));
+        (void)unlink(new_path);
+        return -1;
+    }
+
+    /* A test hook to exercise the rollback branch below without a real
+     * mid-swap crash: pretend the install step failed. */
+    int install_ok = getenv("HULL_TEST_SWAP_FAIL")
+                       ? 0 : (rename(new_path, self_path) == 0);
+    if (!install_ok) {
+        /* ROLLBACK: restore the original from the aside copy so a failed
+         * update never leaves hull missing. */
+        if (rename(old_path, self_path) != 0) {
+            fprintf(stderr,
+                    "self_replace: CRITICAL: install failed AND rollback "
+                    "failed; your hull binary is at %s\n", old_path);
+        } else {
+            fprintf(stderr,
+                    "self_replace: install failed; rolled back to the "
+                    "previous binary\n");
+        }
+        (void)unlink(new_path);
+        return -1;
+    }
+
+    /* Success. The old binary lingers as <self>.old until this process exits
+     * (Windows keeps it locked); the next hull startup sweeps it. */
+    (void)unlink(old_path);
+    return 0;
+}
+
+void hl_release_io_cleanup_stale_self(const char *argv0)
+{
+#if !defined(__COSMOPOLITAN__)
+    /* A deferred swap only happens where the atomic rename fails (a running
+     * .exe on Windows - i.e. a cosmo host). On a native build no `<self>.old`
+     * is ever created, so this startup sweep is pure waste; skip it unless a
+     * test forces the deferred path. */
+    if (!getenv("HULL_FORCE_DEFERRED_SWAP")) return;
+#endif
+    char self[PATH_MAX];
+    if (hl_release_io_self_path(self, sizeof(self)) != 0) {
+        if (!argv0 || !*argv0) return;
+        char *resolved = realpath(argv0, NULL);
+        if (resolved) {
+            snprintf(self, sizeof(self), "%s", resolved);
+            free(resolved);
+        } else {
+            snprintf(self, sizeof(self), "%s", argv0);
+        }
+    }
+    char old_path[PATH_MAX + 8];
+    int n = snprintf(old_path, sizeof(old_path), "%s.old", self);
+    if (n > 0 && (size_t)n < sizeof(old_path))
+        (void)unlink(old_path);   /* best-effort; absent in the common case */
 }

--- a/tests/hull/test_release_io.c
+++ b/tests/hull/test_release_io.c
@@ -287,4 +287,145 @@ UTEST(atomic_write, refuses_unwritable_parent) {
                                          "x", 1, 0644), -1);
 }
 
+/* ── self_replace: self-update-safe replace incl. Windows deferred swap ── */
+
+static int seed(const char *path, const char *s)
+{
+    FILE *f = fopen(path, "w");
+    if (!f) return -1;
+    fputs(s, f);
+    return fclose(f);
+}
+
+static int first_bytes(const char *path, char *buf, size_t n)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) return -1;
+    size_t r = fread(buf, 1, n - 1, f);
+    buf[r] = '\0';
+    fclose(f);
+    return 0;
+}
+
+/* 1 if a `.new` or `.old` sidecar was left behind next to @p tmp. */
+static int has_sidecars(const char *tmp)
+{
+    char side[PATH_MAX];
+    snprintf(side, sizeof(side), "%s.new", tmp);
+    if (access(side, F_OK) == 0) return 1;
+    snprintf(side, sizeof(side), "%s.old", tmp);
+    if (access(side, F_OK) == 0) return 1;
+    return 0;
+}
+
+UTEST(self_replace, atomic_path_replaces) {
+    char tmp[PATH_MAX];
+    snprintf(tmp, sizeof(tmp), "/tmp/hull-sr-%d", getpid());
+    unlink(tmp);
+    ASSERT_EQ(seed(tmp, "OLD-BINARY"), 0);
+
+    const char *nw = "NEW-BINARY-BYTES";
+    ASSERT_EQ(hl_release_io_self_replace(tmp, nw, strlen(nw), 0755), 0);
+
+    char buf[64];
+    ASSERT_EQ(first_bytes(tmp, buf, sizeof(buf)), 0);
+    ASSERT_STREQ(buf, nw);
+    ASSERT_EQ(has_sidecars(tmp), 0);
+    unlink(tmp);
+}
+
+UTEST(self_replace, deferred_swap_replaces) {
+    char tmp[PATH_MAX];
+    snprintf(tmp, sizeof(tmp), "/tmp/hull-sr-def-%d", getpid());
+    unlink(tmp);
+    ASSERT_EQ(seed(tmp, "OLD"), 0);
+
+    /* Force the Windows-style deferred swap on POSIX. */
+    setenv("HULL_FORCE_DEFERRED_SWAP", "1", 1);
+    const char *nw = "NEW-VIA-DEFERRED-SWAP";
+    int rc = hl_release_io_self_replace(tmp, nw, strlen(nw), 0755);
+    unsetenv("HULL_FORCE_DEFERRED_SWAP");
+
+    ASSERT_EQ(rc, 0);
+    char buf[64];
+    ASSERT_EQ(first_bytes(tmp, buf, sizeof(buf)), 0);
+    ASSERT_STREQ(buf, nw);
+    /* On POSIX the aside copy unlinks immediately; no sidecars remain. */
+    ASSERT_EQ(has_sidecars(tmp), 0);
+    unlink(tmp);
+}
+
+UTEST(self_replace, deferred_swap_rolls_back_on_failure) {
+    char tmp[PATH_MAX];
+    snprintf(tmp, sizeof(tmp), "/tmp/hull-sr-rb-%d", getpid());
+    unlink(tmp);
+    ASSERT_EQ(seed(tmp, "ORIGINAL-BINARY"), 0);
+
+    /* Force the deferred swap AND simulate the install step failing mid-swap:
+     * the original must be rolled back from the aside copy. */
+    setenv("HULL_FORCE_DEFERRED_SWAP", "1", 1);
+    setenv("HULL_TEST_SWAP_FAIL", "1", 1);
+    int rc = hl_release_io_self_replace(tmp, "SHOULD-NOT-LAND", 15, 0755);
+    unsetenv("HULL_TEST_SWAP_FAIL");
+    unsetenv("HULL_FORCE_DEFERRED_SWAP");
+
+    ASSERT_EQ(rc, -1);
+    /* Original intact - a failed update never leaves hull missing. */
+    char buf[64];
+    ASSERT_EQ(first_bytes(tmp, buf, sizeof(buf)), 0);
+    ASSERT_STREQ(buf, "ORIGINAL-BINARY");
+    ASSERT_EQ(has_sidecars(tmp), 0);
+    unlink(tmp);
+}
+
+UTEST(self_replace, path_with_spaces) {
+    /* A running hull at a path with spaces (the reporter's Windows scenario). */
+    char dir[PATH_MAX];
+    snprintf(dir, sizeof(dir), "/tmp/hull sr dir-%d", getpid());
+    mkdir(dir, 0755);
+    char tmp[PATH_MAX];
+    snprintf(tmp, sizeof(tmp), "%s/my hull.exe", dir);
+    unlink(tmp);
+    ASSERT_EQ(seed(tmp, "OLD"), 0);
+
+    setenv("HULL_FORCE_DEFERRED_SWAP", "1", 1);
+    const char *nw = "NEW-WITH-SPACES";
+    int rc = hl_release_io_self_replace(tmp, nw, strlen(nw), 0755);
+    unsetenv("HULL_FORCE_DEFERRED_SWAP");
+
+    ASSERT_EQ(rc, 0);
+    char buf[64];
+    ASSERT_EQ(first_bytes(tmp, buf, sizeof(buf)), 0);
+    ASSERT_STREQ(buf, nw);
+    ASSERT_EQ(has_sidecars(tmp), 0);
+    unlink(tmp);
+    rmdir(dir);
+}
+
+UTEST(self_replace, cleanup_removes_stale_old) {
+    /* cleanup resolves the running binary (this test exe) and removes its
+     * `<self>.old`. Plant one next to the test exe and assert it's swept. */
+    char self[PATH_MAX];
+    if (hl_release_io_self_path(self, sizeof(self)) != 0)
+        return;   /* no self-path on this platform (cosmo) - skip */
+    char oldp[PATH_MAX + 8];
+    snprintf(oldp, sizeof(oldp), "%s.old", self);
+    if (seed(oldp, "leftover") != 0)
+        return;   /* dir not writable - skip rather than fail spuriously */
+    ASSERT_EQ(access(oldp, F_OK), 0);
+
+    setenv("HULL_FORCE_DEFERRED_SWAP", "1", 1);   /* enable the sweep on POSIX */
+    hl_release_io_cleanup_stale_self(NULL);
+    unsetenv("HULL_FORCE_DEFERRED_SWAP");
+
+    ASSERT_EQ(access(oldp, F_OK), -1);            /* .old swept */
+    ASSERT_EQ(access(self, F_OK), 0);             /* self untouched */
+}
+
+UTEST(self_replace, null_args_rejected) {
+    ASSERT_EQ(hl_release_io_self_replace(NULL, "x", 1, 0755), -1);
+    ASSERT_EQ(hl_release_io_self_replace("/tmp/x", NULL, 4, 0755), -1);
+    hl_release_io_cleanup_stale_self(NULL);   /* must not crash */
+}
+
 UTEST_MAIN()


### PR DESCRIPTION
Item #6 of the 0.13.1 Windows stabilization sequence: **Windows self-update**.

## Problem

`hull update` replaced the running binary with `hl_release_io_atomic_write` (write `<self>.new`, `rename` over `<self>`). Atomic and correct on POSIX — but on Windows a running `.exe` is **locked**: it can't be overwritten or renamed-over, so a self-update fails.

## Fix

`hl_release_io_self_replace` — a self-update-safe replace with **no OS detection**:

1. Try the atomic `rename(<self>.new → <self>)` first (POSIX fast path, truly atomic).
2. Only if that fails (the running exe is locked → Windows), fall back to a **deferred swap**:
   - `rename(<self> → <self>.old)` — move the running binary aside (allowed while running, even on Windows),
   - `rename(<self>.new → <self>)` — install the new one,
   - best-effort `unlink(<self>.old)` — the old exe stays locked until this process exits, so it's swept on the **next startup** by `hl_release_io_cleanup_stale_self` (wired into `hull_main`; a no-op on native builds).
3. **Rollback**: if the install step fails mid-swap, the original is restored from `<self>.old`, so a failed update never leaves hull missing.

The `.new` write path is factored into a shared `write_new_file` (used by both `atomic_write`, unchanged, and `self_replace`).

## Tests

`test_release_io` exercises the deferred path on POSIX via a `HULL_FORCE_DEFERRED_SWAP` hook and rollback via `HULL_TEST_SWAP_FAIL`: atomic path, deferred swap, **rollback-preserves-original**, a **path with spaces**, stale `.old` cleanup, null-arg rejection — 25 pass. Confirmed the pure-compute (HTTP-off) flavor still links (`release_io.o` is unconditionally linked) and a native hull leaves no stray `.old`.

Real Windows validation (a running `.exe` deferred swap end to end) is part of the 0.13.1 acceptance run; the deferred-swap **code path** is verified here via the hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)