### PR TITLE
db: drop raw-socket includes orphaned by the Keel-v3 transport migration

### DIFF
--- a/src/hull/cap/pg_conn.c
+++ b/src/hull/cap/pg_conn.c
@@ -27,24 +27,14 @@
 #endif
 
 #include <ctype.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <netdb.h>
-#include <poll.h>
+#include <errno.h>       /* EINTR in the notify-wait poll loop */
+#include <poll.h>        /* poll() in hl_pg_wait_notify */
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/socket.h>
-#include <sys/select.h>
-#include <time.h>
+#include <time.h>        /* clock_gettime(CLOCK_MONOTONIC) */
 #include <unistd.h>
-
-#ifdef MSG_NOSIGNAL
-#define PG_SEND_FLAGS MSG_NOSIGNAL
-#else
-#define PG_SEND_FLAGS 0
-#endif
 
 /* Overwrite memory the optimizer cannot elide (secret scrub). */
 static void pg_secure_zero(void *p, size_t n)

--- a/src/hull/cap/valkey_conn.c
+++ b/src/hull/cap/valkey_conn.c
@@ -24,23 +24,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <errno.h>
-#include <fcntl.h>
-#include <netdb.h>
-#include <sys/select.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <unistd.h>
+#include <sys/types.h>   /* ssize_t (io_send/io_recv) */
 
 #ifndef HL_VALKEY_NO_TLS
 #include "hull/cap/db_transport.h"   /* shared Keel-v3 byte transport (bytes + TLS) */
 #include "hull/shared/tls_client.h"
-#endif
-
-#ifdef MSG_NOSIGNAL
-#define VK_SEND_FLAGS MSG_NOSIGNAL
-#else
-#define VK_SEND_FLAGS 0
 #endif
 
 /* Cap the receive buffer so a hostile server can't force unbounded growth. */


### PR DESCRIPTION
Mechanical follow-up to the DB client-transport arc (Slices 3-5): the wire clients
no longer touch raw sockets - all byte I/O rides `cap/db_transport.c` - so the
includes their deleted raw connect/io needed are dead.

- `valkey_conn.c`: drop `<errno.h> <fcntl.h> <netdb.h> <sys/select.h> <sys/socket.h>
  <unistd.h>` + the unused `VK_SEND_FLAGS` (`MSG_NOSIGNAL`) macro; keep
  `<sys/types.h>` for `ssize_t`.
- `pg_conn.c`: drop `<fcntl.h> <netdb.h> <sys/socket.h> <sys/select.h>` + the
  never-used `PG_SEND_FLAGS` macro; keep `<errno.h>` (EINTR in the notify-wait
  poll), `<poll.h>` (`hl_pg_wait_notify`), `<time.h>` (clock_gettime), `<unistd.h>`.

No behavior change. `mysql_conn.c` was already clean. Verified locally: valkey full
+ DSN-only (`HL_VALKEY_NO_TLS`) + respwire and pg conn + transport suites pass;
both files compile clean including the `HL_VALKEY_NO_TLS` fuzzer config.