### PR TITLE
ci(release): Windows acceptance job (self-update, ACL rollback, non-admin)

### DIFF
--- a/.github/workflows/release-acceptance-windows.yml
+++ b/.github/workflows/release-acceptance-windows.yml
@@ -1,0 +1,79 @@
+name: Release acceptance (Windows, read-only)
+
+# The Windows stage of the release-acceptance run (docs/release_acceptance.md):
+# the real Windows behavior that cannot be proven on other hosts - a genuinely
+# non-admin, Developer-Mode-off environment, a real self-update via the
+# maintainer-prepopulated staging mirror, and an ACL-induced mid-swap rollback.
+#
+# READ-ONLY with respect to releases: it downloads the previous release's Windows
+# APE and drives `hull update --repo=<staging>` against the maintainer-populated
+# staging repos. It never creates, modifies, or deletes a tag, release, or asset.
+#
+# All the logic lives in checked-in PowerShell (tests/acceptance/windows/*.ps1);
+# this workflow only wires inputs and uploads the evidence report. Every
+# prerequisite is fail-closed: the run fails unless the child token is proven
+# non-admin, Developer Mode is disabled, control symlink creation is denied, and
+# the ACL test reaches the mid-swap install failure (not an earlier stage).
+
+on:
+  workflow_dispatch:
+    inputs:
+      official_repo:
+        description: Official repository (for the previous-release APE)
+        required: true
+        default: artalis-io/hull
+      prev_tag:
+        description: Previous release tag (the starting APE)
+        required: true
+        default: v0.13.0
+      prev_version:
+        description: Version string the previous APE reports
+        required: true
+        default: 0.13.0
+      staging_rc_repo:
+        description: Staging repo whose latest mirrors the RC (ORG/NAME)
+        required: true
+      expect_version:
+        description: Version string the candidate must report after update
+        required: true
+        default: 0.14.0-rc1
+      staging_prev_repo:
+        description: Staging repo whose latest mirrors the previous release (optional; blank = skip downgrade)
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  windows-acceptance:
+    name: Windows acceptance (non-admin, self-update, ACL rollback)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Run Windows acceptance as a standard user
+        shell: pwsh
+        run: |
+          Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+          $ev = Join-Path $env:RUNNER_TEMP 'windows-acceptance-evidence.md'
+          & tests/acceptance/windows/run.ps1 `
+            -OfficialRepo '${{ inputs.official_repo }}' `
+            -PrevTag '${{ inputs.prev_tag }}' `
+            -PrevVersion '${{ inputs.prev_version }}' `
+            -RcRepo '${{ inputs.staging_rc_repo }}' `
+            -ExpectVersion '${{ inputs.expect_version }}' `
+            -PrevRepo '${{ inputs.staging_prev_repo }}' `
+            -Evidence $ev `
+            -WorkDir (Join-Path $env:RUNNER_TEMP 'wacc')
+          $code = $LASTEXITCODE
+          Get-Content $ev | ForEach-Object { Write-Host $_ }
+          Copy-Item $ev "$env:GITHUB_STEP_SUMMARY" -Force
+          if ($code -ne 0) { throw "Windows acceptance FAILED (see evidence report)" }
+
+      - name: Upload evidence report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: windows-acceptance-evidence
+          path: ${{ runner.temp }}/windows-acceptance-evidence.md

--- a/docs/release_acceptance.md
+++ b/docs/release_acceptance.md
@@ -6,9 +6,19 @@ release. It has two phases, each a checked-in CI workflow:
 - **Automated, read-only stage** (`.github/workflows/release-acceptance.yml`):
   verifies the published RC and the maintainer-prepopulated staging mirror(s),
   and produces an acceptance report. It never mutates a release.
-- **Windows acceptance stage** (a `windows-latest` job, added separately):
-  runs the real Windows behavior that cannot be proven on other hosts -
-  non-admin cosmocc install, a real self-update, and ACL-induced rollback.
+- **Windows acceptance stage** (`.github/workflows/release-acceptance-windows.yml`,
+  logic in `tests/acceptance/windows/*.ps1`): runs the real Windows behavior that
+  cannot be proven on other hosts, all as a freshly-created standard (non-admin)
+  user with Developer Mode disabled. Fail-closed unless the child token is proven
+  non-admin, Developer Mode is off, and control symlink creation is denied
+  (`preconditions.ps1`). Then: a real self-update of the previous APE to the
+  candidate via the RC staging repo (`self_update.ps1`); an ACL-induced mid-swap
+  **rollback** proven to reach the install-step failure, not an earlier stage
+  (`rollback_acl.ps1`); and `extras.ps1` - a spaces-path self-update, non-admin
+  `hull tools install cosmocc`, a Lua and a JS `/ping` build+serve, a nested
+  local-module build+serve, and doctor / tools-list / agent-tools agreement.
+  Optional downgrade via the previous staging repo (`downgrade.ps1`). It is
+  read-only with respect to releases.
 
 Both phases must pass before the final tag is created.
 
@@ -68,7 +78,20 @@ gh workflow run "Release acceptance (automated, read-only)" \
 ```
 
 The run uploads `acceptance-report-automated` (a Markdown report + SBOM delta)
-for review and for the Windows phase to reference.
+for review and for the Windows stage to reference.
+
+## Running the Windows stage
+
+```
+gh workflow run "Release acceptance (Windows, read-only)" \
+  -f staging_rc_repo=<org>/<staging-rc> \
+  -f staging_prev_repo=<org>/<staging-prev> \
+  -f expect_version=0.14.0-rc1
+```
+
+It uploads `windows-acceptance-evidence` (per-check evidence: the non-admin
+token proof, Developer-Mode state, the denied symlink, the self-update residue
+sweep, and the ACL rollback reaching the mid-swap install failure).
 
 ## Promotion
 

--- a/tests/acceptance/windows/downgrade.ps1
+++ b/tests/acceptance/windows/downgrade.ps1
@@ -1,0 +1,54 @@
+<#
+  downgrade.ps1 - prove a real Windows DOWNGRADE via a staging repo, run AS the
+  standard user. `hull update` only reads /releases/latest and only advances by
+  default, so downgrade uses `--force` against a staging repo whose latest
+  mirrors the PREVIOUS signed release.
+
+  Starts from a fresh previous-release APE, updates UP to the candidate (via the
+  RC staging repo), then FORCE-updates back DOWN to the previous release (via the
+  previous staging repo). Fail-closed assertions:
+    - the up-update reports the candidate version;
+    - the forced down-update returns success and reports the previous version;
+    - no <self>.new residue; <self>.old is swept on the next startup.
+
+  Usage: downgrade.ps1 -Hull <exe> -RcRepo <org/staging-rc> -PrevRepo <org/staging-prev> \
+                       -RcVersion 0.14.0-rc1 -PrevVersion 0.13.0 -Evidence <file>
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)][string]$Hull,
+    [Parameter(Mandatory=$true)][string]$RcRepo,
+    [Parameter(Mandatory=$true)][string]$PrevRepo,
+    [Parameter(Mandatory=$true)][string]$RcVersion,
+    [Parameter(Mandatory=$true)][string]$PrevVersion,
+    [Parameter(Mandatory=$true)][string]$Evidence
+)
+
+$ErrorActionPreference = 'Stop'
+function Note($m) { Add-Content -Path $Evidence -Value $m; Write-Host $m }
+function Fail($m) { Note ("  FAIL: {0}" -f $m); $script:fail = 1 }
+$script:fail = 0
+$new = "$Hull.new"; $old = "$Hull.old"
+
+Note "## Downgrade (staging-repo based)"
+# Up to the candidate first.
+& $Hull update --repo $RcRepo *> $null
+$up = (& $Hull version 2>&1 | Select-Object -First 1)
+Note ("- after up-update: {0}" -f $up)
+if ($up -notmatch [regex]::Escape($RcVersion)) { Fail "up-update did not reach $RcVersion"; }
+
+# Forced downgrade to the previous release.
+$out = & $Hull update --force --repo $PrevRepo 2>&1; $code = $LASTEXITCODE
+Note (($out | Out-String) -replace '(?m)^','    ')
+if ($code -ne 0) { Fail "forced downgrade returned non-zero" }
+$down = (& $Hull version 2>&1 | Select-Object -First 1)
+Note ("- after forced down-update: {0}" -f $down)
+if ($down -notmatch [regex]::Escape($PrevVersion)) { Fail "downgrade did not reach $PrevVersion" }
+
+if (Test-Path $new) { Fail "<self>.new residue after downgrade" }
+& $Hull version *> $null
+if (Test-Path $old) { Fail "<self>.old not swept after downgrade" }
+
+if ($script:fail -ne 0) { Note "DOWNGRADE: FAIL"; exit 1 }
+Note "DOWNGRADE: OK ($RcVersion -> $PrevVersion via forced staging update)"
+exit 0

--- a/tests/acceptance/windows/extras.ps1
+++ b/tests/acceptance/windows/extras.ps1
@@ -1,0 +1,132 @@
+<#
+  extras.ps1 - the remaining Windows acceptance bullets, run AS the standard
+  user with the CANDIDATE hull already installed:
+
+    - self-update works from a PATH CONTAINING SPACES;
+    - non-admin `hull tools install cosmocc` succeeds (validated hardlinks, #425);
+    - `hull build` + serve a minimal Lua AND JS /ping app -> "pong";
+    - a nested local-module app builds and serves (extraction/built parity, #423);
+    - `hull doctor`, `hull tools list`, `hull agent tools` agree on cosmocc.
+
+  Fail-closed: any check that does not hold sets the failure flag and the script
+  exits non-zero.
+
+  Usage:
+    extras.ps1 -Hull <candidate-exe> -PrevHull <prev-exe> -RcRepo <org/staging-rc> \
+               -ExpectVersion 0.14.0-rc1 -Evidence <file>
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)][string]$Hull,
+    [Parameter(Mandatory=$true)][string]$PrevHull,
+    [Parameter(Mandatory=$true)][string]$RcRepo,
+    [Parameter(Mandatory=$true)][string]$ExpectVersion,
+    [Parameter(Mandatory=$true)][string]$Evidence
+)
+
+$ErrorActionPreference = 'Stop'
+function Note($m) { Add-Content -Path $Evidence -Value $m; Write-Host $m }
+function Fail($m) { Note ("  FAIL: {0}" -f $m); $script:fail = 1 }
+$script:fail = 0
+$work = Join-Path $env:TEMP ("hull-accept-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $work | Out-Null
+
+# Serve a built APE and curl a path; returns the response body (or '').
+function Serve-And-Get([string]$exe, [string]$appPath, [int]$port, [string]$route) {
+    $p = Start-Process -FilePath $exe -ArgumentList @($appPath, '-p', "$port") -PassThru -WindowStyle Hidden
+    try {
+        for ($i = 0; $i -lt 40; $i++) {
+            Start-Sleep -Milliseconds 250
+            try { return (Invoke-RestMethod -Uri "http://127.0.0.1:$port$route" -TimeoutSec 2) } catch {}
+        }
+        return ''
+    } finally { $p | Stop-Process -Force -ErrorAction SilentlyContinue }
+}
+
+# --- 1. self-update from a path with spaces ---------------------------------
+Note "## Self-update from a path with spaces"
+$spaceDir = Join-Path $work 'hull test dir with spaces'
+New-Item -ItemType Directory -Path $spaceDir | Out-Null
+$spaceHull = Join-Path $spaceDir 'my hull.com'
+Copy-Item $PrevHull $spaceHull
+$sc = & $spaceHull update --repo $RcRepo 2>&1; $rc = $LASTEXITCODE
+Note (($sc | Out-String) -replace '(?m)^','    ')
+if ($rc -ne 0) { Fail "self-update from a spaces path returned non-zero" }
+$sv = (& $spaceHull version 2>&1 | Select-Object -First 1)
+if ($sv -notmatch [regex]::Escape($ExpectVersion)) { Fail "spaces-path candidate is not $ExpectVersion (got '$sv')" }
+else { Note "- OK: updated to '$sv' from a spaces path" }
+
+# --- 2. non-admin cosmocc install -------------------------------------------
+Note "## Non-admin cosmocc install"
+$ci = & $Hull tools install cosmocc 2>&1; $rc = $LASTEXITCODE
+Note (($ci | Out-String) -replace '(?m)^','    ')
+if ($rc -ne 0) { Fail "hull tools install cosmocc returned non-zero (non-admin)" } else { Note "- OK: cosmocc installed non-admin" }
+
+# --- 3. build + serve minimal Lua and JS /ping ------------------------------
+Note "## Build + serve /ping (Lua + JS)"
+$lua = @'
+app.manifest({ modules = { "hull/http-server@1" } })
+app.get("/ping", function(req, res) res:text("pong") end)
+'@
+$js = @'
+import { app } from "hull:app";
+app.manifest({ modules: ["hull/http-server@1"] });
+app.get("/ping", (req, res) => res.text("pong"));
+'@
+foreach ($case in @(@{ext='lua';src=$lua;port=39701}, @{ext='js';src=$js;port=39702})) {
+    $adir = Join-Path $work ("ping-" + $case.ext)
+    New-Item -ItemType Directory -Path $adir | Out-Null
+    Set-Content -Path (Join-Path $adir ("app." + $case.ext)) -Value $case.src
+    $bout = & $Hull build $adir -o (Join-Path $adir 'out.com') 2>&1; $rc = $LASTEXITCODE
+    if ($rc -ne 0) { Note (($bout | Out-String) -replace '(?m)^','    '); Fail ("hull build failed for the " + $case.ext + " /ping app"); continue }
+    $body = Serve-And-Get (Join-Path $adir 'out.com') (Join-Path $adir 'out.com') $case.port '/ping'
+    if ("$body".Trim() -eq 'pong') { Note ("- OK: " + $case.ext + " /ping served pong") }
+    else { Fail ($case.ext + " /ping did not serve pong (got '" + $body + "')") }
+}
+
+# --- 4. nested local-module app builds + serves (extraction/built parity) ----
+Note "## Nested local-module app (built parity)"
+$nd = Join-Path $work 'nested'
+New-Item -ItemType Directory -Path (Join-Path $nd 'routes') | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $nd 'lib')    | Out-Null
+Set-Content (Join-Path $nd 'app.lua') @'
+local users = require("./routes/users")
+app.manifest({ modules = { "hull/http-server@1" } })
+users.register(app)
+'@
+Set-Content (Join-Path $nd 'routes\users.lua') @'
+local auth = require("./../lib/auth")
+local M = {}
+function M.register(app) app.get("/who", function(req, res) res:text(auth.who()) end) end
+return M
+'@
+Set-Content (Join-Path $nd 'lib\auth.lua') @'
+return { who = function() return "nested-ok" end }
+'@
+$nb = & $Hull build $nd -o (Join-Path $nd 'out.com') 2>&1; $rc = $LASTEXITCODE
+if ($rc -ne 0) { Note (($nb | Out-String) -replace '(?m)^','    '); Fail "nested-module app build failed" }
+else {
+    $body = Serve-And-Get (Join-Path $nd 'out.com') (Join-Path $nd 'out.com') 39703 '/who'
+    if ("$body".Trim() -eq 'nested-ok') { Note "- OK: built nested-module app resolved ./routes -> ./../lib and served" }
+    else { Fail "nested-module built app did not serve the deep-resolved value (got '$body')" }
+}
+
+# --- 5. doctor / tools list / agent tools agree on cosmocc -------------------
+Note "## doctor / tools list / agent tools agree on cosmocc"
+$doc = (& $Hull doctor --json 2>$null | ConvertFrom-Json)
+$tl  = (& $Hull tools list --json 2>$null | ConvertFrom-Json)
+$at  = (& $Hull agent tools 2>$null | ConvertFrom-Json)
+$docCosmocc = ($doc.compilers | Where-Object { $_.name -eq 'cosmocc' }).path
+$tlCosmocc  = ($tl.tools     | Where-Object { $_.name -eq 'cosmocc' })
+$atCosmocc  = ($at.tools     | Where-Object { $_.name -eq 'cosmocc' })
+Note ("- doctor cosmocc path: {0}" -f $docCosmocc)
+Note ("- tools-list cosmocc: installed={0} source={1} path={2}" -f $tlCosmocc.installed, $tlCosmocc.source, $tlCosmocc.path)
+Note ("- agent-tools cosmocc: installed={0} path={1}" -f $atCosmocc.installed, $atCosmocc.path)
+if (-not $docCosmocc)         { Fail "doctor did not resolve cosmocc" }
+if (-not $tlCosmocc.installed){ Fail "tools list does not report cosmocc installed" }
+if (-not $atCosmocc.installed){ Fail "agent tools does not report cosmocc installed" }
+
+Remove-Item $work -Recurse -Force -ErrorAction SilentlyContinue
+if ($script:fail -ne 0) { Note "EXTRAS: FAIL"; exit 1 }
+Note "EXTRAS: OK (spaces, cosmocc install, Lua/JS pong, nested parity, doctor/tools agreement)"
+exit 0

--- a/tests/acceptance/windows/preconditions.ps1
+++ b/tests/acceptance/windows/preconditions.ps1
@@ -1,0 +1,70 @@
+<#
+  preconditions.ps1 - FAIL-CLOSED verification that this process runs in a
+  genuinely restricted Windows environment, run AS the standard (non-admin)
+  acceptance user. Records evidence for each check and exits non-zero unless ALL
+  of the following hold:
+
+    1. the current token is NOT an administrator and is NOT elevated;
+    2. Developer Mode is disabled (machine policy);
+    3. creating a symbolic link is DENIED (the runtime signal that this account
+       lacks SeCreateSymbolicLinkPrivilege, i.e. neither elevated nor Dev-Mode).
+
+  This is the gate that makes the non-admin cosmocc-extraction + self-update
+  evidence meaningful: if any precondition is not as expected, the run fails here
+  rather than silently proving something on a too-permissive environment.
+
+  Usage: preconditions.ps1 -Evidence <path-to-evidence-file>
+#>
+[CmdletBinding()]
+param([Parameter(Mandatory=$true)][string]$Evidence)
+
+$ErrorActionPreference = 'Stop'
+function Note($m) { Add-Content -Path $Evidence -Value $m; Write-Host $m }
+
+$fail = 0
+Note "## Windows preconditions (as $(whoami))"
+
+# 1. Non-admin + not elevated -------------------------------------------------
+$id  = [Security.Principal.WindowsIdentity]::GetCurrent()
+$pri = New-Object Security.Principal.WindowsPrincipal($id)
+$isAdmin = $pri.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+# Token elevation: a full (elevated) token has integrity level High (S-1-16-12288).
+$groups  = whoami /groups
+$isHigh  = ($groups -match 'S-1-16-12288')      # High mandatory level
+$isMed   = ($groups -match 'S-1-16-8192')       # Medium mandatory level
+Note ("- token user: {0}" -f $id.Name)
+Note ("- IsInRole(Administrator): {0}" -f $isAdmin)
+Note ("- integrity: High={0} Medium={1}" -f [bool]$isHigh, [bool]$isMed)
+if ($isAdmin) { Note "  FAIL: token is in the Administrators role"; $fail = 1 }
+if ($isHigh)  { Note "  FAIL: token is elevated (High integrity)";  $fail = 1 }
+if (-not $isMed) { Note "  FAIL: token is not Medium integrity (expected for a standard user)"; $fail = 1 }
+
+# 2. Developer Mode disabled --------------------------------------------------
+$devKey = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock'
+$dev = 0
+try {
+    $v = Get-ItemProperty -Path $devKey -Name AllowDevelopmentWithoutDevLicense -ErrorAction Stop
+    $dev = [int]$v.AllowDevelopmentWithoutDevLicense
+} catch { $dev = 0 }   # absent == disabled
+Note ("- Developer Mode (AllowDevelopmentWithoutDevLicense): {0}" -f $dev)
+if ($dev -ne 0) { Note "  FAIL: Developer Mode is enabled"; $fail = 1 }
+
+# 3. Symlink creation DENIED --------------------------------------------------
+$tmp    = Join-Path $env:TEMP ("hull-symcheck-{0}" -f ([guid]::NewGuid()))
+$target = Join-Path $env:TEMP ("hull-symtarget-{0}.txt" -f ([guid]::NewGuid()))
+Set-Content -Path $target -Value 'x'
+$symDenied = $false
+try {
+    New-Item -ItemType SymbolicLink -Path $tmp -Target $target -ErrorAction Stop | Out-Null
+    Note "- control symlink creation: SUCCEEDED (unexpected)"
+    Remove-Item $tmp -Force -ErrorAction SilentlyContinue
+} catch {
+    $symDenied = $true
+    Note ("- control symlink creation: DENIED as expected ({0})" -f $_.Exception.Message)
+}
+Remove-Item $target -Force -ErrorAction SilentlyContinue
+if (-not $symDenied) { Note "  FAIL: symlink creation was allowed - environment is not restricted"; $fail = 1 }
+
+if ($fail -ne 0) { Note "PRECONDITIONS: FAIL"; exit 1 }
+Note "PRECONDITIONS: OK (non-admin, Dev-Mode off, symlink denied)"
+exit 0

--- a/tests/acceptance/windows/rollback_acl.ps1
+++ b/tests/acceptance/windows/rollback_acl.ps1
@@ -1,0 +1,93 @@
+<#
+  rollback_acl.ps1 - Prove the self-update ROLLBACK on a REAL Windows ACL
+  scenario (no test hooks, no helper processes, no timing races), run AS the
+  standard user.
+
+  Setup: the running hull exe sits in a dedicated directory. We deny DELETE to
+  the user on NEWLY-created files via inherit-only ACEs, while leaving the
+  existing exe's own ACL permissive. Consequences during `hull update`:
+
+    - the downloaded <self>.new can be WRITTEN (create/write still allowed)
+      but cannot be renamed (a rename needs DELETE on the source);
+    - the running exe still moves to <self>.old (its own ACL permits delete);
+    - installing <self>.new at the original path fails via real ACL enforcement;
+    - rollback renames <self>.old back to <self> (it kept the permissive ACL).
+
+  Fail-closed assertions:
+    - `hull update` returns FAILURE;
+    - it reached the MID-SWAP install failure - the self-update layer printed
+      "install failed; rolled back to the previous binary" (NOT an earlier
+      download error and NOT "cannot move ... aside", the initial-rename path);
+    - <self>.new was created (evidence the download + write step succeeded);
+    - the original path still exists, runs, and reports the previous version;
+    - no usable candidate was installed (version did not advance).
+
+  Usage: rollback_acl.ps1 -Hull <exe> -Repo <org/staging-rc> -PrevVersion 0.13.0 -Evidence <file>
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)][string]$Hull,
+    [Parameter(Mandatory=$true)][string]$Repo,
+    [Parameter(Mandatory=$true)][string]$PrevVersion,
+    [Parameter(Mandatory=$true)][string]$Evidence
+)
+
+$ErrorActionPreference = 'Stop'
+function Note($m) { Add-Content -Path $Evidence -Value $m; Write-Host $m }
+function Fail($m) { Note ("  FAIL: {0}" -f $m); $script:fail = 1 }
+$script:fail = 0
+
+$dir  = Split-Path -Parent $Hull
+$new  = "$Hull.new"
+$old  = "$Hull.old"
+$me   = "$env:USERDOMAIN\$env:USERNAME"
+
+Note "## Rollback via real Windows ACL"
+Note ("- hull: {0}" -f $Hull)
+
+# Pre-state: the candidate binary reports the previous version.
+$pre = (& $Hull version 2>&1 | Select-Object -First 1)
+Note ("- pre-update version: {0}" -f $pre)
+if ($pre -notmatch [regex]::Escape($PrevVersion)) { Fail "pre-update version is not $PrevVersion" }
+
+# Deny DELETE to the user on NEWLY-created files (inherit-only): (OI) object
+# inherit, (IO) inherit-only so the dir itself is unaffected, (DE) delete. The
+# existing exe predates this ACE and keeps its permissive ACL.
+& icacls $dir /deny "${me}:(OI)(IO)(DE)" | Out-Null
+Note ("- applied inherit-only DELETE deny for {0} on new files in {1}" -f $me, $dir)
+
+# Attempt the self-update. It should fail and roll back.
+$out = & $Hull update --repo $Repo 2>&1
+$code = $LASTEXITCODE
+$text = ($out | Out-String)
+Note "- hull update output:"
+Note ($text -replace '(?m)^', '    ')
+Note ("- hull update exit code: {0}" -f $code)
+
+# Remove the deny so post-run cleanup can delete any residue.
+& icacls $dir /remove:d "${me}" | Out-Null
+
+if ($code -eq 0) { Fail "hull update unexpectedly SUCCEEDED under the ACL lock" }
+
+# Evidence: reached the mid-swap install failure (rollback), not an earlier stage.
+if ($text -match 'rolled back to the previous binary') {
+    Note "- evidence: reached mid-swap install failure -> rolled back"
+} else {
+    Fail "did not reach the mid-swap install/rollback path (no rollback message)"
+}
+if ($text -match 'cannot move .* aside') { Fail "failed at the INITIAL rename, not the install step" }
+if ($text -match 'failed to download|returned HTTP') { Fail "failed during DOWNLOAD, not the install step" }
+
+# Evidence the download + write step succeeded: <self>.new was created.
+if (Test-Path $new) { Note "- evidence: <self>.new exists (download+write succeeded past the ACL create/write allowance)" }
+else { Fail "<self>.new absent - download/write did not complete, so the ACL install failure was not exercised" }
+
+# Original restored, runnable, still the previous version.
+if (-not (Test-Path $Hull)) { Fail "original hull path is missing after rollback" }
+$post = (& $Hull version 2>&1 | Select-Object -First 1)
+Note ("- post-rollback version: {0}" -f $post)
+if ($post -notmatch [regex]::Escape($PrevVersion)) { Fail "post-rollback version is not $PrevVersion (a candidate was partially installed)" }
+
+if ($script:fail -ne 0) { Note "ROLLBACK-ACL: FAIL"; exit 1 }
+Note "ROLLBACK-ACL: OK (real ACL mid-swap install failure -> clean rollback to $PrevVersion)"
+exit 0

--- a/tests/acceptance/windows/run.ps1
+++ b/tests/acceptance/windows/run.ps1
@@ -1,0 +1,113 @@
+<#
+  run.ps1 - orchestrates the Windows acceptance run. Runs as the runner's admin
+  account, but drives every acceptance phase AS a freshly-created STANDARD
+  (non-admin) user, with Developer Mode disabled, so the non-admin / self-update
+  / ACL evidence is meaningful. Aggregates a single evidence report and fails
+  closed if any phase fails.
+
+  It never creates, modifies, or deletes a GitHub release: it only downloads the
+  previous release's Windows APE and drives `hull update --repo=<staging>`
+  against the maintainer-prepopulated staging repos.
+
+  Usage:
+    run.ps1 -OfficialRepo artalis-io/hull -PrevTag v0.13.0 -PrevVersion 0.13.0 \
+            -RcRepo <org/staging-rc> -ExpectVersion 0.14.0-rc1 \
+            -Evidence <file> -WorkDir <dir>
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)][string]$OfficialRepo,
+    [Parameter(Mandatory=$true)][string]$PrevTag,
+    [Parameter(Mandatory=$true)][string]$PrevVersion,
+    [Parameter(Mandatory=$true)][string]$RcRepo,
+    [Parameter(Mandatory=$true)][string]$ExpectVersion,
+    [Parameter(Mandatory=$true)][string]$Evidence,
+    [Parameter(Mandatory=$true)][string]$WorkDir,
+    [string]$PrevRepo = ''
+)
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+function Note($m) { Add-Content -Path $Evidence -Value $m; Write-Host $m }
+
+New-Item -ItemType Directory -Path $WorkDir -Force | Out-Null
+Set-Content -Path $Evidence -Value "# Windows acceptance evidence`n"
+
+# ── Standard (non-admin) user ────────────────────────────────────────────────
+$user = 'hullacc'
+$pw   = ([guid]::NewGuid().ToString() + 'Aa1!')
+$sec  = ConvertTo-SecureString $pw -AsPlainText -Force
+if (Get-LocalUser -Name $user -ErrorAction SilentlyContinue) { Remove-LocalUser -Name $user }
+New-LocalUser -Name $user -Password $sec -AccountNeverExpires -PasswordNeverExpires | Out-Null
+Add-LocalGroupMember -Group 'Users' -Member $user -ErrorAction SilentlyContinue
+# Explicitly NOT in Administrators. Assert.
+if (Get-LocalGroupMember -Group 'Administrators' -Member $user -ErrorAction SilentlyContinue) {
+    Note "FATAL: acceptance user is in Administrators"; exit 1
+}
+$cred = New-Object System.Management.Automation.PSCredential("$env:COMPUTERNAME\$user", $sec)
+Note "- created standard user $user (not in Administrators)"
+
+# ── Disable Developer Mode (machine policy) ──────────────────────────────────
+$devKey = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock'
+New-Item -Path $devKey -Force | Out-Null
+Set-ItemProperty -Path $devKey -Name AllowDevelopmentWithoutDevLicense -Value 0 -Type DWord
+Note "- Developer Mode disabled (AllowDevelopmentWithoutDevLicense=0)"
+
+# ── Make WorkDir + the scripts readable/executable by the user ───────────────
+& icacls $WorkDir /grant "${user}:(OI)(CI)M" | Out-Null
+& icacls $here    /grant "${user}:(OI)(CI)RX" | Out-Null
+
+# ── Download the previous release's Windows APE (read-only) ──────────────────
+$prevExe = Join-Path $WorkDir 'hull-prev.com'
+$url = "https://github.com/$OfficialRepo/releases/download/$PrevTag/hull-cosmo"
+Invoke-WebRequest -Uri $url -OutFile $prevExe
+Note "- downloaded previous APE $PrevTag ($url)"
+
+# Working copies for the phases.
+$suDir  = Join-Path $WorkDir 'selfupdate'; New-Item -ItemType Directory -Path $suDir  | Out-Null
+$aclDir = Join-Path $WorkDir 'acl';        New-Item -ItemType Directory -Path $aclDir | Out-Null
+$suHull  = Join-Path $suDir  'hull.com'; Copy-Item $prevExe $suHull
+$aclHull = Join-Path $aclDir 'hull.com'; Copy-Item $prevExe $aclHull
+& icacls $suDir  /grant "${user}:(OI)(CI)M" | Out-Null
+& icacls $aclDir /grant "${user}:(OI)(CI)M" | Out-Null
+
+# ── Run a phase AS the standard user; return its exit code ───────────────────
+function Invoke-AsUser([string]$script, [string[]]$phaseArgs) {
+    $a = @('-NoProfile','-ExecutionPolicy','Bypass','-File', (Join-Path $here $script)) + $phaseArgs
+    $p = Start-Process -FilePath 'powershell.exe' -Credential $cred -ArgumentList $a `
+                       -WorkingDirectory $WorkDir -Wait -PassThru
+    return $p.ExitCode
+}
+
+$rc = 0
+Note "`n--- PHASE: preconditions ---"
+if ((Invoke-AsUser 'preconditions.ps1' @('-Evidence', $Evidence)) -ne 0) { $rc = 1 }
+
+Note "`n--- PHASE: self-update (upgrade) ---"
+if ((Invoke-AsUser 'self_update.ps1' @('-Hull',$suHull,'-Repo',$RcRepo,'-ExpectVersion',$ExpectVersion,'-Evidence',$Evidence)) -ne 0) { $rc = 1 }
+
+Note "`n--- PHASE: rollback via real ACL ---"
+if ((Invoke-AsUser 'rollback_acl.ps1' @('-Hull',$aclHull,'-Repo',$RcRepo,'-PrevVersion',$PrevVersion,'-Evidence',$Evidence)) -ne 0) { $rc = 1 }
+
+Note "`n--- PHASE: extras (spaces / cosmocc / ping / nested / doctor) ---"
+# $suHull is now the candidate (updated in the self-update phase); PrevHull is a
+# fresh copy for the spaces self-update inside extras.
+$prevForExtras = Join-Path $WorkDir 'hull-prev-extras.com'; Copy-Item $prevExe $prevForExtras
+& icacls $prevForExtras /grant "${user}:RX" | Out-Null
+if ((Invoke-AsUser 'extras.ps1' @('-Hull',$suHull,'-PrevHull',$prevForExtras,'-RcRepo',$RcRepo,'-ExpectVersion',$ExpectVersion,'-Evidence',$Evidence)) -ne 0) { $rc = 1 }
+
+if ($PrevRepo -ne '') {
+    Note "`n--- PHASE: downgrade (staging-based) ---"
+    $dgDir = Join-Path $WorkDir 'downgrade'; New-Item -ItemType Directory -Path $dgDir | Out-Null
+    $dgHull = Join-Path $dgDir 'hull.com'; Copy-Item $prevExe $dgHull
+    & icacls $dgDir /grant "${user}:(OI)(CI)M" | Out-Null
+    if ((Invoke-AsUser 'downgrade.ps1' @('-Hull',$dgHull,'-RcRepo',$RcRepo,'-PrevRepo',$PrevRepo,'-RcVersion',$ExpectVersion,'-PrevVersion',$PrevVersion,'-Evidence',$Evidence)) -ne 0) { $rc = 1 }
+} else {
+    Note "`n--- PHASE: downgrade SKIPPED (no prev staging repo provided) ---"
+}
+
+# ── Cleanup the local user ───────────────────────────────────────────────────
+Remove-LocalUser -Name $user -ErrorAction SilentlyContinue
+
+Note ("`n## RESULT: {0}" -f ($(if ($rc -eq 0) {'ALL PHASES PASSED'} else {'FAILURE'})))
+exit $rc

--- a/tests/acceptance/windows/self_update.ps1
+++ b/tests/acceptance/windows/self_update.ps1
@@ -1,0 +1,61 @@
+<#
+  self_update.ps1 - Prove a REAL Windows self-update of the old (previous
+  release) APE to the candidate, via a maintainer-prepopulated staging repo
+  whose /releases/latest mirrors the RC. Run AS the standard user.
+
+  Fail-closed assertions:
+    - `hull update --repo=<staging>` returns success;
+    - the updating process exits normally (exit 0, no crash);
+    - the NEXT invocation reports the expected candidate version;
+    - the deferred-swap residue is cleaned: no <self>.new remains, and <self>.old
+      is swept by the next startup (the running process holds it until exit).
+
+  Usage: self_update.ps1 -Hull <exe> -Repo <org/staging> -ExpectVersion 0.14.0-rc1 -Evidence <file>
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)][string]$Hull,
+    [Parameter(Mandatory=$true)][string]$Repo,
+    [Parameter(Mandatory=$true)][string]$ExpectVersion,
+    [Parameter(Mandatory=$true)][string]$Evidence
+)
+
+$ErrorActionPreference = 'Stop'
+function Note($m) { Add-Content -Path $Evidence -Value $m; Write-Host $m }
+function Fail($m) { Note ("  FAIL: {0}" -f $m); $script:fail = 1 }
+$script:fail = 0
+
+$new = "$Hull.new"
+$old = "$Hull.old"
+
+Note "## Real self-update (upgrade)"
+$pre = (& $Hull version 2>&1 | Select-Object -First 1)
+Note ("- pre-update version: {0}" -f $pre)
+
+$out  = & $Hull update --repo $Repo 2>&1
+$code = $LASTEXITCODE
+Note "- hull update output:"
+Note (($out | Out-String) -replace '(?m)^', '    ')
+Note ("- hull update exit code: {0}" -f $code)
+if ($code -ne 0) { Fail "hull update returned non-zero" }
+
+# The NEXT invocation (a fresh process; the updated binary is on disk) must
+# report the candidate version, and its startup sweep removes <self>.old.
+$post = (& $Hull version 2>&1 | Select-Object -First 1)
+Note ("- post-update version: {0}" -f $post)
+if ($post -notmatch [regex]::Escape($ExpectVersion)) { Fail "post-update version is not $ExpectVersion" }
+
+if (Test-Path $new) { Fail "<self>.new residue remains after a successful update" }
+if (Test-Path $old) {
+    # One more invocation to give the startup sweep a clean shot (the update
+    # process held the lock; it has since exited).
+    & $Hull version *> $null
+    if (Test-Path $old) { Fail "<self>.old was not swept on the next startup" }
+    else { Note "- <self>.old swept on the next startup" }
+} else {
+    Note "- no <self>.old residue"
+}
+
+if ($script:fail -ne 0) { Note "SELF-UPDATE: FAIL"; exit 1 }
+Note "SELF-UPDATE: OK ($pre -> $post via deferred swap; residue clean)"
+exit 0


### PR DESCRIPTION
The **Windows stage** of the v0.14.0 acceptance run — the real Windows behavior that can't be proven on other hosts. Companion to #432 (automated read-only stage).

## Model
`workflow_dispatch`, `permissions: contents: read`. **Read-only** with respect to releases: downloads the previous release's APE and drives `hull update --repo=<staging>` against the maintainer-prepopulated staging repos; never creates/modifies/deletes a tag, release, or asset. All logic is checked-in PowerShell (`tests/acceptance/windows/*.ps1`); the workflow only wires inputs + uploads the evidence report. Everything runs **as a freshly-created standard (non-admin) user with Developer Mode disabled**.

## Fail-closed evidence (the points you called out)
- **`preconditions.ps1`** records and FAILS unless: the child token is genuinely **non-admin** (not in Administrators, Medium not High integrity), **Developer Mode is disabled**, and a **control symlink creation is denied**.
- **`rollback_acl.ps1`** proves rollback on a deterministic file-specific ACL (inherit-only DELETE deny on new files): `<self>.new` is writable but un-renamable, so after the running exe moves aside, the install step fails via **real Windows ACL enforcement**. It asserts the update fails, the original is rolled back / runnable / still the previous version, no partial candidate is installed, and — the whole point — that it **reached the mid-swap install failure**: the self-update layer printed `install failed; rolled back` (not a download error, not the `cannot move ... aside` initial-rename path) **and** `<self>.new` exists (download succeeded).

## Other bullets
- **`self_update.ps1`**: real previous→candidate self-update via the RC staging repo; asserts success, next invocation reports the candidate, `.new`/`.old` residue cleaned/swept.
- **`extras.ps1`**: spaces-path self-update, non-admin `hull tools install cosmocc`, Lua + JS `/ping` build+serve, nested local-module build+serve (built parity, #423), doctor / tools-list / agent-tools agreement on cosmocc (#428).
- **`downgrade.ps1`** (optional): forced rc→previous downgrade via the previous staging repo.
- **`run.ps1`**: creates the standard user, disables Developer Mode, downloads the previous APE, runs each phase as the user, aggregates one evidence report (`windows-acceptance-evidence`).

## Validation
No local Windows/pwsh, so the PowerShell is validated on **first dispatch** (as the prior cosmocc Windows E2E work was iterated on CI). Local gates (milestone-narration, em-dash, docs-integrity) and YAML lint pass. Runbook: `docs/release_acceptance.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)