### PR TITLE
Slice 3: route the PostgreSQL client transport onto Keel v3 (PgTransport)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1849,6 +1849,28 @@ jobs:
         timeout-minutes: 15
         run: make e2e-postgres
 
+  # The PostgreSQL-over-Keel transport unit test (cap/pg_transport.c) is
+  # HL_ENABLE_POSTGRES-gated, so the base `sanitizers` job does not build it. This
+  # standing leg builds + runs it under ASan+UBSan with LSan (on by default on
+  # Linux), giving durable coverage of the transport's allocation-preservation and
+  # descriptor-lifecycle behavior so it cannot silently regress.
+  pg-transport-sanitize:
+    needs: [classify]
+    if: needs.classify.outputs.run_db_postgres == 'true'
+    name: pg_transport ASan/LSan
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: true
+
+      - name: build test_pg_transport under ASan+UBSan (+LSan), Postgres enabled
+        run: make DEBUG=1 HL_ENABLE_POSTGRES=1 build/test_pg_transport
+
+      - name: run (LSan leak detection on by default on Linux)
+        run: ASAN_OPTIONS=detect_leaks=1 ./build/test_pg_transport
+
   # Real MySQL 8 in Docker: mysql:// DSN -> backend select -> handshake ->
   # parameterized db.exec / db.query (binary prepared statements) -> typed
   # decode; multi-statement migrations; db.async on a worker connection; the
@@ -2596,6 +2618,7 @@ jobs:
       - focused-js-frontend
       - focused-lua-frontend
       - postgres
+      - pg-transport-sanitize
       - mysql
       - valkey
       - analyze

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1850,7 +1850,7 @@ jobs:
         run: make e2e-postgres
 
   # The PostgreSQL-over-Keel unit tests (cap/pg_transport.c AND cap/pg_conn.c,
-  # which since checkpoint 3 drives its connection layer through the transport) are
+  # whose connection layer now drives through the transport) are
   # HL_ENABLE_POSTGRES-gated, so the base `sanitizers` / `build` jobs do not build
   # them. This standing leg builds + runs both under ASan+UBSan with LSan (on by
   # default on Linux), giving durable coverage of the transport's

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1849,11 +1849,13 @@ jobs:
         timeout-minutes: 15
         run: make e2e-postgres
 
-  # The PostgreSQL-over-Keel transport unit test (cap/pg_transport.c) is
-  # HL_ENABLE_POSTGRES-gated, so the base `sanitizers` job does not build it. This
-  # standing leg builds + runs it under ASan+UBSan with LSan (on by default on
-  # Linux), giving durable coverage of the transport's allocation-preservation and
-  # descriptor-lifecycle behavior so it cannot silently regress.
+  # The PostgreSQL-over-Keel unit tests (cap/pg_transport.c AND cap/pg_conn.c,
+  # which since checkpoint 3 drives its connection layer through the transport) are
+  # HL_ENABLE_POSTGRES-gated, so the base `sanitizers` / `build` jobs do not build
+  # them. This standing leg builds + runs both under ASan+UBSan with LSan (on by
+  # default on Linux), giving durable coverage of the transport's
+  # allocation-preservation and descriptor-lifecycle behavior AND the pg_conn
+  # codec / handshake / adopt path so neither can silently regress.
   pg-transport-sanitize:
     needs: [classify]
     if: needs.classify.outputs.run_db_postgres == 'true'
@@ -1865,11 +1867,14 @@ jobs:
         with:
           submodules: true
 
-      - name: build test_pg_transport under ASan+UBSan (+LSan), Postgres enabled
-        run: make DEBUG=1 HL_ENABLE_POSTGRES=1 build/test_pg_transport
+      - name: build test_pg_transport + test_pg_conn under ASan+UBSan (+LSan), Postgres enabled
+        run: make DEBUG=1 HL_ENABLE_POSTGRES=1 build/test_pg_transport build/test_pg_conn
 
-      - name: run (LSan leak detection on by default on Linux)
+      - name: run test_pg_transport (LSan leak detection on by default on Linux)
         run: ASAN_OPTIONS=detect_leaks=1 ./build/test_pg_transport
+
+      - name: run test_pg_conn (LSan leak detection on by default on Linux)
+        run: ASAN_OPTIONS=detect_leaks=1 ./build/test_pg_conn
 
   # Real MySQL 8 in Docker: mysql:// DSN -> backend select -> handshake ->
   # parameterized db.exec / db.query (binary prepared statements) -> typed

--- a/Makefile
+++ b/Makefile
@@ -850,10 +850,11 @@ ifneq ($(HL_ENABLE_SQLITE),1)
       $(CAP_SRCS))
 endif
 ifneq ($(HL_ENABLE_POSTGRES),1)
-  # PostgreSQL wire backend: codec + connection + the vtable.
+  # PostgreSQL wire backend: codec + connection + transport + the vtable.
   CAP_SRCS := $(filter-out \
       $(SRCDIR)/hull/cap/db_postgres.c \
       $(SRCDIR)/hull/cap/pg_conn.c \
+      $(SRCDIR)/hull/cap/pg_transport.c \
       $(SRCDIR)/hull/cap/pgwire.c, \
       $(CAP_SRCS))
 endif

--- a/docs/README.md
+++ b/docs/README.md
@@ -110,6 +110,7 @@ specific signature, parameter list, or return value.
 | [`sidecar_design.md`](sidecar_design.md) | Native sidecars - design only (Phase 0), not yet scheduled. |
 | [`smtp_keel_client_design.md`](smtp_keel_client_design.md) | Design-only transition of Hull SMTP from direct POSIX/blocking transport to an SMTP-owned composition of public Keel v3 primitives, preserving Hull policy and protocol ownership. |
 | [`smtp_keel_slice2c_plan.md`](smtp_keel_slice2c_plan.md) | Plan-only architectural gate for SMTP Slice 2c: moving the transport onto a bounded worker (model 2), with frozen decisions for worker ownership, the linearizable op state machine, the post-resolution deadline, the SMTP pool cap, verified backend-shutdown ownership, TLS trust-material ownership, and the zero-Keel link seam. |
+| [`pg_keel_transport_slice3.md`](pg_keel_transport_slice3.md) | Decisions record for routing the PostgreSQL client transport onto Keel v3 (Slice 3): `KlConnectOp` racing with raw `KlSocketProvider` blocking I/O (no `KlStream`), TLS kept on `hl_tls_client_*`, a TCP-only connect deadline, no async DNS (IP literals via `kl_sockaddr_parse`, hostnames via a blocking `getaddrinfo` adapter), whole-connection transport ownership, an adopt path preserving `hl_pg_conn_start`, and the zero-Keel-in-a-non-Postgres-app link seam. |
 
 ### Roadmap
 

--- a/docs/pg_keel_transport_slice3.md
+++ b/docs/pg_keel_transport_slice3.md
@@ -21,10 +21,14 @@ RFC 8305 Happy-Eyeballs racing, and a provider test seam for the DB client.
 
 Multi-address connection racing uses `KlConnectOp`. Socket creation, connect
 completion, blocking read/write, and close use the raw provider ops
-(`sp->ops->{socket,connect,close,send,recv,set_blocking,set_nonblocking,set_cloexec,set_nosigpipe,get_so_error}`,
-all in `keel/socket.h`). `KlStream` is not used: its queued-write, watcher, and
-lifecycle machinery serve an asynchronous client, and a synchronous PostgreSQL
-connection needs none of it.
+(`sp->ops->{socket,connect,close,send,recv,set_blocking,set_nonblocking,get_so_error}`,
+all in `keel/socket.h`), plus best-effort `set_nosigpipe` where the platform
+offers it. `set_cloexec` is deliberately NOT used: neither the current
+`pg_conn.c` nor the SMTP transport sets close-on-exec (the kernel sandbox blocks
+`exec` outright), so the transport does not require or call it and it is not part
+of the required provider surface. `KlStream` is not used either: its queued-write,
+watcher, and lifecycle machinery serve an asynchronous client, and a synchronous
+PostgreSQL connection needs none of it.
 
 `KlConnectOp` is asynchronous and needs an event loop to drive its attempts plus
 the stagger and deadline timers. The transport therefore owns a private
@@ -63,9 +67,13 @@ absolute connect deadline and gives its remaining budget to `KlConnectOp`'s
 timers must not refresh that deadline. When `timeout_ms <= 0` the transport arms
 no deadline, preserving today's unbounded-connect behavior. On terminal failure
 or timeout the transport calls `kl_connect_op_cancel` and pumps the private loop
-until confirmed detachment (`on_detach` sets `connect_detached`) before freeing
-embedded storage, honoring the "no reuse until confirmed detachment" invariant in
-`keel/connect_op_detail.h`.
+until confirmed detachment before freeing storage, honoring the "no reuse until
+confirmed detachment" invariant in `keel/connect_op_detail.h`. Detachment is
+observed by POLLING `kl_connect_op_is_detached` in the teardown pump; the
+transport installs no `on_detach` callback (the `KlConnectOpHooks.on_detach` slot
+is left NULL) and keeps no `connect_detached` field. The teardown detach pump is
+iteration-bounded and non-blocking, so a pathological op that will not detach is
+declared promptly (see Amendment 4 / Checkpoint 2 review).
 
 ## DNS: no async resolver in this slice (recorded honestly)
 
@@ -171,7 +179,9 @@ grant for a declared network DB. Identical rows, errors, and timeouts.
 - `hull/shared/tls_client.h`: `HlTlsClient` and the raw-fd `hl_tls_client_*`
   helpers.
 - Template: `src/hull/cap/smtp_transport.c` (blocking `getaddrinfo` adapter, a
-  private `KlEventCtx` connect pump, and `co_on_detach` confirmed detachment).
+  private `KlEventCtx` connect pump, confirmed detachment). PG diverges on the
+  last point: it confirms detachment by polling `kl_connect_op_is_detached` in the
+  teardown pump rather than installing the template's `on_detach` callback.
 
 ## Checkpoint 2 review refinements
 

--- a/docs/pg_keel_transport_slice3.md
+++ b/docs/pg_keel_transport_slice3.md
@@ -1,0 +1,187 @@
+# PostgreSQL client transport onto Keel v3 (Slice 3) - decisions record
+
+Status: design record, frozen at Checkpoint 1. Branch
+`feat/pg-keel-transport-slice3` (off `main`). This is the sibling of the SMTP
+Slice 2c work ([`smtp_keel_slice2c_plan.md`](smtp_keel_slice2c_plan.md)); it
+routes the PostgreSQL client's transport onto the same public Keel v3 primitives
+while keeping the connection synchronous and blocking and the wire codec
+untouched.
+
+## Objective
+
+Replace `src/hull/cap/pg_conn.c`'s hand-rolled POSIX socket layer
+(`getaddrinfo` / `socket` / `connect` / `select` / `send` / `recv` / `close`)
+with Keel v3 transport primitives, reusing the pattern proven by
+`cap/smtp_transport.c`. The Postgres wire codec (framing, SCRAM auth, `$n`
+rewrite, typed decode, migrations) and the connection's synchronous blocking
+semantics do not change. The win is one transport stack (a `KlSocketProvider`),
+RFC 8305 Happy-Eyeballs racing, and a provider test seam for the DB client.
+
+## D1. Racing via `KlConnectOp`; blocking I/O via raw `KlSocketProvider` ops
+
+Multi-address connection racing uses `KlConnectOp`. Socket creation, connect
+completion, blocking read/write, and close use the raw provider ops
+(`sp->ops->{socket,connect,close,send,recv,set_blocking,set_nonblocking,set_cloexec,set_nosigpipe,get_so_error}`,
+all in `keel/socket.h`). `KlStream` is not used: its queued-write, watcher, and
+lifecycle machinery serve an asynchronous client, and a synchronous PostgreSQL
+connection needs none of it.
+
+`KlConnectOp` is asynchronous and needs an event loop to drive its attempts plus
+the stagger and deadline timers. The transport therefore owns a private
+`KlEventCtx` that is used ONLY during connect establishment. The transport pumps
+that loop to a terminal state, receives the winning descriptor via
+`kl_connect_op_on_attempt_connected`, and then calls `sp->ops->set_blocking(fd)`.
+After that point the connection is pure synchronous blocking I/O with no event
+loop: startup, SCRAM auth, the TLS handshake, and every query use plain blocking
+`recv` / `send`.
+
+File split: all provider and Keel interaction lives in a new
+`src/hull/cap/pg_transport.c` (plus `include/hull/cap/pg_transport.h`).
+`pg_conn.c` keeps only the wire protocol and calls the transport, mirroring the
+`cap/smtp.c` vs `cap/smtp_transport.c` division (the codec translation unit
+contains no `getaddrinfo` / `socket` / `poll` / raw I/O).
+
+## D2. TLS stays `hl_tls_client_*` on the provider-created blocking descriptor
+
+Keep `hl_tls_client_handshake` / `_read` / `_write` / `_free` / `_shutdown` and
+hand it the blocking descriptor the provider created. This preserves the whole
+existing `sslmode=disable|prefer|require|verify-ca|verify-full` behavior (chain
+plus hostname verification, fail-closed with no plaintext fallback) with the
+smallest security-sensitive diff. `KlTls` is deliberately not adopted: it would
+couple a transport migration to TLS lifecycle and buffering changes for no gain
+on a synchronous contract. The `hl_tls_client_*` helpers take the raw integer
+fd, which under the POSIX provider is exactly the `KlSocketHandle` value the
+transport holds.
+
+## D3. Connect-timeout mapping bounds TCP establishment only
+
+`timeout_ms` bounds TCP connection establishment only. It does not bound DNS, and
+it does not bound the PostgreSQL startup or TLS handshake as a single global
+operation (unchanged meaning). After resolution the transport computes one
+absolute connect deadline and gives its remaining budget to `KlConnectOp`'s
+`arm_deadline` hook (`keel/connect_op.h`). Happy-Eyeballs `arm_delay` stagger
+timers must not refresh that deadline. When `timeout_ms <= 0` the transport arms
+no deadline, preserving today's unbounded-connect behavior. On terminal failure
+or timeout the transport calls `kl_connect_op_cancel` and pumps the private loop
+until confirmed detachment (`on_detach` sets `connect_detached`) before freeing
+embedded storage, honoring the "no reuse until confirmed detachment" invariant in
+`keel/connect_op_detail.h`.
+
+## DNS: no async resolver in this slice (recorded honestly)
+
+Keel's async resolver is not used. It requires event-driven DNS authority that
+Hull's sandbox deliberately avoids, and adopting it would be an async-model
+change. This slice does not buy async-capable DNS.
+
+- IP-literal hosts are parsed directly with `kl_sockaddr_parse` (Keel's
+  documented numeric-literal, no-DNS parser). This matches today's
+  IP-literal-only `databases.dynamic` CIDR gate.
+- Hostnames are resolved through a sandbox-compatible blocking `getaddrinfo`
+  adapter kept in `pg_transport.c` (never in `pg_conn.c`), exactly as
+  `cap/smtp_transport.c` does. The adapter feeds results into `KlConnectOp` via
+  `kl_connect_op_on_resolved(op, naddrs)` and `_on_resolve_failed`.
+- Resolution returns at most `KL_CONNECT_MAX_ADDRS` (8) ordered addresses. Their
+  storage is owned by the transport and remains valid through confirmed
+  detachment of the connect operation.
+
+## Amendment 1: transport lifetime and ownership
+
+`PgTransport` lives for the entire PostgreSQL connection, not only during
+connect. It is embedded in `HlPgConn`, or `HlPgConn` owns an opaque transport
+allocation. It retains the borrowed provider reference (see Amendment 4) and
+owns:
+
+- the private connect-time event context,
+- the `KlConnectOp` storage and its timers,
+- the resolved addresses during connection racing,
+- the winning descriptor,
+- the optional attached `HlTlsClient`.
+
+This yields one close path: TLS shutdown, then TLS free, then provider close,
+performed exactly once in that order.
+
+## Amendment 2: preserve the existing connected-fd test API
+
+`hl_pg_conn_start(conn, fd, dsn)` and its socketpair tests are preserved through
+an explicit transport-adopt operation. Adoption:
+
+- takes ownership of the supplied descriptor exactly once,
+- associates it with the default provider,
+- skips resolution, connection racing, and event-context creation,
+- routes subsequent I/O and close through the same transport API as an ordinary
+  connection.
+
+No second legacy raw-fd I/O path remains in `pg_conn.c`; the adopted descriptor
+and a raced-and-won descriptor converge on one send / receive / close
+implementation.
+
+## Amendment 3: blocking I/O contract
+
+The transport's send and receive wrappers preserve the existing behavior exactly:
+EINTR retry, partial-write completion, the existing error text, and SIGPIPE
+suppression (via the provider's `set_nosigpipe` and the existing send flags).
+Provider `send` / `recv` callbacks may return short operations; the full-write
+loop semantics of `conn_send` remain. No new post-connect read or write timeout
+is introduced.
+
+## Amendment 4: precise provider wording
+
+`PgTransport` does not own the provider itself. It retains a borrowed, immutable
+`KlSocketProvider` reference whose lifetime exceeds the connection (the default
+provider, or a test-supplied one). It owns every descriptor created through that
+provider and disposes every winner, loser, and failure-path descriptor through
+the same provider (`sp->ops->close`), never a bare `close(2)`.
+
+## Frozen ownership rules
+
+1. `PgTransport` retains the borrowed immutable `KlSocketProvider` reference and
+   owns the private `KlEventCtx`, the `KlConnectOp` (embedded via
+   `connect_op_detail.h`), the resolved address set, the winning descriptor, and
+   the optional attached `HlTlsClient`. It lives for the whole connection.
+2. Resolver results outlive every racing attempt and remain valid through
+   confirmed detachment; at most `KL_CONNECT_MAX_ADDRS` ordered addresses.
+3. Every losing descriptor is disposed through the provider, never a bare
+   `close(2)`.
+4. A failed or timed-out connect reaches confirmed detachment before any
+   transport storage is freed.
+5. The provider test seam (`pg_test_socket_provider`) and any
+   attempt-observation or pump hooks compile out of production (nm-verified,
+   gated by `-DHL_PG_TEST_HOOKS`, mirroring SMTP's `-DHL_SMTP_TEST_HOOKS`).
+6. No PostgreSQL or Keel transport objects enter a non-Postgres app.
+   `cap_pg_transport.o` joins `libhull_feature-postgres.a` (today
+   `cap_db_postgres.o` plus `cap_pg_conn.o` plus `cap_pgwire.o`,
+   `mk/features/postgres.mk`); a base or non-Postgres app links zero of it.
+
+## Non-goals
+
+No codec change. No async-model change: the connection stays synchronous and
+blocking, and `db.async` (worker-pool connections) is unchanged. No new
+app-facing manifest or sandbox authority beyond the existing `network_outbound`
+grant for a declared network DB. Identical rows, errors, and timeouts.
+
+## Grounding (verified symbols)
+
+- `keel/socket.h`: provider ops including `set_blocking`, `set_nosigpipe`, and
+  `get_so_error`.
+- `keel/connect_op.h`: `kl_connect_op_init` / `_start` / `_cancel` plus
+  `_on_resolved` / `_on_attempt_connected` / `_on_attempt_failed` / `_on_delay` /
+  `_on_deadline`; terminal-once with detach-gated reuse; `KL_CONNECT_MAX_ADDRS`
+  is 8.
+- `keel/sockaddr.h`: `kl_sockaddr_parse` (numeric literal, no DNS).
+- `hull/shared/tls_client.h`: `HlTlsClient` and the raw-fd `hl_tls_client_*`
+  helpers.
+- Template: `src/hull/cap/smtp_transport.c` (blocking `getaddrinfo` adapter, a
+  private `KlEventCtx` connect pump, and `co_on_detach` confirmed detachment).
+
+## Checkpoints
+
+1. Decisions record (this document). Approved.
+2. Transport plus test seam only, with `pg_conn.c` codec behavior untouched.
+3. Cut `hl_pg_conn_open` / `_start` / `_close` over to the transport (non-TLS);
+   `test_pg_conn` and non-TLS `e2e_postgres` green.
+4. The `sslmode` matrix over the new transport; full `e2e_postgres` green.
+5. Fresh full matrix on the exact head, then squash-merge on approval.
+
+Slice 4 repeats this against `cap/mysql_conn.c` (identical raw-socket shape),
+reusing the Slice 3 transport, as a separate PR under the same checkpoint
+discipline.

--- a/docs/pg_keel_transport_slice3.md
+++ b/docs/pg_keel_transport_slice3.md
@@ -173,6 +173,44 @@ grant for a declared network DB. Identical rows, errors, and timeouts.
 - Template: `src/hull/cap/smtp_transport.c` (blocking `getaddrinfo` adapter, a
   private `KlEventCtx` connect pump, and `co_on_detach` confirmed detachment).
 
+## Checkpoint 2 review refinements
+
+Source review of the first Checkpoint 2 cut froze six additional correctness
+rules, now implemented:
+
+1. **Truly unbounded connect.** `timeout_ms <= 0` imposes NO total deadline and no
+   hidden ceiling: the connect pump loops in bounded `PG_PUMP_STEP_MS` increments
+   until the op completes (the `select(..., NULL)` contract). Only `timeout_ms > 0`
+   arms a deadline.
+2. **Provider error classification via `io_status`.** Connect / send / recv
+   classify would-block / pending / interrupted through the provider's
+   `ops->io_status` when it supplies one, falling back to hosted errno only when it
+   is absent. A mock that reports `io_status` while leaving errno irrelevant is
+   covered.
+3. **Required provider subset + capability, validated up front.** Before creating
+   anything, `validate_provider` requires
+   `socket`/`connect`/`close`/`send`/`recv`/`get_so_error`/`set_nonblocking`/`set_blocking`
+   and `KL_SOCK_CAP_NATIVE_FD` (the private event loop watches provider handles);
+   a missing op or capability fails closed. `set_blocking` is never assumed
+   present (a missing one no longer silently leaves the winner non-blocking).
+4. **Non-detachment is represented safely.** `connect_teardown` and
+   `hl_pg_transport_close` return status. When confirmed detachment fails the
+   ENTIRE heap allocation is PRESERVED (never freed under a live op) and reported:
+   `close` returns -1 without marking anything closed, so the owner may retry or
+   intentionally leak the whole block. This is why the transport is a
+   heap-allocated opaque handle (Amendment 1), not an embedded value.
+5. **One-shot fallible TLS attach.** `hl_pg_transport_attach_tls` requires a live
+   descriptor and a non-NULL session and rejects a second attachment, returning
+   status; an owned session is never silently dropped.
+6. **Tests.** The suite adds deterministic coverage for the connect deadline +
+   detachment, truly-unbounded mode via a controlled completion (no 30 s wait),
+   immediate `connect()` success (rc == 0), `io_status` with an irrelevant errno,
+   missing provider ops + missing native-FD capability, `set_blocking` failure,
+   partial receive, provider-observed close exactly once, TLS attach
+   rejection/replacement, and forced non-detachment proving the allocation is
+   preserved and close is retryable. Run under ASan/UBSan + TSan locally and
+   ASan/LSan in CI; the production-hook nm proof is retained.
+
 ## Checkpoints
 
 1. Decisions record (this document). Approved.

--- a/docs/pg_keel_transport_slice3.md
+++ b/docs/pg_keel_transport_slice3.md
@@ -119,9 +119,24 @@ an explicit transport-adopt operation. Adoption:
 - routes subsequent I/O and close through the same transport API as an ordinary
   connection.
 
+`hl_pg_conn_start`'s public contract is that it takes ownership of the fd and
+closes it on every failure. To keep that intact, `hl_pg_transport_adopt` CONSUMES
+the descriptor (closes it exactly once through the provider) on every failure
+outcome where the provider can close it - i.e. an allocation failure after a valid
+provider is resolved. The only non-consuming failures are an invalid fd (< 0) or
+an invalid provider (no way to close the fd); with the default provider (what
+`hl_pg_conn_start` uses) neither is reachable, so the fd is never leaked. Covered
+by a deterministic test that forces the allocation failure and asserts the
+descriptor is closed exactly once (`pg_transport_adopt.alloc_failure_consumes_fd_once`).
+
 No second legacy raw-fd I/O path remains in `pg_conn.c`; the adopted descriptor
 and a raced-and-won descriptor converge on one send / receive / close
-implementation.
+implementation. One acknowledged exception, deferred to the sslmode/TLS
+checkpoint: the pre-TLS SSLRequest probe (`hl_pg_ssl_negotiate`) still does raw
+`send`/`recv` on the transport's descriptor (obtained via `hl_pg_transport_fd`),
+not `hl_pg_transport_send`/`_recv`. So checkpoint 3 does NOT claim every
+production I/O path is already behind the transport; the SSLRequest path moves
+behind it with the rest of the TLS work.
 
 ## Amendment 3: blocking I/O contract
 

--- a/docs/pg_keel_transport_slice3.md
+++ b/docs/pg_keel_transport_slice3.md
@@ -131,12 +131,33 @@ descriptor is closed exactly once (`pg_transport_adopt.alloc_failure_consumes_fd
 
 No second legacy raw-fd I/O path remains in `pg_conn.c`; the adopted descriptor
 and a raced-and-won descriptor converge on one send / receive / close
-implementation. One acknowledged exception, deferred to the sslmode/TLS
-checkpoint: the pre-TLS SSLRequest probe (`hl_pg_ssl_negotiate`) still does raw
-`send`/`recv` on the transport's descriptor (obtained via `hl_pg_transport_fd`),
-not `hl_pg_transport_send`/`_recv`. So checkpoint 3 does NOT claim every
-production I/O path is already behind the transport; the SSLRequest path moves
-behind it with the rest of the TLS work.
+implementation. The pre-TLS SSLRequest probe (`hl_pg_ssl_negotiate`) now also
+rides the transport: it takes a `PgTransport *` and uses
+`hl_pg_transport_send_all` / `hl_pg_transport_recv` (plaintext, before any TLS is
+attached), so every production PG I/O path is behind the transport. The only raw
+descriptor use left is handing `hl_pg_transport_fd` to `hl_tls_client_handshake`
+(which takes an int fd) for the TLS handshake itself.
+
+## sslmode matrix (verified)
+
+The complete DSN `sslmode` policy is exercised end to end (`tests/e2e_postgres.sh`,
+real Postgres 16 in Docker) plus the negotiation-decision unit matrix
+(`pg_ssl.negotiation_matrix`):
+
+- `disable` - plaintext, no SSLRequest sent.
+- `require` against a TLS server - SSLRequest -> mbedTLS handshake -> SCRAM over
+  TLS, asserted encrypted via `pg_stat_ssl`.
+- `require` against a NON-TLS server - the server answers `N`; the connection
+  HARD-FAILS with no silent plaintext downgrade.
+- `verify-full` against an untrusted self-signed cert - chain verification against
+  the embedded CA bundle REJECTS it (no connection).
+- `prefer`/`require` server-`S`/`N` decisions - covered by the unit matrix.
+
+`verify-full` SUCCESS against a private CA is not e2e-testable here because Hull's
+PG TLS verify trusts only the embedded Mozilla bundle (a private PG cert is never
+in it); the chain + hostname verification logic itself is the shared
+`shared/tls_client.c`, covered by the live-mbedTLS-peer unit suite
+(`test_smtp_tls`), which the PG path reuses unchanged.
 
 ## Amendment 3: blocking I/O contract
 

--- a/include/hull/cap/pg_conn.h
+++ b/include/hull/cap/pg_conn.h
@@ -42,9 +42,11 @@ int hl_pg_dsn_parse(const char *dsn, HlPgDsn *out, char *errbuf, size_t errlen);
 /* Overwrite the password field with zeros (defense in depth). */
 void hl_pg_dsn_scrub(HlPgDsn *dsn);
 
+struct PgTransport;   /* cap/pg_transport.h: the owned byte transport */
+
 /* An open connection, ready for queries once hl_pg_conn_open returns 0. */
 typedef struct HlPgConn {
-    int      fd;
+    struct PgTransport *transport;  /* owned byte transport (bytes + optional TLS) */
     uint8_t *rbuf;        /* receive accumulation buffer                */
     size_t   rlen;        /* valid bytes in rbuf                        */
     size_t   rcap;        /* rbuf capacity                              */
@@ -54,7 +56,6 @@ typedef struct HlPgConn {
     int32_t  backend_key;
     int      tx_status;   /* latest ReadyForQuery status: 'I' / 'T' / 'E' */
     char     errmsg[256];
-    struct HlTlsClient *tls;  /* non-NULL once the TLS handshake completes */
 } HlPgConn;
 
 /*

--- a/include/hull/cap/pg_conn.h
+++ b/include/hull/cap/pg_conn.h
@@ -100,12 +100,13 @@ typedef enum HlPgSslDecision {
 int hl_pg_sslmode_parse(const char *s);
 
 /*
- * Send an SSLRequest on @p fd and read the one-byte server reply, then apply
- * the @p mode policy: DISABLE returns PLAINTEXT without sending anything; a
- * server 'S' returns USE_TLS; a server 'N' returns PLAINTEXT under PREFER and
- * FAIL under REQUIRE/VERIFY. Exposed for tests (socketpair-drivable).
+ * Send an SSLRequest over @p t (the pre-TLS plaintext probe rides the transport)
+ * and read the one-byte server reply, then apply the @p mode policy: DISABLE
+ * returns PLAINTEXT without sending anything; a server 'S' returns USE_TLS; a
+ * server 'N' returns PLAINTEXT under PREFER and FAIL under REQUIRE/VERIFY (no
+ * plaintext downgrade). Exposed for tests (drive it with an adopted socketpair).
  */
-HlPgSslDecision hl_pg_ssl_negotiate(int fd, HlPgSslMode mode,
+HlPgSslDecision hl_pg_ssl_negotiate(struct PgTransport *t, HlPgSslMode mode,
                                     char *errbuf, size_t errlen);
 
 /* ── SCRAM-SHA-256 primitives (exposed for tests) ─────────────────── */

--- a/include/hull/cap/pg_transport.h
+++ b/include/hull/cap/pg_transport.h
@@ -106,8 +106,15 @@ PgTransport *hl_pg_transport_connect(const char *host, const char *port,
  * connection. This backs the existing hl_pg_conn_start(conn, fd, dsn) test API.
  * The provider is validated (required ops + KL_SOCK_CAP_NATIVE_FD) as in connect.
  *
- * Returns a non-NULL transport on success, NULL on a bad argument / invalid
- * provider (writing @p errbuf when provided). On NULL the caller still owns @p fd.
+ * Returns a non-NULL transport on success. On failure returns NULL, and the
+ * descriptor is CONSUMED (closed exactly once through the provider) on every
+ * outcome where the provider can close it - i.e. an allocation failure after a
+ * valid provider was resolved - so the caller never leaks it. The ONLY
+ * non-consuming failures are an invalid @p fd (< 0, nothing to close) or an
+ * invalid provider (@p sp_or_NULL missing a required op / capability, so there is
+ * no way to close @p fd); in those two cases the caller still owns @p fd. This
+ * lets hl_pg_conn_start keep its "takes ownership of fd, closed on every failure"
+ * contract with a valid (default) provider.
  */
 PgTransport *hl_pg_transport_adopt(int fd,
                                    const struct KlSocketProvider *sp_or_NULL,

--- a/include/hull/cap/pg_transport.h
+++ b/include/hull/cap/pg_transport.h
@@ -4,14 +4,23 @@
  *
  * Hull-local adapter that composes Keel's public transport surface -
  * KlConnectOp (resolve + Happy-Eyeballs racing connect), a private KlEventCtx to
- * drive it, and the POSIX socket provider's raw ops - into the blocking byte
- * transport the synchronous PostgreSQL client (cap/pg_conn.c) drives.
+ * drive it, and a KlSocketProvider's raw ops - into the blocking byte transport
+ * the synchronous PostgreSQL client (cap/pg_conn.c) drives.
  *
  * Ownership split (docs/pg_keel_transport_slice3.md): pg_conn.c owns the wire
  * protocol (framing, SCRAM auth, the $n rewrite, typed decode, migrations, the
  * SSLRequest / sslmode negotiation, and the stable error tokens). This transport
  * owns only the bytes: name resolution, the connection race, blocking
  * reads/writes, an optional attached TLS session, and close.
+ *
+ * Heap-allocated + opaque (Amendment 1, refined at Checkpoint 2 review): the
+ * transport is a HEAP allocation reached through an opaque handle. pg_conn.c holds
+ * a PgTransport* in HlPgConn, never an embedded value. This is what lets the
+ * exceptional non-detachment path (a connect op that will not confirm detachment)
+ * leak the WHOLE allocation intentionally and safely - a live op keeps
+ * referencing its own storage, so the storage must never be freed under it, and
+ * only a separately-owned heap block can be dropped whole. Mirrors the SMTP
+ * transport.
  *
  * Scheduling model (design D1): KlConnectOp is asynchronous, so the transport
  * owns a PRIVATE, operation-local KlEventCtx used ONLY during connect
@@ -46,64 +55,18 @@
 #include <stdint.h>
 #include <sys/types.h>   /* ssize_t */
 
-#include <keel/connect_op.h>          /* KL_CONNECT_MAX_ADDRS, KlConnectResult */
-#include <keel/connect_op_detail.h>   /* opt-in layout: embed a KlConnectOp (storage only) */
-#include <keel/event_ctx.h>           /* KlEventCtx (embedded, connect-time only) */
-#include <keel/sockaddr.h>            /* KlSockAddr */
-#include <keel/socket.h>              /* KlSocketProvider, KlSocketHandle */
-#include <keel/allocator.h>           /* KlAllocator (event-ctx lifetime) */
+struct KlSocketProvider;  /* keel/socket.h; the borrowed provider (opaque here) */
+struct HlTlsClient;       /* shared/tls_client.h; the optional attached TLS session */
 
-struct HlTlsClient;   /* shared/tls_client.h; the optional attached TLS session */
-
-/* One connection's byte transport. Standalone storage: the future pg_conn.c
- * embeds or owns one of these. Fields are documented as owned vs borrowed in the
- * header banner above; the struct is exposed (not opaque) so pg_conn.c can embed
- * it by value in HlPgConn, exactly as the design's Amendment 1 anticipates. */
-typedef struct PgTransport {
-    /* Borrowed, immutable, outlives the connection (Amendment 4). */
-    const KlSocketProvider *sp;
-
-    /* Owned: the private connect-time event context. Created only when a race is
-     * needed (hl_pg_transport_connect); the adopt path leaves it uninitialized. */
-    KlEventCtx  ev;
-    int         ev_ready;      /* 1 once kl_event_ctx_init succeeded            */
-    KlAllocator alloc;         /* event-ctx allocator (event-loop lifetime)     */
-
-    /* Owned: the embedded KlConnectOp and its resolved address set. */
-    KlConnectOp connect_op;       /* embedded (connect_op_detail.h: storage only) */
-    int         connect_started;  /* 1 once kl_connect_op_start succeeded        */
-    KlSockAddr  addrs[KL_CONNECT_MAX_ADDRS];
-    int         naddrs;
-    KlSocketHandle attempt_fd[KL_CONNECT_MAX_ADDRS]; /* in-flight racing fds     */
-    int         attempt_armed[KL_CONNECT_MAX_ADDRS]; /* 1 if a watcher is armed  */
-
-    /* Connect outcome. */
-    int             connect_done;      /* on_done fired                          */
-    int             connect_detached;  /* on_detach fired                        */
-    KlConnectResult connect_result;
-    int             connect_error;
-
-    /* Overall connect deadline (TCP establishment only, design D3). */
-    int64_t   deadline_timer;   /* Keel timer id, or -1                          */
-    uint64_t  deadline_ms;      /* absolute monotonic instant, or 0 = unbounded  */
-    int       deadline_fired;
-
-    /* RFC 8305 Connection Attempt Delay timer (the Happy-Eyeballs stagger). */
-    int64_t   delay_timer;      /* Keel timer id, or -1                          */
-
-    /* The winning connected descriptor (blocking after connect). */
-    KlSocketHandle fd;
-
-    /* Owned: optional attached TLS session. When non-NULL, send/recv tunnel
-     * through it (design D2); the transport frees it in close. */
-    struct HlTlsClient *tls;
-
-    int closed;   /* 1 once hl_pg_transport_close has run (idempotency guard)    */
-} PgTransport;
+/* Opaque, heap-allocated. pg_conn.c stores a PgTransport* and reaches every field
+ * through the API below. The concrete struct is defined in pg_transport.c so the
+ * exceptional non-detachment path can drop the whole heap block (see the banner).
+ * The direct-include unit test sees the full definition for white-box checks. */
+typedef struct PgTransport PgTransport;
 
 /**
  * Resolve @p host / @p port, race the addresses through KlConnectOp on a private
- * event loop, and leave @p t holding the winning blocking descriptor.
+ * event loop, and return a transport holding the winning blocking descriptor.
  *
  * An IP-literal @p host is parsed directly via kl_sockaddr_parse (no DNS,
  * matching the IP-literal-only databases.dynamic CIDR gate); a hostname is
@@ -112,21 +75,27 @@ typedef struct PgTransport {
  *
  * @p timeout_ms > 0 bounds TCP establishment only (design D3): one absolute
  * connect deadline is armed after resolution, and the Happy-Eyeballs stagger does
- * not refresh it. @p timeout_ms <= 0 arms no deadline (unbounded connect,
- * preserving pg_connect's prior behavior).
+ * not refresh it. @p timeout_ms <= 0 is TRULY UNBOUNDED (no total deadline, no
+ * hidden ceiling): the loop pumps in bounded event-loop increments until the op
+ * completes, preserving pg_connect's prior select(..., NULL) contract.
  *
  * @p sp_or_NULL, when non-NULL, is a caller-supplied provider (the test seam);
  * NULL selects the default POSIX provider. The reference is borrowed and must
- * outlive @p t.
+ * outlive the returned transport. The provider MUST supply the required op subset
+ * (socket/connect/close/send/recv/get_so_error/set_nonblocking/set_blocking) and
+ * advertise KL_SOCK_CAP_NATIVE_FD (the private event loop watches its handles);
+ * otherwise this fails closed.
  *
- * On failure the transport cancels the op and pumps to confirmed detachment
- * before releasing embedded storage. Returns 0 on success (with @p t ready for
- * send/recv), or -1 with a message written to @p errbuf (which may be NULL),
- * mirroring pg_conn.c's set_err style. On failure @p t holds no live descriptor.
+ * Returns a non-NULL transport on success (ready for send/recv). On failure
+ * returns NULL and writes a message to @p errbuf (which may be NULL), mirroring
+ * pg_conn.c's set_err style; the allocation is either freed (op detached) or, if
+ * a live op will not confirm detachment, intentionally leaked (never freed under a
+ * live op).
  */
-int hl_pg_transport_connect(PgTransport *t, const char *host, const char *port,
-                            int timeout_ms, const KlSocketProvider *sp_or_NULL,
-                            char *errbuf, size_t errlen);
+PgTransport *hl_pg_transport_connect(const char *host, const char *port,
+                                     int timeout_ms,
+                                     const struct KlSocketProvider *sp_or_NULL,
+                                     char *errbuf, size_t errlen);
 
 /**
  * Adopt an already-connected, blocking descriptor @p fd (design Amendment 2).
@@ -135,19 +104,25 @@ int hl_pg_transport_connect(PgTransport *t, const char *host, const char *port,
  * default POSIX provider when NULL), and skips resolution, connection racing, and
  * event-context creation. Subsequent send/recv/close use the same path as a raced
  * connection. This backs the existing hl_pg_conn_start(conn, fd, dsn) test API.
+ * The provider is validated (required ops + KL_SOCK_CAP_NATIVE_FD) as in connect.
  *
- * Returns 0 on success, -1 on a bad argument.
+ * Returns a non-NULL transport on success, NULL on a bad argument / invalid
+ * provider (writing @p errbuf when provided). On NULL the caller still owns @p fd.
  */
-int hl_pg_transport_adopt(PgTransport *t, int fd,
-                          const KlSocketProvider *sp_or_NULL);
+PgTransport *hl_pg_transport_adopt(int fd,
+                                   const struct KlSocketProvider *sp_or_NULL,
+                                   char *errbuf, size_t errlen);
 
 /**
- * Attach an optional TLS session to route subsequent send/recv through (design
- * D2). @p tls is created and handshaked by the caller (pg_conn.c) over the
- * transport's blocking descriptor. Ownership transfers to the transport, which
- * frees it in hl_pg_transport_close. Passing NULL detaches (rarely used).
+ * Attach a TLS session to route subsequent send/recv through (design D2). ONE-SHOT
+ * and fallible: requires a live descriptor and a non-NULL @p tls, and rejects a
+ * second attachment (so an owned session is never silently dropped). @p tls is
+ * created and handshaked by the caller (pg_conn.c) over the transport's blocking
+ * descriptor; on success ownership transfers to the transport, which frees it in
+ * hl_pg_transport_close. Returns 0 on success, -1 on rejection (no descriptor,
+ * NULL session, or already attached) - on -1 the caller still owns @p tls.
  */
-void hl_pg_transport_attach_tls(PgTransport *t, struct HlTlsClient *tls);
+int hl_pg_transport_attach_tls(PgTransport *t, struct HlTlsClient *tls);
 
 /**
  * One blocking send / recv over the transport, EINTR-retried and TLS-aware.
@@ -155,9 +130,11 @@ void hl_pg_transport_attach_tls(PgTransport *t, struct HlTlsClient *tls);
  * When a TLS session is attached the bytes tunnel through hl_tls_client_write /
  * _read; otherwise the provider send / recv is used with SIGPIPE suppression
  * (set_nosigpipe on the fd plus the nosignal send flag where the platform has
- * one). These are SINGLE operations: the provider (or TLS) may return short, so
- * callers that need every byte use hl_pg_transport_send_all. Returns the byte
- * count (> 0), 0 on orderly close, or -1 on error.
+ * one). Interrupted-retry classification uses the provider's io_status when it
+ * supplies one, falling back to hosted errno only when absent. These are SINGLE
+ * operations: the provider (or TLS) may return short, so callers that need every
+ * byte use hl_pg_transport_send_all. Returns the byte count (> 0), 0 on orderly
+ * close, or -1 on error.
  */
 ssize_t hl_pg_transport_send(PgTransport *t, const uint8_t *buf, size_t len);
 ssize_t hl_pg_transport_recv(PgTransport *t, uint8_t *buf, size_t len);
@@ -177,12 +154,19 @@ int hl_pg_transport_send_all(PgTransport *t, const uint8_t *buf, size_t len);
 int hl_pg_transport_fd(const PgTransport *t);
 
 /**
- * Close the transport exactly once: TLS shutdown (if attached), TLS free, then
- * provider close of the winning descriptor. Idempotent and NULL-safe. Does NOT
- * free @p t itself (the storage is caller-owned / embedded); it only retires the
- * descriptor and TLS session. On a still-live (never-detached) connect op it
- * cancels and pumps to confirmed detachment before retiring storage.
+ * Close and free the transport. One close path: TLS shutdown (if attached), TLS
+ * free, then provider close of the winning descriptor. Drives a still-live raced
+ * connect op to confirmed detachment first (frozen rule 4).
+ *
+ * Returns 0 on full success: the descriptor is retired and the heap allocation is
+ * FREED - the caller MUST drop its pointer and never reuse it.
+ *
+ * Returns -1 iff a live connect op would NOT confirm detachment within the
+ * teardown bound. In that case the ENTIRE allocation is PRESERVED (not freed, not
+ * marked closed): the caller may retry hl_pg_transport_close later, or drop its
+ * pointer to intentionally leak the block safely. Freeing storage a live op still
+ * references is never done. NULL-safe (returns 0).
  */
-void hl_pg_transport_close(PgTransport *t);
+int hl_pg_transport_close(PgTransport *t);
 
 #endif /* HL_CAP_PG_TRANSPORT_H */

--- a/include/hull/cap/pg_transport.h
+++ b/include/hull/cap/pg_transport.h
@@ -1,0 +1,188 @@
+/**
+ * @file cap/pg_transport.h
+ * @brief PostgreSQL byte transport over Keel v3 public primitives.
+ *
+ * Hull-local adapter that composes Keel's public transport surface -
+ * KlConnectOp (resolve + Happy-Eyeballs racing connect), a private KlEventCtx to
+ * drive it, and the POSIX socket provider's raw ops - into the blocking byte
+ * transport the synchronous PostgreSQL client (cap/pg_conn.c) drives.
+ *
+ * Ownership split (docs/pg_keel_transport_slice3.md): pg_conn.c owns the wire
+ * protocol (framing, SCRAM auth, the $n rewrite, typed decode, migrations, the
+ * SSLRequest / sslmode negotiation, and the stable error tokens). This transport
+ * owns only the bytes: name resolution, the connection race, blocking
+ * reads/writes, an optional attached TLS session, and close.
+ *
+ * Scheduling model (design D1): KlConnectOp is asynchronous, so the transport
+ * owns a PRIVATE, operation-local KlEventCtx used ONLY during connect
+ * establishment. The transport pumps that loop to a terminal state, receives the
+ * winning descriptor, and then set_blocking()s it. After that point there is no
+ * event loop: startup, SCRAM auth, the TLS handshake, and every query are plain
+ * blocking recv / send on the winning fd. Unlike the SMTP transport this uses no
+ * KlStream and no post-connect event loop.
+ *
+ * TLS (design D2): TLS stays the shared hl_tls_client_* helpers layered over the
+ * provider-created blocking descriptor; the transport merely retains the optional
+ * HlTlsClient and routes send/recv through it once attached. The transport itself
+ * runs no handshake (pg_conn.c owns the SSLRequest negotiation and hands the
+ * resulting session here via hl_pg_transport_attach_tls).
+ *
+ * Ownership (design Amendment 1 / Amendment 4 / frozen rules): the transport
+ * retains a BORROWED immutable KlSocketProvider reference (the default POSIX
+ * provider, or a test-supplied one) whose lifetime exceeds the connection, and it
+ * OWNS the private KlEventCtx, the embedded KlConnectOp and its timers, the
+ * resolved address set (at most KL_CONNECT_MAX_ADDRS, valid through confirmed
+ * detachment), the winning descriptor, and the optional attached HlTlsClient.
+ * Every descriptor - winner, loser, or failure-path - is disposed through the
+ * provider, never a bare close(2).
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef HL_CAP_PG_TRANSPORT_H
+#define HL_CAP_PG_TRANSPORT_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>   /* ssize_t */
+
+#include <keel/connect_op.h>          /* KL_CONNECT_MAX_ADDRS, KlConnectResult */
+#include <keel/connect_op_detail.h>   /* opt-in layout: embed a KlConnectOp (storage only) */
+#include <keel/event_ctx.h>           /* KlEventCtx (embedded, connect-time only) */
+#include <keel/sockaddr.h>            /* KlSockAddr */
+#include <keel/socket.h>              /* KlSocketProvider, KlSocketHandle */
+#include <keel/allocator.h>           /* KlAllocator (event-ctx lifetime) */
+
+struct HlTlsClient;   /* shared/tls_client.h; the optional attached TLS session */
+
+/* One connection's byte transport. Standalone storage: the future pg_conn.c
+ * embeds or owns one of these. Fields are documented as owned vs borrowed in the
+ * header banner above; the struct is exposed (not opaque) so pg_conn.c can embed
+ * it by value in HlPgConn, exactly as the design's Amendment 1 anticipates. */
+typedef struct PgTransport {
+    /* Borrowed, immutable, outlives the connection (Amendment 4). */
+    const KlSocketProvider *sp;
+
+    /* Owned: the private connect-time event context. Created only when a race is
+     * needed (hl_pg_transport_connect); the adopt path leaves it uninitialized. */
+    KlEventCtx  ev;
+    int         ev_ready;      /* 1 once kl_event_ctx_init succeeded            */
+    KlAllocator alloc;         /* event-ctx allocator (event-loop lifetime)     */
+
+    /* Owned: the embedded KlConnectOp and its resolved address set. */
+    KlConnectOp connect_op;       /* embedded (connect_op_detail.h: storage only) */
+    int         connect_started;  /* 1 once kl_connect_op_start succeeded        */
+    KlSockAddr  addrs[KL_CONNECT_MAX_ADDRS];
+    int         naddrs;
+    KlSocketHandle attempt_fd[KL_CONNECT_MAX_ADDRS]; /* in-flight racing fds     */
+    int         attempt_armed[KL_CONNECT_MAX_ADDRS]; /* 1 if a watcher is armed  */
+
+    /* Connect outcome. */
+    int             connect_done;      /* on_done fired                          */
+    int             connect_detached;  /* on_detach fired                        */
+    KlConnectResult connect_result;
+    int             connect_error;
+
+    /* Overall connect deadline (TCP establishment only, design D3). */
+    int64_t   deadline_timer;   /* Keel timer id, or -1                          */
+    uint64_t  deadline_ms;      /* absolute monotonic instant, or 0 = unbounded  */
+    int       deadline_fired;
+
+    /* RFC 8305 Connection Attempt Delay timer (the Happy-Eyeballs stagger). */
+    int64_t   delay_timer;      /* Keel timer id, or -1                          */
+
+    /* The winning connected descriptor (blocking after connect). */
+    KlSocketHandle fd;
+
+    /* Owned: optional attached TLS session. When non-NULL, send/recv tunnel
+     * through it (design D2); the transport frees it in close. */
+    struct HlTlsClient *tls;
+
+    int closed;   /* 1 once hl_pg_transport_close has run (idempotency guard)    */
+} PgTransport;
+
+/**
+ * Resolve @p host / @p port, race the addresses through KlConnectOp on a private
+ * event loop, and leave @p t holding the winning blocking descriptor.
+ *
+ * An IP-literal @p host is parsed directly via kl_sockaddr_parse (no DNS,
+ * matching the IP-literal-only databases.dynamic CIDR gate); a hostname is
+ * resolved through a sandbox-compatible blocking getaddrinfo adapter kept here
+ * (never in pg_conn.c). At most KL_CONNECT_MAX_ADDRS ordered addresses are raced.
+ *
+ * @p timeout_ms > 0 bounds TCP establishment only (design D3): one absolute
+ * connect deadline is armed after resolution, and the Happy-Eyeballs stagger does
+ * not refresh it. @p timeout_ms <= 0 arms no deadline (unbounded connect,
+ * preserving pg_connect's prior behavior).
+ *
+ * @p sp_or_NULL, when non-NULL, is a caller-supplied provider (the test seam);
+ * NULL selects the default POSIX provider. The reference is borrowed and must
+ * outlive @p t.
+ *
+ * On failure the transport cancels the op and pumps to confirmed detachment
+ * before releasing embedded storage. Returns 0 on success (with @p t ready for
+ * send/recv), or -1 with a message written to @p errbuf (which may be NULL),
+ * mirroring pg_conn.c's set_err style. On failure @p t holds no live descriptor.
+ */
+int hl_pg_transport_connect(PgTransport *t, const char *host, const char *port,
+                            int timeout_ms, const KlSocketProvider *sp_or_NULL,
+                            char *errbuf, size_t errlen);
+
+/**
+ * Adopt an already-connected, blocking descriptor @p fd (design Amendment 2).
+ *
+ * Takes ownership of @p fd exactly once, associates it with @p sp_or_NULL (or the
+ * default POSIX provider when NULL), and skips resolution, connection racing, and
+ * event-context creation. Subsequent send/recv/close use the same path as a raced
+ * connection. This backs the existing hl_pg_conn_start(conn, fd, dsn) test API.
+ *
+ * Returns 0 on success, -1 on a bad argument.
+ */
+int hl_pg_transport_adopt(PgTransport *t, int fd,
+                          const KlSocketProvider *sp_or_NULL);
+
+/**
+ * Attach an optional TLS session to route subsequent send/recv through (design
+ * D2). @p tls is created and handshaked by the caller (pg_conn.c) over the
+ * transport's blocking descriptor. Ownership transfers to the transport, which
+ * frees it in hl_pg_transport_close. Passing NULL detaches (rarely used).
+ */
+void hl_pg_transport_attach_tls(PgTransport *t, struct HlTlsClient *tls);
+
+/**
+ * One blocking send / recv over the transport, EINTR-retried and TLS-aware.
+ *
+ * When a TLS session is attached the bytes tunnel through hl_tls_client_write /
+ * _read; otherwise the provider send / recv is used with SIGPIPE suppression
+ * (set_nosigpipe on the fd plus the nosignal send flag where the platform has
+ * one). These are SINGLE operations: the provider (or TLS) may return short, so
+ * callers that need every byte use hl_pg_transport_send_all. Returns the byte
+ * count (> 0), 0 on orderly close, or -1 on error.
+ */
+ssize_t hl_pg_transport_send(PgTransport *t, const uint8_t *buf, size_t len);
+ssize_t hl_pg_transport_recv(PgTransport *t, uint8_t *buf, size_t len);
+
+/**
+ * Send every byte of @p buf (all-or-error), looping over hl_pg_transport_send.
+ * This is conn_send's semantics: returns 0 iff all @p len bytes were written, -1
+ * on any short/failed write.
+ */
+int hl_pg_transport_send_all(PgTransport *t, const uint8_t *buf, size_t len);
+
+/**
+ * The raw integer descriptor (POSIX KlSocketHandle == int) for handing to the
+ * hl_tls_client_* helpers, which take an int fd. Returns -1 when no descriptor is
+ * held.
+ */
+int hl_pg_transport_fd(const PgTransport *t);
+
+/**
+ * Close the transport exactly once: TLS shutdown (if attached), TLS free, then
+ * provider close of the winning descriptor. Idempotent and NULL-safe. Does NOT
+ * free @p t itself (the storage is caller-owned / embedded); it only retires the
+ * descriptor and TLS session. On a still-live (never-detached) connect op it
+ * cancels and pumps to confirmed detachment before retiring storage.
+ */
+void hl_pg_transport_close(PgTransport *t);
+
+#endif /* HL_CAP_PG_TRANSPORT_H */

--- a/mk/features/postgres.mk
+++ b/mk/features/postgres.mk
@@ -4,19 +4,22 @@
 
 # ── PostgreSQL feature archive (composable feature: hull build --with=postgres) ──
 # Bundles the pure-C Postgres v3 wire client (cap_db_postgres.o + cap_pg_conn.o +
-# cap_pgwire.o, defining hl_db_backend_postgres) into ONE archive. Unlike DuckDB
-# there is no vendored engine - it's ~4 KB of Hull's own code, so a straight
-# bundle, no isolation. The backend references base crypto (SCRAM auth) + the
-# shared tls_client (sslmode TLS); both resolve from the platform lib at compose,
-# which build.lua wraps in --start-group because tls_client is not otherwise
-# pulled by a DB-only app (only cap/smtp references it in the base). Native only.
-# `feature-postgres` re-invokes make with HL_ENABLE_POSTGRES=1 so the wire objects
-# (filtered out of a base build) are in scope.
+# cap_pg_transport.o + cap_pgwire.o, defining hl_db_backend_postgres) into ONE
+# archive. Unlike DuckDB there is no vendored engine - it's ~4 KB of Hull's own
+# code, so a straight bundle, no isolation. The backend references base crypto
+# (SCRAM auth) + the shared tls_client (sslmode TLS); both resolve from the
+# platform lib at compose, which build.lua wraps in --start-group because
+# tls_client is not otherwise pulled by a DB-only app (only cap/smtp references it
+# in the base). cap_pg_transport.o additionally references Keel (KlConnectOp +
+# KlEventCtx for the connect race), which is likewise resolved from the base at
+# compose. Native only. `feature-postgres` re-invokes make with
+# HL_ENABLE_POSTGRES=1 so the wire objects (filtered out of a base build) are in
+# scope.
 feature-postgres:
 	$(MAKE) $(BUILDDIR)/libhull_feature-postgres.a HL_ENABLE_POSTGRES=1
 .PHONY: feature-postgres
 
-$(BUILDDIR)/libhull_feature-postgres.a: $(BUILDDIR)/cap_db_postgres.o $(BUILDDIR)/cap_pg_conn.o $(BUILDDIR)/cap_pgwire.o | $(BUILDDIR)
+$(BUILDDIR)/libhull_feature-postgres.a: $(BUILDDIR)/cap_db_postgres.o $(BUILDDIR)/cap_pg_conn.o $(BUILDDIR)/cap_pg_transport.o $(BUILDDIR)/cap_pgwire.o | $(BUILDDIR)
 	@rm -f $@
-	$(AR) rcs $@ $(BUILDDIR)/cap_db_postgres.o $(BUILDDIR)/cap_pg_conn.o $(BUILDDIR)/cap_pgwire.o
+	$(AR) rcs $@ $(BUILDDIR)/cap_db_postgres.o $(BUILDDIR)/cap_pg_conn.o $(BUILDDIR)/cap_pg_transport.o $(BUILDDIR)/cap_pgwire.o
 	@echo "built $@ ($$(du -h $@ | cut -f1))"

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -50,6 +50,14 @@ ifneq ($(HL_ENABLE_POSTGRES),1)
   TEST_SRCS := $(filter-out %/test_pg_transport.c,$(TEST_SRCS))
 endif
 
+# test_pg_conn now drives hl_pg_conn_start through the PgTransport byte transport
+# (adopt path), so like test_pg_transport it needs KlConnectOp + KlEventCtx +
+# cap/pg_transport.c, none of which exist on a base (non-Postgres) build. Gate its
+# discovery on HL_ENABLE_POSTGRES=1; the explicit rule below wires it.
+ifneq ($(HL_ENABLE_POSTGRES),1)
+  TEST_SRCS := $(filter-out %/test_pg_conn.c,$(TEST_SRCS))
+endif
+
 # Under MSan, drop test_js_conformance. Its oracle calls raw JS_Eval on arbitrary JS
 # snippets (including destructuring) to get a ground-truth verdict, which trips a
 # use-of-uninitialized-value INSIDE vendored quickjs.c's js_parse_destructuring_element --
@@ -100,18 +108,28 @@ $(BUILDDIR)/test_pgwire: $(TESTDIR)/hull/cap/test_pgwire.c $(SRCDIR)/hull/cap/pg
 	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ \
 		$(TESTDIR)/hull/cap/test_pgwire.c $(SRCDIR)/hull/cap/pgwire.c $(LDFLAGS)
 
-# pgwire connection / DSN / handshake test: same rationale as test_pgwire.
-# pg_conn.c + pgwire.c are gated out of CAP_OBJS until HL_ENABLE_POSTGRES.
+# pgwire crypto objects, still used by the mysql tests below.
 PG_CRYPTO_OBJS := $(BUILDDIR)/cap_crypto.o $(BUILDDIR)/cap_crypto_hmac_mbedtls.o \
                   $(BUILDDIR)/cap_crypto_asym_mbedtls.o $(MBEDTLS_OBJS) $(TWEETNACL_OBJ)
-# HL_PG_NO_TLS strips the Keel-dependent TLS transport: the tests drive the
-# handshake over a plaintext socketpair, so they need neither tls_client.o nor
-# Keel. sslmode parsing / SSLRequest negotiation stay covered (they are
-# TLS-transport-independent).
-$(BUILDDIR)/test_pg_conn: $(TESTDIR)/hull/cap/test_pg_conn.c $(SRCDIR)/hull/cap/pg_conn.c $(SRCDIR)/hull/cap/pgwire.c $(PG_CRYPTO_OBJS) | $(BUILDDIR)
-	$(CC) $(CFLAGS) -DHL_PG_NO_TLS $(INCLUDES) -I$(VENDDIR) -o $@ \
+
+# pgwire connection / DSN / handshake test. hl_pg_conn_start now rides the
+# PgTransport byte transport (Keel v3), so the test source-compiles pg_conn.c +
+# pgwire.c + pg_transport.c together and links TEST_COMMON_LIBS (which already
+# carries Keel, mbedTLS, tls_client, and the crypto SCRAM depends on), mirroring
+# test_pg_transport's direct-compile-plus-filter pattern. The three cap objects
+# are filtered OUT of the common link so the direct-included definitions do not
+# collide. -DHL_PG_NO_TLS is DROPPED (the connection layer + transport are now
+# linked) and HL_PG_NO_SCRAM stays off (the test exercises SCRAM). Only reached
+# under HL_ENABLE_POSTGRES=1. The socketpair handshake tests stay plaintext (the
+# adopt path drives the descriptor directly), so no TLS server is needed.
+PG_CONN_TEST_LIBS := $(filter-out $(BUILDDIR)/cap_pg_conn.o $(BUILDDIR)/cap_pgwire.o $(BUILDDIR)/cap_pg_transport.o,$(TEST_COMMON_LIBS))
+PG_CONN_TEST_DEPS := $(filter-out $(BUILDDIR)/cap_pg_conn.o $(BUILDDIR)/cap_pgwire.o $(BUILDDIR)/cap_pg_transport.o,$(TEST_COMMON_DEPS))
+$(BUILDDIR)/test_pg_conn: $(TESTDIR)/hull/cap/test_pg_conn.c \
+    $(SRCDIR)/hull/cap/pg_conn.c $(SRCDIR)/hull/cap/pgwire.c $(SRCDIR)/hull/cap/pg_transport.c \
+    $(PG_CONN_TEST_DEPS) | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ \
 		$(TESTDIR)/hull/cap/test_pg_conn.c $(SRCDIR)/hull/cap/pg_conn.c $(SRCDIR)/hull/cap/pgwire.c \
-		$(PG_CRYPTO_OBJS) $(LDFLAGS)
+		$(SRCDIR)/hull/cap/pg_transport.c $(PG_CONN_TEST_LIBS) $(LDFLAGS)
 
 # PostgreSQL-over-Keel transport test: direct-includes src/hull/cap/pg_transport.c
 # (to unit-test its static helpers: the resolve adapter, the connect machinery,

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -40,6 +40,16 @@ ifeq ($(HL_ENABLE_IMAGE),0)
   TEST_SRCS := $(filter-out %/test_image.c,$(TEST_SRCS))
 endif
 
+# The PostgreSQL-over-Keel transport test inherently needs KlConnectOp +
+# KlEventCtx + cap/pg_transport.c, none of which exist on a base (non-Postgres)
+# build - cap/pg_transport.c is filtered out of CAP_OBJS until HL_ENABLE_POSTGRES.
+# Unlike test_pg_conn (which source-compiles the codec free of Keel via
+# -DHL_PG_NO_TLS), the transport cannot avoid Keel, so gate its discovery on
+# HL_ENABLE_POSTGRES=1. The explicit rule below wires it.
+ifneq ($(HL_ENABLE_POSTGRES),1)
+  TEST_SRCS := $(filter-out %/test_pg_transport.c,$(TEST_SRCS))
+endif
+
 # Under MSan, drop test_js_conformance. Its oracle calls raw JS_Eval on arbitrary JS
 # snippets (including destructuring) to get a ground-truth verdict, which trips a
 # use-of-uninitialized-value INSIDE vendored quickjs.c's js_parse_destructuring_element --
@@ -102,6 +112,22 @@ $(BUILDDIR)/test_pg_conn: $(TESTDIR)/hull/cap/test_pg_conn.c $(SRCDIR)/hull/cap/
 	$(CC) $(CFLAGS) -DHL_PG_NO_TLS $(INCLUDES) -I$(VENDDIR) -o $@ \
 		$(TESTDIR)/hull/cap/test_pg_conn.c $(SRCDIR)/hull/cap/pg_conn.c $(SRCDIR)/hull/cap/pgwire.c \
 		$(PG_CRYPTO_OBJS) $(LDFLAGS)
+
+# PostgreSQL-over-Keel transport test: direct-includes src/hull/cap/pg_transport.c
+# (to unit-test its static helpers: the resolve adapter, the connect machinery,
+# the blocking send/recv path) under -DHL_PG_TEST_HOOKS, which compiles in the
+# gated provider / resolve / pump-checkpoint test seam (pg_test_socket_provider /
+# pg_test_resolve / pg_test_checkpoint). The seam is set ONLY on this compile
+# line, so the production object never sees it (nm-verified). cap_pg_transport.o
+# must be EXCLUDED from the common link, else the direct-included definitions
+# collide (mirrors test_smtp_transport). Everything else (Keel, mbedTLS, the
+# tls_client, the rest of the cap layer) comes from TEST_COMMON_LIBS. Only reached
+# under HL_ENABLE_POSTGRES=1 (Keel + cap_pg_transport.o present).
+PG_TP_TEST_LIBS := $(filter-out $(BUILDDIR)/cap_pg_transport.o,$(TEST_COMMON_LIBS))
+PG_TP_TEST_DEPS := $(filter-out $(BUILDDIR)/cap_pg_transport.o,$(TEST_COMMON_DEPS))
+$(BUILDDIR)/test_pg_transport: $(TESTDIR)/hull/cap/test_pg_transport.c \
+    $(SRCDIR)/hull/cap/pg_transport.c $(PG_TP_TEST_DEPS) | $(BUILDDIR)
+	$(CC) $(CFLAGS) -DHL_PG_TEST_HOOKS $(INCLUDES) -I$(VENDDIR) -o $@ $< $(PG_TP_TEST_LIBS) $(LDFLAGS)
 
 # Valkey/Redis RESP2/3 codec test: respwire.c is a self-contained parser gated
 # out of CAP_OBJS until HL_ENABLE_VALKEY, so link it directly (explicit rule

--- a/scripts/ci/classify_changes.py
+++ b/scripts/ci/classify_changes.py
@@ -106,6 +106,7 @@ PLAN = [
 # later step.
 DB_POSTGRES_FILES = frozenset({
     "src/hull/cap/db_postgres.c", "src/hull/cap/pgwire.c", "src/hull/cap/pg_conn.c",
+    "src/hull/cap/pg_transport.c",
 })
 DB_MYSQL_FILES = frozenset({
     "src/hull/cap/db_mysql.c", "src/hull/cap/mysqlwire.c", "src/hull/cap/mysql_conn.c",

--- a/scripts/ci/job_plan.py
+++ b/scripts/ci/job_plan.py
@@ -90,6 +90,7 @@ GROUP = {
     # -- db subsystem (per-backend integrations) --
     "postgres": "db-postgres",
     "postgres-feature": "db-postgres",
+    "pg-transport-sanitize": "db-postgres",
     "mysql": "db-mysql",
     "mysql-feature": "db-mysql",
     "valkey": "db-valkey",

--- a/src/hull/cap/pg_conn.c
+++ b/src/hull/cap/pg_conn.c
@@ -17,10 +17,12 @@
 #ifndef HL_PG_NO_SCRAM
 #include "hull/cap/crypto.h"
 #endif
-/* TLS transport. The pure-parser fuzzers define HL_PG_NO_TLS to
- * stay free of Keel; the real build and tests keep raw send/recv when no TLS
- * session is attached. */
+/* The byte transport (Keel v3) + the TLS client. The pure-parser fuzzers define
+ * HL_PG_NO_TLS to stay free of Keel; the whole connection layer below is wrapped
+ * under the same guard, so those harnesses omit it and reach only the pure
+ * functions (DSN parse / sslmode parse / base64 / SCRAM proof / SQL rewrite). */
 #ifndef HL_PG_NO_TLS
+#include "hull/cap/pg_transport.h"
 #include "hull/shared/tls_client.h"
 #endif
 
@@ -204,81 +206,25 @@ void hl_pg_dsn_scrub(HlPgDsn *dsn)
     if (dsn) pg_secure_zero(dsn->password, sizeof dsn->password);
 }
 
-/* ── Blocking transport ───────────────────────────────────────────── */
+/* ── Connection layer (Keel v3 transport) ─────────────────────────────
+ * Everything from here to the end of hl_pg_conn_close (plus the query path and
+ * hl_pg_wait_notify further down) rides the PgTransport byte transport, which
+ * pulls in Keel + tls_client + mbedTLS. The pure-parser fuzzers set HL_PG_NO_TLS
+ * to omit this whole layer and keep only the DSN parser, sslmode parser, base64,
+ * SCRAM proof, and the SQL rewriter (all outside this guard). */
+#ifndef HL_PG_NO_TLS
 
-/* TCP connect with a bounded wait (non-blocking connect + select), mirroring
- * cap/smtp.c. Returns a blocking fd, or -1. */
-static int pg_connect(const char *host, const char *port, int timeout_ms)
-{
-    struct addrinfo hints;
-    memset(&hints, 0, sizeof hints);
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
-
-    struct addrinfo *res = NULL;
-    if (getaddrinfo(host, port, &hints, &res) != 0 || !res) return -1;
-
-    int fd = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
-    if (fd < 0) { freeaddrinfo(res); return -1; }
-
-#ifdef SO_NOSIGPIPE
-    int on = 1;
-    setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof on);
-#endif
-
-    int flags = fcntl(fd, F_GETFL, 0);
-    fcntl(fd, F_SETFL, flags | O_NONBLOCK);
-
-    int rc = connect(fd, res->ai_addr, res->ai_addrlen);
-    if (rc < 0 && errno == EINPROGRESS) {
-        fd_set wf;
-        FD_ZERO(&wf);
-        FD_SET(fd, &wf);
-        struct timeval tv;
-        tv.tv_sec = timeout_ms / 1000;
-        tv.tv_usec = (timeout_ms % 1000) * 1000;
-        rc = select(fd + 1, NULL, &wf, NULL, timeout_ms > 0 ? &tv : NULL);
-        if (rc > 0) {
-            int soerr = 0;
-            socklen_t l = sizeof soerr;
-            getsockopt(fd, SOL_SOCKET, SO_ERROR, &soerr, &l);
-            rc = soerr == 0 ? 0 : -1;
-        } else {
-            rc = -1;
-        }
-    }
-    freeaddrinfo(res);
-    if (rc < 0) { close(fd); return -1; }
-
-    fcntl(fd, F_SETFL, flags);   /* restore blocking */
-    return fd;
-}
-
-/* Transport helpers. Once the TLS handshake has attached a session
- * (conn->tls != NULL) all bytes tunnel through it; otherwise raw socket
- * send/recv. HL_PG_NO_TLS (fuzzers) drops the TLS branch entirely. */
+/* Transport helpers. All bytes go through the owned PgTransport, which routes
+ * through an attached TLS session when one has been handed to it (see
+ * hl_pg_conn_open) or plain provider send/recv otherwise. */
 static ssize_t io_send(HlPgConn *conn, const uint8_t *buf, size_t len)
 {
-#ifndef HL_PG_NO_TLS
-    if (conn->tls)
-        return hl_tls_client_write(conn->fd, conn->tls, buf, len);
-#endif
-    ssize_t n;
-    do { n = send(conn->fd, buf, len, PG_SEND_FLAGS); }
-    while (n < 0 && errno == EINTR);
-    return n;
+    return hl_pg_transport_send(conn->transport, buf, len);
 }
 
 static ssize_t io_recv(HlPgConn *conn, uint8_t *buf, size_t len)
 {
-#ifndef HL_PG_NO_TLS
-    if (conn->tls)
-        return hl_tls_client_read(conn->fd, conn->tls, buf, len);
-#endif
-    ssize_t n;
-    do { n = recv(conn->fd, buf, len, 0); }
-    while (n < 0 && errno == EINTR);
-    return n;
+    return hl_pg_transport_recv(conn->transport, buf, len);
 }
 
 static int conn_send(HlPgConn *conn, const uint8_t *buf, size_t len)
@@ -343,10 +289,13 @@ static int conn_next_frame(HlPgConn *conn, HlPgFrame *f)
 
 static void conn_teardown(HlPgConn *conn)
 {
-#ifndef HL_PG_NO_TLS
-    if (conn->tls) { hl_tls_client_free(conn->tls); conn->tls = NULL; }
-#endif
-    if (conn->fd >= 0) { close(conn->fd); conn->fd = -1; }
+    /* Best-effort: the transport frees any attached TLS session and closes the
+     * descriptor. A -1 (a live connect op that will not confirm detachment) is an
+     * accepted rare intentional leak, the same contract as the transport. */
+    if (conn->transport) {
+        hl_pg_transport_close(conn->transport);
+        conn->transport = NULL;
+    }
     free(conn->rbuf);
     conn->rbuf = NULL;
     conn->rcap = conn->rlen = conn->consumed = 0;
@@ -521,25 +470,15 @@ static int scram_handle(HlPgConn *conn, PgScram *sc, const HlPgDsn *dsn,
 }
 #endif /* HL_PG_NO_SCRAM */
 
-/* Run the startup + auth handshake on an already-connected fd. When @p tls is
- * non-NULL the socket has already completed a TLS handshake and every byte
- * tunnels through it; ownership of @p tls transfers to conn (freed by
- * conn_teardown). */
-static int pg_start(HlPgConn *conn, int fd, const HlPgDsn *dsn,
-                    struct HlTlsClient *tls)
+/* Run the startup + auth handshake over @p transport, which conn takes ownership
+ * of (freed by conn_teardown). When TLS was negotiated the caller has already
+ * attached the session to @p transport, so every byte tunnels through it
+ * transparently. SIGPIPE suppression is the transport's job (adopt / connect set
+ * SO_NOSIGPIPE on the descriptor). */
+static int pg_start(HlPgConn *conn, PgTransport *transport, const HlPgDsn *dsn)
 {
     memset(conn, 0, sizeof(*conn));
-    conn->fd = fd;
-#ifndef HL_PG_NO_TLS
-    conn->tls = tls;
-#else
-    (void)tls;
-#endif
-
-#ifdef SO_NOSIGPIPE
-    int on = 1;
-    setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof on);
-#endif
+    conn->transport = transport;
 
     HlPgWriter w;
     hl_pg_writer_init(&w);
@@ -654,11 +593,28 @@ static int pg_start(HlPgConn *conn, int fd, const HlPgDsn *dsn,
 
 int hl_pg_conn_start(HlPgConn *conn, int fd, const HlPgDsn *dsn)
 {
-    return pg_start(conn, fd, dsn, NULL);
+    /* Adopt takes ownership of fd on success; on failure the caller still owns
+     * fd (adopt contract), so do NOT close it here. */
+    PgTransport *t = hl_pg_transport_adopt(fd, NULL, conn->errmsg, sizeof conn->errmsg);
+    if (!t) {
+        char saved[sizeof conn->errmsg];
+        snprintf(saved, sizeof saved, "%s", conn->errmsg);
+        memset(conn, 0, sizeof(*conn));
+        snprintf(conn->errmsg, sizeof conn->errmsg, "%s", saved);
+        return -1;
+    }
+    /* On any handshake failure pg_start's error path runs conn_teardown, which
+     * closes the transport (and thus the adopted fd), matching the documented
+     * "closed on handshake failure" behavior without a double close. */
+    return pg_start(conn, t, dsn);
 }
+
+#endif /* HL_PG_NO_TLS: end of the first connection-layer region */
 
 /* ── TLS negotiation (SSLRequest / sslmode) ───────────────────────── */
 
+/* Pure: maps a DSN sslmode string to the enum. Stays outside the transport guard
+ * so the pure-parser fuzzers reach it. */
 int hl_pg_sslmode_parse(const char *s)
 {
     if (!s || !s[0])                   return HL_PG_SSLMODE_PREFER;
@@ -669,6 +625,8 @@ int hl_pg_sslmode_parse(const char *s)
         strcmp(s, "verify-full") == 0) return HL_PG_SSLMODE_VERIFY;
     return -1;
 }
+
+#ifndef HL_PG_NO_TLS
 
 HlPgSslDecision hl_pg_ssl_negotiate(int fd, HlPgSslMode mode,
                                     char *errbuf, size_t errlen)
@@ -708,10 +666,12 @@ HlPgSslDecision hl_pg_ssl_negotiate(int fd, HlPgSslMode mode,
 
 int hl_pg_conn_open(HlPgConn *conn, const HlPgDsn *dsn, int timeout_ms)
 {
-    int fd = pg_connect(dsn->host, dsn->port, timeout_ms);
-    if (fd < 0) {
+    PgTransport *t = hl_pg_transport_connect(dsn->host, dsn->port, timeout_ms,
+                                             NULL, conn->errmsg, sizeof conn->errmsg);
+    if (!t) {
         memset(conn, 0, sizeof(*conn));
-        conn->fd = -1;
+        conn->transport = NULL;
+        /* Overwrite the transport's message with the historical public token. */
         snprintf(conn->errmsg, sizeof conn->errmsg,
                  "cannot connect to %s:%s", dsn->host, dsn->port);
         return -1;
@@ -720,65 +680,71 @@ int hl_pg_conn_open(HlPgConn *conn, const HlPgDsn *dsn, int timeout_ms)
     int mode = hl_pg_sslmode_parse(dsn->sslmode);
     if (mode < 0) {
         memset(conn, 0, sizeof(*conn));
-        conn->fd = -1;
+        conn->transport = NULL;
         snprintf(conn->errmsg, sizeof conn->errmsg,
                  "unknown sslmode: %s", dsn->sslmode);
-        close(fd);
+        hl_pg_transport_close(t);
         return -1;
     }
     if (mode != HL_PG_SSLMODE_DISABLE) {
+        /* Negotiate SSLRequest pre-TLS on the transport's raw descriptor. */
+        int fd = hl_pg_transport_fd(t);
         char e[128] = {0};
         HlPgSslDecision d = hl_pg_ssl_negotiate(fd, (HlPgSslMode)mode, e, sizeof e);
         if (d == HL_PG_SSL_FAIL) {
             memset(conn, 0, sizeof(*conn));
-            conn->fd = -1;
+            conn->transport = NULL;
             snprintf(conn->errmsg, sizeof conn->errmsg, "%s", e);
-            close(fd);
+            hl_pg_transport_close(t);
             return -1;
         }
         if (d == HL_PG_SSL_USE_TLS) {
-#ifndef HL_PG_NO_TLS
             /* verify-ca / verify-full check the chain + hostname against the
-             * embedded CA bundle; require / prefer take the session as-is. */
+             * embedded CA bundle; require / prefer take the session as-is. The
+             * handshake runs over the transport's fd, then the session is handed
+             * to the transport so subsequent bytes tunnel through it. */
             int verify = (mode == HL_PG_SSLMODE_VERIFY);
             struct HlTlsClient *tls =
                 hl_tls_client_handshake(fd, dsn->host, verify, timeout_ms);
             if (!tls) {
                 memset(conn, 0, sizeof(*conn));
-                conn->fd = -1;
+                conn->transport = NULL;
                 snprintf(conn->errmsg, sizeof conn->errmsg,
                          "TLS handshake with %s failed", dsn->host);
-                close(fd);
+                hl_pg_transport_close(t);
                 return -1;
             }
-            return pg_start(conn, fd, dsn, tls);
-#else
-            memset(conn, 0, sizeof(*conn));
-            conn->fd = -1;
-            set_err(conn->errmsg, sizeof conn->errmsg,
-                    "TLS not available in this build");
-            close(fd);
-            return -1;
-#endif
+            if (hl_pg_transport_attach_tls(t, tls) != 0) {
+                hl_tls_client_free(tls);
+                memset(conn, 0, sizeof(*conn));
+                conn->transport = NULL;
+                snprintf(conn->errmsg, sizeof conn->errmsg,
+                         "TLS handshake with %s failed", dsn->host);
+                hl_pg_transport_close(t);
+                return -1;
+            }
+            return pg_start(conn, t, dsn);
         }
         /* PLAINTEXT: server declined TLS and sslmode permits fallback. */
     }
 
-    return hl_pg_conn_start(conn, fd, dsn);
+    return pg_start(conn, t, dsn);
 }
 
 void hl_pg_conn_close(HlPgConn *conn)
 {
     if (!conn) return;
-    if (conn->fd >= 0) {
+    if (conn->transport) {
         HlPgWriter w;
         hl_pg_writer_init(&w);
         hl_pg_build_terminate(&w);
         if (!w.err) (void)conn_send(conn, w.buf, w.len);   /* best effort */
         hl_pg_writer_free(&w);
     }
-    conn_teardown(conn);
+    conn_teardown(conn);   /* closes + frees the transport, idempotent */
 }
+
+#endif /* HL_PG_NO_TLS: end of the second connection-layer region */
 
 /* ── Standard base64 + SCRAM-SHA-256 ──────────────────────────────── */
 
@@ -1003,6 +969,10 @@ int hl_pg_rewrite_sql(const char *sql, char *out, size_t outsize, int *nparams)
 
 /* ── Parameterized query execution ────────────────────────────────── */
 
+/* The query + notify paths ride the transport (recv / send), so they sit inside
+ * the same guard the connection layer uses; the pure-parser fuzzers omit them. */
+#ifndef HL_PG_NO_TLS
+
 /* Row count from a CommandComplete tag ("INSERT 0 5", "UPDATE 3", ...):
  * the last space-separated token when it is numeric, else -1. */
 static int64_t parse_affected(const char *tag)
@@ -1100,7 +1070,7 @@ int hl_pg_query(HlPgConn *conn, const char *sql,
                 int64_t *affected)
 {
     if (affected) *affected = -1;
-    if (!conn || conn->fd < 0) {
+    if (!conn || !conn->transport) {
         if (conn) set_err(conn->errmsg, sizeof conn->errmsg, "not connected");
         return -1;
     }
@@ -1243,7 +1213,7 @@ int hl_pg_query(HlPgConn *conn, const char *sql,
 
 int hl_pg_exec_simple(HlPgConn *conn, const char *sql)
 {
-    if (!conn || conn->fd < 0) {
+    if (!conn || !conn->transport) {
         if (conn) set_err(conn->errmsg, sizeof conn->errmsg, "not connected");
         return -1;
     }
@@ -1315,7 +1285,9 @@ static int64_t mono_ms(void)
 
 int hl_pg_wait_notify(HlPgConn *conn, int timeout_ms)
 {
-    if (!conn || conn->fd < 0) return -1;
+    if (!conn || !conn->transport) return -1;
+    int fd = hl_pg_transport_fd(conn->transport);
+    if (fd < 0) return -1;
     if (timeout_ms < 0) timeout_ms = 0;
     int64_t deadline = mono_ms() + timeout_ms;
 
@@ -1347,7 +1319,7 @@ int hl_pg_wait_notify(HlPgConn *conn, int timeout_ms)
          * frames can't extend the total wait past timeout_ms). */
         int remaining = (int)(deadline - mono_ms());
         if (remaining <= 0) return 0;   /* timed out, no notification */
-        struct pollfd pfd = { .fd = conn->fd, .events = POLLIN, .revents = 0 };
+        struct pollfd pfd = { .fd = fd, .events = POLLIN, .revents = 0 };
         int pr = poll(&pfd, 1, remaining);
         if (pr < 0) { if (errno == EINTR) continue; return -1; }
         if (pr == 0) return 0;          /* timed out */
@@ -1372,3 +1344,5 @@ int hl_pg_wait_notify(HlPgConn *conn, int timeout_ms)
         conn->rlen += (size_t)n;
     }
 }
+
+#endif /* HL_PG_NO_TLS: end of the query / notify connection-layer region */

--- a/src/hull/cap/pg_conn.c
+++ b/src/hull/cap/pg_conn.c
@@ -628,26 +628,23 @@ int hl_pg_sslmode_parse(const char *s)
 
 #ifndef HL_PG_NO_TLS
 
-HlPgSslDecision hl_pg_ssl_negotiate(int fd, HlPgSslMode mode,
+HlPgSslDecision hl_pg_ssl_negotiate(PgTransport *t, HlPgSslMode mode,
                                     char *errbuf, size_t errlen)
 {
     if (mode == HL_PG_SSLMODE_DISABLE) return HL_PG_SSL_PLAINTEXT;
 
-    /* SSLRequest: length(8) then request code 80877103 (0x04d2162f). */
+    /* SSLRequest: length(8) then request code 80877103 (0x04d2162f). This pre-TLS
+     * plaintext probe rides the transport (no TLS attached yet), so send_all / recv
+     * go through the provider - the same production I/O path as the rest of the
+     * protocol, not a separate raw send/recv. */
     static const uint8_t req[8] = { 0, 0, 0, 8, 0x04, 0xd2, 0x16, 0x2f };
-    size_t sent = 0;
-    while (sent < sizeof req) {
-        ssize_t n;
-        do { n = send(fd, req + sent, sizeof req - sent, PG_SEND_FLAGS); }
-        while (n < 0 && errno == EINTR);
-        if (n <= 0) { set_err(errbuf, errlen, "failed to send SSLRequest");
-                      return HL_PG_SSL_FAIL; }
-        sent += (size_t)n;
+    if (hl_pg_transport_send_all(t, req, sizeof req) != 0) {
+        set_err(errbuf, errlen, "failed to send SSLRequest");
+        return HL_PG_SSL_FAIL;
     }
 
     uint8_t resp;
-    ssize_t n;
-    do { n = recv(fd, &resp, 1, 0); } while (n < 0 && errno == EINTR);
+    ssize_t n = hl_pg_transport_recv(t, &resp, 1);
     if (n <= 0) { set_err(errbuf, errlen, "no SSLRequest response from server");
                   return HL_PG_SSL_FAIL; }
 
@@ -687,10 +684,9 @@ int hl_pg_conn_open(HlPgConn *conn, const HlPgDsn *dsn, int timeout_ms)
         return -1;
     }
     if (mode != HL_PG_SSLMODE_DISABLE) {
-        /* Negotiate SSLRequest pre-TLS on the transport's raw descriptor. */
-        int fd = hl_pg_transport_fd(t);
+        /* SSLRequest pre-TLS probe rides the transport (plaintext, no TLS yet). */
         char e[128] = {0};
-        HlPgSslDecision d = hl_pg_ssl_negotiate(fd, (HlPgSslMode)mode, e, sizeof e);
+        HlPgSslDecision d = hl_pg_ssl_negotiate(t, (HlPgSslMode)mode, e, sizeof e);
         if (d == HL_PG_SSL_FAIL) {
             memset(conn, 0, sizeof(*conn));
             conn->transport = NULL;
@@ -701,8 +697,10 @@ int hl_pg_conn_open(HlPgConn *conn, const HlPgDsn *dsn, int timeout_ms)
         if (d == HL_PG_SSL_USE_TLS) {
             /* verify-ca / verify-full check the chain + hostname against the
              * embedded CA bundle; require / prefer take the session as-is. The
-             * handshake runs over the transport's fd, then the session is handed
-             * to the transport so subsequent bytes tunnel through it. */
+             * handshake needs the raw descriptor (hl_tls_client_handshake takes an
+             * int fd); the resulting session is then handed to the transport so
+             * subsequent bytes tunnel through it. */
+            int fd = hl_pg_transport_fd(t);
             int verify = (mode == HL_PG_SSLMODE_VERIFY);
             struct HlTlsClient *tls =
                 hl_tls_client_handshake(fd, dsn->host, verify, timeout_ms);

--- a/src/hull/cap/pg_transport.c
+++ b/src/hull/cap/pg_transport.c
@@ -1,0 +1,735 @@
+/*
+ * pg_transport.c: PostgreSQL byte transport over Keel v3 public primitives.
+ *
+ * See include/hull/cap/pg_transport.h for the ownership split and the contract.
+ *
+ * This composes Keel's PUBLIC transport surface for the CONNECT phase only:
+ * KlConnectOp (resolve + Happy-Eyeballs racing connect) driven on a PRIVATE,
+ * operation-local KlEventCtx, plus the POSIX socket provider's public ops table.
+ * The connect machinery is the reviewed cap/smtp_transport.c pattern (resolve
+ * adapter + KlConnectOp hooks + private KlEventCtx pump + socket-provider
+ * wrappers), MINUS the KlStream: a synchronous PostgreSQL connection needs no
+ * queued-write / read pause-resume / graceful-close machinery. After the race is
+ * won the winning fd is set_blocking()'d and every subsequent byte is plain
+ * blocking recv / send with no event loop (design D1).
+ *
+ * TLS stays the shared hl_tls_client_* helpers layered over the blocking fd
+ * (design D2). This transport only STORES the optional attached HlTlsClient and
+ * routes send/recv through it; the SSLRequest negotiation + handshake belong to
+ * the consumer (pg_conn.c), which hands the session here via attach_tls.
+ *
+ * NO vendor/keel/src header is used. keel/connect_op_detail.h + keel/event_ctx.h
+ * are included solely so KlConnectOp / KlEventCtx can be EMBEDDED fields (storage
+ * sizing via the public opt-in layout); their internal struct fields are never
+ * read or written.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "hull/cap/pg_transport.h"
+#include "hull/shared/tls_client.h"   /* hl_tls_client_read/_write/_shutdown/_free */
+
+/* PUBLIC Keel headers only. */
+#include <keel/connect_op.h>
+#include <keel/connect_op_detail.h> /* opt-in layout: embed a KlConnectOp (storage only) */
+#include <keel/event_ctx.h>
+#include <keel/event.h>
+#include <keel/socket.h>
+#include <keel/sockaddr.h>
+#include <keel/handle.h>
+#include <keel/timer.h>
+#include <keel/error.h>
+#include <keel/allocator.h>
+#include <keel/clock.h>   /* kl_monotonic_ms: monotonic connect deadline */
+
+/* Resolution is a sandbox-compatible BLOCKING getaddrinfo, kept out of
+ * cap/pg_conn.c (which the design keeps free of getaddrinfo/socket/poll/raw I/O).
+ * This preserves the current Postgres behavior: /etc/hosts, search domains, and
+ * the OS resolver the kernel-sandbox network-outbound grant permits. */
+#include <netdb.h>
+#include <sys/socket.h>   /* AF_UNSPEC / AF_INET / AF_INET6 (cosmo needs it explicit) */
+#include <netinet/in.h>   /* struct sockaddr_in / sockaddr_in6 for the resolver */
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>   /* atoi */
+#include <string.h>
+
+#include "log.h"
+
+/* SIGPIPE suppression on send has parity with pg_conn.c: the winning / adopted fd
+ * gets SO_NOSIGPIPE via the provider's set_nosigpipe hook where the platform
+ * offers it, and the POSIX provider's send applies MSG_NOSIGNAL internally
+ * (vendor/keel/src/socket_posix.c), so hl_pg_transport_send never emits SIGPIPE. */
+
+/* Default connect budget when the caller passes timeout_ms <= 0 is NONE: the
+ * transport arms no deadline and the connect is unbounded, preserving
+ * pg_connect's prior select(NULL) behavior. But the pump still needs a per-stage
+ * step budget to bound one kl_event_ctx_run wait; a completed op / detachment is
+ * the real terminal, so a generous fallback only caps how long one pump loop
+ * blocks with no readiness. */
+#define PG_PUMP_STEP_MS   50
+#define PG_PUMP_FALLBACK_MS  30000   /* stage cap when timeout_ms <= 0 (unbounded op) */
+
+/* RFC 8305 Connection Attempt Delay: wait before starting the next address while
+ * an earlier attempt is still in flight (the Happy-Eyeballs stagger). */
+#define PG_CONNECT_ATTEMPT_DELAY_MS  250
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Socket provider: an immutable process-wide ops table. We call its PUBLIC ops
+ * directly, reading errno for would-block / EINPROGRESS classification (the
+ * defined hosted-errno fallback on the POSIX provider).
+ * ────────────────────────────────────────────────────────────────────────── */
+
+static const KlSocketProvider *g_sp;
+static pthread_once_t          g_sp_once = PTHREAD_ONCE_INIT;
+static void init_sp(void) { g_sp = kl_socket_provider_posix(); }
+static const KlSocketProvider *default_provider(void)
+{
+    pthread_once(&g_sp_once, init_sp);
+    return g_sp;
+}
+
+#ifdef HL_PG_TEST_HOOKS
+/* Test-only fault-injection provider (compiled ONLY under -DHL_PG_TEST_HOOKS,
+ * ABSENT from the production object). When non-NULL it REPLACES the default POSIX
+ * provider for every sp_* op, so a test can drive connect attempts to
+ * pending / succeed / fail per address and observe attempt order + timestamps. It
+ * is a COHERENT socket seam: it hands the connect op real fds the event loop can
+ * watch, so the Happy-Eyeballs stagger timer and the connect-deadline timer fire
+ * on the same real clock as production (never a divergent virtual clock). */
+const KlSocketProvider *pg_test_socket_provider;
+
+/* When non-NULL, fills t->addrs[] in EXACT injected order and returns the count
+ * (value-copied into the transport-owned array, so no dangling), replacing the
+ * blocking getaddrinfo. */
+int (*pg_test_resolve)(PgTransport *t, const char *host, int port);
+
+/* Fires at the TOP of every pump check with the transport and a monotonically-
+ * increasing checkpoint index, so a test can observe pump progress without
+ * diverging from Keel's clock. */
+void (*pg_test_checkpoint)(PgTransport *t, unsigned idx);
+static unsigned pg_test_checkpoint_seq;
+#endif
+
+/* The active provider: a test-supplied one when set, else the transport's own
+ * borrowed reference (default POSIX). t->sp is set at connect / adopt time; the
+ * connect hooks run while t->sp is live. */
+static const KlSocketProvider *active_sp(const PgTransport *t)
+{
+#ifdef HL_PG_TEST_HOOKS
+    if (pg_test_socket_provider) return pg_test_socket_provider;
+#endif
+    return t->sp ? t->sp : default_provider();
+}
+
+static KlSocketHandle sp_socket(const PgTransport *t, int domain, int type, int protocol)
+{ const KlSocketProvider *sp = active_sp(t); return sp->ops->socket(sp->context, domain, type, protocol); }
+static int sp_set_nonblocking(const PgTransport *t, KlSocketHandle fd)
+{ const KlSocketProvider *sp = active_sp(t); return sp->ops->set_nonblocking(sp->context, fd); }
+static int sp_set_blocking(const PgTransport *t, KlSocketHandle fd)
+{ const KlSocketProvider *sp = active_sp(t); return sp->ops->set_blocking ? sp->ops->set_blocking(sp->context, fd) : 0; }
+static void sp_set_nosigpipe(const PgTransport *t, KlSocketHandle fd)
+{ const KlSocketProvider *sp = active_sp(t); if (sp->ops->set_nosigpipe) sp->ops->set_nosigpipe(sp->context, fd); }
+static int sp_connect(const PgTransport *t, KlSocketHandle fd, const KlSockAddr *a)
+{ const KlSocketProvider *sp = active_sp(t); return sp->ops->connect(sp->context, fd, a); }
+static int sp_get_so_error(const PgTransport *t, KlSocketHandle fd, int *out)
+{ const KlSocketProvider *sp = active_sp(t); return sp->ops->get_so_error(sp->context, fd, out); }
+static kl_ssize_t sp_send(const PgTransport *t, KlSocketHandle fd, const void *b, size_t n)
+{ const KlSocketProvider *sp = active_sp(t); return sp->ops->send(sp->context, fd, b, n); }
+static kl_ssize_t sp_recv(const PgTransport *t, KlSocketHandle fd, void *b, size_t n)
+{ const KlSocketProvider *sp = active_sp(t); return sp->ops->recv(sp->context, fd, b, n); }
+static int sp_close(const PgTransport *t, KlSocketHandle fd)
+{ const KlSocketProvider *sp = active_sp(t); return sp->ops->close(sp->context, fd); }
+
+static void set_err(char *dst, size_t cap, const char *msg)
+{ if (dst && cap) snprintf(dst, cap, "%s", msg); }
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * KlConnectOp hooks (bring-your-own I/O).
+ *
+ * Resolution is a sandbox-compatible BLOCKING getaddrinfo (or an IP-literal fast
+ * path) that completes synchronously before start; the hook only yields the
+ * pre-filled address list to KlConnectOp.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+static void co_connect_watcher(KlSocketHandle fd, KlEventMask ready, void *user_data);
+
+/* Resolve host:port into t->addrs. An IP-literal host takes the no-DNS
+ * kl_sockaddr_parse fast path; a hostname goes through getaddrinfo. Returns
+ * naddrs (>=1) or 0. */
+static int resolve_addrs(PgTransport *t, const char *host, int port)
+{
+#ifdef HL_PG_TEST_HOOKS
+    if (pg_test_resolve)
+        return pg_test_resolve(t, host, port);
+#endif
+    /* IP-literal fast path: kl_sockaddr_parse is numeric-only (no DNS), matching
+     * the IP-literal-only databases.dynamic CIDR gate. */
+    if (kl_sockaddr_parse(&t->addrs[0], host, (uint16_t)port) == 0)
+        return 1;
+
+    char port_str[8];
+    snprintf(port_str, sizeof port_str, "%d", port);
+
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof hints);
+    hints.ai_family   = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+
+    struct addrinfo *res = NULL;
+    if (getaddrinfo(host, port_str, &hints, &res) != 0 || !res)
+        return 0;
+
+    int n = 0;
+    for (struct addrinfo *ai = res; ai && n < KL_CONNECT_MAX_ADDRS; ai = ai->ai_next) {
+        if (ai->ai_family == AF_INET && ai->ai_addr) {
+            const struct sockaddr_in *s = (const struct sockaddr_in *)(const void *)ai->ai_addr;
+            uint8_t ip[4];
+            memcpy(ip, &s->sin_addr, 4);
+            if (kl_sockaddr_from_ipv4(&t->addrs[n], ip, (uint16_t)port) == 0)
+                n++;
+        } else if (ai->ai_family == AF_INET6 && ai->ai_addr) {
+            const struct sockaddr_in6 *s6 = (const struct sockaddr_in6 *)(const void *)ai->ai_addr;
+            uint8_t ip6[16];
+            memcpy(ip6, &s6->sin6_addr, 16);
+            if (kl_sockaddr_from_ipv6(&t->addrs[n], ip6, (uint16_t)port,
+                                      s6->sin6_scope_id) == 0)
+                n++;
+        }
+    }
+    freeaddrinfo(res);
+    return n;
+}
+
+static int co_start_resolve(void *ctx)
+{
+    PgTransport *t = ctx;
+    /* t->naddrs was filled by resolve_addrs before start (synchronous, inline). */
+    if (t->naddrs < 1) {
+        kl_connect_op_on_resolve_failed(&t->connect_op, (int)KL_ERR_DNS);
+        return 0;
+    }
+    kl_connect_op_on_resolved(&t->connect_op, t->naddrs);
+    return 0;
+}
+
+static int co_start_attempt(void *ctx, int idx, int *out_err)
+{
+    PgTransport *t = ctx;
+    if (idx < 0 || idx >= t->naddrs) { *out_err = (int)KL_ERR_CONNECT; return -1; }
+
+    KlSocketHandle fd = sp_socket(t, t->addrs[idx].family == KL_AF_INET6 ? AF_INET6
+                                                                         : AF_INET,
+                                  SOCK_STREAM, 0);
+    if (!kl_handle_valid(fd)) { *out_err = (int)KL_ERR_CONNECT; return -1; }
+    if (sp_set_nonblocking(t, fd) < 0) { sp_close(t, fd); *out_err = (int)KL_ERR_CONNECT; return -1; }
+    sp_set_nosigpipe(t, fd);
+
+    int rc = sp_connect(t, fd, &t->addrs[idx]);
+    int ce = errno;
+    if (rc < 0 && ce != EINPROGRESS) {
+        sp_close(t, fd);
+        *out_err = (int)KL_ERR_CONNECT;
+        return -1;   /* hard local failure: advance to the next address */
+    }
+    if (kl_watcher_add(&t->ev, fd, KL_EVENT_WRITE, co_connect_watcher, t) != 0) {
+        sp_close(t, fd);
+        *out_err = (int)KL_ERR_CONNECT;
+        return -1;
+    }
+    t->attempt_fd[idx]    = fd;
+    t->attempt_armed[idx] = 1;
+
+    if (rc == 0) {   /* connected immediately (loopback often does) */
+        kl_watcher_del(&t->ev, fd);
+        t->attempt_armed[idx] = 0;
+        t->attempt_fd[idx]    = KL_INVALID_SOCKET;
+        kl_connect_op_on_attempt_connected(&t->connect_op, idx, fd);
+    }
+    return 0;
+}
+
+static void co_connect_watcher(KlSocketHandle fd, KlEventMask ready, void *user_data)
+{
+    PgTransport *t = user_data;
+    (void)ready;
+    int idx = -1;
+    for (int i = 0; i < t->naddrs; i++)
+        if (t->attempt_fd[i] == fd) { idx = i; break; }
+    if (idx < 0) return;
+
+    int soerr = 0;
+    int gsrc = sp_get_so_error(t, fd, &soerr);
+    kl_watcher_del(&t->ev, fd);
+    t->attempt_armed[idx] = 0;
+    if (gsrc == 0 && soerr == 0) {
+        t->attempt_fd[idx] = KL_INVALID_SOCKET;   /* ownership moves to the op */
+        kl_connect_op_on_attempt_connected(&t->connect_op, idx, fd);
+    } else {
+        sp_close(t, fd);
+        t->attempt_fd[idx] = KL_INVALID_SOCKET;
+        kl_connect_op_on_attempt_failed(&t->connect_op, idx, (int)KL_ERR_CONNECT);
+    }
+}
+
+static void co_cancel_attempt(void *ctx, int idx)
+{
+    PgTransport *t = ctx;
+    if (idx >= 0 && idx < t->naddrs && kl_handle_valid(t->attempt_fd[idx])) {
+        if (t->attempt_armed[idx]) {
+            kl_watcher_del(&t->ev, t->attempt_fd[idx]);
+            t->attempt_armed[idx] = 0;
+        }
+        sp_close(t, t->attempt_fd[idx]);
+        t->attempt_fd[idx] = KL_INVALID_SOCKET;
+    }
+    kl_connect_op_on_attempt_failed(&t->connect_op, idx, (int)KL_ERR_CONNECT);
+}
+
+static void co_dispose_fd(void *ctx, KlSocketHandle fd)
+{
+    PgTransport *t = ctx;
+    if (kl_handle_valid(fd))
+        sp_close(t, fd);
+}
+
+static void co_on_deadline_fired(void *user_data)
+{
+    PgTransport *t = user_data;
+    t->deadline_timer = -1;
+    t->deadline_fired = 1;
+    kl_connect_op_on_deadline(&t->connect_op, (int)KL_ERR_TIMEOUT);
+}
+
+/* ── RFC 8305 Connection Attempt Delay (Happy Eyeballs stagger) ─────────────
+ * arm_delay schedules a ~250 ms timer while an attempt is in flight; on fire it
+ * tells the op to start the NEXT address (racing) rather than waiting for the
+ * earlier attempt to fail. cancel_delay retires the timer synchronously (the
+ * KlConnectOp contract requires it when arm_delay is set). */
+static void co_on_delay_fired(void *user_data)
+{
+    PgTransport *t = user_data;
+    t->delay_timer = -1;
+    kl_connect_op_on_delay(&t->connect_op);
+}
+static int co_arm_delay(void *ctx)
+{
+    PgTransport *t = ctx;
+    t->delay_timer = kl_timer_add(&t->ev, PG_CONNECT_ATTEMPT_DELAY_MS,
+                                  co_on_delay_fired, t);
+    if (t->delay_timer < 0)
+        return -1;   /* arm failed: the machine fast-starts the next address */
+    return 0;
+}
+static void co_cancel_delay(void *ctx)
+{
+    PgTransport *t = ctx;
+    if (t->delay_timer >= 0) {
+        kl_timer_cancel(&t->ev, t->delay_timer);
+        t->delay_timer = -1;
+    }
+}
+
+/* The overall connect deadline bounds TCP establishment only (design D3). It is
+ * armed with the caller's remaining budget once, at start; the stagger timer does
+ * not refresh it. When timeout_ms <= 0 the transport leaves arm_deadline OUT of
+ * the hooks table entirely (below), so the op has no deadline (unbounded). */
+static int co_arm_deadline(void *ctx, int *out_err)
+{
+    PgTransport *t = ctx;
+    uint64_t now = kl_monotonic_ms();
+    uint64_t delay = t->deadline_ms > now ? t->deadline_ms - now : 0;
+    t->deadline_timer = kl_timer_add(&t->ev, delay, co_on_deadline_fired, t);
+    if (t->deadline_timer < 0) { *out_err = (int)KL_ERR_TIMEOUT; return -1; }
+    return 0;
+}
+static void co_cancel_deadline(void *ctx)
+{
+    PgTransport *t = ctx;
+    if (t->deadline_timer >= 0) {
+        kl_timer_cancel(&t->ev, t->deadline_timer);
+        t->deadline_timer = -1;
+    }
+}
+
+static void co_on_done(void *ctx, KlConnectResult result, KlSocketHandle fd, int error)
+{
+    PgTransport *t = ctx;
+    t->connect_done = 1;
+    t->connect_result = result;
+    t->connect_error = error;
+    if (result == KL_CONNECT_SUCCESS) {
+        /* The winning fd is non-blocking (created that way for the race). Restore
+         * blocking so every subsequent recv / send is plain blocking I/O with no
+         * event loop (design D1). A set_blocking failure retires the fd + marks
+         * the op failed for the pump. */
+        if (sp_set_blocking(t, fd) < 0) {
+            t->connect_result = KL_CONNECT_FAILED;
+            sp_close(t, fd);
+            t->fd = KL_INVALID_SOCKET;
+        } else {
+            t->fd = fd;
+        }
+    }
+}
+
+static void co_on_detach(void *ctx)
+{
+    PgTransport *t = ctx;
+    t->connect_detached = 1;
+}
+
+/* Two hook tables: one WITH the deadline hooks (timeout_ms > 0), one WITHOUT (an
+ * unbounded connect: no arm_deadline, so no deadline timer). The connect / delay
+ * / dispose hooks are shared. */
+static const KlConnectOpHooks PG_HOOKS_DEADLINE = {
+    .start_resolve   = co_start_resolve,
+    .cancel_resolve  = NULL,
+    .start_attempt   = co_start_attempt,
+    .cancel_attempt  = co_cancel_attempt,
+    .dispose_fd      = co_dispose_fd,
+    .arm_delay       = co_arm_delay,
+    .cancel_delay    = co_cancel_delay,
+    .arm_deadline    = co_arm_deadline,
+    .cancel_deadline = co_cancel_deadline,
+    .on_done         = co_on_done,
+    .on_detach       = co_on_detach,
+};
+static const KlConnectOpHooks PG_HOOKS_NO_DEADLINE = {
+    .start_resolve   = co_start_resolve,
+    .cancel_resolve  = NULL,
+    .start_attempt   = co_start_attempt,
+    .cancel_attempt  = co_cancel_attempt,
+    .dispose_fd      = co_dispose_fd,
+    .arm_delay       = co_arm_delay,
+    .cancel_delay    = co_cancel_delay,
+    .arm_deadline    = NULL,
+    .cancel_deadline = NULL,
+    .on_done         = co_on_done,
+    .on_detach       = co_on_detach,
+};
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Event-loop pump. Runs the private KlEventCtx until @p done() or the stage
+ * deadline elapses so a dead peer cannot hang the synchronous caller.
+ *
+ * The deadline is a MONOTONIC ABSOLUTE instant (kl_monotonic_ms() + budget), NOT
+ * an accumulation of assumed tick durations. Each kl_event_ctx_run waits up to
+ * step_ms for readiness; the check runs BEFORE and AFTER each step, so a
+ * condition that arrives during the step takes effect within one step (~50 ms).
+ * ────────────────────────────────────────────────────────────────────────── */
+
+typedef int (*DonePred)(PgTransport *t);
+
+static int pump_check(PgTransport *t, DonePred done, uint64_t deadline_ms)
+{
+#ifdef HL_PG_TEST_HOOKS
+    if (pg_test_checkpoint)
+        pg_test_checkpoint(t, pg_test_checkpoint_seq++);
+#endif
+    if (done(t))
+        return 1;
+    if (deadline_ms && kl_monotonic_ms() >= deadline_ms)
+        return -1;
+    return 0;
+}
+
+static int pump_until_abs(PgTransport *t, DonePred done, uint64_t deadline_ms)
+{
+    for (;;) {
+        int c = pump_check(t, done, deadline_ms);
+        if (c) return c > 0 ? 0 : -1;
+        if (kl_event_ctx_run(&t->ev, 64, PG_PUMP_STEP_MS) < 0)
+            return -1;
+        c = pump_check(t, done, deadline_ms);
+        if (c) return c > 0 ? 0 : -1;
+    }
+}
+
+/* One pump stage. When the op is bounded (t->deadline_ms != 0) the stage shares
+ * that single connect ceiling; when unbounded, one pump loop is capped by the
+ * fallback so a wedged loop cannot block forever, but a completed op / detachment
+ * is the real terminal (done predicate). */
+static int pump_until(PgTransport *t, DonePred done)
+{
+    uint64_t dl = t->deadline_ms;
+    if (!dl)
+        dl = kl_monotonic_ms() + PG_PUMP_FALLBACK_MS;
+    return pump_until_abs(t, done, dl);
+}
+
+/* Predicates. */
+static int done_connect(PgTransport *t)
+{ return t->connect_done; }
+static int done_connect_detached(PgTransport *t)
+{ return kl_connect_op_is_detached(&t->connect_op); }
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Connect-time teardown: cancel a still-live op and pump to confirmed
+ * detachment before releasing embedded storage (frozen rule 4). Also retire any
+ * winning fd + racing fds + timers. Leaves the event ctx freed. Used on both the
+ * connect-failure path and by hl_pg_transport_close for a raced connection.
+ * ────────────────────────────────────────────────────────────────────────── */
+static void connect_teardown(PgTransport *t)
+{
+    /* If the op was started and has NOT yet reached confirmed detachment, cancel
+     * it (retiring every racing fd via cancel_attempt / dispose_fd and both timers
+     * via cancel_delay / cancel_deadline) and pump to detachment. Fail LOUDLY if
+     * it will not detach within the bound rather than free storage a live op still
+     * references. */
+    if (t->connect_started && !kl_connect_op_is_detached(&t->connect_op)) {
+        kl_connect_op_cancel(&t->connect_op);
+        /* This teardown ignores the (possibly-exhausted) deadline: clear it so an
+         * expired deadline cannot clip the detachment confirm. */
+        t->deadline_ms = 0;
+        if (pump_until(t, done_connect_detached) != 0 ||
+            !kl_connect_op_is_detached(&t->connect_op)) {
+            log_error("pg: connect op did not detach within the bound; leaking "
+                      "transport descriptors rather than freeing a live op");
+            /* Do not free the event ctx: the live op still references it. */
+            return;
+        }
+    }
+
+    /* Retire the winning fd + any escaped racing fds + timers. The op's cancel
+     * path normally retires racing attempt fds already, so these find none. */
+    if (kl_handle_valid(t->fd)) {
+        sp_close(t, t->fd);
+        t->fd = KL_INVALID_SOCKET;
+    }
+    for (int i = 0; i < KL_CONNECT_MAX_ADDRS; i++) {
+        if (kl_handle_valid(t->attempt_fd[i])) {
+            if (t->attempt_armed[i])
+                kl_watcher_del(&t->ev, t->attempt_fd[i]);
+            sp_close(t, t->attempt_fd[i]);
+            t->attempt_fd[i] = KL_INVALID_SOCKET;
+        }
+    }
+    if (t->delay_timer >= 0) {
+        kl_timer_cancel(&t->ev, t->delay_timer);
+        t->delay_timer = -1;
+    }
+    if (t->deadline_timer >= 0) {
+        kl_timer_cancel(&t->ev, t->deadline_timer);
+        t->deadline_timer = -1;
+    }
+    if (t->ev_ready) {
+        kl_event_ctx_free(&t->ev);
+        t->ev_ready = 0;
+    }
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Public API.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+static void transport_zero(PgTransport *t)
+{
+    memset(t, 0, sizeof *t);
+    t->fd = KL_INVALID_SOCKET;
+    t->deadline_timer = -1;
+    t->delay_timer = -1;
+    t->connect_result = KL_CONNECT_CANCELLED;
+    for (int i = 0; i < KL_CONNECT_MAX_ADDRS; i++)
+        t->attempt_fd[i] = KL_INVALID_SOCKET;
+}
+
+int hl_pg_transport_connect(PgTransport *t, const char *host, const char *port,
+                            int timeout_ms, const KlSocketProvider *sp_or_NULL,
+                            char *errbuf, size_t errlen)
+{
+    if (!t || !host || !port) {
+        set_err(errbuf, errlen, "invalid connect arguments");
+        return -1;
+    }
+    int port_n = atoi(port);
+    if (port_n < 1 || port_n > 65535) {
+        set_err(errbuf, errlen, "invalid port");
+        return -1;
+    }
+
+    transport_zero(t);
+    t->sp = sp_or_NULL ? sp_or_NULL : default_provider();
+    t->alloc = kl_allocator_default();
+    /* timeout_ms > 0 bounds TCP establishment (design D3); <= 0 = unbounded (no
+     * deadline hooks, deadline_ms 0). */
+    t->deadline_ms = 0;
+
+    if (kl_event_ctx_init(&t->ev, &t->alloc) != 0) {
+        set_err(errbuf, errlen, "failed to init event context");
+        return -1;
+    }
+    t->ev_ready = 1;
+
+    /* Sandbox-compatible blocking system resolve (or IP-literal fast path),
+     * inline before start. */
+    t->naddrs = resolve_addrs(t, host, port_n);
+    if (t->naddrs < 1) {
+        set_err(errbuf, errlen, "could not resolve host");
+        connect_teardown(t);
+        return -1;
+    }
+
+    /* Freeze the connect deadline AFTER the blocking resolve (DNS is outside the
+     * TCP-establishment bound, design D3). */
+    const KlConnectOpHooks *hooks;
+    if (timeout_ms > 0) {
+        t->deadline_ms = kl_monotonic_ms() + (uint64_t)timeout_ms;
+        hooks = &PG_HOOKS_DEADLINE;
+    } else {
+        hooks = &PG_HOOKS_NO_DEADLINE;   /* unbounded connect: no deadline armed */
+    }
+
+    if (kl_connect_op_init(&t->connect_op, hooks, t) != 0) {
+        set_err(errbuf, errlen, "failed to init connect op");
+        connect_teardown(t);
+        return -1;
+    }
+    if (kl_connect_op_start(&t->connect_op) != 0) {
+        set_err(errbuf, errlen, "failed to start connect op");
+        connect_teardown(t);
+        return -1;
+    }
+    t->connect_started = 1;
+
+    if (pump_until(t, done_connect) != 0 ||
+        t->connect_result != KL_CONNECT_SUCCESS || !kl_handle_valid(t->fd)) {
+        set_err(errbuf, errlen, "connection failed");
+        connect_teardown(t);
+        return -1;
+    }
+
+    /* Connect succeeded: the op still needs confirmed detachment before its
+     * embedded storage is reusable, but the winning fd is already handed to us and
+     * blocking. Pump the op to detachment (it retires its own timers), then free
+     * the connect-only event ctx: post-connect I/O is pure blocking, no loop. */
+    if (!kl_connect_op_is_detached(&t->connect_op)) {
+        if (pump_until(t, done_connect_detached) != 0 ||
+            !kl_connect_op_is_detached(&t->connect_op)) {
+            /* The op will not detach: we cannot free the event ctx it references.
+             * The fd is live and usable, but leaving a live op wedged is a hard
+             * failure - fail closed, retire the fd, and report. */
+            set_err(errbuf, errlen, "connect op did not detach");
+            if (kl_handle_valid(t->fd)) { sp_close(t, t->fd); t->fd = KL_INVALID_SOCKET; }
+            log_error("pg: connect op did not detach after success; failing closed");
+            return -1;
+        }
+    }
+    if (t->delay_timer >= 0) {
+        kl_timer_cancel(&t->ev, t->delay_timer);
+        t->delay_timer = -1;
+    }
+    if (t->deadline_timer >= 0) {
+        kl_timer_cancel(&t->ev, t->deadline_timer);
+        t->deadline_timer = -1;
+    }
+    if (t->ev_ready) {
+        kl_event_ctx_free(&t->ev);
+        t->ev_ready = 0;
+    }
+    return 0;
+}
+
+int hl_pg_transport_adopt(PgTransport *t, int fd,
+                          const KlSocketProvider *sp_or_NULL)
+{
+    if (!t || fd < 0)
+        return -1;
+    transport_zero(t);
+    t->sp = sp_or_NULL ? sp_or_NULL : default_provider();
+    t->fd = (KlSocketHandle)fd;
+    /* SIGPIPE suppression parity: adopt() takes a connected blocking fd and every
+     * subsequent write goes through hl_pg_transport_send (nosignal flag) plus
+     * this per-fd SO_NOSIGPIPE where the platform offers it. No event ctx, no
+     * resolution, no racing (design Amendment 2). */
+    sp_set_nosigpipe(t, t->fd);
+    return 0;
+}
+
+void hl_pg_transport_attach_tls(PgTransport *t, struct HlTlsClient *tls)
+{
+    if (!t)
+        return;
+    t->tls = tls;
+}
+
+ssize_t hl_pg_transport_send(PgTransport *t, const uint8_t *buf, size_t len)
+{
+    if (!t || !kl_handle_valid(t->fd))
+        return -1;
+    if (t->tls)
+        return hl_tls_client_write((int)t->fd, t->tls, buf, len);
+    /* SIGPIPE suppression + EINTR retry: the POSIX provider's send already applies
+     * MSG_NOSIGNAL and retries EINTR internally (socket_posix.c), and we set
+     * SO_NOSIGPIPE on the fd where the platform offers it (sp_set_nosigpipe at
+     * adopt / attempt). The extra EINTR guard here is defense in depth for a
+     * provider whose send does not retry (e.g. the test mock). */
+    kl_ssize_t n;
+    do { n = sp_send(t, t->fd, buf, len); }
+    while (n < 0 && errno == EINTR);
+    return (ssize_t)n;
+}
+
+ssize_t hl_pg_transport_recv(PgTransport *t, uint8_t *buf, size_t len)
+{
+    if (!t || !kl_handle_valid(t->fd))
+        return -1;
+    if (t->tls)
+        return hl_tls_client_read((int)t->fd, t->tls, buf, len);
+    kl_ssize_t n;
+    do { n = sp_recv(t, t->fd, buf, len); }
+    while (n < 0 && errno == EINTR);
+    return (ssize_t)n;
+}
+
+int hl_pg_transport_send_all(PgTransport *t, const uint8_t *buf, size_t len)
+{
+    size_t sent = 0;
+    while (sent < len) {
+        ssize_t n = hl_pg_transport_send(t, buf + sent, len - sent);
+        if (n <= 0)
+            return -1;
+        sent += (size_t)n;
+    }
+    return 0;
+}
+
+int hl_pg_transport_fd(const PgTransport *t)
+{
+    if (!t || !kl_handle_valid(t->fd))
+        return -1;
+    return (int)t->fd;
+}
+
+void hl_pg_transport_close(PgTransport *t)
+{
+    if (!t || t->closed)
+        return;
+    t->closed = 1;
+
+    /* One close path: TLS shutdown, then TLS free, then provider close (design
+     * Amendment 1). */
+    if (t->tls) {
+        if (kl_handle_valid(t->fd))
+            hl_tls_client_shutdown((int)t->fd, t->tls);
+        hl_tls_client_free(t->tls);
+        t->tls = NULL;
+    }
+
+    /* A raced connection that never freed its event ctx (an error path returned
+     * before detachment, or a caller closes without a successful connect): drive
+     * the op to detachment and retire storage. On the common paths (successful
+     * connect freed the ev ctx, or an adopted fd never had one) this is a plain
+     * fd close. */
+    if (t->connect_started && t->ev_ready) {
+        connect_teardown(t);   /* cancels + detaches + closes fd + frees ev ctx */
+        return;
+    }
+
+    if (kl_handle_valid(t->fd)) {
+        sp_close(t, t->fd);
+        t->fd = KL_INVALID_SOCKET;
+    }
+}

--- a/src/hull/cap/pg_transport.c
+++ b/src/hull/cap/pg_transport.c
@@ -5,18 +5,22 @@
  *
  * This composes Keel's PUBLIC transport surface for the CONNECT phase only:
  * KlConnectOp (resolve + Happy-Eyeballs racing connect) driven on a PRIVATE,
- * operation-local KlEventCtx, plus the POSIX socket provider's public ops table.
- * The connect machinery is the reviewed cap/smtp_transport.c pattern (resolve
- * adapter + KlConnectOp hooks + private KlEventCtx pump + socket-provider
- * wrappers), MINUS the KlStream: a synchronous PostgreSQL connection needs no
- * queued-write / read pause-resume / graceful-close machinery. After the race is
- * won the winning fd is set_blocking()'d and every subsequent byte is plain
- * blocking recv / send with no event loop (design D1).
+ * operation-local KlEventCtx, plus a KlSocketProvider's public ops table. The
+ * connect machinery is the reviewed cap/smtp_transport.c pattern (resolve adapter
+ * + KlConnectOp hooks + private KlEventCtx pump + socket-provider wrappers), MINUS
+ * the KlStream: a synchronous PostgreSQL connection needs no queued-write /
+ * read pause-resume / graceful-close machinery. After the race is won the winning
+ * fd is set_blocking()'d and every subsequent byte is plain blocking recv / send
+ * with no event loop (design D1).
  *
  * TLS stays the shared hl_tls_client_* helpers layered over the blocking fd
  * (design D2). This transport only STORES the optional attached HlTlsClient and
  * routes send/recv through it; the SSLRequest negotiation + handshake belong to
  * the consumer (pg_conn.c), which hands the session here via attach_tls.
+ *
+ * The transport is a HEAP allocation reached through an opaque handle so the
+ * exceptional non-detachment path can drop the whole block intentionally and
+ * safely (a live op keeps referencing its own storage). See the header banner.
  *
  * NO vendor/keel/src header is used. keel/connect_op_detail.h + keel/event_ctx.h
  * are included solely so KlConnectOp / KlEventCtx can be EMBEDDED fields (storage
@@ -53,24 +57,66 @@
 #include <errno.h>
 #include <pthread.h>
 #include <stdio.h>
-#include <stdlib.h>   /* atoi */
+#include <stdlib.h>   /* atoi, calloc, free */
 #include <string.h>
 
 #include "log.h"
 
+/* One connection's byte transport (opaque to consumers; defined here). Heap-
+ * allocated; the exceptional non-detachment path leaks the whole block. */
+struct PgTransport {
+    /* Borrowed, immutable, outlives the connection (Amendment 4). */
+    const KlSocketProvider *sp;
+
+    /* Owned: the private connect-time event context. Created only when a race is
+     * needed (hl_pg_transport_connect); the adopt path leaves it uninitialized. */
+    KlEventCtx  ev;
+    int         ev_ready;      /* 1 once kl_event_ctx_init succeeded            */
+    KlAllocator alloc;         /* event-ctx allocator (event-loop lifetime)     */
+
+    /* Owned: the embedded KlConnectOp and its resolved address set. */
+    KlConnectOp connect_op;       /* embedded (connect_op_detail.h: storage only) */
+    int         connect_started;  /* 1 once kl_connect_op_start succeeded        */
+    KlSockAddr  addrs[KL_CONNECT_MAX_ADDRS];
+    int         naddrs;
+    KlSocketHandle attempt_fd[KL_CONNECT_MAX_ADDRS]; /* in-flight racing fds     */
+    int         attempt_armed[KL_CONNECT_MAX_ADDRS]; /* 1 if a watcher is armed  */
+
+    /* Connect outcome. */
+    int             connect_done;      /* on_done fired                          */
+    KlConnectResult connect_result;
+    int             connect_error;
+
+    /* Overall connect deadline (TCP establishment only, design D3). */
+    int64_t   deadline_timer;   /* Keel timer id, or -1                          */
+    uint64_t  deadline_ms;      /* absolute monotonic instant, or 0 = unbounded  */
+    int       deadline_fired;
+
+    /* RFC 8305 Connection Attempt Delay timer (the Happy-Eyeballs stagger). */
+    int64_t   delay_timer;      /* Keel timer id, or -1                          */
+
+    /* The winning connected descriptor (blocking after connect). */
+    KlSocketHandle fd;
+
+    /* Owned: optional attached TLS session. When non-NULL, send/recv tunnel
+     * through it (design D2); the transport frees it in close. */
+    struct HlTlsClient *tls;
+};
+
 /* SIGPIPE suppression on send has parity with pg_conn.c: the winning / adopted fd
  * gets SO_NOSIGPIPE via the provider's set_nosigpipe hook where the platform
- * offers it, and the POSIX provider's send applies MSG_NOSIGNAL internally
- * (vendor/keel/src/socket_posix.c), so hl_pg_transport_send never emits SIGPIPE. */
+ * offers it, and the POSIX provider's send applies MSG_NOSIGNAL internally, so
+ * hl_pg_transport_send never emits SIGPIPE. */
 
-/* Default connect budget when the caller passes timeout_ms <= 0 is NONE: the
- * transport arms no deadline and the connect is unbounded, preserving
- * pg_connect's prior select(NULL) behavior. But the pump still needs a per-stage
- * step budget to bound one kl_event_ctx_run wait; a completed op / detachment is
- * the real terminal, so a generous fallback only caps how long one pump loop
- * blocks with no readiness. */
-#define PG_PUMP_STEP_MS   50
-#define PG_PUMP_FALLBACK_MS  30000   /* stage cap when timeout_ms <= 0 (unbounded op) */
+#define PG_PUMP_STEP_MS   50   /* one kl_event_ctx_run readiness wait (a bounded increment) */
+
+/* Teardown detachment confirm is ITERATION-bounded (deterministic), NOT
+ * wall-bounded: after cancel a well-behaved op retires everything synchronously
+ * and detaches within 0-1 steps, so this bound only decides when to declare a
+ * pathological non-detachment (fail closed, preserve storage). This is a teardown
+ * safety bound, never the connect operation's deadline (which stays select(NULL)
+ * unbounded when timeout_ms <= 0). */
+#define PG_DETACH_MAX_STEPS  256
 
 /* RFC 8305 Connection Attempt Delay: wait before starting the next address while
  * an earlier attempt is still in flight (the Happy-Eyeballs stagger). */
@@ -78,8 +124,8 @@
 
 /* ────────────────────────────────────────────────────────────────────────────
  * Socket provider: an immutable process-wide ops table. We call its PUBLIC ops
- * directly, reading errno for would-block / EINPROGRESS classification (the
- * defined hosted-errno fallback on the POSIX provider).
+ * directly. Would-block / EINPROGRESS / EINTR classification prefers the
+ * provider's io_status op and falls back to hosted errno only when it is absent.
  * ────────────────────────────────────────────────────────────────────────── */
 
 static const KlSocketProvider *g_sp;
@@ -92,30 +138,21 @@ static const KlSocketProvider *default_provider(void)
 }
 
 #ifdef HL_PG_TEST_HOOKS
-/* Test-only fault-injection provider (compiled ONLY under -DHL_PG_TEST_HOOKS,
- * ABSENT from the production object). When non-NULL it REPLACES the default POSIX
- * provider for every sp_* op, so a test can drive connect attempts to
- * pending / succeed / fail per address and observe attempt order + timestamps. It
- * is a COHERENT socket seam: it hands the connect op real fds the event loop can
- * watch, so the Happy-Eyeballs stagger timer and the connect-deadline timer fire
- * on the same real clock as production (never a divergent virtual clock). */
+/* Test-only seam (compiled ONLY under -DHL_PG_TEST_HOOKS, ABSENT from the
+ * production object). pg_test_socket_provider REPLACES the default POSIX provider
+ * for every sp_* op; pg_test_resolve fills t->addrs in exact injected order;
+ * pg_test_checkpoint observes each pump checkpoint; pg_test_force_no_detach makes
+ * the detach-confirm predicate report "not detached" so a test can drive the
+ * pathological non-detachment path (preserve storage + retryable close). */
 const KlSocketProvider *pg_test_socket_provider;
-
-/* When non-NULL, fills t->addrs[] in EXACT injected order and returns the count
- * (value-copied into the transport-owned array, so no dangling), replacing the
- * blocking getaddrinfo. */
 int (*pg_test_resolve)(PgTransport *t, const char *host, int port);
-
-/* Fires at the TOP of every pump check with the transport and a monotonically-
- * increasing checkpoint index, so a test can observe pump progress without
- * diverging from Keel's clock. */
 void (*pg_test_checkpoint)(PgTransport *t, unsigned idx);
+int  pg_test_force_no_detach;
 static unsigned pg_test_checkpoint_seq;
 #endif
 
 /* The active provider: a test-supplied one when set, else the transport's own
- * borrowed reference (default POSIX). t->sp is set at connect / adopt time; the
- * connect hooks run while t->sp is live. */
+ * borrowed reference. */
 static const KlSocketProvider *active_sp(const PgTransport *t)
 {
 #ifdef HL_PG_TEST_HOOKS
@@ -124,12 +161,29 @@ static const KlSocketProvider *active_sp(const PgTransport *t)
     return t->sp ? t->sp : default_provider();
 }
 
+/* Required provider op subset + capability. Missing any is fail-closed: the
+ * private event loop watches provider handles (needs KL_SOCK_CAP_NATIVE_FD), and
+ * the connect / I/O / close paths dereference these ops. io_status and
+ * set_nosigpipe are OPTIONAL (documented hosted-errno / no-op fallbacks). */
+static int validate_provider(const KlSocketProvider *sp)
+{
+    if (!sp || !sp->ops)
+        return -1;
+    const KlSocketOps *o = sp->ops;
+    if (!o->socket || !o->connect || !o->close || !o->send || !o->recv ||
+        !o->get_so_error || !o->set_nonblocking || !o->set_blocking)
+        return -1;
+    if (!kl_socket_provider_has_cap(sp, KL_SOCK_CAP_NATIVE_FD))
+        return -1;
+    return 0;
+}
+
 static KlSocketHandle sp_socket(const PgTransport *t, int domain, int type, int protocol)
 { const KlSocketProvider *sp = active_sp(t); return sp->ops->socket(sp->context, domain, type, protocol); }
 static int sp_set_nonblocking(const PgTransport *t, KlSocketHandle fd)
 { const KlSocketProvider *sp = active_sp(t); return sp->ops->set_nonblocking(sp->context, fd); }
 static int sp_set_blocking(const PgTransport *t, KlSocketHandle fd)
-{ const KlSocketProvider *sp = active_sp(t); return sp->ops->set_blocking ? sp->ops->set_blocking(sp->context, fd) : 0; }
+{ const KlSocketProvider *sp = active_sp(t); return sp->ops->set_blocking(sp->context, fd); }
 static void sp_set_nosigpipe(const PgTransport *t, KlSocketHandle fd)
 { const KlSocketProvider *sp = active_sp(t); if (sp->ops->set_nosigpipe) sp->ops->set_nosigpipe(sp->context, fd); }
 static int sp_connect(const PgTransport *t, KlSocketHandle fd, const KlSockAddr *a)
@@ -142,6 +196,28 @@ static kl_ssize_t sp_recv(const PgTransport *t, KlSocketHandle fd, void *b, size
 { const KlSocketProvider *sp = active_sp(t); return sp->ops->recv(sp->context, fd, b, n); }
 static int sp_close(const PgTransport *t, KlSocketHandle fd)
 { const KlSocketProvider *sp = active_sp(t); return sp->ops->close(sp->context, fd); }
+
+/* Classify the last op: prefer the provider's io_status, else hosted errno. */
+static KlIoStatus sp_io_status(const PgTransport *t)
+{
+    const KlSocketProvider *sp = active_sp(t);
+    if (sp->ops->io_status)
+        return sp->ops->io_status(sp->context);
+    switch (errno) {
+        case EINTR:       return KL_IO_INTERRUPTED;
+        case EINPROGRESS: return KL_IO_PENDING;
+#if EAGAIN != EWOULDBLOCK
+        case EAGAIN:      return KL_IO_PENDING;
+        case EWOULDBLOCK: return KL_IO_PENDING;
+#else
+        case EAGAIN:      return KL_IO_PENDING;
+#endif
+        case EPIPE:       return KL_IO_CLOSED;
+        case ECONNRESET:  return KL_IO_RESET;
+        case 0:           return KL_IO_OK;
+        default:          return KL_IO_FATAL;
+    }
+}
 
 static void set_err(char *dst, size_t cap, const char *msg)
 { if (dst && cap) snprintf(dst, cap, "%s", msg); }
@@ -228,8 +304,7 @@ static int co_start_attempt(void *ctx, int idx, int *out_err)
     sp_set_nosigpipe(t, fd);
 
     int rc = sp_connect(t, fd, &t->addrs[idx]);
-    int ce = errno;
-    if (rc < 0 && ce != EINPROGRESS) {
+    if (rc < 0 && sp_io_status(t) != KL_IO_PENDING) {
         sp_close(t, fd);
         *out_err = (int)KL_ERR_CONNECT;
         return -1;   /* hard local failure: advance to the next address */
@@ -363,8 +438,8 @@ static void co_on_done(void *ctx, KlConnectResult result, KlSocketHandle fd, int
     if (result == KL_CONNECT_SUCCESS) {
         /* The winning fd is non-blocking (created that way for the race). Restore
          * blocking so every subsequent recv / send is plain blocking I/O with no
-         * event loop (design D1). A set_blocking failure retires the fd + marks
-         * the op failed for the pump. */
+         * event loop (design D1). set_blocking is a validated-present required op;
+         * a failure retires the fd + marks the op failed for the pump. */
         if (sp_set_blocking(t, fd) < 0) {
             t->connect_result = KL_CONNECT_FAILED;
             sp_close(t, fd);
@@ -375,15 +450,10 @@ static void co_on_done(void *ctx, KlConnectResult result, KlSocketHandle fd, int
     }
 }
 
-static void co_on_detach(void *ctx)
-{
-    PgTransport *t = ctx;
-    t->connect_detached = 1;
-}
-
 /* Two hook tables: one WITH the deadline hooks (timeout_ms > 0), one WITHOUT (an
  * unbounded connect: no arm_deadline, so no deadline timer). The connect / delay
- * / dispose hooks are shared. */
+ * / dispose hooks are shared. on_detach is omitted: detachment is observed via
+ * kl_connect_op_is_detached (no per-transport flag needed). */
 static const KlConnectOpHooks PG_HOOKS_DEADLINE = {
     .start_resolve   = co_start_resolve,
     .cancel_resolve  = NULL,
@@ -395,7 +465,7 @@ static const KlConnectOpHooks PG_HOOKS_DEADLINE = {
     .arm_deadline    = co_arm_deadline,
     .cancel_deadline = co_cancel_deadline,
     .on_done         = co_on_done,
-    .on_detach       = co_on_detach,
+    .on_detach       = NULL,
 };
 static const KlConnectOpHooks PG_HOOKS_NO_DEADLINE = {
     .start_resolve   = co_start_resolve,
@@ -408,88 +478,86 @@ static const KlConnectOpHooks PG_HOOKS_NO_DEADLINE = {
     .arm_deadline    = NULL,
     .cancel_deadline = NULL,
     .on_done         = co_on_done,
-    .on_detach       = co_on_detach,
+    .on_detach       = NULL,
 };
 
 /* ────────────────────────────────────────────────────────────────────────────
- * Event-loop pump. Runs the private KlEventCtx until @p done() or the stage
- * deadline elapses so a dead peer cannot hang the synchronous caller.
- *
- * The deadline is a MONOTONIC ABSOLUTE instant (kl_monotonic_ms() + budget), NOT
- * an accumulation of assumed tick durations. Each kl_event_ctx_run waits up to
- * step_ms for readiness; the check runs BEFORE and AFTER each step, so a
- * condition that arrives during the step takes effect within one step (~50 ms).
+ * Event-loop pumps. The private KlEventCtx drives ONLY the connect phase.
  * ────────────────────────────────────────────────────────────────────────── */
 
-typedef int (*DonePred)(PgTransport *t);
+static int done_connect(PgTransport *t)
+{ return t->connect_done; }
 
-static int pump_check(PgTransport *t, DonePred done, uint64_t deadline_ms)
+static int done_connect_detached(PgTransport *t)
+{
+#ifdef HL_PG_TEST_HOOKS
+    if (pg_test_force_no_detach) return 0;
+#endif
+    return kl_connect_op_is_detached(&t->connect_op);
+}
+
+static void pump_checkpoint(PgTransport *t)
 {
 #ifdef HL_PG_TEST_HOOKS
     if (pg_test_checkpoint)
         pg_test_checkpoint(t, pg_test_checkpoint_seq++);
+#else
+    (void)t;
 #endif
-    if (done(t))
-        return 1;
-    if (deadline_ms && kl_monotonic_ms() >= deadline_ms)
-        return -1;
-    return 0;
 }
 
-static int pump_until_abs(PgTransport *t, DonePred done, uint64_t deadline_ms)
+/* Pump the connect op to its terminal (done_connect). When t->deadline_ms is set
+ * (timeout_ms > 0) the loop is bounded by that single absolute connect ceiling;
+ * when it is 0 (timeout_ms <= 0) the connect is TRULY UNBOUNDED - the loop pumps
+ * in bounded PG_PUMP_STEP_MS increments with NO total deadline, until the op
+ * completes (the select(..., NULL) contract, no hidden ceiling). Returns 0 when
+ * done, -1 on a deadline expiry or an event-loop error. */
+static int pump_connect(PgTransport *t)
 {
+    uint64_t dl = t->deadline_ms;   /* 0 == unbounded */
     for (;;) {
-        int c = pump_check(t, done, deadline_ms);
-        if (c) return c > 0 ? 0 : -1;
-        if (kl_event_ctx_run(&t->ev, 64, PG_PUMP_STEP_MS) < 0)
-            return -1;
-        c = pump_check(t, done, deadline_ms);
-        if (c) return c > 0 ? 0 : -1;
+        pump_checkpoint(t);
+        if (done_connect(t)) return 0;
+        if (dl && kl_monotonic_ms() >= dl) return -1;
+        if (kl_event_ctx_run(&t->ev, 64, PG_PUMP_STEP_MS) < 0) return -1;
+        if (done_connect(t)) return 0;
+        if (dl && kl_monotonic_ms() >= dl) return -1;
     }
 }
 
-/* One pump stage. When the op is bounded (t->deadline_ms != 0) the stage shares
- * that single connect ceiling; when unbounded, one pump loop is capped by the
- * fallback so a wedged loop cannot block forever, but a completed op / detachment
- * is the real terminal (done predicate). */
-static int pump_until(PgTransport *t, DonePred done)
+/* Confirm the op has detached, ITERATION-bounded (a teardown safety bound, not
+ * the connect deadline). Returns 0 detached, -1 if not within PG_DETACH_MAX_STEPS.
+ * After kl_connect_op_cancel a well-behaved op retires everything and detaches
+ * synchronously (or via queued work), so this returns at step 0-1. The pump is
+ * NON-BLOCKING (timeout 0): detachment is never fd-readiness-driven here, so a
+ * blocking wait would only stall the pathological non-detachment case; a bounded
+ * non-blocking spin declares it promptly instead. */
+static int pump_detach(PgTransport *t)
 {
-    uint64_t dl = t->deadline_ms;
-    if (!dl)
-        dl = kl_monotonic_ms() + PG_PUMP_FALLBACK_MS;
-    return pump_until_abs(t, done, dl);
+    for (int i = 0; i < PG_DETACH_MAX_STEPS; i++) {
+        if (done_connect_detached(t)) return 0;
+        if (kl_event_ctx_run(&t->ev, 64, 0 /* non-blocking poll */) < 0) return -1;
+        if (done_connect_detached(t)) return 0;
+    }
+    return -1;
 }
 
-/* Predicates. */
-static int done_connect(PgTransport *t)
-{ return t->connect_done; }
-static int done_connect_detached(PgTransport *t)
-{ return kl_connect_op_is_detached(&t->connect_op); }
-
 /* ────────────────────────────────────────────────────────────────────────────
- * Connect-time teardown: cancel a still-live op and pump to confirmed
- * detachment before releasing embedded storage (frozen rule 4). Also retire any
- * winning fd + racing fds + timers. Leaves the event ctx freed. Used on both the
- * connect-failure path and by hl_pg_transport_close for a raced connection.
+ * Connect-time teardown. Cancels a still-live op and confirms detachment before
+ * retiring embedded storage (frozen rule 4). Returns 0 when the transport is fully
+ * quiesced (event ctx freed, no live op) and the heap block may be freed; returns
+ * -1 iff the op will NOT confirm detachment - in which case NOTHING is freed (the
+ * live op still references its storage) and the caller must preserve or leak the
+ * whole allocation.
  * ────────────────────────────────────────────────────────────────────────── */
-static void connect_teardown(PgTransport *t)
+static int connect_teardown(PgTransport *t)
 {
-    /* If the op was started and has NOT yet reached confirmed detachment, cancel
-     * it (retiring every racing fd via cancel_attempt / dispose_fd and both timers
-     * via cancel_delay / cancel_deadline) and pump to detachment. Fail LOUDLY if
-     * it will not detach within the bound rather than free storage a live op still
-     * references. */
     if (t->connect_started && !kl_connect_op_is_detached(&t->connect_op)) {
         kl_connect_op_cancel(&t->connect_op);
-        /* This teardown ignores the (possibly-exhausted) deadline: clear it so an
-         * expired deadline cannot clip the detachment confirm. */
-        t->deadline_ms = 0;
-        if (pump_until(t, done_connect_detached) != 0 ||
-            !kl_connect_op_is_detached(&t->connect_op)) {
-            log_error("pg: connect op did not detach within the bound; leaking "
-                      "transport descriptors rather than freeing a live op");
-            /* Do not free the event ctx: the live op still references it. */
-            return;
+        if (pump_detach(t) != 0 || !kl_connect_op_is_detached(&t->connect_op)) {
+            log_error("pg: connect op did not confirm detachment; preserving the "
+                      "whole transport allocation (a live op still references it)");
+            return -1;   /* preserve: do NOT free the event ctx / the block */
         }
     }
 
@@ -519,102 +587,110 @@ static void connect_teardown(PgTransport *t)
         kl_event_ctx_free(&t->ev);
         t->ev_ready = 0;
     }
+    return 0;
 }
 
 /* ────────────────────────────────────────────────────────────────────────────
  * Public API.
  * ────────────────────────────────────────────────────────────────────────── */
 
-static void transport_zero(PgTransport *t)
+static PgTransport *transport_new(const KlSocketProvider *sp)
 {
-    memset(t, 0, sizeof *t);
+    PgTransport *t = calloc(1, sizeof *t);
+    if (!t) return NULL;
+    t->sp = sp;
     t->fd = KL_INVALID_SOCKET;
     t->deadline_timer = -1;
     t->delay_timer = -1;
     t->connect_result = KL_CONNECT_CANCELLED;
     for (int i = 0; i < KL_CONNECT_MAX_ADDRS; i++)
         t->attempt_fd[i] = KL_INVALID_SOCKET;
+    return t;
 }
 
-int hl_pg_transport_connect(PgTransport *t, const char *host, const char *port,
-                            int timeout_ms, const KlSocketProvider *sp_or_NULL,
-                            char *errbuf, size_t errlen)
+/* Fail a connect: tear down, then free the block iff fully quiesced; otherwise
+ * leak the whole allocation intentionally (a live op still references it). Always
+ * returns NULL. */
+static PgTransport *connect_fail(PgTransport *t, char *errbuf, size_t errlen,
+                                 const char *msg)
 {
-    if (!t || !host || !port) {
+    set_err(errbuf, errlen, msg);
+    if (connect_teardown(t) == 0)
+        free(t);
+    /* else: intentional safe leak - the op will not detach; never free under it. */
+    return NULL;
+}
+
+PgTransport *hl_pg_transport_connect(const char *host, const char *port,
+                                     int timeout_ms,
+                                     const KlSocketProvider *sp_or_NULL,
+                                     char *errbuf, size_t errlen)
+{
+    if (!host || !port) {
         set_err(errbuf, errlen, "invalid connect arguments");
-        return -1;
+        return NULL;
     }
     int port_n = atoi(port);
     if (port_n < 1 || port_n > 65535) {
         set_err(errbuf, errlen, "invalid port");
-        return -1;
+        return NULL;
+    }
+    const KlSocketProvider *sp = sp_or_NULL ? sp_or_NULL : default_provider();
+    if (validate_provider(sp) != 0) {
+        set_err(errbuf, errlen, "socket provider missing a required op or KL_SOCK_CAP_NATIVE_FD");
+        return NULL;
     }
 
-    transport_zero(t);
-    t->sp = sp_or_NULL ? sp_or_NULL : default_provider();
+    PgTransport *t = transport_new(sp);
+    if (!t) { set_err(errbuf, errlen, "out of memory"); return NULL; }
     t->alloc = kl_allocator_default();
-    /* timeout_ms > 0 bounds TCP establishment (design D3); <= 0 = unbounded (no
-     * deadline hooks, deadline_ms 0). */
-    t->deadline_ms = 0;
 
     if (kl_event_ctx_init(&t->ev, &t->alloc) != 0) {
         set_err(errbuf, errlen, "failed to init event context");
-        return -1;
+        free(t);
+        return NULL;
     }
     t->ev_ready = 1;
 
     /* Sandbox-compatible blocking system resolve (or IP-literal fast path),
      * inline before start. */
     t->naddrs = resolve_addrs(t, host, port_n);
-    if (t->naddrs < 1) {
-        set_err(errbuf, errlen, "could not resolve host");
-        connect_teardown(t);
-        return -1;
-    }
+    if (t->naddrs < 1)
+        return connect_fail(t, errbuf, errlen, "could not resolve host");
 
     /* Freeze the connect deadline AFTER the blocking resolve (DNS is outside the
-     * TCP-establishment bound, design D3). */
+     * TCP-establishment bound, design D3). timeout_ms <= 0 leaves deadline_ms 0
+     * (unbounded) and picks the no-deadline hook table. */
     const KlConnectOpHooks *hooks;
     if (timeout_ms > 0) {
         t->deadline_ms = kl_monotonic_ms() + (uint64_t)timeout_ms;
         hooks = &PG_HOOKS_DEADLINE;
     } else {
-        hooks = &PG_HOOKS_NO_DEADLINE;   /* unbounded connect: no deadline armed */
+        hooks = &PG_HOOKS_NO_DEADLINE;
     }
 
-    if (kl_connect_op_init(&t->connect_op, hooks, t) != 0) {
-        set_err(errbuf, errlen, "failed to init connect op");
-        connect_teardown(t);
-        return -1;
-    }
-    if (kl_connect_op_start(&t->connect_op) != 0) {
-        set_err(errbuf, errlen, "failed to start connect op");
-        connect_teardown(t);
-        return -1;
-    }
+    if (kl_connect_op_init(&t->connect_op, hooks, t) != 0)
+        return connect_fail(t, errbuf, errlen, "failed to init connect op");
+    if (kl_connect_op_start(&t->connect_op) != 0)
+        return connect_fail(t, errbuf, errlen, "failed to start connect op");
     t->connect_started = 1;
 
-    if (pump_until(t, done_connect) != 0 ||
-        t->connect_result != KL_CONNECT_SUCCESS || !kl_handle_valid(t->fd)) {
-        set_err(errbuf, errlen, "connection failed");
-        connect_teardown(t);
-        return -1;
-    }
+    if (pump_connect(t) != 0 ||
+        t->connect_result != KL_CONNECT_SUCCESS || !kl_handle_valid(t->fd))
+        return connect_fail(t, errbuf, errlen, "connection failed");
 
-    /* Connect succeeded: the op still needs confirmed detachment before its
-     * embedded storage is reusable, but the winning fd is already handed to us and
-     * blocking. Pump the op to detachment (it retires its own timers), then free
-     * the connect-only event ctx: post-connect I/O is pure blocking, no loop. */
+    /* Connect succeeded: the winning fd is already blocking and handed to us, but
+     * the op still needs confirmed detachment before its embedded storage is
+     * reusable. Confirm detachment, then free the connect-only event ctx: post-
+     * connect I/O is pure blocking, no loop. If it will not detach, fail closed
+     * (retire the fd) and leak the whole allocation - never free under a live op. */
     if (!kl_connect_op_is_detached(&t->connect_op)) {
-        if (pump_until(t, done_connect_detached) != 0 ||
-            !kl_connect_op_is_detached(&t->connect_op)) {
-            /* The op will not detach: we cannot free the event ctx it references.
-             * The fd is live and usable, but leaving a live op wedged is a hard
-             * failure - fail closed, retire the fd, and report. */
+        if (pump_detach(t) != 0 || !kl_connect_op_is_detached(&t->connect_op)) {
             set_err(errbuf, errlen, "connect op did not detach");
             if (kl_handle_valid(t->fd)) { sp_close(t, t->fd); t->fd = KL_INVALID_SOCKET; }
-            log_error("pg: connect op did not detach after success; failing closed");
-            return -1;
+            log_error("pg: connect op did not detach after success; leaking the "
+                      "transport allocation (a live op still references it)");
+            return NULL;   /* intentional safe leak */
         }
     }
     if (t->delay_timer >= 0) {
@@ -625,34 +701,40 @@ int hl_pg_transport_connect(PgTransport *t, const char *host, const char *port,
         kl_timer_cancel(&t->ev, t->deadline_timer);
         t->deadline_timer = -1;
     }
-    if (t->ev_ready) {
-        kl_event_ctx_free(&t->ev);
-        t->ev_ready = 0;
+    kl_event_ctx_free(&t->ev);
+    t->ev_ready = 0;
+    return t;
+}
+
+PgTransport *hl_pg_transport_adopt(int fd, const KlSocketProvider *sp_or_NULL,
+                                   char *errbuf, size_t errlen)
+{
+    if (fd < 0) {
+        set_err(errbuf, errlen, "invalid descriptor");
+        return NULL;
     }
-    return 0;
-}
-
-int hl_pg_transport_adopt(PgTransport *t, int fd,
-                          const KlSocketProvider *sp_or_NULL)
-{
-    if (!t || fd < 0)
-        return -1;
-    transport_zero(t);
-    t->sp = sp_or_NULL ? sp_or_NULL : default_provider();
+    const KlSocketProvider *sp = sp_or_NULL ? sp_or_NULL : default_provider();
+    if (validate_provider(sp) != 0) {
+        set_err(errbuf, errlen, "socket provider missing a required op or KL_SOCK_CAP_NATIVE_FD");
+        return NULL;
+    }
+    PgTransport *t = transport_new(sp);
+    if (!t) { set_err(errbuf, errlen, "out of memory"); return NULL; }
     t->fd = (KlSocketHandle)fd;
-    /* SIGPIPE suppression parity: adopt() takes a connected blocking fd and every
-     * subsequent write goes through hl_pg_transport_send (nosignal flag) plus
-     * this per-fd SO_NOSIGPIPE where the platform offers it. No event ctx, no
-     * resolution, no racing (design Amendment 2). */
+    /* SIGPIPE suppression parity: every subsequent write goes through
+     * hl_pg_transport_send (nosignal flag) plus this per-fd SO_NOSIGPIPE where the
+     * platform offers it. No event ctx, no resolution, no racing (Amendment 2). */
     sp_set_nosigpipe(t, t->fd);
-    return 0;
+    return t;
 }
 
-void hl_pg_transport_attach_tls(PgTransport *t, struct HlTlsClient *tls)
+int hl_pg_transport_attach_tls(PgTransport *t, struct HlTlsClient *tls)
 {
-    if (!t)
-        return;
+    if (!t || !tls)                    return -1;  /* one-shot + non-NULL required */
+    if (!kl_handle_valid(t->fd))       return -1;  /* require a live descriptor    */
+    if (t->tls)                        return -1;  /* reject a second attachment   */
     t->tls = tls;
+    return 0;
 }
 
 ssize_t hl_pg_transport_send(PgTransport *t, const uint8_t *buf, size_t len)
@@ -661,14 +743,12 @@ ssize_t hl_pg_transport_send(PgTransport *t, const uint8_t *buf, size_t len)
         return -1;
     if (t->tls)
         return hl_tls_client_write((int)t->fd, t->tls, buf, len);
-    /* SIGPIPE suppression + EINTR retry: the POSIX provider's send already applies
-     * MSG_NOSIGNAL and retries EINTR internally (socket_posix.c), and we set
-     * SO_NOSIGPIPE on the fd where the platform offers it (sp_set_nosigpipe at
-     * adopt / attempt). The extra EINTR guard here is defense in depth for a
-     * provider whose send does not retry (e.g. the test mock). */
+    /* EINTR retry classified via the provider's io_status (hosted-errno fallback
+     * when absent). SIGPIPE suppression is the fd's SO_NOSIGPIPE + the provider's
+     * internal nosignal send flag. */
     kl_ssize_t n;
     do { n = sp_send(t, t->fd, buf, len); }
-    while (n < 0 && errno == EINTR);
+    while (n < 0 && sp_io_status(t) == KL_IO_INTERRUPTED);
     return (ssize_t)n;
 }
 
@@ -680,7 +760,7 @@ ssize_t hl_pg_transport_recv(PgTransport *t, uint8_t *buf, size_t len)
         return hl_tls_client_read((int)t->fd, t->tls, buf, len);
     kl_ssize_t n;
     do { n = sp_recv(t, t->fd, buf, len); }
-    while (n < 0 && errno == EINTR);
+    while (n < 0 && sp_io_status(t) == KL_IO_INTERRUPTED);
     return (ssize_t)n;
 }
 
@@ -703,14 +783,14 @@ int hl_pg_transport_fd(const PgTransport *t)
     return (int)t->fd;
 }
 
-void hl_pg_transport_close(PgTransport *t)
+int hl_pg_transport_close(PgTransport *t)
 {
-    if (!t || t->closed)
-        return;
-    t->closed = 1;
+    if (!t)
+        return 0;
 
     /* One close path: TLS shutdown, then TLS free, then provider close (design
-     * Amendment 1). */
+     * Amendment 1). TLS teardown is idempotent (t->tls cleared), so a retry after
+     * a preserved non-detachment does not repeat it. */
     if (t->tls) {
         if (kl_handle_valid(t->fd))
             hl_tls_client_shutdown((int)t->fd, t->tls);
@@ -718,18 +798,23 @@ void hl_pg_transport_close(PgTransport *t)
         t->tls = NULL;
     }
 
-    /* A raced connection that never freed its event ctx (an error path returned
-     * before detachment, or a caller closes without a successful connect): drive
-     * the op to detachment and retire storage. On the common paths (successful
-     * connect freed the ev ctx, or an adopted fd never had one) this is a plain
-     * fd close. */
+    /* A raced connection whose event ctx is still live (a caller closing without a
+     * successful connect, or retrying after a preserved non-detachment): drive the
+     * op to detachment. On non-detachment PRESERVE the whole allocation (do not
+     * free) and report -1 so the owner can retry or intentionally leak. */
     if (t->connect_started && t->ev_ready) {
-        connect_teardown(t);   /* cancels + detaches + closes fd + frees ev ctx */
-        return;
+        if (connect_teardown(t) != 0)
+            return -1;   /* preserved: caller retries hl_pg_transport_close or leaks */
+        free(t);
+        return 0;
     }
 
+    /* Common paths: a successful connect already freed the ev ctx, or an adopted
+     * fd never had one. Plain provider close of the descriptor, then free. */
     if (kl_handle_valid(t->fd)) {
         sp_close(t, t->fd);
         t->fd = KL_INVALID_SOCKET;
     }
+    free(t);
+    return 0;
 }

--- a/src/hull/cap/pg_transport.c
+++ b/src/hull/cap/pg_transport.c
@@ -143,11 +143,14 @@ static const KlSocketProvider *default_provider(void)
  * for every sp_* op; pg_test_resolve fills t->addrs in exact injected order;
  * pg_test_checkpoint observes each pump checkpoint; pg_test_force_no_detach makes
  * the detach-confirm predicate report "not detached" so a test can drive the
- * pathological non-detachment path (preserve storage + retryable close). */
+ * pathological non-detachment path (preserve storage + retryable close);
+ * pg_test_force_alloc_fail makes transport_new return NULL so a test can drive the
+ * allocation-failure path (adopt must still consume the descriptor). */
 const KlSocketProvider *pg_test_socket_provider;
 int (*pg_test_resolve)(PgTransport *t, const char *host, int port);
 void (*pg_test_checkpoint)(PgTransport *t, unsigned idx);
 int  pg_test_force_no_detach;
+int  pg_test_force_alloc_fail;
 static unsigned pg_test_checkpoint_seq;
 #endif
 
@@ -596,6 +599,9 @@ static int connect_teardown(PgTransport *t)
 
 static PgTransport *transport_new(const KlSocketProvider *sp)
 {
+#ifdef HL_PG_TEST_HOOKS
+    if (pg_test_force_alloc_fail) return NULL;   /* simulate calloc failure */
+#endif
     PgTransport *t = calloc(1, sizeof *t);
     if (!t) return NULL;
     t->sp = sp;
@@ -715,11 +721,21 @@ PgTransport *hl_pg_transport_adopt(int fd, const KlSocketProvider *sp_or_NULL,
     }
     const KlSocketProvider *sp = sp_or_NULL ? sp_or_NULL : default_provider();
     if (validate_provider(sp) != 0) {
+        /* Invalid provider: we cannot know how to close @p fd, so leave it with
+         * the caller (the only non-consuming failure other than fd < 0). */
         set_err(errbuf, errlen, "socket provider missing a required op or KL_SOCK_CAP_NATIVE_FD");
         return NULL;
     }
     PgTransport *t = transport_new(sp);
-    if (!t) { set_err(errbuf, errlen, "out of memory"); return NULL; }
+    if (!t) {
+        /* CONSUME @p fd: the provider is valid, so close the descriptor through it
+         * rather than leaking it. This upholds hl_pg_conn_start's take-ownership
+         * contract (fd is closed on every failure once adoption has a valid
+         * provider), and closes it EXACTLY once. */
+        sp->ops->close(sp->context, (KlSocketHandle)fd);
+        set_err(errbuf, errlen, "out of memory");
+        return NULL;
+    }
     t->fd = (KlSocketHandle)fd;
     /* SIGPIPE suppression parity: every subsequent write goes through
      * hl_pg_transport_send (nosignal flag) plus this per-fd SO_NOSIGPIPE where the

--- a/tests/e2e_postgres.sh
+++ b/tests/e2e_postgres.sh
@@ -708,36 +708,43 @@ end)'
 echo "=== LISTEN reconnect after a dropped connection ==="
 check_reconnect "lua" "lua" "$LUA_RC_WORKER"
 
-# ── sslmode matrix: no plaintext downgrade ────────────────────────────────
-# The container has no SSL yet, so it answers the SSLRequest with 'N'.
-# sslmode=require MUST hard-fail rather than silently downgrade to plaintext.
-# The connection is lazy, so `/` (db-free) serves for readiness and `/db`
-# triggers the connect attempt.
+# ── sslmode matrix: a connection that MUST be refused ─────────────────────
+# The default -d connection opens EAGERLY at app-context init, so a DSN that must
+# not connect makes `hull` exit at startup rather than serve. That startup failure
+# IS the proof the connection was refused: a silent success (e.g. a plaintext
+# downgrade, or verify-full accepting a bad cert) would instead leave the server
+# running. Assert the process exits and the log shows the connection failure.
+# $1 = label, $2 = DSN.
+assert_connect_refused() {
+    _lbl=$1; _dsn=$2
+    _d=$(mktemp -d)
+    printf 'app.manifest({ modules = { "hull/db@1", "hull/http-server@1" } })\nrequire("hull.db").default()\napp.get("/", function(req, res) res:json({ up = true }) end)\n' > "$_d/app.lua"
+    ./build/hull -d "$_dsn" -p "$PORT" "$_d/app.lua" >"$_d/serve.log" 2>&1 &
+    _pid=$!
+    _exited=0
+    for _ in $(seq 1 20); do
+        if ! kill -0 "$_pid" 2>/dev/null; then _exited=1; break; fi
+        sleep 0.5
+    done
+    if [ "$_exited" = 0 ]; then
+        kill "$_pid" 2>/dev/null || true; wait "$_pid" 2>/dev/null || true
+        echo "::error $_lbl: connection unexpectedly succeeded (server stayed up)"
+        cat "$_d/serve.log" 2>/dev/null || true; rm -rf "$_d"; exit 1
+    fi
+    wait "$_pid" 2>/dev/null || true
+    echo "--- $_lbl serve.log ---"; cat "$_d/serve.log" 2>/dev/null || true
+    if grep -qi 'failed to open database' "$_d/serve.log"; then
+        echo "PASS: $_lbl (connection refused, no silent success)"; rm -rf "$_d"
+    else
+        echo "::error $_lbl: expected a connection-failure log"; rm -rf "$_d"; exit 1
+    fi
+}
+
+# No plaintext downgrade: the container has no SSL yet, so it answers the
+# SSLRequest with 'N'; sslmode=require MUST hard-fail, not downgrade to plaintext.
 echo "=== sslmode=require against a non-TLS server must fail (no downgrade) ==="
-APPDIR_ND=$(mktemp -d)
-cat > "$APPDIR_ND/app.lua" <<'LUA'
-app.manifest({ modules = { "hull/db@1", "hull/http-server@1" } })
-local db = require("hull.db").default()
-app.get("/", function(req, res) res:json({ ready = true }) end)
-app.get("/db", function(req, res)
-    local ok, r = pcall(function() return db.query("SELECT 1") end)
-    if ok and r then res:json({ connected = true })
-    else res:json({ error = tostring(r) }) end
-end)
-LUA
-./build/hull -d "postgres://hull:s3cretpw@127.0.0.1:${PGPORT}/hulldb?sslmode=require" \
-    -p "$PORT" "$APPDIR_ND/app.lua" >"$APPDIR_ND/serve.log" 2>&1 &
-SVR=$!
-wait_for_server "$APPDIR_ND/serve.log" || { echo "::error no-downgrade server did not start"; exit 1; }
-RESP_ND=$(curl -sS "http://127.0.0.1:${PORT}/db" 2>/dev/null || true)
-kill "$SVR" 2>/dev/null || true; SVR=
-echo "response: $RESP_ND"
-if echo "$RESP_ND" | grep -qi '"connected":true'; then
-    echo "::error sslmode=require silently downgraded to plaintext"; exit 1
-fi
-echo "$RESP_ND" | grep -qi 'error' || { echo "::error expected a require-vs-nonTLS failure: $RESP_ND"; exit 1; }
-echo "PASS: sslmode=require refuses a non-TLS server (no plaintext downgrade)"
-rm -rf "$APPDIR_ND"
+assert_connect_refused "no-downgrade (require vs non-TLS)" \
+    "postgres://hull:s3cretpw@127.0.0.1:${PGPORT}/hulldb?sslmode=require"
 
 # ── TLS phase ────────────────────────────────────────────
 # Enable SSL on the running container with a self-signed cert, then connect
@@ -809,27 +816,5 @@ fi
 # verification logic itself is covered by the shared tls_client live-peer unit
 # suite.)
 echo "=== sslmode=verify-full rejects the untrusted self-signed cert ==="
-APPDIR_VF=$(mktemp -d)
-cat > "$APPDIR_VF/app.lua" <<'LUA'
-app.manifest({ modules = { "hull/db@1", "hull/http-server@1" } })
-local db = require("hull.db").default()
-app.get("/", function(req, res) res:json({ ready = true }) end)
-app.get("/db", function(req, res)
-    local ok, r = pcall(function() return db.query("SELECT 1") end)
-    if ok and r then res:json({ connected = true })
-    else res:json({ error = tostring(r) }) end
-end)
-LUA
-./build/hull -d "postgres://hull:s3cretpw@127.0.0.1:${PGPORT}/hulldb?sslmode=verify-full" \
-    -p "$PORT" "$APPDIR_VF/app.lua" >"$APPDIR_VF/serve.log" 2>&1 &
-SVR=$!
-wait_for_server "$APPDIR_VF/serve.log" || { echo "::error verify-full server did not start"; exit 1; }
-RESP_VF=$(curl -sS "http://127.0.0.1:${PORT}/db" 2>/dev/null || true)
-kill "$SVR" 2>/dev/null || true; SVR=
-echo "response: $RESP_VF"
-if echo "$RESP_VF" | grep -qi '"connected":true'; then
-    echo "::error verify-full accepted an untrusted self-signed cert"; exit 1
-fi
-echo "$RESP_VF" | grep -qi 'error' || { echo "::error expected a verify-full chain rejection: $RESP_VF"; exit 1; }
-echo "PASS: sslmode=verify-full rejects the untrusted self-signed cert (chain verification)"
-rm -rf "$APPDIR_VF"
+assert_connect_refused "verify-full (untrusted self-signed cert)" \
+    "postgres://hull:s3cretpw@127.0.0.1:${PGPORT}/hulldb?sslmode=verify-full"

--- a/tests/e2e_postgres.sh
+++ b/tests/e2e_postgres.sh
@@ -5,10 +5,13 @@
 # and exercises the full path: postgres:// DSN -> backend selection -> connect
 # + startup handshake -> parameterized db.exec / db.query -> typed row decode.
 #
-# Auth is SCRAM-SHA-256 (Phase 3, the postgres:16 default). Two transports are
-# exercised: plaintext (sslmode=disable) and TLS (SSLRequest ->
-# mbedTLS handshake -> SCRAM over TLS, asserted via pg_stat_ssl). Skips cleanly
-# when Docker (or, for the TLS phase, openssl) is unavailable.
+# Auth is SCRAM-SHA-256 (Phase 3, the postgres:16 default). The sslmode matrix is
+# exercised: plaintext (sslmode=disable); TLS (sslmode=require: SSLRequest ->
+# mbedTLS handshake -> SCRAM over TLS, asserted via pg_stat_ssl); no plaintext
+# downgrade (sslmode=require against a non-TLS server hard-fails); and
+# sslmode=verify-full rejecting an untrusted self-signed cert (chain
+# verification). Skips cleanly when Docker (or, for the TLS phases, openssl) is
+# unavailable.
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 set -eu
@@ -705,6 +708,37 @@ end)'
 echo "=== LISTEN reconnect after a dropped connection ==="
 check_reconnect "lua" "lua" "$LUA_RC_WORKER"
 
+# ── sslmode matrix: no plaintext downgrade ────────────────────────────────
+# The container has no SSL yet, so it answers the SSLRequest with 'N'.
+# sslmode=require MUST hard-fail rather than silently downgrade to plaintext.
+# The connection is lazy, so `/` (db-free) serves for readiness and `/db`
+# triggers the connect attempt.
+echo "=== sslmode=require against a non-TLS server must fail (no downgrade) ==="
+APPDIR_ND=$(mktemp -d)
+cat > "$APPDIR_ND/app.lua" <<'LUA'
+app.manifest({ modules = { "hull/db@1", "hull/http-server@1" } })
+local db = require("hull.db").default()
+app.get("/", function(req, res) res:json({ ready = true }) end)
+app.get("/db", function(req, res)
+    local ok, r = pcall(function() return db.query("SELECT 1") end)
+    if ok and r then res:json({ connected = true })
+    else res:json({ error = tostring(r) }) end
+end)
+LUA
+./build/hull -d "postgres://hull:s3cretpw@127.0.0.1:${PGPORT}/hulldb?sslmode=require" \
+    -p "$PORT" "$APPDIR_ND/app.lua" >"$APPDIR_ND/serve.log" 2>&1 &
+SVR=$!
+wait_for_server "$APPDIR_ND/serve.log" || { echo "::error no-downgrade server did not start"; exit 1; }
+RESP_ND=$(curl -sS "http://127.0.0.1:${PORT}/db" 2>/dev/null || true)
+kill "$SVR" 2>/dev/null || true; SVR=
+echo "response: $RESP_ND"
+if echo "$RESP_ND" | grep -qi '"connected":true'; then
+    echo "::error sslmode=require silently downgraded to plaintext"; exit 1
+fi
+echo "$RESP_ND" | grep -qi 'error' || { echo "::error expected a require-vs-nonTLS failure: $RESP_ND"; exit 1; }
+echo "PASS: sslmode=require refuses a non-TLS server (no plaintext downgrade)"
+rm -rf "$APPDIR_ND"
+
 # ── TLS phase ────────────────────────────────────────────
 # Enable SSL on the running container with a self-signed cert, then connect
 # with sslmode=require and assert (via pg_stat_ssl) the session is encrypted.
@@ -766,3 +800,36 @@ else
     echo "--- server log ---"; cat "$APPDIR_TLS/serve.log" 2>/dev/null || true
     exit 1
 fi
+
+# ── sslmode matrix: verify-full rejects an untrusted certificate ──────────
+# The container now serves TLS with a self-signed cert that is NOT in the embedded
+# Mozilla CA bundle, so sslmode=verify-full must fail chain verification instead of
+# connecting. (verify-full SUCCESS against a private CA is not e2e-testable here:
+# Hull's pg TLS verify trusts only the embedded bundle; the chain + hostname
+# verification logic itself is covered by the shared tls_client live-peer unit
+# suite.)
+echo "=== sslmode=verify-full rejects the untrusted self-signed cert ==="
+APPDIR_VF=$(mktemp -d)
+cat > "$APPDIR_VF/app.lua" <<'LUA'
+app.manifest({ modules = { "hull/db@1", "hull/http-server@1" } })
+local db = require("hull.db").default()
+app.get("/", function(req, res) res:json({ ready = true }) end)
+app.get("/db", function(req, res)
+    local ok, r = pcall(function() return db.query("SELECT 1") end)
+    if ok and r then res:json({ connected = true })
+    else res:json({ error = tostring(r) }) end
+end)
+LUA
+./build/hull -d "postgres://hull:s3cretpw@127.0.0.1:${PGPORT}/hulldb?sslmode=verify-full" \
+    -p "$PORT" "$APPDIR_VF/app.lua" >"$APPDIR_VF/serve.log" 2>&1 &
+SVR=$!
+wait_for_server "$APPDIR_VF/serve.log" || { echo "::error verify-full server did not start"; exit 1; }
+RESP_VF=$(curl -sS "http://127.0.0.1:${PORT}/db" 2>/dev/null || true)
+kill "$SVR" 2>/dev/null || true; SVR=
+echo "response: $RESP_VF"
+if echo "$RESP_VF" | grep -qi '"connected":true'; then
+    echo "::error verify-full accepted an untrusted self-signed cert"; exit 1
+fi
+echo "$RESP_VF" | grep -qi 'error' || { echo "::error expected a verify-full chain rejection: $RESP_VF"; exit 1; }
+echo "PASS: sslmode=verify-full rejects the untrusted self-signed cert (chain verification)"
+rm -rf "$APPDIR_VF"

--- a/tests/hull/cap/test_pg_conn.c
+++ b/tests/hull/cap/test_pg_conn.c
@@ -11,6 +11,7 @@
 
 #include "utest.h"
 #include "hull/cap/pg_conn.h"
+#include "hull/cap/pg_transport.h"
 #include "hull/cap/pgwire.h"
 
 #include <stdint.h>
@@ -296,7 +297,8 @@ UTEST(pg_query, select_rows_and_affected)
 
     HlPgConn conn;
     memset(&conn, 0, sizeof conn);
-    conn.fd = sv[1];
+    conn.transport = hl_pg_transport_adopt(sv[1], NULL, conn.errmsg, sizeof conn.errmsg);
+    ASSERT_TRUE(conn.transport != NULL);
 
     struct qcollect co;
     memset(&co, 0, sizeof co);
@@ -347,7 +349,8 @@ UTEST(pg_query, exec_affected_count)
 
     HlPgConn conn;
     memset(&conn, 0, sizeof conn);
-    conn.fd = sv[1];
+    conn.transport = hl_pg_transport_adopt(sv[1], NULL, conn.errmsg, sizeof conn.errmsg);
+    ASSERT_TRUE(conn.transport != NULL);
 
     int64_t affected = -1;
     ASSERT_EQ(0, hl_pg_query(&conn, "UPDATE t SET n=1 WHERE id > ?",
@@ -381,7 +384,8 @@ UTEST(pg_query, wait_notify)
 
     HlPgConn conn;
     memset(&conn, 0, sizeof conn);
-    conn.fd = sv[1];
+    conn.transport = hl_pg_transport_adopt(sv[1], NULL, conn.errmsg, sizeof conn.errmsg);
+    ASSERT_TRUE(conn.transport != NULL);
 
     /* 1. A notification is queued -> 1. */
     ASSERT_EQ(1, hl_pg_wait_notify(&conn, 1000));
@@ -415,7 +419,8 @@ UTEST(pg_query, server_error_then_ready)
 
     HlPgConn conn;
     memset(&conn, 0, sizeof conn);
-    conn.fd = sv[1];
+    conn.transport = hl_pg_transport_adopt(sv[1], NULL, conn.errmsg, sizeof conn.errmsg);
+    ASSERT_TRUE(conn.transport != NULL);
 
     HlPgParam p = { .text = "7", .len = 1 };
     ASSERT_EQ(-1, hl_pg_query(&conn, "SELECT ?", &p, 1, NULL, NULL, NULL, NULL));
@@ -445,7 +450,8 @@ UTEST(pg_exec_simple, multi_statement_ok)
 
     HlPgConn conn;
     memset(&conn, 0, sizeof conn);
-    conn.fd = sv[1];
+    conn.transport = hl_pg_transport_adopt(sv[1], NULL, conn.errmsg, sizeof conn.errmsg);
+    ASSERT_TRUE(conn.transport != NULL);
 
     ASSERT_EQ(0, hl_pg_exec_simple(&conn,
         "CREATE TABLE t (id int); INSERT INTO t VALUES (1)"));
@@ -481,7 +487,8 @@ UTEST(pg_exec_simple, error_then_ready)
 
     HlPgConn conn;
     memset(&conn, 0, sizeof conn);
-    conn.fd = sv[1];
+    conn.transport = hl_pg_transport_adopt(sv[1], NULL, conn.errmsg, sizeof conn.errmsg);
+    ASSERT_TRUE(conn.transport != NULL);
 
     ASSERT_EQ(-1, hl_pg_exec_simple(&conn, "CREATE TABLE t (id int)"));
     ASSERT_TRUE(strstr(conn.errmsg, "relation already exists") != NULL);

--- a/tests/hull/cap/test_pg_conn.c
+++ b/tests/hull/cap/test_pg_conn.c
@@ -517,10 +517,13 @@ static HlPgSslDecision negotiate_with(HlPgSslMode mode, int have_resp, char resp
     int sv[2];
     if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) return HL_PG_SSL_FAIL;
     if (have_resp) { ssize_t w = write(sv[0], &resp, 1); (void)w; }
+    /* Negotiation now rides the transport: adopt the socketpair end and drive it. */
+    PgTransport *t = hl_pg_transport_adopt(sv[1], NULL, NULL, 0);
+    if (!t) { close(sv[0]); close(sv[1]); return HL_PG_SSL_FAIL; }
     char e[128] = {0};
-    HlPgSslDecision d = hl_pg_ssl_negotiate(sv[1], mode, e, sizeof e);
+    HlPgSslDecision d = hl_pg_ssl_negotiate(t, mode, e, sizeof e);
+    hl_pg_transport_close(t);   /* closes sv[1] */
     close(sv[0]);
-    close(sv[1]);
     return d;
 }
 

--- a/tests/hull/cap/test_pg_transport.c
+++ b/tests/hull/cap/test_pg_transport.c
@@ -77,6 +77,8 @@ static int    g_fk_close_n;          /* total provider close() calls           *
 static int    g_fk_bogus_errno;      /* when 1, connect leaves errno = EPERM   */
 static KlIoStatus g_fk_io_status_val;/* value fk_io_status returns             */
 static int    g_fk_send_eintr_once;  /* when 1, first send reports INTERRUPTED  */
+static int    g_fk_send_max;         /* > 0 caps bytes per send (forces partial)*/
+static int    g_fk_send_n;           /* count of send() calls (partial-write proof) */
 
 static void fk_reset(void)
 {
@@ -92,6 +94,8 @@ static void fk_reset(void)
     g_fk_bogus_errno = 0;
     g_fk_io_status_val = KL_IO_OK;
     g_fk_send_eintr_once = 0;
+    g_fk_send_max = 0;
+    g_fk_send_n = 0;
     /* The checkpoint counter is a process-global static in pg_transport.c; reset it
      * per test so a "complete at checkpoint N" hook fires deterministically (a
      * prior test's checkpoints must not advance it past N). Visible because this
@@ -165,7 +169,9 @@ static int fk_get_so_error(void *c, KlSocketHandle fd, int *out)
 static kl_ssize_t fk_send(void *c, KlSocketHandle fd, const void *b, size_t n)
 {
     (void)c;
+    g_fk_send_n++;
     if (g_fk_send_eintr_once) { g_fk_send_eintr_once = 0; errno = 0; return -1; }
+    if (g_fk_send_max > 0 && n > (size_t)g_fk_send_max) n = (size_t)g_fk_send_max;
     return send((int)fd, b, n, 0);
 }
 static kl_ssize_t fk_recv(void *c, KlSocketHandle fd, void *b, size_t n)
@@ -506,6 +512,42 @@ UTEST(pg_transport_io, partial_recv_short_count)
     ssize_t n = hl_pg_transport_recv(t, buf, sizeof buf);  /* asked 16, gets 2 */
     ASSERT_EQ((int)n, 2);
     ASSERT_EQ(buf[0], 5); ASSERT_EQ(buf[1], 6);
+    ASSERT_EQ(hl_pg_transport_close(t), 0);
+    close(sv[1]);
+    seam_clear(); tp_disarm_watchdog();
+}
+
+/* ── send_all completes over FORCED partial writes, preserving order ──
+ *    The provider caps every send() at 1 byte, so an 8-byte payload requires 8
+ *    send() calls: this proves hl_pg_transport_send_all loops over short writes
+ *    (advancing buf + remaining len each time) and that the bytes arrive in order.
+ *    The prior adopt roundtrip sent through the raw provider which completes in
+ *    one call, so it did not exercise the partial-write path. ─────────────────── */
+UTEST(pg_transport_io, send_all_completes_forced_partial_writes)
+{
+    fk_reset(); tp_arm_watchdog();
+    int sv[2]; ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+    pg_test_socket_provider = &FK_PROVIDER;
+    PgTransport *t = hl_pg_transport_adopt(sv[0], &FK_PROVIDER, NULL, 0);
+    ASSERT_TRUE(t != NULL);
+
+    const uint8_t payload[8] = { 10, 20, 30, 40, 50, 60, 70, 80 };
+    g_fk_send_max = 1;                    /* 1 byte per send() -> forced partials */
+    g_fk_send_n   = 0;
+    ASSERT_EQ(hl_pg_transport_send_all(t, payload, sizeof payload), 0);   /* all sent */
+    ASSERT_EQ(g_fk_send_n, 8);            /* 8 short sends: the loop ran, not one call */
+
+    /* Read every byte back and assert order is preserved. */
+    uint8_t got[8] = {0};
+    size_t r = 0;
+    while (r < sizeof got) {
+        ssize_t k = recv(sv[1], got + r, sizeof got - r, 0);
+        if (k <= 0) break;
+        r += (size_t)k;
+    }
+    ASSERT_EQ((int)r, 8);
+    for (int i = 0; i < 8; i++) ASSERT_EQ(got[i], payload[i]);
+
     ASSERT_EQ(hl_pg_transport_close(t), 0);
     close(sv[1]);
     seam_clear(); tp_disarm_watchdog();

--- a/tests/hull/cap/test_pg_transport.c
+++ b/tests/hull/cap/test_pg_transport.c
@@ -224,6 +224,7 @@ static void seam_clear(void)
     pg_test_socket_provider = NULL;
     pg_test_checkpoint      = NULL;
     pg_test_force_no_detach = 0;
+    pg_test_force_alloc_fail = 0;
 }
 
 /* Proxy for "confirmed detachment retired everything": every mock socketpair was
@@ -497,6 +498,29 @@ UTEST(pg_transport_io, adopt_roundtrip_close_once)
     ASSERT_EQ(g_fk_close_n, 1);           /* the descriptor was closed exactly once */
     close(sv[1]);
     seam_clear(); tp_disarm_watchdog();
+}
+
+/* ── adopt allocation failure CONSUMES the descriptor (closed exactly once) ─
+ *    hl_pg_conn_start relies on adopt taking ownership of the fd and closing it on
+ *    every failure. Force transport_new() to fail (pg_test_force_alloc_fail): adopt
+ *    must return NULL AND close the descriptor through the provider exactly once,
+ *    so the caller never leaks it. ─────────────────────────────────────────────── */
+UTEST(pg_transport_adopt, alloc_failure_consumes_fd_once)
+{
+    fk_reset();
+    int sv[2]; ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+    g_fk_close_n = 0;
+    pg_test_force_alloc_fail = 1;         /* transport_new() returns NULL */
+
+    char err[64] = {0};
+    PgTransport *t = hl_pg_transport_adopt(sv[0], &FK_PROVIDER, err, sizeof err);
+    ASSERT_TRUE(t == NULL);               /* allocation failed */
+    ASSERT_TRUE(err[0] != '\0');
+    ASSERT_EQ(g_fk_close_n, 1);           /* fd CONSUMED: closed exactly once via the provider */
+
+    /* sv[0] is closed by adopt; only the peer remains for the test to close. */
+    close(sv[1]);
+    seam_clear();
 }
 
 /* ── partial recv returns the short count ───────────────────────────── */

--- a/tests/hull/cap/test_pg_transport.c
+++ b/tests/hull/cap/test_pg_transport.c
@@ -322,13 +322,15 @@ UTEST(pg_transport_connect, deadline_fires_detaches)
 }
 
 /* ── truly unbounded (timeout_ms <= 0): NO hidden ceiling. A pending attempt is
- *    driven to completion by the test at pump checkpoint 3 (we drain the peer so
- *    the fd becomes writable), proving the loop pumps until completion and does
- *    not impose a 30 s (or any) total deadline. The 5 s watchdog would trip on a
- *    hang; success well under it is the proof. ─────────────────────────────── */
-static void tp_complete_pending_at_cp3(PgTransport *t, unsigned idx)
+ *    driven to completion by the test a few pump ticks in (the hook drains the
+ *    peer once the pump-tick counter reaches a small threshold, so the fd becomes
+ *    writable), proving the loop pumps until completion and does not impose a 30 s
+ *    (or any) total deadline. The 5 s watchdog would trip on a hang; success well
+ *    under it is the proof. ────────────────────────────────────────────────── */
+#define TP_COMPLETE_AT_TICK 3
+static void tp_complete_pending_at_tick(PgTransport *t, unsigned idx)
 {
-    if (idx != 3) return;
+    if (idx != TP_COMPLETE_AT_TICK) return;
     /* Drain the peer of the single in-flight attempt so its fd becomes writable. */
     for (int i = 0; i < t->naddrs; i++) {
         if (kl_handle_valid(t->attempt_fd[i])) {
@@ -342,7 +344,7 @@ UTEST(pg_transport_connect, unbounded_no_hidden_ceiling)
     fk_reset(); tp_arm_watchdog();
     g_fk_naddr = 1; g_fk_disp[0] = FK_PENDING;
     pg_test_resolve = fk_resolve; pg_test_socket_provider = &FK_PROVIDER;
-    pg_test_checkpoint = tp_complete_pending_at_cp3;
+    pg_test_checkpoint = tp_complete_pending_at_tick;
 
     PgTransport *t = hl_pg_transport_connect("h", "5432", 0 /* unbounded */,
                                              &FK_PROVIDER, NULL, 0);
@@ -363,7 +365,7 @@ UTEST(pg_transport_io, io_status_overrides_errno)
     g_fk_bogus_errno = 1;                 /* connect sets errno = EPERM */
     g_fk_io_status_val = KL_IO_PENDING;   /* but io_status says PENDING */
     pg_test_resolve = fk_resolve; pg_test_socket_provider = &FK_PROVIDER_IOS;
-    pg_test_checkpoint = tp_complete_pending_at_cp3;
+    pg_test_checkpoint = tp_complete_pending_at_tick;
 
     PgTransport *t = hl_pg_transport_connect("h", "5432", 0, &FK_PROVIDER_IOS, NULL, 0);
     /* On completion get_so_error reports 0 -> success, despite errno == EPERM. */

--- a/tests/hull/cap/test_pg_transport.c
+++ b/tests/hull/cap/test_pg_transport.c
@@ -1,0 +1,487 @@
+/*
+ * test_pg_transport.c - Focused tests for the PostgreSQL-over-Keel-v3 transport
+ * (Checkpoint 2 of docs/pg_keel_transport_slice3.md).
+ *
+ * These drive the transport's connect machinery + blocking I/O + lifecycle
+ * through the -DHL_PG_TEST_HOOKS seam, WITHOUT any network or DNS:
+ *
+ *   - a connect attempt that is PENDING, then SUCCEEDS (the connect op races to a
+ *     winning fd and set_blocking()s it);
+ *   - a connect that FAILS on every address (all dispositions fail);
+ *   - the IP-literal fast path (kl_sockaddr_parse, no DNS resolve callback);
+ *   - a partial send that completes via hl_pg_transport_send_all;
+ *   - hl_pg_transport_recv returns data written by the peer;
+ *   - hl_pg_transport_adopt(fd) routes I/O + closes exactly once;
+ *   - hl_pg_transport_close is idempotent (double-close is safe);
+ *   - confirmed connect-op detachment on a failed connect (no leaked op / fd).
+ *
+ * The static helpers are reached by direct-including the capability .c; the
+ * Makefile rule for this binary therefore EXCLUDES cap_pg_transport.o from the
+ * common link (mirrors test_smtp_transport / test_pg_conn's direct-source
+ * pattern). This test source is never in the shipped binary.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "utest.h"
+
+/* Direct-source include: the static helpers (resolve_addrs, the connect hooks,
+ * the pump, connect_teardown) plus the public API are the unit under test. */
+#include "../../../src/hull/cap/pg_transport.c"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+
+#include <keel/sockaddr.h>
+
+/* ════════════════════════════════════════════════════════════════════
+ *  A watchdog so a wedged pump can never hang CI: SIGALRM aborts the test.
+ * ════════════════════════════════════════════════════════════════════ */
+static void tp_watchdog_fired(int sig) { (void)sig; _exit(77); }
+
+/* ════════════════════════════════════════════════════════════════════
+ *  Fake socket provider (pg_test_socket_provider). It hands the connect op real
+ *  fds the event loop can watch, keeping ONE clock domain: a "pending" address is
+ *  a socketpair whose send buffer is filled so its fd is never write-ready (both
+ *  epoll and kqueue respect a full send buffer), so the attempt stays pending
+ *  under kernel semantics. "succeed" / "fail" leave the fd writable and let
+ *  get_so_error report SO_ERROR. Attempts are recorded (address index) so a test
+ *  can assert the winner and the attempt count.
+ * ════════════════════════════════════════════════════════════════════ */
+
+enum { FK_PENDING = 0, FK_SUCCEED = 1, FK_FAIL = 2 };
+
+typedef struct { int used; int a; int b; int disp; int idx; } FkSlot;
+static FkSlot g_fk[32];
+static int    g_fk_disp[KL_CONNECT_MAX_ADDRS];  /* per-address disposition       */
+static int    g_fk_order[KL_CONNECT_MAX_ADDRS]; /* attempt order (address index) */
+static int    g_fk_n;                           /* number of connect() attempts  */
+static int    g_fk_succeeded_idx;               /* address that read SO_ERROR==0  */
+static int    g_fk_naddr;                        /* injected address count        */
+static int    g_fk_blocking_set;                 /* count of set_blocking calls    */
+
+static void fk_reset(void)
+{
+    memset(g_fk, 0, sizeof g_fk);
+    memset(g_fk_disp, 0, sizeof g_fk_disp);
+    memset(g_fk_order, 0, sizeof g_fk_order);
+    g_fk_n = 0;
+    g_fk_succeeded_idx = -1;
+    g_fk_naddr = 0;
+    g_fk_blocking_set = 0;
+}
+
+static FkSlot *fk_slot_for(int a)
+{
+    for (size_t i = 0; i < sizeof g_fk / sizeof g_fk[0]; i++)
+        if (g_fk[i].used && g_fk[i].a == a) return &g_fk[i];
+    return NULL;
+}
+
+static KlSocketHandle fk_socket(void *c, int d, int ty, int p)
+{
+    (void)c; (void)d; (void)ty; (void)p;
+    int sv[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) return KL_INVALID_SOCKET;
+    int small = 2048;
+    setsockopt(sv[0], SOL_SOCKET, SO_SNDBUF, &small, sizeof small);
+    setsockopt(sv[1], SOL_SOCKET, SO_RCVBUF, &small, sizeof small);
+    for (size_t i = 0; i < sizeof g_fk / sizeof g_fk[0]; i++)
+        if (!g_fk[i].used) {
+            g_fk[i].used = 1; g_fk[i].a = sv[0]; g_fk[i].b = sv[1];
+            g_fk[i].disp = -1; g_fk[i].idx = -1;
+            return (KlSocketHandle)sv[0];
+        }
+    close(sv[0]); close(sv[1]);
+    return KL_INVALID_SOCKET;
+}
+static int  fk_set_nb(void *c, KlSocketHandle fd)
+{ (void)c; int a = (int)fd; int fl = fcntl(a, F_GETFL, 0); return fcntl(a, F_SETFL, fl | O_NONBLOCK); }
+static int  fk_set_blocking(void *c, KlSocketHandle fd)
+{ (void)c; g_fk_blocking_set++; int a = (int)fd; int fl = fcntl(a, F_GETFL, 0); return fcntl(a, F_SETFL, fl & ~O_NONBLOCK); }
+static int  fk_set_int(void *c, KlSocketHandle fd, int on) { (void)c; (void)fd; (void)on; return 0; }
+static void fk_set_void(void *c, KlSocketHandle fd) { (void)c; (void)fd; }
+static int  fk_get_local(void *c, KlSocketHandle fd, KlSockAddr *out)
+{ (void)c; (void)fd; uint8_t ip[4] = {127,0,0,1}; return kl_sockaddr_from_ipv4(out, ip, 0); }
+
+static int fk_connect(void *c, KlSocketHandle fd, const KlSockAddr *addr)
+{
+    (void)c;
+    int a = (int)fd;
+    int idx = (addr->addr_len == 4) ? (addr->u.ip[3] - 1) : 0;
+    if (idx < 0 || idx >= KL_CONNECT_MAX_ADDRS) idx = 0;
+    int disp = g_fk_disp[idx];
+    if (g_fk_n < KL_CONNECT_MAX_ADDRS)
+        g_fk_order[g_fk_n++] = idx;
+    FkSlot *s = fk_slot_for(a);
+    if (s) { s->disp = disp; s->idx = idx; }
+    if (disp == FK_PENDING) {
+        /* Fill the send buffer so 'a' never becomes write-ready. */
+        char buf[2048];
+        memset(buf, 'x', sizeof buf);
+        int fl = fcntl(a, F_GETFL, 0); fcntl(a, F_SETFL, fl | O_NONBLOCK);
+        while (write(a, buf, sizeof buf) > 0) { }
+    }
+    errno = EINPROGRESS;
+    return -1;
+}
+static int fk_get_so_error(void *c, KlSocketHandle fd, int *out)
+{
+    (void)c;
+    FkSlot *s = fk_slot_for((int)fd);
+    if (s && s->disp == FK_FAIL) { *out = ECONNREFUSED; }
+    else { *out = 0; if (s) g_fk_succeeded_idx = s->idx; }
+    return 0;
+}
+static kl_ssize_t fk_send(void *c, KlSocketHandle fd, const void *b, size_t n)
+{ (void)c; return send((int)fd, b, n, 0); }
+static kl_ssize_t fk_recv(void *c, KlSocketHandle fd, void *b, size_t n)
+{ (void)c; return recv((int)fd, b, n, 0); }
+static kl_ssize_t fk_recv_peek(void *c, KlSocketHandle fd, void *b, size_t n)
+{ (void)c; return recv((int)fd, b, n, MSG_PEEK); }
+static int fk_close(void *c, KlSocketHandle fd)
+{
+    (void)c; int a = (int)fd;
+    FkSlot *s = fk_slot_for(a);
+    if (s) { close(s->b); s->used = 0; }
+    return close(a);
+}
+
+static const KlSocketOps FK_OPS = {
+    .set_nonblocking = fk_set_nb,
+    .set_blocking    = fk_set_blocking,
+    .set_cloexec     = fk_set_void,
+    .set_nosigpipe   = fk_set_void,
+    .set_reuseaddr   = fk_set_int,
+    .set_reuseport   = fk_set_int,
+    .set_ipv6only    = fk_set_int,
+    .set_tcp_nodelay = fk_set_int,
+    .set_cork        = fk_set_int,
+    .socket          = fk_socket,
+    .connect         = fk_connect,
+    .close           = fk_close,
+    .get_local_addr  = fk_get_local,
+    .get_so_error    = fk_get_so_error,
+    .send            = fk_send,
+    .recv            = fk_recv,
+    .recv_peek       = fk_recv_peek,
+};
+static const KlSocketProvider FK_PROVIDER = { .ops = &FK_OPS, .context = NULL };
+
+/* Inject N addresses 10.11.12.(i+1) in order; disposition comes from g_fk_disp.
+ * Also records whether the resolve hook was actually called (so the IP-literal
+ * fast path can assert it was NOT). */
+static int g_fk_resolve_called;
+static int fk_resolve(PgTransport *t, const char *host, int port)
+{
+    (void)host;
+    g_fk_resolve_called++;
+    for (int i = 0; i < g_fk_naddr && i < KL_CONNECT_MAX_ADDRS; i++) {
+        uint8_t ip[4] = { 10, 11, 12, (uint8_t)(i + 1) };
+        if (kl_sockaddr_from_ipv4(&t->addrs[i], ip, (uint16_t)port) != 0) return i;
+    }
+    return g_fk_naddr;
+}
+
+/* ════════════════════════════════════════════════════════════════════
+ *  Connect: pending -> succeed.
+ * ════════════════════════════════════════════════════════════════════ */
+UTEST(pg_transport_connect, pending_then_succeed)
+{
+    fk_reset();
+    g_fk_naddr   = 1;
+    g_fk_disp[0] = FK_SUCCEED;
+    g_fk_resolve_called = 0;
+    pg_test_resolve         = fk_resolve;
+    pg_test_socket_provider = &FK_PROVIDER;
+
+    void (*prev)(int) = signal(SIGALRM, tp_watchdog_fired); alarm(30);
+
+    PgTransport t;
+    char err[128] = {0};
+    int rc = hl_pg_transport_connect(&t, "db.example.test", "5432", 5000,
+                                     &FK_PROVIDER, err, sizeof err);
+
+    alarm(0); signal(SIGALRM, prev);
+    pg_test_resolve         = NULL;
+    pg_test_socket_provider = NULL;
+
+    ASSERT_EQ(rc, 0);                          /* the race won */
+    ASSERT_GE(g_fk_n, 1);                       /* at least one attempt */
+    ASSERT_EQ(g_fk_succeeded_idx, 0);           /* address 0 connected */
+    ASSERT_GE(g_fk_blocking_set, 1);            /* the winner was set_blocking()'d */
+    ASSERT_TRUE(hl_pg_transport_fd(&t) >= 0);   /* a live descriptor is held */
+    /* The connect-only event ctx is freed after a successful connect + detach. */
+    ASSERT_EQ(t.ev_ready, 0);
+    ASSERT_TRUE(kl_connect_op_is_detached(&t.connect_op));
+
+    hl_pg_transport_close(&t);
+    ASSERT_TRUE(hl_pg_transport_fd(&t) < 0);    /* fd retired by close */
+}
+
+/* Two addresses: the first is FK_PENDING, the second FK_SUCCEED. The RFC 8305
+ * stagger must start address 1 while 0 is pending, and address 1 wins. */
+UTEST(pg_transport_connect, stagger_second_address_wins)
+{
+    fk_reset();
+    g_fk_naddr   = 2;
+    g_fk_disp[0] = FK_PENDING;
+    g_fk_disp[1] = FK_SUCCEED;
+    pg_test_resolve         = fk_resolve;
+    pg_test_socket_provider = &FK_PROVIDER;
+
+    void (*prev)(int) = signal(SIGALRM, tp_watchdog_fired); alarm(30);
+
+    PgTransport t;
+    int rc = hl_pg_transport_connect(&t, "db.example.test", "5432", 5000,
+                                     &FK_PROVIDER, NULL, 0);
+
+    alarm(0); signal(SIGALRM, prev);
+    pg_test_resolve         = NULL;
+    pg_test_socket_provider = NULL;
+
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(g_fk_n, 2);               /* both addresses attempted */
+    ASSERT_EQ(g_fk_order[0], 0);
+    ASSERT_EQ(g_fk_order[1], 1);
+    ASSERT_EQ(g_fk_succeeded_idx, 1);   /* address 1 connected */
+
+    hl_pg_transport_close(&t);
+}
+
+/* ════════════════════════════════════════════════════════════════════
+ *  Connect: all addresses fail. The transport reports -1 AND the connect op
+ *  reaches confirmed detachment (no leaked op / fd).
+ * ════════════════════════════════════════════════════════════════════ */
+UTEST(pg_transport_connect, all_addresses_fail_detach)
+{
+    fk_reset();
+    g_fk_naddr   = 2;
+    g_fk_disp[0] = FK_FAIL;
+    g_fk_disp[1] = FK_FAIL;
+    pg_test_resolve         = fk_resolve;
+    pg_test_socket_provider = &FK_PROVIDER;
+
+    void (*prev)(int) = signal(SIGALRM, tp_watchdog_fired); alarm(30);
+
+    PgTransport t;
+    char err[128] = {0};
+    int rc = hl_pg_transport_connect(&t, "db.example.test", "5432", 5000,
+                                     &FK_PROVIDER, err, sizeof err);
+
+    alarm(0); signal(SIGALRM, prev);
+    pg_test_resolve         = NULL;
+    pg_test_socket_provider = NULL;
+
+    ASSERT_EQ(rc, -1);                             /* connect failed */
+    ASSERT_TRUE(err[0] != '\0');                    /* a message was written */
+    /* connect_teardown pumped to confirmed detachment before returning: the op is
+     * detached and the event ctx freed (no leaked op / fd). */
+    ASSERT_TRUE(kl_connect_op_is_detached(&t.connect_op));
+    ASSERT_EQ(t.ev_ready, 0);
+    ASSERT_TRUE(hl_pg_transport_fd(&t) < 0);
+
+    hl_pg_transport_close(&t);   /* idempotent: safe after a failed connect */
+}
+
+/* A resolve that yields zero addresses fails cleanly (the op never starts). */
+UTEST(pg_transport_connect, resolve_empty_fails)
+{
+    fk_reset();
+    g_fk_naddr   = 0;             /* fk_resolve returns 0 */
+    pg_test_resolve         = fk_resolve;
+    pg_test_socket_provider = &FK_PROVIDER;
+
+    PgTransport t;
+    char err[128] = {0};
+    int rc = hl_pg_transport_connect(&t, "nope.example.test", "5432", 5000,
+                                     &FK_PROVIDER, err, sizeof err);
+
+    pg_test_resolve         = NULL;
+    pg_test_socket_provider = NULL;
+
+    ASSERT_EQ(rc, -1);
+    ASSERT_TRUE(err[0] != '\0');
+    ASSERT_EQ(t.ev_ready, 0);      /* event ctx torn down */
+}
+
+/* ════════════════════════════════════════════════════════════════════
+ *  IP-literal fast path: with NO resolve hook installed, resolve_addrs takes the
+ *  kl_sockaddr_parse (no-DNS) branch for a numeric host. Prove the fast path via
+ *  resolve_addrs directly (no socket needed) and via a full connect.
+ * ════════════════════════════════════════════════════════════════════ */
+UTEST(pg_transport_resolve, ip_literal_no_dns)
+{
+    pg_test_resolve         = NULL;   /* force the real resolve_addrs */
+    pg_test_socket_provider = NULL;
+
+    PgTransport t;
+    transport_zero(&t);
+    t.sp = &FK_PROVIDER;
+    int n = resolve_addrs(&t, "127.0.0.1", 5432);
+    ASSERT_EQ(n, 1);                         /* exactly one address, no DNS */
+    ASSERT_EQ((int)t.addrs[0].addr_len, 4);   /* an IPv4 literal */
+
+    /* An IPv6 literal too. */
+    int n6 = resolve_addrs(&t, "::1", 5432);
+    ASSERT_EQ(n6, 1);
+    ASSERT_EQ((int)t.addrs[0].addr_len, 16);
+}
+
+/* Full connect to an IP literal with NO resolve hook installed: the real
+ * resolve_addrs must take the kl_sockaddr_parse (no-DNS) branch, and the connect
+ * still races through the fake socket provider and wins. Proves the fast path
+ * drives a real connect end to end without any getaddrinfo / resolve callback. */
+UTEST(pg_transport_resolve, ip_literal_connect_no_dns)
+{
+    fk_reset();
+    /* g_fk_disp is indexed by (ip[3]-1); a "127.0.0.1" literal parses to
+     * addr_len 4 with ip[3]==1, so index 0. Make index 0 succeed. */
+    g_fk_disp[0] = FK_SUCCEED;
+    g_fk_resolve_called = 0;
+    pg_test_resolve         = NULL;            /* force the real resolve_addrs */
+    pg_test_socket_provider = &FK_PROVIDER;    /* fake connect, no real network */
+
+    void (*prev)(int) = signal(SIGALRM, tp_watchdog_fired); alarm(30);
+
+    PgTransport t;
+    int rc = hl_pg_transport_connect(&t, "127.0.0.1", "5432", 5000,
+                                     &FK_PROVIDER, NULL, 0);
+
+    alarm(0); signal(SIGALRM, prev);
+    pg_test_socket_provider = NULL;
+
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(g_fk_resolve_called, 0);   /* the resolve callback never ran (fast path) */
+    ASSERT_EQ(g_fk_succeeded_idx, 0);    /* the parsed 127.0.0.1 address connected */
+
+    hl_pg_transport_close(&t);
+}
+
+/* ════════════════════════════════════════════════════════════════════
+ *  Blocking I/O over an ADOPTED descriptor (design Amendment 2): a real
+ *  socketpair, the default POSIX provider, no event ctx / resolve / race.
+ * ════════════════════════════════════════════════════════════════════ */
+UTEST(pg_transport_io, adopt_send_recv_roundtrip)
+{
+    int sv[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+
+    PgTransport t;
+    ASSERT_EQ(hl_pg_transport_adopt(&t, sv[0], NULL), 0);
+    ASSERT_EQ(hl_pg_transport_fd(&t), sv[0]);
+    ASSERT_EQ(t.ev_ready, 0);                 /* adopt never inits an event ctx */
+    ASSERT_EQ(t.connect_started, 0);
+
+    /* send_all -> the peer sees every byte. */
+    const uint8_t msg[] = "SELECT 1";
+    ASSERT_EQ(hl_pg_transport_send_all(&t, msg, sizeof msg), 0);
+    uint8_t peer[64] = {0};
+    ssize_t got = recv(sv[1], peer, sizeof peer, 0);
+    ASSERT_EQ(got, (ssize_t)sizeof msg);
+    ASSERT_EQ(memcmp(peer, msg, sizeof msg), 0);
+
+    /* recv -> the transport reads what the peer wrote. */
+    const uint8_t reply[] = "ReadyForQuery";
+    ASSERT_EQ(write(sv[1], reply, sizeof reply), (ssize_t)sizeof reply);
+    uint8_t rbuf[64] = {0};
+    ssize_t rn = hl_pg_transport_recv(&t, rbuf, sizeof rbuf);
+    ASSERT_EQ(rn, (ssize_t)sizeof reply);
+    ASSERT_EQ(memcmp(rbuf, reply, sizeof reply), 0);
+
+    hl_pg_transport_close(&t);
+    ASSERT_TRUE(hl_pg_transport_fd(&t) < 0);   /* fd retired */
+    close(sv[1]);
+}
+
+/* A partial send (the peer's receive buffer is tiny, so one send returns short)
+ * still completes via hl_pg_transport_send_all's full-write loop. A background
+ * drain keeps the pipe moving so the loop makes progress. */
+static int   g_drain_fd;
+static size_t g_drain_target;
+static void *drain_thread(void *arg)
+{
+    (void)arg;
+    size_t got = 0;
+    uint8_t buf[4096];
+    while (got < g_drain_target) {
+        ssize_t n = recv(g_drain_fd, buf, sizeof buf, 0);
+        if (n <= 0) break;
+        got += (size_t)n;
+    }
+    return NULL;
+}
+
+UTEST(pg_transport_io, send_all_completes_partial)
+{
+    int sv[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+    int small = 4096;
+    setsockopt(sv[0], SOL_SOCKET, SO_SNDBUF, &small, sizeof small);
+    setsockopt(sv[1], SOL_SOCKET, SO_RCVBUF, &small, sizeof small);
+
+    PgTransport t;
+    ASSERT_EQ(hl_pg_transport_adopt(&t, sv[0], NULL), 0);
+
+    /* A payload larger than the socket buffers, so a single send goes short and
+     * send_all must loop. A background reader drains the far end. */
+    size_t big = 256 * 1024;
+    uint8_t *payload = malloc(big);
+    ASSERT_TRUE(payload != NULL);
+    for (size_t i = 0; i < big; i++) payload[i] = (uint8_t)(i & 0xff);
+
+    g_drain_fd = sv[1]; g_drain_target = big;
+    pthread_t th;
+    ASSERT_EQ(pthread_create(&th, NULL, drain_thread, NULL), 0);
+
+    void (*prev)(int) = signal(SIGALRM, tp_watchdog_fired); alarm(30);
+    int rc = hl_pg_transport_send_all(&t, payload, big);
+    alarm(0); signal(SIGALRM, prev);
+
+    pthread_join(th, NULL);
+    ASSERT_EQ(rc, 0);   /* every byte written despite short sends */
+
+    free(payload);
+    hl_pg_transport_close(&t);
+    close(sv[1]);
+}
+
+/* ════════════════════════════════════════════════════════════════════
+ *  Close is idempotent: a second close (and a close on a fresh-zeroed transport)
+ *  is safe and does not touch a retired fd twice.
+ * ════════════════════════════════════════════════════════════════════ */
+UTEST(pg_transport_close, idempotent_double_close)
+{
+    int sv[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+
+    PgTransport t;
+    ASSERT_EQ(hl_pg_transport_adopt(&t, sv[0], NULL), 0);
+
+    hl_pg_transport_close(&t);
+    ASSERT_TRUE(hl_pg_transport_fd(&t) < 0);
+    /* Second close: the guard makes it a no-op (no double sp_close of the fd). */
+    hl_pg_transport_close(&t);
+    ASSERT_TRUE(hl_pg_transport_fd(&t) < 0);
+
+    close(sv[1]);
+}
+
+/* Close on an adopted-then-never-used transport, and a NULL-safe close. */
+UTEST(pg_transport_close, null_and_fresh_safe)
+{
+    hl_pg_transport_close(NULL);   /* NULL-safe */
+
+    int sv[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+    PgTransport t;
+    ASSERT_EQ(hl_pg_transport_adopt(&t, sv[0], NULL), 0);
+    hl_pg_transport_close(&t);
+    close(sv[1]);
+}
+
+UTEST_MAIN()

--- a/tests/hull/cap/test_pg_transport.c
+++ b/tests/hull/cap/test_pg_transport.c
@@ -3,22 +3,28 @@
  * (Checkpoint 2 of docs/pg_keel_transport_slice3.md).
  *
  * These drive the transport's connect machinery + blocking I/O + lifecycle
- * through the -DHL_PG_TEST_HOOKS seam, WITHOUT any network or DNS:
+ * through the -DHL_PG_TEST_HOOKS seam, WITHOUT any network or DNS. Coverage:
  *
- *   - a connect attempt that is PENDING, then SUCCEEDS (the connect op races to a
- *     winning fd and set_blocking()s it);
- *   - a connect that FAILS on every address (all dispositions fail);
- *   - the IP-literal fast path (kl_sockaddr_parse, no DNS resolve callback);
- *   - a partial send that completes via hl_pg_transport_send_all;
- *   - hl_pg_transport_recv returns data written by the peer;
- *   - hl_pg_transport_adopt(fd) routes I/O + closes exactly once;
- *   - hl_pg_transport_close is idempotent (double-close is safe);
- *   - confirmed connect-op detachment on a failed connect (no leaked op / fd).
+ *   - pending -> succeed, and immediate connect() success (rc == 0);
+ *   - RFC 8305 stagger: the second address wins;
+ *   - every-address failure reaches confirmed detachment (no fd leak);
+ *   - the connect deadline fires and reaches confirmed detachment;
+ *   - truly unbounded connect (timeout_ms <= 0) with NO hidden ceiling, driven to
+ *     completion by the test (controlled), not by waiting;
+ *   - provider io_status classification with an IRRELEVANT hosted errno;
+ *   - a provider missing a required op, or missing KL_SOCK_CAP_NATIVE_FD, fails
+ *     closed;
+ *   - set_blocking failure fails the connect closed;
+ *   - the IP-literal fast path (kl_sockaddr_parse, no DNS callback);
+ *   - partial send completes via send_all; partial recv returns the short count;
+ *   - adopt(fd) routes I/O and closes the descriptor EXACTLY once;
+ *   - TLS attach is one-shot + fallible (NULL / no-fd / double rejected);
+ *   - forced non-detachment PRESERVES the whole allocation and close is retryable.
  *
- * The static helpers are reached by direct-including the capability .c; the
- * Makefile rule for this binary therefore EXCLUDES cap_pg_transport.o from the
- * common link (mirrors test_smtp_transport / test_pg_conn's direct-source
- * pattern). This test source is never in the shipped binary.
+ * The static helpers + the opaque struct are reached by direct-including the
+ * capability .c; the Makefile rule for this binary EXCLUDES cap_pg_transport.o
+ * from the common link (mirrors test_smtp_transport / test_pg_conn). This test
+ * source is never in the shipped binary. Run under ASan/LSan + TSan in CI.
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -26,7 +32,8 @@
 #include "utest.h"
 
 /* Direct-source include: the static helpers (resolve_addrs, the connect hooks,
- * the pump, connect_teardown) plus the public API are the unit under test. */
+ * the pumps, connect_teardown) plus the opaque struct + public API are under
+ * test. */
 #include "../../../src/hull/cap/pg_transport.c"
 
 #include <errno.h>
@@ -38,31 +45,38 @@
 
 #include <keel/sockaddr.h>
 
-/* ════════════════════════════════════════════════════════════════════
- *  A watchdog so a wedged pump can never hang CI: SIGALRM aborts the test.
- * ════════════════════════════════════════════════════════════════════ */
+/* A watchdog so a wedged pump can never hang CI: SIGALRM aborts the test. Every
+ * test that pumps arms alarm(5); a truly-unbounded loop with no completion would
+ * trip it, so the unbounded test proves it completes via controlled completion,
+ * NOT via a hidden ceiling. */
 static void tp_watchdog_fired(int sig) { (void)sig; _exit(77); }
+static void tp_arm_watchdog(void)
+{ signal(SIGALRM, tp_watchdog_fired); alarm(5); }
+static void tp_disarm_watchdog(void) { alarm(0); }
 
 /* ════════════════════════════════════════════════════════════════════
- *  Fake socket provider (pg_test_socket_provider). It hands the connect op real
- *  fds the event loop can watch, keeping ONE clock domain: a "pending" address is
- *  a socketpair whose send buffer is filled so its fd is never write-ready (both
- *  epoll and kqueue respect a full send buffer), so the attempt stays pending
- *  under kernel semantics. "succeed" / "fail" leave the fd writable and let
- *  get_so_error report SO_ERROR. Attempts are recorded (address index) so a test
- *  can assert the winner and the attempt count.
+ *  Fake socket provider. It hands the connect op REAL fds the event loop can
+ *  watch (ONE clock domain): a "pending" address is a socketpair whose send
+ *  buffer is filled so its fd is never write-ready; "succeed" leaves it writable
+ *  and get_so_error reports 0; "fail" reports ECONNREFUSED; "immediate" makes
+ *  connect() return 0. Close calls are counted per fd.
  * ════════════════════════════════════════════════════════════════════ */
 
-enum { FK_PENDING = 0, FK_SUCCEED = 1, FK_FAIL = 2 };
+enum { FK_PENDING = 0, FK_SUCCEED = 1, FK_FAIL = 2, FK_IMMEDIATE = 3 };
 
 typedef struct { int used; int a; int b; int disp; int idx; } FkSlot;
 static FkSlot g_fk[32];
-static int    g_fk_disp[KL_CONNECT_MAX_ADDRS];  /* per-address disposition       */
-static int    g_fk_order[KL_CONNECT_MAX_ADDRS]; /* attempt order (address index) */
-static int    g_fk_n;                           /* number of connect() attempts  */
-static int    g_fk_succeeded_idx;               /* address that read SO_ERROR==0  */
-static int    g_fk_naddr;                        /* injected address count        */
-static int    g_fk_blocking_set;                 /* count of set_blocking calls    */
+static int    g_fk_disp[KL_CONNECT_MAX_ADDRS];
+static int    g_fk_order[KL_CONNECT_MAX_ADDRS];
+static int    g_fk_n;
+static int    g_fk_succeeded_idx;
+static int    g_fk_naddr;
+static int    g_fk_blocking_set;
+static int    g_fk_blocking_fail;    /* when 1, set_blocking returns -1        */
+static int    g_fk_close_n;          /* total provider close() calls           */
+static int    g_fk_bogus_errno;      /* when 1, connect leaves errno = EPERM   */
+static KlIoStatus g_fk_io_status_val;/* value fk_io_status returns             */
+static int    g_fk_send_eintr_once;  /* when 1, first send reports INTERRUPTED  */
 
 static void fk_reset(void)
 {
@@ -73,6 +87,16 @@ static void fk_reset(void)
     g_fk_succeeded_idx = -1;
     g_fk_naddr = 0;
     g_fk_blocking_set = 0;
+    g_fk_blocking_fail = 0;
+    g_fk_close_n = 0;
+    g_fk_bogus_errno = 0;
+    g_fk_io_status_val = KL_IO_OK;
+    g_fk_send_eintr_once = 0;
+    /* The checkpoint counter is a process-global static in pg_transport.c; reset it
+     * per test so a "complete at checkpoint N" hook fires deterministically (a
+     * prior test's checkpoints must not advance it past N). Visible because this
+     * test direct-includes the capability .c under -DHL_PG_TEST_HOOKS. */
+    pg_test_checkpoint_seq = 0;
 }
 
 static FkSlot *fk_slot_for(int a)
@@ -102,7 +126,8 @@ static KlSocketHandle fk_socket(void *c, int d, int ty, int p)
 static int  fk_set_nb(void *c, KlSocketHandle fd)
 { (void)c; int a = (int)fd; int fl = fcntl(a, F_GETFL, 0); return fcntl(a, F_SETFL, fl | O_NONBLOCK); }
 static int  fk_set_blocking(void *c, KlSocketHandle fd)
-{ (void)c; g_fk_blocking_set++; int a = (int)fd; int fl = fcntl(a, F_GETFL, 0); return fcntl(a, F_SETFL, fl & ~O_NONBLOCK); }
+{ (void)c; if (g_fk_blocking_fail) return -1; g_fk_blocking_set++;
+  int a = (int)fd; int fl = fcntl(a, F_GETFL, 0); return fcntl(a, F_SETFL, fl & ~O_NONBLOCK); }
 static int  fk_set_int(void *c, KlSocketHandle fd, int on) { (void)c; (void)fd; (void)on; return 0; }
 static void fk_set_void(void *c, KlSocketHandle fd) { (void)c; (void)fd; }
 static int  fk_get_local(void *c, KlSocketHandle fd, KlSockAddr *out)
@@ -119,14 +144,14 @@ static int fk_connect(void *c, KlSocketHandle fd, const KlSockAddr *addr)
         g_fk_order[g_fk_n++] = idx;
     FkSlot *s = fk_slot_for(a);
     if (s) { s->disp = disp; s->idx = idx; }
+    if (disp == FK_IMMEDIATE) { errno = 0; return 0; }   /* rc == 0 fast path */
     if (disp == FK_PENDING) {
-        /* Fill the send buffer so 'a' never becomes write-ready. */
         char buf[2048];
         memset(buf, 'x', sizeof buf);
         int fl = fcntl(a, F_GETFL, 0); fcntl(a, F_SETFL, fl | O_NONBLOCK);
         while (write(a, buf, sizeof buf) > 0) { }
     }
-    errno = EINPROGRESS;
+    errno = g_fk_bogus_errno ? EPERM : EINPROGRESS;
     return -1;
 }
 static int fk_get_so_error(void *c, KlSocketHandle fd, int *out)
@@ -138,7 +163,11 @@ static int fk_get_so_error(void *c, KlSocketHandle fd, int *out)
     return 0;
 }
 static kl_ssize_t fk_send(void *c, KlSocketHandle fd, const void *b, size_t n)
-{ (void)c; return send((int)fd, b, n, 0); }
+{
+    (void)c;
+    if (g_fk_send_eintr_once) { g_fk_send_eintr_once = 0; errno = 0; return -1; }
+    return send((int)fd, b, n, 0);
+}
 static kl_ssize_t fk_recv(void *c, KlSocketHandle fd, void *b, size_t n)
 { (void)c; return recv((int)fd, b, n, 0); }
 static kl_ssize_t fk_recv_peek(void *c, KlSocketHandle fd, void *b, size_t n)
@@ -146,35 +175,31 @@ static kl_ssize_t fk_recv_peek(void *c, KlSocketHandle fd, void *b, size_t n)
 static int fk_close(void *c, KlSocketHandle fd)
 {
     (void)c; int a = (int)fd;
+    g_fk_close_n++;
     FkSlot *s = fk_slot_for(a);
     if (s) { close(s->b); s->used = 0; }
     return close(a);
 }
+static KlIoStatus fk_io_status(void *c) { (void)c; return g_fk_io_status_val; }
 
-static const KlSocketOps FK_OPS = {
-    .set_nonblocking = fk_set_nb,
-    .set_blocking    = fk_set_blocking,
-    .set_cloexec     = fk_set_void,
-    .set_nosigpipe   = fk_set_void,
-    .set_reuseaddr   = fk_set_int,
-    .set_reuseport   = fk_set_int,
-    .set_ipv6only    = fk_set_int,
-    .set_tcp_nodelay = fk_set_int,
-    .set_cork        = fk_set_int,
-    .socket          = fk_socket,
-    .connect         = fk_connect,
-    .close           = fk_close,
-    .get_local_addr  = fk_get_local,
-    .get_so_error    = fk_get_so_error,
-    .send            = fk_send,
-    .recv            = fk_recv,
-    .recv_peek       = fk_recv_peek,
-};
-static const KlSocketProvider FK_PROVIDER = { .ops = &FK_OPS, .context = NULL };
+/* Two op tables: FK_OPS has NO io_status (transport uses the hosted-errno
+ * fallback); FK_OPS_IOS supplies io_status (transport uses it, never errno). */
+#define FK_OPS_COMMON \
+    .set_nonblocking = fk_set_nb, .set_blocking = fk_set_blocking, \
+    .set_cloexec = fk_set_void, .set_nosigpipe = fk_set_void, \
+    .set_reuseaddr = fk_set_int, .set_reuseport = fk_set_int, \
+    .set_ipv6only = fk_set_int, .set_tcp_nodelay = fk_set_int, .set_cork = fk_set_int, \
+    .socket = fk_socket, .connect = fk_connect, .close = fk_close, \
+    .get_local_addr = fk_get_local, .get_so_error = fk_get_so_error, \
+    .send = fk_send, .recv = fk_recv, .recv_peek = fk_recv_peek
 
-/* Inject N addresses 10.11.12.(i+1) in order; disposition comes from g_fk_disp.
- * Also records whether the resolve hook was actually called (so the IP-literal
- * fast path can assert it was NOT). */
+static const KlSocketOps FK_OPS     = { FK_OPS_COMMON };
+static const KlSocketOps FK_OPS_IOS = { FK_OPS_COMMON, .io_status = fk_io_status };
+static const KlSocketProvider FK_PROVIDER =
+    { .ops = &FK_OPS, .context = NULL, .capabilities = KL_SOCK_CAP_NATIVE_FD };
+static const KlSocketProvider FK_PROVIDER_IOS =
+    { .ops = &FK_OPS_IOS, .context = NULL, .capabilities = KL_SOCK_CAP_NATIVE_FD };
+
 static int g_fk_resolve_called;
 static int fk_resolve(PgTransport *t, const char *host, int port)
 {
@@ -187,301 +212,420 @@ static int fk_resolve(PgTransport *t, const char *host, int port)
     return g_fk_naddr;
 }
 
-/* ════════════════════════════════════════════════════════════════════
- *  Connect: pending -> succeed.
- * ════════════════════════════════════════════════════════════════════ */
+static void seam_clear(void)
+{
+    pg_test_resolve         = NULL;
+    pg_test_socket_provider = NULL;
+    pg_test_checkpoint      = NULL;
+    pg_test_force_no_detach = 0;
+}
+
+/* Proxy for "confirmed detachment retired everything": every mock socketpair was
+ * closed, so no racing fd leaked. */
+static int fk_all_fds_closed(void)
+{
+    for (size_t i = 0; i < sizeof g_fk / sizeof g_fk[0]; i++)
+        if (g_fk[i].used) return 0;
+    return 1;
+}
+
+/* ── pending -> succeed ─────────────────────────────────────────────── */
 UTEST(pg_transport_connect, pending_then_succeed)
 {
-    fk_reset();
-    g_fk_naddr   = 1;
-    g_fk_disp[0] = FK_SUCCEED;
+    fk_reset(); tp_arm_watchdog();
+    g_fk_naddr = 1; g_fk_disp[0] = FK_SUCCEED;
     g_fk_resolve_called = 0;
-    pg_test_resolve         = fk_resolve;
-    pg_test_socket_provider = &FK_PROVIDER;
+    pg_test_resolve = fk_resolve; pg_test_socket_provider = &FK_PROVIDER;
 
-    void (*prev)(int) = signal(SIGALRM, tp_watchdog_fired); alarm(30);
-
-    PgTransport t;
     char err[128] = {0};
-    int rc = hl_pg_transport_connect(&t, "db.example.test", "5432", 5000,
-                                     &FK_PROVIDER, err, sizeof err);
+    PgTransport *t = hl_pg_transport_connect("db.example", "5432", 0, &FK_PROVIDER, err, sizeof err);
+    ASSERT_TRUE(t != NULL);
+    ASSERT_GE(g_fk_n, 1);
+    ASSERT_EQ(g_fk_succeeded_idx, 0);
+    ASSERT_GE(g_fk_blocking_set, 1);              /* the winner was set_blocking()'d */
+    ASSERT_TRUE(hl_pg_transport_fd(t) >= 0);
+    ASSERT_TRUE(kl_connect_op_is_detached(&t->connect_op));
+    ASSERT_EQ(t->ev_ready, 0);                    /* connect-only ev ctx freed       */
 
-    alarm(0); signal(SIGALRM, prev);
-    pg_test_resolve         = NULL;
-    pg_test_socket_provider = NULL;
-
-    ASSERT_EQ(rc, 0);                          /* the race won */
-    ASSERT_GE(g_fk_n, 1);                       /* at least one attempt */
-    ASSERT_EQ(g_fk_succeeded_idx, 0);           /* address 0 connected */
-    ASSERT_GE(g_fk_blocking_set, 1);            /* the winner was set_blocking()'d */
-    ASSERT_TRUE(hl_pg_transport_fd(&t) >= 0);   /* a live descriptor is held */
-    /* The connect-only event ctx is freed after a successful connect + detach. */
-    ASSERT_EQ(t.ev_ready, 0);
-    ASSERT_TRUE(kl_connect_op_is_detached(&t.connect_op));
-
-    hl_pg_transport_close(&t);
-    ASSERT_TRUE(hl_pg_transport_fd(&t) < 0);    /* fd retired by close */
+    ASSERT_EQ(hl_pg_transport_close(t), 0);
+    seam_clear(); tp_disarm_watchdog();
 }
 
-/* Two addresses: the first is FK_PENDING, the second FK_SUCCEED. The RFC 8305
- * stagger must start address 1 while 0 is pending, and address 1 wins. */
+/* ── immediate connect() success (rc == 0), not EINPROGRESS ─────────── */
+UTEST(pg_transport_connect, immediate_success_rc0)
+{
+    fk_reset(); tp_arm_watchdog();
+    g_fk_naddr = 1; g_fk_disp[0] = FK_IMMEDIATE;
+    pg_test_resolve = fk_resolve; pg_test_socket_provider = &FK_PROVIDER;
+
+    PgTransport *t = hl_pg_transport_connect("h", "5432", 0, &FK_PROVIDER, NULL, 0);
+    ASSERT_TRUE(t != NULL);
+    ASSERT_GE(g_fk_blocking_set, 1);
+    ASSERT_TRUE(hl_pg_transport_fd(t) >= 0);
+    ASSERT_EQ(hl_pg_transport_close(t), 0);
+    seam_clear(); tp_disarm_watchdog();
+}
+
+/* ── RFC 8305 stagger: address 0 pends, the stagger starts address 1 which wins ─ */
 UTEST(pg_transport_connect, stagger_second_address_wins)
 {
-    fk_reset();
-    g_fk_naddr   = 2;
-    g_fk_disp[0] = FK_PENDING;
-    g_fk_disp[1] = FK_SUCCEED;
-    pg_test_resolve         = fk_resolve;
-    pg_test_socket_provider = &FK_PROVIDER;
+    fk_reset(); tp_arm_watchdog();
+    g_fk_naddr = 2; g_fk_disp[0] = FK_PENDING; g_fk_disp[1] = FK_SUCCEED;
+    pg_test_resolve = fk_resolve; pg_test_socket_provider = &FK_PROVIDER;
 
-    void (*prev)(int) = signal(SIGALRM, tp_watchdog_fired); alarm(30);
-
-    PgTransport t;
-    int rc = hl_pg_transport_connect(&t, "db.example.test", "5432", 5000,
-                                     &FK_PROVIDER, NULL, 0);
-
-    alarm(0); signal(SIGALRM, prev);
-    pg_test_resolve         = NULL;
-    pg_test_socket_provider = NULL;
-
-    ASSERT_EQ(rc, 0);
-    ASSERT_EQ(g_fk_n, 2);               /* both addresses attempted */
+    PgTransport *t = hl_pg_transport_connect("h", "5432", 0, &FK_PROVIDER, NULL, 0);
+    ASSERT_TRUE(t != NULL);
+    ASSERT_EQ(g_fk_n, 2);
     ASSERT_EQ(g_fk_order[0], 0);
     ASSERT_EQ(g_fk_order[1], 1);
-    ASSERT_EQ(g_fk_succeeded_idx, 1);   /* address 1 connected */
-
-    hl_pg_transport_close(&t);
+    ASSERT_EQ(g_fk_succeeded_idx, 1);
+    ASSERT_EQ(hl_pg_transport_close(t), 0);
+    seam_clear(); tp_disarm_watchdog();
 }
 
-/* ════════════════════════════════════════════════════════════════════
- *  Connect: all addresses fail. The transport reports -1 AND the connect op
- *  reaches confirmed detachment (no leaked op / fd).
- * ════════════════════════════════════════════════════════════════════ */
+/* ── every address fails -> NULL + confirmed detachment (no fd leak) ── */
 UTEST(pg_transport_connect, all_addresses_fail_detach)
 {
-    fk_reset();
-    g_fk_naddr   = 2;
-    g_fk_disp[0] = FK_FAIL;
-    g_fk_disp[1] = FK_FAIL;
-    pg_test_resolve         = fk_resolve;
-    pg_test_socket_provider = &FK_PROVIDER;
+    fk_reset(); tp_arm_watchdog();
+    g_fk_naddr = 2; g_fk_disp[0] = FK_FAIL; g_fk_disp[1] = FK_FAIL;
+    pg_test_resolve = fk_resolve; pg_test_socket_provider = &FK_PROVIDER;
 
-    void (*prev)(int) = signal(SIGALRM, tp_watchdog_fired); alarm(30);
-
-    PgTransport t;
     char err[128] = {0};
-    int rc = hl_pg_transport_connect(&t, "db.example.test", "5432", 5000,
-                                     &FK_PROVIDER, err, sizeof err);
-
-    alarm(0); signal(SIGALRM, prev);
-    pg_test_resolve         = NULL;
-    pg_test_socket_provider = NULL;
-
-    ASSERT_EQ(rc, -1);                             /* connect failed */
-    ASSERT_TRUE(err[0] != '\0');                    /* a message was written */
-    /* connect_teardown pumped to confirmed detachment before returning: the op is
-     * detached and the event ctx freed (no leaked op / fd). */
-    ASSERT_TRUE(kl_connect_op_is_detached(&t.connect_op));
-    ASSERT_EQ(t.ev_ready, 0);
-    ASSERT_TRUE(hl_pg_transport_fd(&t) < 0);
-
-    hl_pg_transport_close(&t);   /* idempotent: safe after a failed connect */
+    PgTransport *t = hl_pg_transport_connect("h", "5432", 0, &FK_PROVIDER, err, sizeof err);
+    ASSERT_TRUE(t == NULL);
+    ASSERT_TRUE(err[0] != '\0');
+    ASSERT_TRUE(fk_all_fds_closed());   /* teardown disposed every racing fd */
+    seam_clear(); tp_disarm_watchdog();
 }
 
-/* A resolve that yields zero addresses fails cleanly (the op never starts). */
-UTEST(pg_transport_connect, resolve_empty_fails)
+/* ── the connect deadline fires -> NULL + confirmed detachment ──────── */
+UTEST(pg_transport_connect, deadline_fires_detaches)
+{
+    fk_reset(); tp_arm_watchdog();
+    g_fk_naddr = 1; g_fk_disp[0] = FK_PENDING;   /* never completes on its own */
+    pg_test_resolve = fk_resolve; pg_test_socket_provider = &FK_PROVIDER;
+
+    char err[128] = {0};
+    /* 150 ms TCP-establishment bound; the address stays pending, so the deadline
+     * fires and the op fails + detaches. */
+    PgTransport *t = hl_pg_transport_connect("h", "5432", 150, &FK_PROVIDER, err, sizeof err);
+    ASSERT_TRUE(t == NULL);
+    ASSERT_TRUE(err[0] != '\0');
+    ASSERT_TRUE(fk_all_fds_closed());
+    seam_clear(); tp_disarm_watchdog();
+}
+
+/* ── truly unbounded (timeout_ms <= 0): NO hidden ceiling. A pending attempt is
+ *    driven to completion by the test at pump checkpoint 3 (we drain the peer so
+ *    the fd becomes writable), proving the loop pumps until completion and does
+ *    not impose a 30 s (or any) total deadline. The 5 s watchdog would trip on a
+ *    hang; success well under it is the proof. ─────────────────────────────── */
+static void tp_complete_pending_at_cp3(PgTransport *t, unsigned idx)
+{
+    if (idx != 3) return;
+    /* Drain the peer of the single in-flight attempt so its fd becomes writable. */
+    for (int i = 0; i < t->naddrs; i++) {
+        if (kl_handle_valid(t->attempt_fd[i])) {
+            FkSlot *s = fk_slot_for((int)t->attempt_fd[i]);
+            if (s) { char b[4096]; while (recv(s->b, b, sizeof b, MSG_DONTWAIT) > 0) { } }
+        }
+    }
+}
+UTEST(pg_transport_connect, unbounded_no_hidden_ceiling)
+{
+    fk_reset(); tp_arm_watchdog();
+    g_fk_naddr = 1; g_fk_disp[0] = FK_PENDING;
+    pg_test_resolve = fk_resolve; pg_test_socket_provider = &FK_PROVIDER;
+    pg_test_checkpoint = tp_complete_pending_at_cp3;
+
+    PgTransport *t = hl_pg_transport_connect("h", "5432", 0 /* unbounded */,
+                                             &FK_PROVIDER, NULL, 0);
+    ASSERT_TRUE(t != NULL);
+    ASSERT_EQ(g_fk_succeeded_idx, 0);
+    ASSERT_EQ(hl_pg_transport_close(t), 0);
+    seam_clear(); tp_disarm_watchdog();
+}
+
+/* ── provider io_status classification with an IRRELEVANT hosted errno ─
+ *    connect leaves errno = EPERM (a FATAL-looking code) but io_status reports
+ *    KL_IO_PENDING, so the transport must treat it as pending (consulting
+ *    io_status, not errno) and complete. ────────────────────────────────────── */
+UTEST(pg_transport_io, io_status_overrides_errno)
+{
+    fk_reset(); tp_arm_watchdog();
+    g_fk_naddr = 1; g_fk_disp[0] = FK_PENDING;
+    g_fk_bogus_errno = 1;                 /* connect sets errno = EPERM */
+    g_fk_io_status_val = KL_IO_PENDING;   /* but io_status says PENDING */
+    pg_test_resolve = fk_resolve; pg_test_socket_provider = &FK_PROVIDER_IOS;
+    pg_test_checkpoint = tp_complete_pending_at_cp3;
+
+    PgTransport *t = hl_pg_transport_connect("h", "5432", 0, &FK_PROVIDER_IOS, NULL, 0);
+    /* On completion get_so_error reports 0 -> success, despite errno == EPERM. */
+    ASSERT_TRUE(t != NULL);
+    ASSERT_EQ(g_fk_succeeded_idx, 0);
+    ASSERT_EQ(hl_pg_transport_close(t), 0);
+    seam_clear(); tp_disarm_watchdog();
+}
+
+/* ── send EINTR retry classified via io_status (irrelevant errno) ───── */
+UTEST(pg_transport_io, send_eintr_retry_via_io_status)
+{
+    fk_reset(); tp_arm_watchdog();
+    int sv[2]; ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+    pg_test_socket_provider = &FK_PROVIDER_IOS;
+    char err[64] = {0};
+    PgTransport *t = hl_pg_transport_adopt(sv[0], &FK_PROVIDER_IOS, err, sizeof err);
+    ASSERT_TRUE(t != NULL);
+
+    /* First send() returns -1 with io_status INTERRUPTED (errno left 0); the retry
+     * loop must retry. The one-shot clears after the first call, so the second
+     * send() hits the real socket and returns 3 (> 0), exiting the loop - no
+     * io_status flip is needed since the loop exits on a positive count. */
+    g_fk_send_eintr_once = 1;
+    g_fk_io_status_val   = KL_IO_INTERRUPTED;
+    const uint8_t msg[3] = { 1, 2, 3 };
+    ssize_t n = hl_pg_transport_send(t, msg, sizeof msg);
+    ASSERT_EQ((int)n, 3);                 /* retried past the interrupt */
+    /* Confirm the 3 bytes arrived after the retry. */
+    uint8_t got[3] = {0};
+    ssize_t r = recv(sv[1], got, sizeof got, 0);
+    ASSERT_EQ((int)r, 3);
+    ASSERT_EQ(got[0], 1); ASSERT_EQ(got[2], 3);
+    ASSERT_EQ(hl_pg_transport_close(t), 0);
+    close(sv[1]);
+    seam_clear(); tp_disarm_watchdog();
+}
+
+/* ── provider validation: missing a required op fails closed ────────── */
+UTEST(pg_transport_provider, missing_required_op_fails)
 {
     fk_reset();
-    g_fk_naddr   = 0;             /* fk_resolve returns 0 */
-    pg_test_resolve         = fk_resolve;
-    pg_test_socket_provider = &FK_PROVIDER;
+    static KlSocketOps ops_no_setblocking = { FK_OPS_COMMON };
+    ops_no_setblocking.set_blocking = NULL;   /* drop a required op */
+    static KlSocketProvider prov;
+    prov.ops = &ops_no_setblocking; prov.context = NULL;
+    prov.capabilities = KL_SOCK_CAP_NATIVE_FD;
 
-    PgTransport t;
     char err[128] = {0};
-    int rc = hl_pg_transport_connect(&t, "nope.example.test", "5432", 5000,
-                                     &FK_PROVIDER, err, sizeof err);
-
-    pg_test_resolve         = NULL;
-    pg_test_socket_provider = NULL;
-
-    ASSERT_EQ(rc, -1);
-    ASSERT_TRUE(err[0] != '\0');
-    ASSERT_EQ(t.ev_ready, 0);      /* event ctx torn down */
+    PgTransport *t = hl_pg_transport_connect("h", "5432", 0, &prov, err, sizeof err);
+    ASSERT_TRUE(t == NULL);
+    ASSERT_TRUE(strstr(err, "provider") != NULL);
 }
 
-/* ════════════════════════════════════════════════════════════════════
- *  IP-literal fast path: with NO resolve hook installed, resolve_addrs takes the
- *  kl_sockaddr_parse (no-DNS) branch for a numeric host. Prove the fast path via
- *  resolve_addrs directly (no socket needed) and via a full connect.
- * ════════════════════════════════════════════════════════════════════ */
+/* ── provider validation: missing KL_SOCK_CAP_NATIVE_FD fails closed ── */
+UTEST(pg_transport_provider, missing_native_fd_cap_fails)
+{
+    fk_reset();
+    static KlSocketProvider prov;
+    prov.ops = &FK_OPS; prov.context = NULL; prov.capabilities = 0;   /* no NATIVE_FD */
+
+    char err[128] = {0};
+    PgTransport *t = hl_pg_transport_connect("h", "5432", 0, &prov, err, sizeof err);
+    ASSERT_TRUE(t == NULL);
+    /* adopt validates too. */
+    int sv[2]; ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+    PgTransport *ta = hl_pg_transport_adopt(sv[0], &prov, err, sizeof err);
+    ASSERT_TRUE(ta == NULL);
+    close(sv[0]); close(sv[1]);
+}
+
+/* ── set_blocking failure fails the connect closed ──────────────────── */
+UTEST(pg_transport_connect, set_blocking_failure_fails)
+{
+    fk_reset(); tp_arm_watchdog();
+    g_fk_naddr = 1; g_fk_disp[0] = FK_SUCCEED;
+    g_fk_blocking_fail = 1;               /* set_blocking returns -1 on the winner */
+    pg_test_resolve = fk_resolve; pg_test_socket_provider = &FK_PROVIDER;
+
+    char err[128] = {0};
+    PgTransport *t = hl_pg_transport_connect("h", "5432", 0, &FK_PROVIDER, err, sizeof err);
+    ASSERT_TRUE(t == NULL);
+    ASSERT_TRUE(fk_all_fds_closed());     /* the winner was retired, not leaked */
+    seam_clear(); tp_disarm_watchdog();
+}
+
+/* ── IP-literal fast path: kl_sockaddr_parse, no resolve callback ───── */
 UTEST(pg_transport_resolve, ip_literal_no_dns)
 {
-    pg_test_resolve         = NULL;   /* force the real resolve_addrs */
-    pg_test_socket_provider = NULL;
-
-    PgTransport t;
-    transport_zero(&t);
-    t.sp = &FK_PROVIDER;
-    int n = resolve_addrs(&t, "127.0.0.1", 5432);
-    ASSERT_EQ(n, 1);                         /* exactly one address, no DNS */
-    ASSERT_EQ((int)t.addrs[0].addr_len, 4);   /* an IPv4 literal */
-
-    /* An IPv6 literal too. */
-    int n6 = resolve_addrs(&t, "::1", 5432);
-    ASSERT_EQ(n6, 1);
-    ASSERT_EQ((int)t.addrs[0].addr_len, 16);
-}
-
-/* Full connect to an IP literal with NO resolve hook installed: the real
- * resolve_addrs must take the kl_sockaddr_parse (no-DNS) branch, and the connect
- * still races through the fake socket provider and wins. Proves the fast path
- * drives a real connect end to end without any getaddrinfo / resolve callback. */
-UTEST(pg_transport_resolve, ip_literal_connect_no_dns)
-{
-    fk_reset();
-    /* g_fk_disp is indexed by (ip[3]-1); a "127.0.0.1" literal parses to
-     * addr_len 4 with ip[3]==1, so index 0. Make index 0 succeed. */
+    fk_reset(); tp_arm_watchdog();
     g_fk_disp[0] = FK_SUCCEED;
     g_fk_resolve_called = 0;
-    pg_test_resolve         = NULL;            /* force the real resolve_addrs */
-    pg_test_socket_provider = &FK_PROVIDER;    /* fake connect, no real network */
+    pg_test_resolve = NULL;               /* force the real resolve_addrs */
+    pg_test_socket_provider = &FK_PROVIDER;
 
-    void (*prev)(int) = signal(SIGALRM, tp_watchdog_fired); alarm(30);
-
-    PgTransport t;
-    int rc = hl_pg_transport_connect(&t, "127.0.0.1", "5432", 5000,
-                                     &FK_PROVIDER, NULL, 0);
-
-    alarm(0); signal(SIGALRM, prev);
-    pg_test_socket_provider = NULL;
-
-    ASSERT_EQ(rc, 0);
-    ASSERT_EQ(g_fk_resolve_called, 0);   /* the resolve callback never ran (fast path) */
-    ASSERT_EQ(g_fk_succeeded_idx, 0);    /* the parsed 127.0.0.1 address connected */
-
-    hl_pg_transport_close(&t);
+    PgTransport *t = hl_pg_transport_connect("127.0.0.1", "5432", 0, &FK_PROVIDER, NULL, 0);
+    ASSERT_TRUE(t != NULL);
+    ASSERT_EQ(g_fk_resolve_called, 0);    /* the DNS callback was never consulted */
+    ASSERT_EQ(hl_pg_transport_close(t), 0);
+    seam_clear(); tp_disarm_watchdog();
 }
 
-/* ════════════════════════════════════════════════════════════════════
- *  Blocking I/O over an ADOPTED descriptor (design Amendment 2): a real
- *  socketpair, the default POSIX provider, no event ctx / resolve / race.
- * ════════════════════════════════════════════════════════════════════ */
-UTEST(pg_transport_io, adopt_send_recv_roundtrip)
+/* ── adopt: I/O roundtrip + close disposes the descriptor EXACTLY once ─ */
+UTEST(pg_transport_io, adopt_roundtrip_close_once)
 {
-    int sv[2];
-    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+    fk_reset(); tp_arm_watchdog();
+    int sv[2]; ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+    pg_test_socket_provider = &FK_PROVIDER;
+    PgTransport *t = hl_pg_transport_adopt(sv[0], &FK_PROVIDER, NULL, 0);
+    ASSERT_TRUE(t != NULL);
+    ASSERT_EQ(hl_pg_transport_fd(t), sv[0]);
 
-    PgTransport t;
-    ASSERT_EQ(hl_pg_transport_adopt(&t, sv[0], NULL), 0);
-    ASSERT_EQ(hl_pg_transport_fd(&t), sv[0]);
-    ASSERT_EQ(t.ev_ready, 0);                 /* adopt never inits an event ctx */
-    ASSERT_EQ(t.connect_started, 0);
+    const uint8_t out[4] = { 9, 8, 7, 6 };
+    ASSERT_EQ(hl_pg_transport_send_all(t, out, sizeof out), 0);
+    uint8_t got[4] = {0};
+    ssize_t r = recv(sv[1], got, sizeof got, 0);
+    ASSERT_EQ((int)r, 4);
+    ASSERT_EQ(got[0], 9); ASSERT_EQ(got[3], 6);
 
-    /* send_all -> the peer sees every byte. */
-    const uint8_t msg[] = "SELECT 1";
-    ASSERT_EQ(hl_pg_transport_send_all(&t, msg, sizeof msg), 0);
-    uint8_t peer[64] = {0};
-    ssize_t got = recv(sv[1], peer, sizeof peer, 0);
-    ASSERT_EQ(got, (ssize_t)sizeof msg);
-    ASSERT_EQ(memcmp(peer, msg, sizeof msg), 0);
+    /* peer -> transport recv */
+    const uint8_t rep[2] = { 42, 43 };
+    ASSERT_EQ((int)send(sv[1], rep, sizeof rep, 0), 2);
+    uint8_t in[2] = {0};
+    ASSERT_EQ((int)hl_pg_transport_recv(t, in, sizeof in), 2);
+    ASSERT_EQ(in[0], 42); ASSERT_EQ(in[1], 43);
 
-    /* recv -> the transport reads what the peer wrote. */
-    const uint8_t reply[] = "ReadyForQuery";
-    ASSERT_EQ(write(sv[1], reply, sizeof reply), (ssize_t)sizeof reply);
-    uint8_t rbuf[64] = {0};
-    ssize_t rn = hl_pg_transport_recv(&t, rbuf, sizeof rbuf);
-    ASSERT_EQ(rn, (ssize_t)sizeof reply);
-    ASSERT_EQ(memcmp(rbuf, reply, sizeof reply), 0);
-
-    hl_pg_transport_close(&t);
-    ASSERT_TRUE(hl_pg_transport_fd(&t) < 0);   /* fd retired */
+    g_fk_close_n = 0;
+    ASSERT_EQ(hl_pg_transport_close(t), 0);
+    ASSERT_EQ(g_fk_close_n, 1);           /* the descriptor was closed exactly once */
     close(sv[1]);
+    seam_clear(); tp_disarm_watchdog();
 }
 
-/* A partial send (the peer's receive buffer is tiny, so one send returns short)
- * still completes via hl_pg_transport_send_all's full-write loop. A background
- * drain keeps the pipe moving so the loop makes progress. */
-static int   g_drain_fd;
-static size_t g_drain_target;
-static void *drain_thread(void *arg)
+/* ── partial recv returns the short count ───────────────────────────── */
+UTEST(pg_transport_io, partial_recv_short_count)
 {
-    (void)arg;
-    size_t got = 0;
-    uint8_t buf[4096];
-    while (got < g_drain_target) {
-        ssize_t n = recv(g_drain_fd, buf, sizeof buf, 0);
-        if (n <= 0) break;
-        got += (size_t)n;
-    }
-    return NULL;
-}
+    fk_reset(); tp_arm_watchdog();
+    int sv[2]; ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+    pg_test_socket_provider = &FK_PROVIDER;
+    PgTransport *t = hl_pg_transport_adopt(sv[0], &FK_PROVIDER, NULL, 0);
+    ASSERT_TRUE(t != NULL);
 
-UTEST(pg_transport_io, send_all_completes_partial)
-{
-    int sv[2];
-    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
-    int small = 4096;
-    setsockopt(sv[0], SOL_SOCKET, SO_SNDBUF, &small, sizeof small);
-    setsockopt(sv[1], SOL_SOCKET, SO_RCVBUF, &small, sizeof small);
-
-    PgTransport t;
-    ASSERT_EQ(hl_pg_transport_adopt(&t, sv[0], NULL), 0);
-
-    /* A payload larger than the socket buffers, so a single send goes short and
-     * send_all must loop. A background reader drains the far end. */
-    size_t big = 256 * 1024;
-    uint8_t *payload = malloc(big);
-    ASSERT_TRUE(payload != NULL);
-    for (size_t i = 0; i < big; i++) payload[i] = (uint8_t)(i & 0xff);
-
-    g_drain_fd = sv[1]; g_drain_target = big;
-    pthread_t th;
-    ASSERT_EQ(pthread_create(&th, NULL, drain_thread, NULL), 0);
-
-    void (*prev)(int) = signal(SIGALRM, tp_watchdog_fired); alarm(30);
-    int rc = hl_pg_transport_send_all(&t, payload, big);
-    alarm(0); signal(SIGALRM, prev);
-
-    pthread_join(th, NULL);
-    ASSERT_EQ(rc, 0);   /* every byte written despite short sends */
-
-    free(payload);
-    hl_pg_transport_close(&t);
+    const uint8_t two[2] = { 5, 6 };
+    ASSERT_EQ((int)send(sv[1], two, sizeof two, 0), 2);
+    uint8_t buf[16] = {0};
+    ssize_t n = hl_pg_transport_recv(t, buf, sizeof buf);  /* asked 16, gets 2 */
+    ASSERT_EQ((int)n, 2);
+    ASSERT_EQ(buf[0], 5); ASSERT_EQ(buf[1], 6);
+    ASSERT_EQ(hl_pg_transport_close(t), 0);
     close(sv[1]);
+    seam_clear(); tp_disarm_watchdog();
 }
 
-/* ════════════════════════════════════════════════════════════════════
- *  Close is idempotent: a second close (and a close on a fresh-zeroed transport)
- *  is safe and does not touch a retired fd twice.
- * ════════════════════════════════════════════════════════════════════ */
-UTEST(pg_transport_close, idempotent_double_close)
+/* ── TLS attach is one-shot + fallible ──────────────────────────────── */
+UTEST(pg_transport_tls, attach_one_shot_and_fallible)
 {
-    int sv[2];
-    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+    fk_reset(); tp_arm_watchdog();
+    int sv[2]; ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+    pg_test_socket_provider = &FK_PROVIDER;
+    PgTransport *t = hl_pg_transport_adopt(sv[0], &FK_PROVIDER, NULL, 0);
+    ASSERT_TRUE(t != NULL);
 
-    PgTransport t;
-    ASSERT_EQ(hl_pg_transport_adopt(&t, sv[0], NULL), 0);
+    /* NULL session rejected. */
+    ASSERT_EQ(hl_pg_transport_attach_tls(t, NULL), -1);
+    ASSERT_TRUE(t->tls == NULL);
 
-    hl_pg_transport_close(&t);
-    ASSERT_TRUE(hl_pg_transport_fd(&t) < 0);
-    /* Second close: the guard makes it a no-op (no double sp_close of the fd). */
-    hl_pg_transport_close(&t);
-    ASSERT_TRUE(hl_pg_transport_fd(&t) < 0);
+    /* A non-NULL (opaque, never dereferenced here) session attaches once. We use a
+     * sentinel pointer and NEVER close through it: white-box-clear t->tls before
+     * close so the transport does not shutdown/free the sentinel. This tests the
+     * attach LOGIC (one-shot / non-NULL / live-fd), not a real TLS handshake. */
+    struct HlTlsClient *sentinel = (struct HlTlsClient *)(void *)&sv;   /* any non-NULL */
+    ASSERT_EQ(hl_pg_transport_attach_tls(t, sentinel), 0);
+    ASSERT_TRUE(t->tls == sentinel);
+    /* Second attach rejected; the first is NOT dropped. */
+    struct HlTlsClient *other = (struct HlTlsClient *)(void *)&t;
+    ASSERT_EQ(hl_pg_transport_attach_tls(t, other), -1);
+    ASSERT_TRUE(t->tls == sentinel);      /* unchanged: no silent drop */
 
+    t->tls = NULL;                        /* white-box: do not free the sentinel */
+    ASSERT_EQ(hl_pg_transport_close(t), 0);
     close(sv[1]);
+    seam_clear(); tp_disarm_watchdog();
 }
 
-/* Close on an adopted-then-never-used transport, and a NULL-safe close. */
-UTEST(pg_transport_close, null_and_fresh_safe)
+/* Attach requires a live descriptor. */
+UTEST(pg_transport_tls, attach_requires_live_fd)
 {
-    hl_pg_transport_close(NULL);   /* NULL-safe */
-
-    int sv[2];
-    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
-    PgTransport t;
-    ASSERT_EQ(hl_pg_transport_adopt(&t, sv[0], NULL), 0);
-    hl_pg_transport_close(&t);
+    fk_reset();
+    /* An adopt with a real fd, then white-box drop the fd to INVALID and attempt
+     * to attach: rejected because the descriptor is not live. */
+    int sv[2]; ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sv), 0);
+    pg_test_socket_provider = &FK_PROVIDER;
+    PgTransport *t = hl_pg_transport_adopt(sv[0], &FK_PROVIDER, NULL, 0);
+    ASSERT_TRUE(t != NULL);
+    KlSocketHandle saved = t->fd;
+    t->fd = KL_INVALID_SOCKET;
+    struct HlTlsClient *sentinel = (struct HlTlsClient *)(void *)&sv;
+    ASSERT_EQ(hl_pg_transport_attach_tls(t, sentinel), -1);
+    t->fd = saved;
+    ASSERT_EQ(hl_pg_transport_close(t), 0);
     close(sv[1]);
+    seam_clear();
+}
+
+/* Build a transport parked in the "live started raced op" state (an attempt in
+ * flight, ev ctx live), stopping before terminal - the exact state the preserve/
+ * retry contract must handle. Returns the transport (caller drives close/teardown
+ * + frees). */
+static PgTransport *tp_make_live_op(void)
+{
+    g_fk_naddr = 1; g_fk_disp[0] = FK_PENDING;
+    pg_test_resolve = fk_resolve; pg_test_socket_provider = &FK_PROVIDER;
+    PgTransport *t = transport_new(&FK_PROVIDER);
+    if (!t) return NULL;
+    t->alloc = kl_allocator_default();
+    if (kl_event_ctx_init(&t->ev, &t->alloc) != 0) { free(t); return NULL; }
+    t->ev_ready = 1;
+    t->naddrs = resolve_addrs(t, "h", 5432);
+    if (t->naddrs < 1) { kl_event_ctx_free(&t->ev); free(t); return NULL; }
+    if (kl_connect_op_init(&t->connect_op, &PG_HOOKS_NO_DEADLINE, t) != 0 ||
+        kl_connect_op_start(&t->connect_op) != 0) { kl_event_ctx_free(&t->ev); free(t); return NULL; }
+    t->connect_started = 1;
+    (void)kl_event_ctx_run(&t->ev, 64, 10);   /* let the attempt arm */
+    return t;
+}
+
+/* ── connect_teardown preserve/retry contract at the unit level ──────
+ *    A live started op with force_no_detach set -> teardown returns -1 (preserve,
+ *    frees nothing); clear -> teardown returns 0 (quiesce + free ev ctx). This is
+ *    the exact contract hl_pg_transport_close relies on. ────────────────────────── */
+UTEST(pg_transport_close, teardown_returns_status)
+{
+    fk_reset(); tp_arm_watchdog();
+    PgTransport *t = tp_make_live_op();
+    ASSERT_TRUE(t != NULL);
+
+    pg_test_force_no_detach = 1;
+    ASSERT_EQ(connect_teardown(t), -1);        /* PRESERVE */
+    ASSERT_EQ(t->ev_ready, 1);                 /* ev ctx NOT freed */
+
+    pg_test_force_no_detach = 0;
+    ASSERT_EQ(connect_teardown(t), 0);         /* quiesce + free ev ctx */
+    ASSERT_EQ(t->ev_ready, 0);
+    ASSERT_TRUE(fk_all_fds_closed());
+    free(t);                                   /* op detached; block freeable */
+    seam_clear(); tp_disarm_watchdog();
+}
+
+/* ── forced non-detachment: hl_pg_transport_close PRESERVES the whole allocation
+ *    and is RETRYABLE. First close (force_no_detach) returns -1 without freeing
+ *    (t stays valid); clearing the flag lets a retry detach + free cleanly, so
+ *    LSan sees no leak. Proves both preservation and the retryable close. ──────── */
+UTEST(pg_transport_close, forced_non_detach_close_preserves_then_retry)
+{
+    fk_reset(); tp_arm_watchdog();
+    PgTransport *t = tp_make_live_op();
+    ASSERT_TRUE(t != NULL);
+
+    /* First close cannot confirm detachment -> -1, allocation PRESERVED (t is
+     * still a valid pointer; nothing freed). */
+    pg_test_force_no_detach = 1;
+    ASSERT_EQ(hl_pg_transport_close(t), -1);
+    ASSERT_EQ(t->ev_ready, 1);                 /* not freed / not quiesced */
+
+    /* Retry after clearing the forced state: detaches, frees, returns 0. */
+    pg_test_force_no_detach = 0;
+    ASSERT_EQ(hl_pg_transport_close(t), 0);    /* t freed here */
+    seam_clear(); tp_disarm_watchdog();
 }
 
 UTEST_MAIN()


### PR DESCRIPTION
Routes the PostgreSQL client's transport onto Keel v3 public primitives, mirroring
the SMTP Slice-2c pattern, while keeping the connection synchronous + blocking and
the wire codec unchanged. Design record: `docs/pg_keel_transport_slice3.md`.

Built and reviewed in five gated checkpoints (exact head `20d9f016`).

## What changed
- **New `cap/pg_transport.{c,h}`** - a heap-allocated, opaque blocking byte
  transport composing Keel's public surface for the CONNECT phase only:
  `KlConnectOp` (resolve + Happy-Eyeballs racing) on a private operation-local
  `KlEventCtx`, then `set_blocking()` the winning descriptor so all subsequent I/O
  is plain blocking `recv`/`send` with no event loop. No `KlStream`. TLS stays the
  shared `hl_tls_client_*` layered over the descriptor (attached to the transport).
- **`cap/pg_conn.c` cut over**: `hl_pg_conn_open`/`_start`/`_close`, the I/O
  helpers, the query guards, `hl_pg_wait_notify`, and the SSLRequest probe
  (`hl_pg_ssl_negotiate`) all ride `PgTransport`. The hand-rolled `pg_connect` and
  the raw `fd`/`tls` fields are gone; `HlPgConn` holds one `PgTransport *`.
  Production has a single I/O path; every public error token is byte-for-byte
  preserved and the pgwire codec + SCRAM + startup are unchanged. The only raw
  descriptor use left is handing `hl_pg_transport_fd` to
  `hl_tls_client_handshake(int fd, ...)` for the TLS handshake itself.

## Correctness properties (per review)
- **Ownership:** `hl_pg_transport_adopt` CONSUMES the descriptor (closes it exactly
  once through the provider) on allocation failure, upholding
  `hl_pg_conn_start`'s "closes fd on every failure" contract
  (`pg_transport_adopt.alloc_failure_consumes_fd_once`).
- **Provider validation:** required op subset + `KL_SOCK_CAP_NATIVE_FD` validated
  up front; `io_status`-based classification; truly-unbounded connect (no hidden
  ceiling); one-shot fallible TLS attach; fallible teardown/close with safe
  allocation preservation on non-detachment.
- **Test seam** (`-DHL_PG_TEST_HOOKS`) is production-absent (nm-verified).

## sslmode matrix (verified e2e, real Postgres 16)
- `disable` -> plaintext.
- `require` + TLS server -> SSLRequest -> mbedTLS handshake -> SCRAM over TLS
  (encrypted, asserted via `pg_stat_ssl`).
- `require` + non-TLS server -> hard fail, **no plaintext downgrade**.
- `verify-full` + untrusted self-signed cert -> **chain-verification rejection**.
`verify-full` SUCCESS against a private CA is not e2e-testable (Hull's PG TLS
trusts only the embedded Mozilla bundle); the chain + hostname verifier is the
shared `shared/tls_client.c`, covered by the live-mbedTLS-peer SMTP unit suite that
the PG path reuses unchanged.

## Composition / link seam (checkpoint-5 focused checks, exact head)
- Non-Postgres base hull: **0** PG symbols; base platform lib: **0** PG objects.
- A composed non-PG `hull build` app: **0** `hl_pg_transport`/`hl_pg_conn`/
  `hl_pg_ssl` symbols. The `kl_connect_op` references present are pre-existing Keel
  (main's `smtp_transport.c` uses `KlConnectOp` 24x; this PR does not touch it) -
  the sole new consumer `cap_pg_transport.o` is absent from a non-PG app, so this
  PR introduces zero new Keel-transport references into the base.
- `sqlite+postgres` links; `postgres-only` (`HL_ENABLE_SQLITE=0`) links;
  pure-compute (`HL_ENABLE_HTTP=0`) links.
- `libhull_feature-postgres.a` composes `cap_db_postgres.o + cap_pg_conn.o +
  cap_pg_transport.o + cap_pgwire.o`.

## Test coverage + CI
- `test_pg_transport` 20/20, `test_pg_conn` 22/22 - both run under ASan/LSan on
  Linux via the standing `pg_transport ASan/LSan` CI job (wired through the
  classifier + applicability map + aggregate gate). Fuzzers stay Keel-free.
- Exact-head aggregate matrix (`20d9f016`): 65 success, 1 skipped, 0 failures,
  including Postgres e2e (full sslmode matrix) and both PG suites under ASan/LSan.

Follow-up (separate PR): Slice 4 repeats this against `cap/mysql_conn.c`.