### PR TITLE
ci: reusable read-only Windows release-artifact smoke

### DIFF
--- a/.github/workflows/release-smoke-windows.yml
+++ b/.github/workflows/release-smoke-windows.yml
@@ -1,0 +1,72 @@
+name: Release smoke (Windows artifact, read-only)
+
+# Minimal smoke of a PUBLISHED release's Windows artifact (hull-cosmo). It
+# downloads the artifact from the official release, verifies its signature,
+# checksum, and reported version BEFORE execution, then - under a freshly-created
+# standard (non-admin) user with Developer Mode disabled - installs cosmocc and
+# builds + serves a Lua and a JS /ping app, requiring pong.
+#
+# READ-ONLY: downloads from the official release only. It never updates, rolls
+# back, mutates staging, creates/modifies/deletes a release or asset, or alters
+# "latest". All logic lives in checked-in PowerShell (tests/acceptance/windows/
+# run-smoke.ps1 + smoke.ps1, reusing preconditions.ps1). The release_tag +
+# expect_version inputs are REQUIRED with no default, so the smoke never silently
+# targets "latest".
+
+on:
+  workflow_dispatch:
+    inputs:
+      official_repo:
+        description: Repo hosting the release (download source)
+        required: true
+        default: artalis-io/hull
+      release_tag:
+        description: Release tag to smoke (REQUIRED; no silent latest)
+        required: true
+      expect_version:
+        description: Version string the artifact must report (REQUIRED)
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  windows-smoke:
+    name: Windows artifact smoke (non-admin, verify + cosmocc + /ping)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Extract the source-controlled release pubkey
+        id: pk
+        shell: pwsh
+        run: |
+          $line = Select-String -Path include/hull/release.h -Pattern '[0-9a-fA-F]{64}' | Select-Object -First 1
+          $hex  = [regex]::Match($line.Line, '[0-9a-fA-F]{64}').Value
+          if (-not $hex) { throw "could not extract the release pubkey from include/hull/release.h" }
+          "pubkey=$hex" >> $env:GITHUB_OUTPUT
+
+      - name: Smoke the published artifact as a standard user
+        shell: pwsh
+        run: |
+          Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+          $wd = Join-Path $env:RUNNER_TEMP 'wsmoke'
+          $ev = Join-Path $wd 'windows-smoke-evidence.md'
+          & tests/acceptance/windows/run-smoke.ps1 `
+            -OfficialRepo '${{ inputs.official_repo }}' `
+            -ReleaseTag '${{ inputs.release_tag }}' `
+            -ExpectVersion '${{ inputs.expect_version }}' `
+            -Pubkey '${{ steps.pk.outputs.pubkey }}' `
+            -Evidence $ev `
+            -WorkDir $wd
+          $code = $LASTEXITCODE
+          Get-Content $ev | ForEach-Object { Write-Host $_ }
+          Copy-Item $ev "$env:GITHUB_STEP_SUMMARY" -Force
+          if ($code -ne 0) { throw "Windows artifact smoke FAILED (see evidence report)" }
+
+      - name: Upload evidence report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: windows-smoke-evidence
+          path: ${{ runner.temp }}/wsmoke/windows-smoke-evidence.md

--- a/tests/acceptance/windows/run-smoke.ps1
+++ b/tests/acceptance/windows/run-smoke.ps1
@@ -1,0 +1,109 @@
+<#
+  run-smoke.ps1 - orchestrates the minimal Windows artifact smoke. Runs as the
+  runner's admin account but drives verification + the cosmocc build AS a
+  freshly-created STANDARD (non-admin) user with Developer Mode disabled, so the
+  non-admin evidence is meaningful. It ONLY downloads the published artifact +
+  its manifest + signature from the official release; it never updates, rolls
+  back, mutates staging, or touches any release/asset.
+
+  The standard-user smoke (smoke.ps1) checksums the downloaded bytes BEFORE
+  executing them, then verifies the signature + reported version, and only then
+  installs cosmocc and builds+serves the /ping fixtures. This orchestrator never
+  executes the downloaded binary itself, so the bytes stay pristine until the
+  checksum.
+
+  Usage:
+    run-smoke.ps1 -OfficialRepo artalis-io/hull -ReleaseTag v0.14.0 \
+                  -ExpectVersion 0.14.0 -Pubkey <hex> -Evidence <file> -WorkDir <dir>
+#>
+[CmdletBinding()]
+param(
+    [string]$OfficialRepo  = 'artalis-io/hull',
+    [string]$ReleaseTag    = '',
+    [string]$ExpectVersion = '',
+    [string]$Pubkey        = '',
+    [Parameter(Mandatory=$true)][string]$Evidence,
+    [Parameter(Mandatory=$true)][string]$WorkDir
+)
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+function Note($m) { Add-Content -Path $Evidence -Value $m; Write-Host $m }
+
+New-Item -ItemType Directory -Path $WorkDir -Force | Out-Null
+Set-Content -Path $Evidence -Value "# Windows artifact smoke evidence`n"
+
+# Fail closed on missing inputs (never silently target "latest").
+if (-not $ReleaseTag)    { Note 'FATAL: -ReleaseTag is required (no silent latest)'; exit 2 }
+if (-not $ExpectVersion) { Note 'FATAL: -ExpectVersion is required'; exit 2 }
+Note ("- repo={0} tag={1} expect={2}" -f $OfficialRepo, $ReleaseTag, $ExpectVersion)
+
+# ── Download the published artifact + manifest + signature (official only) ────
+$exe = Join-Path $WorkDir 'hull-cosmo'
+$man = Join-Path $WorkDir 'hull.sha256'
+$sig = Join-Path $WorkDir 'hull.sha256.sig'
+$base = "https://github.com/$OfficialRepo/releases/download/$ReleaseTag"
+Invoke-WebRequest -Uri "$base/hull-cosmo"      -OutFile $exe
+Invoke-WebRequest -Uri "$base/hull.sha256"     -OutFile $man
+Invoke-WebRequest -Uri "$base/hull.sha256.sig" -OutFile $sig
+Note "- downloaded hull-cosmo + hull.sha256 + hull.sha256.sig from the official release"
+
+# ── Standard (non-admin) user + Developer-Mode-off environment ────────────────
+$user = 'hullsmoke'
+$pw   = ([guid]::NewGuid().ToString() + 'Aa1!')
+$sec  = ConvertTo-SecureString $pw -AsPlainText -Force
+if (Get-LocalUser -Name $user -ErrorAction SilentlyContinue) { Remove-LocalUser -Name $user }
+New-LocalUser -Name $user -Password $sec -AccountNeverExpires -PasswordNeverExpires | Out-Null
+Add-LocalGroupMember -Group 'Users' -Member $user -ErrorAction SilentlyContinue
+if (Get-LocalGroupMember -Group 'Administrators' -Member $user -ErrorAction SilentlyContinue) {
+    Note "FATAL: smoke user is in Administrators"; exit 1
+}
+$cred = New-Object System.Management.Automation.PSCredential("$env:COMPUTERNAME\$user", $sec)
+Note "- created standard user $user (not in Administrators)"
+
+$devKey = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock'
+New-Item -Path $devKey -Force | Out-Null
+Set-ItemProperty -Path $devKey -Name AllowDevelopmentWithoutDevLicense -Value 0 -Type DWord
+Note "- Developer Mode disabled (AllowDevelopmentWithoutDevLicense=0)"
+
+# The runas child loads no profile and otherwise inherits the runner-admin's
+# unwritable HOME/TEMP/APPDATA; redirect them at granted subdirs of the workdir.
+& icacls $WorkDir  /grant "${user}:(OI)(CI)M"  | Out-Null
+& icacls $here     /grant "${user}:(OI)(CI)RX" | Out-Null
+& icacls $Evidence /grant "${user}:M"          | Out-Null
+$homeDir = Join-Path $WorkDir 'home'; $tmpDir = Join-Path $WorkDir 'tmp'
+$appData = Join-Path $WorkDir 'appdata'; $localApp = Join-Path $WorkDir 'localappdata'
+foreach ($d in @($homeDir,$tmpDir,$appData,$localApp)) { New-Item -ItemType Directory -Path $d -Force | Out-Null }
+$env:HOME = $homeDir; $env:USERPROFILE = $homeDir
+$env:TEMP = $tmpDir;  $env:TMP = $tmpDir
+$env:APPDATA = $appData; $env:LOCALAPPDATA = $localApp
+Note ("- child env: HOME/TEMP/APPDATA under {0}" -f $WorkDir)
+
+# ── Run a phase AS the standard user; fold its output into the evidence ───────
+function Invoke-AsUser([string]$script, [string[]]$phaseArgs) {
+    $b = [IO.Path]::GetFileNameWithoutExtension($script)
+    $o = Join-Path $WorkDir ("phase-$b.out.log"); $e = Join-Path $WorkDir ("phase-$b.err.log")
+    $a = @('-NoProfile','-ExecutionPolicy','Bypass','-File', (Join-Path $here $script)) + $phaseArgs
+    $p = Start-Process -FilePath 'powershell.exe' -Credential $cred -ArgumentList $a `
+                       -WorkingDirectory $WorkDir -Wait -PassThru `
+                       -RedirectStandardOutput $o -RedirectStandardError $e
+    foreach ($f in @($o, $e)) {
+        if ((Test-Path $f) -and (Get-Item $f).Length -gt 0) {
+            Get-Content $f | ForEach-Object { Note ("    [child] " + $_) }
+        }
+    }
+    return $p.ExitCode
+}
+
+$rc = 0
+Note "`n--- PHASE: preconditions ---"
+if ((Invoke-AsUser 'preconditions.ps1' @('-Evidence',$Evidence)) -ne 0) { $rc = 1 }
+
+Note "`n--- PHASE: artifact smoke (verify -> cosmocc -> /ping) ---"
+$smokeArgs = @('-Hull',$exe,'-Manifest',$man,'-Sig',$sig,'-Pubkey',$Pubkey,
+               '-ExpectVersion',$ExpectVersion,'-Evidence',$Evidence)
+if ((Invoke-AsUser 'smoke.ps1' $smokeArgs) -ne 0) { $rc = 1 }
+
+Remove-LocalUser -Name $user -ErrorAction SilentlyContinue
+Note ("`n## RESULT: {0}" -f ($(if ($rc -eq 0) {'ALL SMOKE CHECKS PASSED'} else {'FAILURE'})))
+exit $rc

--- a/tests/acceptance/windows/smoke.ps1
+++ b/tests/acceptance/windows/smoke.ps1
@@ -1,0 +1,143 @@
+<#
+  smoke.ps1 - the minimal artifact smoke body, run AS the standard (non-admin)
+  user. Verifies the published hull-cosmo BEFORE execution, then installs cosmocc
+  and builds + serves a Lua and a JS /ping app.
+
+  Order (fail-closed; a failed pre-execution verify stops before any build/run):
+    1. checksum the downloaded bytes against hull.sha256 (Get-FileHash, NO
+       execution - so the bytes are verified before they are ever run);
+    2. verify hull.sha256.sig (against the source release pubkey when provided,
+       else the artifact's embedded key);
+    3. the artifact reports the expected version;
+    4. non-admin `hull tools install cosmocc` succeeds;
+    5. `hull build` + serve a Lua and a JS /ping app, each returning pong.
+
+  Read-only: no update, rollback, staging, or release/asset mutation.
+
+  Usage: smoke.ps1 -Hull <hull-cosmo> -Manifest <hull.sha256> -Sig <hull.sha256.sig> \
+                   -Pubkey <hex?> -ExpectVersion 0.14.0 -Evidence <file>
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)][string]$Hull,
+    [Parameter(Mandatory=$true)][string]$Manifest,
+    [Parameter(Mandatory=$true)][string]$Sig,
+    [string]$Pubkey = '',
+    [Parameter(Mandatory=$true)][string]$ExpectVersion,
+    [Parameter(Mandatory=$true)][string]$Evidence
+)
+
+$ErrorActionPreference = 'Stop'
+function Note($m) { Add-Content -Path $Evidence -Value $m; Write-Host $m }
+function Fail($m) { Note ("  FAIL: {0}" -f $m); $script:fail = 1 }
+# hull writes progress to stdout and logs/errors to stderr; under -EA Stop a
+# 2>&1 merge of native stderr becomes a terminating error. Capture through a
+# helper that locally relaxes the preference and merges both streams.
+function Cap([scriptblock]$sb) { $ErrorActionPreference = 'Continue'; & $sb 2>&1 }
+$script:fail = 0
+$work = Join-Path $env:TEMP ("hull-smoke-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $work | Out-Null
+
+# Serve a BUILT standalone APE and curl a path; returns the response body (or '').
+# A built binary IS the app, so it is run directly as `<exe> -p <port>`.
+function Serve-And-Get([string]$exe, [int]$port, [string]$route) {
+    $so = Join-Path $work ("serve-$port.out.log")
+    $se = Join-Path $work ("serve-$port.err.log")
+    $p = Start-Process -FilePath $exe -ArgumentList @('-p', "$port") -PassThru `
+                       -WindowStyle Hidden -RedirectStandardOutput $so -RedirectStandardError $se
+    try {
+        for ($i = 0; $i -lt 60; $i++) {
+            Start-Sleep -Milliseconds 250
+            try { return (Invoke-RestMethod -Uri "http://127.0.0.1:$port$route" -TimeoutSec 2) } catch {}
+            if ($p.HasExited) { break }
+        }
+        Note ("- serve diagnostics for port {0} (exited={1} code={2}):" -f $port, $p.HasExited, $p.ExitCode)
+        foreach ($f in @($so, $se)) {
+            if ((Test-Path $f) -and (Get-Item $f).Length -gt 0) {
+                Get-Content $f | Select-Object -First 20 | ForEach-Object { Note ("    [serve] " + $_) }
+            }
+        }
+        return ''
+    } finally { $p | Stop-Process -Force -ErrorAction SilentlyContinue }
+}
+
+# `hull build` drives dual-arch cosmocc, whose process spawning is intermittently
+# flaky on Windows under repeated heavy use. Retry ONLY spawn-specific signatures;
+# a genuine link regression is returned on the first try.
+function Build-Retry([string]$dir, [string]$outCom) {
+    $flake   = 'posix_spawn|ERROR_KERNEL_APC|Bad file number|cannot execute'
+    $hometmp = Join-Path $env:HOME '.hull\tmp'
+    $out = $null; $rc = 1
+    for ($t = 1; $t -le 3; $t++) {
+        Get-ChildItem -Path $hometmp -Filter 'fatcosmocc*' -ErrorAction SilentlyContinue |
+            Remove-Item -Force -ErrorAction SilentlyContinue
+        $out = Cap { & $Hull build $dir -o $outCom }
+        $rc  = $LASTEXITCODE
+        if ($rc -eq 0) { return @{ rc = 0; out = $out; tries = $t } }
+        if (($out | Out-String) -notmatch $flake) { return @{ rc = $rc; out = $out; tries = $t } }
+        Note ("- build attempt {0} hit a cosmocc spawn flake; cleaning temp and retrying" -f $t)
+        Remove-Item $outCom -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 3
+    }
+    return @{ rc = $rc; out = $out; tries = 3 }
+}
+
+Note "## Published artifact smoke (as $(whoami))"
+
+# --- 1. checksum BEFORE executing the binary -------------------------------
+$want = ((Get-Content $Manifest | Where-Object { $_ -match '\shull-cosmo$' } | Select-Object -First 1) -replace '\s.*','').ToLower()
+$got  = (Get-FileHash $Hull -Algorithm SHA256).Hash.ToLower()
+Note ("- checksum want={0} got={1}" -f $want, $got)
+if ($want -and ($want -eq $got)) { Note "- OK: checksum matches hull.sha256 (verified before execution)" }
+else { Fail "checksum mismatch (or hull-cosmo absent from hull.sha256)" }
+
+# --- 2. signature ----------------------------------------------------------
+$sa = @('verify-release', $Manifest, $Sig)
+if ($Pubkey) { $sa += @('--pubkey', $Pubkey) }
+$so = Cap { & $Hull @sa }; $sr = $LASTEXITCODE
+Note (($so | Out-String) -replace '(?m)^','    ')
+if ($sr -eq 0) { Note ("- OK: signature verified" + $(if ($Pubkey) { " (source release pubkey)" } else { " (embedded key)" })) }
+else { Fail "hull.sha256.sig did not verify" }
+
+# --- 3. version ------------------------------------------------------------
+$ver = (Cap { & $Hull version } | Select-Object -First 1)
+Note ("- version: {0}" -f $ver)
+if ($ver -match [regex]::Escape($ExpectVersion)) { Note "- OK: reports $ExpectVersion" }
+else { Fail "version is not $ExpectVersion" }
+
+# A failed pre-execution verify stops here - never build/run unverified bytes.
+if ($script:fail -ne 0) { Note "SMOKE: FAIL (pre-execution verify)"; exit 1 }
+
+# --- 4. non-admin cosmocc install ------------------------------------------
+Note "## Non-admin cosmocc install"
+$ci = Cap { & $Hull tools install cosmocc }; $rc = $LASTEXITCODE
+Note (($ci | Out-String) -replace '(?m)^','    ')
+if ($rc -ne 0) { Fail "hull tools install cosmocc returned non-zero (non-admin)" }
+else { Note "- OK: cosmocc installed non-admin" }
+
+# --- 5. build + serve minimal Lua and JS /ping -----------------------------
+Note "## Build + serve /ping (Lua + JS)"
+$lua = @'
+app.manifest({ modules = { "hull/http-server@1" } })
+app.get("/ping", function(req, res) res:text("pong") end)
+'@
+$js = @'
+import { app } from "hull:app";
+app.manifest({ modules: ["hull/http-server@1"] });
+app.get("/ping", (req, res) => res.text("pong"));
+'@
+foreach ($case in @(@{ext='lua';src=$lua;port=39761}, @{ext='js';src=$js;port=39762})) {
+    $adir = Join-Path $work ("ping-" + $case.ext)
+    New-Item -ItemType Directory -Path $adir | Out-Null
+    Set-Content -Path (Join-Path $adir ("app." + $case.ext)) -Value $case.src
+    $r = Build-Retry $adir (Join-Path $adir 'out.com')
+    if ($r.rc -ne 0) { Note (($r.out | Out-String) -replace '(?m)^','    '); Fail ("hull build failed for the " + $case.ext + " /ping app after " + $r.tries + " attempt(s)"); continue }
+    $body = Serve-And-Get (Join-Path $adir 'out.com') $case.port '/ping'
+    if ("$body".Trim() -eq 'pong') { Note ("- OK: " + $case.ext + " /ping served pong") }
+    else { Fail ($case.ext + " /ping did not serve pong (got '" + $body + "')") }
+}
+
+Remove-Item $work -Recurse -Force -ErrorAction SilentlyContinue
+if ($script:fail -ne 0) { Note "SMOKE: FAIL"; exit 1 }
+Note "SMOKE: OK (checksum + signature + version + non-admin cosmocc + Lua/JS pong)"
+exit 0


### PR DESCRIPTION
## What

A small, reusable **read-only** smoke of a PUBLISHED release's Windows artifact
(`hull-cosmo`), dispatchable per release tag via `workflow_dispatch`. It closes
step 5 of the v0.14.0 release acceptance (a minimal final Windows artifact smoke)
and stays useful for every future release.

Under a freshly-created standard (non-admin) user with Developer Mode disabled,
after downloading the artifact + `hull.sha256` + `hull.sha256.sig` from the
official release:

1. **checksum** the downloaded bytes against `hull.sha256` with `Get-FileHash` -
   NO execution, so the bytes are verified before they are ever run;
2. **verify** `hull.sha256.sig` against the source-controlled release pubkey
   (extracted from `include/hull/release.h`), else the embedded key;
3. assert the artifact **reports the expected version**;
4. non-admin **`hull tools install cosmocc`** succeeds;
5. **`hull build` + serve** a Lua and a JS `/ping` app, each returning `pong`.

A failed pre-execution verify stops before any build/run.

## Guarantees

- **Read-only w.r.t. releases** (`permissions: contents: read`): downloads from
  the official release only; never updates, rolls back, mutates staging, or
  creates/modifies/deletes a release, asset, or `latest`. No asset-upload logic.
- `release_tag` + `expect_version` are **required inputs with no default**, so
  the smoke never silently targets `latest`.
- Reuses the proven `preconditions.ps1` non-admin/Dev-Mode-off gate and the
  `extras.ps1` build/serve helpers (`Cap`, `Build-Retry`, `Serve-And-Get`).

## Files

- `.github/workflows/release-smoke-windows.yml` - the dispatchable workflow.
- `tests/acceptance/windows/run-smoke.ps1` - orchestrator (download + non-admin
  scaffolding; never executes the downloaded binary itself).
- `tests/acceptance/windows/smoke.ps1` - the verify + cosmocc + `/ping` body.

## After merge

Dispatch against `v0.14.0` (`release_tag=v0.14.0`, `expect_version=0.14.0`).
Public-reference updates and staging cleanup stay blocked until it passes.