### PR TITLE
ci(release-smoke-windows): pwsh child + .NET checksum + hull.com execution

### DIFF
--- a/tests/acceptance/windows/run-smoke.ps1
+++ b/tests/acceptance/windows/run-smoke.ps1
@@ -39,7 +39,9 @@ if (-not $ExpectVersion) { Note 'FATAL: -ExpectVersion is required'; exit 2 }
 Note ("- repo={0} tag={1} expect={2}" -f $OfficialRepo, $ReleaseTag, $ExpectVersion)
 
 # ── Download the published artifact + manifest + signature (official only) ────
-$exe = Join-Path $WorkDir 'hull-cosmo'
+# Save the APE with a .com extension: Windows will not execute a PE/APE that has
+# no recognized executable extension (the download asset is named "hull-cosmo").
+$exe = Join-Path $WorkDir 'hull.com'
 $man = Join-Path $WorkDir 'hull.sha256'
 $sig = Join-Path $WorkDir 'hull.sha256.sig'
 $base = "https://github.com/$OfficialRepo/releases/download/$ReleaseTag"

--- a/tests/acceptance/windows/run-smoke.ps1
+++ b/tests/acceptance/windows/run-smoke.ps1
@@ -79,12 +79,20 @@ $env:TEMP = $tmpDir;  $env:TMP = $tmpDir
 $env:APPDATA = $appData; $env:LOCALAPPDATA = $localApp
 Note ("- child env: HOME/TEMP/APPDATA under {0}" -f $WorkDir)
 
+# Launch the child phases under pwsh (PowerShell 7, the workflow's own shell)
+# rather than powershell.exe (Windows PowerShell 5.1). A runas child inherits the
+# pwsh-7 parent's $PSModulePath, under which the WinPS 5.1 host cannot resolve its
+# Microsoft.PowerShell.Utility cmdlets (Get-FileHash / Select-Object / ...); using
+# the same pwsh binary the parent runs keeps every cmdlet available.
+$childExe = Join-Path $PSHOME 'pwsh.exe'
+if (-not (Test-Path $childExe)) { $childExe = 'pwsh' }
+
 # ── Run a phase AS the standard user; fold its output into the evidence ───────
 function Invoke-AsUser([string]$script, [string[]]$phaseArgs) {
     $b = [IO.Path]::GetFileNameWithoutExtension($script)
     $o = Join-Path $WorkDir ("phase-$b.out.log"); $e = Join-Path $WorkDir ("phase-$b.err.log")
     $a = @('-NoProfile','-ExecutionPolicy','Bypass','-File', (Join-Path $here $script)) + $phaseArgs
-    $p = Start-Process -FilePath 'powershell.exe' -Credential $cred -ArgumentList $a `
+    $p = Start-Process -FilePath $childExe -Credential $cred -ArgumentList $a `
                        -WorkingDirectory $WorkDir -Wait -PassThru `
                        -RedirectStandardOutput $o -RedirectStandardError $e
     foreach ($f in @($o, $e)) {

--- a/tests/acceptance/windows/smoke.ps1
+++ b/tests/acceptance/windows/smoke.ps1
@@ -101,9 +101,14 @@ else { Fail "checksum mismatch (or hull-cosmo absent from hull.sha256)" }
 $sa = @('verify-release', $Manifest, $Sig)
 if ($Pubkey) { $sa += @('--pubkey', $Pubkey) }
 $so = Cap { & $Hull @sa }; $sr = $LASTEXITCODE
-Note (($so | Out-String) -replace '(?m)^','    ')
-if ($sr -eq 0) { Note ("- OK: signature verified" + $(if ($Pubkey) { " (source release pubkey)" } else { " (embedded key)" })) }
-else { Fail "hull.sha256.sig did not verify" }
+$sigText = ($so | Out-String)
+Note ($sigText -replace '(?m)^','    ')
+# Require the positive success output, not just the exit code: if the binary
+# failed to START (e.g. a permission/extension error) $LASTEXITCODE would be
+# stale, so match the explicit "verify-release: OK" line to avoid a false pass.
+if ($sr -eq 0 -and $sigText -match 'verify-release:\s*OK') {
+    Note ("- OK: signature verified" + $(if ($Pubkey) { " (source release pubkey)" } else { " (embedded key)" }))
+} else { Fail "hull.sha256.sig did not verify (or hull failed to run)" }
 
 # --- 3. version ------------------------------------------------------------
 $ver = (Cap { & $Hull version } | Select-Object -First 1)

--- a/tests/acceptance/windows/smoke.ps1
+++ b/tests/acceptance/windows/smoke.ps1
@@ -85,8 +85,14 @@ function Build-Retry([string]$dir, [string]$outCom) {
 Note "## Published artifact smoke (as $(whoami))"
 
 # --- 1. checksum BEFORE executing the binary -------------------------------
+# Compute the digest via .NET (no cmdlet/module dependency) so the security-
+# critical pre-execution checksum is robust across PowerShell hosts.
 $want = ((Get-Content $Manifest | Where-Object { $_ -match '\shull-cosmo$' } | Select-Object -First 1) -replace '\s.*','').ToLower()
-$got  = (Get-FileHash $Hull -Algorithm SHA256).Hash.ToLower()
+$fsHash = [System.IO.File]::OpenRead($Hull)
+try {
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    $got = ([System.BitConverter]::ToString($sha256.ComputeHash($fsHash)) -replace '-','').ToLower()
+} finally { $fsHash.Dispose() }
 Note ("- checksum want={0} got={1}" -f $want, $got)
 if ($want -and ($want -eq $got)) { Note "- OK: checksum matches hull.sha256 (verified before execution)" }
 else { Fail "checksum mismatch (or hull-cosmo absent from hull.sha256)" }


### PR DESCRIPTION
## What

Two fixes to the Windows release-artifact smoke (added in #436) found while
running it against the published **v0.14.0** `hull-cosmo`. With both, the smoke
passes end to end on the real artifact (evidence below).

1. **Run child phases under pwsh, not powershell.exe.** A runas child launched as
   Windows PowerShell 5.1 inherits the pwsh-7 parent's `$PSModulePath`, under
   which the WinPS 5.1 host cannot resolve its `Microsoft.PowerShell.Utility`
   cmdlets (`Get-FileHash` was "not recognized"). Launch the child under pwsh
   (the workflow's own shell) so every cmdlet is available. Also compute the
   pre-execution checksum via `.NET` (`System.Security.Cryptography`) so the
   security-critical byte verification carries no cmdlet/module dependency.

2. **Save the APE as `hull.com`; require positive signature output.** The
   download was saved as `hull-cosmo` with no extension, and Windows refuses to
   execute a PE/APE without a recognized executable extension ("Access is
   denied"). Save it as `hull.com` (matching the proven acceptance pattern).
   Additionally, the signature check printed OK on a failed-to-start process
   because `$LASTEXITCODE` was stale; it now also requires the explicit
   `verify-release: OK` output, so a start failure can never read as verified.

## Evidence (published v0.14.0 artifact, non-admin)

```
PRECONDITIONS: OK (non-admin, Dev-Mode off, symlink denied)
- OK: checksum matches hull.sha256 (verified before execution)
- OK: signature verified (source release pubkey)   [hull verify-release: OK]
- OK: reports 0.14.0
- OK: cosmocc installed non-admin
- OK: lua /ping served pong
- OK: js /ping served pong
## RESULT: ALL SMOKE CHECKS PASSED
```

Validated via a branch dispatch against `v0.14.0`; after merge the same run can
be reproduced from `main` for a clean-provenance record.