### PR TITLE
ci(windows-acceptance): honest before/after self-update contract, green end to end

### DIFF
--- a/.github/workflows/release-acceptance-windows.yml
+++ b/.github/workflows/release-acceptance-windows.yml
@@ -56,7 +56,11 @@ jobs:
         shell: pwsh
         run: |
           Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
-          $ev = Join-Path $env:RUNNER_TEMP 'windows-acceptance-evidence.md'
+          # Keep the evidence file INSIDE the workdir: the phases run as a
+          # standard user who is granted access to the workdir, so it can append
+          # its per-check evidence there.
+          $wd = Join-Path $env:RUNNER_TEMP 'wacc'
+          $ev = Join-Path $wd 'windows-acceptance-evidence.md'
           & tests/acceptance/windows/run.ps1 `
             -OfficialRepo '${{ inputs.official_repo }}' `
             -PrevTag '${{ inputs.prev_tag }}' `
@@ -65,7 +69,7 @@ jobs:
             -ExpectVersion '${{ inputs.expect_version }}' `
             -PrevRepo '${{ inputs.staging_prev_repo }}' `
             -Evidence $ev `
-            -WorkDir (Join-Path $env:RUNNER_TEMP 'wacc')
+            -WorkDir $wd
           $code = $LASTEXITCODE
           Get-Content $ev | ForEach-Object { Write-Host $_ }
           Copy-Item $ev "$env:GITHUB_STEP_SUMMARY" -Force
@@ -76,4 +80,4 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: windows-acceptance-evidence
-          path: ${{ runner.temp }}/windows-acceptance-evidence.md
+          path: ${{ runner.temp }}/wacc/windows-acceptance-evidence.md

--- a/.github/workflows/release-acceptance-windows.yml
+++ b/.github/workflows/release-acceptance-windows.yml
@@ -30,6 +30,10 @@ on:
         description: Version string the previous APE reports
         required: true
         default: 0.13.0
+      rc_tag:
+        description: Candidate release tag (the APE under test)
+        required: true
+        default: v0.14.0-rc1
       staging_rc_repo:
         description: Staging repo whose latest mirrors the RC (ORG/NAME)
         required: true
@@ -63,6 +67,7 @@ jobs:
           $ev = Join-Path $wd 'windows-acceptance-evidence.md'
           & tests/acceptance/windows/run.ps1 `
             -OfficialRepo '${{ inputs.official_repo }}' `
+            -RcTag '${{ inputs.rc_tag }}' `
             -PrevTag '${{ inputs.prev_tag }}' `
             -PrevVersion '${{ inputs.prev_version }}' `
             -RcRepo '${{ inputs.staging_rc_repo }}' `

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ resolution with hardened security; `hull update` self-replaces safely on a
 locked Windows executable; and the tool-resolution surfaces (`doctor` /
 `tools list` / `agent tools`) agree. Several fixes are security-relevant.
 
+### Upgrade notes (Windows)
+
+- **One-time manual step to reach 0.14.0 on Windows.** The Windows self-update
+  fix ships *in* 0.14.0, so a 0.13.0 binary cannot install it: 0.13.0's updater
+  tries to overwrite the running `.exe` in place, which Windows refuses, and it
+  fails with an `atomic_write: rename ... failed` error, leaving the old binary
+  intact. To move from 0.13.0 to 0.14.0 on Windows, **download `hull-cosmo` from
+  the 0.14.0 release and replace your `hull` executable manually while Hull is
+  not running** (close any running instance first). From 0.14.0 onward `hull
+  update` self-updates normally on Windows via the deferred rename-aside swap.
+  macOS and Linux are unaffected (their atomic-rename self-update already
+  works). (#429)
+
 ### Added
 
 - **Unified tool resolution.** `hull tools list`, `hull agent tools`, and

--- a/docs/release_acceptance.md
+++ b/docs/release_acceptance.md
@@ -11,14 +11,27 @@ release. It has two phases, each a checked-in CI workflow:
   cannot be proven on other hosts, all as a freshly-created standard (non-admin)
   user with Developer Mode disabled. Fail-closed unless the child token is proven
   non-admin, Developer Mode is off, and control symlink creation is denied
-  (`preconditions.ps1`). Then: a real self-update of the previous APE to the
-  candidate via the RC staging repo (`self_update.ps1`); an ACL-induced mid-swap
-  **rollback** proven to reach the install-step failure, not an earlier stage
-  (`rollback_acl.ps1`); and `extras.ps1` - a spaces-path self-update, non-admin
-  `hull tools install cosmocc`, a Lua and a JS `/ping` build+serve, a nested
-  local-module build+serve, and doctor / tools-list / agent-tools agreement.
-  Optional downgrade via the previous staging repo (`downgrade.ps1`). It is
-  read-only with respect to releases.
+  (`preconditions.ps1`). It proves the honest before/after self-update contract:
+
+  - the **previous** APE (`v0.13.0`, which predates the deferred-swap fix) MUST
+    FAIL to self-update on Windows, at the atomic-rename of the running binary
+    (`old_update_fails.ps1`) - the exact bug the release fixes;
+  - the **candidate** MUST self-update successfully via the deferred rename-aside
+    swap, force-reinstalling the RC over itself through the RC staging repo
+    (`self_update.ps1`);
+  - an ACL-induced mid-swap **rollback**, run from the candidate, proven to reach
+    the install-step failure (not an earlier stage) and cleanly restore the
+    candidate (`rollback_acl.ps1`);
+  - `extras.ps1` - a spaces-path self-update from the candidate, non-admin
+    `hull tools install cosmocc`, a Lua and a JS `/ping` build+serve, a nested
+    local-module build+serve, and doctor / tools-list / agent-tools agreement;
+  - an optional **downgrade** from the candidate to the previous release via the
+    previous staging repo (`downgrade.ps1`), proving target-version independence
+    of the fixed updater. The installed `v0.13.0` lacks the startup sweeper, so
+    the `<self>.old` residue is a recorded, expected pre-fix limitation and is
+    cleaned explicitly rather than claimed as auto-swept.
+
+  The whole stage is read-only with respect to releases.
 
 Both phases must pass before the final tag is created.
 

--- a/tests/acceptance/windows/downgrade.ps1
+++ b/tests/acceptance/windows/downgrade.ps1
@@ -28,17 +28,21 @@ param(
 $ErrorActionPreference = 'Stop'
 function Note($m) { Add-Content -Path $Evidence -Value $m; Write-Host $m }
 function Fail($m) { Note ("  FAIL: {0}" -f $m); $script:fail = 1 }
+# hull writes progress to stdout and errors/logs to stderr; under -EA Stop a
+# 2>&1 merge of native stderr becomes a terminating error. Capture through a
+# helper that locally relaxes the preference and merges both streams.
+function Cap([scriptblock]$sb) { $ErrorActionPreference = 'Continue'; & $sb 2>&1 }
 $script:fail = 0
 $new = "$Hull.new"; $old = "$Hull.old"
 
 Note "## Downgrade: candidate -> previous (staging, forced)"
-$out = & $Hull update --force --repo $PrevRepo 2>&1
+$out = Cap { & $Hull update --force --repo $PrevRepo }
 $code = $LASTEXITCODE
 Note (($out | Out-String) -replace '(?m)^','    ')
 Note ("- exit code: {0}" -f $code)
 if ($code -ne 0) { Fail "forced downgrade returned non-zero" }
 
-$down = (& $Hull version 2>&1 | Select-Object -First 1)
+$down = (Cap { & $Hull version } | Select-Object -First 1)
 Note ("- installed version now runs as: {0}" -f $down)
 if ($down -notmatch [regex]::Escape($PrevVersion)) { Fail "downgrade did not install a runnable $PrevVersion" }
 

--- a/tests/acceptance/windows/downgrade.ps1
+++ b/tests/acceptance/windows/downgrade.ps1
@@ -1,25 +1,26 @@
 <#
-  downgrade.ps1 - prove a real Windows DOWNGRADE via a staging repo, run AS the
-  standard user. `hull update` only reads /releases/latest and only advances by
-  default, so downgrade uses `--force` against a staging repo whose latest
-  mirrors the PREVIOUS signed release.
+  downgrade.ps1 - the running CANDIDATE downgrades to the PREVIOUS release,
+  proving target-version independence of the (fixed) updater. Run AS the standard
+  user. `hull update` only advances by default, so downgrade uses `--force`
+  against a staging repo whose latest mirrors the previous signed release.
 
-  Starts from a fresh previous-release APE, updates UP to the candidate (via the
-  RC staging repo), then FORCE-updates back DOWN to the previous release (via the
-  previous staging repo). Fail-closed assertions:
-    - the up-update reports the candidate version;
-    - the forced down-update returns success and reports the previous version;
-    - no <self>.new residue; <self>.old is swept on the next startup.
+  Fail-closed assertions:
+    - the forced down-update returns success;
+    - the installed previous binary RUNS and reports the previous version.
 
-  Usage: downgrade.ps1 -Hull <exe> -RcRepo <org/staging-rc> -PrevRepo <org/staging-prev> \
-                       -RcVersion 0.14.0-rc1 -PrevVersion 0.13.0 -Evidence <file>
+  Expected pre-fix limitation (recorded, NOT failed): the candidate's deferred
+  swap installs the previous binary and leaves <self>.old (the aside candidate,
+  which was locked while the updating process ran). The NEXT startup would
+  normally sweep it - but the newly-installed PREVIOUS binary predates the
+  startup sweeper, so <self>.old persists. We verify the previous binary runs,
+  then clean the residue explicitly and record this as expected.
+
+  Usage: downgrade.ps1 -Hull <candidate-exe> -PrevRepo <org/staging-prev> -PrevVersion 0.13.0 -Evidence <file>
 #>
 [CmdletBinding()]
 param(
     [Parameter(Mandatory=$true)][string]$Hull,
-    [Parameter(Mandatory=$true)][string]$RcRepo,
     [Parameter(Mandatory=$true)][string]$PrevRepo,
-    [Parameter(Mandatory=$true)][string]$RcVersion,
     [Parameter(Mandatory=$true)][string]$PrevVersion,
     [Parameter(Mandatory=$true)][string]$Evidence
 )
@@ -30,25 +31,29 @@ function Fail($m) { Note ("  FAIL: {0}" -f $m); $script:fail = 1 }
 $script:fail = 0
 $new = "$Hull.new"; $old = "$Hull.old"
 
-Note "## Downgrade (staging-repo based)"
-# Up to the candidate first.
-& $Hull update --repo $RcRepo *> $null
-$up = (& $Hull version 2>&1 | Select-Object -First 1)
-Note ("- after up-update: {0}" -f $up)
-if ($up -notmatch [regex]::Escape($RcVersion)) { Fail "up-update did not reach $RcVersion"; }
-
-# Forced downgrade to the previous release.
-$out = & $Hull update --force --repo $PrevRepo 2>&1; $code = $LASTEXITCODE
+Note "## Downgrade: candidate -> previous (staging, forced)"
+$out = & $Hull update --force --repo $PrevRepo 2>&1
+$code = $LASTEXITCODE
 Note (($out | Out-String) -replace '(?m)^','    ')
+Note ("- exit code: {0}" -f $code)
 if ($code -ne 0) { Fail "forced downgrade returned non-zero" }
+
 $down = (& $Hull version 2>&1 | Select-Object -First 1)
-Note ("- after forced down-update: {0}" -f $down)
-if ($down -notmatch [regex]::Escape($PrevVersion)) { Fail "downgrade did not reach $PrevVersion" }
+Note ("- installed version now runs as: {0}" -f $down)
+if ($down -notmatch [regex]::Escape($PrevVersion)) { Fail "downgrade did not install a runnable $PrevVersion" }
 
 if (Test-Path $new) { Fail "<self>.new residue after downgrade" }
-& $Hull version *> $null
-if (Test-Path $old) { Fail "<self>.old not swept after downgrade" }
+
+# Expected pre-fix limitation: the installed previous binary has no startup
+# sweeper, so <self>.old is NOT auto-cleaned. Record it and clean explicitly.
+if (Test-Path $old) {
+    Note ("- expected pre-fix limitation: <self>.old remains ({0} has no startup sweeper); cleaning explicitly" -f $PrevVersion)
+    Remove-Item $old -Force -ErrorAction SilentlyContinue
+    if (Test-Path $old) { Note "  (note: explicit cleanup could not remove it either)" }
+} else {
+    Note "- no <self>.old residue"
+}
 
 if ($script:fail -ne 0) { Note "DOWNGRADE: FAIL"; exit 1 }
-Note "DOWNGRADE: OK ($RcVersion -> $PrevVersion via forced staging update)"
+Note "DOWNGRADE: OK (candidate installed a runnable $PrevVersion; .old residue is an expected pre-fix limitation)"
 exit 0

--- a/tests/acceptance/windows/extras.ps1
+++ b/tests/acceptance/windows/extras.ps1
@@ -26,6 +26,11 @@ param(
 $ErrorActionPreference = 'Stop'
 function Note($m) { Add-Content -Path $Evidence -Value $m; Write-Host $m }
 function Fail($m) { Note ("  FAIL: {0}" -f $m); $script:fail = 1 }
+# hull writes progress to stdout and logs/errors to stderr (e.g. `hull build`
+# emits an INFO sandbox line to stderr); under -EA Stop a 2>&1 merge of native
+# stderr becomes a terminating error. Capture through a helper that locally
+# relaxes the preference and merges both streams.
+function Cap([scriptblock]$sb) { $ErrorActionPreference = 'Continue'; & $sb 2>&1 }
 $script:fail = 0
 $work = Join-Path $env:TEMP ("hull-accept-" + [guid]::NewGuid())
 New-Item -ItemType Directory -Path $work | Out-Null
@@ -50,17 +55,17 @@ $spaceDir = Join-Path $work 'hull test dir with spaces'
 New-Item -ItemType Directory -Path $spaceDir | Out-Null
 $spaceHull = Join-Path $spaceDir 'my hull.com'
 Copy-Item $Hull $spaceHull
-$sc = & $spaceHull update --force --repo $RcRepo 2>&1; $rc = $LASTEXITCODE
+$sc = Cap { & $spaceHull update --force --repo $RcRepo }; $rc = $LASTEXITCODE
 Note (($sc | Out-String) -replace '(?m)^','    ')
 if ($rc -ne 0) { Fail "self-update from a spaces path returned non-zero" }
-$sv = (& $spaceHull version 2>&1 | Select-Object -First 1)
+$sv = (Cap { & $spaceHull version } | Select-Object -First 1)
 if ($sv -notmatch [regex]::Escape($ExpectVersion)) { Fail "spaces-path candidate is not $ExpectVersion (got '$sv')" }
 elseif (Test-Path "$spaceHull.new") { Fail "spaces-path <self>.new residue after a successful update" }
 else { Note "- OK: updated to '$sv' from a spaces path via the deferred swap" }
 
 # --- 2. non-admin cosmocc install -------------------------------------------
 Note "## Non-admin cosmocc install"
-$ci = & $Hull tools install cosmocc 2>&1; $rc = $LASTEXITCODE
+$ci = Cap { & $Hull tools install cosmocc }; $rc = $LASTEXITCODE
 Note (($ci | Out-String) -replace '(?m)^','    ')
 if ($rc -ne 0) { Fail "hull tools install cosmocc returned non-zero (non-admin)" } else { Note "- OK: cosmocc installed non-admin" }
 
@@ -79,7 +84,7 @@ foreach ($case in @(@{ext='lua';src=$lua;port=39701}, @{ext='js';src=$js;port=39
     $adir = Join-Path $work ("ping-" + $case.ext)
     New-Item -ItemType Directory -Path $adir | Out-Null
     Set-Content -Path (Join-Path $adir ("app." + $case.ext)) -Value $case.src
-    $bout = & $Hull build $adir -o (Join-Path $adir 'out.com') 2>&1; $rc = $LASTEXITCODE
+    $bout = Cap { & $Hull build $adir -o (Join-Path $adir 'out.com') }; $rc = $LASTEXITCODE
     if ($rc -ne 0) { Note (($bout | Out-String) -replace '(?m)^','    '); Fail ("hull build failed for the " + $case.ext + " /ping app"); continue }
     $body = Serve-And-Get (Join-Path $adir 'out.com') (Join-Path $adir 'out.com') $case.port '/ping'
     if ("$body".Trim() -eq 'pong') { Note ("- OK: " + $case.ext + " /ping served pong") }
@@ -105,7 +110,7 @@ return M
 Set-Content (Join-Path $nd 'lib\auth.lua') @'
 return { who = function() return "nested-ok" end }
 '@
-$nb = & $Hull build $nd -o (Join-Path $nd 'out.com') 2>&1; $rc = $LASTEXITCODE
+$nb = Cap { & $Hull build $nd -o (Join-Path $nd 'out.com') }; $rc = $LASTEXITCODE
 if ($rc -ne 0) { Note (($nb | Out-String) -replace '(?m)^','    '); Fail "nested-module app build failed" }
 else {
     $body = Serve-And-Get (Join-Path $nd 'out.com') (Join-Path $nd 'out.com') 39703 '/who'
@@ -114,10 +119,21 @@ else {
 }
 
 # --- 5. doctor / tools list / agent tools agree on cosmocc -------------------
+# stdout-only capture (stderr discarded so it can't corrupt the JSON), parsed
+# defensively so empty/invalid output is a clean Fail, not an -EA Stop throw.
+function AsJson([string[]]$cmd) {
+    $ErrorActionPreference = 'Continue'
+    $raw = (& $Hull @cmd 2>$null | Out-String)
+    if ([string]::IsNullOrWhiteSpace($raw)) { return $null }
+    try { return ($raw | ConvertFrom-Json) } catch { return $null }
+}
 Note "## doctor / tools list / agent tools agree on cosmocc"
-$doc = (& $Hull doctor --json 2>$null | ConvertFrom-Json)
-$tl  = (& $Hull tools list --json 2>$null | ConvertFrom-Json)
-$at  = (& $Hull agent tools 2>$null | ConvertFrom-Json)
+$doc = AsJson @('doctor','--json')
+$tl  = AsJson @('tools','list','--json')
+$at  = AsJson @('agent','tools')
+if (-not $doc) { Fail 'hull doctor --json produced no parseable JSON' }
+if (-not $tl)  { Fail 'hull tools list --json produced no parseable JSON' }
+if (-not $at)  { Fail 'hull agent tools produced no parseable JSON' }
 $docCosmocc = ($doc.compilers | Where-Object { $_.name -eq 'cosmocc' }).path
 $tlCosmocc  = ($tl.tools     | Where-Object { $_.name -eq 'cosmocc' })
 $atCosmocc  = ($at.tools     | Where-Object { $_.name -eq 'cosmocc' })

--- a/tests/acceptance/windows/extras.ps1
+++ b/tests/acceptance/windows/extras.ps1
@@ -12,13 +12,12 @@
   exits non-zero.
 
   Usage:
-    extras.ps1 -Hull <candidate-exe> -PrevHull <prev-exe> -RcRepo <org/staging-rc> \
+    extras.ps1 -Hull <candidate-exe> -RcRepo <org/staging-rc> \
                -ExpectVersion 0.14.0-rc1 -Evidence <file>
 #>
 [CmdletBinding()]
 param(
     [Parameter(Mandatory=$true)][string]$Hull,
-    [Parameter(Mandatory=$true)][string]$PrevHull,
     [Parameter(Mandatory=$true)][string]$RcRepo,
     [Parameter(Mandatory=$true)][string]$ExpectVersion,
     [Parameter(Mandatory=$true)][string]$Evidence
@@ -44,17 +43,20 @@ function Serve-And-Get([string]$exe, [string]$appPath, [int]$port, [string]$rout
 }
 
 # --- 1. self-update from a path with spaces ---------------------------------
-Note "## Self-update from a path with spaces"
+# Force-reinstall the RC over the CANDIDATE placed in a spaces path: exercises
+# the real deferred rename-aside swap (running .exe) with spaces in every path.
+Note "## Self-update from a path with spaces (candidate deferred swap)"
 $spaceDir = Join-Path $work 'hull test dir with spaces'
 New-Item -ItemType Directory -Path $spaceDir | Out-Null
 $spaceHull = Join-Path $spaceDir 'my hull.com'
-Copy-Item $PrevHull $spaceHull
-$sc = & $spaceHull update --repo $RcRepo 2>&1; $rc = $LASTEXITCODE
+Copy-Item $Hull $spaceHull
+$sc = & $spaceHull update --force --repo $RcRepo 2>&1; $rc = $LASTEXITCODE
 Note (($sc | Out-String) -replace '(?m)^','    ')
 if ($rc -ne 0) { Fail "self-update from a spaces path returned non-zero" }
 $sv = (& $spaceHull version 2>&1 | Select-Object -First 1)
 if ($sv -notmatch [regex]::Escape($ExpectVersion)) { Fail "spaces-path candidate is not $ExpectVersion (got '$sv')" }
-else { Note "- OK: updated to '$sv' from a spaces path" }
+elseif (Test-Path "$spaceHull.new") { Fail "spaces-path <self>.new residue after a successful update" }
+else { Note "- OK: updated to '$sv' from a spaces path via the deferred swap" }
 
 # --- 2. non-admin cosmocc install -------------------------------------------
 Note "## Non-admin cosmocc install"

--- a/tests/acceptance/windows/extras.ps1
+++ b/tests/acceptance/windows/extras.ps1
@@ -61,6 +61,33 @@ function Serve-And-Get([string]$exe, [int]$port, [string]$route) {
     } finally { $p | Stop-Process -Force -ErrorAction SilentlyContinue }
 }
 
+# `hull build` on Windows drives cosmocc (a dual-arch APE link). cosmocc's own
+# process spawning is intermittently flaky under repeated heavy use on Windows
+# (posix_spawn EBADF / ERROR_KERNEL_APC inside collect2), and can leave a locked
+# fatcosmocc temp that trips the next build. Retry a spawn-flake link failure a
+# couple of times, cleaning the cosmocc temp before each attempt. A NON-flake
+# failure (a genuine Hull compose/resolve error) is returned on the first try so
+# a real regression is never masked. Returns @{ rc; out; tries }.
+function Build-Retry([string]$dir, [string]$outCom) {
+    # Spawn-specific signatures only. NOT `collect2:`/`linking failed` alone -
+    # those also mark a genuine link regression, which must fail on the first try.
+    $flake   = 'posix_spawn|ERROR_KERNEL_APC|Bad file number|cannot execute'
+    $hometmp = Join-Path $env:HOME '.hull\tmp'
+    $out = $null; $rc = 1
+    for ($t = 1; $t -le 3; $t++) {
+        Get-ChildItem -Path $hometmp -Filter 'fatcosmocc*' -ErrorAction SilentlyContinue |
+            Remove-Item -Force -ErrorAction SilentlyContinue
+        $out = Cap { & $Hull build $dir -o $outCom }
+        $rc  = $LASTEXITCODE
+        if ($rc -eq 0) { return @{ rc = 0; out = $out; tries = $t } }
+        if (($out | Out-String) -notmatch $flake) { return @{ rc = $rc; out = $out; tries = $t } }
+        Note ("- build attempt {0} hit a cosmocc spawn flake; cleaning temp and retrying" -f $t)
+        Remove-Item $outCom -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 3
+    }
+    return @{ rc = $rc; out = $out; tries = 3 }
+}
+
 # --- 1. self-update from a path with spaces ---------------------------------
 # Force-reinstall the RC over the CANDIDATE placed in a spaces path: exercises
 # the real deferred rename-aside swap (running .exe) with spaces in every path.
@@ -98,8 +125,8 @@ foreach ($case in @(@{ext='lua';src=$lua;port=39701}, @{ext='js';src=$js;port=39
     $adir = Join-Path $work ("ping-" + $case.ext)
     New-Item -ItemType Directory -Path $adir | Out-Null
     Set-Content -Path (Join-Path $adir ("app." + $case.ext)) -Value $case.src
-    $bout = Cap { & $Hull build $adir -o (Join-Path $adir 'out.com') }; $rc = $LASTEXITCODE
-    if ($rc -ne 0) { Note (($bout | Out-String) -replace '(?m)^','    '); Fail ("hull build failed for the " + $case.ext + " /ping app"); continue }
+    $r = Build-Retry $adir (Join-Path $adir 'out.com')
+    if ($r.rc -ne 0) { Note (($r.out | Out-String) -replace '(?m)^','    '); Fail ("hull build failed for the " + $case.ext + " /ping app after " + $r.tries + " attempt(s)"); continue }
     $body = Serve-And-Get (Join-Path $adir 'out.com') $case.port '/ping'
     if ("$body".Trim() -eq 'pong') { Note ("- OK: " + $case.ext + " /ping served pong") }
     else { Fail ($case.ext + " /ping did not serve pong (got '" + $body + "')") }
@@ -124,8 +151,8 @@ return M
 Set-Content (Join-Path $nd 'lib\auth.lua') @'
 return { who = function() return "nested-ok" end }
 '@
-$nb = Cap { & $Hull build $nd -o (Join-Path $nd 'out.com') }; $rc = $LASTEXITCODE
-if ($rc -ne 0) { Note (($nb | Out-String) -replace '(?m)^','    '); Fail "nested-module app build failed" }
+$r = Build-Retry $nd (Join-Path $nd 'out.com')
+if ($r.rc -ne 0) { Note (($r.out | Out-String) -replace '(?m)^','    '); Fail ("nested-module app build failed after " + $r.tries + " attempt(s)") }
 else {
     $body = Serve-And-Get (Join-Path $nd 'out.com') 39703 '/who'
     if ("$body".Trim() -eq 'nested-ok') { Note "- OK: built nested-module app resolved ./routes -> ./../lib and served" }

--- a/tests/acceptance/windows/extras.ps1
+++ b/tests/acceptance/windows/extras.ps1
@@ -35,13 +35,27 @@ $script:fail = 0
 $work = Join-Path $env:TEMP ("hull-accept-" + [guid]::NewGuid())
 New-Item -ItemType Directory -Path $work | Out-Null
 
-# Serve a built APE and curl a path; returns the response body (or '').
-function Serve-And-Get([string]$exe, [string]$appPath, [int]$port, [string]$route) {
-    $p = Start-Process -FilePath $exe -ArgumentList @($appPath, '-p', "$port") -PassThru -WindowStyle Hidden
+# Serve a BUILT standalone APE and curl a path; returns the response body (or
+# ''). A built binary IS the app, so it is run directly as `<exe> -p <port>` -
+# passing an app path would hand the app a spurious positional arg. On failure to
+# get a response, the app's stdout/stderr are dumped into the evidence so a
+# genuine serve failure is diagnosable rather than a silent empty body.
+function Serve-And-Get([string]$exe, [int]$port, [string]$route) {
+    $so = Join-Path $work ("serve-$port.out.log")
+    $se = Join-Path $work ("serve-$port.err.log")
+    $p = Start-Process -FilePath $exe -ArgumentList @('-p', "$port") -PassThru `
+                       -WindowStyle Hidden -RedirectStandardOutput $so -RedirectStandardError $se
     try {
-        for ($i = 0; $i -lt 40; $i++) {
+        for ($i = 0; $i -lt 60; $i++) {
             Start-Sleep -Milliseconds 250
             try { return (Invoke-RestMethod -Uri "http://127.0.0.1:$port$route" -TimeoutSec 2) } catch {}
+            if ($p.HasExited) { break }   # the app died; stop waiting
+        }
+        Note ("- serve diagnostics for port {0} (exe exited={1}, code={2}):" -f $port, $p.HasExited, $p.ExitCode)
+        foreach ($f in @($so, $se)) {
+            if ((Test-Path $f) -and (Get-Item $f).Length -gt 0) {
+                Get-Content $f | Select-Object -First 20 | ForEach-Object { Note ("    [serve] " + $_) }
+            }
         }
         return ''
     } finally { $p | Stop-Process -Force -ErrorAction SilentlyContinue }
@@ -86,7 +100,7 @@ foreach ($case in @(@{ext='lua';src=$lua;port=39701}, @{ext='js';src=$js;port=39
     Set-Content -Path (Join-Path $adir ("app." + $case.ext)) -Value $case.src
     $bout = Cap { & $Hull build $adir -o (Join-Path $adir 'out.com') }; $rc = $LASTEXITCODE
     if ($rc -ne 0) { Note (($bout | Out-String) -replace '(?m)^','    '); Fail ("hull build failed for the " + $case.ext + " /ping app"); continue }
-    $body = Serve-And-Get (Join-Path $adir 'out.com') (Join-Path $adir 'out.com') $case.port '/ping'
+    $body = Serve-And-Get (Join-Path $adir 'out.com') $case.port '/ping'
     if ("$body".Trim() -eq 'pong') { Note ("- OK: " + $case.ext + " /ping served pong") }
     else { Fail ($case.ext + " /ping did not serve pong (got '" + $body + "')") }
 }
@@ -113,7 +127,7 @@ return { who = function() return "nested-ok" end }
 $nb = Cap { & $Hull build $nd -o (Join-Path $nd 'out.com') }; $rc = $LASTEXITCODE
 if ($rc -ne 0) { Note (($nb | Out-String) -replace '(?m)^','    '); Fail "nested-module app build failed" }
 else {
-    $body = Serve-And-Get (Join-Path $nd 'out.com') (Join-Path $nd 'out.com') 39703 '/who'
+    $body = Serve-And-Get (Join-Path $nd 'out.com') 39703 '/who'
     if ("$body".Trim() -eq 'nested-ok') { Note "- OK: built nested-module app resolved ./routes -> ./../lib and served" }
     else { Fail "nested-module built app did not serve the deep-resolved value (got '$body')" }
 }

--- a/tests/acceptance/windows/old_update_fails.ps1
+++ b/tests/acceptance/windows/old_update_fails.ps1
@@ -1,0 +1,57 @@
+<#
+  old_update_fails.ps1 - the honest "before" half of the self-update contract:
+  the OLD v0.13.0 APE cannot self-update on Windows, because its update code
+  predates the deferred-swap fix (it renames the new binary over the RUNNING
+  .exe, which Windows refuses, with no fallback). Run AS the standard user.
+
+  Fail-closed assertions:
+    - `hull update` returns FAILURE;
+    - it fails at the atomic replace of the running binary (the pre-fix path):
+      the output contains "atomic_write: rename ... failed" and NOT the
+      deferred-swap "rolled back" / "self_replace" messages;
+    - the original v0.13.0 binary is untouched, runs, and still reports 0.13.0.
+
+  Usage: old_update_fails.ps1 -Hull <exe> -Repo <org/staging-rc> -PrevVersion 0.13.0 -Evidence <file>
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)][string]$Hull,
+    [Parameter(Mandatory=$true)][string]$Repo,
+    [Parameter(Mandatory=$true)][string]$PrevVersion,
+    [Parameter(Mandatory=$true)][string]$Evidence
+)
+
+$ErrorActionPreference = 'Stop'
+function Note($m) { Add-Content -Path $Evidence -Value $m; Write-Host $m }
+function Fail($m) { Note ("  FAIL: {0}" -f $m); $script:fail = 1 }
+$script:fail = 0
+
+Note "## Old v0.13.0 self-update MUST FAIL (pre-fix Windows bug)"
+$pre = (& $Hull version 2>&1 | Select-Object -First 1)
+Note ("- pre-update version: {0}" -f $pre)
+
+$out  = & $Hull update --repo $Repo 2>&1
+$code = $LASTEXITCODE
+$text = ($out | Out-String)
+Note (($text) -replace '(?m)^','    ')
+Note ("- exit code: {0}" -f $code)
+
+if ($code -eq 0) { Fail "old v0.13.0 hull update unexpectedly SUCCEEDED on Windows" }
+if ($text -match 'atomic_write: rename.*failed') {
+    Note "- confirmed: failed at the atomic replace of the running binary (the pre-fix path)"
+} else {
+    Fail "did not fail via the expected atomic-rename path (unexpected failure mode)"
+}
+if ($text -match 'rolled back|self_replace') { Fail "the old binary appears to have the deferred-swap code (unexpected)" }
+
+# Original untouched.
+$post = (& $Hull version 2>&1 | Select-Object -First 1)
+Note ("- post-attempt version: {0}" -f $post)
+if ($post -notmatch [regex]::Escape($PrevVersion)) { Fail "old binary changed / not $PrevVersion after the failed update" }
+
+# Any half-written sidecar must not have replaced the binary.
+Remove-Item "$Hull.new" -Force -ErrorAction SilentlyContinue
+
+if ($script:fail -ne 0) { Note "OLD-UPDATE-FAILS: FAIL"; exit 1 }
+Note "OLD-UPDATE-FAILS: OK (v0.13.0 cannot self-update on Windows; binary intact - the bug #429 fixes going forward)"
+exit 0

--- a/tests/acceptance/windows/old_update_fails.ps1
+++ b/tests/acceptance/windows/old_update_fails.ps1
@@ -24,13 +24,19 @@ param(
 $ErrorActionPreference = 'Stop'
 function Note($m) { Add-Content -Path $Evidence -Value $m; Write-Host $m }
 function Fail($m) { Note ("  FAIL: {0}" -f $m); $script:fail = 1 }
+# hull writes progress to stdout and errors/logs to stderr; under -EA Stop a
+# 2>&1 merge of native stderr becomes a terminating error. The 0.13.0 failure we
+# assert here IS printed to stderr, so capture through a helper that locally
+# relaxes the preference and merges both streams (else the script would die
+# before it can assert the expected failure).
+function Cap([scriptblock]$sb) { $ErrorActionPreference = 'Continue'; & $sb 2>&1 }
 $script:fail = 0
 
 Note "## Old v0.13.0 self-update MUST FAIL (pre-fix Windows bug)"
-$pre = (& $Hull version 2>&1 | Select-Object -First 1)
+$pre = (Cap { & $Hull version } | Select-Object -First 1)
 Note ("- pre-update version: {0}" -f $pre)
 
-$out  = & $Hull update --repo $Repo 2>&1
+$out  = Cap { & $Hull update --repo $Repo }
 $code = $LASTEXITCODE
 $text = ($out | Out-String)
 Note (($text) -replace '(?m)^','    ')
@@ -45,7 +51,7 @@ if ($text -match 'atomic_write: rename.*failed') {
 if ($text -match 'rolled back|self_replace') { Fail "the old binary appears to have the deferred-swap code (unexpected)" }
 
 # Original untouched.
-$post = (& $Hull version 2>&1 | Select-Object -First 1)
+$post = (Cap { & $Hull version } | Select-Object -First 1)
 Note ("- post-attempt version: {0}" -f $post)
 if ($post -notmatch [regex]::Escape($PrevVersion)) { Fail "old binary changed / not $PrevVersion after the failed update" }
 

--- a/tests/acceptance/windows/old_update_fails.ps1
+++ b/tests/acceptance/windows/old_update_fails.ps1
@@ -39,16 +39,21 @@ Note ("- pre-update version: {0}" -f $pre)
 $out  = Cap { & $Hull update --repo $Repo }
 $code = $LASTEXITCODE
 $text = ($out | Out-String)
+# Out-String word-wraps a long ErrorRecord at the console width, so the message
+# can break across newlines (e.g. "atomic_write: rename <path> -> \n <path>
+# failed"). Match against a whitespace-collapsed copy so the wrap does not defeat
+# the assertion.
+$flat = ($text -replace '\s+', ' ')
 Note (($text) -replace '(?m)^','    ')
 Note ("- exit code: {0}" -f $code)
 
 if ($code -eq 0) { Fail "old v0.13.0 hull update unexpectedly SUCCEEDED on Windows" }
-if ($text -match 'atomic_write: rename.*failed') {
+if ($flat -match 'atomic_write: rename .* failed') {
     Note "- confirmed: failed at the atomic replace of the running binary (the pre-fix path)"
 } else {
     Fail "did not fail via the expected atomic-rename path (unexpected failure mode)"
 }
-if ($text -match 'rolled back|self_replace') { Fail "the old binary appears to have the deferred-swap code (unexpected)" }
+if ($flat -match 'rolled back|self_replace') { Fail "the old binary appears to have the deferred-swap code (unexpected)" }
 
 # Original untouched.
 $post = (Cap { & $Hull version } | Select-Object -First 1)

--- a/tests/acceptance/windows/preconditions.ps1
+++ b/tests/acceptance/windows/preconditions.ps1
@@ -49,21 +49,30 @@ try {
 Note ("- Developer Mode (AllowDevelopmentWithoutDevLicense): {0}" -f $dev)
 if ($dev -ne 0) { Note "  FAIL: Developer Mode is enabled"; $fail = 1 }
 
-# 3. Symlink creation DENIED --------------------------------------------------
+# 3. Symlink creation DENIED (specifically - not a target/dir write failure) --
+# First prove the target + directory ARE writable (write the target file); only
+# THEN attempt the symlink, so a failure is unambiguously the missing
+# SeCreateSymbolicLinkPrivilege (no elevation / Developer Mode), not an
+# unwritable path.
 $tmp    = Join-Path $env:TEMP ("hull-symcheck-{0}" -f ([guid]::NewGuid()))
 $target = Join-Path $env:TEMP ("hull-symtarget-{0}.txt" -f ([guid]::NewGuid()))
-Set-Content -Path $target -Value 'x'
-$symDenied = $false
-try {
-    New-Item -ItemType SymbolicLink -Path $tmp -Target $target -ErrorAction Stop | Out-Null
-    Note "- control symlink creation: SUCCEEDED (unexpected)"
-    Remove-Item $tmp -Force -ErrorAction SilentlyContinue
-} catch {
-    $symDenied = $true
-    Note ("- control symlink creation: DENIED as expected ({0})" -f $_.Exception.Message)
+$targetWritable = $false
+try { Set-Content -Path $target -Value 'x' -ErrorAction Stop; $targetWritable = $true }
+catch { Note ("  FAIL(harness): symlink target/dir is not writable ({0}) - cannot isolate the symlink-privilege check" -f $_.Exception.Message); $fail = 1 }
+if ($targetWritable) {
+    Note "- symlink target is writable (so a symlink failure is privilege-specific)"
+    $symDenied = $false
+    try {
+        New-Item -ItemType SymbolicLink -Path $tmp -Target $target -ErrorAction Stop | Out-Null
+        Note "- control symlink creation: SUCCEEDED (unexpected - env is not restricted)"
+        Remove-Item $tmp -Force -ErrorAction SilentlyContinue
+    } catch {
+        $symDenied = $true
+        Note ("- control symlink creation: DENIED as expected ({0})" -f $_.Exception.Message)
+    }
+    if (-not $symDenied) { Note "  FAIL: symlink creation was allowed - environment is not restricted"; $fail = 1 }
+    Remove-Item $target -Force -ErrorAction SilentlyContinue
 }
-Remove-Item $target -Force -ErrorAction SilentlyContinue
-if (-not $symDenied) { Note "  FAIL: symlink creation was allowed - environment is not restricted"; $fail = 1 }
 
 if ($fail -ne 0) { Note "PRECONDITIONS: FAIL"; exit 1 }
 Note "PRECONDITIONS: OK (non-admin, Dev-Mode off, symlink denied)"

--- a/tests/acceptance/windows/rollback_acl.ps1
+++ b/tests/acceptance/windows/rollback_acl.ps1
@@ -1,34 +1,37 @@
 <#
-  rollback_acl.ps1 - Prove the self-update ROLLBACK on a REAL Windows ACL
-  scenario (no test hooks, no helper processes, no timing races), run AS the
+  rollback_acl.ps1 - prove the candidate's self-update ROLLBACK on a REAL Windows
+  ACL scenario (no test hooks, no helper processes, no timing races), run AS the
   standard user.
 
-  Setup: the running hull exe sits in a dedicated directory. We deny DELETE to
-  the user on NEWLY-created files via inherit-only ACEs, while leaving the
-  existing exe's own ACL permissive. Consequences during `hull update`:
-
-    - the downloaded <self>.new can be WRITTEN (create/write still allowed)
-      but cannot be renamed (a rename needs DELETE on the source);
-    - the running exe still moves to <self>.old (its own ACL permits delete);
+  Setup: the running CANDIDATE exe sits in a dedicated directory. First we
+  DISCONNECT inheritance on the existing exe (`icacls /inheritance:d` converts
+  its current permissions to explicit ACEs), so the deny we add next cannot
+  propagate onto it. Then we deny DELETE to the user on NEWLY-created files in
+  the directory via an inherit-only ACE. Result: the existing exe (and its
+  rename to <self>.old) keeps a permissive, DELETE-allowing ACL, while any file
+  created afterwards (<self>.new) inherits the DELETE deny. During `hull update`:
+    - the downloaded <self>.new can be WRITTEN but not renamed (rename needs
+      DELETE on the source);
+    - the running exe still moves to <self>.old (its ACL permits delete);
     - installing <self>.new at the original path fails via real ACL enforcement;
     - rollback renames <self>.old back to <self> (it kept the permissive ACL).
 
   Fail-closed assertions:
     - `hull update` returns FAILURE;
-    - it reached the MID-SWAP install failure - the self-update layer printed
+    - it REACHED the mid-swap install failure: the self-update layer printed
       "install failed; rolled back to the previous binary" (NOT an earlier
       download error and NOT "cannot move ... aside", the initial-rename path);
-    - <self>.new was created (evidence the download + write step succeeded);
-    - the original path still exists, runs, and reports the previous version;
-    - no usable candidate was installed (version did not advance).
+    - <self>.new was created (the download + write step succeeded);
+    - the original candidate is restored, runs, and still reports the candidate
+      version; no partial candidate/other version was installed.
 
-  Usage: rollback_acl.ps1 -Hull <exe> -Repo <org/staging-rc> -PrevVersion 0.13.0 -Evidence <file>
+  Usage: rollback_acl.ps1 -Hull <candidate-exe> -Repo <org/staging-rc> -RcVersion 0.14.0-rc1 -Evidence <file>
 #>
 [CmdletBinding()]
 param(
     [Parameter(Mandatory=$true)][string]$Hull,
     [Parameter(Mandatory=$true)][string]$Repo,
-    [Parameter(Mandatory=$true)][string]$PrevVersion,
+    [Parameter(Mandatory=$true)][string]$RcVersion,
     [Parameter(Mandatory=$true)][string]$Evidence
 )
 
@@ -37,57 +40,52 @@ function Note($m) { Add-Content -Path $Evidence -Value $m; Write-Host $m }
 function Fail($m) { Note ("  FAIL: {0}" -f $m); $script:fail = 1 }
 $script:fail = 0
 
-$dir  = Split-Path -Parent $Hull
-$new  = "$Hull.new"
-$old  = "$Hull.old"
-$me   = "$env:USERDOMAIN\$env:USERNAME"
+$dir = Split-Path -Parent $Hull
+$new = "$Hull.new"
+$me  = "$env:USERDOMAIN\$env:USERNAME"
 
-Note "## Rollback via real Windows ACL"
-Note ("- hull: {0}" -f $Hull)
-
-# Pre-state: the candidate binary reports the previous version.
+Note "## Rollback via real Windows ACL (from the candidate)"
 $pre = (& $Hull version 2>&1 | Select-Object -First 1)
 Note ("- pre-update version: {0}" -f $pre)
-if ($pre -notmatch [regex]::Escape($PrevVersion)) { Fail "pre-update version is not $PrevVersion" }
+if ($pre -notmatch [regex]::Escape($RcVersion)) { Fail "candidate is not $RcVersion pre-update" }
 
-# Deny DELETE to the user on NEWLY-created files (inherit-only): (OI) object
-# inherit, (IO) inherit-only so the dir itself is unaffected, (DE) delete. The
-# existing exe predates this ACE and keeps its permissive ACL.
+# Protect the existing exe's ACL from the deny we are about to add: convert its
+# inherited permissions to explicit ACEs and disconnect inheritance, so the
+# directory-level deny cannot propagate onto it (it must stay renamable to .old).
+& icacls $Hull /inheritance:d | Out-Null
+Note ("- disconnected inheritance on the running exe (keeps its permissive ACL)")
+
+# Deny DELETE to the user on NEWLY-created files (inherit-only). Only files
+# created AFTER this - i.e. <self>.new - inherit it; the existing exe does not.
 & icacls $dir /deny "${me}:(OI)(IO)(DE)" | Out-Null
 Note ("- applied inherit-only DELETE deny for {0} on new files in {1}" -f $me, $dir)
 
-# Attempt the self-update. It should fail and roll back.
-$out = & $Hull update --repo $Repo 2>&1
+# Force-reinstall the RC; the ACL makes the install rename fail -> rollback.
+$out = & $Hull update --force --repo $Repo 2>&1
 $code = $LASTEXITCODE
 $text = ($out | Out-String)
-Note "- hull update output:"
-Note ($text -replace '(?m)^', '    ')
-Note ("- hull update exit code: {0}" -f $code)
+Note ($text -replace '(?m)^','    ')
+Note ("- exit code: {0}" -f $code)
 
-# Remove the deny so post-run cleanup can delete any residue.
+# Remove the deny so post-run cleanup can delete residue.
 & icacls $dir /remove:d "${me}" | Out-Null
 
 if ($code -eq 0) { Fail "hull update unexpectedly SUCCEEDED under the ACL lock" }
-
-# Evidence: reached the mid-swap install failure (rollback), not an earlier stage.
 if ($text -match 'rolled back to the previous binary') {
-    Note "- evidence: reached mid-swap install failure -> rolled back"
+    Note "- evidence: reached the mid-swap install failure -> rolled back"
 } else {
     Fail "did not reach the mid-swap install/rollback path (no rollback message)"
 }
-if ($text -match 'cannot move .* aside') { Fail "failed at the INITIAL rename, not the install step" }
+if ($text -match 'cannot move .* aside')       { Fail "failed at the INITIAL rename, not the install step" }
 if ($text -match 'failed to download|returned HTTP') { Fail "failed during DOWNLOAD, not the install step" }
-
-# Evidence the download + write step succeeded: <self>.new was created.
 if (Test-Path $new) { Note "- evidence: <self>.new exists (download+write succeeded past the ACL create/write allowance)" }
-else { Fail "<self>.new absent - download/write did not complete, so the ACL install failure was not exercised" }
+else { Fail "<self>.new absent - the ACL install failure was not exercised" }
 
-# Original restored, runnable, still the previous version.
-if (-not (Test-Path $Hull)) { Fail "original hull path is missing after rollback" }
+if (-not (Test-Path $Hull)) { Fail "original candidate path missing after rollback" }
 $post = (& $Hull version 2>&1 | Select-Object -First 1)
 Note ("- post-rollback version: {0}" -f $post)
-if ($post -notmatch [regex]::Escape($PrevVersion)) { Fail "post-rollback version is not $PrevVersion (a candidate was partially installed)" }
+if ($post -notmatch [regex]::Escape($RcVersion)) { Fail "post-rollback version is not $RcVersion (a partial install landed)" }
 
 if ($script:fail -ne 0) { Note "ROLLBACK-ACL: FAIL"; exit 1 }
-Note "ROLLBACK-ACL: OK (real ACL mid-swap install failure -> clean rollback to $PrevVersion)"
+Note "ROLLBACK-ACL: OK (real ACL mid-swap install failure -> clean rollback to $RcVersion)"
 exit 0

--- a/tests/acceptance/windows/rollback_acl.ps1
+++ b/tests/acceptance/windows/rollback_acl.ps1
@@ -3,18 +3,18 @@
   ACL scenario (no test hooks, no helper processes, no timing races), run AS the
   standard user.
 
-  Setup: the running CANDIDATE exe sits in a dedicated directory. First we
-  DISCONNECT inheritance on the existing exe (`icacls /inheritance:d` converts
-  its current permissions to explicit ACEs), so the deny we add next cannot
-  propagate onto it. Then we deny DELETE to the user on NEWLY-created files in
-  the directory via an inherit-only ACE. Result: the existing exe (and its
-  rename to <self>.old) keeps a permissive, DELETE-allowing ACL, while any file
-  created afterwards (<self>.new) inherits the DELETE deny. During `hull update`:
-    - the downloaded <self>.new can be WRITTEN but not renamed (rename needs
-      DELETE on the source);
-    - the running exe still moves to <self>.old (its ACL permits delete);
+  The ACL is prepared by the orchestrator (run.ps1) BEFORE this phase, because
+  changing a DACL needs WRITE_DAC/ownership that the standard user lacks. Setup:
+    - inheritance on the running exe is disconnected and it keeps an explicit
+      permissive (DELETE-allowing) ACE, so it can be renamed to <self>.old;
+    - the directory carries an inherit-only DELETE deny for THIS user, so any
+      file created afterwards (<self>.new) cannot be deleted/renamed by us.
+  During `hull update --force`:
+    - the downloaded <self>.new is written but cannot be renamed (needs DELETE
+      on the source, which is denied);
+    - the running exe still moves to <self>.old;
     - installing <self>.new at the original path fails via real ACL enforcement;
-    - rollback renames <self>.old back to <self> (it kept the permissive ACL).
+    - rollback renames <self>.old back to <self>.
 
   Fail-closed assertions:
     - `hull update` returns FAILURE;
@@ -38,37 +38,24 @@ param(
 $ErrorActionPreference = 'Stop'
 function Note($m) { Add-Content -Path $Evidence -Value $m; Write-Host $m }
 function Fail($m) { Note ("  FAIL: {0}" -f $m); $script:fail = 1 }
+# hull writes progress to stdout and errors/logs to stderr; under -EA Stop a
+# 2>&1 merge of native stderr becomes a terminating error. Capture through a
+# helper that locally relaxes the preference and merges both streams.
+function Cap([scriptblock]$sb) { $ErrorActionPreference = 'Continue'; & $sb 2>&1 }
 $script:fail = 0
-
-$dir = Split-Path -Parent $Hull
 $new = "$Hull.new"
-$me  = "$env:USERDOMAIN\$env:USERNAME"
 
-Note "## Rollback via real Windows ACL (from the candidate)"
-$pre = (& $Hull version 2>&1 | Select-Object -First 1)
+Note "## Rollback via real Windows ACL (from the candidate, as $(whoami))"
+$pre = (Cap { & $Hull version } | Select-Object -First 1)
 Note ("- pre-update version: {0}" -f $pre)
 if ($pre -notmatch [regex]::Escape($RcVersion)) { Fail "candidate is not $RcVersion pre-update" }
 
-# Protect the existing exe's ACL from the deny we are about to add: convert its
-# inherited permissions to explicit ACEs and disconnect inheritance, so the
-# directory-level deny cannot propagate onto it (it must stay renamable to .old).
-& icacls $Hull /inheritance:d | Out-Null
-Note ("- disconnected inheritance on the running exe (keeps its permissive ACL)")
-
-# Deny DELETE to the user on NEWLY-created files (inherit-only). Only files
-# created AFTER this - i.e. <self>.new - inherit it; the existing exe does not.
-& icacls $dir /deny "${me}:(OI)(IO)(DE)" | Out-Null
-Note ("- applied inherit-only DELETE deny for {0} on new files in {1}" -f $me, $dir)
-
-# Force-reinstall the RC; the ACL makes the install rename fail -> rollback.
-$out = & $Hull update --force --repo $Repo 2>&1
+# The DELETE deny on new files is already in place (prepared by run.ps1).
+$out = Cap { & $Hull update --force --repo $Repo }
 $code = $LASTEXITCODE
 $text = ($out | Out-String)
 Note ($text -replace '(?m)^','    ')
 Note ("- exit code: {0}" -f $code)
-
-# Remove the deny so post-run cleanup can delete residue.
-& icacls $dir /remove:d "${me}" | Out-Null
 
 if ($code -eq 0) { Fail "hull update unexpectedly SUCCEEDED under the ACL lock" }
 if ($text -match 'rolled back to the previous binary') {
@@ -76,13 +63,13 @@ if ($text -match 'rolled back to the previous binary') {
 } else {
     Fail "did not reach the mid-swap install/rollback path (no rollback message)"
 }
-if ($text -match 'cannot move .* aside')       { Fail "failed at the INITIAL rename, not the install step" }
-if ($text -match 'failed to download|returned HTTP') { Fail "failed during DOWNLOAD, not the install step" }
+if ($text -match 'cannot move .* aside')            { Fail "failed at the INITIAL rename, not the install step" }
+if ($text -match 'failed to download|returned HTTP'){ Fail "failed during DOWNLOAD, not the install step" }
 if (Test-Path $new) { Note "- evidence: <self>.new exists (download+write succeeded past the ACL create/write allowance)" }
 else { Fail "<self>.new absent - the ACL install failure was not exercised" }
 
 if (-not (Test-Path $Hull)) { Fail "original candidate path missing after rollback" }
-$post = (& $Hull version 2>&1 | Select-Object -First 1)
+$post = (Cap { & $Hull version } | Select-Object -First 1)
 Note ("- post-rollback version: {0}" -f $post)
 if ($post -notmatch [regex]::Escape($RcVersion)) { Fail "post-rollback version is not $RcVersion (a partial install landed)" }
 

--- a/tests/acceptance/windows/run.ps1
+++ b/tests/acceptance/windows/run.ps1
@@ -53,9 +53,14 @@ New-Item -Path $devKey -Force | Out-Null
 Set-ItemProperty -Path $devKey -Name AllowDevelopmentWithoutDevLicense -Value 0 -Type DWord
 Note "- Developer Mode disabled (AllowDevelopmentWithoutDevLicense=0)"
 
-# ── Make WorkDir + the scripts readable/executable by the user ───────────────
+# ── Make WorkDir + the scripts readable/executable by the user, and the
+#    evidence file writable (the phases run AS the user and append to it) ──────
 & icacls $WorkDir /grant "${user}:(OI)(CI)M" | Out-Null
 & icacls $here    /grant "${user}:(OI)(CI)RX" | Out-Null
+# The evidence file already exists (the parent wrote the header); grant the user
+# Modify on the file itself. Keep it inside WorkDir so the user can traverse to
+# it (the caller passes an evidence path under WorkDir).
+& icacls $Evidence /grant "${user}:M" | Out-Null
 
 # ── Download the previous release's Windows APE (read-only) ──────────────────
 $prevExe = Join-Path $WorkDir 'hull-prev.com'
@@ -71,11 +76,33 @@ $aclHull = Join-Path $aclDir 'hull.com'; Copy-Item $prevExe $aclHull
 & icacls $suDir  /grant "${user}:(OI)(CI)M" | Out-Null
 & icacls $aclDir /grant "${user}:(OI)(CI)M" | Out-Null
 
+# A writable HOME for the standard user's phases: a runas session has no loaded
+# profile, so hull's ~/.hull (update, tools install, doctor) needs an explicit,
+# user-writable home. Set it in this parent env so the child processes inherit
+# it (Start-Process passes the caller's environment).
+$homeDir = Join-Path $WorkDir 'home'
+New-Item -ItemType Directory -Path $homeDir -Force | Out-Null
+& icacls $homeDir /grant "${user}:(OI)(CI)M" | Out-Null
+$env:HOME        = $homeDir
+$env:USERPROFILE = $homeDir
+Note ("- HOME for phases: {0}" -f $homeDir)
+
 # ── Run a phase AS the standard user; return its exit code ───────────────────
+# Redirects the child's console output to a log and folds it into the evidence,
+# so a phase is diagnosable even if the child cannot append evidence itself.
 function Invoke-AsUser([string]$script, [string[]]$phaseArgs) {
+    $base = [IO.Path]::GetFileNameWithoutExtension($script)
+    $out  = Join-Path $WorkDir ("phase-$base.out.log")
+    $err  = Join-Path $WorkDir ("phase-$base.err.log")
     $a = @('-NoProfile','-ExecutionPolicy','Bypass','-File', (Join-Path $here $script)) + $phaseArgs
     $p = Start-Process -FilePath 'powershell.exe' -Credential $cred -ArgumentList $a `
-                       -WorkingDirectory $WorkDir -Wait -PassThru
+                       -WorkingDirectory $WorkDir -Wait -PassThru `
+                       -RedirectStandardOutput $out -RedirectStandardError $err
+    foreach ($f in @($out, $err)) {
+        if ((Test-Path $f) -and (Get-Item $f).Length -gt 0) {
+            Get-Content $f | ForEach-Object { Note ("    [child] " + $_) }
+        }
+    }
     return $p.ExitCode
 }
 

--- a/tests/acceptance/windows/run.ps1
+++ b/tests/acceptance/windows/run.ps1
@@ -1,22 +1,30 @@
 <#
   run.ps1 - orchestrates the Windows acceptance run. Runs as the runner's admin
-  account, but drives every acceptance phase AS a freshly-created STANDARD
-  (non-admin) user, with Developer Mode disabled, so the non-admin / self-update
-  / ACL evidence is meaningful. Aggregates a single evidence report and fails
-  closed if any phase fails.
+  account but drives every phase AS a freshly-created STANDARD (non-admin) user
+  with Developer Mode disabled, so the non-admin / self-update / ACL evidence is
+  meaningful. Aggregates a single evidence report; fails closed if any phase
+  fails.
 
-  It never creates, modifies, or deletes a GitHub release: it only downloads the
-  previous release's Windows APE and drives `hull update --repo=<staging>`
-  against the maintainer-prepopulated staging repos.
+  Honest before/after self-update contract (v0.14.0):
+    - the OLD v0.13.0 APE `hull update` MUST FAIL on Windows (its update code
+      predates the deferred-swap fix - a running .exe can't be replaced);
+    - the CANDIDATE performing an update MUST SUCCEED via the deferred swap
+      (force-reinstall to the RC, and downgrade to the previous release);
+    - the ACL-induced rollback and the path-with-spaces coverage run FROM the
+      candidate.
+
+  Read-only w.r.t. releases: downloads the previous + candidate APEs and drives
+  `hull update --repo=<staging>` against maintainer-prepopulated staging repos.
 
   Usage:
-    run.ps1 -OfficialRepo artalis-io/hull -PrevTag v0.13.0 -PrevVersion 0.13.0 \
-            -RcRepo <org/staging-rc> -ExpectVersion 0.14.0-rc1 \
-            -Evidence <file> -WorkDir <dir>
+    run.ps1 -OfficialRepo artalis-io/hull -RcTag v0.14.0-rc1 -PrevTag v0.13.0 \
+            -PrevVersion 0.13.0 -RcRepo <org/staging-rc> -ExpectVersion 0.14.0-rc1 \
+            -PrevRepo <org/staging-prev> -Evidence <file> -WorkDir <dir>
 #>
 [CmdletBinding()]
 param(
     [Parameter(Mandatory=$true)][string]$OfficialRepo,
+    [Parameter(Mandatory=$true)][string]$RcTag,
     [Parameter(Mandatory=$true)][string]$PrevTag,
     [Parameter(Mandatory=$true)][string]$PrevVersion,
     [Parameter(Mandatory=$true)][string]$RcRepo,
@@ -40,7 +48,6 @@ $sec  = ConvertTo-SecureString $pw -AsPlainText -Force
 if (Get-LocalUser -Name $user -ErrorAction SilentlyContinue) { Remove-LocalUser -Name $user }
 New-LocalUser -Name $user -Password $sec -AccountNeverExpires -PasswordNeverExpires | Out-Null
 Add-LocalGroupMember -Group 'Users' -Member $user -ErrorAction SilentlyContinue
-# Explicitly NOT in Administrators. Assert.
 if (Get-LocalGroupMember -Group 'Administrators' -Member $user -ErrorAction SilentlyContinue) {
     Note "FATAL: acceptance user is in Administrators"; exit 1
 }
@@ -53,43 +60,48 @@ New-Item -Path $devKey -Force | Out-Null
 Set-ItemProperty -Path $devKey -Name AllowDevelopmentWithoutDevLicense -Value 0 -Type DWord
 Note "- Developer Mode disabled (AllowDevelopmentWithoutDevLicense=0)"
 
-# ── Make WorkDir + the scripts readable/executable by the user, and the
-#    evidence file writable (the phases run AS the user and append to it) ──────
-& icacls $WorkDir /grant "${user}:(OI)(CI)M" | Out-Null
-& icacls $here    /grant "${user}:(OI)(CI)RX" | Out-Null
-# The evidence file already exists (the parent wrote the header); grant the user
-# Modify on the file itself. Keep it inside WorkDir so the user can traverse to
-# it (the caller passes an evidence path under WorkDir).
-& icacls $Evidence /grant "${user}:M" | Out-Null
-
-# ── Download the previous release's Windows APE (read-only) ──────────────────
-$prevExe = Join-Path $WorkDir 'hull-prev.com'
-$url = "https://github.com/$OfficialRepo/releases/download/$PrevTag/hull-cosmo"
-Invoke-WebRequest -Uri $url -OutFile $prevExe
-Note "- downloaded previous APE $PrevTag ($url)"
-
-# Working copies for the phases.
-$suDir  = Join-Path $WorkDir 'selfupdate'; New-Item -ItemType Directory -Path $suDir  | Out-Null
-$aclDir = Join-Path $WorkDir 'acl';        New-Item -ItemType Directory -Path $aclDir | Out-Null
-$suHull  = Join-Path $suDir  'hull.com'; Copy-Item $prevExe $suHull
-$aclHull = Join-Path $aclDir 'hull.com'; Copy-Item $prevExe $aclHull
-& icacls $suDir  /grant "${user}:(OI)(CI)M" | Out-Null
-& icacls $aclDir /grant "${user}:(OI)(CI)M" | Out-Null
-
-# A writable HOME for the standard user's phases: a runas session has no loaded
-# profile, so hull's ~/.hull (update, tools install, doctor) needs an explicit,
-# user-writable home. Set it in this parent env so the child processes inherit
-# it (Start-Process passes the caller's environment).
+# ── Grants + a fully user-writable environment for the child phases ──────────
+# Start-Process -Credential inherits THIS process's environment, which by default
+# points HOME/TEMP/APPDATA at the RUNNER-ADMIN's profile (unwritable by hullacc).
+# Redirect all of them at user-granted dirs so a runas child (no loaded profile)
+# has writable home/temp/appdata for hull's ~/.hull and for scratch files.
+& icacls $WorkDir  /grant "${user}:(OI)(CI)M"  | Out-Null
+& icacls $here     /grant "${user}:(OI)(CI)RX" | Out-Null
+& icacls $Evidence /grant "${user}:M"          | Out-Null
 $homeDir = Join-Path $WorkDir 'home'
-New-Item -ItemType Directory -Path $homeDir -Force | Out-Null
-& icacls $homeDir /grant "${user}:(OI)(CI)M" | Out-Null
-$env:HOME        = $homeDir
-$env:USERPROFILE = $homeDir
-Note ("- HOME for phases: {0}" -f $homeDir)
+$tmpDir  = Join-Path $WorkDir 'tmp'
+$appData = Join-Path $WorkDir 'appdata'
+$localApp= Join-Path $WorkDir 'localappdata'
+foreach ($d in @($homeDir,$tmpDir,$appData,$localApp)) { New-Item -ItemType Directory -Path $d -Force | Out-Null }
+$env:HOME          = $homeDir
+$env:USERPROFILE   = $homeDir
+$env:TEMP          = $tmpDir
+$env:TMP           = $tmpDir
+$env:APPDATA       = $appData
+$env:LOCALAPPDATA  = $localApp
+Note ("- child env: HOME/TEMP/APPDATA under {0}" -f $WorkDir)
 
-# ── Run a phase AS the standard user; return its exit code ───────────────────
-# Redirects the child's console output to a log and folds it into the evidence,
-# so a phase is diagnosable even if the child cannot append evidence itself.
+# ── Download the previous + candidate Windows APEs (read-only) ───────────────
+$prevExe = Join-Path $WorkDir 'hull-prev.com'
+$candExe = Join-Path $WorkDir 'hull-cand.com'
+Invoke-WebRequest -Uri "https://github.com/$OfficialRepo/releases/download/$PrevTag/hull-cosmo" -OutFile $prevExe
+Invoke-WebRequest -Uri "https://github.com/$OfficialRepo/releases/download/$RcTag/hull-cosmo"   -OutFile $candExe
+Note "- downloaded previous APE $PrevTag and candidate APE $RcTag"
+
+# Per-phase working copies (each in its own granted dir).
+function New-PhaseCopy([string]$name, [string]$src) {
+    $d = Join-Path $WorkDir $name; New-Item -ItemType Directory -Path $d -Force | Out-Null
+    & icacls $d /grant "${user}:(OI)(CI)M" | Out-Null
+    $p = Join-Path $d 'hull.com'; Copy-Item $src $p
+    return $p
+}
+$oldHull  = New-PhaseCopy 'oldfail'    $prevExe   # v0.13.0: update MUST fail
+$candHull = New-PhaseCopy 'selfupdate' $candExe   # candidate --force: MUST succeed
+$aclHull  = New-PhaseCopy 'acl'        $candExe   # candidate + ACL: rollback
+$dgHull   = New-PhaseCopy 'downgrade'  $candExe   # candidate -> prev
+$exHull   = New-PhaseCopy 'extras'     $candExe   # candidate: spaces/cosmocc/ping/...
+
+# ── Run a phase AS the standard user; fold its output into the evidence ──────
 function Invoke-AsUser([string]$script, [string[]]$phaseArgs) {
     $base = [IO.Path]::GetFileNameWithoutExtension($script)
     $out  = Join-Path $WorkDir ("phase-$base.out.log")
@@ -108,33 +120,27 @@ function Invoke-AsUser([string]$script, [string[]]$phaseArgs) {
 
 $rc = 0
 Note "`n--- PHASE: preconditions ---"
-if ((Invoke-AsUser 'preconditions.ps1' @('-Evidence', $Evidence)) -ne 0) { $rc = 1 }
+if ((Invoke-AsUser 'preconditions.ps1' @('-Evidence',$Evidence)) -ne 0) { $rc = 1 }
 
-Note "`n--- PHASE: self-update (upgrade) ---"
-if ((Invoke-AsUser 'self_update.ps1' @('-Hull',$suHull,'-Repo',$RcRepo,'-ExpectVersion',$ExpectVersion,'-Evidence',$Evidence)) -ne 0) { $rc = 1 }
+Note "`n--- PHASE: old v0.13.0 update MUST FAIL (pre-fix bug) ---"
+if ((Invoke-AsUser 'old_update_fails.ps1' @('-Hull',$oldHull,'-Repo',$RcRepo,'-PrevVersion',$PrevVersion,'-Evidence',$Evidence)) -ne 0) { $rc = 1 }
 
-Note "`n--- PHASE: rollback via real ACL ---"
-if ((Invoke-AsUser 'rollback_acl.ps1' @('-Hull',$aclHull,'-Repo',$RcRepo,'-PrevVersion',$PrevVersion,'-Evidence',$Evidence)) -ne 0) { $rc = 1 }
+Note "`n--- PHASE: candidate self-update (force-reinstall RC) MUST SUCCEED ---"
+if ((Invoke-AsUser 'self_update.ps1' @('-Hull',$candHull,'-Repo',$RcRepo,'-ExpectVersion',$ExpectVersion,'-Evidence',$Evidence)) -ne 0) { $rc = 1 }
+
+Note "`n--- PHASE: candidate rollback via real ACL ---"
+if ((Invoke-AsUser 'rollback_acl.ps1' @('-Hull',$aclHull,'-Repo',$RcRepo,'-RcVersion',$ExpectVersion,'-Evidence',$Evidence)) -ne 0) { $rc = 1 }
 
 Note "`n--- PHASE: extras (spaces / cosmocc / ping / nested / doctor) ---"
-# $suHull is now the candidate (updated in the self-update phase); PrevHull is a
-# fresh copy for the spaces self-update inside extras.
-$prevForExtras = Join-Path $WorkDir 'hull-prev-extras.com'; Copy-Item $prevExe $prevForExtras
-& icacls $prevForExtras /grant "${user}:RX" | Out-Null
-if ((Invoke-AsUser 'extras.ps1' @('-Hull',$suHull,'-PrevHull',$prevForExtras,'-RcRepo',$RcRepo,'-ExpectVersion',$ExpectVersion,'-Evidence',$Evidence)) -ne 0) { $rc = 1 }
+if ((Invoke-AsUser 'extras.ps1' @('-Hull',$exHull,'-RcRepo',$RcRepo,'-ExpectVersion',$ExpectVersion,'-Evidence',$Evidence)) -ne 0) { $rc = 1 }
 
 if ($PrevRepo -ne '') {
-    Note "`n--- PHASE: downgrade (staging-based) ---"
-    $dgDir = Join-Path $WorkDir 'downgrade'; New-Item -ItemType Directory -Path $dgDir | Out-Null
-    $dgHull = Join-Path $dgDir 'hull.com'; Copy-Item $prevExe $dgHull
-    & icacls $dgDir /grant "${user}:(OI)(CI)M" | Out-Null
-    if ((Invoke-AsUser 'downgrade.ps1' @('-Hull',$dgHull,'-RcRepo',$RcRepo,'-PrevRepo',$PrevRepo,'-RcVersion',$ExpectVersion,'-PrevVersion',$PrevVersion,'-Evidence',$Evidence)) -ne 0) { $rc = 1 }
+    Note "`n--- PHASE: downgrade candidate -> previous (staging) ---"
+    if ((Invoke-AsUser 'downgrade.ps1' @('-Hull',$dgHull,'-PrevRepo',$PrevRepo,'-PrevVersion',$PrevVersion,'-Evidence',$Evidence)) -ne 0) { $rc = 1 }
 } else {
-    Note "`n--- PHASE: downgrade SKIPPED (no prev staging repo provided) ---"
+    Note "`n--- PHASE: downgrade SKIPPED (no prev staging repo) ---"
 }
 
-# ── Cleanup the local user ───────────────────────────────────────────────────
 Remove-LocalUser -Name $user -ErrorAction SilentlyContinue
-
 Note ("`n## RESULT: {0}" -f ($(if ($rc -eq 0) {'ALL PHASES PASSED'} else {'FAILURE'})))
 exit $rc

--- a/tests/acceptance/windows/run.ps1
+++ b/tests/acceptance/windows/run.ps1
@@ -129,7 +129,20 @@ Note "`n--- PHASE: candidate self-update (force-reinstall RC) MUST SUCCEED ---"
 if ((Invoke-AsUser 'self_update.ps1' @('-Hull',$candHull,'-Repo',$RcRepo,'-ExpectVersion',$ExpectVersion,'-Evidence',$Evidence)) -ne 0) { $rc = 1 }
 
 Note "`n--- PHASE: candidate rollback via real ACL ---"
+# ACL setup runs HERE (as the owner/admin): the standard user lacks WRITE_DAC on
+# these runner-admin-owned files, and $env:USERNAME in the child is the inherited
+# parent name, so the deny must be applied by the orchestrator against the real
+# standard-user principal. Freeze the exe's ACEs so the deny cannot propagate
+# onto it (it must stay renamable to <self>.old), then deny the STANDARD USER
+# DELETE on any newly-created file (<self>.new) via an inherit-only ACE.
+$aclDir   = Split-Path -Parent $aclHull
+$fullUser = "$env:COMPUTERNAME\$user"
+& icacls $aclHull /inheritance:d | Out-Null
+& icacls $aclHull /grant "${fullUser}:(M)" | Out-Null
+& icacls $aclDir  /deny  "${fullUser}:(OI)(IO)(DE)" | Out-Null
+Note ("- ACL: froze {0} ACEs; denied {1} DELETE on new files in {2}" -f $aclHull, $fullUser, $aclDir)
 if ((Invoke-AsUser 'rollback_acl.ps1' @('-Hull',$aclHull,'-Repo',$RcRepo,'-RcVersion',$ExpectVersion,'-Evidence',$Evidence)) -ne 0) { $rc = 1 }
+& icacls $aclDir /remove:d "${fullUser}" | Out-Null   # lift the deny for cleanup
 
 Note "`n--- PHASE: extras (spaces / cosmocc / ping / nested / doctor) ---"
 if ((Invoke-AsUser 'extras.ps1' @('-Hull',$exHull,'-RcRepo',$RcRepo,'-ExpectVersion',$ExpectVersion,'-Evidence',$Evidence)) -ne 0) { $rc = 1 }

--- a/tests/acceptance/windows/self_update.ps1
+++ b/tests/acceptance/windows/self_update.ps1
@@ -24,27 +24,31 @@ param(
 $ErrorActionPreference = 'Stop'
 function Note($m) { Add-Content -Path $Evidence -Value $m; Write-Host $m }
 function Fail($m) { Note ("  FAIL: {0}" -f $m); $script:fail = 1 }
+# hull writes progress to stdout and errors/logs to stderr; under -EA Stop a
+# 2>&1 merge of native stderr becomes a terminating error. Capture through a
+# helper that locally relaxes the preference and merges both streams.
+function Cap([scriptblock]$sb) { $ErrorActionPreference = 'Continue'; & $sb 2>&1 }
 $script:fail = 0
 $new = "$Hull.new"; $old = "$Hull.old"
 
 Note "## Candidate self-update via the deferred swap (force-reinstall RC)"
-$pre = (& $Hull version 2>&1 | Select-Object -First 1)
+$pre = (Cap { & $Hull version } | Select-Object -First 1)
 Note ("- pre-update version: {0}" -f $pre)
 if ($pre -notmatch [regex]::Escape($ExpectVersion)) { Fail "candidate does not report $ExpectVersion pre-update" }
 
-$out  = & $Hull update --force --repo $Repo 2>&1
+$out  = Cap { & $Hull update --force --repo $Repo }
 $code = $LASTEXITCODE
 Note (($out | Out-String) -replace '(?m)^','    ')
 Note ("- exit code: {0}" -f $code)
-if ($code -ne 0) { Fail "candidate `hull update --force` returned non-zero" }
+if ($code -ne 0) { Fail "candidate ``hull update --force`` returned non-zero" }
 
-$post = (& $Hull version 2>&1 | Select-Object -First 1)
+$post = (Cap { & $Hull version } | Select-Object -First 1)
 Note ("- post-update version: {0}" -f $post)
 if ($post -notmatch [regex]::Escape($ExpectVersion)) { Fail "post-update version is not $ExpectVersion" }
 
 if (Test-Path $new) { Fail "<self>.new residue remains after a successful update" }
 if (Test-Path $old) {
-    & $Hull version *> $null   # next startup: the sweeper (present in the candidate) removes .old
+    Cap { & $Hull version } | Out-Null   # next startup: the sweeper (present in the candidate) removes .old
     if (Test-Path $old) { Fail "<self>.old was not swept on the next startup" }
     else { Note "- <self>.old swept on the next startup (candidate sweeper)" }
 } else {

--- a/tests/acceptance/windows/self_update.ps1
+++ b/tests/acceptance/windows/self_update.ps1
@@ -1,16 +1,17 @@
 <#
-  self_update.ps1 - Prove a REAL Windows self-update of the old (previous
-  release) APE to the candidate, via a maintainer-prepopulated staging repo
-  whose /releases/latest mirrors the RC. Run AS the standard user.
+  self_update.ps1 - the "after" half: the CANDIDATE (which HAS the deferred-swap
+  fix) self-updates successfully on Windows. Force-reinstalls the RC over itself
+  (a running .exe), exercising the exact deferred rename-aside swap. Run AS the
+  standard user.
 
   Fail-closed assertions:
-    - `hull update --repo=<staging>` returns success;
+    - `hull update --force --repo=<rc-staging>` returns success;
     - the updating process exits normally (exit 0, no crash);
-    - the NEXT invocation reports the expected candidate version;
-    - the deferred-swap residue is cleaned: no <self>.new remains, and <self>.old
-      is swept by the next startup (the running process holds it until exit).
+    - the next invocation reports the candidate version;
+    - the residue is cleaned: no <self>.new, and <self>.old is swept on the next
+      startup (the candidate carries the startup sweeper).
 
-  Usage: self_update.ps1 -Hull <exe> -Repo <org/staging> -ExpectVersion 0.14.0-rc1 -Evidence <file>
+  Usage: self_update.ps1 -Hull <candidate-exe> -Repo <org/staging-rc> -ExpectVersion 0.14.0-rc1 -Evidence <file>
 #>
 [CmdletBinding()]
 param(
@@ -24,38 +25,32 @@ $ErrorActionPreference = 'Stop'
 function Note($m) { Add-Content -Path $Evidence -Value $m; Write-Host $m }
 function Fail($m) { Note ("  FAIL: {0}" -f $m); $script:fail = 1 }
 $script:fail = 0
+$new = "$Hull.new"; $old = "$Hull.old"
 
-$new = "$Hull.new"
-$old = "$Hull.old"
-
-Note "## Real self-update (upgrade)"
+Note "## Candidate self-update via the deferred swap (force-reinstall RC)"
 $pre = (& $Hull version 2>&1 | Select-Object -First 1)
 Note ("- pre-update version: {0}" -f $pre)
+if ($pre -notmatch [regex]::Escape($ExpectVersion)) { Fail "candidate does not report $ExpectVersion pre-update" }
 
-$out  = & $Hull update --repo $Repo 2>&1
+$out  = & $Hull update --force --repo $Repo 2>&1
 $code = $LASTEXITCODE
-Note "- hull update output:"
-Note (($out | Out-String) -replace '(?m)^', '    ')
-Note ("- hull update exit code: {0}" -f $code)
-if ($code -ne 0) { Fail "hull update returned non-zero" }
+Note (($out | Out-String) -replace '(?m)^','    ')
+Note ("- exit code: {0}" -f $code)
+if ($code -ne 0) { Fail "candidate `hull update --force` returned non-zero" }
 
-# The NEXT invocation (a fresh process; the updated binary is on disk) must
-# report the candidate version, and its startup sweep removes <self>.old.
 $post = (& $Hull version 2>&1 | Select-Object -First 1)
 Note ("- post-update version: {0}" -f $post)
 if ($post -notmatch [regex]::Escape($ExpectVersion)) { Fail "post-update version is not $ExpectVersion" }
 
 if (Test-Path $new) { Fail "<self>.new residue remains after a successful update" }
 if (Test-Path $old) {
-    # One more invocation to give the startup sweep a clean shot (the update
-    # process held the lock; it has since exited).
-    & $Hull version *> $null
+    & $Hull version *> $null   # next startup: the sweeper (present in the candidate) removes .old
     if (Test-Path $old) { Fail "<self>.old was not swept on the next startup" }
-    else { Note "- <self>.old swept on the next startup" }
+    else { Note "- <self>.old swept on the next startup (candidate sweeper)" }
 } else {
     Note "- no <self>.old residue"
 }
 
 if ($script:fail -ne 0) { Note "SELF-UPDATE: FAIL"; exit 1 }
-Note "SELF-UPDATE: OK ($pre -> $post via deferred swap; residue clean)"
+Note "SELF-UPDATE: OK (candidate force-reinstalled $ExpectVersion via the deferred swap; residue clean)"
 exit 0


### PR DESCRIPTION
## What

Reworks the Windows stage of the release-acceptance run
(`.github/workflows/release-acceptance-windows.yml` + `tests/acceptance/windows/*.ps1`)
into an honest **before/after** self-update contract, and fixes the several
harness bugs that surfaced while driving it to green on a real
`windows-latest` runner as a freshly-created standard (non-admin) user with
Developer Mode disabled.

Read-only w.r.t. releases throughout (`permissions: contents: read`): it only
downloads the previous + candidate APEs and drives `hull update --repo=<staging>`
against the maintainer-prepopulated staging mirrors. It never creates, modifies,
or deletes a tag, release, asset, or `latest`.

## The contract (all six phases green)

Evidence from the passing run (33273285534): `## RESULT: ALL PHASES PASSED`.

- **preconditions** - fail-closed proof the child token is non-admin + Medium
  integrity, Developer Mode is off, and control symlink creation is denied
  specifically for lack of `SeCreateSymbolicLinkPrivilege` (the target is proven
  writable first, so the failure is privilege-specific, not a write failure).
- **old_update_fails** - the previous **v0.13.0** APE MUST FAIL to self-update on
  Windows, at the atomic-rename of the running binary (`atomic_write: rename ...
  failed`). This is exactly the bug #429 fixes.
- **self_update** - the **candidate** MUST succeed via the real deferred
  rename-aside swap (force-reinstall the RC over itself), with residue cleaned
  and `<self>.old` swept on next startup.
- **rollback_acl** - run from the candidate; a real Windows ACL (inherit-only
  DELETE deny on newly-created files, applied by the privileged orchestrator)
  forces the mid-swap install failure and the updater rolls back cleanly to the
  RC. No test hooks, no helper processes, no timing races.
- **extras** - spaces-path self-update from the candidate, non-admin
  `hull tools install cosmocc`, a Lua and a JS `/ping` build+serve returning
  `pong`, a nested local-module built-parity build+serve, and doctor /
  tools-list / agent-tools agreement on cosmocc.
- **downgrade** - the candidate downgrades to the previous release (target-version
  independence of the fixed updater). The installed 0.13.0 lacks the startup
  sweeper, so the `<self>.old` residue is recorded as an expected pre-fix
  limitation and cleaned explicitly, not claimed as auto-swept.

## Harness fixes made while getting there

- **Standard-user environment.** The runas child loads no profile and otherwise
  inherits the runner-admin's unwritable `HOME`/`TEMP`/`APPDATA`. `run.ps1` now
  points all of `HOME`/`USERPROFILE`/`TEMP`/`TMP`/`APPDATA`/`LOCALAPPDATA` at
  granted subdirs of the workdir; evidence lives there and child stdout/stderr
  are folded into the report.
- **Native-stderr terminating error.** Under `-EA Stop`, a `& $hull ... 2>&1`
  capture throws `NativeCommandError` the moment hull writes to stderr. A `Cap`
  helper locally relaxes the preference and merges both streams; JSON reads parse
  defensively.
- **ACL applied by the owner, to the real principal.** `$env:USERNAME` in the
  child is the inherited parent (runneradmin), and the standard user lacks
  `WRITE_DAC` on the runner-admin-owned files. The ACL setup/teardown moved into
  `run.ps1` (owner/admin), targeting the real standard-user principal; the exe's
  inheritance is frozen so the deny reaches only `<self>.new`.
- **Built APEs run as `<exe> -p PORT`.** A built standalone binary IS the app; a
  leading app-path positional was taken by `hull_serve` as an app-dir override,
  bypassing the embedded app. Serve now also dumps app stdout/stderr on failure.
- **cosmocc spawn-flake retry.** `hull build` drives dual-arch cosmocc; its own
  process spawning is intermittently flaky on Windows under repeated heavy use
  (`posix_spawn: Bad file number` / `ERROR_KERNEL_APC` in collect2). A
  `Build-Retry` cleans the cosmocc temp and retries ONLY spawn-specific
  signatures - a genuine link regression still fails on the first try.
- **Whitespace-collapsed assertion.** `Out-String` word-wraps a long ErrorRecord;
  the 0.13.0 atomic-rename assertion now matches a whitespace-collapsed copy.

## Docs + changelog

- `CHANGELOG.md`: prominent Windows upgrade note - 0.13.0 users must manually
  download+replace Hull once while it is not running; 0.14.0 onward self-updates.
- `docs/release_acceptance.md`: describes the before/after contract and phases.

## Follow-on (maintainer-gated, after merge)

Promote to v0.14.0 (fresh signed tag) -> final smoke -> update public refs
(site / README / install.sh) -> remove the staging releases. BuildContext
checkpoint 1 stays frozen until that final smoke.