### PR TITLE
fix(sandbox): fail closed when Linux lacks Landlock

### DIFF
--- a/docs/agent_guide.md
+++ b/docs/agent_guide.md
@@ -340,6 +340,9 @@ Grouped by purpose. Run `hull <cmd> --help` for full per-command flags.
 --tls-cert / --tls-key   TLS certs
 --no-migrate         Skip auto-run migrations
 --no-sandbox         Disable kernel sandbox (debug)
+--allow-degraded-sandbox
+                     Linux only: explicitly allow seccomp + Hull capability
+                     enforcement when the kernel has no Landlock support
 --audit              Enable capability audit JSON logging
 --max-instructions N Override instruction limit (default 100m)
 --max-connections N  Max concurrent connections (default 256)

--- a/docs/security.md
+++ b/docs/security.md
@@ -518,6 +518,14 @@ Trust chain: Customer → You (platform builder) → App developer. gethull.dev 
 | W^X / dynamic code | seccomp-bpf denies `mmap` and `mprotect` adding `PROT_EXEC`; `memfd_create` returns ENOSYS; `execve`/`execveat`/`ptrace`/`process_vm_*` are not in any granted promise group | SIGKILL or ENOSYS |
 | Mode | `__pledge_mode = KILL_PROCESS \| STDERR_LOGGING` | Process killed + diagnostic to stderr |
 
+Hull probes the Landlock ABI before loading application code. If the kernel was
+built without Landlock, startup fails closed instead of silently treating the
+vendored `unveil()` compatibility no-op as filesystem confinement. Operators on
+such kernels may pass `--allow-degraded-sandbox` to retain seccomp, W^X, and the
+C capability layer while explicitly accepting that filesystem paths lack the
+second, kernel-enforced Landlock boundary. This is safer than `--no-sandbox`,
+but it is not equivalent to the full Linux sandbox and is logged as degraded.
+
 **Allowed pledge promises:** `stdio inet rpath wpath cpath flock dns` (dns only if hosts declared). Notably absent: `prot_exec`, `exec`, `proc`. These grant the very syscalls Hull's W^X policy forbids.
 
 **CVE classes prevented:**

--- a/include/hull/sandbox.h
+++ b/include/hull/sandbox.h
@@ -94,6 +94,12 @@ typedef struct HlSandboxPolicy {
     int wx_enforced;
     int allow_dynamic_code;
     int allow_dynamic_libraries;
+
+    /* Linux only: permit the seccomp + capability-layer fallback when the
+     * running kernel has no Landlock filesystem LSM.  This is deliberately
+     * operator policy rather than a manifest capability: application code
+     * must not be able to downgrade its own kernel confinement. */
+    int allow_degraded;
 } HlSandboxPolicy;
 
 /*

--- a/src/hull/sandbox.c
+++ b/src/hull/sandbox.c
@@ -22,6 +22,7 @@
 #include "hull/cap/db_backend.h"   /* hl_db_feature_backends: detect a composed DuckDB feature */
 #endif
 
+#include <errno.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -145,6 +146,26 @@ static int sb_supported(void) { return 1; }
 extern int pledge(const char *promises, const char *execpromises);
 extern int unveil(const char *path, const char *permissions);
 extern int __pledge_mode;
+extern int landlock_create_ruleset(const void *attr, size_t size,
+                                    unsigned int flags);
+
+/* LANDLOCK_CREATE_RULESET_VERSION has been stable since Landlock's first ABI.
+ * Declare the value locally so Hull still builds with old libc kernel headers. */
+#define HL_LANDLOCK_CREATE_RULESET_VERSION 1u
+
+static int linux_landlock_abi(void)
+{
+    static int probed;
+    static int abi;
+    if (!probed) {
+        int saved_errno = errno;
+        abi = landlock_create_ruleset(NULL, 0,
+                                      HL_LANDLOCK_CREATE_RULESET_VERSION);
+        errno = saved_errno;
+        probed = 1;
+    }
+    return abi;
+}
 
 static int sb_supported(void) { return 1; }
 
@@ -576,6 +597,11 @@ int hl_sandbox_apply_pledge(void)
 #endif
 
 #ifdef __linux__
+    if (linux_landlock_abi() < 1) {
+        log_warn("[sandbox] Landlock unavailable in this Linux kernel; "
+                 "phase 1 will apply seccomp only. Phase 2 will fail closed "
+                 "unless --allow-degraded-sandbox is set");
+    }
     __pledge_mode = 0x0001 | 0x0010; /* KILL_PROCESS | STDERR_LOGGING */
 #endif
 
@@ -656,6 +682,22 @@ int hl_sandbox_apply(const HlSandboxPolicy *policy, const char *app_dir,
         log_info("[sandbox] kernel sandbox not available on this platform");
         return 0;
     }
+
+#ifdef __linux__
+    int landlock_abi = linux_landlock_abi();
+    if (landlock_abi < 1 && !policy->allow_degraded) {
+        log_error("[sandbox] Landlock filesystem confinement is unavailable "
+                  "in this Linux kernel - refusing to report a full sandbox. "
+                  "Enable CONFIG_SECURITY_LANDLOCK, or explicitly use "
+                  "--allow-degraded-sandbox for seccomp + Hull capability "
+                  "enforcement");
+        return -1;
+    }
+    if (landlock_abi < 1) {
+        log_warn("[sandbox] DEGRADED: Landlock unavailable; filesystem paths "
+                 "are enforced by Hull's capability layer, not by the kernel");
+    }
+#endif
 
 #ifdef __APPLE__
     /* ── macOS: Hardened Runtime check (release-only fail-closed) ─
@@ -973,8 +1015,16 @@ int hl_sandbox_apply(const HlSandboxPolicy *policy, const char *app_dir,
         return -1;
     }
 
-    log_info("[sandbox] applied (unveil: %d read, %d write; pledge: %s)",
-             policy->fs_read_count, policy->fs_write_count, promises);
+#if defined(__linux__)
+    if (landlock_abi < 1) {
+        log_warn("[sandbox] applied DEGRADED (filesystem: capability layer; "
+                 "syscalls: seccomp pledge: %s)", promises);
+    } else
+#endif
+    {
+        log_info("[sandbox] applied (unveil: %d read, %d write; pledge: %s)",
+                 policy->fs_read_count, policy->fs_write_count, promises);
+    }
 
     return 0;
 }
@@ -1086,4 +1136,5 @@ void hl_sandbox_policy_from_manifest(HlSandboxPolicy *policy,
      * (deny). `hl_sandbox_apply` enforces the W^X conflict check. */
     policy->allow_dynamic_code      = manifest->allow_dynamic_code;
     policy->allow_dynamic_libraries = manifest->allow_dynamic_libraries;
+    policy->allow_degraded = 0;
 }

--- a/src/hull/serve.c
+++ b/src/hull/serve.c
@@ -263,6 +263,9 @@ static void usage(const char *prog)
             "  --workers N          Thread pool worker count (default: 4)\n"
             "  --queue-capacity N   Thread pool queue capacity (default: 64)\n"
             "  --no-compress        Disable response compression\n"
+            "  --allow-degraded-sandbox\n"
+            "                       Allow seccomp + capability enforcement when Linux\n"
+            "                       Landlock filesystem confinement is unavailable\n"
             "  --no-sandbox         Disable kernel sandbox (dev/debug only)\n"
             "\n"
             "WASM compute options:\n"
@@ -337,6 +340,7 @@ typedef struct {
     int log_level;
     int no_migrate;
     int no_sandbox;
+    int allow_degraded_sandbox;
     int no_db;
     int no_compress;
     int no_verify_platform;  /* skip gethull platform-sig check on --verify-sig */
@@ -429,6 +433,8 @@ static int hl_parse_serve_args(int argc, char **argv, HlServeConfig *cfg)
             cfg->no_migrate = 1;
         } else if (strcmp(argv[i], "--no-sandbox") == 0) {
             cfg->no_sandbox = 1;
+        } else if (strcmp(argv[i], "--allow-degraded-sandbox") == 0) {
+            cfg->allow_degraded_sandbox = 1;
         } else if (strcmp(argv[i], "--no-verify-platform") == 0) {
             cfg->no_verify_platform = 1;
         } else if (strcmp(argv[i], "--no-db") == 0) {
@@ -1647,6 +1653,7 @@ static int hl_serve_apply_sandbox(HlServerState *s)
     if (!s->cfg.no_sandbox) {
         HlSandboxPolicy sandbox_policy;
         hl_sandbox_policy_from_manifest(&sandbox_policy, &s->manifest);
+        sandbox_policy.allow_degraded = s->cfg.allow_degraded_sandbox;
 
         /* The `-d` default DSN lives in cfg, not the manifest, so
          * hl_sandbox_policy_from_manifest can't see it. A `-d postgres://...`

--- a/src/hull/serve_cli.c
+++ b/src/hull/serve_cli.c
@@ -72,6 +72,7 @@ static const char **build_env_allowlist(const HlManifest *m)
 static int cli_parse_args(int argc, char **argv,
                           int *out_app_argc, char ***out_app_argv,
                           int *out_no_migrate, int *out_no_sandbox,
+                          int *out_allow_degraded_sandbox,
                           const char **out_db_path)
 {
     int entry_idx = -1;
@@ -79,6 +80,7 @@ static int cli_parse_args(int argc, char **argv,
     *out_app_argv = NULL;
     *out_no_migrate = 0;
     *out_no_sandbox = 0;
+    *out_allow_degraded_sandbox = 0;
     *out_db_path = NULL;
 
     for (int i = 1; i < argc; i++) {
@@ -93,6 +95,10 @@ static int cli_parse_args(int argc, char **argv,
         }
         if (strcmp(argv[i], "--no-sandbox") == 0) {
             *out_no_sandbox = 1;
+            continue;
+        }
+        if (strcmp(argv[i], "--allow-degraded-sandbox") == 0) {
+            *out_allow_degraded_sandbox = 1;
             continue;
         }
         if (strcmp(argv[i], "-d") == 0 && i + 1 < argc) {
@@ -117,11 +123,12 @@ int hull_serve(int argc, char **argv)
 {
     int app_argc = 0;
     char **app_argv = NULL;
-    int no_migrate = 0, no_sandbox = 0;
+    int no_migrate = 0, no_sandbox = 0, allow_degraded_sandbox = 0;
     const char *db_path = NULL;
 
     int entry_idx = cli_parse_args(argc, argv, &app_argc, &app_argv,
-                                    &no_migrate, &no_sandbox, &db_path);
+                                    &no_migrate, &no_sandbox,
+                                    &allow_degraded_sandbox, &db_path);
     if (!db_path) db_path = getenv("HULL_DB");
 
     /* Resolve the entry point. A `hull build` binary embeds its app and is run
@@ -318,6 +325,7 @@ int hull_serve(int argc, char **argv)
     if (!no_sandbox) {
         HlSandboxPolicy sandbox_policy;
         hl_sandbox_policy_from_manifest(&sandbox_policy, &manifest);
+        sandbox_policy.allow_degraded = allow_degraded_sandbox;
         /* CLI mode → no inbound network. */
         sandbox_policy.network_inbound = 0;
 

--- a/vendor/pledge/libc/calls/unveil.c
+++ b/vendor/pledge/libc/calls/unveil.c
@@ -428,6 +428,15 @@ int sys_unveil_linux(const char *path, const char *permissions) {
 int unveil(const char *path, const char *permissions) {
   int e, rc;
   e = errno;
+  /* The ABI probe runs in a constructor.  Do not rely on its errno still
+   * being current when unveil() is called later: unrelated startup work may
+   * have changed errno.  Hull probes and reports this degraded state itself;
+   * the compatibility function must consistently retain its documented
+   * no-op behavior on kernels built without Landlock. */
+  if (landlock_abi_version < 1) {
+    errno = e;
+    return 0;
+  }
   /*if (IsGenuineBlink()) {
     rc = 0;  // blink doesn't support landlock
   } else if (IsLinux()) {*/


### PR DESCRIPTION
## Summary

- detect the Landlock ABI directly on Linux and fail closed when filesystem confinement is unavailable
- add an explicit operator-only `--allow-degraded-sandbox` escape hatch that retains seccomp and Hull capability enforcement
- make the vendored unveil fallback independent of stale `errno` and document the security posture

## Raspberry Pi Zero 2 W validation

Tested natively on Debian 13, Linux 6.18.39+rpt-rpi-v8, aarch64, with `CONFIG_SECURITY_LANDLOCK` disabled.

- full native Hull build succeeds
- default built app exits 1 with an explicit Landlock fail-closed error
- `--allow-degraded-sandbox` starts successfully with an explicit degraded warning
- live degraded process has `NoNewPrivs: 1`, `Seccomp: 2`, and two seccomp filters

No Raspberry Pi OS or system configuration was modified.

## Audit and tests

- `/c-audit`: no findings across memory safety, input validation, resource lifetimes, integer safety, races, capability boundaries, and downgrade handling
- `make`
- `make build/serve_cli.o`
- `make hardening`
- `make check-hardening` (3 pass, 0 fail; expected unsigned-local-build Hardened Runtime warning on macOS)
- docs integrity, no-em-dash, and no-milestone checks
- native aarch64 build and runtime verification on the affected Raspberry Pi Zero 2 W