### PR TITLE
ci(release): automated read-only acceptance workflow (Phase 3a, v0.14.0)

### DIFF
--- a/.github/workflows/release-acceptance.yml
+++ b/.github/workflows/release-acceptance.yml
@@ -1,0 +1,210 @@
+name: Release acceptance (automated, read-only)
+
+# Phase 3a of the release-acceptance run (docs/release_acceptance.md). Verifies a
+# published release candidate and the maintainer-prepopulated staging mirror(s)
+# WITHOUT mutating any release, and produces an acceptance report the Windows
+# job (Phase 3b) consumes. This workflow NEVER creates, modifies, or deletes a
+# tag, release, or asset, and never alters "latest": it only reads and verifies.
+#
+# Prerequisite (a manual, auditable maintainer step - NOT done here):
+#   - Publish v0.14.0-rc1 as an official prerelease on the main repo.
+#   - Mirror the exact signed RC assets into <staging_rc_repo> as ITS latest
+#     NON-prerelease (so `hull update --repo=<staging_rc_repo>` selects them).
+#   - For downgrade: mirror the signed v0.13.0 assets into <staging_prev_repo>
+#     as its latest non-prerelease.
+#   - Remove the staging releases after final promotion (also manual).
+
+on:
+  workflow_dispatch:
+    inputs:
+      rc_tag:
+        description: RC tag on the official repo (e.g. v0.14.0-rc1)
+        required: true
+        default: v0.14.0-rc1
+      expect_version:
+        description: Version string the RC binary must report
+        required: true
+        default: 0.14.0-rc1
+      official_repo:
+        description: Official repository
+        required: true
+        default: artalis-io/hull
+      staging_rc_repo:
+        description: Staging repo whose latest mirrors the RC (ORG/NAME)
+        required: true
+      prev_tag:
+        description: Previous release tag (for downgrade), on the official repo
+        required: true
+        default: v0.13.0
+      staging_prev_repo:
+        description: Staging repo whose latest mirrors the previous release (optional; blank = skip downgrade)
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  automated-acceptance:
+    name: Verify RC + staging (read-only) + produce report
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Extract the source-controlled release pubkey
+        id: pubkey
+        run: |
+          hex=$(python3 - <<'PY'
+          import re
+          s = open('include/hull/release.h').read()
+          m = re.search(r'define\s+HL_RELEASE_PUBKEY_HEX(.*?)(?=\n#|\n\n|\Z)', s, re.S)
+          h = ''.join(re.findall(r'"([0-9a-fA-F]*)"', m.group(1))) if m else ''
+          print(h if len(h) == 64 else '')
+          PY
+          )
+          echo "hex=$hex" >> "$GITHUB_OUTPUT"
+          if [ -n "$hex" ]; then echo "source release pubkey extracted"; else echo "using the candidate's embedded key (source pubkey not a 64-hex literal)"; fi
+
+      - name: Acceptance report - header
+        run: |
+          {
+            echo "# Release acceptance report (automated, read-only)"
+            echo
+            echo "- Official repo: \`${{ inputs.official_repo }}\`"
+            echo "- RC tag: \`${{ inputs.rc_tag }}\` (expect version \`${{ inputs.expect_version }}\`)"
+            echo "- Staging RC repo: \`${{ inputs.staging_rc_repo }}\`"
+            echo "- Prev tag: \`${{ inputs.prev_tag }}\`; staging prev repo: \`${{ inputs.staging_prev_repo || '(skipped)' }}\`"
+            echo "- Commit: \`${{ github.sha }}\`  Run: ${{ github.run_id }}"
+            echo
+            echo "| check | result |"
+            echo "| --- | --- |"
+          } > acceptance-report.md
+
+      - name: Verify official RC assets (signature, hashes, version)
+        run: |
+          sh tests/acceptance/verify_release_assets.sh \
+            "${{ inputs.official_repo }}" "${{ inputs.rc_tag }}" \
+            "${{ inputs.expect_version }}" "$PWD/rc-official" \
+            "${{ steps.pubkey.outputs.hex }}"
+          echo "| Official RC assets (sig + SHA-256 + version) | PASS |" >> acceptance-report.md
+
+      - name: Verify official previous-release assets
+        run: |
+          # Strip a leading 'v' for the version-string check.
+          prev_ver="${{ inputs.prev_tag }}"; prev_ver="${prev_ver#v}"
+          sh tests/acceptance/verify_release_assets.sh \
+            "${{ inputs.official_repo }}" "${{ inputs.prev_tag }}" \
+            "$prev_ver" "$PWD/prev-official" \
+            "${{ steps.pubkey.outputs.hex }}"
+          echo "| Official previous release ($prev_ver) assets | PASS |" >> acceptance-report.md
+
+      - name: Verify staging RC mirrors the official RC exactly
+        run: |
+          sh tests/acceptance/verify_staging_equivalence.sh \
+            "${{ inputs.staging_rc_repo }}" "$PWD/rc-official" \
+            "${{ inputs.expect_version }}" "$PWD/rc-staging" \
+            "${{ steps.pubkey.outputs.hex }}"
+          echo "| Staging RC /releases/latest mirrors official RC | PASS |" >> acceptance-report.md
+
+      - name: Verify staging previous mirrors the official previous (downgrade)
+        if: inputs.staging_prev_repo != ''
+        run: |
+          prev_ver="${{ inputs.prev_tag }}"; prev_ver="${prev_ver#v}"
+          sh tests/acceptance/verify_staging_equivalence.sh \
+            "${{ inputs.staging_prev_repo }}" "$PWD/prev-official" \
+            "$prev_ver" "$PWD/prev-staging" \
+            "${{ steps.pubkey.outputs.hex }}"
+          echo "| Staging previous /releases/latest mirrors official previous | PASS |" >> acceptance-report.md
+
+      - name: SBOM validation + delta vs previous
+        run: |
+          rc=./rc-official/hull-linux-x86_64
+          prev=./prev-official/hull-linux-x86_64
+          "$rc"   sbom --format=json > rc.sbom.json
+          "$prev" sbom --format=json > prev.sbom.json
+          # Well-formed + non-empty + carries the expected vendored components.
+          python3 - <<'PY'
+          import json,sys
+          rc=json.load(open('rc.sbom.json')); prev=json.load(open('prev.sbom.json'))
+          def names(s):
+              items = s if isinstance(s,list) else s.get('components', s.get('packages', []))
+              out=set()
+              for c in items:
+                  n=c.get('name') or c.get('packageName')
+                  if n: out.add(n)
+              return out
+          rcn, prevn = names(rc), names(prev)
+          assert rcn, 'RC SBOM has no components'
+          for core in ('keel','quickjs','lua','sqlite','mbedtls','wamr'):
+              assert any(core in x.lower() for x in rcn), f'RC SBOM missing {core}'
+          added=sorted(rcn-prevn); removed=sorted(prevn-rcn)
+          open('sbom-delta.txt','w').write(
+              'added: '+(', '.join(added) or '(none)')+'\n'+
+              'removed: '+(', '.join(removed) or '(none)')+'\n')
+          print('SBOM ok; added',added,'removed',removed)
+          PY
+          {
+            echo "| SBOM well-formed + core components present | PASS |"
+            echo
+            echo '### SBOM delta (RC vs previous)'
+            echo '```'
+            cat sbom-delta.txt
+            echo '```'
+          } >> acceptance-report.md
+
+      - name: install.sh dry-run + completions
+        run: |
+          sh tests/e2e_install.sh
+          echo "| install.sh dry-run (platform/flavor/prefix) + completions | PASS |" >> acceptance-report.md
+
+      - name: Release smoke (install a signed tool from the RC, read-only)
+        run: |
+          # release_smoke.sh installs a signed tool from the RC release into a
+          # throwaway HOME, exercises it, and uninstalls - it never touches a
+          # release. Pinned to the RC via the candidate binary's HL_VERSION.
+          export HOME="$RUNNER_TEMP/smoke-home"; mkdir -p "$HOME"
+          HULL="$PWD/rc-official/hull-linux-x86_64" sh tests/release_smoke.sh
+          echo "| Release smoke (signed tool install from RC) | PASS |" >> acceptance-report.md
+
+      - name: Reproducible-build confirmation on the RC commit
+        run: |
+          # Read-only: assert the RC tag's commit has passing reproducible-build
+          # check runs (the per-commit Reproducible build jobs already gate bit
+          # reproducibility; we confirm they are green on the tagged commit).
+          sha=$(gh api "repos/${{ inputs.official_repo }}/git/refs/tags/${{ inputs.rc_tag }}" \
+                  --jq '.object.sha')
+          # tags may be annotated; deref to the commit
+          typ=$(gh api "repos/${{ inputs.official_repo }}/git/tags/$sha" --jq '.object.sha' 2>/dev/null || echo "")
+          [ -n "$typ" ] && sha="$typ"
+          runs=$(gh api "repos/${{ inputs.official_repo }}/commits/$sha/check-runs" --paginate \
+                   --jq '.check_runs[] | select(.name|test("Reproducible build")) | .name+"="+(.conclusion//"pending")')
+          echo "$runs"
+          if [ -z "$runs" ]; then
+            echo "FAIL: no reproducible-build check runs found on $sha"; exit 1
+          fi
+          if echo "$runs" | grep -vq '=success$'; then
+            echo "FAIL: a reproducible-build check is not green on the RC commit"; exit 1
+          fi
+          echo "| Reproducible-build checks green on RC commit | PASS |" >> acceptance-report.md
+
+      - name: Acceptance report - footer
+        if: always()
+        run: |
+          {
+            echo
+            echo "_Automated read-only phase complete. Windows acceptance (Phase 3b)"
+            echo "runs against \`${{ inputs.staging_rc_repo }}\` (upgrade) and the previous"
+            echo "staging repo (downgrade)._"
+          } >> acceptance-report.md
+          echo '--- report ---'; cat acceptance-report.md
+
+      - name: Upload acceptance report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: acceptance-report-automated
+          path: |
+            acceptance-report.md
+            sbom-delta.txt

--- a/.github/workflows/release-acceptance.yml
+++ b/.github/workflows/release-acceptance.yml
@@ -1,9 +1,10 @@
 name: Release acceptance (automated, read-only)
 
-# Phase 3a of the release-acceptance run (docs/release_acceptance.md). Verifies a
-# published release candidate and the maintainer-prepopulated staging mirror(s)
-# WITHOUT mutating any release, and produces an acceptance report the Windows
-# job (Phase 3b) consumes. This workflow NEVER creates, modifies, or deletes a
+# The automated, read-only stage of the release-acceptance run
+# (docs/release_acceptance.md). Verifies a published release candidate and the
+# maintainer-prepopulated staging mirror(s) WITHOUT mutating any release, and
+# produces an acceptance report the Windows acceptance job consumes. This
+# workflow NEVER creates, modifies, or deletes a
 # tag, release, or asset, and never alters "latest": it only reads and verifies.
 #
 # Prerequisite (a manual, auditable maintainer step - NOT done here):
@@ -194,7 +195,7 @@ jobs:
         run: |
           {
             echo
-            echo "_Automated read-only phase complete. Windows acceptance (Phase 3b)"
+            echo "_Automated read-only stage complete. The Windows acceptance job"
             echo "runs against \`${{ inputs.staging_rc_repo }}\` (upgrade) and the previous"
             echo "staging repo (downgrade)._"
           } >> acceptance-report.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,7 @@ specific signature, parameter list, or return value.
 | [`tools_install.md`](tools_install.md) | Side-loaded companion tools (`hull tools install`), the version-coupled trust chain, single-binary vs bundle assets. |
 | [`composed_feature_signing.md`](composed_feature_signing.md) | `package.sig.gethull.composed` - attesting every composed archive across the platform + release trust domains. |
 | [`release_signing.md`](release_signing.md) | Three-layer signature system + the release-key flow (embedding, sign step, `hull update` verification). |
+| [`release_acceptance.md`](release_acceptance.md) | The pre-promotion acceptance run: the read-only fail-closed verification workflow, the maintainer-prepopulated staging-repo model for testing `hull update`, and the Windows acceptance stage. |
 | [`sbom.md`](sbom.md) | The SBOM subsystem (human / JSON / CycloneDX / SPDX formats). |
 | [`compiler_free_build.md`](compiler_free_build.md) | The object-emitter path: `hull build` needs only a linker (no C compiler). |
 | [`toolchain_free_build.md`](toolchain_free_build.md) | Linker-as-tool + cross-compilation (`--linker=zig`), the musl static-link floors. |

--- a/docs/release_acceptance.md
+++ b/docs/release_acceptance.md
@@ -1,0 +1,78 @@
+# Release acceptance run
+
+The acceptance run gates a release candidate before it is promoted to a final
+release. It has two phases, each a checked-in CI workflow:
+
+- **Phase 3a - automated, read-only** (`.github/workflows/release-acceptance.yml`):
+  verifies the published RC and the maintainer-prepopulated staging mirror(s),
+  and produces an acceptance report. It never mutates a release.
+- **Phase 3b - Windows acceptance** (a `windows-latest` job, added separately):
+  runs the real Windows behavior that cannot be proven on other hosts -
+  non-admin cosmocc install, a real self-update, and ACL-induced rollback.
+
+Both phases must pass before the final tag is created.
+
+## Why staging repositories
+
+`hull update` always reads a repository's `/releases/latest` endpoint. `--repo`
+changes *which* repository, but it cannot select a tag or a prerelease. So to
+exercise a real Windows self-update against a candidate, the candidate's signed
+assets are mirrored into a dedicated **staging repository** as *that* repo's
+latest **non-prerelease**, and the Windows job runs
+`hull update --repo=<staging>`.
+
+Two small staging repositories are used so upgrade and downgrade each have a
+stable `/releases/latest` without mutating release state during the run:
+
+- `<staging_rc_repo>` - latest mirrors the RC (e.g. `v0.14.0-rc1`).
+- `<staging_prev_repo>` - latest mirrors the previous signed release
+  (e.g. `v0.13.0`), for downgrade.
+
+## Maintainer preconditions (manual, auditable - not done by CI)
+
+1. Publish `v0.14.0-rc1` as an official **prerelease** on the main repo (the
+   tag-triggered release workflow builds + signs + publishes the four binaries,
+   `hull.sha256`, and `hull.sha256.sig`).
+2. Mirror the **exact** signed RC assets, unchanged, into `<staging_rc_repo>` as
+   its latest **non-prerelease**.
+3. Mirror the exact signed `v0.13.0` assets into `<staging_prev_repo>` as its
+   latest non-prerelease.
+4. The acceptance workflows are **read-only**: they never create, modify, or
+   delete a tag, release, or asset, and never alter "latest". Removing the
+   staging releases after final promotion is likewise a manual maintainer step.
+
+## Fail-closed verification
+
+Phase 3a fails unless **all** hold (per repo checked):
+
+- every mirrored asset exists;
+- each staging asset's SHA-256 **exactly** matches the official asset;
+- `hull.sha256.sig` verifies (against the source-controlled release pubkey when
+  extractable, else the candidate's embedded key);
+- the staging release is **not** a prerelease **and** is returned by
+  `/releases/latest`;
+- the candidate binary reports the expected version (`0.14.0-rc1`).
+
+It also validates the SBOM (well-formed, core components present) and reports the
+delta vs the previous release, runs the `install.sh` dry-run and the signed-tool
+release smoke, and confirms the RC commit's reproducible-build checks are green.
+
+## Running Phase 3a
+
+```
+gh workflow run "Release acceptance (automated, read-only)" \
+  -f rc_tag=v0.14.0-rc1 \
+  -f expect_version=0.14.0-rc1 \
+  -f staging_rc_repo=<org>/<staging-rc> \
+  -f staging_prev_repo=<org>/<staging-prev>
+```
+
+The run uploads `acceptance-report-automated` (a Markdown report + SBOM delta)
+for review and for the Windows phase to reference.
+
+## Promotion
+
+Only after both phases are green: create the final `v0.14.0` tag (fresh signed
+artifacts), re-run the smoke checks against the final release, update
+`install.sh` / the site / README to advertise `0.14.0`, and remove the staging
+releases.

--- a/docs/release_acceptance.md
+++ b/docs/release_acceptance.md
@@ -3,10 +3,10 @@
 The acceptance run gates a release candidate before it is promoted to a final
 release. It has two phases, each a checked-in CI workflow:
 
-- **Phase 3a - automated, read-only** (`.github/workflows/release-acceptance.yml`):
+- **Automated, read-only stage** (`.github/workflows/release-acceptance.yml`):
   verifies the published RC and the maintainer-prepopulated staging mirror(s),
   and produces an acceptance report. It never mutates a release.
-- **Phase 3b - Windows acceptance** (a `windows-latest` job, added separately):
+- **Windows acceptance stage** (a `windows-latest` job, added separately):
   runs the real Windows behavior that cannot be proven on other hosts -
   non-admin cosmocc install, a real self-update, and ACL-induced rollback.
 
@@ -43,7 +43,7 @@ stable `/releases/latest` without mutating release state during the run:
 
 ## Fail-closed verification
 
-Phase 3a fails unless **all** hold (per repo checked):
+The automated read-only stage fails unless **all** hold (per repo checked):
 
 - every mirrored asset exists;
 - each staging asset's SHA-256 **exactly** matches the official asset;
@@ -57,7 +57,7 @@ It also validates the SBOM (well-formed, core components present) and reports th
 delta vs the previous release, runs the `install.sh` dry-run and the signed-tool
 release smoke, and confirms the RC commit's reproducible-build checks are green.
 
-## Running Phase 3a
+## Running the automated read-only stage
 
 ```
 gh workflow run "Release acceptance (automated, read-only)" \

--- a/tests/acceptance/verify_release_assets.sh
+++ b/tests/acceptance/verify_release_assets.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# verify_release_assets.sh - READ-ONLY verification of a published release.
+#
+# Downloads a release's assets and verifies, WITHOUT mutating any release:
+#   1. all six assets are present
+#      (hull-linux-x86_64 / -aarch64 / hull-darwin-arm64 / hull-cosmo /
+#       hull.sha256 / hull.sha256.sig)
+#   2. hull.sha256.sig verifies (against the source-controlled release pubkey
+#      when one is passed, else the candidate binary's embedded key)
+#   3. each binary's SHA-256 matches its hull.sha256 line
+#   4. the linux-x86_64 binary reports the expected version string
+#
+# Never creates, modifies, or deletes a release. Only HTTP GETs.
+#
+# Usage: verify_release_assets.sh <repo> <tag> <expect_version> <workdir> [pubkey_hex]
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+repo="$1"; tag="$2"; expect_ver="$3"; work="$4"; pubkey="${5:-}"
+base="https://github.com/$repo/releases/download/$tag"
+bins="hull-linux-x86_64 hull-linux-aarch64 hull-darwin-arm64 hull-cosmo"
+all="$bins hull.sha256 hull.sha256.sig"
+
+mkdir -p "$work"
+cd "$work"
+
+# 1. presence
+for a in $all; do
+    curl -fsSL -o "$a" "$base/$a" \
+        || { echo "FAIL: missing asset '$a' in $repo@$tag"; exit 1; }
+done
+chmod +x hull-linux-x86_64
+
+# 2. signature - source pubkey if given (verification independent of the
+#    artifact's own embedded key), otherwise the embedded key.
+if [ -n "$pubkey" ]; then
+    ./hull-linux-x86_64 verify-release hull.sha256 hull.sha256.sig --pubkey "$pubkey" \
+        || { echo "FAIL: hull.sha256.sig does not verify against the source release pubkey"; exit 1; }
+else
+    ./hull-linux-x86_64 verify-release hull.sha256 hull.sha256.sig \
+        || { echo "FAIL: hull.sha256.sig does not verify against the embedded key"; exit 1; }
+fi
+
+# 3. per-binary SHA-256 vs the manifest
+for a in $bins; do
+    want=$(grep "  $a\$" hull.sha256 | awk '{print $1}')
+    [ -n "$want" ] || { echo "FAIL: $a has no line in hull.sha256"; exit 1; }
+    got=$(sha256sum "$a" | awk '{print $1}')
+    [ "$want" = "$got" ] \
+        || { echo "FAIL: $a SHA-256 mismatch (manifest $want, file $got)"; exit 1; }
+done
+
+# 4. candidate version
+ver=$(./hull-linux-x86_64 version 2>&1 | head -1)
+echo "$ver" | grep -q "$expect_ver" \
+    || { echo "FAIL: candidate reports '$ver', expected to contain '$expect_ver'"; exit 1; }
+
+echo "OK: $repo@$tag - 6 assets present, signature valid, hashes match, version '$ver'"

--- a/tests/acceptance/verify_staging_equivalence.sh
+++ b/tests/acceptance/verify_staging_equivalence.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# verify_staging_equivalence.sh - READ-ONLY proof that a maintainer-prepopulated
+# staging repository's /releases/latest mirrors an official release EXACTLY, so
+# the Windows self-update job can point `hull update --repo=<staging>` at it
+# (hull update only ever reads a repo's /releases/latest; it cannot select a tag
+# or a prerelease).
+#
+# Fails closed unless ALL hold:
+#   - the staging repo's /releases/latest exists and is NOT a prerelease
+#   - every asset the reference release has is present in the staging release
+#   - each staging asset's SHA-256 EXACTLY matches the reference asset
+#   - hull.sha256.sig verifies (source pubkey when passed, else embedded)
+#   - the staging binary reports the expected version
+#
+# Never creates, modifies, or deletes a release. `gh api` GET + HTTP GETs only.
+#
+# Usage:
+#   verify_staging_equivalence.sh <staging_repo> <ref_dir> <expect_version> \
+#                                 <workdir> [pubkey_hex]
+#   <ref_dir> is a directory already holding the trusted OFFICIAL assets
+#   (produced by verify_release_assets.sh) to compare against.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+staging="$1"; ref="$2"; expect_ver="$3"; work="$4"; pubkey="${5:-}"
+bins="hull-linux-x86_64 hull-linux-aarch64 hull-darwin-arm64 hull-cosmo"
+all="$bins hull.sha256 hull.sha256.sig"
+
+# /releases/latest metadata (read-only)
+meta=$(gh api "repos/$staging/releases/latest" 2>/dev/null) \
+    || { echo "FAIL: $staging has no /releases/latest (nothing published as latest)"; exit 1; }
+pre=$(printf '%s' "$meta" | python3 -c 'import sys,json;print(json.load(sys.stdin)["prerelease"])')
+tag=$(printf '%s' "$meta" | python3 -c 'import sys,json;print(json.load(sys.stdin)["tag_name"])')
+[ "$pre" = "False" ] \
+    || { echo "FAIL: $staging /releases/latest ($tag) is a prerelease; hull update would not select it"; exit 1; }
+
+base="https://github.com/$staging/releases/download/$tag"
+mkdir -p "$work"
+cd "$work"
+
+# Every reference asset must be present in staging AND byte-identical.
+for a in $all; do
+    [ -f "$ref/$a" ] || { echo "FAIL: reference set is missing $a"; exit 1; }
+    curl -fsSL -o "$a" "$base/$a" \
+        || { echo "FAIL: $staging is missing asset '$a'"; exit 1; }
+    s=$(sha256sum "$a"       | awk '{print $1}')
+    r=$(sha256sum "$ref/$a"  | awk '{print $1}')
+    [ "$s" = "$r" ] \
+        || { echo "FAIL: $staging $a differs from the official release (staging $s, official $r)"; exit 1; }
+done
+chmod +x hull-linux-x86_64
+
+if [ -n "$pubkey" ]; then
+    ./hull-linux-x86_64 verify-release hull.sha256 hull.sha256.sig --pubkey "$pubkey" \
+        || { echo "FAIL: $staging hull.sha256.sig does not verify against the source pubkey"; exit 1; }
+else
+    ./hull-linux-x86_64 verify-release hull.sha256 hull.sha256.sig \
+        || { echo "FAIL: $staging hull.sha256.sig does not verify against the embedded key"; exit 1; }
+fi
+
+ver=$(./hull-linux-x86_64 version 2>&1 | head -1)
+echo "$ver" | grep -q "$expect_ver" \
+    || { echo "FAIL: $staging candidate reports '$ver', expected to contain '$expect_ver'"; exit 1; }
+
+echo "OK: $staging /releases/latest ($tag) mirrors the official release exactly; version '$ver'"


### PR DESCRIPTION
Phase 3a of the v0.14.0 release-acceptance run — the **automated, read-only** half of the split (Phase 3b = the Windows job, separate PR).

## What it is
A `workflow_dispatch` workflow (`permissions: contents: read`) that verifies a published RC and the maintainer-prepopulated staging mirror(s) and emits an acceptance report. It **never** creates/modifies/deletes a tag, release, or asset, and never alters `latest` — only HTTP GETs and `gh api` reads.

## Why staging repos
`hull update` only reads a repo's `/releases/latest` and cannot select a tag or prerelease. So the real Windows self-update (3b) points `hull update --repo=<staging>` at a maintainer-prepopulated staging repo whose latest **non-prerelease** mirrors the signed RC. **3a proves that mirror is byte-for-byte the official RC** before 3b trusts it. Two staging repos (RC + previous) so upgrade and downgrade each have a stable `/releases/latest`.

## Fail-closed checks
- **Official RC** (`verify_release_assets.sh`): 6 assets present; `hull.sha256.sig` verifies against the source-controlled release pubkey (extracted from `release.h`, else the candidate's embedded key); per-binary SHA-256 matches `hull.sha256`; candidate reports `0.14.0-rc1`.
- **Official previous** (`v0.13.0`) verified the same way (downgrade baseline).
- **Staging RC / staging previous** (`verify_staging_equivalence.sh`): `/releases/latest` is non-prerelease **and** byte-identical to the official release.
- **SBOM**: well-formed + core components present + delta vs previous reported.
- **install.sh** dry-run + completions (`e2e_install.sh`).
- **Release smoke**: signed-tool install from the RC into a throwaway HOME (`release_smoke.sh`).
- **Reproducibility**: the RC commit's reproducible-build checks are green.

Uploads `acceptance-report-automated` (report + SBOM delta) for the Windows job.

## Files
- `.github/workflows/release-acceptance.yml`
- `tests/acceptance/verify_release_assets.sh`, `verify_staging_equivalence.sh`
- `docs/release_acceptance.md` (maintainer runbook + the read-only / staging model)

## Local validation
Pubkey extraction returns a 64-hex key; the SBOM parser finds 15 components incl. all 6 core libs; scripts pass `sh -n`; workflow YAML parses. The full run is exercised on first dispatch (needs the published RC + staging repos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)