### PR TITLE
feat(windows): first-party install.ps1 + non-admin installer tests (Slice B)

### DIFF
--- a/.github/workflows/installer-windows.yml
+++ b/.github/workflows/installer-windows.yml
@@ -1,0 +1,57 @@
+name: Installer (Windows, non-admin)
+
+# Installer-specific Windows tests for install.ps1. Runs the test suite as a
+# freshly-created standard (non-admin) user with Developer Mode disabled, under
+# BOTH Windows PowerShell 5.1 and PowerShell 7. Read-only with respect to GitHub
+# releases (downloads the official release only; never publishes or mutates a
+# release, asset, tag, or latest). All logic is checked-in PowerShell.
+#
+# This is the installer's own gate; broad permanent Windows product CI is a
+# separate initiative.
+
+on:
+  pull_request:
+    paths:
+      - install.ps1
+      - tests/acceptance/windows/installer/**
+      - tests/acceptance/windows/preconditions.ps1
+      - .github/workflows/installer-windows.yml
+  push:
+    branches: [main]
+    paths:
+      - install.ps1
+      - tests/acceptance/windows/installer/**
+      - .github/workflows/installer-windows.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  installer:
+    name: install.ps1 (non-admin, PS 5.1 + 7)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Run installer tests as a standard user
+        shell: pwsh
+        run: |
+          Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+          $wd = Join-Path $env:RUNNER_TEMP 'installer'
+          $ev = Join-Path $wd 'windows-installer-evidence.md'
+          & tests/acceptance/windows/installer/run-installer-tests.ps1 `
+            -RepoRoot (Get-Location).Path `
+            -Evidence $ev `
+            -WorkDir $wd
+          $code = $LASTEXITCODE
+          Get-Content $ev | ForEach-Object { Write-Host $_ }
+          Copy-Item $ev "$env:GITHUB_STEP_SUMMARY" -Force
+          if ($code -ne 0) { throw "Windows installer tests FAILED (see evidence report)" }
+
+      - name: Upload evidence report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: windows-installer-evidence
+          path: ${{ runner.temp }}/installer/windows-installer-evidence.md

--- a/install.ps1
+++ b/install.ps1
@@ -13,11 +13,12 @@
     Trust: a same-channel SHA-256 protects against corruption and a mismatched
     asset, not a compromised release channel. Hull's Ed25519 release signature is
     the channel-independent authenticity root; a freshly-downloaded Hull cannot
-    authenticate itself. On an upgrade, if a pre-existing Hull supports
-    'verify-release', its signature check runs before replacement and a FAILURE
-    aborts the install (never a silent downgrade to checksum-only). A first
-    install proceeds under bootstrap trust (GitHub HTTPS + a matched SHA-256);
-    verify further out-of-band with 'hull verify-release' and Sigstore/Rekor.
+    authenticate itself. On an upgrade, if a pre-existing Hull can verify the
+    release signature, its check runs before replacement and a FAILURE or an
+    ambiguous/timed-out probe aborts the install (never a silent downgrade to
+    checksum-only). A first install proceeds under bootstrap trust (GitHub HTTPS
+    + a matched SHA-256); verify further out-of-band with 'hull verify-release'
+    and Sigstore/Rekor.
 
 .EXAMPLE
     irm https://gethull.dev/install.ps1 | iex
@@ -50,9 +51,11 @@ param(
 )
 
 # The upstream repository is FIXED. The public installer exposes no override.
-$script:HullRepo   = 'artalis-io/hull'
-$script:HullAsset  = 'hull-cosmo'
+$script:HullRepo    = 'artalis-io/hull'
+$script:HullAsset   = 'hull-cosmo'
 $script:HullBinName = 'hull.com'
+$script:HullMarkerName = '.hull-install.json'
+$script:HullMarkerSchema = 1
 $script:VersionTagPattern = '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'
 
 # ── Output helpers (never log secrets, proxy creds, or temp URLs) ─────────────
@@ -60,21 +63,51 @@ function Write-HullInfo([string]$m) { Write-Host "hull: $m" }
 function Write-HullWarn([string]$m) { Write-Host "hull: warning: $m" -ForegroundColor Yellow }
 function Write-HullErr ([string]$m) { Write-Host "hull: error: $m" -ForegroundColor Red }
 
-# ── TLS + defaults ───────────────────────────────────────────────────────────
 function Set-HullTls {
-    # Windows PowerShell 5.1 defaults to TLS 1.0/1.1; force >= 1.2. Add flags
-    # rather than replacing so PowerShell 7 keeps its negotiated set.
+    # Windows PowerShell 5.1 defaults to TLS 1.0/1.1; add >= 1.2 without dropping
+    # PowerShell 7's negotiated set.
     try {
         [Net.ServicePointManager]::SecurityProtocol =
-            [Net.ServicePointManager]::SecurityProtocol -bor
-            [Net.SecurityProtocolType]::Tls12
+            [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
     } catch { }
 }
 
-# ── Version + release resolution ─────────────────────────────────────────────
-function Test-HullVersionTag([string]$Tag) {
-    return ($Tag -match $script:VersionTagPattern)
+# ── Bounded native execution (works on both PS 5.1 and 7; no hangs) ──────────
+function ConvertTo-HullArgString([string[]]$Arguments) {
+    $parts = @()
+    foreach ($a in $Arguments) {
+        if ($a -match '[\s"]') { $parts += '"' + ($a -replace '"', '\"') + '"' } else { $parts += $a }
+    }
+    return ($parts -join ' ')
 }
+
+function Invoke-HullBounded([string]$Exe, [string[]]$Arguments, [int]$TimeoutSec = 20) {
+    # Returns @{ Code; Out; TimedOut }. Uses System.Diagnostics.Process (so it
+    # works under Windows PowerShell 5.1, whose Start-Process/ArgumentList mangles
+    # spaces) with a hard timeout and async pipe reads (no deadlock, no hang).
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $Exe
+    $psi.Arguments = ConvertTo-HullArgString $Arguments
+    $psi.UseShellExecute = $false
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError = $true
+    $psi.CreateNoWindow = $true
+    $p = New-Object System.Diagnostics.Process
+    $p.StartInfo = $psi
+    try { [void]$p.Start() } catch { return @{ Code = $null; Out = ''; TimedOut = $true } }
+    $outTask = $p.StandardOutput.ReadToEndAsync()
+    $errTask = $p.StandardError.ReadToEndAsync()
+    if (-not $p.WaitForExit($TimeoutSec * 1000)) {
+        try { $p.Kill() } catch { }
+        return @{ Code = $null; Out = ''; TimedOut = $true }
+    }
+    $out = ''
+    try { $out = ($outTask.Result + "`n" + $errTask.Result) } catch { }
+    return @{ Code = $p.ExitCode; Out = $out; TimedOut = $false }
+}
+
+# ── Version + release resolution ─────────────────────────────────────────────
+function Test-HullVersionTag([string]$Tag) { return ($Tag -match $script:VersionTagPattern) }
 
 function Resolve-HullTag([string]$Requested) {
     if ($Requested -and $Requested -ne 'latest') {
@@ -85,35 +118,24 @@ function Resolve-HullTag([string]$Requested) {
     }
     # /releases/latest already excludes drafts and prereleases.
     $api = "https://api.github.com/repos/$($script:HullRepo)/releases/latest"
-    $headers = @{ 'Accept' = 'application/vnd.github+json'; 'User-Agent' = 'hull-install.ps1' }
-    $resp = Invoke-RestMethod -Uri $api -Headers $headers -UseBasicParsing
+    $resp = Invoke-RestMethod -Uri $api -Headers @{ 'Accept' = 'application/vnd.github+json'; 'User-Agent' = 'hull-install.ps1' } -UseBasicParsing
+    if ($resp.draft -eq $true -or $resp.prerelease -eq $true) { throw "latest resolved to a draft/prerelease ($($resp.tag_name)); refusing" }
     $tag = $resp.tag_name
-    if ($resp.draft -eq $true -or $resp.prerelease -eq $true) {
-        throw "latest release resolved to a draft/prerelease ($tag); refusing"
-    }
-    if (-not $tag -or -not (Test-HullVersionTag $tag)) {
-        throw "could not resolve a valid latest release tag (got '$tag')"
-    }
+    if (-not $tag -or -not (Test-HullVersionTag $tag)) { throw "could not resolve a valid latest release tag (got '$tag')" }
     return $tag
 }
 
 function Get-HullAssetUrls([string]$Tag) {
     $base = "https://github.com/$($script:HullRepo)/releases/download/$Tag"
-    return @{
-        Asset    = "$base/$($script:HullAsset)"
-        Manifest = "$base/hull.sha256"
-        Sig      = "$base/hull.sha256.sig"
-    }
+    return @{ Asset = "$base/$($script:HullAsset)"; Manifest = "$base/hull.sha256"; Sig = "$base/hull.sha256.sig" }
 }
 
-# ── Download + checksum ──────────────────────────────────────────────────────
 function Get-HullFile([string]$Url, [string]$OutFile) {
-    # Respects the default system proxy. Do not print $Url beyond a generic note.
     Invoke-WebRequest -Uri $Url -OutFile $OutFile -UseBasicParsing -Headers @{ 'User-Agent' = 'hull-install.ps1' }
 }
 
+# ── Checksum ─────────────────────────────────────────────────────────────────
 function Get-HullFileSha256([string]$Path) {
-    # .NET SHA-256 (no cmdlet/module dependency); streams the file.
     $fs = [System.IO.File]::OpenRead($Path)
     try {
         $sha = [System.Security.Cryptography.SHA256]::Create()
@@ -122,12 +144,8 @@ function Get-HullFileSha256([string]$Path) {
 }
 
 function Get-HullManifestHash([string]$ManifestPath, [string]$AssetName) {
-    # Return the single expected hash for $AssetName. Fail closed on a missing,
-    # duplicate, or malformed entry.
-    $lines = Get-Content -LiteralPath $ManifestPath
     $matched = @()
-    foreach ($ln in $lines) {
-        # Format: <64 lowercase hex><two spaces><asset-name>
+    foreach ($ln in (Get-Content -LiteralPath $ManifestPath)) {
         if ($ln -match '^([0-9a-fA-F]{64})\s\s(.+)$') {
             if ($Matches[2] -ceq $AssetName) { $matched += $Matches[1].ToLower() }
         }
@@ -139,48 +157,53 @@ function Get-HullManifestHash([string]$ManifestPath, [string]$AssetName) {
 
 function Test-HullChecksum([string]$Path, [string]$Expected) {
     $actual = Get-HullFileSha256 $Path
-    if ($actual -ne $Expected) {
-        throw "checksum mismatch: expected $Expected, got $actual"
-    }
+    if ($actual -ne $Expected) { throw "checksum mismatch: expected $Expected, got $actual" }
     return $actual
 }
 
-# ── Upgrade signature check (strict three-outcome contract) ──────────────────
-# Bootstrap trust is permitted ONLY when there is no existing hull or the
-# existing hull genuinely lacks 'verify-release'. Once an existing hull is proven
-# verifier-capable, a missing / unfetched / unparseable / invalid signature MUST
-# abort - never a silent downgrade to checksum-only.
-function Test-HullVerifierCapable([string]$ExistingHull) {
-    if (-not $ExistingHull -or -not (Test-Path -LiteralPath $ExistingHull)) { return $false }
-    # Probe without letting the native command's stderr become a terminating error.
-    $prevEA = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
-    try {
-        $out = & $ExistingHull verify-release --help 2>&1
-        $code = $LASTEXITCODE
-    } finally { $ErrorActionPreference = $prevEA }
-    return ($code -eq 0 -and (($out | Out-String) -match 'verify-release'))
+# ── Verifier detection (tri-state, bounded) + signature assertion ────────────
+# States: 'none' (no existing hull), 'capable' (can verify signatures),
+# 'absent' (a real hull that genuinely lacks verify-release), 'ambiguous'
+# (exists but the probe failed / timed out / was unrecognizable). Only 'none'
+# and 'absent' permit bootstrap trust; 'ambiguous' MUST abort - it is never
+# treated as "verifier absent".
+function Get-HullVerifierState([string]$ExistingHull, [int]$TimeoutSec = 20) {
+    if (-not $ExistingHull -or -not (Test-Path -LiteralPath $ExistingHull)) { return 'none' }
+    $a = Invoke-HullBounded $ExistingHull @('verify-release', '--help') $TimeoutSec
+    if ($a.TimedOut) { return 'ambiguous' }
+    if ($a.Code -eq 0 -and $a.Out -match 'verify-release') { return 'capable' }
+    # Not obviously capable: consult the top-level command inventory to tell a
+    # genuine "command absent" apart from an ambiguous/failed probe.
+    $b = Invoke-HullBounded $ExistingHull @('help') $TimeoutSec
+    if ($b.TimedOut) { return 'ambiguous' }
+    if ($b.Code -eq 0) {
+        if ($b.Out -match 'verify-release') { return 'capable' }
+        if ($b.Out -match '(?im)usage:' -or $b.Out -match '(?im)^\s*version\b') { return 'absent' }
+    }
+    return 'ambiguous'
 }
 
 function Assert-HullSignature([string]$ExistingHull, [string]$ManifestPath, [string]$SigPath) {
-    # Precondition: the caller has established $ExistingHull is verifier-capable.
-    # ANY failure here throws (abort); there is no bootstrap fallback.
+    # Precondition: the caller established $ExistingHull is 'capable'. Any failure
+    # here throws (abort); there is no bootstrap fallback.
     $sigItem = Get-Item -LiteralPath $SigPath -ErrorAction SilentlyContinue
     if (-not $sigItem -or $sigItem.Length -eq 0) {
         throw "release signature (hull.sha256.sig) is missing or empty; aborting (the existing hull can verify signatures, so a signature is required)"
     }
-    $prevEA = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
-    try {
-        $out = & $ExistingHull verify-release $ManifestPath $SigPath 2>&1
-        $code = $LASTEXITCODE
-    } finally { $ErrorActionPreference = $prevEA }
-    if ($code -ne 0) {
-        throw "release signature did not verify; aborting (output: $(($out | Out-String).Trim()))"
-    }
+    $r = Invoke-HullBounded $ExistingHull @('verify-release', $ManifestPath, $SigPath) 30
+    if ($r.TimedOut) { throw "release signature verification timed out; aborting" }
+    if ($r.Code -ne 0) { throw "release signature did not verify; aborting (output: $($r.Out.Trim()))" }
 }
 
-# ── User PATH (HKCU only; idempotent; type-preserving) ───────────────────────
+function Get-HullArtifactVersion([string]$ExePath, [int]$TimeoutSec = 20) {
+    $r = Invoke-HullBounded $ExePath @('version') $TimeoutSec
+    if ($r.TimedOut) { return $null }
+    if ($r.Out -match '([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?)') { return $Matches[1] }
+    return $null
+}
+
+# ── User PATH (HKCU only; idempotent; type-preserving; exact-entry ownership) ─
 function Get-HullUserPathRaw {
-    # Raw (unexpanded) value + its registry kind, so we can preserve REG_EXPAND_SZ.
     $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $false)
     if ($null -eq $key) { return @{ Value = ''; Kind = [Microsoft.Win32.RegistryValueKind]::ExpandString } }
     try {
@@ -192,10 +215,9 @@ function Get-HullUserPathRaw {
 }
 
 function ConvertTo-HullPathKey([string]$Component) {
-    # Normalize for COMPARISON only (the raw component is always preserved when
-    # writing): strip surrounding quotes and whitespace, expand environment
-    # variables (so %LOCALAPPDATA%\Programs\Hull matches its expansion), unify
-    # separators, drop trailing separators, and lowercase.
+    # Comparison key only (the raw component is preserved on write): strip quotes
+    # + whitespace, expand %VAR%, unify separators, drop trailing separators,
+    # lowercase.
     $c = $Component.Trim().Trim('"')
     $c = [System.Environment]::ExpandEnvironmentVariables($c)
     $c = $c -replace '/', '\'
@@ -219,7 +241,6 @@ function Set-HullUserPathRaw([string]$Value, $Kind) {
 }
 
 function Send-HullEnvBroadcast {
-    # Notify running shells that the environment changed. Best-effort.
     if (-not ('HullNative.Win32' -as [type])) {
         Add-Type -Namespace HullNative -Name Win32 -MemberDefinition @'
 [System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
@@ -227,45 +248,46 @@ public static extern System.IntPtr SendMessageTimeout(System.IntPtr hWnd, uint M
 '@ -ErrorAction SilentlyContinue
     }
     try {
-        $HWND_BROADCAST = [System.IntPtr]0xffff
-        $WM_SETTINGCHANGE = 0x1a
-        $SMTO_ABORTIFHUNG = 0x2
         $out = [System.UIntPtr]::Zero
-        [void][HullNative.Win32]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [System.UIntPtr]::Zero, 'Environment', $SMTO_ABORTIFHUNG, 5000, [ref]$out)
+        [void][HullNative.Win32]::SendMessageTimeout([System.IntPtr]0xffff, 0x1a, [System.UIntPtr]::Zero, 'Environment', 0x2, 5000, [ref]$out)
     } catch { }
 }
 
 function Add-HullToUserPath([string]$Dir, [bool]$DryRun) {
+    # Returns the exact raw component it added (for ownership recording), or $null
+    # if nothing was added.
     $cur = Get-HullUserPathRaw
-    if (Test-HullPathContains $cur.Value $Dir) {
-        Write-HullInfo "PATH already contains $Dir"
-        return $false
-    }
-    if ($DryRun) { Write-HullInfo "[dry-run] would add $Dir to user PATH"; return $false }
+    if (Test-HullPathContains $cur.Value $Dir) { Write-HullInfo "PATH already contains $Dir"; return $null }
+    if ($DryRun) { Write-HullInfo "[dry-run] would add $Dir to user PATH"; return $null }
     $newValue = if ([string]::IsNullOrEmpty($cur.Value)) { $Dir } else { ($cur.Value.TrimEnd(';') + ';' + $Dir) }
     Set-HullUserPathRaw $newValue $cur.Kind
     Send-HullEnvBroadcast
     Write-HullInfo "added $Dir to user PATH"
-    return $true
+    return $Dir
 }
 
-function Remove-HullFromUserPath([string]$Dir, [bool]$DryRun) {
+function Remove-HullPathEntry([string]$RawEntry, [bool]$DryRun) {
+    # Remove exactly ONE occurrence matching the recorded entry's normalized key;
+    # preserve all other entries (including any equivalent the user added).
+    if ([string]::IsNullOrEmpty($RawEntry)) { return $false }
     $cur = Get-HullUserPathRaw
-    if (-not (Test-HullPathContains $cur.Value $Dir)) { return $false }
-    if ($DryRun) { Write-HullInfo "[dry-run] would remove $Dir from user PATH"; return $false }
-    $want = ConvertTo-HullPathKey $Dir
-    $kept = @()
+    $wantKey = ConvertTo-HullPathKey $RawEntry
+    $kept = New-Object System.Collections.Generic.List[string]
+    $removed = $false
     foreach ($c in ($cur.Value -split ';')) {
         if ($c -eq '') { continue }
-        if ((ConvertTo-HullPathKey $c) -ne $want) { $kept += $c }
+        if (-not $removed -and (ConvertTo-HullPathKey $c) -eq $wantKey) { $removed = $true; continue }
+        $kept.Add($c)
     }
-    Set-HullUserPathRaw ($kept -join ';') $cur.Kind
+    if (-not $removed) { return $false }
+    if ($DryRun) { Write-HullInfo "[dry-run] would remove one PATH entry: $RawEntry"; return $false }
+    Set-HullUserPathRaw ([string]::Join(';', $kept)) $cur.Kind
     Send-HullEnvBroadcast
-    Write-HullInfo "removed $Dir from user PATH"
+    Write-HullInfo "removed PATH entry: $RawEntry"
     return $true
 }
 
-# ── Prefix + version-of-installed ────────────────────────────────────────────
+# ── Prefix ───────────────────────────────────────────────────────────────────
 function Resolve-HullPrefix([string]$Requested) {
     if ($Requested) { return $Requested }
     $localApp = $env:LOCALAPPDATA
@@ -273,46 +295,17 @@ function Resolve-HullPrefix([string]$Requested) {
     return (Join-Path $localApp 'Programs\Hull')
 }
 
-function Get-HullInstalledVersion([string]$BinPath) {
-    if (-not (Test-Path -LiteralPath $BinPath)) { return $null }
-    try {
-        $v = (& $BinPath version 2>$null | Select-Object -First 1)
-        if ($v -match '([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?)') { return $Matches[1] }
-    } catch { }
-    return $null
-}
+# ── Installer ownership marker (validated schema + recorded prefix + entry) ───
+function Get-HullMarkerPath([string]$PrefixDir) { return (Join-Path $PrefixDir $script:HullMarkerName) }
 
-function Get-HullArtifactVersion([string]$ExePath, [int]$TimeoutSec = 20) {
-    # Run '<exe> version' with a bounded timeout and return the parsed version.
-    # Returns $null on timeout / failure / unparseable output. Never hangs.
-    $outFile = [System.IO.Path]::GetTempFileName()
-    $errFile = [System.IO.Path]::GetTempFileName()
-    try {
-        $p = Start-Process -FilePath $ExePath -ArgumentList 'version' -PassThru -NoNewWindow `
-                           -RedirectStandardOutput $outFile -RedirectStandardError $errFile
-        if (-not $p.WaitForExit($TimeoutSec * 1000)) {
-            try { $p.Kill() } catch { }
-            return $null
-        }
-        $line = (Get-Content -LiteralPath $outFile | Select-Object -First 1)
-        if ($line -match '([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?)') { return $Matches[1] }
-        return $null
-    } catch {
-        return $null
-    } finally {
-        Remove-Item -LiteralPath $outFile, $errFile -Force -ErrorAction SilentlyContinue
-    }
-}
-
-# ── Installer ownership marker (so uninstall only touches what it installed) ──
-function Get-HullMarkerPath([string]$PrefixDir) { return (Join-Path $PrefixDir '.hull-install.json') }
-
-function Write-HullMarker([string]$PrefixDir, [string]$InstalledVersion, [bool]$PathAdded) {
+function Write-HullMarker([string]$PrefixDir, [string]$Ver, [bool]$PathAdded, [string]$PathEntry) {
     $rec = [ordered]@{
         installer = 'install.ps1'
+        schema    = $script:HullMarkerSchema
         prefix    = $PrefixDir
-        version   = $InstalledVersion
+        version   = $Ver
         pathAdded = $PathAdded
+        pathEntry = $PathEntry
     }
     Set-Content -LiteralPath (Get-HullMarkerPath $PrefixDir) -Value ($rec | ConvertTo-Json) -Encoding ASCII
 }
@@ -323,29 +316,52 @@ function Read-HullMarker([string]$PrefixDir) {
     try { return (Get-Content -LiteralPath $m -Raw | ConvertFrom-Json) } catch { return $null }
 }
 
-# ── Atomic install with rollback ─────────────────────────────────────────────
-function Install-HullAtomicMove([string]$Src, [string]$Dest, [switch]$SimulateFailure, [switch]$SimulateRestoreFailure) {
-    # Stage the new binary beside the destination under UNIQUE names (so an
-    # unrelated pre-existing sidecar is never clobbered), back up any existing
-    # binary, move the new one into place, and drop the backup. On ANY failure,
-    # restore the previous binary and PROVE it is back; if restoration fails,
-    # raise a distinct CRITICAL error naming the preserved backup. The two
-    # -Simulate* switches are test-only injections for the rollback paths.
+function Test-HullMarkerValid($Rec, [string]$PrefixDir) {
+    # A marker is ours only if it parses, carries our identity + schema + required
+    # fields, and its recorded prefix is equivalent to the current prefix.
+    if ($null -eq $Rec) { return $false }
+    $names = @($Rec.PSObject.Properties.Name)
+    foreach ($f in @('installer', 'schema', 'prefix', 'version', 'pathAdded')) {
+        if ($names -notcontains $f) { return $false }
+    }
+    if ($Rec.installer -ne 'install.ps1') { return $false }
+    if ([int]$Rec.schema -ne $script:HullMarkerSchema) { return $false }
+    if ((ConvertTo-HullPathKey ([string]$Rec.prefix)) -ne (ConvertTo-HullPathKey $PrefixDir)) { return $false }
+    return $true
+}
+
+function Test-HullManagedHere([string]$PrefixDir) {
+    return (Test-HullMarkerValid (Read-HullMarker $PrefixDir) $PrefixDir)
+}
+
+function Set-HullOwnershipMarker([string]$PrefixDir, [string]$Ver, [string]$AddedEntry) {
+    # pathEntry is sticky: once THIS installer added a PATH entry, keep the exact
+    # recorded entry across re-installs so uninstall still removes what we added.
+    $prev = Read-HullMarker $PrefixDir
+    $pathEntry = $AddedEntry
+    if (-not $pathEntry -and (Test-HullMarkerValid $prev $PrefixDir) -and $prev.pathAdded) { $pathEntry = [string]$prev.pathEntry }
+    Write-HullMarker $PrefixDir $Ver ([bool]$pathEntry) $pathEntry
+}
+
+# ── Binary swap as part of a binary+PATH+marker transaction ──────────────────
+function Start-HullBinarySwap([string]$Src, [string]$Dest, [switch]$SimulateFailure, [switch]$SimulateRestoreFailure) {
+    # Stage under a unique name, back up any existing binary under a unique name,
+    # move the new one into place. Returns @{ Backup; HadPrev } and KEEPS the
+    # backup (the transaction commits/undoes it later). If the swap itself fails,
+    # it restores + proves, raising a distinct CRITICAL error on restore failure.
     $dir = Split-Path -Parent $Dest
     New-Item -ItemType Directory -Path $dir -Force | Out-Null
     $staged = Join-Path $dir (".hull-stage-" + [guid]::NewGuid().ToString('N'))
     $backup = Join-Path $dir (".hull-backup-" + [guid]::NewGuid().ToString('N'))
-    if (Test-Path -LiteralPath $staged) { throw "staging path already exists: $staged" }
-    if (Test-Path -LiteralPath $backup) { throw "backup path already exists: $backup" }
+    if ((Test-Path -LiteralPath $staged) -or (Test-Path -LiteralPath $backup)) { throw "sidecar path collision under $dir" }
     Copy-Item -LiteralPath $Src -Destination $staged -Force
     $hadPrev = Test-Path -LiteralPath $Dest
     try {
         if ($hadPrev) { Move-Item -LiteralPath $Dest -Destination $backup -Force }
         if ($SimulateFailure) { throw "simulated install failure (test)" }
         Move-Item -LiteralPath $staged -Destination $Dest -Force
-        if ($hadPrev) { Remove-Item -LiteralPath $backup -Force -ErrorAction SilentlyContinue }
     } catch {
-        $installErr = $_
+        $err = $_
         Remove-Item -LiteralPath $staged -Force -ErrorAction SilentlyContinue
         if ($hadPrev) {
             if (-not $SimulateRestoreFailure -and -not (Test-Path -LiteralPath $Dest)) {
@@ -356,19 +372,56 @@ function Install-HullAtomicMove([string]$Src, [string]$Dest, [switch]$SimulateFa
             }
             Remove-Item -LiteralPath $backup -Force -ErrorAction SilentlyContinue
         }
-        throw $installErr
+        throw $err
+    }
+    return @{ Backup = $(if ($hadPrev) { $backup } else { $null }); HadPrev = $hadPrev }
+}
+
+function Complete-HullBinarySwap($Swap) {
+    if ($Swap.HadPrev -and $Swap.Backup -and (Test-Path -LiteralPath $Swap.Backup)) {
+        Remove-Item -LiteralPath $Swap.Backup -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Undo-HullBinarySwap($Swap, [string]$Dest, [switch]$SimulateRestoreFailure) {
+    # Restore the prior binary after a LATER-phase (PATH/marker) failure.
+    if (-not $Swap.HadPrev) { Remove-Item -LiteralPath $Dest -Force -ErrorAction SilentlyContinue; return }
+    if (-not $Swap.Backup -or -not (Test-Path -LiteralPath $Swap.Backup)) {
+        throw "CRITICAL: cannot restore the previous hull (backup missing); the new binary is at $Dest"
+    }
+    Remove-Item -LiteralPath $Dest -Force -ErrorAction SilentlyContinue
+    if (-not $SimulateRestoreFailure) { Move-Item -LiteralPath $Swap.Backup -Destination $Dest -Force -ErrorAction SilentlyContinue }
+    if (-not (Test-Path -LiteralPath $Dest)) {
+        throw "CRITICAL: install failed AND rollback failed; your previous hull is preserved at $($Swap.Backup)"
+    }
+    Remove-Item -LiteralPath $Swap.Backup -Force -ErrorAction SilentlyContinue
+}
+
+function Invoke-HullCommitInstall([string]$Src, [string]$Dest, [string]$PrefixDir, [string]$Ver, [bool]$NoPath,
+    [switch]$SimulateSwapFailure, [switch]$SimulateUndoFailure, [switch]$FailPath, [switch]$FailMarker) {
+    # ONE transaction: swap the binary, add PATH, write the marker. If ANY step
+    # fails, undo the PATH we added, remove any partial marker, and restore the
+    # previous binary (all-or-nothing).
+    $swap = Start-HullBinarySwap $Src $Dest -SimulateFailure:$SimulateSwapFailure
+    $addedEntry = $null
+    try {
+        if (-not $NoPath) {
+            if ($FailPath) { throw "simulated PATH failure (test)" }
+            $addedEntry = Add-HullToUserPath $PrefixDir $false
+        }
+        if ($FailMarker) { throw "simulated marker write failure (test)" }
+        Set-HullOwnershipMarker $PrefixDir $Ver $addedEntry
+        Complete-HullBinarySwap $swap
+    } catch {
+        $err = $_
+        if ($addedEntry) { [void](Remove-HullPathEntry $addedEntry $false) }
+        Remove-Item -LiteralPath (Get-HullMarkerPath $PrefixDir) -Force -ErrorAction SilentlyContinue
+        Undo-HullBinarySwap $swap $Dest -SimulateRestoreFailure:$SimulateUndoFailure
+        throw $err
     }
 }
 
 # ── Install / uninstall ──────────────────────────────────────────────────────
-function Set-HullOwnershipMarker([string]$PrefixDir, [string]$Ver, [bool]$AddedNow) {
-    # pathAdded is sticky: once THIS installer added the PATH entry, keep it true
-    # across re-installs so a later uninstall still removes exactly what we added.
-    $prev = Read-HullMarker $PrefixDir
-    $pathAdded = [bool]($AddedNow -or ($prev -and $prev.pathAdded))
-    Write-HullMarker $PrefixDir $Ver $pathAdded
-}
-
 function Invoke-HullInstall {
     param([string]$Version, [string]$Prefix, [bool]$Force, [bool]$DryRun, [bool]$NoPath)
     $ErrorActionPreference = 'Stop'
@@ -384,8 +437,7 @@ function Invoke-HullInstall {
     Write-HullInfo "version: $tag"
     Write-HullInfo "prefix:  $prefixDir"
 
-    # DRY-RUN: resolve metadata and print the plan; touch NO disk (no temp dir, no
-    # download, no prefix, no PATH).
+    # DRY-RUN: resolve metadata + print the plan; touch NO disk.
     if ($DryRun) {
         Write-HullWarn "dry-run: no files, downloads, or PATH changes will be made"
         Write-HullInfo "[dry-run] would download $($script:HullAsset) for $tag and verify its SHA-256"
@@ -394,14 +446,18 @@ function Invoke-HullInstall {
         return
     }
 
-    # Same-version / overwrite rule.
-    $installedVer = Get-HullInstalledVersion $dest
+    # Same-version / overwrite rule (do not ADOPT an unmanaged same-version binary).
+    $installedVer = Get-HullArtifactVersion $dest
     if ((Test-Path -LiteralPath $dest) -and -not $Force) {
         if ($installedVer -eq $wantVer) {
-            Write-HullInfo "hull $installedVer already installed at $dest"
-            $added = $false
-            if (-not $NoPath) { $added = Add-HullToUserPath $prefixDir $false }
-            Set-HullOwnershipMarker $prefixDir $installedVer $added
+            if (Test-HullManagedHere $prefixDir) {
+                $added = $null
+                if (-not $NoPath) { $added = Add-HullToUserPath $prefixDir $false }
+                Set-HullOwnershipMarker $prefixDir $installedVer $added
+                Write-HullInfo "hull $installedVer already installed and managed at $dest"
+            } else {
+                Write-HullInfo "hull $installedVer is already present at $dest but was not installed by install.ps1; not adopting it. Use -Force to replace it with a managed install."
+            }
             return
         }
         throw "a different hull ($installedVer) is already installed at $dest; use -Force to replace it"
@@ -423,43 +479,38 @@ function Invoke-HullInstall {
         }
 
         # 1. checksum against the exact manifest entry for hull-cosmo.
-        $expected = Get-HullManifestHash $man $script:HullAsset
-        $actual = Test-HullChecksum $asset $expected
+        $actual = Test-HullChecksum $asset (Get-HullManifestHash $man $script:HullAsset)
         Write-HullInfo "checksum verified ($actual)"
 
-        # 2. upgrade signature (strict). A verifier-capable existing hull makes the
-        #    signature MANDATORY: a download failure, missing, unparseable, or
-        #    invalid signature all abort. No existing hull, or one lacking
-        #    verify-release, proceeds under bootstrap trust.
+        # 2. upgrade signature (tri-state, bounded). 'capable' => signature
+        #    mandatory (download failure / missing / invalid / timeout all abort).
+        #    'absent' => bootstrap. 'ambiguous' => abort (never a silent downgrade).
         if (Test-Path -LiteralPath $dest) {
-            if (Test-HullVerifierCapable $dest) {
-                Get-HullFile $urls.Sig $sig            # a download failure THROWS -> abort
-                Assert-HullSignature $dest $man $sig   # missing / invalid THROWS -> abort
-                Write-HullInfo "existing hull verified the release signature"
-            } else {
-                Write-HullWarn "existing hull lacks 'verify-release'; proceeding under bootstrap trust (GitHub HTTPS + matched SHA-256)"
+            switch (Get-HullVerifierState $dest) {
+                'capable' {
+                    Get-HullFile $urls.Sig $sig            # download failure THROWS -> abort
+                    Assert-HullSignature $dest $man $sig   # missing / invalid / timeout THROWS -> abort
+                    Write-HullInfo "existing hull verified the release signature"
+                }
+                'absent' { Write-HullWarn "existing hull lacks 'verify-release'; proceeding under bootstrap trust (GitHub HTTPS + matched SHA-256)" }
+                default  { throw "cannot determine whether the existing hull can verify signatures (the probe was ambiguous or timed out); aborting rather than downgrading trust. Remove or replace it, or use -Force with a fresh -Prefix." }
             }
         } else {
             Write-HullWarn "first install: bootstrap trust (GitHub HTTPS + matched SHA-256). Verify further with 'hull verify-release' and Sigstore/Rekor."
         }
 
         # 3. candidate-version check (after checksum, before replacement): the
-        #    verified artifact must report the requested version, else abort
-        #    WITHOUT touching the existing installation.
+        #    verified artifact must report the requested version or abort WITHOUT
+        #    touching the existing installation.
         $candVer = Get-HullArtifactVersion $asset
         if ($candVer -ne $wantVer) {
             throw "downloaded artifact reports version '$candVer', expected '$wantVer'; aborting without changing the existing installation"
         }
         Write-HullInfo "artifact version check: $candVer"
 
-        # 4. install atomically with rollback.
-        Install-HullAtomicMove $asset $dest
+        # 4. transactional commit: binary + PATH + marker (all-or-nothing).
+        Invoke-HullCommitInstall $asset $dest $prefixDir $wantVer $NoPath
         Write-HullInfo "installed hull: $dest"
-
-        # 5. PATH + ownership marker.
-        $added = $false
-        if (-not $NoPath) { $added = Add-HullToUserPath $prefixDir $false }
-        Set-HullOwnershipMarker $prefixDir $wantVer $added
 
         Write-Host ""
         Write-HullInfo "next steps:"
@@ -481,14 +532,13 @@ function Invoke-HullUninstall {
 
     $prefixDir = Resolve-HullPrefix $Prefix
     $dest = Join-Path $prefixDir $script:HullBinName
-    $marker = Get-HullMarkerPath $prefixDir
     $rec = Read-HullMarker $prefixDir
 
-    # Ownership gate: only remove what THIS installer recorded installing. This
-    # prevents `-Uninstall -Prefix <arbitrary>` from deleting an unrelated hull.com
-    # and prevents removing a PATH entry the user owned.
-    if (-not $rec) {
-        Write-HullInfo "no installer ownership record at $prefixDir; refusing to remove anything not installed by install.ps1"
+    # Ownership gate: act ONLY on a valid marker whose recorded prefix matches.
+    # This prevents `-Uninstall -Prefix <arbitrary>` from deleting an unrelated
+    # hull.com and prevents touching a PATH entry the installer did not add.
+    if (-not (Test-HullMarkerValid $rec $prefixDir)) {
+        Write-HullInfo "no valid install.ps1 ownership record at $prefixDir; refusing to remove anything not installed by install.ps1"
         return
     }
 
@@ -499,11 +549,11 @@ function Invoke-HullUninstall {
         Write-HullInfo "no hull found at $dest"
     }
 
-    if ($rec.pathAdded) { [void](Remove-HullFromUserPath $prefixDir $DryRun) }
-    else { Write-HullInfo "user PATH not modified (installer did not add $prefixDir)" }
+    if ($rec.pathAdded -and $rec.pathEntry) { [void](Remove-HullPathEntry ([string]$rec.pathEntry) $DryRun) }
+    else { Write-HullInfo "user PATH not modified (installer did not add an entry)" }
 
     if (-not $DryRun) {
-        Remove-Item -LiteralPath $marker -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath (Get-HullMarkerPath $prefixDir) -Force -ErrorAction SilentlyContinue
         if (Test-Path -LiteralPath $prefixDir) {
             $remaining = @(Get-ChildItem -LiteralPath $prefixDir -Force -ErrorAction SilentlyContinue)
             if ($remaining.Count -eq 0) { Remove-Item -LiteralPath $prefixDir -Force -ErrorAction SilentlyContinue; Write-HullInfo "removed empty $prefixDir" }
@@ -533,8 +583,8 @@ function Invoke-HullInstallerMain {
 }
 
 # Dot-sourcing (`. .\install.ps1`) defines the functions WITHOUT running main, so
-# the Pester tests can exercise them with local fixtures. Normal execution and
-# `irm | iex` run main.
+# the Pester-free tests can exercise them with local fixtures. Normal execution
+# and `irm | iex` run main.
 if ($MyInvocation.InvocationName -ne '.') {
     Invoke-HullInstallerMain
 }

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,417 @@
+<#
+.SYNOPSIS
+    Hull installer for Windows (PowerShell). Installs, upgrades, verifies, and
+    removes Hull for the current user - no admin rights or Developer Mode.
+
+.DESCRIPTION
+    Downloads the official Cosmopolitan APE (hull-cosmo) from the artalis-io/hull
+    GitHub release, verifies its SHA-256 against the signed hull.sha256 manifest
+    before installation, and installs it as %LOCALAPPDATA%\Programs\Hull\hull.com
+    on the current user's PATH. See docs/windows_install_design.md for the trust
+    model.
+
+    Trust: a same-channel SHA-256 protects against corruption and a mismatched
+    asset, not a compromised release channel. Hull's Ed25519 release signature is
+    the channel-independent authenticity root; a freshly-downloaded Hull cannot
+    authenticate itself. On an upgrade, if a pre-existing Hull supports
+    'verify-release', its signature check runs before replacement and a FAILURE
+    aborts the install (never a silent downgrade to checksum-only). A first
+    install proceeds under bootstrap trust (GitHub HTTPS + a matched SHA-256);
+    verify further out-of-band with 'hull verify-release' and Sigstore/Rekor.
+
+.EXAMPLE
+    irm https://gethull.dev/install.ps1 | iex
+
+.EXAMPLE
+    Invoke-WebRequest https://gethull.dev/install.ps1 -OutFile install.ps1
+    .\install.ps1 -Version v0.14.0
+
+.EXAMPLE
+    .\install.ps1 -Uninstall
+#>
+[CmdletBinding(DefaultParameterSetName = 'Install')]
+param(
+    [Parameter(ParameterSetName = 'Install')]
+    [string]$Version = 'latest',
+
+    # -Prefix and -DryRun compose with both install and uninstall.
+    [string]$Prefix,
+
+    [Parameter(ParameterSetName = 'Install')]
+    [switch]$Force,
+
+    [switch]$DryRun,
+
+    [Parameter(ParameterSetName = 'Install')]
+    [switch]$NoPath,
+
+    [Parameter(ParameterSetName = 'Uninstall')]
+    [switch]$Uninstall
+)
+
+# The upstream repository is FIXED. The public installer exposes no override.
+$script:HullRepo   = 'artalis-io/hull'
+$script:HullAsset  = 'hull-cosmo'
+$script:HullBinName = 'hull.com'
+$script:VersionTagPattern = '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'
+
+# ── Output helpers (never log secrets, proxy creds, or temp URLs) ─────────────
+function Write-HullInfo([string]$m) { Write-Host "hull: $m" }
+function Write-HullWarn([string]$m) { Write-Host "hull: warning: $m" -ForegroundColor Yellow }
+function Write-HullErr ([string]$m) { Write-Host "hull: error: $m" -ForegroundColor Red }
+
+# ── TLS + defaults ───────────────────────────────────────────────────────────
+function Set-HullTls {
+    # Windows PowerShell 5.1 defaults to TLS 1.0/1.1; force >= 1.2. Add flags
+    # rather than replacing so PowerShell 7 keeps its negotiated set.
+    try {
+        [Net.ServicePointManager]::SecurityProtocol =
+            [Net.ServicePointManager]::SecurityProtocol -bor
+            [Net.SecurityProtocolType]::Tls12
+    } catch { }
+}
+
+# ── Version + release resolution ─────────────────────────────────────────────
+function Test-HullVersionTag([string]$Tag) {
+    return ($Tag -match $script:VersionTagPattern)
+}
+
+function Resolve-HullTag([string]$Requested) {
+    if ($Requested -and $Requested -ne 'latest') {
+        if (-not (Test-HullVersionTag $Requested)) {
+            throw "invalid -Version '$Requested' (expected a release tag like v0.14.0)"
+        }
+        return $Requested
+    }
+    # /releases/latest already excludes drafts and prereleases.
+    $api = "https://api.github.com/repos/$($script:HullRepo)/releases/latest"
+    $headers = @{ 'Accept' = 'application/vnd.github+json'; 'User-Agent' = 'hull-install.ps1' }
+    $resp = Invoke-RestMethod -Uri $api -Headers $headers -UseBasicParsing
+    $tag = $resp.tag_name
+    if ($resp.draft -eq $true -or $resp.prerelease -eq $true) {
+        throw "latest release resolved to a draft/prerelease ($tag); refusing"
+    }
+    if (-not $tag -or -not (Test-HullVersionTag $tag)) {
+        throw "could not resolve a valid latest release tag (got '$tag')"
+    }
+    return $tag
+}
+
+function Get-HullAssetUrls([string]$Tag) {
+    $base = "https://github.com/$($script:HullRepo)/releases/download/$Tag"
+    return @{
+        Asset    = "$base/$($script:HullAsset)"
+        Manifest = "$base/hull.sha256"
+        Sig      = "$base/hull.sha256.sig"
+    }
+}
+
+# ── Download + checksum ──────────────────────────────────────────────────────
+function Get-HullFile([string]$Url, [string]$OutFile) {
+    # Respects the default system proxy. Do not print $Url beyond a generic note.
+    Invoke-WebRequest -Uri $Url -OutFile $OutFile -UseBasicParsing -Headers @{ 'User-Agent' = 'hull-install.ps1' }
+}
+
+function Get-HullFileSha256([string]$Path) {
+    # .NET SHA-256 (no cmdlet/module dependency); streams the file.
+    $fs = [System.IO.File]::OpenRead($Path)
+    try {
+        $sha = [System.Security.Cryptography.SHA256]::Create()
+        return ([System.BitConverter]::ToString($sha.ComputeHash($fs)) -replace '-', '').ToLower()
+    } finally { $fs.Dispose() }
+}
+
+function Get-HullManifestHash([string]$ManifestPath, [string]$AssetName) {
+    # Return the single expected hash for $AssetName. Fail closed on a missing,
+    # duplicate, or malformed entry.
+    $lines = Get-Content -LiteralPath $ManifestPath
+    $matched = @()
+    foreach ($ln in $lines) {
+        # Format: <64 lowercase hex><two spaces><asset-name>
+        if ($ln -match '^([0-9a-fA-F]{64})\s\s(.+)$') {
+            if ($Matches[2] -ceq $AssetName) { $matched += $Matches[1].ToLower() }
+        }
+    }
+    if ($matched.Count -eq 0) { throw "no checksum entry for '$AssetName' in hull.sha256" }
+    if ($matched.Count -gt 1) { throw "duplicate checksum entries for '$AssetName' in hull.sha256" }
+    return $matched[0]
+}
+
+function Test-HullChecksum([string]$Path, [string]$Expected) {
+    $actual = Get-HullFileSha256 $Path
+    if ($actual -ne $Expected) {
+        throw "checksum mismatch: expected $Expected, got $actual"
+    }
+    return $actual
+}
+
+# ── Upgrade signature check (three explicit outcomes) ────────────────────────
+function Test-HullUpgradeSignature([string]$ExistingHull, [string]$ManifestPath, [string]$SigPath) {
+    # Returns 'verified' | 'bootstrap'. Throws on a present-but-failing verifier.
+    if (-not $ExistingHull -or -not (Test-Path -LiteralPath $ExistingHull)) { return 'bootstrap' }
+    # Probe for the verify-release subcommand without failing on its absence.
+    $help = & $ExistingHull verify-release --help 2>&1
+    if ($LASTEXITCODE -ne 0 -or (($help | Out-String) -notmatch 'verify-release')) {
+        return 'bootstrap'  # older hull lacks the command
+    }
+    if (-not (Test-Path -LiteralPath $SigPath)) { return 'bootstrap' }  # no sig fetched
+    $out = & $ExistingHull verify-release $ManifestPath $SigPath 2>&1
+    if ($LASTEXITCODE -eq 0) { return 'verified' }
+    throw "existing hull failed to verify hull.sha256.sig; aborting (output: $(($out | Out-String).Trim()))"
+}
+
+# ── User PATH (HKCU only; idempotent; type-preserving) ───────────────────────
+function Get-HullUserPathRaw {
+    # Raw (unexpanded) value + its registry kind, so we can preserve REG_EXPAND_SZ.
+    $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $false)
+    if ($null -eq $key) { return @{ Value = ''; Kind = [Microsoft.Win32.RegistryValueKind]::ExpandString } }
+    try {
+        $val = $key.GetValue('Path', '', [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+        $kind = [Microsoft.Win32.RegistryValueKind]::ExpandString
+        try { if ($null -ne $key.GetValue('Path')) { $kind = $key.GetValueKind('Path') } } catch { }
+        return @{ Value = [string]$val; Kind = $kind }
+    } finally { $key.Close() }
+}
+
+function ConvertTo-HullPathKey([string]$Component) {
+    # Normalize for comparison only: trim trailing separators, lowercase.
+    return ($Component.TrimEnd('\', '/')).ToLowerInvariant()
+}
+
+function Test-HullPathContains([string]$RawPath, [string]$Dir) {
+    $want = ConvertTo-HullPathKey $Dir
+    foreach ($c in ($RawPath -split ';')) {
+        if ($c -eq '') { continue }
+        if ((ConvertTo-HullPathKey $c) -eq $want) { return $true }
+    }
+    return $false
+}
+
+function Set-HullUserPathRaw([string]$Value, $Kind) {
+    $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
+    if ($null -eq $key) { $key = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey('Environment') }
+    try { $key.SetValue('Path', $Value, $Kind) } finally { $key.Close() }
+}
+
+function Send-HullEnvBroadcast {
+    # Notify running shells that the environment changed. Best-effort.
+    if (-not ('HullNative.Win32' -as [type])) {
+        Add-Type -Namespace HullNative -Name Win32 -MemberDefinition @'
+[System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
+public static extern System.IntPtr SendMessageTimeout(System.IntPtr hWnd, uint Msg, System.UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out System.UIntPtr lpdwResult);
+'@ -ErrorAction SilentlyContinue
+    }
+    try {
+        $HWND_BROADCAST = [System.IntPtr]0xffff
+        $WM_SETTINGCHANGE = 0x1a
+        $SMTO_ABORTIFHUNG = 0x2
+        $out = [System.UIntPtr]::Zero
+        [void][HullNative.Win32]::SendMessageTimeout($HWND_BROADCAST, $WM_SETTINGCHANGE, [System.UIntPtr]::Zero, 'Environment', $SMTO_ABORTIFHUNG, 5000, [ref]$out)
+    } catch { }
+}
+
+function Add-HullToUserPath([string]$Dir, [bool]$DryRun) {
+    $cur = Get-HullUserPathRaw
+    if (Test-HullPathContains $cur.Value $Dir) {
+        Write-HullInfo "PATH already contains $Dir"
+        return $false
+    }
+    if ($DryRun) { Write-HullInfo "[dry-run] would add $Dir to user PATH"; return $false }
+    $newValue = if ([string]::IsNullOrEmpty($cur.Value)) { $Dir } else { ($cur.Value.TrimEnd(';') + ';' + $Dir) }
+    Set-HullUserPathRaw $newValue $cur.Kind
+    Send-HullEnvBroadcast
+    Write-HullInfo "added $Dir to user PATH"
+    return $true
+}
+
+function Remove-HullFromUserPath([string]$Dir, [bool]$DryRun) {
+    $cur = Get-HullUserPathRaw
+    if (-not (Test-HullPathContains $cur.Value $Dir)) { return $false }
+    if ($DryRun) { Write-HullInfo "[dry-run] would remove $Dir from user PATH"; return $false }
+    $want = ConvertTo-HullPathKey $Dir
+    $kept = @()
+    foreach ($c in ($cur.Value -split ';')) {
+        if ($c -eq '') { continue }
+        if ((ConvertTo-HullPathKey $c) -ne $want) { $kept += $c }
+    }
+    Set-HullUserPathRaw ($kept -join ';') $cur.Kind
+    Send-HullEnvBroadcast
+    Write-HullInfo "removed $Dir from user PATH"
+    return $true
+}
+
+# ── Prefix + version-of-installed ────────────────────────────────────────────
+function Resolve-HullPrefix([string]$Requested) {
+    if ($Requested) { return $Requested }
+    $localApp = $env:LOCALAPPDATA
+    if (-not $localApp) { $localApp = Join-Path $env:USERPROFILE 'AppData\Local' }
+    return (Join-Path $localApp 'Programs\Hull')
+}
+
+function Get-HullInstalledVersion([string]$BinPath) {
+    if (-not (Test-Path -LiteralPath $BinPath)) { return $null }
+    try {
+        $v = (& $BinPath version 2>$null | Select-Object -First 1)
+        if ($v -match '([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?)') { return $Matches[1] }
+    } catch { }
+    return $null
+}
+
+# ── Atomic install with rollback ─────────────────────────────────────────────
+function Install-HullAtomicMove([string]$Src, [string]$Dest, [switch]$SimulateFailure) {
+    # Stage the new binary beside the destination, back up any existing binary,
+    # move the new one into place, and drop the backup. On ANY failure, restore
+    # the previous binary so a failed install never destroys a runnable hull.
+    # -SimulateFailure is a test-only injection to exercise the rollback path.
+    $dir = Split-Path -Parent $Dest
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    $staged = "$Dest.new"
+    $backup = "$Dest.bak"
+    Copy-Item -LiteralPath $Src -Destination $staged -Force
+    $hadPrev = Test-Path -LiteralPath $Dest
+    try {
+        if ($hadPrev) { Move-Item -LiteralPath $Dest -Destination $backup -Force }
+        if ($SimulateFailure) { throw "simulated install failure (test)" }
+        Move-Item -LiteralPath $staged -Destination $Dest -Force
+        if ($hadPrev) { Remove-Item -LiteralPath $backup -Force -ErrorAction SilentlyContinue }
+    } catch {
+        if ($hadPrev -and (Test-Path -LiteralPath $backup) -and -not (Test-Path -LiteralPath $Dest)) {
+            Move-Item -LiteralPath $backup -Destination $Dest -Force -ErrorAction SilentlyContinue
+        }
+        Remove-Item -LiteralPath $staged -Force -ErrorAction SilentlyContinue
+        throw
+    }
+}
+
+# ── Install / uninstall ──────────────────────────────────────────────────────
+function Invoke-HullInstall {
+    param([string]$Version, [string]$Prefix, [bool]$Force, [bool]$DryRun, [bool]$NoPath)
+
+    Set-HullTls
+    $tag = Resolve-HullTag $Version
+    $urls = Get-HullAssetUrls $tag
+    $prefixDir = Resolve-HullPrefix $Prefix
+    $dest = Join-Path $prefixDir $script:HullBinName
+
+    Write-HullInfo "repo:    $($script:HullRepo)"
+    Write-HullInfo "version: $tag"
+    Write-HullInfo "prefix:  $prefixDir"
+    if ($DryRun) { Write-HullWarn "dry-run: no files or PATH changes will be written" }
+
+    # Same-version / overwrite rule.
+    $installedVer = Get-HullInstalledVersion $dest
+    $wantVer = $tag.TrimStart('v')
+    if ((Test-Path -LiteralPath $dest) -and -not $Force) {
+        if ($installedVer -eq $wantVer) {
+            Write-HullInfo "hull $installedVer already installed at $dest"
+            if (-not $NoPath) { [void](Add-HullToUserPath $prefixDir $DryRun) }
+            return
+        }
+        throw "a different hull ($installedVer) is already installed at $dest; use -Force to replace it"
+    }
+
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("hull-install-" + [guid]::NewGuid())
+    New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+    try {
+        $asset = Join-Path $tmp $script:HullAsset
+        $man   = Join-Path $tmp 'hull.sha256'
+        $sig   = Join-Path $tmp 'hull.sha256.sig'
+
+        Write-HullInfo "downloading $($script:HullAsset)"
+        if (-not $DryRun) {
+            Get-HullFile $urls.Asset $asset
+            Get-HullFile $urls.Manifest $man
+            if (-not (Test-Path -LiteralPath $asset) -or (Get-Item $asset).Length -eq 0) {
+                throw "download produced an empty file; release may not exist at $tag"
+            }
+        }
+
+        if (-not $DryRun) {
+            $expected = Get-HullManifestHash $man $script:HullAsset
+            $actual = Test-HullChecksum $asset $expected
+            Write-HullInfo "checksum verified ($actual)"
+        }
+
+        # Upgrade signature check via a pre-existing trusted hull (3 outcomes).
+        if (-not $DryRun -and (Test-Path -LiteralPath $dest)) {
+            try { Get-HullFile $urls.Sig $sig } catch { }
+            $verdict = Test-HullUpgradeSignature $dest $man $sig  # throws on present+fail
+            if ($verdict -eq 'verified') { Write-HullInfo "existing hull verified the release signature" }
+            else { Write-HullWarn "existing hull cannot verify signatures; proceeding under bootstrap trust (GitHub HTTPS + matched SHA-256)" }
+        } elseif (-not $DryRun) {
+            Write-HullWarn "first install: bootstrap trust (GitHub HTTPS + matched SHA-256). Verify further with 'hull verify-release' and Sigstore/Rekor."
+        }
+
+        if ($DryRun) { Write-HullInfo "[dry-run] would install to $dest"; }
+        else {
+            Install-HullAtomicMove $asset $dest
+            Write-HullInfo "installed hull: $dest"
+        }
+
+        if (-not $NoPath) { [void](Add-HullToUserPath $prefixDir $DryRun) }
+
+        if (-not $DryRun) {
+            Write-Host ""
+            Write-HullInfo "next steps:"
+            Write-Host "  hull doctor         . check the environment"
+            Write-Host "  hull verify-release . verify a release manifest signature"
+            Write-Host "  hull update         . install future releases"
+            Write-Host ""
+            Write-Host "Windows note: a v0.13.0 hull cannot self-update to v0.14.0 (the fix ships"
+            Write-Host "in v0.14.0). If you are upgrading from v0.13.0, this manual install is the"
+            Write-Host "one-time replacement; 'hull update' works normally from v0.14.0 onward."
+        }
+    } finally {
+        Remove-Item -LiteralPath $tmp -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Invoke-HullUninstall {
+    param([string]$Prefix, [bool]$DryRun)
+
+    $prefixDir = Resolve-HullPrefix $Prefix
+    $dest = Join-Path $prefixDir $script:HullBinName
+
+    if (Test-Path -LiteralPath $dest) {
+        if ($DryRun) { Write-HullInfo "[dry-run] would remove $dest" }
+        else { Remove-Item -LiteralPath $dest -Force; Write-HullInfo "removed $dest" }
+    } else {
+        Write-HullInfo "no hull found at $dest (nothing to remove)"
+    }
+
+    # Remove the install directory only when empty.
+    if ((Test-Path -LiteralPath $prefixDir) -and -not $DryRun) {
+        $remaining = @(Get-ChildItem -LiteralPath $prefixDir -Force -ErrorAction SilentlyContinue)
+        if ($remaining.Count -eq 0) { Remove-Item -LiteralPath $prefixDir -Force -ErrorAction SilentlyContinue; Write-HullInfo "removed empty $prefixDir" }
+    }
+
+    [void](Remove-HullFromUserPath $prefixDir $DryRun)
+
+    Write-Host ""
+    Write-HullInfo "Hull state under ~/.hull (tools, caches, app data) was retained."
+    Write-Host "  To remove it manually: Remove-Item -Recurse -Force `"$env:USERPROFILE\.hull`""
+}
+
+# ── Entry ────────────────────────────────────────────────────────────────────
+function Invoke-HullInstallerMain {
+    Write-Host ""
+    Write-Host "Hull installer (Windows)" -ForegroundColor Cyan
+    Write-Host ""
+    try {
+        if ($Uninstall) {
+            Invoke-HullUninstall -Prefix $Prefix -DryRun:$DryRun.IsPresent
+        } else {
+            Invoke-HullInstall -Version $Version -Prefix $Prefix -Force:$Force.IsPresent -DryRun:$DryRun.IsPresent -NoPath:$NoPath.IsPresent
+        }
+    } catch {
+        Write-HullErr $_.Exception.Message
+        exit 1
+    }
+}
+
+# Dot-sourcing (`. .\install.ps1`) defines the functions WITHOUT running main, so
+# the Pester tests can exercise them with local fixtures. Normal execution and
+# `irm | iex` run main.
+if ($MyInvocation.InvocationName -ne '.') {
+    Invoke-HullInstallerMain
+}

--- a/install.ps1
+++ b/install.ps1
@@ -284,17 +284,46 @@ function Resolve-HullPrefix([string]$Requested) {
 # ── Ownership marker (validated schema + prefix + recorded raw PATH entry) ────
 function Get-HullMarkerPath([string]$PrefixDir) { return (Join-Path $PrefixDir $script:HullMarkerName) }
 
+function Import-HullMoveFileEx {
+    if (-not ('HullNative.Fs' -as [type])) {
+        Add-Type -Namespace HullNative -Name Fs -MemberDefinition @'
+[System.Runtime.InteropServices.DllImport("kernel32.dll", SetLastError = true, CharSet = System.Runtime.InteropServices.CharSet.Unicode)]
+public static extern bool MoveFileEx(string lpExistingFileName, string lpNewFileName, uint dwFlags);
+'@ -ErrorAction SilentlyContinue
+    }
+}
+
+function Move-HullFileAtomicReplace([string]$Src, [string]$Dst) {
+    # True atomic same-volume replace via MoveFileEx(REPLACE_EXISTING|WRITE_THROUGH):
+    # on the same volume the destination is never in a "no file" state. Retries a
+    # few times for a transient scanner lock; every attempt is itself atomic.
+    Import-HullMoveFileEx
+    $flags = 0x1 -bor 0x8   # MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH
+    for ($i = 0; $i -lt 5; $i++) {
+        if ([HullNative.Fs]::MoveFileEx($Src, $Dst, $flags)) { return $true }
+        Start-Sleep -Milliseconds 100
+    }
+    return $false
+}
+
 function Write-HullMarkerAtomic([string]$PrefixDir, [byte[]]$Bytes) {
-    # Write a unique temp in the same directory, then rename it into place. Uses
-    # remove-then-rename (robust across NTFS/AV; File.Replace can throw when a
-    # scanner briefly holds the destination).
+    # Write a unique temp in the same directory, then atomically rename it into
+    # place. For a first marker a plain same-directory move suffices; to REPLACE
+    # an existing marker use MoveFileEx so the marker is never absent. If the
+    # atomic replace is blocked, throw (retain the old marker) - never fall back
+    # to a non-atomic delete-then-move.
     New-Item -ItemType Directory -Path $PrefixDir -Force | Out-Null
     $final = Get-HullMarkerPath $PrefixDir
     $tmp = Join-Path $PrefixDir (".hull-marker-" + [guid]::NewGuid().ToString('N'))
     [System.IO.File]::WriteAllBytes($tmp, $Bytes)
     try {
-        if (Test-Path -LiteralPath $final) { Remove-Item -LiteralPath $final -Force }
-        [System.IO.File]::Move($tmp, $final)
+        if (Test-Path -LiteralPath $final) {
+            if (-not (Move-HullFileAtomicReplace $tmp $final)) {
+                throw "could not atomically replace the marker at $final (it is retained unchanged)"
+            }
+        } else {
+            [System.IO.File]::Move($tmp, $final)
+        }
     } catch { Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue; throw }
 }
 
@@ -336,7 +365,13 @@ function Test-HullMarkerValid($Rec, [string]$PrefixDir) {
     if (-not $schemaOk) { return $false }
     if ($Rec.pathAdded -isnot [bool]) { return $false }
     if ([string]::IsNullOrEmpty([string]$Rec.prefix)) { return $false }
-    if (($Rec.pathAdded -eq $true) -and [string]::IsNullOrEmpty([string]$Rec.pathEntry)) { return $false }
+    if ($Rec.pathAdded -eq $true) {
+        # An owned PATH entry must be nonempty AND bind to the recorded prefix, so
+        # a valid-looking marker can never authorize removing an unrelated PATH
+        # component.
+        if ([string]::IsNullOrEmpty([string]$Rec.pathEntry)) { return $false }
+        if ((ConvertTo-HullPathKey ([string]$Rec.pathEntry)) -ne (ConvertTo-HullPathKey ([string]$Rec.prefix))) { return $false }
+    }
     if ((ConvertTo-HullPathKey ([string]$Rec.prefix)) -ne (ConvertTo-HullPathKey $PrefixDir)) { return $false }
     return $true
 }
@@ -431,11 +466,40 @@ function Invoke-HullCommitInstall([string]$Src, [string]$Dest, [string]$PrefixDi
         Complete-HullBinarySwap $swap
     } catch {
         $err = $_
-        # Restore the binary FIRST (the anchor: a runnable hull), then the PATH
-        # and marker to their exact prior state.
-        Undo-HullBinarySwap $swap -SimulateRestoreFailure:$SimulateUndoFailure -SimulateRemoveFailure:$SimulateUndoRemoveFailure
-        Restore-HullUserPathExact $pathSnap
-        Restore-HullMarkerExact $PrefixDir $prevMarkerBytes
+        # Attempt ALL of binary + PATH + marker restoration even if one throws, so
+        # a failed binary rollback never skips metadata rollback. Collect every
+        # rollback failure and report a combined CRITICAL.
+        $rollbackErrors = @()
+        try { Undo-HullBinarySwap $swap -SimulateRestoreFailure:$SimulateUndoFailure -SimulateRemoveFailure:$SimulateUndoRemoveFailure }
+        catch { $rollbackErrors += "binary: $($_.Exception.Message)" }
+        try { Restore-HullUserPathExact $pathSnap }
+        catch { $rollbackErrors += "PATH: $($_.Exception.Message)" }
+        try { Restore-HullMarkerExact $PrefixDir $prevMarkerBytes }
+        catch { $rollbackErrors += "marker: $($_.Exception.Message)" }
+        if ($rollbackErrors.Count -gt 0) {
+            throw ("CRITICAL: install failed and rollback was incomplete (" + ($rollbackErrors -join '; ') + "); original error: $($err.Exception.Message)")
+        }
+        throw $err
+    }
+}
+
+function Invoke-HullReaffirm([string]$PrefixDir, [string]$Ver, [bool]$NoPath, [switch]$FailMarker) {
+    # Re-affirm a managed same-version install: ensure PATH + refresh the marker
+    # as ONE transaction. If the marker refresh fails, undo the PATH add and
+    # restore the prior marker so a partial PATH mutation never survives.
+    $markerPath = Get-HullMarkerPath $PrefixDir
+    $prevMarkerBytes = $null
+    if (Test-Path -LiteralPath $markerPath) { $prevMarkerBytes = [System.IO.File]::ReadAllBytes($markerPath) }
+    $pathSnap = Get-HullUserPathRaw
+    try {
+        $addedEntry = $null
+        if (-not $NoPath) { $addedEntry = Add-HullToUserPath $PrefixDir $false }
+        if ($FailMarker) { throw "simulated marker write failure (test)" }
+        Set-HullOwnershipMarker $PrefixDir $Ver $addedEntry
+    } catch {
+        $err = $_
+        try { Restore-HullUserPathExact $pathSnap } catch { }
+        try { Restore-HullMarkerExact $PrefixDir $prevMarkerBytes } catch { }
         throw $err
     }
 }
@@ -468,9 +532,7 @@ function Invoke-HullInstall {
     if ((Test-Path -LiteralPath $dest) -and -not $Force) {
         if ($installedVer -eq $wantVer) {
             if (Test-HullManagedHere $prefixDir) {
-                $added = $null
-                if (-not $NoPath) { $added = Add-HullToUserPath $prefixDir $false }
-                Set-HullOwnershipMarker $prefixDir $installedVer $added
+                Invoke-HullReaffirm $prefixDir $installedVer $NoPath
                 Write-HullInfo "hull $installedVer already installed and managed at $dest"
             } else {
                 Write-HullInfo "hull $installedVer is already present at $dest but was not installed by install.ps1; not adopting it. Use -Force to replace it with a managed install."

--- a/install.ps1
+++ b/install.ps1
@@ -285,14 +285,16 @@ function Resolve-HullPrefix([string]$Requested) {
 function Get-HullMarkerPath([string]$PrefixDir) { return (Join-Path $PrefixDir $script:HullMarkerName) }
 
 function Write-HullMarkerAtomic([string]$PrefixDir, [byte[]]$Bytes) {
-    # Unique temp in the same directory, then an atomic replace/rename.
+    # Write a unique temp in the same directory, then rename it into place. Uses
+    # remove-then-rename (robust across NTFS/AV; File.Replace can throw when a
+    # scanner briefly holds the destination).
     New-Item -ItemType Directory -Path $PrefixDir -Force | Out-Null
     $final = Get-HullMarkerPath $PrefixDir
     $tmp = Join-Path $PrefixDir (".hull-marker-" + [guid]::NewGuid().ToString('N'))
     [System.IO.File]::WriteAllBytes($tmp, $Bytes)
     try {
-        if (Test-Path -LiteralPath $final) { [System.IO.File]::Replace($tmp, $final, $null) }
-        else { [System.IO.File]::Move($tmp, $final) }
+        if (Test-Path -LiteralPath $final) { Remove-Item -LiteralPath $final -Force }
+        [System.IO.File]::Move($tmp, $final)
     } catch { Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue; throw }
 }
 
@@ -312,9 +314,14 @@ function Restore-HullMarkerExact([string]$PrefixDir, [byte[]]$PrevBytes) {
     if ($null -eq $PrevBytes) {
         if (Test-Path -LiteralPath $final) { Remove-Item -LiteralPath $final -Force }
         if (Test-Path -LiteralPath $final) { throw "CRITICAL: could not remove a stray marker during rollback" }
-    } else {
-        Write-HullMarkerAtomic $PrefixDir $PrevBytes
+        return
     }
+    # If the marker on disk already matches the prior bytes, no rewrite is needed.
+    $cur = $null
+    if (Test-Path -LiteralPath $final) { try { $cur = [System.IO.File]::ReadAllBytes($final) } catch { } }
+    $same = ($null -ne $cur) -and ($cur.Length -eq $PrevBytes.Length)
+    if ($same) { for ($i = 0; $i -lt $cur.Length; $i++) { if ($cur[$i] -ne $PrevBytes[$i]) { $same = $false; break } } }
+    if (-not $same) { Write-HullMarkerAtomic $PrefixDir $PrevBytes }
 }
 
 function Test-HullMarkerValid($Rec, [string]$PrefixDir) {
@@ -424,9 +431,11 @@ function Invoke-HullCommitInstall([string]$Src, [string]$Dest, [string]$PrefixDi
         Complete-HullBinarySwap $swap
     } catch {
         $err = $_
+        # Restore the binary FIRST (the anchor: a runnable hull), then the PATH
+        # and marker to their exact prior state.
+        Undo-HullBinarySwap $swap -SimulateRestoreFailure:$SimulateUndoFailure -SimulateRemoveFailure:$SimulateUndoRemoveFailure
         Restore-HullUserPathExact $pathSnap
         Restore-HullMarkerExact $PrefixDir $prevMarkerBytes
-        Undo-HullBinarySwap $swap -SimulateRestoreFailure:$SimulateUndoFailure -SimulateRemoveFailure:$SimulateUndoRemoveFailure
         throw $err
     }
 }

--- a/install.ps1
+++ b/install.ps1
@@ -145,19 +145,37 @@ function Test-HullChecksum([string]$Path, [string]$Expected) {
     return $actual
 }
 
-# ── Upgrade signature check (three explicit outcomes) ────────────────────────
-function Test-HullUpgradeSignature([string]$ExistingHull, [string]$ManifestPath, [string]$SigPath) {
-    # Returns 'verified' | 'bootstrap'. Throws on a present-but-failing verifier.
-    if (-not $ExistingHull -or -not (Test-Path -LiteralPath $ExistingHull)) { return 'bootstrap' }
-    # Probe for the verify-release subcommand without failing on its absence.
-    $help = & $ExistingHull verify-release --help 2>&1
-    if ($LASTEXITCODE -ne 0 -or (($help | Out-String) -notmatch 'verify-release')) {
-        return 'bootstrap'  # older hull lacks the command
+# ── Upgrade signature check (strict three-outcome contract) ──────────────────
+# Bootstrap trust is permitted ONLY when there is no existing hull or the
+# existing hull genuinely lacks 'verify-release'. Once an existing hull is proven
+# verifier-capable, a missing / unfetched / unparseable / invalid signature MUST
+# abort - never a silent downgrade to checksum-only.
+function Test-HullVerifierCapable([string]$ExistingHull) {
+    if (-not $ExistingHull -or -not (Test-Path -LiteralPath $ExistingHull)) { return $false }
+    # Probe without letting the native command's stderr become a terminating error.
+    $prevEA = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
+    try {
+        $out = & $ExistingHull verify-release --help 2>&1
+        $code = $LASTEXITCODE
+    } finally { $ErrorActionPreference = $prevEA }
+    return ($code -eq 0 -and (($out | Out-String) -match 'verify-release'))
+}
+
+function Assert-HullSignature([string]$ExistingHull, [string]$ManifestPath, [string]$SigPath) {
+    # Precondition: the caller has established $ExistingHull is verifier-capable.
+    # ANY failure here throws (abort); there is no bootstrap fallback.
+    $sigItem = Get-Item -LiteralPath $SigPath -ErrorAction SilentlyContinue
+    if (-not $sigItem -or $sigItem.Length -eq 0) {
+        throw "release signature (hull.sha256.sig) is missing or empty; aborting (the existing hull can verify signatures, so a signature is required)"
     }
-    if (-not (Test-Path -LiteralPath $SigPath)) { return 'bootstrap' }  # no sig fetched
-    $out = & $ExistingHull verify-release $ManifestPath $SigPath 2>&1
-    if ($LASTEXITCODE -eq 0) { return 'verified' }
-    throw "existing hull failed to verify hull.sha256.sig; aborting (output: $(($out | Out-String).Trim()))"
+    $prevEA = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
+    try {
+        $out = & $ExistingHull verify-release $ManifestPath $SigPath 2>&1
+        $code = $LASTEXITCODE
+    } finally { $ErrorActionPreference = $prevEA }
+    if ($code -ne 0) {
+        throw "release signature did not verify; aborting (output: $(($out | Out-String).Trim()))"
+    }
 }
 
 # ── User PATH (HKCU only; idempotent; type-preserving) ───────────────────────
@@ -174,8 +192,15 @@ function Get-HullUserPathRaw {
 }
 
 function ConvertTo-HullPathKey([string]$Component) {
-    # Normalize for comparison only: trim trailing separators, lowercase.
-    return ($Component.TrimEnd('\', '/')).ToLowerInvariant()
+    # Normalize for COMPARISON only (the raw component is always preserved when
+    # writing): strip surrounding quotes and whitespace, expand environment
+    # variables (so %LOCALAPPDATA%\Programs\Hull matches its expansion), unify
+    # separators, drop trailing separators, and lowercase.
+    $c = $Component.Trim().Trim('"')
+    $c = [System.Environment]::ExpandEnvironmentVariables($c)
+    $c = $c -replace '/', '\'
+    $c = $c.TrimEnd('\')
+    return $c.ToLowerInvariant()
 }
 
 function Test-HullPathContains([string]$RawPath, [string]$Dir) {
@@ -257,16 +282,61 @@ function Get-HullInstalledVersion([string]$BinPath) {
     return $null
 }
 
+function Get-HullArtifactVersion([string]$ExePath, [int]$TimeoutSec = 20) {
+    # Run '<exe> version' with a bounded timeout and return the parsed version.
+    # Returns $null on timeout / failure / unparseable output. Never hangs.
+    $outFile = [System.IO.Path]::GetTempFileName()
+    $errFile = [System.IO.Path]::GetTempFileName()
+    try {
+        $p = Start-Process -FilePath $ExePath -ArgumentList 'version' -PassThru -NoNewWindow `
+                           -RedirectStandardOutput $outFile -RedirectStandardError $errFile
+        if (-not $p.WaitForExit($TimeoutSec * 1000)) {
+            try { $p.Kill() } catch { }
+            return $null
+        }
+        $line = (Get-Content -LiteralPath $outFile | Select-Object -First 1)
+        if ($line -match '([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?)') { return $Matches[1] }
+        return $null
+    } catch {
+        return $null
+    } finally {
+        Remove-Item -LiteralPath $outFile, $errFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# ── Installer ownership marker (so uninstall only touches what it installed) ──
+function Get-HullMarkerPath([string]$PrefixDir) { return (Join-Path $PrefixDir '.hull-install.json') }
+
+function Write-HullMarker([string]$PrefixDir, [string]$InstalledVersion, [bool]$PathAdded) {
+    $rec = [ordered]@{
+        installer = 'install.ps1'
+        prefix    = $PrefixDir
+        version   = $InstalledVersion
+        pathAdded = $PathAdded
+    }
+    Set-Content -LiteralPath (Get-HullMarkerPath $PrefixDir) -Value ($rec | ConvertTo-Json) -Encoding ASCII
+}
+
+function Read-HullMarker([string]$PrefixDir) {
+    $m = Get-HullMarkerPath $PrefixDir
+    if (-not (Test-Path -LiteralPath $m)) { return $null }
+    try { return (Get-Content -LiteralPath $m -Raw | ConvertFrom-Json) } catch { return $null }
+}
+
 # ── Atomic install with rollback ─────────────────────────────────────────────
-function Install-HullAtomicMove([string]$Src, [string]$Dest, [switch]$SimulateFailure) {
-    # Stage the new binary beside the destination, back up any existing binary,
-    # move the new one into place, and drop the backup. On ANY failure, restore
-    # the previous binary so a failed install never destroys a runnable hull.
-    # -SimulateFailure is a test-only injection to exercise the rollback path.
+function Install-HullAtomicMove([string]$Src, [string]$Dest, [switch]$SimulateFailure, [switch]$SimulateRestoreFailure) {
+    # Stage the new binary beside the destination under UNIQUE names (so an
+    # unrelated pre-existing sidecar is never clobbered), back up any existing
+    # binary, move the new one into place, and drop the backup. On ANY failure,
+    # restore the previous binary and PROVE it is back; if restoration fails,
+    # raise a distinct CRITICAL error naming the preserved backup. The two
+    # -Simulate* switches are test-only injections for the rollback paths.
     $dir = Split-Path -Parent $Dest
     New-Item -ItemType Directory -Path $dir -Force | Out-Null
-    $staged = "$Dest.new"
-    $backup = "$Dest.bak"
+    $staged = Join-Path $dir (".hull-stage-" + [guid]::NewGuid().ToString('N'))
+    $backup = Join-Path $dir (".hull-backup-" + [guid]::NewGuid().ToString('N'))
+    if (Test-Path -LiteralPath $staged) { throw "staging path already exists: $staged" }
+    if (Test-Path -LiteralPath $backup) { throw "backup path already exists: $backup" }
     Copy-Item -LiteralPath $Src -Destination $staged -Force
     $hadPrev = Test-Path -LiteralPath $Dest
     try {
@@ -275,36 +345,63 @@ function Install-HullAtomicMove([string]$Src, [string]$Dest, [switch]$SimulateFa
         Move-Item -LiteralPath $staged -Destination $Dest -Force
         if ($hadPrev) { Remove-Item -LiteralPath $backup -Force -ErrorAction SilentlyContinue }
     } catch {
-        if ($hadPrev -and (Test-Path -LiteralPath $backup) -and -not (Test-Path -LiteralPath $Dest)) {
-            Move-Item -LiteralPath $backup -Destination $Dest -Force -ErrorAction SilentlyContinue
-        }
+        $installErr = $_
         Remove-Item -LiteralPath $staged -Force -ErrorAction SilentlyContinue
-        throw
+        if ($hadPrev) {
+            if (-not $SimulateRestoreFailure -and -not (Test-Path -LiteralPath $Dest)) {
+                Move-Item -LiteralPath $backup -Destination $Dest -Force -ErrorAction SilentlyContinue
+            }
+            if (-not (Test-Path -LiteralPath $Dest)) {
+                throw "CRITICAL: install failed AND rollback failed; your previous hull is preserved at $backup"
+            }
+            Remove-Item -LiteralPath $backup -Force -ErrorAction SilentlyContinue
+        }
+        throw $installErr
     }
 }
 
 # ── Install / uninstall ──────────────────────────────────────────────────────
+function Set-HullOwnershipMarker([string]$PrefixDir, [string]$Ver, [bool]$AddedNow) {
+    # pathAdded is sticky: once THIS installer added the PATH entry, keep it true
+    # across re-installs so a later uninstall still removes exactly what we added.
+    $prev = Read-HullMarker $PrefixDir
+    $pathAdded = [bool]($AddedNow -or ($prev -and $prev.pathAdded))
+    Write-HullMarker $PrefixDir $Ver $pathAdded
+}
+
 function Invoke-HullInstall {
     param([string]$Version, [string]$Prefix, [bool]$Force, [bool]$DryRun, [bool]$NoPath)
+    $ErrorActionPreference = 'Stop'
 
     Set-HullTls
-    $tag = Resolve-HullTag $Version
+    $tag = Resolve-HullTag $Version           # metadata resolution is allowed in dry-run
     $urls = Get-HullAssetUrls $tag
     $prefixDir = Resolve-HullPrefix $Prefix
     $dest = Join-Path $prefixDir $script:HullBinName
+    $wantVer = $tag.TrimStart('v')
 
     Write-HullInfo "repo:    $($script:HullRepo)"
     Write-HullInfo "version: $tag"
     Write-HullInfo "prefix:  $prefixDir"
-    if ($DryRun) { Write-HullWarn "dry-run: no files or PATH changes will be written" }
+
+    # DRY-RUN: resolve metadata and print the plan; touch NO disk (no temp dir, no
+    # download, no prefix, no PATH).
+    if ($DryRun) {
+        Write-HullWarn "dry-run: no files, downloads, or PATH changes will be made"
+        Write-HullInfo "[dry-run] would download $($script:HullAsset) for $tag and verify its SHA-256"
+        Write-HullInfo "[dry-run] would install to $dest"
+        if (-not $NoPath) { Write-HullInfo "[dry-run] would ensure $prefixDir is on the user PATH" }
+        return
+    }
 
     # Same-version / overwrite rule.
     $installedVer = Get-HullInstalledVersion $dest
-    $wantVer = $tag.TrimStart('v')
     if ((Test-Path -LiteralPath $dest) -and -not $Force) {
         if ($installedVer -eq $wantVer) {
             Write-HullInfo "hull $installedVer already installed at $dest"
-            if (-not $NoPath) { [void](Add-HullToUserPath $prefixDir $DryRun) }
+            $added = $false
+            if (-not $NoPath) { $added = Add-HullToUserPath $prefixDir $false }
+            Set-HullOwnershipMarker $prefixDir $installedVer $added
             return
         }
         throw "a different hull ($installedVer) is already installed at $dest; use -Force to replace it"
@@ -313,54 +410,66 @@ function Invoke-HullInstall {
     $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("hull-install-" + [guid]::NewGuid())
     New-Item -ItemType Directory -Path $tmp -Force | Out-Null
     try {
-        $asset = Join-Path $tmp $script:HullAsset
+        # Stage the download AS hull.com so it is runnable for the candidate check.
+        $asset = Join-Path $tmp $script:HullBinName
         $man   = Join-Path $tmp 'hull.sha256'
         $sig   = Join-Path $tmp 'hull.sha256.sig'
 
         Write-HullInfo "downloading $($script:HullAsset)"
-        if (-not $DryRun) {
-            Get-HullFile $urls.Asset $asset
-            Get-HullFile $urls.Manifest $man
-            if (-not (Test-Path -LiteralPath $asset) -or (Get-Item $asset).Length -eq 0) {
-                throw "download produced an empty file; release may not exist at $tag"
+        Get-HullFile $urls.Asset $asset
+        Get-HullFile $urls.Manifest $man
+        if (-not (Test-Path -LiteralPath $asset) -or (Get-Item $asset).Length -eq 0) {
+            throw "download produced an empty file; release may not exist at $tag"
+        }
+
+        # 1. checksum against the exact manifest entry for hull-cosmo.
+        $expected = Get-HullManifestHash $man $script:HullAsset
+        $actual = Test-HullChecksum $asset $expected
+        Write-HullInfo "checksum verified ($actual)"
+
+        # 2. upgrade signature (strict). A verifier-capable existing hull makes the
+        #    signature MANDATORY: a download failure, missing, unparseable, or
+        #    invalid signature all abort. No existing hull, or one lacking
+        #    verify-release, proceeds under bootstrap trust.
+        if (Test-Path -LiteralPath $dest) {
+            if (Test-HullVerifierCapable $dest) {
+                Get-HullFile $urls.Sig $sig            # a download failure THROWS -> abort
+                Assert-HullSignature $dest $man $sig   # missing / invalid THROWS -> abort
+                Write-HullInfo "existing hull verified the release signature"
+            } else {
+                Write-HullWarn "existing hull lacks 'verify-release'; proceeding under bootstrap trust (GitHub HTTPS + matched SHA-256)"
             }
-        }
-
-        if (-not $DryRun) {
-            $expected = Get-HullManifestHash $man $script:HullAsset
-            $actual = Test-HullChecksum $asset $expected
-            Write-HullInfo "checksum verified ($actual)"
-        }
-
-        # Upgrade signature check via a pre-existing trusted hull (3 outcomes).
-        if (-not $DryRun -and (Test-Path -LiteralPath $dest)) {
-            try { Get-HullFile $urls.Sig $sig } catch { }
-            $verdict = Test-HullUpgradeSignature $dest $man $sig  # throws on present+fail
-            if ($verdict -eq 'verified') { Write-HullInfo "existing hull verified the release signature" }
-            else { Write-HullWarn "existing hull cannot verify signatures; proceeding under bootstrap trust (GitHub HTTPS + matched SHA-256)" }
-        } elseif (-not $DryRun) {
+        } else {
             Write-HullWarn "first install: bootstrap trust (GitHub HTTPS + matched SHA-256). Verify further with 'hull verify-release' and Sigstore/Rekor."
         }
 
-        if ($DryRun) { Write-HullInfo "[dry-run] would install to $dest"; }
-        else {
-            Install-HullAtomicMove $asset $dest
-            Write-HullInfo "installed hull: $dest"
+        # 3. candidate-version check (after checksum, before replacement): the
+        #    verified artifact must report the requested version, else abort
+        #    WITHOUT touching the existing installation.
+        $candVer = Get-HullArtifactVersion $asset
+        if ($candVer -ne $wantVer) {
+            throw "downloaded artifact reports version '$candVer', expected '$wantVer'; aborting without changing the existing installation"
         }
+        Write-HullInfo "artifact version check: $candVer"
 
-        if (-not $NoPath) { [void](Add-HullToUserPath $prefixDir $DryRun) }
+        # 4. install atomically with rollback.
+        Install-HullAtomicMove $asset $dest
+        Write-HullInfo "installed hull: $dest"
 
-        if (-not $DryRun) {
-            Write-Host ""
-            Write-HullInfo "next steps:"
-            Write-Host "  hull doctor         . check the environment"
-            Write-Host "  hull verify-release . verify a release manifest signature"
-            Write-Host "  hull update         . install future releases"
-            Write-Host ""
-            Write-Host "Windows note: a v0.13.0 hull cannot self-update to v0.14.0 (the fix ships"
-            Write-Host "in v0.14.0). If you are upgrading from v0.13.0, this manual install is the"
-            Write-Host "one-time replacement; 'hull update' works normally from v0.14.0 onward."
-        }
+        # 5. PATH + ownership marker.
+        $added = $false
+        if (-not $NoPath) { $added = Add-HullToUserPath $prefixDir $false }
+        Set-HullOwnershipMarker $prefixDir $wantVer $added
+
+        Write-Host ""
+        Write-HullInfo "next steps:"
+        Write-Host "  hull doctor         . check the environment"
+        Write-Host "  hull verify-release . verify a release manifest signature"
+        Write-Host "  hull update         . install future releases"
+        Write-Host ""
+        Write-Host "Windows note: a v0.13.0 hull cannot self-update to v0.14.0 (the fix ships"
+        Write-Host "in v0.14.0). If you are upgrading from v0.13.0, this manual install is the"
+        Write-Host "one-time replacement; 'hull update' works normally from v0.14.0 onward."
     } finally {
         Remove-Item -LiteralPath $tmp -Recurse -Force -ErrorAction SilentlyContinue
     }
@@ -368,24 +477,38 @@ function Invoke-HullInstall {
 
 function Invoke-HullUninstall {
     param([string]$Prefix, [bool]$DryRun)
+    $ErrorActionPreference = 'Stop'
 
     $prefixDir = Resolve-HullPrefix $Prefix
     $dest = Join-Path $prefixDir $script:HullBinName
+    $marker = Get-HullMarkerPath $prefixDir
+    $rec = Read-HullMarker $prefixDir
+
+    # Ownership gate: only remove what THIS installer recorded installing. This
+    # prevents `-Uninstall -Prefix <arbitrary>` from deleting an unrelated hull.com
+    # and prevents removing a PATH entry the user owned.
+    if (-not $rec) {
+        Write-HullInfo "no installer ownership record at $prefixDir; refusing to remove anything not installed by install.ps1"
+        return
+    }
 
     if (Test-Path -LiteralPath $dest) {
         if ($DryRun) { Write-HullInfo "[dry-run] would remove $dest" }
         else { Remove-Item -LiteralPath $dest -Force; Write-HullInfo "removed $dest" }
     } else {
-        Write-HullInfo "no hull found at $dest (nothing to remove)"
+        Write-HullInfo "no hull found at $dest"
     }
 
-    # Remove the install directory only when empty.
-    if ((Test-Path -LiteralPath $prefixDir) -and -not $DryRun) {
-        $remaining = @(Get-ChildItem -LiteralPath $prefixDir -Force -ErrorAction SilentlyContinue)
-        if ($remaining.Count -eq 0) { Remove-Item -LiteralPath $prefixDir -Force -ErrorAction SilentlyContinue; Write-HullInfo "removed empty $prefixDir" }
-    }
+    if ($rec.pathAdded) { [void](Remove-HullFromUserPath $prefixDir $DryRun) }
+    else { Write-HullInfo "user PATH not modified (installer did not add $prefixDir)" }
 
-    [void](Remove-HullFromUserPath $prefixDir $DryRun)
+    if (-not $DryRun) {
+        Remove-Item -LiteralPath $marker -Force -ErrorAction SilentlyContinue
+        if (Test-Path -LiteralPath $prefixDir) {
+            $remaining = @(Get-ChildItem -LiteralPath $prefixDir -Force -ErrorAction SilentlyContinue)
+            if ($remaining.Count -eq 0) { Remove-Item -LiteralPath $prefixDir -Force -ErrorAction SilentlyContinue; Write-HullInfo "removed empty $prefixDir" }
+        }
+    }
 
     Write-Host ""
     Write-HullInfo "Hull state under ~/.hull (tools, caches, app data) was retained."

--- a/install.ps1
+++ b/install.ps1
@@ -483,10 +483,11 @@ function Invoke-HullCommitInstall([string]$Src, [string]$Dest, [string]$PrefixDi
     }
 }
 
-function Invoke-HullReaffirm([string]$PrefixDir, [string]$Ver, [bool]$NoPath, [switch]$FailMarker) {
+function Invoke-HullReaffirm([string]$PrefixDir, [string]$Ver, [bool]$NoPath, [switch]$FailMarker, [switch]$SimulateRestoreFailure) {
     # Re-affirm a managed same-version install: ensure PATH + refresh the marker
-    # as ONE transaction. If the marker refresh fails, undo the PATH add and
-    # restore the prior marker so a partial PATH mutation never survives.
+    # as ONE transaction. If the marker refresh fails, restore PATH + marker to
+    # their exact prior state. Rollback attempts are INDEPENDENT and failures are
+    # collected into a combined CRITICAL (fail loudly - never a silent discard).
     $markerPath = Get-HullMarkerPath $PrefixDir
     $prevMarkerBytes = $null
     if (Test-Path -LiteralPath $markerPath) { $prevMarkerBytes = [System.IO.File]::ReadAllBytes($markerPath) }
@@ -498,8 +499,18 @@ function Invoke-HullReaffirm([string]$PrefixDir, [string]$Ver, [bool]$NoPath, [s
         Set-HullOwnershipMarker $PrefixDir $Ver $addedEntry
     } catch {
         $err = $_
-        try { Restore-HullUserPathExact $pathSnap } catch { }
-        try { Restore-HullMarkerExact $PrefixDir $prevMarkerBytes } catch { }
+        $rollbackErrors = @()
+        try {
+            if ($SimulateRestoreFailure) { throw "simulated PATH restore failure (test)" }
+            Restore-HullUserPathExact $pathSnap
+        } catch { $rollbackErrors += "PATH: $($_.Exception.Message)" }
+        try {
+            if ($SimulateRestoreFailure) { throw "simulated marker restore failure (test)" }
+            Restore-HullMarkerExact $PrefixDir $prevMarkerBytes
+        } catch { $rollbackErrors += "marker: $($_.Exception.Message)" }
+        if ($rollbackErrors.Count -gt 0) {
+            throw ("CRITICAL: re-affirmation failed and rollback was incomplete (" + ($rollbackErrors -join '; ') + "); original error: $($err.Exception.Message)")
+        }
         throw $err
     }
 }

--- a/install.ps1
+++ b/install.ps1
@@ -16,9 +16,7 @@
     authenticate itself. On an upgrade, if a pre-existing Hull can verify the
     release signature, its check runs before replacement and a FAILURE or an
     ambiguous/timed-out probe aborts the install (never a silent downgrade to
-    checksum-only). A first install proceeds under bootstrap trust (GitHub HTTPS
-    + a matched SHA-256); verify further out-of-band with 'hull verify-release'
-    and Sigstore/Rekor.
+    checksum-only). A first install proceeds under bootstrap trust.
 
 .EXAMPLE
     irm https://gethull.dev/install.ps1 | iex
@@ -35,7 +33,6 @@ param(
     [Parameter(ParameterSetName = 'Install')]
     [string]$Version = 'latest',
 
-    # -Prefix and -DryRun compose with both install and uninstall.
     [string]$Prefix,
 
     [Parameter(ParameterSetName = 'Install')]
@@ -50,29 +47,25 @@ param(
     [switch]$Uninstall
 )
 
-# The upstream repository is FIXED. The public installer exposes no override.
-$script:HullRepo    = 'artalis-io/hull'
-$script:HullAsset   = 'hull-cosmo'
-$script:HullBinName = 'hull.com'
+$script:HullRepo       = 'artalis-io/hull'
+$script:HullAsset      = 'hull-cosmo'
+$script:HullBinName    = 'hull.com'
 $script:HullMarkerName = '.hull-install.json'
 $script:HullMarkerSchema = 1
 $script:VersionTagPattern = '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'
 
-# ── Output helpers (never log secrets, proxy creds, or temp URLs) ─────────────
 function Write-HullInfo([string]$m) { Write-Host "hull: $m" }
 function Write-HullWarn([string]$m) { Write-Host "hull: warning: $m" -ForegroundColor Yellow }
 function Write-HullErr ([string]$m) { Write-Host "hull: error: $m" -ForegroundColor Red }
 
 function Set-HullTls {
-    # Windows PowerShell 5.1 defaults to TLS 1.0/1.1; add >= 1.2 without dropping
-    # PowerShell 7's negotiated set.
     try {
         [Net.ServicePointManager]::SecurityProtocol =
             [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
     } catch { }
 }
 
-# ── Bounded native execution (works on both PS 5.1 and 7; no hangs) ──────────
+# ── Bounded native execution (PS 5.1 + 7; no hangs) ──────────────────────────
 function ConvertTo-HullArgString([string[]]$Arguments) {
     $parts = @()
     foreach ($a in $Arguments) {
@@ -82,9 +75,6 @@ function ConvertTo-HullArgString([string[]]$Arguments) {
 }
 
 function Invoke-HullBounded([string]$Exe, [string[]]$Arguments, [int]$TimeoutSec = 20) {
-    # Returns @{ Code; Out; TimedOut }. Uses System.Diagnostics.Process (so it
-    # works under Windows PowerShell 5.1, whose Start-Process/ArgumentList mangles
-    # spaces) with a hard timeout and async pipe reads (no deadlock, no hang).
     $psi = New-Object System.Diagnostics.ProcessStartInfo
     $psi.FileName = $Exe
     $psi.Arguments = ConvertTo-HullArgString $Arguments
@@ -111,12 +101,9 @@ function Test-HullVersionTag([string]$Tag) { return ($Tag -match $script:Version
 
 function Resolve-HullTag([string]$Requested) {
     if ($Requested -and $Requested -ne 'latest') {
-        if (-not (Test-HullVersionTag $Requested)) {
-            throw "invalid -Version '$Requested' (expected a release tag like v0.14.0)"
-        }
+        if (-not (Test-HullVersionTag $Requested)) { throw "invalid -Version '$Requested' (expected a release tag like v0.14.0)" }
         return $Requested
     }
-    # /releases/latest already excludes drafts and prereleases.
     $api = "https://api.github.com/repos/$($script:HullRepo)/releases/latest"
     $resp = Invoke-RestMethod -Uri $api -Headers @{ 'Accept' = 'application/vnd.github+json'; 'User-Agent' = 'hull-install.ps1' } -UseBasicParsing
     if ($resp.draft -eq $true -or $resp.prerelease -eq $true) { throw "latest resolved to a draft/prerelease ($($resp.tag_name)); refusing" }
@@ -143,12 +130,16 @@ function Get-HullFileSha256([string]$Path) {
     } finally { $fs.Dispose() }
 }
 
+function Test-HullFileMatches([string]$Path, [string]$Hash, [long]$Size) {
+    if (-not (Test-Path -LiteralPath $Path)) { return $false }
+    if ((Get-Item -LiteralPath $Path).Length -ne $Size) { return $false }
+    return ((Get-HullFileSha256 $Path) -eq $Hash)
+}
+
 function Get-HullManifestHash([string]$ManifestPath, [string]$AssetName) {
     $matched = @()
     foreach ($ln in (Get-Content -LiteralPath $ManifestPath)) {
-        if ($ln -match '^([0-9a-fA-F]{64})\s\s(.+)$') {
-            if ($Matches[2] -ceq $AssetName) { $matched += $Matches[1].ToLower() }
-        }
+        if ($ln -match '^([0-9a-fA-F]{64})\s\s(.+)$') { if ($Matches[2] -ceq $AssetName) { $matched += $Matches[1].ToLower() } }
     }
     if ($matched.Count -eq 0) { throw "no checksum entry for '$AssetName' in hull.sha256" }
     if ($matched.Count -gt 1) { throw "duplicate checksum entries for '$AssetName' in hull.sha256" }
@@ -162,18 +153,11 @@ function Test-HullChecksum([string]$Path, [string]$Expected) {
 }
 
 # ── Verifier detection (tri-state, bounded) + signature assertion ────────────
-# States: 'none' (no existing hull), 'capable' (can verify signatures),
-# 'absent' (a real hull that genuinely lacks verify-release), 'ambiguous'
-# (exists but the probe failed / timed out / was unrecognizable). Only 'none'
-# and 'absent' permit bootstrap trust; 'ambiguous' MUST abort - it is never
-# treated as "verifier absent".
 function Get-HullVerifierState([string]$ExistingHull, [int]$TimeoutSec = 20) {
     if (-not $ExistingHull -or -not (Test-Path -LiteralPath $ExistingHull)) { return 'none' }
     $a = Invoke-HullBounded $ExistingHull @('verify-release', '--help') $TimeoutSec
     if ($a.TimedOut) { return 'ambiguous' }
     if ($a.Code -eq 0 -and $a.Out -match 'verify-release') { return 'capable' }
-    # Not obviously capable: consult the top-level command inventory to tell a
-    # genuine "command absent" apart from an ambiguous/failed probe.
     $b = Invoke-HullBounded $ExistingHull @('help') $TimeoutSec
     if ($b.TimedOut) { return 'ambiguous' }
     if ($b.Code -eq 0) {
@@ -184,12 +168,8 @@ function Get-HullVerifierState([string]$ExistingHull, [int]$TimeoutSec = 20) {
 }
 
 function Assert-HullSignature([string]$ExistingHull, [string]$ManifestPath, [string]$SigPath) {
-    # Precondition: the caller established $ExistingHull is 'capable'. Any failure
-    # here throws (abort); there is no bootstrap fallback.
     $sigItem = Get-Item -LiteralPath $SigPath -ErrorAction SilentlyContinue
-    if (-not $sigItem -or $sigItem.Length -eq 0) {
-        throw "release signature (hull.sha256.sig) is missing or empty; aborting (the existing hull can verify signatures, so a signature is required)"
-    }
+    if (-not $sigItem -or $sigItem.Length -eq 0) { throw "release signature (hull.sha256.sig) is missing or empty; aborting" }
     $r = Invoke-HullBounded $ExistingHull @('verify-release', $ManifestPath, $SigPath) 30
     if ($r.TimedOut) { throw "release signature verification timed out; aborting" }
     if ($r.Code -ne 0) { throw "release signature did not verify; aborting (output: $($r.Out.Trim()))" }
@@ -202,7 +182,7 @@ function Get-HullArtifactVersion([string]$ExePath, [int]$TimeoutSec = 20) {
     return $null
 }
 
-# ── User PATH (HKCU only; idempotent; type-preserving; exact-entry ownership) ─
+# ── User PATH (HKCU only; type-preserving; normalized dedup, exact removal) ───
 function Get-HullUserPathRaw {
     $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $false)
     if ($null -eq $key) { return @{ Value = ''; Kind = [Microsoft.Win32.RegistryValueKind]::ExpandString } }
@@ -215,9 +195,6 @@ function Get-HullUserPathRaw {
 }
 
 function ConvertTo-HullPathKey([string]$Component) {
-    # Comparison key only (the raw component is preserved on write): strip quotes
-    # + whitespace, expand %VAR%, unify separators, drop trailing separators,
-    # lowercase.
     $c = $Component.Trim().Trim('"')
     $c = [System.Environment]::ExpandEnvironmentVariables($c)
     $c = $c -replace '/', '\'
@@ -240,6 +217,15 @@ function Set-HullUserPathRaw([string]$Value, $Kind) {
     try { $key.SetValue('Path', $Value, $Kind) } finally { $key.Close() }
 }
 
+function Restore-HullUserPathExact($Snap) {
+    # Restore the EXACT raw value + registry kind, and prove it took.
+    Set-HullUserPathRaw $Snap.Value $Snap.Kind
+    $now = Get-HullUserPathRaw
+    if (($now.Value -cne $Snap.Value) -or ($now.Kind -ne $Snap.Kind)) {
+        throw "CRITICAL: could not restore the user PATH to its prior value/kind during rollback"
+    }
+}
+
 function Send-HullEnvBroadcast {
     if (-not ('HullNative.Win32' -as [type])) {
         Add-Type -Namespace HullNative -Name Win32 -MemberDefinition @'
@@ -254,8 +240,8 @@ public static extern System.IntPtr SendMessageTimeout(System.IntPtr hWnd, uint M
 }
 
 function Add-HullToUserPath([string]$Dir, [bool]$DryRun) {
-    # Returns the exact raw component it added (for ownership recording), or $null
-    # if nothing was added.
+    # Normalized dedup PREVENTS adding an equivalent duplicate. Returns the exact
+    # raw component added (recorded for ownership), or $null if nothing added.
     $cur = Get-HullUserPathRaw
     if (Test-HullPathContains $cur.Value $Dir) { Write-HullInfo "PATH already contains $Dir"; return $null }
     if ($DryRun) { Write-HullInfo "[dry-run] would add $Dir to user PATH"; return $null }
@@ -266,17 +252,17 @@ function Add-HullToUserPath([string]$Dir, [bool]$DryRun) {
     return $Dir
 }
 
-function Remove-HullPathEntry([string]$RawEntry, [bool]$DryRun) {
-    # Remove exactly ONE occurrence matching the recorded entry's normalized key;
-    # preserve all other entries (including any equivalent the user added).
+function Remove-HullPathEntryExact([string]$RawEntry, [bool]$DryRun) {
+    # Ownership at removal is proven by EXACT raw equality (ordinal), so a
+    # differently-spelled equivalent that the user added is never deleted. Removes
+    # at most one occurrence.
     if ([string]::IsNullOrEmpty($RawEntry)) { return $false }
     $cur = Get-HullUserPathRaw
-    $wantKey = ConvertTo-HullPathKey $RawEntry
     $kept = New-Object System.Collections.Generic.List[string]
     $removed = $false
     foreach ($c in ($cur.Value -split ';')) {
         if ($c -eq '') { continue }
-        if (-not $removed -and (ConvertTo-HullPathKey $c) -eq $wantKey) { $removed = $true; continue }
+        if (-not $removed -and [string]::Equals($c, $RawEntry, [System.StringComparison]::Ordinal)) { $removed = $true; continue }
         $kept.Add($c)
     }
     if (-not $removed) { return $false }
@@ -295,19 +281,24 @@ function Resolve-HullPrefix([string]$Requested) {
     return (Join-Path $localApp 'Programs\Hull')
 }
 
-# ── Installer ownership marker (validated schema + recorded prefix + entry) ───
+# ── Ownership marker (validated schema + prefix + recorded raw PATH entry) ────
 function Get-HullMarkerPath([string]$PrefixDir) { return (Join-Path $PrefixDir $script:HullMarkerName) }
 
+function Write-HullMarkerAtomic([string]$PrefixDir, [byte[]]$Bytes) {
+    # Unique temp in the same directory, then an atomic replace/rename.
+    New-Item -ItemType Directory -Path $PrefixDir -Force | Out-Null
+    $final = Get-HullMarkerPath $PrefixDir
+    $tmp = Join-Path $PrefixDir (".hull-marker-" + [guid]::NewGuid().ToString('N'))
+    [System.IO.File]::WriteAllBytes($tmp, $Bytes)
+    try {
+        if (Test-Path -LiteralPath $final) { [System.IO.File]::Replace($tmp, $final, $null) }
+        else { [System.IO.File]::Move($tmp, $final) }
+    } catch { Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue; throw }
+}
+
 function Write-HullMarker([string]$PrefixDir, [string]$Ver, [bool]$PathAdded, [string]$PathEntry) {
-    $rec = [ordered]@{
-        installer = 'install.ps1'
-        schema    = $script:HullMarkerSchema
-        prefix    = $PrefixDir
-        version   = $Ver
-        pathAdded = $PathAdded
-        pathEntry = $PathEntry
-    }
-    Set-Content -LiteralPath (Get-HullMarkerPath $PrefixDir) -Value ($rec | ConvertTo-Json) -Encoding ASCII
+    $rec = [ordered]@{ installer = 'install.ps1'; schema = $script:HullMarkerSchema; prefix = $PrefixDir; version = $Ver; pathAdded = $PathAdded; pathEntry = $PathEntry }
+    Write-HullMarkerAtomic $PrefixDir ([System.Text.Encoding]::ASCII.GetBytes(($rec | ConvertTo-Json)))
 }
 
 function Read-HullMarker([string]$PrefixDir) {
@@ -316,39 +307,63 @@ function Read-HullMarker([string]$PrefixDir) {
     try { return (Get-Content -LiteralPath $m -Raw | ConvertFrom-Json) } catch { return $null }
 }
 
+function Restore-HullMarkerExact([string]$PrefixDir, [byte[]]$PrevBytes) {
+    $final = Get-HullMarkerPath $PrefixDir
+    if ($null -eq $PrevBytes) {
+        if (Test-Path -LiteralPath $final) { Remove-Item -LiteralPath $final -Force }
+        if (Test-Path -LiteralPath $final) { throw "CRITICAL: could not remove a stray marker during rollback" }
+    } else {
+        Write-HullMarkerAtomic $PrefixDir $PrevBytes
+    }
+}
+
 function Test-HullMarkerValid($Rec, [string]$PrefixDir) {
-    # A marker is ours only if it parses, carries our identity + schema + required
-    # fields, and its recorded prefix is equivalent to the current prefix.
+    # Ours only if it parses, carries our identity + schema + ALL required fields
+    # with the right types, its recorded prefix is equivalent, and (when
+    # pathAdded) it records a nonempty raw entry. Fail closed on malformed values.
     if ($null -eq $Rec) { return $false }
     $names = @($Rec.PSObject.Properties.Name)
-    foreach ($f in @('installer', 'schema', 'prefix', 'version', 'pathAdded')) {
-        if ($names -notcontains $f) { return $false }
-    }
+    foreach ($f in @('installer', 'schema', 'prefix', 'version', 'pathAdded', 'pathEntry')) { if ($names -notcontains $f) { return $false } }
     if ($Rec.installer -ne 'install.ps1') { return $false }
-    if ([int]$Rec.schema -ne $script:HullMarkerSchema) { return $false }
+    $schemaOk = $false; try { $schemaOk = ([int]$Rec.schema -eq $script:HullMarkerSchema) } catch { $schemaOk = $false }
+    if (-not $schemaOk) { return $false }
+    if ($Rec.pathAdded -isnot [bool]) { return $false }
+    if ([string]::IsNullOrEmpty([string]$Rec.prefix)) { return $false }
+    if (($Rec.pathAdded -eq $true) -and [string]::IsNullOrEmpty([string]$Rec.pathEntry)) { return $false }
     if ((ConvertTo-HullPathKey ([string]$Rec.prefix)) -ne (ConvertTo-HullPathKey $PrefixDir)) { return $false }
     return $true
 }
 
-function Test-HullManagedHere([string]$PrefixDir) {
-    return (Test-HullMarkerValid (Read-HullMarker $PrefixDir) $PrefixDir)
-}
+function Test-HullManagedHere([string]$PrefixDir) { return (Test-HullMarkerValid (Read-HullMarker $PrefixDir) $PrefixDir) }
 
 function Set-HullOwnershipMarker([string]$PrefixDir, [string]$Ver, [string]$AddedEntry) {
-    # pathEntry is sticky: once THIS installer added a PATH entry, keep the exact
-    # recorded entry across re-installs so uninstall still removes what we added.
+    # pathEntry is sticky: keep the exact recorded installer-added entry across
+    # re-installs so uninstall removes exactly what we added.
     $prev = Read-HullMarker $PrefixDir
     $pathEntry = $AddedEntry
     if (-not $pathEntry -and (Test-HullMarkerValid $prev $PrefixDir) -and $prev.pathAdded) { $pathEntry = [string]$prev.pathEntry }
     Write-HullMarker $PrefixDir $Ver ([bool]$pathEntry) $pathEntry
 }
 
-# ── Binary swap as part of a binary+PATH+marker transaction ──────────────────
-function Start-HullBinarySwap([string]$Src, [string]$Dest, [switch]$SimulateFailure, [switch]$SimulateRestoreFailure) {
-    # Stage under a unique name, back up any existing binary under a unique name,
-    # move the new one into place. Returns @{ Backup; HadPrev } and KEEPS the
-    # backup (the transaction commits/undoes it later). If the swap itself fails,
-    # it restores + proves, raising a distinct CRITICAL error on restore failure.
+# ── Binary swap + transaction (binary + PATH + marker, all-or-nothing) ───────
+function Restore-HullPrevBinary([string]$Dest, [string]$Backup, [string]$PrevHash, [long]$PrevSize, [switch]$SimulateRestoreFailure, [switch]$SimulateRemoveFailure) {
+    # Remove whatever occupies $Dest (the new/staged binary). A failure here is
+    # CRITICAL - NEVER SilentlyContinue, and NEVER assume "the file exists" means
+    # "the old binary is restored".
+    if (Test-Path -LiteralPath $Dest) {
+        if ($SimulateRemoveFailure) { throw "CRITICAL: could not remove the new binary during rollback; your previous hull is preserved at $Backup" }
+        try { Remove-Item -LiteralPath $Dest -Force } catch { throw "CRITICAL: could not remove the new binary during rollback ($($_.Exception.Message)); your previous hull is preserved at $Backup" }
+    }
+    if (-not $SimulateRestoreFailure) { try { Move-Item -LiteralPath $Backup -Destination $Dest -Force } catch { } }
+    # PROVE the restored binary is byte-identical to the recorded previous one
+    # BEFORE deleting the backup.
+    if (-not (Test-HullFileMatches $Dest $PrevHash $PrevSize)) {
+        throw "CRITICAL: install failed AND rollback could not restore the previous hull; it is preserved at $Backup"
+    }
+    Remove-Item -LiteralPath $Backup -Force -ErrorAction SilentlyContinue
+}
+
+function Start-HullBinarySwap([string]$Src, [string]$Dest, [switch]$SimulateFailure) {
     $dir = Split-Path -Parent $Dest
     New-Item -ItemType Directory -Path $dir -Force | Out-Null
     $staged = Join-Path $dir (".hull-stage-" + [guid]::NewGuid().ToString('N'))
@@ -356,6 +371,8 @@ function Start-HullBinarySwap([string]$Src, [string]$Dest, [switch]$SimulateFail
     if ((Test-Path -LiteralPath $staged) -or (Test-Path -LiteralPath $backup)) { throw "sidecar path collision under $dir" }
     Copy-Item -LiteralPath $Src -Destination $staged -Force
     $hadPrev = Test-Path -LiteralPath $Dest
+    $prevHash = $null; $prevSize = [long]0
+    if ($hadPrev) { $prevHash = Get-HullFileSha256 $Dest; $prevSize = (Get-Item -LiteralPath $Dest).Length }
     try {
         if ($hadPrev) { Move-Item -LiteralPath $Dest -Destination $backup -Force }
         if ($SimulateFailure) { throw "simulated install failure (test)" }
@@ -363,18 +380,10 @@ function Start-HullBinarySwap([string]$Src, [string]$Dest, [switch]$SimulateFail
     } catch {
         $err = $_
         Remove-Item -LiteralPath $staged -Force -ErrorAction SilentlyContinue
-        if ($hadPrev) {
-            if (-not $SimulateRestoreFailure -and -not (Test-Path -LiteralPath $Dest)) {
-                Move-Item -LiteralPath $backup -Destination $Dest -Force -ErrorAction SilentlyContinue
-            }
-            if (-not (Test-Path -LiteralPath $Dest)) {
-                throw "CRITICAL: install failed AND rollback failed; your previous hull is preserved at $backup"
-            }
-            Remove-Item -LiteralPath $backup -Force -ErrorAction SilentlyContinue
-        }
+        if ($hadPrev) { Restore-HullPrevBinary $Dest $backup $prevHash $prevSize }
         throw $err
     }
-    return @{ Backup = $(if ($hadPrev) { $backup } else { $null }); HadPrev = $hadPrev }
+    return @{ Backup = $(if ($hadPrev) { $backup } else { $null }); HadPrev = $hadPrev; PrevHash = $prevHash; PrevSize = $prevSize; Dest = $Dest }
 }
 
 function Complete-HullBinarySwap($Swap) {
@@ -383,28 +392,29 @@ function Complete-HullBinarySwap($Swap) {
     }
 }
 
-function Undo-HullBinarySwap($Swap, [string]$Dest, [switch]$SimulateRestoreFailure) {
-    # Restore the prior binary after a LATER-phase (PATH/marker) failure.
-    if (-not $Swap.HadPrev) { Remove-Item -LiteralPath $Dest -Force -ErrorAction SilentlyContinue; return }
-    if (-not $Swap.Backup -or -not (Test-Path -LiteralPath $Swap.Backup)) {
-        throw "CRITICAL: cannot restore the previous hull (backup missing); the new binary is at $Dest"
+function Undo-HullBinarySwap($Swap, [switch]$SimulateRestoreFailure, [switch]$SimulateRemoveFailure) {
+    if (-not $Swap.HadPrev) {
+        if (Test-Path -LiteralPath $Swap.Dest) {
+            try { Remove-Item -LiteralPath $Swap.Dest -Force } catch { throw "CRITICAL: could not remove the newly-installed hull during rollback: $($Swap.Dest)" }
+        }
+        return
     }
-    Remove-Item -LiteralPath $Dest -Force -ErrorAction SilentlyContinue
-    if (-not $SimulateRestoreFailure) { Move-Item -LiteralPath $Swap.Backup -Destination $Dest -Force -ErrorAction SilentlyContinue }
-    if (-not (Test-Path -LiteralPath $Dest)) {
-        throw "CRITICAL: install failed AND rollback failed; your previous hull is preserved at $($Swap.Backup)"
-    }
-    Remove-Item -LiteralPath $Swap.Backup -Force -ErrorAction SilentlyContinue
+    Restore-HullPrevBinary $Swap.Dest $Swap.Backup $Swap.PrevHash $Swap.PrevSize -SimulateRestoreFailure:$SimulateRestoreFailure -SimulateRemoveFailure:$SimulateRemoveFailure
 }
 
 function Invoke-HullCommitInstall([string]$Src, [string]$Dest, [string]$PrefixDir, [string]$Ver, [bool]$NoPath,
-    [switch]$SimulateSwapFailure, [switch]$SimulateUndoFailure, [switch]$FailPath, [switch]$FailMarker) {
-    # ONE transaction: swap the binary, add PATH, write the marker. If ANY step
-    # fails, undo the PATH we added, remove any partial marker, and restore the
-    # previous binary (all-or-nothing).
+    [switch]$SimulateSwapFailure, [switch]$SimulateUndoFailure, [switch]$SimulateUndoRemoveFailure, [switch]$FailPath, [switch]$FailMarker) {
+
+    # Snapshot the EXACT prior marker bytes (or absence) and raw PATH value+kind
+    # BEFORE any mutation, so a later-phase failure restores them exactly.
+    $markerPath = Get-HullMarkerPath $PrefixDir
+    $prevMarkerBytes = $null
+    if (Test-Path -LiteralPath $markerPath) { $prevMarkerBytes = [System.IO.File]::ReadAllBytes($markerPath) }
+    $pathSnap = Get-HullUserPathRaw
+
     $swap = Start-HullBinarySwap $Src $Dest -SimulateFailure:$SimulateSwapFailure
-    $addedEntry = $null
     try {
+        $addedEntry = $null
         if (-not $NoPath) {
             if ($FailPath) { throw "simulated PATH failure (test)" }
             $addedEntry = Add-HullToUserPath $PrefixDir $false
@@ -414,9 +424,9 @@ function Invoke-HullCommitInstall([string]$Src, [string]$Dest, [string]$PrefixDi
         Complete-HullBinarySwap $swap
     } catch {
         $err = $_
-        if ($addedEntry) { [void](Remove-HullPathEntry $addedEntry $false) }
-        Remove-Item -LiteralPath (Get-HullMarkerPath $PrefixDir) -Force -ErrorAction SilentlyContinue
-        Undo-HullBinarySwap $swap $Dest -SimulateRestoreFailure:$SimulateUndoFailure
+        Restore-HullUserPathExact $pathSnap
+        Restore-HullMarkerExact $PrefixDir $prevMarkerBytes
+        Undo-HullBinarySwap $swap -SimulateRestoreFailure:$SimulateUndoFailure -SimulateRemoveFailure:$SimulateUndoRemoveFailure
         throw $err
     }
 }
@@ -427,7 +437,7 @@ function Invoke-HullInstall {
     $ErrorActionPreference = 'Stop'
 
     Set-HullTls
-    $tag = Resolve-HullTag $Version           # metadata resolution is allowed in dry-run
+    $tag = Resolve-HullTag $Version
     $urls = Get-HullAssetUrls $tag
     $prefixDir = Resolve-HullPrefix $Prefix
     $dest = Join-Path $prefixDir $script:HullBinName
@@ -437,7 +447,6 @@ function Invoke-HullInstall {
     Write-HullInfo "version: $tag"
     Write-HullInfo "prefix:  $prefixDir"
 
-    # DRY-RUN: resolve metadata + print the plan; touch NO disk.
     if ($DryRun) {
         Write-HullWarn "dry-run: no files, downloads, or PATH changes will be made"
         Write-HullInfo "[dry-run] would download $($script:HullAsset) for $tag and verify its SHA-256"
@@ -446,7 +455,6 @@ function Invoke-HullInstall {
         return
     }
 
-    # Same-version / overwrite rule (do not ADOPT an unmanaged same-version binary).
     $installedVer = Get-HullArtifactVersion $dest
     if ((Test-Path -LiteralPath $dest) -and -not $Force) {
         if ($installedVer -eq $wantVer) {
@@ -466,7 +474,6 @@ function Invoke-HullInstall {
     $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("hull-install-" + [guid]::NewGuid())
     New-Item -ItemType Directory -Path $tmp -Force | Out-Null
     try {
-        # Stage the download AS hull.com so it is runnable for the candidate check.
         $asset = Join-Path $tmp $script:HullBinName
         $man   = Join-Path $tmp 'hull.sha256'
         $sig   = Join-Path $tmp 'hull.sha256.sig'
@@ -474,22 +481,16 @@ function Invoke-HullInstall {
         Write-HullInfo "downloading $($script:HullAsset)"
         Get-HullFile $urls.Asset $asset
         Get-HullFile $urls.Manifest $man
-        if (-not (Test-Path -LiteralPath $asset) -or (Get-Item $asset).Length -eq 0) {
-            throw "download produced an empty file; release may not exist at $tag"
-        }
+        if (-not (Test-Path -LiteralPath $asset) -or (Get-Item $asset).Length -eq 0) { throw "download produced an empty file; release may not exist at $tag" }
 
-        # 1. checksum against the exact manifest entry for hull-cosmo.
         $actual = Test-HullChecksum $asset (Get-HullManifestHash $man $script:HullAsset)
         Write-HullInfo "checksum verified ($actual)"
 
-        # 2. upgrade signature (tri-state, bounded). 'capable' => signature
-        #    mandatory (download failure / missing / invalid / timeout all abort).
-        #    'absent' => bootstrap. 'ambiguous' => abort (never a silent downgrade).
         if (Test-Path -LiteralPath $dest) {
             switch (Get-HullVerifierState $dest) {
                 'capable' {
-                    Get-HullFile $urls.Sig $sig            # download failure THROWS -> abort
-                    Assert-HullSignature $dest $man $sig   # missing / invalid / timeout THROWS -> abort
+                    Get-HullFile $urls.Sig $sig
+                    Assert-HullSignature $dest $man $sig
                     Write-HullInfo "existing hull verified the release signature"
                 }
                 'absent' { Write-HullWarn "existing hull lacks 'verify-release'; proceeding under bootstrap trust (GitHub HTTPS + matched SHA-256)" }
@@ -499,16 +500,10 @@ function Invoke-HullInstall {
             Write-HullWarn "first install: bootstrap trust (GitHub HTTPS + matched SHA-256). Verify further with 'hull verify-release' and Sigstore/Rekor."
         }
 
-        # 3. candidate-version check (after checksum, before replacement): the
-        #    verified artifact must report the requested version or abort WITHOUT
-        #    touching the existing installation.
         $candVer = Get-HullArtifactVersion $asset
-        if ($candVer -ne $wantVer) {
-            throw "downloaded artifact reports version '$candVer', expected '$wantVer'; aborting without changing the existing installation"
-        }
+        if ($candVer -ne $wantVer) { throw "downloaded artifact reports version '$candVer', expected '$wantVer'; aborting without changing the existing installation" }
         Write-HullInfo "artifact version check: $candVer"
 
-        # 4. transactional commit: binary + PATH + marker (all-or-nothing).
         Invoke-HullCommitInstall $asset $dest $prefixDir $wantVer $NoPath
         Write-HullInfo "installed hull: $dest"
 
@@ -534,9 +529,6 @@ function Invoke-HullUninstall {
     $dest = Join-Path $prefixDir $script:HullBinName
     $rec = Read-HullMarker $prefixDir
 
-    # Ownership gate: act ONLY on a valid marker whose recorded prefix matches.
-    # This prevents `-Uninstall -Prefix <arbitrary>` from deleting an unrelated
-    # hull.com and prevents touching a PATH entry the installer did not add.
     if (-not (Test-HullMarkerValid $rec $prefixDir)) {
         Write-HullInfo "no valid install.ps1 ownership record at $prefixDir; refusing to remove anything not installed by install.ps1"
         return
@@ -545,11 +537,9 @@ function Invoke-HullUninstall {
     if (Test-Path -LiteralPath $dest) {
         if ($DryRun) { Write-HullInfo "[dry-run] would remove $dest" }
         else { Remove-Item -LiteralPath $dest -Force; Write-HullInfo "removed $dest" }
-    } else {
-        Write-HullInfo "no hull found at $dest"
-    }
+    } else { Write-HullInfo "no hull found at $dest" }
 
-    if ($rec.pathAdded -and $rec.pathEntry) { [void](Remove-HullPathEntry ([string]$rec.pathEntry) $DryRun) }
+    if ($rec.pathAdded -and $rec.pathEntry) { [void](Remove-HullPathEntryExact ([string]$rec.pathEntry) $DryRun) }
     else { Write-HullInfo "user PATH not modified (installer did not add an entry)" }
 
     if (-not $DryRun) {
@@ -571,20 +561,14 @@ function Invoke-HullInstallerMain {
     Write-Host "Hull installer (Windows)" -ForegroundColor Cyan
     Write-Host ""
     try {
-        if ($Uninstall) {
-            Invoke-HullUninstall -Prefix $Prefix -DryRun:$DryRun.IsPresent
-        } else {
-            Invoke-HullInstall -Version $Version -Prefix $Prefix -Force:$Force.IsPresent -DryRun:$DryRun.IsPresent -NoPath:$NoPath.IsPresent
-        }
+        if ($Uninstall) { Invoke-HullUninstall -Prefix $Prefix -DryRun:$DryRun.IsPresent }
+        else { Invoke-HullInstall -Version $Version -Prefix $Prefix -Force:$Force.IsPresent -DryRun:$DryRun.IsPresent -NoPath:$NoPath.IsPresent }
     } catch {
         Write-HullErr $_.Exception.Message
         exit 1
     }
 }
 
-# Dot-sourcing (`. .\install.ps1`) defines the functions WITHOUT running main, so
-# the Pester-free tests can exercise them with local fixtures. Normal execution
-# and `irm | iex` run main.
-if ($MyInvocation.InvocationName -ne '.') {
-    Invoke-HullInstallerMain
-}
+# Dot-sourcing defines the functions WITHOUT running main (for the tests). Normal
+# execution and `irm | iex` run main.
+if ($MyInvocation.InvocationName -ne '.') { Invoke-HullInstallerMain }

--- a/tests/acceptance/windows/installer/installer_tests.ps1
+++ b/tests/acceptance/windows/installer/installer_tests.ps1
@@ -309,6 +309,18 @@ try {
         Check (-not (Test-HullPathContains (Get-HullUserPathRaw).Value $rfdir)) "re-affirmation marker failure undid the PATH add"
     } finally { Set-HullUserPathRaw $rfSnap.Value $rfSnap.Kind }
 
+    # re-affirmation rollback failure must fail loudly (combined CRITICAL)
+    $rf2dir = Join-Path $work 'reaffirm2'; New-Item -ItemType Directory -Path $rf2dir -Force | Out-Null
+    WriteBytes (Join-Path $rf2dir 'hull.com') 'RF2'
+    Write-HullMarker $rf2dir '1.0.0' $false ''
+    $rf2Snap = Get-HullUserPathRaw
+    try {
+        $critRf = $null
+        try { Invoke-HullReaffirm $rf2dir '2.0.0' $false -FailMarker -SimulateRestoreFailure } catch { $critRf = $_.Exception.Message }
+        Check ($critRf -match 'CRITICAL') "re-affirmation rollback failure surfaces a combined CRITICAL"
+        Check (($critRf -match 'PATH:') -and ($critRf -match 'marker:')) "the combined CRITICAL identifies the unrestored PATH and marker state"
+    } finally { Set-HullUserPathRaw $rf2Snap.Value $rf2Snap.Kind }
+
     # --- a critical binary rollback still restores PATH + marker ---------------
     Note "## critical binary rollback still restores metadata"
     $cbdir = Join-Path $work 'critbin'; New-Item -ItemType Directory -Path $cbdir -Force | Out-Null

--- a/tests/acceptance/windows/installer/installer_tests.ps1
+++ b/tests/acceptance/windows/installer/installer_tests.ps1
@@ -29,6 +29,12 @@ function Throws([scriptblock]$sb, [string]$m) {
 }
 function WriteBytes([string]$p, [string]$s) { [System.IO.File]::WriteAllBytes($p, [System.Text.Encoding]::ASCII.GetBytes($s)) }
 function ReadTrim([string]$p) { return ((Get-Content -LiteralPath $p -Raw).Trim()) }
+function BytesEqual([byte[]]$a, [byte[]]$b) {
+    if ($null -eq $a -or $null -eq $b) { return $false }
+    if ($a.Length -ne $b.Length) { return $false }
+    for ($i = 0; $i -lt $a.Length; $i++) { if ($a[$i] -ne $b[$i]) { return $false } }
+    return $true
+}
 
 Note ("## installer_tests under PowerShell $($PSVersionTable.PSVersion) (as $(whoami))")
 
@@ -120,22 +126,28 @@ try {
     Check (Test-HullPathContains '%HULL_ITEST_VAR%' 'C:\itest\dir') "matches an expanded %VAR% against its expansion"
     Remove-Item Env:\HULL_ITEST_VAR -ErrorAction SilentlyContinue
 
-    # --- user PATH add + exact one-entry removal (HKCU, snapshot/restore) ------
-    Note "## user PATH add + one-entry removal"
+    # --- user PATH add (normalized dedup) + EXACT-raw removal ownership -------
+    Note "## user PATH add + exact-raw removal"
     $snap = Get-HullUserPathRaw
     try {
         $ptest = Join-Path $work 'pathdir'
         Check ((Add-HullToUserPath $ptest $false) -eq $ptest) "add returns the exact raw entry"
         Check (Test-HullPathContains (Get-HullUserPathRaw).Value $ptest) "dir is present after add"
-        Check ($null -eq (Add-HullToUserPath $ptest $false)) "second add is idempotent (returns null)"
-        # inject a user-owned EQUIVALENT (trailing slash); removal must drop ONLY one
-        $cur = Get-HullUserPathRaw; Set-HullUserPathRaw ($cur.Value.TrimEnd(';') + ';' + $ptest + '\') $cur.Kind
-        $before = @(((Get-HullUserPathRaw).Value -split ';') | Where-Object { (ConvertTo-HullPathKey $_) -eq (ConvertTo-HullPathKey $ptest) }).Count
-        Check ($before -eq 2) "two equivalent entries present before removal"
-        Check (Remove-HullPathEntry $ptest $false) "removes one entry"
-        $after = @(((Get-HullUserPathRaw).Value -split ';') | Where-Object { (ConvertTo-HullPathKey $_) -eq (ConvertTo-HullPathKey $ptest) }).Count
-        Check ($after -eq 1) "exactly one equivalent entry removed, the other preserved"
-        [void](Remove-HullPathEntry ($ptest + '\') $false)
+        Check ($null -eq (Add-HullToUserPath $ptest $false)) "second add is idempotent (normalized dedup returns null)"
+        # The user manually removes the installer's raw entry and later adds an
+        # EQUIVALENT differently-spelled entry (trailing slash). Uninstall's exact
+        # removal must NOT delete the user's replacement.
+        $cur = Get-HullUserPathRaw
+        $withoutOurs = (($cur.Value -split ';') | Where-Object { $_ -ne '' -and -not [string]::Equals($_, $ptest, [System.StringComparison]::Ordinal) })
+        $userSpelling = $ptest + '\'
+        Set-HullUserPathRaw ([string]::Join(';', (@($withoutOurs) + @($userSpelling)))) $cur.Kind
+        Check (-not (Remove-HullPathEntryExact $ptest $false)) "exact removal of the installer entry is a no-op when only a differently-spelled user entry exists"
+        Check (((Get-HullUserPathRaw).Value -split ';') -ccontains $userSpelling) "the user's differently-spelled equivalent is preserved"
+        # Re-add ours alongside the user's, then exact-remove ONLY ours.
+        $cur = Get-HullUserPathRaw; Set-HullUserPathRaw ($cur.Value.TrimEnd(';') + ';' + $ptest) $cur.Kind
+        Check (Remove-HullPathEntryExact $ptest $false) "exact removal removes the installer's own raw entry"
+        $parts = (Get-HullUserPathRaw).Value -split ';'
+        Check (($parts -ccontains $userSpelling) -and (-not ($parts -ccontains $ptest))) "only the installer's raw entry was removed; the user's stayed"
         Check ((Get-HullUserPathRaw).Kind -eq $snap.Kind) "registry value kind preserved"
     } finally { Set-HullUserPathRaw $snap.Value $snap.Kind }
 
@@ -175,6 +187,42 @@ try {
     Check (Test-HullMarkerValid (Read-HullMarker $tdir) $tdir) "successful commit writes a valid marker"
     Check (@(Get-ChildItem -LiteralPath $tdir -Force -ErrorAction SilentlyContinue | Where-Object { $_.Name -like '.hull-stage-*' -or $_.Name -like '.hull-backup-*' }).Count -eq 0) "no staging/backup residue after commit"
 
+    # --- UPGRADE rollback preserves the EXACT prior marker + PATH -------------
+    Note "## upgrade rollback preserves the exact prior marker + PATH"
+    $updir = Join-Path $work 'upgrade'; New-Item -ItemType Directory -Path $updir -Force | Out-Null
+    $updest = Join-Path $updir 'hull.com'; WriteBytes $updest 'OLDBIN'
+    Write-HullMarker $updir '0.13.0' $true $updir     # a valid prior managed marker (pathAdded, pathEntry=$updir)
+    $priorMarkerBytes = [System.IO.File]::ReadAllBytes((Get-HullMarkerPath $updir))
+    $snapU = Get-HullUserPathRaw
+    try {
+        # a nontrivial prior PATH containing the managed entry + odd formatting
+        Set-HullUserPathRaw ($snapU.Value.TrimEnd(';') + ';' + $updir + ';C:\Weird Dir\;%TEMP%') $snapU.Kind
+        $priorPath = Get-HullUserPathRaw
+        $upsrc = Join-Path $work 'upsrc'; WriteBytes $upsrc 'NEWBIN'
+        Throws { Invoke-HullCommitInstall $upsrc $updest $updir '0.14.0' $false -FailMarker } "upgrade marker failure throws"
+        Check ((ReadTrim $updest) -eq 'OLDBIN') "upgrade rollback restores the previous binary"
+        Check (BytesEqual ([System.IO.File]::ReadAllBytes((Get-HullMarkerPath $updir))) $priorMarkerBytes) "upgrade rollback preserves the prior marker BYTE-FOR-BYTE"
+        $nowPath = Get-HullUserPathRaw
+        Check (($nowPath.Value -ceq $priorPath.Value) -and ($nowPath.Kind -eq $priorPath.Kind)) "upgrade rollback restores the exact prior PATH value + kind"
+    } finally { Set-HullUserPathRaw $snapU.Value $snapU.Kind }
+
+    # --- rollback proof: a REAL (locked) removal failure preserves the backup -
+    Note "## rollback proof: real locked-binary removal failure"
+    $ldir = Join-Path $work 'lock'; New-Item -ItemType Directory -Path $ldir -Force | Out-Null
+    $ldest = Join-Path $ldir 'hull.com'; WriteBytes $ldest 'OLDLOCK'
+    $lsrc = Join-Path $work 'locksrc'; WriteBytes $lsrc 'NEWLOCK'
+    $lswap = Start-HullBinarySwap $lsrc $ldest       # $ldest now = NEWLOCK, backup = OLDLOCK
+    $fsLock = [System.IO.File]::Open($ldest, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::None)
+    try {
+        $critL = $null
+        try { Undo-HullBinarySwap $lswap } catch { $critL = $_.Exception.Message }
+        Check ($critL -match 'CRITICAL') "a locked (undeletable) new binary makes rollback raise CRITICAL"
+        Check (Test-Path -LiteralPath $lswap.Backup) "the backup is preserved when the new binary cannot be removed"
+        Check ((ReadTrim $lswap.Backup) -eq 'OLDLOCK') "the preserved backup still holds the previous binary bytes"
+    } finally { $fsLock.Close(); $fsLock.Dispose() }
+    Remove-Item -LiteralPath $ldest -Force -ErrorAction SilentlyContinue
+    if ($lswap.Backup) { Remove-Item -LiteralPath $lswap.Backup -Force -ErrorAction SilentlyContinue }
+
     # --- verifier detection (tri-state, bounded) ------------------------------
     Note "## verifier detection (tri-state, bounded)"
     # Compile a real fake hull.exe with the Framework C# compiler (Add-Type
@@ -212,18 +260,27 @@ try {
     Remove-Item Env:\HULL_FAKE_MODE -ErrorAction SilentlyContinue
     Remove-Item Env:\HULL_FAKE_VERSION -ErrorAction SilentlyContinue
 
-    # --- marker schema + prefix validation ------------------------------------
-    Note "## marker schema + prefix validation"
+    # --- marker schema + prefix + type validation (fail closed) ---------------
+    Note "## marker schema + prefix + type validation"
     $mdir = Join-Path $work 'marker'; New-Item -ItemType Directory -Path $mdir -Force | Out-Null
+    $mk = Get-HullMarkerPath $mdir
     Write-HullMarker $mdir '1.0.0' $true 'C:\x'
     Check (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir) "a well-formed marker at its prefix is valid"
     Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) (Join-Path $work 'other'))) "marker rejected for a different prefix"
-    Set-Content -LiteralPath (Get-HullMarkerPath $mdir) -Encoding ASCII -Value (@{ installer = 'someone-else'; schema = 1; prefix = $mdir; version = '1'; pathAdded = $false } | ConvertTo-Json)
-    Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir)) "marker with a foreign installer id rejected"
-    Set-Content -LiteralPath (Get-HullMarkerPath $mdir) -Encoding ASCII -Value (@{ installer = 'install.ps1'; prefix = $mdir } | ConvertTo-Json)
-    Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir)) "marker missing required fields rejected"
-    Set-Content -LiteralPath (Get-HullMarkerPath $mdir) -Encoding ASCII -Value (@{ installer = 'install.ps1'; schema = 999; prefix = $mdir; version = '1'; pathAdded = $false } | ConvertTo-Json)
-    Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir)) "marker with an unknown schema rejected"
+    Set-Content -LiteralPath $mk -Encoding ASCII -Value (@{ installer = 'someone-else'; schema = 1; prefix = $mdir; version = '1'; pathAdded = $false; pathEntry = '' } | ConvertTo-Json)
+    Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir)) "foreign installer id rejected"
+    Set-Content -LiteralPath $mk -Encoding ASCII -Value (@{ installer = 'install.ps1'; prefix = $mdir; version = '1'; pathAdded = $false; pathEntry = '' } | ConvertTo-Json)
+    Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir)) "missing required field (schema) rejected"
+    Set-Content -LiteralPath $mk -Encoding ASCII -Value (@{ installer = 'install.ps1'; schema = 1; prefix = $mdir; version = '1'; pathAdded = $false } | ConvertTo-Json)
+    Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir)) "missing pathEntry field rejected"
+    Set-Content -LiteralPath $mk -Encoding ASCII -Value (@{ installer = 'install.ps1'; schema = 999; prefix = $mdir; version = '1'; pathAdded = $false; pathEntry = '' } | ConvertTo-Json)
+    Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir)) "unknown schema rejected"
+    Set-Content -LiteralPath $mk -Encoding ASCII -Value (@{ installer = 'install.ps1'; schema = 'abc'; prefix = $mdir; version = '1'; pathAdded = $false; pathEntry = '' } | ConvertTo-Json)
+    Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir)) "non-numeric schema rejected (fail closed, no conversion error escapes)"
+    Set-Content -LiteralPath $mk -Encoding ASCII -Value (@{ installer = 'install.ps1'; schema = 1; prefix = $mdir; version = '1'; pathAdded = 'yes'; pathEntry = 'x' } | ConvertTo-Json)
+    Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir)) "non-boolean pathAdded rejected"
+    Set-Content -LiteralPath $mk -Encoding ASCII -Value (@{ installer = 'install.ps1'; schema = 1; prefix = $mdir; version = '1'; pathAdded = $true; pathEntry = '' } | ConvertTo-Json)
+    Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir)) "pathAdded=true with an empty pathEntry rejected"
 
     # --- no-adoption + uninstall ownership gate -------------------------------
     Note "## no-adoption + uninstall ownership gate"

--- a/tests/acceptance/windows/installer/installer_tests.ps1
+++ b/tests/acceptance/windows/installer/installer_tests.ps1
@@ -97,6 +97,11 @@ try {
     Check (Test-HullPathContains 'C:\a;C:\b\' 'C:\b') "matches ignoring a trailing separator"
     Check (Test-HullPathContains 'C:\A' 'c:\a') "matches case-insensitively"
     Check (-not (Test-HullPathContains 'C:\a;C:\b' 'C:\c')) "does not match an absent dir"
+    Check (Test-HullPathContains 'C:/a;C:/b' 'C:\b') "matches across / and \ separators"
+    Check (Test-HullPathContains '"C:\a";C:\b' 'C:\a') "matches ignoring surrounding quotes"
+    $env:HULL_ITEST_VAR = 'C:\itest\dir'
+    Check (Test-HullPathContains '%HULL_ITEST_VAR%' 'C:\itest\dir') "matches an expanded %VAR% against its expansion"
+    Remove-Item Env:\HULL_ITEST_VAR -ErrorAction SilentlyContinue
 
     # --- rollback: a failed install leaves the previous binary runnable -------
     Note "## atomic install rollback"
@@ -105,15 +110,77 @@ try {
     $rsrc = Join-Path $work 'newbin'
     [System.IO.File]::WriteAllBytes($rsrc, [System.Text.Encoding]::ASCII.GetBytes('NEWBINARY'))
     [System.IO.File]::WriteAllBytes($rdest, [System.Text.Encoding]::ASCII.GetBytes('PREVIOUS'))
+    # pre-existing sidecars at the OLD predictable names must NOT be clobbered
+    $occNew = "$rdest.new"; $occBak = "$rdest.bak"
+    [System.IO.File]::WriteAllBytes($occNew, [System.Text.Encoding]::ASCII.GetBytes('KEEPNEW'))
+    [System.IO.File]::WriteAllBytes($occBak, [System.Text.Encoding]::ASCII.GetBytes('KEEPBAK'))
+
     Throws { Install-HullAtomicMove $rsrc $rdest -SimulateFailure } "simulated failed install throws"
-    Check (Test-Path -LiteralPath $rdest) "previous binary still present after rollback"
+    Check (Test-Path -LiteralPath $rdest) "previous binary present after rollback"
     Check (((Get-Content -LiteralPath $rdest -Raw).Trim()) -eq 'PREVIOUS') "previous binary content intact (runnable)"
-    Check (-not (Test-Path -LiteralPath "$rdest.new")) "staged .new cleaned up on failure"
-    Check (-not (Test-Path -LiteralPath "$rdest.bak")) "backup .bak consumed by rollback"
-    # success path replaces atomically and leaves no residue
+    Check (((Get-Content -LiteralPath $occNew -Raw).Trim()) -eq 'KEEPNEW') "pre-existing .new sidecar untouched"
+    Check (((Get-Content -LiteralPath $occBak -Raw).Trim()) -eq 'KEEPBAK') "pre-existing .bak sidecar untouched"
+    Check (@(Get-ChildItem -LiteralPath $rdir -Filter '.hull-*' -Force -ErrorAction SilentlyContinue).Count -eq 0) "no unique staging/backup residue after rollback"
+
+    # forced restoration failure -> a distinct CRITICAL error naming the backup,
+    # and the previous binary is preserved in that backup.
+    $critMsg = $null
+    try { Install-HullAtomicMove $rsrc $rdest -SimulateFailure -SimulateRestoreFailure } catch { $critMsg = $_.Exception.Message }
+    Check ($critMsg -match 'CRITICAL') "restore failure raises a distinct CRITICAL error"
+    Check ($critMsg -match '\.hull-backup-') "critical error names the preserved backup path"
+    $bak = @(Get-ChildItem -LiteralPath $rdir -Filter '.hull-backup-*' -Force -ErrorAction SilentlyContinue)
+    Check (($bak.Count -ge 1) -and (((Get-Content -LiteralPath $bak[0].FullName -Raw).Trim()) -eq 'PREVIOUS')) "previous binary preserved in the backup on restore failure"
+    $bak | ForEach-Object { Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue }
+    if (-not (Test-Path -LiteralPath $rdest)) { [System.IO.File]::WriteAllBytes($rdest, [System.Text.Encoding]::ASCII.GetBytes('PREVIOUS')) }
+
+    # success path replaces and leaves no unique residue
     Install-HullAtomicMove $rsrc $rdest
     Check (((Get-Content -LiteralPath $rdest -Raw).Trim()) -eq 'NEWBINARY') "successful install replaces the binary"
-    Check (-not (Test-Path -LiteralPath "$rdest.new") -and -not (Test-Path -LiteralPath "$rdest.bak")) "no staging residue after success"
+    Check (@(Get-ChildItem -LiteralPath $rdir -Filter '.hull-*' -Force -ErrorAction SilentlyContinue).Count -eq 0) "no staging residue after a successful install"
+
+    # --- upgrade signature outcomes (strict, fixtures) ------------------------
+    Note "## upgrade signature outcomes"
+    $fdir = Join-Path $work 'fake'; New-Item -ItemType Directory -Path $fdir -Force | Out-Null
+    $okHull  = Join-Path $fdir 'hull-ok.cmd'
+    $badHull = Join-Path $fdir 'hull-bad.cmd'
+    $oldHull = Join-Path $fdir 'hull-old.cmd'
+    Set-Content -LiteralPath $okHull -Encoding ASCII -Value @(
+        '@echo off',
+        'if "%1"=="verify-release" (',
+        '  if "%2"=="--help" ( echo usage: hull verify-release ^<manifest^> ^<signature^> & exit /b 0 )',
+        '  exit /b 0',
+        ')',
+        'exit /b 1')
+    Set-Content -LiteralPath $badHull -Encoding ASCII -Value @(
+        '@echo off',
+        'if "%1"=="verify-release" (',
+        '  if "%2"=="--help" ( echo usage: hull verify-release ^<manifest^> ^<signature^> & exit /b 0 )',
+        '  exit /b 1',
+        ')',
+        'exit /b 1')
+    Set-Content -LiteralPath $oldHull -Encoding ASCII -Value @('@echo off', 'echo unknown command 1>&2', 'exit /b 1')
+    $sigFile = Join-Path $work 'sig.bin'; [System.IO.File]::WriteAllBytes($sigFile, [System.Text.Encoding]::ASCII.GetBytes('SIG'))
+    $missingSig = Join-Path $work 'nope.sig'
+
+    Check (-not (Test-HullVerifierCapable (Join-Path $work 'does-not-exist.com'))) "absent existing hull -> bootstrap (not verifier-capable)"
+    Check (-not (Test-HullVerifierCapable $oldHull)) "existing hull lacking verify-release -> bootstrap"
+    Check (Test-HullVerifierCapable $okHull) "a verify-release-capable hull is detected"
+    Check (Test-HullVerifierCapable $badHull) "capability is independent of a later verify verdict"
+    $vok = $true; try { Assert-HullSignature $okHull $man $sigFile } catch { $vok = $false }
+    Check $vok "verifier present + valid signature proceeds"
+    Throws { Assert-HullSignature $badHull $man $sigFile } "verifier present + invalid signature aborts"
+    Throws { Assert-HullSignature $okHull $man $missingSig } "verifier present + missing/undownloaded signature aborts"
+
+    # --- uninstall ownership gate (unit) --------------------------------------
+    Note "## uninstall ownership gate"
+    $udir = Join-Path $work 'unmanaged'; New-Item -ItemType Directory -Path $udir -Force | Out-Null
+    $ubin = Join-Path $udir 'hull.com'
+    [System.IO.File]::WriteAllBytes($ubin, [System.Text.Encoding]::ASCII.GetBytes('NOTOURS'))
+    Invoke-HullUninstall -Prefix $udir -DryRun:$false | Out-Null
+    Check (Test-Path -LiteralPath $ubin) "uninstall refuses to remove an unmanaged hull.com (no ownership marker)"
+    Write-HullMarker $udir '0.0.0' $false
+    Invoke-HullUninstall -Prefix $udir -DryRun:$false | Out-Null
+    Check (-not (Test-Path -LiteralPath $ubin)) "uninstall removes a managed hull.com (marker present, pathAdded=false leaves PATH alone)"
 
     # --- user PATH add/remove (idempotent, exact, non-corrupting) -------------
     Note "## user PATH add/remove (HKCU, snapshot/restore)"
@@ -142,10 +209,14 @@ try {
     if ($IncludeNetwork) {
         Note "## network end-to-end (official release, read-only)"
 
-        # dry-run writes nothing
+        # dry-run: resolves metadata but writes nothing (no prefix, no temp dir)
         $dpre = Join-Path $work 'dry\Hull'
+        $tempBefore = @(Get-ChildItem -LiteralPath $env:TEMP -Filter 'hull-install-*' -Directory -Force -ErrorAction SilentlyContinue).Count
         [void](Invoke-Install @('-Version', 'v0.14.0', '-Prefix', $dpre, '-NoPath', '-DryRun') (Join-Path $work 'dry.log'))
-        Check (-not (Test-Path -LiteralPath (Join-Path $dpre 'hull.com'))) "dry-run performed no install"
+        $tempAfter = @(Get-ChildItem -LiteralPath $env:TEMP -Filter 'hull-install-*' -Directory -Force -ErrorAction SilentlyContinue).Count
+        Check (-not (Test-Path -LiteralPath $dpre)) "dry-run did not create the prefix"
+        Check (-not (Test-Path -LiteralPath (Join-Path $dpre 'hull.com'))) "dry-run installed nothing"
+        Check ($tempAfter -le $tempBefore) "dry-run created no hull-install temp dir"
 
         # default (latest) install into a spaces path, no PATH change
         $spre = Join-Path $work 'with space\Hull'
@@ -154,6 +225,8 @@ try {
         Check ($rc -eq 0 -and (Test-Path -LiteralPath $sbin)) "latest install created hull.com in a spaces path"
         $sv = (& $sbin version 2>$null | Select-Object -First 1)
         Check ($sv -match '[0-9]+\.[0-9]+\.[0-9]+') "installed hull runs and reports a version ($sv)"
+        Check ((Get-HullArtifactVersion $sbin 20) -match '[0-9]+\.[0-9]+\.[0-9]+') "bounded artifact version reader parses the real binary"
+        Check (Test-Path -LiteralPath (Join-Path $spre '.hull-install.json')) "install wrote an ownership marker"
 
         # same-version reinstall without -Force is a clean no-op (not an error)
         $rc = Invoke-Install @('-Prefix', $spre, '-NoPath') (Join-Path $work 'inst-again.log')

--- a/tests/acceptance/windows/installer/installer_tests.ps1
+++ b/tests/acceptance/windows/installer/installer_tests.ps1
@@ -264,9 +264,11 @@ try {
     Note "## marker schema + prefix + type validation"
     $mdir = Join-Path $work 'marker'; New-Item -ItemType Directory -Path $mdir -Force | Out-Null
     $mk = Get-HullMarkerPath $mdir
-    Write-HullMarker $mdir '1.0.0' $true 'C:\x'
+    Write-HullMarker $mdir '1.0.0' $true $mdir
     Check (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir) "a well-formed marker at its prefix is valid"
     Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) (Join-Path $work 'other'))) "marker rejected for a different prefix"
+    Set-Content -LiteralPath $mk -Encoding ASCII -Value (@{ installer = 'install.ps1'; schema = 1; prefix = $mdir; version = '1'; pathAdded = $true; pathEntry = 'C:\somewhere\else' } | ConvertTo-Json)
+    Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir)) "pathAdded=true with a pathEntry not bound to the prefix rejected"
     Set-Content -LiteralPath $mk -Encoding ASCII -Value (@{ installer = 'someone-else'; schema = 1; prefix = $mdir; version = '1'; pathAdded = $false; pathEntry = '' } | ConvertTo-Json)
     Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir)) "foreign installer id rejected"
     Set-Content -LiteralPath $mk -Encoding ASCII -Value (@{ installer = 'install.ps1'; prefix = $mdir; version = '1'; pathAdded = $false; pathEntry = '' } | ConvertTo-Json)
@@ -281,6 +283,51 @@ try {
     Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir)) "non-boolean pathAdded rejected"
     Set-Content -LiteralPath $mk -Encoding ASCII -Value (@{ installer = 'install.ps1'; schema = 1; prefix = $mdir; version = '1'; pathAdded = $true; pathEntry = '' } | ConvertTo-Json)
     Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir)) "pathAdded=true with an empty pathEntry rejected"
+
+    # --- atomic marker replace: a blocked replace retains the OLD marker ------
+    Note "## atomic marker replace failure retains the old marker"
+    $amdir = Join-Path $work 'atomicmarker'; New-Item -ItemType Directory -Path $amdir -Force | Out-Null
+    $amdest = Join-Path $amdir 'hull.com'; WriteBytes $amdest 'OLDAM'
+    Write-HullMarker $amdir '0.13.0' $true $amdir
+    $oldAmBytes = [System.IO.File]::ReadAllBytes((Get-HullMarkerPath $amdir))
+    $amsrc = Join-Path $work 'amsrc'; WriteBytes $amsrc 'NEWAM'
+    $fsAm = [System.IO.File]::Open((Get-HullMarkerPath $amdir), [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+    try {
+        Throws { Invoke-HullCommitInstall $amsrc $amdest $amdir '0.14.0' $true } "commit fails when the marker cannot be atomically replaced"
+    } finally { $fsAm.Close(); $fsAm.Dispose() }
+    Check ((ReadTrim $amdest) -eq 'OLDAM') "binary rolled back when marker replacement fails"
+    Check (BytesEqual ([System.IO.File]::ReadAllBytes((Get-HullMarkerPath $amdir))) $oldAmBytes) "the OLD marker is retained (never deleted) when replacement fails"
+
+    # --- same-version re-affirmation is transactional -------------------------
+    Note "## same-version re-affirmation transaction"
+    $rfdir = Join-Path $work 'reaffirm'; New-Item -ItemType Directory -Path $rfdir -Force | Out-Null
+    WriteBytes (Join-Path $rfdir 'hull.com') 'RFBIN'
+    Write-HullMarker $rfdir '1.0.0' $false ''
+    $rfSnap = Get-HullUserPathRaw
+    try {
+        Throws { Invoke-HullReaffirm $rfdir '1.0.0' $false -FailMarker } "re-affirmation marker failure throws"
+        Check (-not (Test-HullPathContains (Get-HullUserPathRaw).Value $rfdir)) "re-affirmation marker failure undid the PATH add"
+    } finally { Set-HullUserPathRaw $rfSnap.Value $rfSnap.Kind }
+
+    # --- a critical binary rollback still restores PATH + marker ---------------
+    Note "## critical binary rollback still restores metadata"
+    $cbdir = Join-Path $work 'critbin'; New-Item -ItemType Directory -Path $cbdir -Force | Out-Null
+    $cbdest = Join-Path $cbdir 'hull.com'; WriteBytes $cbdest 'OLDCB'
+    Write-HullMarker $cbdir '0.13.0' $true $cbdir
+    $cbMarker = [System.IO.File]::ReadAllBytes((Get-HullMarkerPath $cbdir))
+    $cbSnap = Get-HullUserPathRaw
+    try {
+        Set-HullUserPathRaw ($cbSnap.Value.TrimEnd(';') + ';' + $cbdir + ';C:\Odd Path\') $cbSnap.Kind
+        $cbPrior = Get-HullUserPathRaw
+        $cbsrc = Join-Path $work 'cbsrc'; WriteBytes $cbsrc 'NEWCB'
+        $critCB = $null
+        try { Invoke-HullCommitInstall $cbsrc $cbdest $cbdir '0.14.0' $false -FailMarker -SimulateUndoFailure } catch { $critCB = $_.Exception.Message }
+        Check ($critCB -match 'CRITICAL') "a failed binary rollback surfaces a combined CRITICAL"
+        $cbNow = Get-HullUserPathRaw
+        Check (($cbNow.Value -ceq $cbPrior.Value) -and ($cbNow.Kind -eq $cbPrior.Kind)) "PATH restored despite the critical binary rollback"
+        Check (BytesEqual ([System.IO.File]::ReadAllBytes((Get-HullMarkerPath $cbdir))) $cbMarker) "marker restored despite the critical binary rollback"
+        Get-ChildItem -LiteralPath $cbdir -Filter '.hull-backup-*' -Force -ErrorAction SilentlyContinue | ForEach-Object { Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue }
+    } finally { Set-HullUserPathRaw $cbSnap.Value $cbSnap.Kind }
 
     # --- no-adoption + uninstall ownership gate -------------------------------
     Note "## no-adoption + uninstall ownership gate"

--- a/tests/acceptance/windows/installer/installer_tests.ps1
+++ b/tests/acceptance/windows/installer/installer_tests.ps1
@@ -5,8 +5,7 @@
   Dot-sources install.ps1 (which defines its functions without running main) and
   exercises the factored logic with LOCAL fixtures (no network) for the
   fail-closed paths, plus gated network end-to-end installs against the official
-  release when -IncludeNetwork is passed. Read-only w.r.t. GitHub releases:
-  downloads only, never publishes or mutates anything.
+  release when -IncludeNetwork is passed. Read-only w.r.t. GitHub releases.
 
   Usage: installer_tests.ps1 -InstallPs1 <path> [-IncludeNetwork] [-Evidence <file>]
 #>
@@ -28,17 +27,15 @@ function Throws([scriptblock]$sb, [string]$m) {
     try { & $sb } catch { $threw = $true }
     Check $threw $m
 }
+function WriteBytes([string]$p, [string]$s) { [System.IO.File]::WriteAllBytes($p, [System.Text.Encoding]::ASCII.GetBytes($s)) }
+function ReadTrim([string]$p) { return ((Get-Content -LiteralPath $p -Raw).Trim()) }
 
 Note ("## installer_tests under PowerShell $($PSVersionTable.PSVersion) (as $(whoami))")
 
-# Dot-source: defines the Hull* functions; the guard suppresses main because
-# InvocationName is '.'.
 . $InstallPs1
 
-# Run install.ps1 as a CHILD PROCESS of the current PowerShell host, so its
-# `exit` cannot terminate this test script and its exit code is observable. The
-# child inherits this process's environment (redirected HOME/TEMP, and, on the
-# 5.1 leg, the corrected PSModulePath).
+# Run install.ps1 as a CHILD PROCESS of the current host so its `exit` cannot
+# terminate this test and its exit code is observable.
 $script:psExe = (Get-Process -Id $PID).Path
 function Invoke-Install {
     param([string[]]$IArgs, [string]$Log)
@@ -47,41 +44,61 @@ function Invoke-Install {
     return $LASTEXITCODE
 }
 
+# A compiled fake hull.exe (System.Diagnostics.Process runs a real PE, not a
+# .cmd) whose behavior is env-driven: HULL_FAKE_MODE = ok|bad|absent|hang and
+# HULL_FAKE_VERSION.
+$script:FakeSrc = @'
+using System;
+class Program {
+  static int Main(string[] a) {
+    string mode = Environment.GetEnvironmentVariable("HULL_FAKE_MODE"); if (mode == null) mode = "ok";
+    string cmd = a.Length > 0 ? a[0] : "";
+    if (cmd == "version") {
+      string v = Environment.GetEnvironmentVariable("HULL_FAKE_VERSION"); if (v == null) v = "9.9.9";
+      Console.WriteLine("hull " + v); return 0;
+    }
+    if (cmd == "help" || cmd == "--help") {
+      Console.WriteLine("Usage: hull <command>");
+      Console.WriteLine("  version");
+      Console.WriteLine("  build");
+      if (mode != "absent") Console.WriteLine("  verify-release");
+      return 0;
+    }
+    if (cmd == "verify-release") {
+      bool help = a.Length > 1 && a[1] == "--help";
+      if (mode == "absent") { Console.Error.WriteLine("unknown command: verify-release"); return 1; }
+      if (mode == "hang") { System.Threading.Thread.Sleep(60000); return 0; }
+      if (help) { Console.WriteLine("Usage: hull verify-release <manifest> <signature>"); return 0; }
+      if (mode == "bad") return 1;
+      return 0;
+    }
+    return 1;
+  }
+}
+'@
+
 $work = Join-Path $env:TEMP ("hull-itest-" + [guid]::NewGuid())
 New-Item -ItemType Directory -Path $work -Force | Out-Null
 
 try {
     # --- version tag grammar --------------------------------------------------
     Note "## version tag grammar"
-    foreach ($v in @('v0.14.0', 'v1.2.3', 'v0.14.0-rc1', 'v10.0.0-beta.2')) {
-        Check (Test-HullVersionTag $v) "accepts $v"
-    }
-    foreach ($v in @('0.14.0', 'v0.14', 'latest', 'v0.14.0; rm', '../evil', 'v0.14.0/..', 'v0.14.0 x')) {
-        Check (-not (Test-HullVersionTag $v)) "rejects '$v'"
-    }
+    foreach ($v in @('v0.14.0', 'v1.2.3', 'v0.14.0-rc1', 'v10.0.0-beta.2')) { Check (Test-HullVersionTag $v) "accepts $v" }
+    foreach ($v in @('0.14.0', 'v0.14', 'latest', 'v0.14.0; rm', '../evil', 'v0.14.0/..', 'v0.14.0 x')) { Check (-not (Test-HullVersionTag $v)) "rejects '$v'" }
 
     # --- manifest hash selection (fail closed) --------------------------------
     Note "## manifest hash selection"
     $h1 = ('a' * 64); $h2 = ('b' * 64); $h3 = ('c' * 64)
     $man = Join-Path $work 'hull.sha256'
-    # Format is <64 hex><two spaces><name>.
-    Set-Content -LiteralPath $man -Value @(
-        "$h1  hull-cosmo",
-        "$h2  hull-linux-x86_64",
-        "garbage line without a hash",
-        "$h3  hull-cosmocc.tar"
-    )
+    Set-Content -LiteralPath $man -Value @("$h1  hull-cosmo", "$h2  hull-linux-x86_64", "garbage line without a hash", "$h3  hull-cosmocc.tar")
     Check ((Get-HullManifestHash $man 'hull-cosmo') -eq $h1) "selects the exact hull-cosmo entry"
-    Check ((Get-HullManifestHash $man 'hull-linux-x86_64') -eq $h2) "selects a different exact entry"
     Throws { Get-HullManifestHash $man 'hull-darwin-arm64' } "throws on a missing entry"
-    $dup = Join-Path $work 'dup.sha256'
-    Set-Content -LiteralPath $dup -Value @("$h1  hull-cosmo", "$h2  hull-cosmo")
+    $dup = Join-Path $work 'dup.sha256'; Set-Content -LiteralPath $dup -Value @("$h1  hull-cosmo", "$h2  hull-cosmo")
     Throws { Get-HullManifestHash $dup 'hull-cosmo' } "throws on a duplicate entry"
 
-    # --- sha-256 + checksum (fail closed) -------------------------------------
+    # --- sha-256 + checksum ---------------------------------------------------
     Note "## sha-256 + checksum"
-    $blob = Join-Path $work 'blob'
-    [System.IO.File]::WriteAllBytes($blob, [System.Text.Encoding]::ASCII.GetBytes('hello'))
+    $blob = Join-Path $work 'blob'; WriteBytes $blob 'hello'
     $known = '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
     Check ((Get-HullFileSha256 $blob) -eq $known) "sha256('hello') is correct"
     Check ((Test-HullChecksum $blob $known) -eq $known) "checksum match returns the hash"
@@ -103,137 +120,135 @@ try {
     Check (Test-HullPathContains '%HULL_ITEST_VAR%' 'C:\itest\dir') "matches an expanded %VAR% against its expansion"
     Remove-Item Env:\HULL_ITEST_VAR -ErrorAction SilentlyContinue
 
-    # --- rollback: a failed install leaves the previous binary runnable -------
-    Note "## atomic install rollback"
-    $rdir = Join-Path $work 'roll'; New-Item -ItemType Directory -Path $rdir -Force | Out-Null
-    $rdest = Join-Path $rdir 'hull.com'
-    $rsrc = Join-Path $work 'newbin'
-    [System.IO.File]::WriteAllBytes($rsrc, [System.Text.Encoding]::ASCII.GetBytes('NEWBINARY'))
-    [System.IO.File]::WriteAllBytes($rdest, [System.Text.Encoding]::ASCII.GetBytes('PREVIOUS'))
-    # pre-existing sidecars at the OLD predictable names must NOT be clobbered
-    $occNew = "$rdest.new"; $occBak = "$rdest.bak"
-    [System.IO.File]::WriteAllBytes($occNew, [System.Text.Encoding]::ASCII.GetBytes('KEEPNEW'))
-    [System.IO.File]::WriteAllBytes($occBak, [System.Text.Encoding]::ASCII.GetBytes('KEEPBAK'))
-
-    Throws { Install-HullAtomicMove $rsrc $rdest -SimulateFailure } "simulated failed install throws"
-    Check (Test-Path -LiteralPath $rdest) "previous binary present after rollback"
-    Check (((Get-Content -LiteralPath $rdest -Raw).Trim()) -eq 'PREVIOUS') "previous binary content intact (runnable)"
-    Check (((Get-Content -LiteralPath $occNew -Raw).Trim()) -eq 'KEEPNEW') "pre-existing .new sidecar untouched"
-    Check (((Get-Content -LiteralPath $occBak -Raw).Trim()) -eq 'KEEPBAK') "pre-existing .bak sidecar untouched"
-    Check (@(Get-ChildItem -LiteralPath $rdir -Filter '.hull-*' -Force -ErrorAction SilentlyContinue).Count -eq 0) "no unique staging/backup residue after rollback"
-
-    # forced restoration failure -> a distinct CRITICAL error naming the backup,
-    # and the previous binary is preserved in that backup.
-    $critMsg = $null
-    try { Install-HullAtomicMove $rsrc $rdest -SimulateFailure -SimulateRestoreFailure } catch { $critMsg = $_.Exception.Message }
-    Check ($critMsg -match 'CRITICAL') "restore failure raises a distinct CRITICAL error"
-    Check ($critMsg -match '\.hull-backup-') "critical error names the preserved backup path"
-    $bak = @(Get-ChildItem -LiteralPath $rdir -Filter '.hull-backup-*' -Force -ErrorAction SilentlyContinue)
-    Check (($bak.Count -ge 1) -and (((Get-Content -LiteralPath $bak[0].FullName -Raw).Trim()) -eq 'PREVIOUS')) "previous binary preserved in the backup on restore failure"
-    $bak | ForEach-Object { Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue }
-    if (-not (Test-Path -LiteralPath $rdest)) { [System.IO.File]::WriteAllBytes($rdest, [System.Text.Encoding]::ASCII.GetBytes('PREVIOUS')) }
-
-    # success path replaces and leaves no unique residue
-    Install-HullAtomicMove $rsrc $rdest
-    Check (((Get-Content -LiteralPath $rdest -Raw).Trim()) -eq 'NEWBINARY') "successful install replaces the binary"
-    Check (@(Get-ChildItem -LiteralPath $rdir -Filter '.hull-*' -Force -ErrorAction SilentlyContinue).Count -eq 0) "no staging residue after a successful install"
-
-    # --- upgrade signature outcomes (strict, fixtures) ------------------------
-    Note "## upgrade signature outcomes"
-    $fdir = Join-Path $work 'fake'; New-Item -ItemType Directory -Path $fdir -Force | Out-Null
-    $okHull  = Join-Path $fdir 'hull-ok.cmd'
-    $badHull = Join-Path $fdir 'hull-bad.cmd'
-    $oldHull = Join-Path $fdir 'hull-old.cmd'
-    Set-Content -LiteralPath $okHull -Encoding ASCII -Value @(
-        '@echo off',
-        'if "%1"=="verify-release" (',
-        '  if "%2"=="--help" ( echo usage: hull verify-release ^<manifest^> ^<signature^> & exit /b 0 )',
-        '  exit /b 0',
-        ')',
-        'exit /b 1')
-    Set-Content -LiteralPath $badHull -Encoding ASCII -Value @(
-        '@echo off',
-        'if "%1"=="verify-release" (',
-        '  if "%2"=="--help" ( echo usage: hull verify-release ^<manifest^> ^<signature^> & exit /b 0 )',
-        '  exit /b 1',
-        ')',
-        'exit /b 1')
-    Set-Content -LiteralPath $oldHull -Encoding ASCII -Value @('@echo off', 'echo unknown command 1>&2', 'exit /b 1')
-    $sigFile = Join-Path $work 'sig.bin'; [System.IO.File]::WriteAllBytes($sigFile, [System.Text.Encoding]::ASCII.GetBytes('SIG'))
-    $missingSig = Join-Path $work 'nope.sig'
-
-    Check (-not (Test-HullVerifierCapable (Join-Path $work 'does-not-exist.com'))) "absent existing hull -> bootstrap (not verifier-capable)"
-    Check (-not (Test-HullVerifierCapable $oldHull)) "existing hull lacking verify-release -> bootstrap"
-    Check (Test-HullVerifierCapable $okHull) "a verify-release-capable hull is detected"
-    Check (Test-HullVerifierCapable $badHull) "capability is independent of a later verify verdict"
-    $vok = $true; try { Assert-HullSignature $okHull $man $sigFile } catch { $vok = $false }
-    Check $vok "verifier present + valid signature proceeds"
-    Throws { Assert-HullSignature $badHull $man $sigFile } "verifier present + invalid signature aborts"
-    Throws { Assert-HullSignature $okHull $man $missingSig } "verifier present + missing/undownloaded signature aborts"
-
-    # --- uninstall ownership gate (unit) --------------------------------------
-    Note "## uninstall ownership gate"
-    $udir = Join-Path $work 'unmanaged'; New-Item -ItemType Directory -Path $udir -Force | Out-Null
-    $ubin = Join-Path $udir 'hull.com'
-    [System.IO.File]::WriteAllBytes($ubin, [System.Text.Encoding]::ASCII.GetBytes('NOTOURS'))
-    Invoke-HullUninstall -Prefix $udir -DryRun:$false | Out-Null
-    Check (Test-Path -LiteralPath $ubin) "uninstall refuses to remove an unmanaged hull.com (no ownership marker)"
-    Write-HullMarker $udir '0.0.0' $false
-    Invoke-HullUninstall -Prefix $udir -DryRun:$false | Out-Null
-    Check (-not (Test-Path -LiteralPath $ubin)) "uninstall removes a managed hull.com (marker present, pathAdded=false leaves PATH alone)"
-
-    # --- user PATH add/remove (idempotent, exact, non-corrupting) -------------
-    Note "## user PATH add/remove (HKCU, snapshot/restore)"
+    # --- user PATH add + exact one-entry removal (HKCU, snapshot/restore) ------
+    Note "## user PATH add + one-entry removal"
     $snap = Get-HullUserPathRaw
     try {
         $ptest = Join-Path $work 'pathdir'
-        Check (Add-HullToUserPath $ptest $false) "adds an absent dir (returns added)"
+        Check ((Add-HullToUserPath $ptest $false) -eq $ptest) "add returns the exact raw entry"
         Check (Test-HullPathContains (Get-HullUserPathRaw).Value $ptest) "dir is present after add"
-        Check (-not (Add-HullToUserPath $ptest $false)) "second add is idempotent (no-op)"
-        $occ = @(((Get-HullUserPathRaw).Value -split ';') | Where-Object { (ConvertTo-HullPathKey $_) -eq (ConvertTo-HullPathKey $ptest) }).Count
-        Check ($occ -eq 1) "exactly one occurrence after repeated adds"
-        # original snapshot entries are all still present (non-corrupting)
-        $curKeys = ((Get-HullUserPathRaw).Value -split ';') | ForEach-Object { ConvertTo-HullPathKey $_ }
-        $allKept = $true
-        foreach ($c in ($snap.Value -split ';')) { if ($c -eq '') { continue }; if (($curKeys -notcontains (ConvertTo-HullPathKey $c))) { $allKept = $false } }
-        Check $allKept "existing PATH entries preserved after add"
-        Check (Remove-HullFromUserPath $ptest $false) "removes the managed dir"
-        Check (-not (Test-HullPathContains (Get-HullUserPathRaw).Value $ptest)) "dir absent after remove"
-        Check (-not (Remove-HullFromUserPath $ptest $false)) "second remove is idempotent (no-op)"
+        Check ($null -eq (Add-HullToUserPath $ptest $false)) "second add is idempotent (returns null)"
+        # inject a user-owned EQUIVALENT (trailing slash); removal must drop ONLY one
+        $cur = Get-HullUserPathRaw; Set-HullUserPathRaw ($cur.Value.TrimEnd(';') + ';' + $ptest + '\') $cur.Kind
+        $before = @(((Get-HullUserPathRaw).Value -split ';') | Where-Object { (ConvertTo-HullPathKey $_) -eq (ConvertTo-HullPathKey $ptest) }).Count
+        Check ($before -eq 2) "two equivalent entries present before removal"
+        Check (Remove-HullPathEntry $ptest $false) "removes one entry"
+        $after = @(((Get-HullUserPathRaw).Value -split ';') | Where-Object { (ConvertTo-HullPathKey $_) -eq (ConvertTo-HullPathKey $ptest) }).Count
+        Check ($after -eq 1) "exactly one equivalent entry removed, the other preserved"
+        [void](Remove-HullPathEntry ($ptest + '\') $false)
         Check ((Get-HullUserPathRaw).Kind -eq $snap.Kind) "registry value kind preserved"
-    } finally {
-        Set-HullUserPathRaw $snap.Value $snap.Kind  # restore exactly
-    }
+    } finally { Set-HullUserPathRaw $snap.Value $snap.Kind }
+
+    # --- install transaction (binary + PATH + marker, all-or-nothing) ---------
+    Note "## install transaction rollback"
+    $tdir = Join-Path $work 'txn'; New-Item -ItemType Directory -Path $tdir -Force | Out-Null
+    $tdest = Join-Path $tdir 'hull.com'
+    $tsrc = Join-Path $work 'txnsrc'; WriteBytes $tsrc 'NEWTXN'
+    WriteBytes $tdest 'PREVTXN'
+    # pre-existing predictable sidecars must never be clobbered
+    WriteBytes "$tdest.new" 'KEEPNEW'; WriteBytes "$tdest.bak" 'KEEPBAK'
+
+    Throws { Invoke-HullCommitInstall $tsrc $tdest $tdir '9.9.9' $true -SimulateSwapFailure } "swap-phase failure throws"
+    Check ((ReadTrim $tdest) -eq 'PREVTXN') "swap-phase failure restores the previous binary"
+    Check (-not (Test-Path (Get-HullMarkerPath $tdir))) "swap-phase failure writes no marker"
+    Check ((ReadTrim "$tdest.new") -eq 'KEEPNEW' -and (ReadTrim "$tdest.bak") -eq 'KEEPBAK') "pre-existing .new/.bak sidecars untouched"
+
+    $snap2 = Get-HullUserPathRaw
+    try {
+        Throws { Invoke-HullCommitInstall $tsrc $tdest $tdir '9.9.9' $false -FailMarker } "marker-phase failure throws"
+        Check ((ReadTrim $tdest) -eq 'PREVTXN') "marker-phase failure restores the previous binary"
+        Check (-not (Test-Path (Get-HullMarkerPath $tdir))) "marker-phase failure leaves no marker"
+        Check (-not (Test-HullPathContains (Get-HullUserPathRaw).Value $tdir)) "marker-phase failure undoes the PATH add"
+    } finally { Set-HullUserPathRaw $snap2.Value $snap2.Kind }
+
+    $critTxn = $null
+    try { Invoke-HullCommitInstall $tsrc $tdest $tdir '9.9.9' $true -FailMarker -SimulateUndoFailure } catch { $critTxn = $_.Exception.Message }
+    Check ($critTxn -match 'CRITICAL') "restore failure during commit raises CRITICAL"
+    Check ($critTxn -match '\.hull-backup-') "CRITICAL names the preserved backup"
+    $bakTxn = @(Get-ChildItem $tdir -Filter '.hull-backup-*' -Force -ErrorAction SilentlyContinue)
+    Check (($bakTxn.Count -ge 1) -and ((ReadTrim $bakTxn[0].FullName) -eq 'PREVTXN')) "previous binary preserved in the backup"
+    $bakTxn | ForEach-Object { Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue }
+    if (-not (Test-Path $tdest)) { WriteBytes $tdest 'PREVTXN' }
+
+    Invoke-HullCommitInstall $tsrc $tdest $tdir '9.9.9' $true
+    Check ((ReadTrim $tdest) -eq 'NEWTXN') "successful commit installs the new binary"
+    Check (Test-HullMarkerValid (Read-HullMarker $tdir) $tdir) "successful commit writes a valid marker"
+    Check (@(Get-ChildItem $tdir -Filter '.hull-*' -Force -ErrorAction SilentlyContinue).Count -eq 0) "no staging/backup residue after commit"
+
+    # --- verifier detection (tri-state, bounded) ------------------------------
+    Note "## verifier detection (tri-state, bounded)"
+    $fakeExe = Join-Path $work 'fakehull.exe'
+    Add-Type -TypeDefinition $script:FakeSrc -OutputAssembly $fakeExe -OutputType ConsoleApplication
+    $sigFile = Join-Path $work 'sig.bin'; WriteBytes $sigFile 'SIG'
+    $missingSig = Join-Path $work 'nope.sig'
+
+    Check ((Get-HullVerifierState (Join-Path $work 'nope.com')) -eq 'none') "absent existing hull -> none (bootstrap ok)"
+    $env:HULL_FAKE_MODE = 'ok';     Check ((Get-HullVerifierState $fakeExe) -eq 'capable') "verify-release-capable hull -> capable"
+    $env:HULL_FAKE_MODE = 'bad';    Check ((Get-HullVerifierState $fakeExe) -eq 'capable') "capability is independent of the verify verdict"
+    $env:HULL_FAKE_MODE = 'absent'; Check ((Get-HullVerifierState $fakeExe) -eq 'absent') "hull genuinely lacking verify-release -> absent (bootstrap ok)"
+    $env:HULL_FAKE_MODE = 'hang';   Check ((Get-HullVerifierState $fakeExe 2) -eq 'ambiguous') "hung/timed-out probe -> ambiguous (abort, NOT bootstrap)"
+
+    Note "## signature assertion"
+    $env:HULL_FAKE_MODE = 'ok'
+    $vok = $true; try { Assert-HullSignature $fakeExe $man $sigFile } catch { $vok = $false }
+    Check $vok "capable + valid signature proceeds"
+    $env:HULL_FAKE_MODE = 'bad'
+    Throws { Assert-HullSignature $fakeExe $man $sigFile } "capable + invalid signature aborts"
+    $env:HULL_FAKE_MODE = 'ok'
+    Throws { Assert-HullSignature $fakeExe $man $missingSig } "capable + missing/undownloaded signature aborts"
+
+    Note "## bounded artifact version"
+    $env:HULL_FAKE_MODE = 'ok'; $env:HULL_FAKE_VERSION = '1.2.3'
+    Check ((Get-HullArtifactVersion $fakeExe) -eq '1.2.3') "parses the artifact version"
+    Remove-Item Env:\HULL_FAKE_MODE -ErrorAction SilentlyContinue
+    Remove-Item Env:\HULL_FAKE_VERSION -ErrorAction SilentlyContinue
+
+    # --- marker schema + prefix validation ------------------------------------
+    Note "## marker schema + prefix validation"
+    $mdir = Join-Path $work 'marker'; New-Item -ItemType Directory -Path $mdir -Force | Out-Null
+    Write-HullMarker $mdir '1.0.0' $true 'C:\x'
+    Check (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir) "a well-formed marker at its prefix is valid"
+    Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) (Join-Path $work 'other'))) "marker rejected for a different prefix"
+    Set-Content -LiteralPath (Get-HullMarkerPath $mdir) -Encoding ASCII -Value (@{ installer = 'someone-else'; schema = 1; prefix = $mdir; version = '1'; pathAdded = $false } | ConvertTo-Json)
+    Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir)) "marker with a foreign installer id rejected"
+    Set-Content -LiteralPath (Get-HullMarkerPath $mdir) -Encoding ASCII -Value (@{ installer = 'install.ps1'; prefix = $mdir } | ConvertTo-Json)
+    Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir)) "marker missing required fields rejected"
+    Set-Content -LiteralPath (Get-HullMarkerPath $mdir) -Encoding ASCII -Value (@{ installer = 'install.ps1'; schema = 999; prefix = $mdir; version = '1'; pathAdded = $false } | ConvertTo-Json)
+    Check (-not (Test-HullMarkerValid (Read-HullMarker $mdir) $mdir)) "marker with an unknown schema rejected"
+
+    # --- no-adoption + uninstall ownership gate -------------------------------
+    Note "## no-adoption + uninstall ownership gate"
+    $udir = Join-Path $work 'unmanaged'; New-Item -ItemType Directory -Path $udir -Force | Out-Null
+    $ubin = Join-Path $udir 'hull.com'; WriteBytes $ubin 'NOTOURS'
+    Check (-not (Test-HullManagedHere $udir)) "an unmarked prefix is not managed (no adoption)"
+    Invoke-HullUninstall -Prefix $udir -DryRun:$false | Out-Null
+    Check (Test-Path -LiteralPath $ubin) "uninstall refuses to remove an unmanaged hull.com"
+    Write-HullMarker $udir '0.0.0' $false ''
+    Check (Test-HullManagedHere $udir) "a valid marker marks the prefix managed"
+    Invoke-HullUninstall -Prefix $udir -DryRun:$false | Out-Null
+    Check (-not (Test-Path -LiteralPath $ubin)) "uninstall removes a managed hull.com (pathAdded=false leaves PATH alone)"
 
     # --- network end-to-end (gated) -------------------------------------------
     if ($IncludeNetwork) {
         Note "## network end-to-end (official release, read-only)"
 
-        # dry-run: resolves metadata but writes nothing (no prefix, no temp dir)
         $dpre = Join-Path $work 'dry\Hull'
         $tempBefore = @(Get-ChildItem -LiteralPath $env:TEMP -Filter 'hull-install-*' -Directory -Force -ErrorAction SilentlyContinue).Count
         [void](Invoke-Install @('-Version', 'v0.14.0', '-Prefix', $dpre, '-NoPath', '-DryRun') (Join-Path $work 'dry.log'))
         $tempAfter = @(Get-ChildItem -LiteralPath $env:TEMP -Filter 'hull-install-*' -Directory -Force -ErrorAction SilentlyContinue).Count
         Check (-not (Test-Path -LiteralPath $dpre)) "dry-run did not create the prefix"
-        Check (-not (Test-Path -LiteralPath (Join-Path $dpre 'hull.com'))) "dry-run installed nothing"
         Check ($tempAfter -le $tempBefore) "dry-run created no hull-install temp dir"
 
-        # default (latest) install into a spaces path, no PATH change
         $spre = Join-Path $work 'with space\Hull'
         $rc = Invoke-Install @('-Prefix', $spre, '-NoPath') (Join-Path $work 'inst-latest.log')
         $sbin = Join-Path $spre 'hull.com'
         Check ($rc -eq 0 -and (Test-Path -LiteralPath $sbin)) "latest install created hull.com in a spaces path"
-        $sv = (& $sbin version 2>$null | Select-Object -First 1)
-        Check ($sv -match '[0-9]+\.[0-9]+\.[0-9]+') "installed hull runs and reports a version ($sv)"
-        Check ((Get-HullArtifactVersion $sbin 20) -match '[0-9]+\.[0-9]+\.[0-9]+') "bounded artifact version reader parses the real binary"
-        Check (Test-Path -LiteralPath (Join-Path $spre '.hull-install.json')) "install wrote an ownership marker"
+        Check ((& $sbin version 2>$null | Select-Object -First 1) -match '[0-9]+\.[0-9]+\.[0-9]+') "installed hull runs and reports a version"
+        Check (Test-HullMarkerValid (Read-HullMarker $spre) $spre) "install wrote a valid ownership marker"
 
-        # same-version reinstall without -Force is a clean no-op (not an error)
         $rc = Invoke-Install @('-Prefix', $spre, '-NoPath') (Join-Path $work 'inst-again.log')
         Check ($rc -eq 0) "same-version reinstall without -Force did not error"
 
-        # explicit older version, then a different version without -Force must fail,
-        # and with -Force must succeed.
         $vpre = Join-Path $work 'ver\Hull'
         [void](Invoke-Install @('-Version', 'v0.13.0', '-Prefix', $vpre, '-NoPath') (Join-Path $work 'inst-013.log'))
         $vbin = Join-Path $vpre 'hull.com'
@@ -242,9 +257,8 @@ try {
         Check ($rc -ne 0) "different-version install without -Force is refused"
         Check ((& $vbin version 2>$null | Select-Object -First 1) -match '0\.13\.0') "the refused install left v0.13.0 runnable"
         $rc = Invoke-Install @('-Version', 'v0.14.0', '-Prefix', $vpre, '-NoPath', '-Force') (Join-Path $work 'inst-014-force.log')
-        Check (($rc -eq 0) -and ((& $vbin version 2>$null | Select-Object -First 1) -match '0\.14\.0')) "forced replacement installs 0.14.0"
+        Check (($rc -eq 0) -and ((& $vbin version 2>$null | Select-Object -First 1) -match '0\.14\.0')) "forced replacement (with a real signature check) installs 0.14.0"
 
-        # uninstall removes the managed exe + empty dir, idempotently
         [void](Invoke-Install @('-Uninstall', '-Prefix', $vpre) (Join-Path $work 'uninstall.log'))
         Check (-not (Test-Path -LiteralPath $vbin)) "uninstall removed the managed hull.com"
         $rc = Invoke-Install @('-Uninstall', '-Prefix', $vpre) (Join-Path $work 'uninstall2.log')

--- a/tests/acceptance/windows/installer/installer_tests.ps1
+++ b/tests/acceptance/windows/installer/installer_tests.ps1
@@ -173,12 +173,21 @@ try {
     Invoke-HullCommitInstall $tsrc $tdest $tdir '9.9.9' $true
     Check ((ReadTrim $tdest) -eq 'NEWTXN') "successful commit installs the new binary"
     Check (Test-HullMarkerValid (Read-HullMarker $tdir) $tdir) "successful commit writes a valid marker"
-    Check (@(Get-ChildItem $tdir -Filter '.hull-*' -Force -ErrorAction SilentlyContinue).Count -eq 0) "no staging/backup residue after commit"
+    Check (@(Get-ChildItem -LiteralPath $tdir -Force -ErrorAction SilentlyContinue | Where-Object { $_.Name -like '.hull-stage-*' -or $_.Name -like '.hull-backup-*' }).Count -eq 0) "no staging/backup residue after commit"
 
     # --- verifier detection (tri-state, bounded) ------------------------------
     Note "## verifier detection (tri-state, bounded)"
+    # Compile a real fake hull.exe with the Framework C# compiler (Add-Type
+    # -OutputType ConsoleApplication is Windows-PowerShell-5.1-only, so csc.exe is
+    # used directly for parity with PowerShell 7). System.Diagnostics.Process
+    # needs a real PE, not a .cmd shim.
     $fakeExe = Join-Path $work 'fakehull.exe'
-    Add-Type -TypeDefinition $script:FakeSrc -OutputAssembly $fakeExe -OutputType ConsoleApplication
+    $csFile = Join-Path $work 'fakehull.cs'; Set-Content -LiteralPath $csFile -Value $script:FakeSrc -Encoding ASCII
+    $csc = Join-Path $env:WINDIR 'Microsoft.NET\Framework64\v4.0.30319\csc.exe'
+    if (-not (Test-Path -LiteralPath $csc)) { $csc = Join-Path $env:WINDIR 'Microsoft.NET\Framework\v4.0.30319\csc.exe' }
+    Check (Test-Path -LiteralPath $csc) "found a C# compiler for the test fake"
+    & $csc /nologo "/out:$fakeExe" /target:exe "$csFile" *> (Join-Path $work 'csc.log')
+    Check (Test-Path -LiteralPath $fakeExe) "compiled the fake hull.exe"
     $sigFile = Join-Path $work 'sig.bin'; WriteBytes $sigFile 'SIG'
     $missingSig = Join-Path $work 'nope.sig'
 

--- a/tests/acceptance/windows/installer/installer_tests.ps1
+++ b/tests/acceptance/windows/installer/installer_tests.ps1
@@ -1,0 +1,188 @@
+<#
+  installer_tests.ps1 - installer-specific tests for install.ps1, run AS a
+  standard (non-admin) user under BOTH Windows PowerShell 5.1 and PowerShell 7.
+
+  Dot-sources install.ps1 (which defines its functions without running main) and
+  exercises the factored logic with LOCAL fixtures (no network) for the
+  fail-closed paths, plus gated network end-to-end installs against the official
+  release when -IncludeNetwork is passed. Read-only w.r.t. GitHub releases:
+  downloads only, never publishes or mutates anything.
+
+  Usage: installer_tests.ps1 -InstallPs1 <path> [-IncludeNetwork] [-Evidence <file>]
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$InstallPs1,
+    [switch]$IncludeNetwork,
+    [string]$Evidence
+)
+
+$ErrorActionPreference = 'Stop'
+$script:pass = 0; $script:fail = 0
+function Note($m) { if ($Evidence) { Add-Content -Path $Evidence -Value $m }; Write-Host $m }
+function Ok($m)   { $script:pass++; Note ("  ok   " + $m) }
+function Bad($m)  { $script:fail++; Note ("  FAIL " + $m) }
+function Check([bool]$cond, [string]$m) { if ($cond) { Ok $m } else { Bad $m } }
+function Throws([scriptblock]$sb, [string]$m) {
+    $threw = $false
+    try { & $sb } catch { $threw = $true }
+    Check $threw $m
+}
+
+Note ("## installer_tests under PowerShell $($PSVersionTable.PSVersion) (as $(whoami))")
+
+# Dot-source: defines the Hull* functions; the guard suppresses main because
+# InvocationName is '.'.
+. $InstallPs1
+
+# Run install.ps1 as a CHILD PROCESS of the current PowerShell host, so its
+# `exit` cannot terminate this test script and its exit code is observable. The
+# child inherits this process's environment (redirected HOME/TEMP, and, on the
+# 5.1 leg, the corrected PSModulePath).
+$script:psExe = (Get-Process -Id $PID).Path
+function Invoke-Install {
+    param([string[]]$IArgs, [string]$Log)
+    $a = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $InstallPs1) + $IArgs
+    if ($Log) { & $script:psExe @a *> $Log } else { & $script:psExe @a *> $null }
+    return $LASTEXITCODE
+}
+
+$work = Join-Path $env:TEMP ("hull-itest-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $work -Force | Out-Null
+
+try {
+    # --- version tag grammar --------------------------------------------------
+    Note "## version tag grammar"
+    foreach ($v in @('v0.14.0', 'v1.2.3', 'v0.14.0-rc1', 'v10.0.0-beta.2')) {
+        Check (Test-HullVersionTag $v) "accepts $v"
+    }
+    foreach ($v in @('0.14.0', 'v0.14', 'latest', 'v0.14.0; rm', '../evil', 'v0.14.0/..', 'v0.14.0 x')) {
+        Check (-not (Test-HullVersionTag $v)) "rejects '$v'"
+    }
+
+    # --- manifest hash selection (fail closed) --------------------------------
+    Note "## manifest hash selection"
+    $h1 = ('a' * 64); $h2 = ('b' * 64); $h3 = ('c' * 64)
+    $man = Join-Path $work 'hull.sha256'
+    # Format is <64 hex><two spaces><name>.
+    Set-Content -LiteralPath $man -Value @(
+        "$h1  hull-cosmo",
+        "$h2  hull-linux-x86_64",
+        "garbage line without a hash",
+        "$h3  hull-cosmocc.tar"
+    )
+    Check ((Get-HullManifestHash $man 'hull-cosmo') -eq $h1) "selects the exact hull-cosmo entry"
+    Check ((Get-HullManifestHash $man 'hull-linux-x86_64') -eq $h2) "selects a different exact entry"
+    Throws { Get-HullManifestHash $man 'hull-darwin-arm64' } "throws on a missing entry"
+    $dup = Join-Path $work 'dup.sha256'
+    Set-Content -LiteralPath $dup -Value @("$h1  hull-cosmo", "$h2  hull-cosmo")
+    Throws { Get-HullManifestHash $dup 'hull-cosmo' } "throws on a duplicate entry"
+
+    # --- sha-256 + checksum (fail closed) -------------------------------------
+    Note "## sha-256 + checksum"
+    $blob = Join-Path $work 'blob'
+    [System.IO.File]::WriteAllBytes($blob, [System.Text.Encoding]::ASCII.GetBytes('hello'))
+    $known = '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
+    Check ((Get-HullFileSha256 $blob) -eq $known) "sha256('hello') is correct"
+    Check ((Test-HullChecksum $blob $known) -eq $known) "checksum match returns the hash"
+    Throws { Test-HullChecksum $blob ('d' * 64) } "throws on a checksum mismatch"
+
+    # --- prefix resolution ----------------------------------------------------
+    Note "## prefix resolution"
+    Check ((Resolve-HullPrefix '') -like '*\Programs\Hull') "default prefix is under Programs\Hull"
+    Check ((Resolve-HullPrefix 'C:\x y\Hull') -eq 'C:\x y\Hull') "-Prefix override with spaces is honored verbatim"
+
+    # --- PATH component comparison (pure) -------------------------------------
+    Note "## PATH component comparison"
+    Check (Test-HullPathContains 'C:\a;C:\b\' 'C:\b') "matches ignoring a trailing separator"
+    Check (Test-HullPathContains 'C:\A' 'c:\a') "matches case-insensitively"
+    Check (-not (Test-HullPathContains 'C:\a;C:\b' 'C:\c')) "does not match an absent dir"
+
+    # --- rollback: a failed install leaves the previous binary runnable -------
+    Note "## atomic install rollback"
+    $rdir = Join-Path $work 'roll'; New-Item -ItemType Directory -Path $rdir -Force | Out-Null
+    $rdest = Join-Path $rdir 'hull.com'
+    $rsrc = Join-Path $work 'newbin'
+    [System.IO.File]::WriteAllBytes($rsrc, [System.Text.Encoding]::ASCII.GetBytes('NEWBINARY'))
+    [System.IO.File]::WriteAllBytes($rdest, [System.Text.Encoding]::ASCII.GetBytes('PREVIOUS'))
+    Throws { Install-HullAtomicMove $rsrc $rdest -SimulateFailure } "simulated failed install throws"
+    Check (Test-Path -LiteralPath $rdest) "previous binary still present after rollback"
+    Check (((Get-Content -LiteralPath $rdest -Raw).Trim()) -eq 'PREVIOUS') "previous binary content intact (runnable)"
+    Check (-not (Test-Path -LiteralPath "$rdest.new")) "staged .new cleaned up on failure"
+    Check (-not (Test-Path -LiteralPath "$rdest.bak")) "backup .bak consumed by rollback"
+    # success path replaces atomically and leaves no residue
+    Install-HullAtomicMove $rsrc $rdest
+    Check (((Get-Content -LiteralPath $rdest -Raw).Trim()) -eq 'NEWBINARY') "successful install replaces the binary"
+    Check (-not (Test-Path -LiteralPath "$rdest.new") -and -not (Test-Path -LiteralPath "$rdest.bak")) "no staging residue after success"
+
+    # --- user PATH add/remove (idempotent, exact, non-corrupting) -------------
+    Note "## user PATH add/remove (HKCU, snapshot/restore)"
+    $snap = Get-HullUserPathRaw
+    try {
+        $ptest = Join-Path $work 'pathdir'
+        Check (Add-HullToUserPath $ptest $false) "adds an absent dir (returns added)"
+        Check (Test-HullPathContains (Get-HullUserPathRaw).Value $ptest) "dir is present after add"
+        Check (-not (Add-HullToUserPath $ptest $false)) "second add is idempotent (no-op)"
+        $occ = @(((Get-HullUserPathRaw).Value -split ';') | Where-Object { (ConvertTo-HullPathKey $_) -eq (ConvertTo-HullPathKey $ptest) }).Count
+        Check ($occ -eq 1) "exactly one occurrence after repeated adds"
+        # original snapshot entries are all still present (non-corrupting)
+        $curKeys = ((Get-HullUserPathRaw).Value -split ';') | ForEach-Object { ConvertTo-HullPathKey $_ }
+        $allKept = $true
+        foreach ($c in ($snap.Value -split ';')) { if ($c -eq '') { continue }; if (($curKeys -notcontains (ConvertTo-HullPathKey $c))) { $allKept = $false } }
+        Check $allKept "existing PATH entries preserved after add"
+        Check (Remove-HullFromUserPath $ptest $false) "removes the managed dir"
+        Check (-not (Test-HullPathContains (Get-HullUserPathRaw).Value $ptest)) "dir absent after remove"
+        Check (-not (Remove-HullFromUserPath $ptest $false)) "second remove is idempotent (no-op)"
+        Check ((Get-HullUserPathRaw).Kind -eq $snap.Kind) "registry value kind preserved"
+    } finally {
+        Set-HullUserPathRaw $snap.Value $snap.Kind  # restore exactly
+    }
+
+    # --- network end-to-end (gated) -------------------------------------------
+    if ($IncludeNetwork) {
+        Note "## network end-to-end (official release, read-only)"
+
+        # dry-run writes nothing
+        $dpre = Join-Path $work 'dry\Hull'
+        [void](Invoke-Install @('-Version', 'v0.14.0', '-Prefix', $dpre, '-NoPath', '-DryRun') (Join-Path $work 'dry.log'))
+        Check (-not (Test-Path -LiteralPath (Join-Path $dpre 'hull.com'))) "dry-run performed no install"
+
+        # default (latest) install into a spaces path, no PATH change
+        $spre = Join-Path $work 'with space\Hull'
+        $rc = Invoke-Install @('-Prefix', $spre, '-NoPath') (Join-Path $work 'inst-latest.log')
+        $sbin = Join-Path $spre 'hull.com'
+        Check ($rc -eq 0 -and (Test-Path -LiteralPath $sbin)) "latest install created hull.com in a spaces path"
+        $sv = (& $sbin version 2>$null | Select-Object -First 1)
+        Check ($sv -match '[0-9]+\.[0-9]+\.[0-9]+') "installed hull runs and reports a version ($sv)"
+
+        # same-version reinstall without -Force is a clean no-op (not an error)
+        $rc = Invoke-Install @('-Prefix', $spre, '-NoPath') (Join-Path $work 'inst-again.log')
+        Check ($rc -eq 0) "same-version reinstall without -Force did not error"
+
+        # explicit older version, then a different version without -Force must fail,
+        # and with -Force must succeed.
+        $vpre = Join-Path $work 'ver\Hull'
+        [void](Invoke-Install @('-Version', 'v0.13.0', '-Prefix', $vpre, '-NoPath') (Join-Path $work 'inst-013.log'))
+        $vbin = Join-Path $vpre 'hull.com'
+        Check ((& $vbin version 2>$null | Select-Object -First 1) -match '0\.13\.0') "explicit v0.13.0 install reports 0.13.0"
+        $rc = Invoke-Install @('-Version', 'v0.14.0', '-Prefix', $vpre, '-NoPath') (Join-Path $work 'inst-014-noforce.log')
+        Check ($rc -ne 0) "different-version install without -Force is refused"
+        Check ((& $vbin version 2>$null | Select-Object -First 1) -match '0\.13\.0') "the refused install left v0.13.0 runnable"
+        $rc = Invoke-Install @('-Version', 'v0.14.0', '-Prefix', $vpre, '-NoPath', '-Force') (Join-Path $work 'inst-014-force.log')
+        Check (($rc -eq 0) -and ((& $vbin version 2>$null | Select-Object -First 1) -match '0\.14\.0')) "forced replacement installs 0.14.0"
+
+        # uninstall removes the managed exe + empty dir, idempotently
+        [void](Invoke-Install @('-Uninstall', '-Prefix', $vpre) (Join-Path $work 'uninstall.log'))
+        Check (-not (Test-Path -LiteralPath $vbin)) "uninstall removed the managed hull.com"
+        $rc = Invoke-Install @('-Uninstall', '-Prefix', $vpre) (Join-Path $work 'uninstall2.log')
+        Check ($rc -eq 0) "uninstall is idempotent (clean no-op)"
+    } else {
+        Note "## network end-to-end SKIPPED (no -IncludeNetwork)"
+    }
+} finally {
+    Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Note ("## RESULT: $($script:pass) passed, $($script:fail) failed")
+if ($script:fail -ne 0) { exit 1 }
+exit 0

--- a/tests/acceptance/windows/installer/run-installer-tests.ps1
+++ b/tests/acceptance/windows/installer/run-installer-tests.ps1
@@ -1,0 +1,99 @@
+<#
+  run-installer-tests.ps1 - orchestrates the installer-specific Windows tests.
+  Runs as the runner's admin account but drives the tests AS a freshly-created
+  STANDARD (non-admin) user with Developer Mode disabled, under BOTH Windows
+  PowerShell 5.1 and PowerShell 7. Read-only w.r.t. GitHub releases.
+
+  Usage: run-installer-tests.ps1 -RepoRoot <dir> -Evidence <file> -WorkDir <dir>
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$RepoRoot,
+    [Parameter(Mandatory = $true)][string]$Evidence,
+    [Parameter(Mandatory = $true)][string]$WorkDir
+)
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+function Note($m) { Add-Content -Path $Evidence -Value $m; Write-Host $m }
+
+New-Item -ItemType Directory -Path $WorkDir -Force | Out-Null
+Set-Content -Path $Evidence -Value "# Windows installer test evidence`n"
+
+# ── Standard (non-admin) user + Developer-Mode-off ───────────────────────────
+$user = 'hullinst'
+$pw   = ([guid]::NewGuid().ToString() + 'Aa1!')
+$sec  = ConvertTo-SecureString $pw -AsPlainText -Force
+if (Get-LocalUser -Name $user -ErrorAction SilentlyContinue) { Remove-LocalUser -Name $user }
+New-LocalUser -Name $user -Password $sec -AccountNeverExpires -PasswordNeverExpires | Out-Null
+Add-LocalGroupMember -Group 'Users' -Member $user -ErrorAction SilentlyContinue
+if (Get-LocalGroupMember -Group 'Administrators' -Member $user -ErrorAction SilentlyContinue) {
+    Note "FATAL: installer test user is in Administrators"; exit 1
+}
+$cred = New-Object System.Management.Automation.PSCredential("$env:COMPUTERNAME\$user", $sec)
+Note "- created standard user $user (not in Administrators)"
+
+$devKey = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock'
+New-Item -Path $devKey -Force | Out-Null
+Set-ItemProperty -Path $devKey -Name AllowDevelopmentWithoutDevLicense -Value 0 -Type DWord
+Note "- Developer Mode disabled"
+
+# ── Stage the files the child reads + a user-writable environment ────────────
+Copy-Item (Join-Path $RepoRoot 'install.ps1') (Join-Path $WorkDir 'install.ps1') -Force
+Copy-Item (Join-Path $here 'installer_tests.ps1') (Join-Path $WorkDir 'installer_tests.ps1') -Force
+Copy-Item (Join-Path (Split-Path -Parent $here) 'preconditions.ps1') (Join-Path $WorkDir 'preconditions.ps1') -Force
+
+& icacls $WorkDir  /grant "${user}:(OI)(CI)M"  | Out-Null
+& icacls $Evidence /grant "${user}:M"          | Out-Null
+$homeDir = Join-Path $WorkDir 'home'; $tmpDir = Join-Path $WorkDir 'tmp'
+$appData = Join-Path $WorkDir 'appdata'; $localApp = Join-Path $WorkDir 'localappdata'
+foreach ($d in @($homeDir, $tmpDir, $appData, $localApp)) { New-Item -ItemType Directory -Path $d -Force | Out-Null }
+$env:HOME = $homeDir; $env:USERPROFILE = $homeDir
+$env:TEMP = $tmpDir;  $env:TMP = $tmpDir
+$env:APPDATA = $appData; $env:LOCALAPPDATA = $localApp
+Note ("- child env: HOME/TEMP/LOCALAPPDATA under {0}" -f $WorkDir)
+
+$pwsh7 = Join-Path $PSHOME 'pwsh.exe'
+if (-not (Test-Path $pwsh7)) { $pwsh7 = 'pwsh' }
+$ps51  = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
+$ps51Modules = Join-Path $env:SystemRoot 'System32\WindowsPowerShell\v1.0\Modules'
+
+# ── Run a phase AS the standard user under a chosen shell ────────────────────
+function Invoke-AsUser([string]$ShellExe, [string]$Script, [string[]]$PhaseArgs, [string]$Label, [string]$ModulePath) {
+    $o = Join-Path $WorkDir ("phase-$Label.out.log"); $e = Join-Path $WorkDir ("phase-$Label.err.log")
+    $a = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', (Join-Path $WorkDir $Script)) + $PhaseArgs
+    $restore = $env:PSModulePath
+    if ($ModulePath) { $env:PSModulePath = $ModulePath }   # correct WinPS 5.1 module resolution for the runas child
+    try {
+        $p = Start-Process -FilePath $ShellExe -Credential $cred -ArgumentList $a `
+                           -WorkingDirectory $WorkDir -Wait -PassThru `
+                           -RedirectStandardOutput $o -RedirectStandardError $e
+    } finally { $env:PSModulePath = $restore }
+    foreach ($f in @($o, $e)) {
+        if ((Test-Path $f) -and (Get-Item $f).Length -gt 0) {
+            Get-Content $f | ForEach-Object { Note ("    [$Label] " + $_) }
+        }
+    }
+    return $p.ExitCode
+}
+
+$installPs1Path = Join-Path $WorkDir 'install.ps1'
+$rc = 0
+
+Note "`n--- PHASE: preconditions (non-admin, Dev-Mode off, symlink denied) ---"
+if ((Invoke-AsUser $pwsh7 'preconditions.ps1' @('-Evidence', $Evidence) 'precond' $null) -ne 0) { $rc = 1 }
+
+Note "`n--- PHASE: installer tests under PowerShell 7 (with network) ---"
+if ((Invoke-AsUser $pwsh7 'installer_tests.ps1' @('-InstallPs1', $installPs1Path, '-IncludeNetwork', '-Evidence', $Evidence) 'ps7' $null) -ne 0) { $rc = 1 }
+
+if (Test-Path $ps51) {
+    Note "`n--- PHASE: installer tests under Windows PowerShell 5.1 (with network) ---"
+    if ((Invoke-AsUser $ps51 'installer_tests.ps1' @('-InstallPs1', $installPs1Path, '-IncludeNetwork', '-Evidence', $Evidence) 'ps51' $ps51Modules) -ne 0) { $rc = 1 }
+} else {
+    Note "`n--- PHASE: Windows PowerShell 5.1 not present; SKIPPED ---"
+    $rc = 1   # 5.1 must be available on windows-latest; fail if it is not
+}
+
+Remove-LocalUser -Name $user -ErrorAction SilentlyContinue
+Note ("`n## RESULT: {0}" -f ($(if ($rc -eq 0) { 'ALL INSTALLER TESTS PASSED' } else { 'FAILURE' })))
+exit $rc


### PR DESCRIPTION
## What

Slice B of the Windows install/trust initiative: the first-party PowerShell
installer + its own non-admin Windows test suite, implementing the frozen Slice A
contract ([`docs/windows_install_design.md`](docs/windows_install_design.md)). No
Winget, Scoop, or Authenticode work here; no production signing.

## `install.ps1`

- `irm https://gethull.dev/install.ps1 | iex` or download-then-run.
- Params `-Version` / `-Prefix` / `-Force` / `-DryRun` / `-NoPath` / `-Uninstall`;
  parameter sets make `-Uninstall` mutually exclusive with install-only params
  (only `-Prefix` / `-DryRun` compose).
- Upstream **fixed** to `artalis-io/hull` (no repo override); `-Version` validated
  against a strict tag grammar before any URL is constructed.
- Resolves the official release (rejecting drafts/prereleases for `latest`),
  downloads only `hull-cosmo` + `hull.sha256` (+ `.sig` for the upgrade check)
  into a unique temp dir, verifies SHA-256 against the exact manifest entry via
  .NET (fail closed on missing/duplicate/malformed/mismatch), installs
  `hull.com` to `%LOCALAPPDATA%\Programs\Hull` atomically with rollback. TLS 1.2+
  forced on 5.1.
- **Upgrade signature check, three explicit outcomes:** pre-existing verifier
  present + passes -> proceed; present + fails -> **abort** (no silent downgrade);
  absent -> proceed under **bootstrap trust** with a clear notice. No Ed25519 in
  PowerShell (delegated to `hull verify-release`).
- **User PATH:** HKCU only, idempotent, exact-match, non-truncating,
  value-kind-preserving (`REG_EXPAND_SZ`), broadcast `WM_SETTINGCHANGE` on
  success, untouched under `-DryRun`/`-NoPath`.
- **`-Uninstall`:** removes only the managed exe (+ the dir when empty + the
  exact managed PATH component), retains `~/.hull`, idempotent.

## Tests (read-only w.r.t. releases)

- `installer_tests.ps1` dot-sources `install.ps1` and checks the factored logic
  with local fixtures: version-tag grammar; exact manifest selection + missing /
  duplicate rejection; SHA-256 + mismatch; atomic rollback (via a test-only
  failure switch) leaving the previous binary runnable; PATH add/remove
  idempotency + non-corruption + kind preservation. Gated network end-to-end:
  dry-run writes nothing, spaces-prefix install, same-version no-op,
  different-version refused-without-`-Force` then forced, uninstall idempotency.
- `run-installer-tests.ps1` drives the suite AS a standard non-admin user with
  Developer Mode disabled under **both Windows PowerShell 5.1** (with a corrected
  module path) **and PowerShell 7**.
- `installer-windows.yml` runs it on `pull_request` / `push` (installer paths) +
  `workflow_dispatch`; uploads an evidence report.

## Review ask

Per the cadence this **stops for review after the installer + tests**; I will not
begin Winget, Scoop, or Authenticode in this slice. The installer-windows job
runs on this PR (I will iterate to green like the acceptance/smoke). Please review
the installer contract + test coverage; on approval and a green installer gate I
proceed to Slice C (installation docs) on its own branch.