### PR TITLE
fix(update): compile self-update fault-injection hooks out of production

### DIFF
--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -503,8 +503,13 @@ CRYPTO_TEST_OBJS := $(BUILDDIR)/cap_crypto.o $(BUILDDIR)/cap_crypto_hmac_mbedtls
 # atomic write). Skipped on HL_ENABLE_HTTP_CLIENT=0 builds where the
 # helper module isn't compiled in.
 ifneq ($(HL_ENABLE_HTTP_CLIENT),0)
-$(BUILDDIR)/test_release_io: $(TESTDIR)/hull/test_release_io.c $(RELEASE_IO_OBJ) $(RELEASE_OBJ) $(HEX_OBJ) $(CACERT_OBJ) $(TLS_TRANSPORT_OBJ) $(TLS_TRANSPORT_STUB_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) | $(BUILDDIR)
-	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(RELEASE_IO_OBJ) $(RELEASE_OBJ) $(HEX_OBJ) $(CACERT_OBJ) $(TLS_TRANSPORT_OBJ) $(TLS_TRANSPORT_STUB_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) -lm -lpthread
+# release_io.c is COMPILED here (not linked as $(RELEASE_IO_OBJ)) with
+# -DHL_RELEASE_IO_TEST_HOOKS so the self-update fault-injection hooks
+# (HULL_FORCE_DEFERRED_SWAP / HULL_TEST_SWAP_FAIL) exist ONLY in this test
+# binary - they are compiled out of the production object that hull links.
+# Mirrors test_pg_conn's -DHL_PG_NO_TLS source-compile pattern.
+$(BUILDDIR)/test_release_io: $(TESTDIR)/hull/test_release_io.c $(SRCDIR)/hull/release_io.c $(RELEASE_OBJ) $(HEX_OBJ) $(CACERT_OBJ) $(TLS_TRANSPORT_OBJ) $(TLS_TRANSPORT_STUB_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) | $(BUILDDIR)
+	$(CC) $(CFLAGS) -DHL_RELEASE_IO_TEST_HOOKS $(INCLUDES) -I$(VENDDIR) -o $@ $< $(SRCDIR)/hull/release_io.c $(RELEASE_OBJ) $(HEX_OBJ) $(CACERT_OBJ) $(TLS_TRANSPORT_OBJ) $(TLS_TRANSPORT_STUB_OBJ) $(CRYPTO_TEST_OBJS) $(MBEDTLS_OBJS) $(KEEL_LIB) -lm -lpthread
 endif
 
 # Verify-self helpers test. Reuses release_io.{c,h} for asset-name,

--- a/src/hull/release_io.c
+++ b/src/hull/release_io.c
@@ -511,9 +511,17 @@ int hl_release_io_self_replace(const char *self_path,
 
     if (write_new_file(new_path, data, len, mode) != 0) return -1;
 
-    /* Fast path: on POSIX, rename over the running exe is atomic and works.
-     * HULL_FORCE_DEFERRED_SWAP forces the fallback for tests. */
-    if (!getenv("HULL_FORCE_DEFERRED_SWAP")) {
+    /* Fast path: on POSIX, rename over the running exe is atomic and works; on
+     * Windows a locked running exe makes it fail and we fall through to the
+     * deferred swap. A test-only build (HL_RELEASE_IO_TEST_HOOKS) can force the
+     * deferred path on POSIX via HULL_FORCE_DEFERRED_SWAP - the env read is
+     * compiled out of production so the hook cannot ship. */
+#ifdef HL_RELEASE_IO_TEST_HOOKS
+    int force_deferred = (getenv("HULL_FORCE_DEFERRED_SWAP") != NULL);
+#else
+    const int force_deferred = 0;
+#endif
+    if (!force_deferred) {
         if (rename(new_path, self_path) == 0)
             return 0;
         /* The atomic rename failed - most likely the running exe is locked
@@ -532,10 +540,15 @@ int hl_release_io_self_replace(const char *self_path,
         return -1;
     }
 
-    /* A test hook to exercise the rollback branch below without a real
-     * mid-swap crash: pretend the install step failed. */
+    /* Install the new binary at the now-freed path. A test-only build can
+     * simulate a mid-swap install failure (to exercise the rollback below)
+     * via HULL_TEST_SWAP_FAIL; the hook is compiled out of production. */
+#ifdef HL_RELEASE_IO_TEST_HOOKS
     int install_ok = getenv("HULL_TEST_SWAP_FAIL")
                        ? 0 : (rename(new_path, self_path) == 0);
+#else
+    int install_ok = (rename(new_path, self_path) == 0);
+#endif
     if (!install_ok) {
         /* ROLLBACK: restore the original from the aside copy so a failed
          * update never leaves hull missing. */
@@ -563,9 +576,13 @@ void hl_release_io_cleanup_stale_self(const char *argv0)
 #if !defined(__COSMOPOLITAN__)
     /* A deferred swap only happens where the atomic rename fails (a running
      * .exe on Windows - i.e. a cosmo host). On a native build no `<self>.old`
-     * is ever created, so this startup sweep is pure waste; skip it unless a
-     * test forces the deferred path. */
+     * is ever created, so this startup sweep is pure waste and is skipped. A
+     * test-only build runs it when the deferred path is forced. */
+#  ifdef HL_RELEASE_IO_TEST_HOOKS
     if (!getenv("HULL_FORCE_DEFERRED_SWAP")) return;
+#  else
+    return;
+#  endif
 #endif
     char self[PATH_MAX];
     if (hl_release_io_self_path(self, sizeof(self)) != 0) {


### PR DESCRIPTION
Phase 2 of the 0.14.0 release (pre-tag blocker).

#429's self-update deferred-swap tests reached into `release_io.c` via two env-var hooks — `HULL_FORCE_DEFERRED_SWAP` (force the Windows deferred path on POSIX) and `HULL_TEST_SWAP_FAIL` (simulate a mid-swap install failure for rollback coverage). Those **shipped in the production binary**, where the environment could alter self-update behavior. Test-only fault injection must not ship.

## Fix

Gate both behind `HL_RELEASE_IO_TEST_HOOKS` (undefined in production):
- the env reads and the forced-failure branch are `#ifdef`-compiled out;
- the native startup `.old` sweep becomes an unconditional no-op (a native build never performs a deferred swap → no `<self>.old` is ever created).

Production behavior is unchanged: the deferred swap still triggers on a **real** failed atomic rename (a locked running `.exe` on Windows), which needs no hook.

`test_release_io` now **compiles** `release_io.c` with `-DHL_RELEASE_IO_TEST_HOOKS` (mirroring `test_pg_conn`'s `-DHL_PG_NO_TLS` source-compile) instead of linking the shared production object, so the hooks exist only in that test binary.

## Verified

- `strings build/hull` contains **neither** hook name; `strings build/test_release_io` contains both.
- `test_release_io` 25/25 pass (deferred swap, rollback, path-with-spaces, stale-`.old` cleanup).

Acceptance rollback evidence will come from a **real Windows lock scenario**, not this hook (Phase 3 acceptance workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)