### PR TITLE
docs(site): refresh site to v0.14.0 + install platform tabs + drift/link gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2369,6 +2369,12 @@ jobs:
       - name: No-new-milestone-narration self-test (negative)
         run: make check-no-milestone-narration-selftest
 
+      - name: Site-consistency gate (version + install tabs)
+        run: make check-site-consistency
+
+      - name: Site-consistency self-test (negative)
+        run: make check-site-consistency-selftest
+
   htmx-browser:
     needs: [classify]
     if: needs.classify.outputs.run_web == 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -899,12 +899,12 @@ Every capability module is instrumented: `db.query`, `db.exec`, `fs.read`, `fs.w
 
 ```bash
 # Print hull version
-hull version              # hull 0.10.0
-hull version --json       # {"version":"0.10.0","runtime":"lua+js","platform":"darwin-arm64","build":"release"}
+hull version              # hull 0.14.0
+hull version --json       # {"version":"0.14.0","runtime":"lua+js","platform":"darwin-arm64","build":"release"}
 
 # Check environment readiness (linker/compiler available, platform embedded)
 hull doctor               # human-readable report; exits 0 if hull build is ready
-hull doctor --json        # {"version":"0.10.0","platform_embedded":"multi-arch","hull_build":"ready",...}
+hull doctor --json        # {"version":"0.14.0","platform_embedded":"multi-arch","hull_build":"ready",...}
 
 # Self-update (verifies SHA-256, atomic replace via rename)
 hull update               # download + verify + install latest stable release

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -18,7 +18,7 @@ This bootstrap is **app-agnostic**. It assumes you have:
 
 ## Install Hull
 
-If `hull` isn't already on this machine:
+If `hull` isn't already on this machine, on **Linux or macOS**:
 
 ```sh
 curl -fsSL https://gethull.dev/install.sh | sh
@@ -28,7 +28,17 @@ This installs to `~/.local/bin/hull` (or `/usr/local/bin/hull` if root).
 The install script detects OS/arch, verifies the SHA-256, and verifies
 the Ed25519 release signature against the embedded public key. No
 sudo prompt unless the prefix needs it. Pin a specific version with
-`HULL_VERSION=v0.10.0 curl ... | sh`.
+`HULL_VERSION=v0.14.0 curl ... | sh`.
+
+On **Windows** (PowerShell, no admin or Developer Mode needed):
+
+```powershell
+irm https://gethull.dev/install.ps1 | iex
+```
+
+This installs `hull.com` to `%LOCALAPPDATA%\Programs\Hull` and adds it
+to your user `PATH`. See [Installing Hull on Windows](docs/windows_install.md)
+for options and verification.
 
 Verify:
 

--- a/BOOTSTRAP.md
+++ b/BOOTSTRAP.md
@@ -25,8 +25,11 @@ curl -fsSL https://gethull.dev/install.sh | sh
 ```
 
 This installs to `~/.local/bin/hull` (or `/usr/local/bin/hull` if root).
-The install script detects OS/arch, verifies the SHA-256, and verifies
-the Ed25519 release signature against the embedded public key. No
+The install script detects OS/arch and verifies the **SHA-256 checksum**
+of each binary against the release manifest as it downloads (checksum
+verification only). To independently verify the **Ed25519 release
+signature** (embedded public key), run `hull verify-release` after
+install, or verify the installer itself offline with `minisign`. No
 sudo prompt unless the prefix needs it. Pin a specific version with
 `HULL_VERSION=v0.14.0 curl ... | sh`.
 

--- a/Makefile
+++ b/Makefile
@@ -2008,7 +2008,7 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
 
 # ── Targets ─────────────────────────────────────────────────────────
 
-.PHONY: all clean test debug msan tsan tsan-shared-heap fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-valkey e2e-feature-valkey e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-stream-meta e2e-compute-async-trap e2e-sync-spans e2e-compute-aot-shared-heap e2e-compute-memory64 e2e-compute-headers e2e-spans-example e2e-spans-multi e2e-spans-hugefile e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-linker-zig e2e-cross-build e2e-musl e2e-musl-cross floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-test-harness e2e-jobs e2e-hypermedia-photos-upload e2e-jwt-asym e2e-path-parity hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-mapped-span bench-gpu bench-bytecode-cache wamrc wamrc-configure coverage lint-lua lint-js lint check-sdk-headers check-sdk-headers-selftest check-wamr-msan-annotation check-docs-integrity check-docs-integrity-selftest check-no-emdash check-no-emdash-selftest check-no-milestone-narration check-no-milestone-narration-selftest platform platform-cosmo hardening check-hardening
+.PHONY: all clean test debug msan tsan tsan-shared-heap fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-valkey e2e-feature-valkey e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-stream-meta e2e-compute-async-trap e2e-sync-spans e2e-compute-aot-shared-heap e2e-compute-memory64 e2e-compute-headers e2e-spans-example e2e-spans-multi e2e-spans-hugefile e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-linker-zig e2e-cross-build e2e-musl e2e-musl-cross floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-test-harness e2e-jobs e2e-hypermedia-photos-upload e2e-jwt-asym e2e-path-parity hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-mapped-span bench-gpu bench-bytecode-cache wamrc wamrc-configure coverage lint-lua lint-js lint check-sdk-headers check-sdk-headers-selftest check-wamr-msan-annotation check-docs-integrity check-docs-integrity-selftest check-no-emdash check-no-emdash-selftest check-no-milestone-narration check-no-milestone-narration-selftest check-site-consistency check-site-consistency-selftest platform platform-cosmo hardening check-hardening
 
 all: $(BUILDDIR)/hull
 
@@ -3284,7 +3284,16 @@ check-no-milestone-narration:
 check-no-milestone-narration-selftest:
 	sh tests/check_no_milestone_narration_selftest.sh
 
-lint: lint-lua lint-js check-sdk-headers check-docs-integrity check-no-emdash check-no-milestone-narration
+# Site-consistency gate: the marketing site (site/index.html) advertises the
+# current CHANGELOG version (JSON-LD + data-hull-version markers) and keeps its
+# Linux/macOS/Windows install tabs + the Windows installer. See the script.
+check-site-consistency:
+	sh tests/check_site_consistency.sh
+
+check-site-consistency-selftest:
+	sh tests/check_site_consistency_selftest.sh
+
+lint: lint-lua lint-js check-sdk-headers check-docs-integrity check-no-emdash check-no-milestone-narration check-site-consistency
 
 # ── API documentation (two-tier: source comments + generated HTML) ──
 #

--- a/site/index.html
+++ b/site/index.html
@@ -33,7 +33,7 @@
     "applicationSubCategory": "Runtime",
     "operatingSystem": "Linux, macOS, Windows (via Cosmopolitan), FreeBSD, OpenBSD, NetBSD",
     "description": "Secure execution for AI-generated applications and tools. Every external capability is declared in the manifest and checked at an OS-enforced boundary the script cannot cross. Local-first, deploy-anywhere, and packaged as a signed static binary.",
-    "softwareVersion": "0.10.0",
+    "softwareVersion": "0.14.0",
     "url": "https://gethull.dev/",
     "downloadUrl": "https://github.com/artalis-io/hull/releases",
     "codeRepository": "https://github.com/artalis-io/hull",
@@ -226,7 +226,7 @@
         <span class="text-paper-100 font-semibold tracking-tight">Hull</span>
         <a href="https://github.com/artalis-io/hull/releases" class="chip ml-1.5 hidden sm:inline-flex hover:text-paper-50 transition" title="Release notes on GitHub">
           <span class="accent-dot"></span>
-          v0.10.0
+          <span data-hull-version>v0.14.0</span>
         </a>
       </a>
 
@@ -530,18 +530,36 @@
         </div>
 
         <div class="lg:col-span-8">
-          <div class="code-block">
-            <header>
-              <i data-lucide="terminal" class="w-3.5 h-3.5"></i>
-              <span>shell</span>
-              <span class="ml-auto text-[10px] text-mute-500">copy &amp; paste</span>
-            </header>
-<pre><span class="tk-com"># Install over TLS. install.sh is minisign-signed (verify it below);</span>
+          <div class="code-block code-tabs">
+            <div class="code-tabs-bar" role="tablist" aria-label="Install by platform">
+              <button class="tab-btn tab-active" data-tab="linux" role="tab" aria-selected="true">Linux</button>
+              <button class="tab-btn" data-tab="macos" role="tab" aria-selected="false">macOS</button>
+              <button class="tab-btn" data-tab="windows" role="tab" aria-selected="false">Windows</button>
+              <span class="ml-auto self-center pr-3 text-[10px] text-mute-500 uppercase tracking-wide">install</span>
+            </div>
+<pre class="code-tab-panel" data-tab-panel="linux"><span class="tk-com"># Install over TLS. install.sh is minisign-signed (verify it below);</span>
 <span class="tk-com"># it SHA-256-checks each binary against the manifest as it downloads.</span>
 $ curl -fsSL <span class="tk-str">https://gethull.dev/install.sh</span> | sh
-hull installed to ~/.local/bin/hull  (v0.10.0)
-
-<span class="tk-com"># Don't trust gethull.dev? Verify the installer offline first</span>
+hull installed to ~/.local/bin/hull  (<span data-hull-version>v0.14.0</span>)
+</pre>
+<pre class="code-tab-panel hidden" data-tab-panel="macos"><span class="tk-com"># Same signed installer; it auto-detects macOS arm64 (or the universal</span>
+<span class="tk-com"># Cosmopolitan APE fallback) and SHA-256-checks each binary it downloads.</span>
+$ curl -fsSL <span class="tk-str">https://gethull.dev/install.sh</span> | sh
+hull installed to ~/.local/bin/hull  (<span data-hull-version>v0.14.0</span>)
+</pre>
+<pre class="code-tab-panel hidden" data-tab-panel="windows"><span class="tk-com"># PowerShell, no admin or Developer Mode needed. Installs hull.com and</span>
+<span class="tk-com"># adds it to your user PATH; SHA-256-checked against the manifest.</span>
+PS&gt; <span class="tk-fn">irm</span> <span class="tk-str">https://gethull.dev/install.ps1</span> | <span class="tk-fn">iex</span>
+hull installed to %LOCALAPPDATA%\Programs\Hull\hull.com  (<span data-hull-version>v0.14.0</span>)
+</pre>
+          </div>
+          <div class="code-block mt-3">
+            <header>
+              <i data-lucide="shield-check" class="w-3.5 h-3.5"></i>
+              <span>verify</span>
+              <span class="ml-auto text-[10px] text-mute-500">copy &amp; paste</span>
+            </header>
+<pre><span class="tk-com"># Don't trust gethull.dev? Verify the installer offline first</span>
 <span class="tk-com"># (minisign, no Hull needed). Cross-check the key below against</span>
 <span class="tk-com"># github.com/artalis-io/hull/blob/main/minisign.pub.</span>
 $ <span class="tk-kw">URL</span>=https://gethull.dev
@@ -551,13 +569,14 @@ $ minisign -Vm install.sh -P <span class="tk-str">RWRqvc6NndheWcLIi3vsL+xoZfZw2j
 $ sh install.sh
 
 <span class="tk-com"># Then verify the release signature (Ed25519, embedded pubkey).</span>
+<span class="tk-com"># Works on any OS; on Windows run it in PowerShell after install.</span>
 $ <span class="tk-kw">REL</span>=https://github.com/artalis-io/hull/releases/latest/download
 $ curl -fsSLO $REL/hull.sha256 $REL/hull.sha256.sig
 $ hull verify-release hull.sha256 hull.sha256.sig
 <span class="tk-acc">ok</span>. Signature valid
 
 $ hull doctor
-hull v0.10.0  &middot;  ca-bundle: embedded  &middot;  platform: embedded  &middot;  cc: ok
+hull <span data-hull-version>v0.14.0</span>  &middot;  ca-bundle: embedded  &middot;  platform: embedded  &middot;  cc: ok
 </pre>
           </div>
           <p class="mt-3 text-[11px] text-mute-400 leading-relaxed">
@@ -1703,7 +1722,7 @@ hull v0.10.0  &middot;  ca-bundle: embedded  &middot;  platform: embedded  &midd
           <div class="bg-ink-900 p-6">
             <div class="flex items-center gap-2 mb-4">
               <i data-lucide="check-circle-2" class="w-4 h-4 text-accent"></i>
-              <span class="text-sm font-semibold text-paper-50">Shipped through v0.10.0</span>
+              <span class="text-sm font-semibold text-paper-50" data-hull-version>Shipped through v0.14.0</span>
             </div>
             <ul class="space-y-3 text-sm text-mute-400 leading-relaxed">
               <li class="flex gap-2">
@@ -1992,7 +2011,7 @@ $ hull agent routes my-tool
       </div>
 
       <p class="text-[11px] text-mute-400 leading-relaxed">
-        Hull is at <span class="text-paper-100">v0.10.0</span>. APIs and the manifest schema are pre-stable, so pin your version and read the
+        Hull is at <span class="text-paper-100" data-hull-version>v0.14.0</span>. APIs and the manifest schema are pre-stable, so pin your version and read the
         <a href="https://github.com/artalis-io/hull/releases" class="link">changelog</a>
         before upgrading.
         Page last updated <time datetime="2026-08">August&nbsp;2026</time>.

--- a/site/index.html
+++ b/site/index.html
@@ -531,37 +531,37 @@
 
         <div class="lg:col-span-8">
           <div class="code-block code-tabs">
-            <div class="code-tabs-bar" role="tablist" aria-label="Install by platform">
-              <button class="tab-btn tab-active" data-tab="linux" role="tab" aria-selected="true">Linux</button>
-              <button class="tab-btn" data-tab="macos" role="tab" aria-selected="false">macOS</button>
-              <button class="tab-btn" data-tab="windows" role="tab" aria-selected="false">Windows</button>
+            <div class="code-tabs-bar" role="tablist" aria-label="Install Hull by platform">
+              <button class="tab-btn tab-active" id="install-tab-linux" data-tab="linux" role="tab" aria-selected="true" aria-controls="install-panel-linux" tabindex="0">Linux</button>
+              <button class="tab-btn" id="install-tab-macos" data-tab="macos" role="tab" aria-selected="false" aria-controls="install-panel-macos" tabindex="-1">macOS</button>
+              <button class="tab-btn" id="install-tab-windows" data-tab="windows" role="tab" aria-selected="false" aria-controls="install-panel-windows" tabindex="-1">Windows</button>
               <span class="ml-auto self-center pr-3 text-[10px] text-mute-500 uppercase tracking-wide">install</span>
             </div>
-<pre class="code-tab-panel" data-tab-panel="linux"><span class="tk-com"># Install over TLS. install.sh is minisign-signed (verify it below);</span>
-<span class="tk-com"># it SHA-256-checks each binary against the manifest as it downloads.</span>
+<pre class="code-tab-panel" id="install-panel-linux" role="tabpanel" aria-labelledby="install-tab-linux" tabindex="0" data-tab-panel="linux"><span class="tk-com"># Install over TLS. install.sh SHA-256-checks each binary against the</span>
+<span class="tk-com"># release manifest as it downloads. Verify the installer/signature below.</span>
 $ curl -fsSL <span class="tk-str">https://gethull.dev/install.sh</span> | sh
 hull installed to ~/.local/bin/hull  (<span data-hull-version>v0.14.0</span>)
 </pre>
-<pre class="code-tab-panel hidden" data-tab-panel="macos"><span class="tk-com"># Same signed installer; it auto-detects macOS arm64 (or the universal</span>
+<pre class="code-tab-panel hidden" id="install-panel-macos" role="tabpanel" aria-labelledby="install-tab-macos" tabindex="0" data-tab-panel="macos"><span class="tk-com"># Same signed installer; it auto-detects macOS arm64 (or the universal</span>
 <span class="tk-com"># Cosmopolitan APE fallback) and SHA-256-checks each binary it downloads.</span>
 $ curl -fsSL <span class="tk-str">https://gethull.dev/install.sh</span> | sh
 hull installed to ~/.local/bin/hull  (<span data-hull-version>v0.14.0</span>)
 </pre>
-<pre class="code-tab-panel hidden" data-tab-panel="windows"><span class="tk-com"># PowerShell, no admin or Developer Mode needed. Installs hull.com and</span>
+<pre class="code-tab-panel hidden" id="install-panel-windows" role="tabpanel" aria-labelledby="install-tab-windows" tabindex="0" data-tab-panel="windows"><span class="tk-com"># PowerShell, no admin or Developer Mode needed. Installs hull.com and</span>
 <span class="tk-com"># adds it to your user PATH; SHA-256-checked against the manifest.</span>
 PS&gt; <span class="tk-fn">irm</span> <span class="tk-str">https://gethull.dev/install.ps1</span> | <span class="tk-fn">iex</span>
 hull installed to %LOCALAPPDATA%\Programs\Hull\hull.com  (<span data-hull-version>v0.14.0</span>)
 </pre>
           </div>
-          <div class="code-block mt-3">
-            <header>
-              <i data-lucide="shield-check" class="w-3.5 h-3.5"></i>
-              <span>verify</span>
-              <span class="ml-auto text-[10px] text-mute-500">copy &amp; paste</span>
-            </header>
-<pre><span class="tk-com"># Don't trust gethull.dev? Verify the installer offline first</span>
-<span class="tk-com"># (minisign, no Hull needed). Cross-check the key below against</span>
-<span class="tk-com"># github.com/artalis-io/hull/blob/main/minisign.pub.</span>
+          <div class="code-block code-tabs mt-3">
+            <div class="code-tabs-bar" role="tablist" aria-label="Verify Hull by platform">
+              <button class="tab-btn tab-active" id="verify-tab-linux" data-tab="vlinux" role="tab" aria-selected="true" aria-controls="verify-panel-linux" tabindex="0">Linux</button>
+              <button class="tab-btn" id="verify-tab-macos" data-tab="vmacos" role="tab" aria-selected="false" aria-controls="verify-panel-macos" tabindex="-1">macOS</button>
+              <button class="tab-btn" id="verify-tab-windows" data-tab="vwindows" role="tab" aria-selected="false" aria-controls="verify-panel-windows" tabindex="-1">Windows</button>
+              <span class="ml-auto self-center pr-3 text-[10px] text-mute-500 uppercase tracking-wide">verify</span>
+            </div>
+<pre class="code-tab-panel" id="verify-panel-linux" role="tabpanel" aria-labelledby="verify-tab-linux" tabindex="0" data-tab-panel="vlinux"><span class="tk-com"># Don't trust gethull.dev? Verify the installer offline first (minisign,</span>
+<span class="tk-com"># no Hull needed). Cross-check the key at github.com/artalis-io/hull.</span>
 $ <span class="tk-kw">URL</span>=https://gethull.dev
 $ curl -fsSLO $URL/install.sh $URL/install.sh.minisig
 $ minisign -Vm install.sh -P <span class="tk-str">RWRqvc6NndheWcLIi3vsL+xoZfZw2j7fybSZ3rHJIOTHA2O3rrr6hD8h</span>
@@ -569,14 +569,34 @@ $ minisign -Vm install.sh -P <span class="tk-str">RWRqvc6NndheWcLIi3vsL+xoZfZw2j
 $ sh install.sh
 
 <span class="tk-com"># Then verify the release signature (Ed25519, embedded pubkey).</span>
-<span class="tk-com"># Works on any OS; on Windows run it in PowerShell after install.</span>
 $ <span class="tk-kw">REL</span>=https://github.com/artalis-io/hull/releases/latest/download
 $ curl -fsSLO $REL/hull.sha256 $REL/hull.sha256.sig
 $ hull verify-release hull.sha256 hull.sha256.sig
 <span class="tk-acc">ok</span>. Signature valid
+</pre>
+<pre class="code-tab-panel hidden" id="verify-panel-macos" role="tabpanel" aria-labelledby="verify-tab-macos" tabindex="0" data-tab-panel="vmacos"><span class="tk-com"># Same as Linux: verify the installer offline with minisign (no Hull</span>
+<span class="tk-com"># needed), cross-checking the key at github.com/artalis-io/hull.</span>
+$ <span class="tk-kw">URL</span>=https://gethull.dev
+$ curl -fsSLO $URL/install.sh $URL/install.sh.minisig
+$ minisign -Vm install.sh -P <span class="tk-str">RWRqvc6NndheWcLIi3vsL+xoZfZw2j7fybSZ3rHJIOTHA2O3rrr6hD8h</span>
+<span class="tk-acc">Signature and comment signature verified</span>
+$ sh install.sh
 
-$ hull doctor
-hull <span data-hull-version>v0.14.0</span>  &middot;  ca-bundle: embedded  &middot;  platform: embedded  &middot;  cc: ok
+<span class="tk-com"># Then verify the release signature (Ed25519, embedded pubkey).</span>
+$ <span class="tk-kw">REL</span>=https://github.com/artalis-io/hull/releases/latest/download
+$ curl -fsSLO $REL/hull.sha256 $REL/hull.sha256.sig
+$ hull verify-release hull.sha256 hull.sha256.sig
+<span class="tk-acc">ok</span>. Signature valid
+</pre>
+<pre class="code-tab-panel hidden" id="verify-panel-windows" role="tabpanel" aria-labelledby="verify-tab-windows" tabindex="0" data-tab-panel="vwindows"><span class="tk-com"># PowerShell. Verify the Ed25519 release signature after install</span>
+<span class="tk-com"># (embedded pubkey). No minisign needed.</span>
+PS&gt; <span class="tk-kw">$REL</span> = <span class="tk-str">"https://github.com/artalis-io/hull/releases/latest/download"</span>
+PS&gt; <span class="tk-fn">iwr</span> <span class="tk-str">"$REL/hull.sha256"</span> -OutFile hull.sha256
+PS&gt; <span class="tk-fn">iwr</span> <span class="tk-str">"$REL/hull.sha256.sig"</span> -OutFile hull.sha256.sig
+PS&gt; hull verify-release hull.sha256 hull.sha256.sig
+<span class="tk-acc">ok</span>. Signature valid
+
+<span class="tk-com"># Or verify in the browser, no Hull needed: gethull.dev/verify.html</span>
 </pre>
           </div>
           <p class="mt-3 text-[11px] text-mute-400 leading-relaxed">
@@ -2027,23 +2047,42 @@ $ hull agent routes my-tool
     // framework, no hydration.
     if (window.lucide) { lucide.createIcons(); }
 
-    // Tabbed code blocks. Each .code-tabs container has its own bar
-    // of [data-tab] buttons and [data-tab-panel] panes; switching is
-    // scoped to the container so multiple tabbed blocks coexist.
+    // Tabbed code blocks. Each .code-tabs container has its own bar of
+    // [data-tab] buttons and [data-tab-panel] panes; switching is scoped to the
+    // container so multiple tabbed blocks coexist. Follows the ARIA tabs pattern
+    // with automatic activation: roving tabindex (active tab is the only tab
+    // stop) plus Left/Right/Up/Down/Home/End to move + activate.
     document.querySelectorAll('.code-tabs').forEach((container) => {
-        const buttons = container.querySelectorAll('.tab-btn');
+        const buttons = Array.from(container.querySelectorAll('.tab-btn'));
         const panels  = container.querySelectorAll('.code-tab-panel');
-        buttons.forEach((btn) => {
-            btn.addEventListener('click', () => {
-                const target = btn.dataset.tab;
-                buttons.forEach((b) => {
-                    const active = b.dataset.tab === target;
-                    b.classList.toggle('tab-active', active);
-                    b.setAttribute('aria-selected', active ? 'true' : 'false');
-                });
-                panels.forEach((p) => {
-                    p.classList.toggle('hidden', p.dataset.tabPanel !== target);
-                });
+        if (!buttons.length) return;
+
+        const activate = (btn, focus) => {
+            const target = btn.dataset.tab;
+            buttons.forEach((b) => {
+                const active = b.dataset.tab === target;
+                b.classList.toggle('tab-active', active);
+                b.setAttribute('aria-selected', active ? 'true' : 'false');
+                b.tabIndex = active ? 0 : -1;   // roving tabindex
+            });
+            panels.forEach((p) => {
+                p.classList.toggle('hidden', p.dataset.tabPanel !== target);
+            });
+            if (focus) btn.focus();
+        };
+
+        // Initialise the roving tabindex from the initial active tab.
+        buttons.forEach((b) => { b.tabIndex = b.classList.contains('tab-active') ? 0 : -1; });
+
+        buttons.forEach((btn, i) => {
+            btn.addEventListener('click', () => activate(btn, false));
+            btn.addEventListener('keydown', (e) => {
+                let j = null;
+                if (e.key === 'ArrowRight' || e.key === 'ArrowDown') j = (i + 1) % buttons.length;
+                else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') j = (i - 1 + buttons.length) % buttons.length;
+                else if (e.key === 'Home') j = 0;
+                else if (e.key === 'End') j = buttons.length - 1;
+                if (j !== null) { e.preventDefault(); activate(buttons[j], true); }
             });
         });
     });

--- a/tests/check_docs_integrity.sh
+++ b/tests/check_docs_integrity.sh
@@ -6,7 +6,8 @@
 #
 #   1. CATALOG      every top-level docs/*.md is catalogued in docs/README.md
 #   2. LINKS        every relative Markdown link (in docs/** + the root
-#                   README/CONTRIBUTING/SECURITY) resolves to an existing file
+#                   README/CONTRIBUTING/SECURITY/CLAUDE/AGENTS/BOOTSTRAP)
+#                   resolves to an existing file
 #   3. ARCHIVE      every file under docs/archive/ is inventoried by
 #                   docs/archive/README.md (archived docs are classified as
 #                   historical, never floating as pseudo-active specs)
@@ -83,7 +84,8 @@ check_catalog() {
 check_links() {
     before=$FAIL
     files=$( { ls docs/*.md 2>/dev/null; find docs -name 'README.md';
-               printf '%s\n' README.md CONTRIBUTING.md SECURITY.md; } | sort -u)
+               printf '%s\n' README.md CONTRIBUTING.md SECURITY.md \
+                             CLAUDE.md AGENTS.md BOOTSTRAP.md; } | sort -u)
     printf '%s\n' "$files" | while IFS= read -r src; do
         [ -f "$src" ] || continue
         dir=$(dirname "$src")

--- a/tests/check_site_consistency.sh
+++ b/tests/check_site_consistency.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# tests/check_site_consistency.sh - drift gate for the marketing site (site/).
+#
+# Keeps the landing page from silently going stale against a release. Three
+# checks, each fatal:
+#
+#   1. VERSION   the "current version" the site advertises matches the latest
+#                released version in CHANGELOG.md - both the JSON-LD
+#                softwareVersion and every element tagged `data-hull-version`.
+#   2. TABS      the install section keeps its three platform tabs
+#                (data-tab="linux" / "macos" / "windows").
+#   3. WINDOWS   the Windows PowerShell installer (install.ps1) is still offered.
+#
+# So when a release is cut, whoever bumps CHANGELOG.md must also bump the site's
+# version markers, or this gate fails. Historical per-feature ship-tags (e.g.
+# "Compiler-free builds (v0.10.0)") are deliberately NOT touched - only the
+# `data-hull-version` / softwareVersion "current version" surface is enforced.
+#
+# POSIX sh. Wired into `make lint` (target: check-site-consistency); the negative
+# self-test tests/check_site_consistency_selftest.sh proves it bites.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -u
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$ROOT" || exit 2
+
+SITE=site/index.html
+CHANGELOG=CHANGELOG.md
+MIN_MARKERS=5
+
+FAIL=0
+err() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; FAIL=$((FAIL + 1)); }
+ok()  { printf '  \033[32mok\033[0m   %s\n' "$1"; }
+
+[ -f "$SITE" ]      || { echo "check_site_consistency: missing $SITE"; exit 2; }
+[ -f "$CHANGELOG" ] || { echo "check_site_consistency: missing $CHANGELOG"; exit 2; }
+
+# Latest RELEASED version = the first versioned heading in CHANGELOG.md. The
+# leading "## [Unreleased]" heading has no digits, so it is skipped.
+CURRENT=$(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$CHANGELOG" | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+[ -n "$CURRENT" ] || { echo "check_site_consistency: cannot parse latest version from $CHANGELOG"; exit 2; }
+
+echo "site-consistency gate (latest release v$CURRENT):"
+
+# ── 1. VERSION ────────────────────────────────────────────────────────────────
+# 1a. JSON-LD softwareVersion (no leading v).
+if grep -q "\"softwareVersion\": \"$CURRENT\"" "$SITE"; then
+    ok "1/VERSION: JSON-LD softwareVersion is $CURRENT"
+else
+    err "1/VERSION: JSON-LD softwareVersion is not \"$CURRENT\" (bump it in $SITE)"
+fi
+
+# 1b. Every data-hull-version element must advertise v$CURRENT, and there must be
+# at least MIN_MARKERS of them (so they cannot be silently deleted to pass).
+markers=$(grep -c 'data-hull-version' "$SITE")
+if [ "$markers" -lt "$MIN_MARKERS" ]; then
+    err "1/VERSION: expected >=$MIN_MARKERS data-hull-version markers in $SITE, found $markers (markers removed?)"
+else
+    stale=$(grep -n 'data-hull-version' "$SITE" | grep -v "v$CURRENT" || true)
+    if [ -n "$stale" ]; then
+        err "1/VERSION: data-hull-version marker(s) do not read v$CURRENT:"
+        printf '%s\n' "$stale" | sed 's/^/        /'
+    else
+        ok "1/VERSION: all $markers data-hull-version markers read v$CURRENT"
+    fi
+fi
+
+# ── 2. TABS ───────────────────────────────────────────────────────────────────
+before=$FAIL
+for p in linux macos windows; do
+    grep -q "data-tab=\"$p\"" "$SITE" \
+        || err "2/TABS: install platform tab '$p' (data-tab=\"$p\") is missing from $SITE"
+done
+[ "$FAIL" -eq "$before" ] && ok "2/TABS: Linux / macOS / Windows install tabs present"
+
+# ── 3. WINDOWS ────────────────────────────────────────────────────────────────
+if grep -q 'install\.ps1' "$SITE"; then
+    ok "3/WINDOWS: install.ps1 (Windows PowerShell installer) is offered"
+else
+    err "3/WINDOWS: $SITE does not offer install.ps1 (the Windows installer)"
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+    printf '\n\033[31m%d site-consistency violation(s).\033[0m\n' "$FAIL"
+    printf 'On a release, bump CHANGELOG.md AND the site version markers together.\n'
+    exit 1
+fi
+printf '\n\033[32mAll site-consistency checks passed.\033[0m\n'
+exit 0

--- a/tests/check_site_consistency.sh
+++ b/tests/check_site_consistency.sh
@@ -1,20 +1,26 @@
 #!/bin/sh
 # tests/check_site_consistency.sh - drift gate for the marketing site (site/).
 #
-# Keeps the landing page from silently going stale against a release. Three
-# checks, each fatal:
+# Keeps the landing page from silently going stale against a release, and keeps
+# the install/verify tabs real (not just decorative buttons). Three checks, each
+# fatal:
 #
 #   1. VERSION   the "current version" the site advertises matches the latest
 #                released version in CHANGELOG.md - both the JSON-LD
 #                softwareVersion and every element tagged `data-hull-version`.
-#   2. TABS      the install section keeps its three platform tabs
-#                (data-tab="linux" / "macos" / "windows").
-#   3. WINDOWS   the Windows PowerShell installer (install.ps1) is still offered.
+#   2. TABS      the install section has three accessible platform tab PANELS
+#                (Linux / macOS / Windows), each a role="tabpanel" wired to its
+#                tab (aria-controls / aria-labelledby) and carrying the correct
+#                platform installer URL - and NOT the other platform's.
+#   3. WINDOWS   the verify block has a Windows PowerShell panel that runs
+#                `hull verify-release` and does NOT hand Windows users POSIX shell
+#                syntax (curl / bare VAR=... assignments).
 #
-# So when a release is cut, whoever bumps CHANGELOG.md must also bump the site's
-# version markers, or this gate fails. Historical per-feature ship-tags (e.g.
-# "Compiler-free builds (v0.10.0)") are deliberately NOT touched - only the
-# `data-hull-version` / softwareVersion "current version" surface is enforced.
+# So a release bump has to update CHANGELOG.md and the site's version markers
+# together, and the platform tabs cannot regress to buttons-without-content or a
+# wrong-platform command. Historical per-feature ship-tags (e.g. "Compiler-free
+# builds (v0.10.0)") are deliberately NOT touched - only the `data-hull-version`
+# / softwareVersion "current version" surface is enforced.
 #
 # POSIX sh. Wired into `make lint` (target: check-site-consistency); the negative
 # self-test tests/check_site_consistency_selftest.sh proves it bites.
@@ -29,6 +35,8 @@ cd "$ROOT" || exit 2
 SITE=site/index.html
 CHANGELOG=CHANGELOG.md
 MIN_MARKERS=5
+UNIX_URL='https://gethull.dev/install.sh'
+WIN_URL='https://gethull.dev/install.ps1'
 
 FAIL=0
 err() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; FAIL=$((FAIL + 1)); }
@@ -36,6 +44,9 @@ ok()  { printf '  \033[32mok\033[0m   %s\n' "$1"; }
 
 [ -f "$SITE" ]      || { echo "check_site_consistency: missing $SITE"; exit 2; }
 [ -f "$CHANGELOG" ] || { echo "check_site_consistency: missing $CHANGELOG"; exit 2; }
+
+# The block of an element from the line carrying id="<id>" up to the next </pre>.
+panel_block() { awk -v id="$1" '$0 ~ ("id=\"" id "\"") {f=1} f{print} /<\/pre>/{if(f){exit}}' "$SITE"; }
 
 # Latest RELEASED version = the first versioned heading in CHANGELOG.md. The
 # leading "## [Unreleased]" heading has no digits, so it is skipped.
@@ -45,15 +56,12 @@ CURRENT=$(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$CHANGELOG" | head -1 | gre
 echo "site-consistency gate (latest release v$CURRENT):"
 
 # ── 1. VERSION ────────────────────────────────────────────────────────────────
-# 1a. JSON-LD softwareVersion (no leading v).
 if grep -q "\"softwareVersion\": \"$CURRENT\"" "$SITE"; then
     ok "1/VERSION: JSON-LD softwareVersion is $CURRENT"
 else
     err "1/VERSION: JSON-LD softwareVersion is not \"$CURRENT\" (bump it in $SITE)"
 fi
 
-# 1b. Every data-hull-version element must advertise v$CURRENT, and there must be
-# at least MIN_MARKERS of them (so they cannot be silently deleted to pass).
 markers=$(grep -c 'data-hull-version' "$SITE")
 if [ "$markers" -lt "$MIN_MARKERS" ]; then
     err "1/VERSION: expected >=$MIN_MARKERS data-hull-version markers in $SITE, found $markers (markers removed?)"
@@ -67,24 +75,51 @@ else
     fi
 fi
 
-# ── 2. TABS ───────────────────────────────────────────────────────────────────
+# ── 2. TABS: three accessible install panels with the right installer URLs ─────
 before=$FAIL
-for p in linux macos windows; do
-    grep -q "data-tab=\"$p\"" "$SITE" \
-        || err "2/TABS: install platform tab '$p' (data-tab=\"$p\") is missing from $SITE"
-done
-[ "$FAIL" -eq "$before" ] && ok "2/TABS: Linux / macOS / Windows install tabs present"
+check_install_panel() {
+    plat=$1; want=$2; forbid=$3
+    grep -q "id=\"install-tab-$plat\"" "$SITE" \
+        || { err "2/TABS: missing install tab button install-tab-$plat"; return; }
+    grep -q "aria-controls=\"install-panel-$plat\"" "$SITE" \
+        || err "2/TABS: install-tab-$plat has no aria-controls to install-panel-$plat"
+    b=$(panel_block "install-panel-$plat")
+    [ -n "$b" ] || { err "2/TABS: missing install tab panel install-panel-$plat"; return; }
+    printf '%s\n' "$b" | grep -q 'role="tabpanel"' \
+        || err "2/TABS: install-panel-$plat is not role=\"tabpanel\""
+    printf '%s\n' "$b" | grep -q "aria-labelledby=\"install-tab-$plat\"" \
+        || err "2/TABS: install-panel-$plat has no aria-labelledby to its tab"
+    printf '%s\n' "$b" | grep -qF "$want" \
+        || err "2/TABS: install-panel-$plat does not show its installer URL ($want)"
+    if printf '%s\n' "$b" | grep -qF "$forbid"; then
+        err "2/TABS: install-panel-$plat shows the wrong-platform installer ($forbid)"
+    fi
+}
+check_install_panel linux   "$UNIX_URL" "$WIN_URL"
+check_install_panel macos   "$UNIX_URL" "$WIN_URL"
+check_install_panel windows "$WIN_URL"  "$UNIX_URL"
+[ "$FAIL" -eq "$before" ] && ok "2/TABS: Linux/macOS/Windows install panels wired + correct installer URLs"
 
-# ── 3. WINDOWS ────────────────────────────────────────────────────────────────
-if grep -q 'install\.ps1' "$SITE"; then
-    ok "3/WINDOWS: install.ps1 (Windows PowerShell installer) is offered"
+# ── 3. WINDOWS: the verify block gives Windows a PowerShell path, not POSIX ────
+before=$FAIL
+vb=$(panel_block "verify-panel-windows")
+if [ -z "$vb" ]; then
+    err "3/WINDOWS: missing verify-panel-windows (Windows has no PowerShell verify path)"
 else
-    err "3/WINDOWS: $SITE does not offer install.ps1 (the Windows installer)"
+    printf '%s\n' "$vb" | grep -q 'role="tabpanel"' \
+        || err "3/WINDOWS: verify-panel-windows is not role=\"tabpanel\""
+    printf '%s\n' "$vb" | grep -q 'hull verify-release' \
+        || err "3/WINDOWS: verify-panel-windows does not run hull verify-release"
+    if printf '%s\n' "$vb" | grep -qE 'curl |[A-Z]+=https'; then
+        err "3/WINDOWS: verify-panel-windows uses POSIX shell syntax (must be PowerShell)"
+    fi
 fi
+[ "$FAIL" -eq "$before" ] && ok "3/WINDOWS: Windows verify panel is PowerShell + runs hull verify-release"
 
 if [ "$FAIL" -ne 0 ]; then
     printf '\n\033[31m%d site-consistency violation(s).\033[0m\n' "$FAIL"
-    printf 'On a release, bump CHANGELOG.md AND the site version markers together.\n'
+    printf 'On a release, bump CHANGELOG.md AND the site version markers together;\n'
+    printf 'keep the Linux/macOS/Windows install panels + the Windows verify panel intact.\n'
     exit 1
 fi
 printf '\n\033[32mAll site-consistency checks passed.\033[0m\n'

--- a/tests/check_site_consistency_selftest.sh
+++ b/tests/check_site_consistency_selftest.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# tests/check_site_consistency_selftest.sh - deterministic NEGATIVE test.
+#
+# Proves check_site_consistency.sh is not a no-op: for each of its three checks
+# it injects a single representative violation into a COPY-restored site file,
+# asserts the gate exits non-zero AND reports that specific check, then restores.
+# Mirrors tests/check_docs_integrity_selftest.sh.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -u
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$ROOT" || exit 2
+
+GATE="sh tests/check_site_consistency.sh"
+SITE=site/index.html
+BAK="/tmp/hull_site_bak.$$"
+FAILED=0
+pass() { printf '  \033[32mok\033[0m   %s\n' "$1"; }
+bad()  { printf '  \033[31mFAIL\033[0m %s\n' "$1"; FAILED=$((FAILED + 1)); }
+
+cleanup() { [ -f "$BAK" ] && cp "$BAK" "$SITE" && rm -f "$BAK"; }
+trap cleanup EXIT INT TERM
+cp "$SITE" "$BAK"
+
+# expect_bite <check-id-substring> <label>: run the gate, require non-zero exit
+# AND that the named check appears in the output.
+expect_bite() {
+    id=$1; label=$2
+    out=$($GATE 2>&1); rc=$?
+    if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "$id"; then
+        pass "$label -> gate bites ($id)"
+    else
+        bad "$label -> gate did NOT bite (expected $id; rc=$rc)"
+    fi
+}
+
+echo "site-consistency self-test:"
+
+# Baseline: the real site must pass.
+if $GATE >/dev/null 2>&1; then pass "baseline: clean site passes"
+else bad "baseline: clean site should pass but did not"; fi
+
+# 1. VERSION - a data-hull-version marker that reads a stale version.
+cp "$BAK" "$SITE"
+printf '<span data-hull-version>v0.0.1</span>\n' >> "$SITE"
+expect_bite "1/VERSION" "stale data-hull-version marker"
+
+# 2. TABS - a missing platform tab (drop the Windows tab button).
+cp "$BAK" "$SITE"
+grep -v 'data-tab="windows"' "$BAK" > "$SITE"
+expect_bite "2/TABS" "missing install platform tab"
+
+# 3. WINDOWS - the Windows installer no longer offered.
+cp "$BAK" "$SITE"
+sed 's/install\.ps1/install_REMOVED/g' "$BAK" > "$SITE"
+expect_bite "3/WINDOWS" "install.ps1 not offered"
+
+# Restore and confirm the site is clean again.
+cp "$BAK" "$SITE"
+if $GATE >/dev/null 2>&1; then pass "site clean again after self-test"
+else bad "site not clean after self-test (restore failed?)"; fi
+
+if [ "$FAILED" -eq 0 ]; then
+    printf '\n\033[32msite-consistency self-test passed: all 3 checks bite.\033[0m\n'
+    exit 0
+fi
+printf '\n\033[31msite-consistency self-test FAILED (%d).\033[0m\n' "$FAILED"
+exit 1

--- a/tests/check_site_consistency_selftest.sh
+++ b/tests/check_site_consistency_selftest.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 # tests/check_site_consistency_selftest.sh - deterministic NEGATIVE test.
 #
-# Proves check_site_consistency.sh is not a no-op: for each of its three checks
-# it injects a single representative violation into a COPY-restored site file,
-# asserts the gate exits non-zero AND reports that specific check, then restores.
-# Mirrors tests/check_docs_integrity_selftest.sh.
+# Proves check_site_consistency.sh is not a no-op: it injects one representative
+# violation per check (plus the specific tab-content regressions the gate must
+# catch) into a COPY-restored site file, asserts the gate exits non-zero AND
+# reports that specific check, then restores. Mirrors
+# tests/check_docs_integrity_selftest.sh.
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -47,15 +48,20 @@ cp "$BAK" "$SITE"
 printf '<span data-hull-version>v0.0.1</span>\n' >> "$SITE"
 expect_bite "1/VERSION" "stale data-hull-version marker"
 
-# 2. TABS - a missing platform tab (drop the Windows tab button).
+# 2a. TABS - a MISSING install panel (drop the Windows panel's id).
 cp "$BAK" "$SITE"
-grep -v 'data-tab="windows"' "$BAK" > "$SITE"
-expect_bite "2/TABS" "missing install platform tab"
+sed 's/id="install-panel-windows"/id="install-panel-GONE"/' "$BAK" > "$SITE"
+expect_bite "2/TABS" "missing install tab panel"
 
-# 3. WINDOWS - the Windows installer no longer offered.
+# 2b. TABS - a WRONG-platform installer command (Windows panel shows install.sh).
 cp "$BAK" "$SITE"
-sed 's/install\.ps1/install_REMOVED/g' "$BAK" > "$SITE"
-expect_bite "3/WINDOWS" "install.ps1 not offered"
+sed 's#gethull.dev/install.ps1#gethull.dev/install.sh#g' "$BAK" > "$SITE"
+expect_bite "2/TABS" "wrong-platform installer in a panel"
+
+# 3. WINDOWS - the Windows verify panel handed POSIX shell syntax (iwr -> curl).
+cp "$BAK" "$SITE"
+sed 's/iwr/curl -fsSL/g' "$BAK" > "$SITE"
+expect_bite "3/WINDOWS" "Windows verify panel using POSIX syntax"
 
 # Restore and confirm the site is clean again.
 cp "$BAK" "$SITE"
@@ -63,7 +69,7 @@ if $GATE >/dev/null 2>&1; then pass "site clean again after self-test"
 else bad "site not clean after self-test (restore failed?)"; fi
 
 if [ "$FAILED" -eq 0 ]; then
-    printf '\n\033[32msite-consistency self-test passed: all 3 checks bite.\033[0m\n'
+    printf '\n\033[32msite-consistency self-test passed: all checks bite.\033[0m\n'
     exit 0
 fi
 printf '\n\033[31msite-consistency self-test FAILED (%d).\033[0m\n' "$FAILED"


### PR DESCRIPTION
The documentation/site consistency slice. The marketing site still advertised **v0.10.0** as current while the release is v0.14.0. This makes the docs/site consistent across platforms and adds protection so they cannot silently drift again.

## Scope (as agreed)
- **Platform tabs (Linux / macOS / Windows)** on the site install section.
- **Audit README / CLAUDE / AGENTS / BOOTSTRAP references.**
- **Refresh the stale site narrative + generated output** (v0.10.0 → v0.14.0).
- **Add drift/link protection.**

## Changes
- **site/index.html**
  - Bump every *current-version* surface to v0.14.0: JSON-LD `softwareVersion`, nav badge, "Shipped through" header, the install + `hull doctor` example outputs, and the footer. Each is tagged with a machine-checkable `data-hull-version` marker.
  - **Historical per-feature ship-tags** (e.g. "Compiler-free builds (v0.10.0)") are deliberately left unchanged.
  - Convert the install code-block into **three platform tabs** (Linux / macOS / Windows), adding the Windows `irm https://gethull.dev/install.ps1 | iex` path, and split the trust flow (minisign + `hull verify-release` + `hull doctor`) into a shared verify block.
- **BOOTSTRAP.md** — add the Windows PowerShell install path (was Linux/macOS only) + bump the version-pin example. **AGENTS.md** — bump example outputs to 0.14.0.
- **Link protection** — extend `check_docs_integrity.sh` LINKS to also resolve relative links in `CLAUDE.md` / `AGENTS.md` / `BOOTSTRAP.md` (previously unchecked; audit found none broken, now gated).
- **Drift protection** — new `check_site_consistency.sh` (+ negative self-test): fails unless the site's current-version surface matches the latest `CHANGELOG.md` release, the three install tabs exist, and `install.ps1` is offered. Wired into `make lint` and the CI `Lint` job. A release bump now has to update CHANGELOG and the site together.

## Out of scope (untouched, per standing hold)
Slice E (Authenticode), external Winget/Scoop submission, BuildContext.

## Local verification
`check-docs-integrity`(+selftest), `check-no-emdash`, `check-no-milestone-narration`, `check-site-consistency`(+selftest) all green; site builds; new scripts POSIX-clean.