### PR TITLE
agent: route request.c off raw sockets onto Keel's client + socket provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1357,10 +1357,12 @@ ifeq ($(HL_ENABLE_HTTP_SERVER),0)
   # agent/request.c, agent/eval.c, agent/perf.c, agent/endpoint.c also
   # exercise HTTP routes. All server-only - the `hull agent` subcommands
   # that depend on a running server (test/request/eval/perf/endpoint)
-  # lose their backends.
+  # lose their backends. agent/probe.c is request.c's TCP-liveness helper
+  # (its sole consumer is hl_agent_status), so it drops with request.c.
   AGENT_LIB_SRCS := $(filter-out \
       $(SRCDIR)/hull/agent/test.c \
       $(SRCDIR)/hull/agent/request.c \
+      $(SRCDIR)/hull/agent/probe.c \
       $(SRCDIR)/hull/agent/eval.c \
       $(SRCDIR)/hull/agent/perf.c \
       $(SRCDIR)/hull/agent/endpoint.c, \

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -240,6 +240,18 @@ $(BUILDDIR)/test_tls_client: $(TESTDIR)/hull/test_tls_client.c \
 	$(CC) $(CFLAGS) -DHL_TLS_CLIENT_TEST_HOOKS $(INCLUDES) -I$(VENDDIR) -o $@ \
 		$(TESTDIR)/hull/test_tls_client.c $(TLS_CLIENT_TEST_LIBS) $(LDFLAGS)
 
+# agent TCP-connect liveness probe (`hull agent status`): white-box direct-include
+# of agent/probe.c under -DHL_AGENT_PROBE_TEST_HOOKS to drive immediate-success /
+# refusal / pending-timeout / pending-succeed / close-once through a fake
+# socketpair provider (the private KlEventCtx watches real fds). probe.c is NOT in
+# TEST_COMMON_LIBS (no agent_*.o there), so no symbol filter is needed; keel + libc
+# supply the rest. Not under tests/hull/cap/, so the generic pattern rule misses it
+# - this explicit rule builds it; it still runs in the default `make test`.
+$(BUILDDIR)/test_agent_probe: $(TESTDIR)/hull/agent/test_agent_probe.c \
+    $(SRCDIR)/hull/agent/probe.c $(TEST_COMMON_DEPS) | $(BUILDDIR)
+	$(CC) $(CFLAGS) -DHL_AGENT_PROBE_TEST_HOOKS $(INCLUDES) -I$(VENDDIR) -o $@ \
+		$(TESTDIR)/hull/agent/test_agent_probe.c $(TEST_COMMON_LIBS) $(LDFLAGS)
+
 # MySQL/MariaDB codec + DSN test: mysqlwire.c + mysql_conn.c are
 # self-contained (no socket/TLS/crypto yet) and gated out of CAP_OBJS until
 # HL_ENABLE_MYSQL, so link them directly. Explicit rule wins over the pattern.

--- a/src/hull/agent/internal.h
+++ b/src/hull/agent/internal.h
@@ -19,6 +19,14 @@ struct sqlite3;
 /* Emit {"error": msg} as JSON. Always returns -1. */
 int hl_agent_write_error(ShJsonBuf *out, const char *msg);
 
+/*
+ * Bounded TCP-connect liveness probe to 127.0.0.1:<port> through Keel's socket
+ * provider + a private KlEventCtx. Returns 1 iff a connection establishes
+ * within timeout_ms, 0 otherwise. Closes the descriptor exactly once.
+ * (agent/probe.c; used by hl_agent_status.)
+ */
+int hl_agent_tcp_probe(int port, int timeout_ms);
+
 #ifdef HL_ENABLE_DB
 /*
  * Open an app database for read-only introspection.

--- a/src/hull/agent/probe.c
+++ b/src/hull/agent/probe.c
@@ -1,0 +1,141 @@
+/*
+ * agent/probe.c - bounded TCP-connect liveness probe for `hull agent status`.
+ *
+ * Drives a single-address (127.0.0.1:<port>) connect through Keel's socket
+ * provider + a private KlEventCtx watcher: nonblocking connect, provider
+ * io_status classification (documented hosted-errno fallback), and a
+ * writability wait bounded by ONE monotonic deadline. No raw Berkeley
+ * socket call and no hand-rolled poll()/errno event axis. Returns 1 iff a
+ * connection establishes within timeout_ms, 0 otherwise (refused, error, or
+ * timeout). The probe never keeps the connection: the descriptor is closed
+ * exactly once on every path.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "internal.h"
+
+#include <errno.h>
+#include <stdint.h>
+#include <sys/socket.h>   /* AF_INET / SOCK_STREAM ints for the provider socket() op */
+
+#include <keel/allocator.h>
+#include <keel/clock.h>       /* kl_monotonic_ms: one monotonic connect deadline */
+#include <keel/event.h>       /* KL_EVENT_WRITE */
+#include <keel/event_ctx.h>   /* private KlEventCtx + watcher API */
+#include <keel/handle.h>      /* KlSocketHandle, kl_handle_valid */
+#include <keel/sockaddr.h>    /* kl_sockaddr_from_ipv4 */
+#include <keel/socket.h>      /* kl_socket_provider_posix + ops table */
+
+#ifdef HL_AGENT_PROBE_TEST_HOOKS
+/* Test-only seam (compiled ONLY under -DHL_AGENT_PROBE_TEST_HOOKS, ABSENT from
+ * the production object). When set, REPLACES the default POSIX provider so a
+ * white-box test can script immediate-connect / refusal / pending outcomes over
+ * real socketpair fds the private event loop can watch. */
+const KlSocketProvider *hl_agent_probe_test_provider;
+#endif
+
+static const KlSocketProvider *probe_provider(void)
+{
+#ifdef HL_AGENT_PROBE_TEST_HOOKS
+    if (hl_agent_probe_test_provider)
+        return hl_agent_probe_test_provider;
+#endif
+    return kl_socket_provider_posix();
+}
+
+/* Classify the last provider op: prefer the provider's io_status op, else the
+ * documented hosted-errno fallback (mirrors cap/db_transport.c). */
+static KlIoStatus probe_io_status(const KlSocketProvider *sp)
+{
+    if (sp->ops->io_status)
+        return sp->ops->io_status(sp->context);
+    switch (errno) {
+        case EINTR:       return KL_IO_INTERRUPTED;
+        case EINPROGRESS: return KL_IO_PENDING;
+        case 0:           return KL_IO_OK;
+        default:          return KL_IO_FATAL;
+    }
+}
+
+/* Writability-wait state for a pending connect. */
+typedef struct {
+    const KlSocketProvider *sp;
+    KlSocketHandle          fd;
+    int                     done;     /* 1 once the connect resolved */
+    int                     running;  /* 1 on established, 0 on error */
+} ProbeWait;
+
+static void probe_on_writable(KlSocketHandle fd, KlEventMask ready, void *user)
+{
+    (void)fd;
+    (void)ready;
+    ProbeWait *w = user;
+    int soerr = 0;
+    if (w->sp->ops->get_so_error(w->sp->context, w->fd, &soerr) == 0 && soerr == 0)
+        w->running = 1;
+    w->done = 1;
+}
+
+int hl_agent_tcp_probe(int port, int timeout_ms)
+{
+    const KlSocketProvider *sp = probe_provider();
+    if (!sp || !sp->ops || !sp->ops->socket || !sp->ops->connect ||
+        !sp->ops->close || !sp->ops->set_nonblocking || !sp->ops->get_so_error)
+        return 0;
+    if (!kl_socket_provider_has_cap(sp, KL_SOCK_CAP_NATIVE_FD))
+        return 0;
+    const KlSocketOps *ops = sp->ops;
+    void *sctx = sp->context;
+
+    KlSockAddr addr;
+    const uint8_t loopback[4] = { 127, 0, 0, 1 };
+    if (kl_sockaddr_from_ipv4(&addr, loopback, (uint16_t)port) != 0)
+        return 0;
+
+    KlSocketHandle fd = ops->socket(sctx, AF_INET, SOCK_STREAM, 0);
+    if (!kl_handle_valid(fd))
+        return 0;
+
+    int running = 0;
+    if (ops->set_nonblocking(sctx, fd) == 0) {
+        errno = 0;
+        int cr = ops->connect(sctx, fd, &addr);
+        if (cr == 0) {
+            running = 1;                    /* connected at once (common on loopback) */
+        } else {
+            KlIoStatus st = probe_io_status(sp);
+            if (st == KL_IO_OK) {
+                running = 1;
+            } else if (st == KL_IO_PENDING || st == KL_IO_INTERRUPTED) {
+                /* Wait for writability on a private event context, bounded by a
+                 * single monotonic deadline - no raw poll()/errno spin. */
+                KlEventCtx ev;
+                KlAllocator alloc = kl_allocator_default();
+                if (kl_event_ctx_init(&ev, &alloc) == 0) {
+                    ProbeWait w = { .sp = sp, .fd = fd, .done = 0, .running = 0 };
+                    if (kl_watcher_add(&ev, fd, KL_EVENT_WRITE,
+                                       probe_on_writable, &w) == 0) {
+                        uint64_t deadline = kl_monotonic_ms() +
+                            (uint64_t)(timeout_ms > 0 ? timeout_ms : 0);
+                        while (!w.done) {
+                            uint64_t now = kl_monotonic_ms();
+                            if (timeout_ms > 0 && now >= deadline)
+                                break;               /* deadline is the sole timeout */
+                            int wait = (timeout_ms > 0) ? (int)(deadline - now) : -1;
+                            if (kl_event_ctx_run(&ev, 4, wait) < 0)
+                                break;
+                        }
+                        kl_watcher_del(&ev, fd);
+                        running = w.running;
+                    }
+                    kl_event_ctx_free(&ev);
+                }
+            }
+            /* any other status (closed / reset / error): hard failure -> 0 */
+        }
+    }
+
+    ops->close(sctx, fd);
+    return running;
+}

--- a/src/hull/agent/request.c
+++ b/src/hull/agent/request.c
@@ -9,192 +9,115 @@
 
 #include <sh_json.h>
 
-#include <errno.h>
-#include <limits.h>
+#include <errno.h>       /* EINPROGRESS classification in the connect probe */
+#include <limits.h>      /* PATH_MAX */
+#include <poll.h>        /* poll(): writability wait in the connect probe */
+#include <stdint.h>      /* uint8_t / uint16_t (KlSockAddr construction) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
+#include <sys/socket.h>  /* AF_INET / SOCK_STREAM ints for the provider socket() op */
 
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <sys/stat.h>
-#include <sys/time.h>
+#include <keel/allocator.h>    /* kl_allocator_default */
+#include <keel/clock.h>        /* kl_monotonic_ms: request elapsed timing */
+#include <keel/handle.h>       /* KlSocketHandle, kl_handle_valid */
+#include <keel/http_client.h>  /* kl_http_client_request (sync HTTP client) */
+#include <keel/sockaddr.h>     /* kl_sockaddr_from_ipv4 */
+#include <keel/socket.h>       /* kl_socket_provider_posix + ops table */
 
 int hl_agent_request(const char *method, const char *path, int port,
                      const char *body, const char **headers, int nhdrs,
                      ShJsonBuf *out)
 {
-    int sock = socket(AF_INET, SOCK_STREAM, 0);
-    if (sock < 0)
-        return hl_agent_write_error(out, "cannot create socket");
+    /* Each caller header is a full "Name: Value" line; Keel's sync client
+     * wants split {name, value} pairs. The caller's lines are const and not
+     * NUL-terminated at the colon, so copy the split fields into one bounded
+     * scratch buffer and point the pair array into it. */
+    if (nhdrs < 0)
+        nhdrs = 0;
+    if (nhdrs > KL_HTTP_CLIENT_MAX_REQ_HEADERS)
+        return hl_agent_write_error(out, "too many request headers");
+    KlHttpClientHeader kh[KL_HTTP_CLIENT_MAX_REQ_HEADERS];
+    char hbuf[8192];
+    size_t hoff = 0;
+    for (int i = 0; i < nhdrs; i++) {
+        const char *hline = headers[i] ? headers[i] : "";
+        const char *colon = strchr(hline, ':');
+        if (!colon)
+            return hl_agent_write_error(out, "malformed request header");
+        size_t nlen = (size_t)(colon - hline);
+        const char *val = colon + 1;
+        while (*val == ' ')
+            val++;
+        size_t vlen = strlen(val);
+        if (hoff + nlen + 1 + vlen + 1 > sizeof(hbuf))
+            return hl_agent_write_error(out, "request headers too large");
+        char *nm = hbuf + hoff;
+        memcpy(nm, hline, nlen);
+        nm[nlen] = '\0';
+        hoff += nlen + 1;
+        char *vl = hbuf + hoff;
+        memcpy(vl, val, vlen);
+        vl[vlen] = '\0';
+        hoff += vlen + 1;
+        kh[i].name  = nm;
+        kh[i].value = vl;
+    }
 
-    struct sockaddr_in addr;
-    memset(&addr, 0, sizeof(addr));
-    addr.sin_family = AF_INET;
-    addr.sin_port = htons((uint16_t)port);
-    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    char url[PATH_MAX + 64];
+    int un = snprintf(url, sizeof(url), "http://127.0.0.1:%d%s",
+                      port, path ? path : "/");
+    if (un < 0 || (size_t)un >= sizeof(url))
+        return hl_agent_write_error(out, "request path too long");
 
-    struct timeval tv = { .tv_sec = 5, .tv_usec = 0 };
-    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-    setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+    /* Blocking HTTP/1.1 exchange via Keel's sync client: it owns connect,
+     * send, recv, and the status-line + header parse. timeout_ms/max_response
+     * preserve the former 5s socket timeout + 1 MB response cap. */
+    KlHttpClientConfig cfg = {
+        .timeout_ms        = 5000,
+        .max_response_size = 1024 * 1024,
+    };
+    KlAllocator alloc = kl_allocator_default();
+    KlHttpClientResponse resp;
+    memset(&resp, 0, sizeof resp);
 
-    struct timeval start, end;
-    gettimeofday(&start, NULL);
-
-    if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-        close(sock);
-        char err[128];
-        snprintf(err, sizeof(err), "cannot connect to 127.0.0.1:%d", port);
+    size_t body_len = body ? strlen(body) : 0;
+    uint64_t t0 = kl_monotonic_ms();
+    int rc = kl_http_client_request(&alloc, &cfg, method, url,
+                                    kh, nhdrs, body, body_len, &resp);
+    long elapsed_ms = (long)(kl_monotonic_ms() - t0);
+    if (rc != 0) {
+        char err[160];
+        snprintf(err, sizeof(err),
+                 "request to 127.0.0.1:%d failed (error %d)",
+                 port, (int)resp.error);
+        kl_http_client_response_free(&resp);
         return hl_agent_write_error(out, err);
     }
 
-    /* Build HTTP request.
-     *
-     * Each `snprintf` returns the would-be length even on truncation, so
-     * naively accumulating `req_len += snprintf(...)` past `sizeof(req_buf)`
-     * causes `sizeof(req_buf) - req_len` to wrap to a huge size_t on the
-     * next call, writing past the end of `req_buf`. Check truncation after
-     * every call and bail with a clear error (M-1). */
-    size_t body_len = body ? strlen(body) : 0;
-    char req_buf[8192];
-    int req_len = snprintf(req_buf, sizeof(req_buf),
-        "%s %s HTTP/1.1\r\n"
-        "Host: 127.0.0.1:%d\r\n"
-        "Connection: close\r\n",
-        method, path, port);
-    if (req_len < 0 || (size_t)req_len >= sizeof(req_buf)) {
-        close(sock);
-        return hl_agent_write_error(out, "request too large");
-    }
-
-    #define APPEND_FMT(...) do { \
-        int _n = snprintf(req_buf + req_len, \
-                          sizeof(req_buf) - (size_t)req_len, __VA_ARGS__); \
-        if (_n < 0 || (size_t)_n >= sizeof(req_buf) - (size_t)req_len) { \
-            close(sock); \
-            return hl_agent_write_error(out, "request too large"); \
-        } \
-        req_len += _n; \
-    } while (0)
-
-    if (body_len > 0)
-        APPEND_FMT("Content-Length: %zu\r\n", body_len);
-
-    for (int i = 0; i < nhdrs; i++)
-        APPEND_FMT("%s\r\n", headers[i]);
-
-    APPEND_FMT("\r\n");
-
-    #undef APPEND_FMT
-
-    ssize_t sent = send(sock, req_buf, (size_t)req_len, 0);
-    if (sent < 0) {
-        close(sock);
-        return hl_agent_write_error(out, "send failed");
-    }
-
-    if (body && body_len > 0) {
-        sent = send(sock, body, body_len, 0);
-        if (sent < 0) {
-            close(sock);
-            return hl_agent_write_error(out, "send body failed");
-        }
-    }
-
-    /* Read response */
-    char *resp_buf = malloc(1024 * 1024);
-    if (!resp_buf) {
-        close(sock);
-        return hl_agent_write_error(out, "allocation failed");
-    }
-
-    size_t resp_len = 0;
-    for (;;) {
-        ssize_t n = recv(sock, resp_buf + resp_len,
-                         1024 * 1024 - resp_len - 1, 0);
-        if (n <= 0) break;
-        resp_len += (size_t)n;
-        if (resp_len >= 1024 * 1024 - 1) break;
-    }
-    resp_buf[resp_len] = '\0';
-    close(sock);
-
-    gettimeofday(&end, NULL);
-    long elapsed_ms = (end.tv_sec - start.tv_sec) * 1000 +
-                      (end.tv_usec - start.tv_usec) / 1000;
-
-    /* Parse status line */
-    int status = 0;
-    const char *header_end = strstr(resp_buf, "\r\n\r\n");
-    if (!header_end) {
-        ShJsonWriter w;
-        sh_json_writer_init(&w, sh_json_buf_write, out);
-        sh_json_write_object_start(&w);
-        sh_json_write_kv_string(&w, "error", "malformed response");
-        sh_json_write_kv_string(&w, "raw", resp_buf);
-        sh_json_write_object_end(&w);
-        free(resp_buf);
-        return -1;
-    }
-
-    if (resp_len > 12) {
-        char *sp = memchr(resp_buf, ' ', 12);
-        if (sp) status = (int)strtol(sp + 1, NULL, 10);
-    }
-
-    const char *resp_body = header_end + 4;
-    size_t resp_body_len = resp_len - (size_t)(resp_body - resp_buf);
-
-    /* Write JSON output */
     ShJsonWriter w;
     sh_json_writer_init(&w, sh_json_buf_write, out);
     sh_json_write_object_start(&w);
-    sh_json_write_kv_int(&w, "status", status);
-    sh_json_write_kv_int(&w, "elapsed_ms", elapsed_ms);
+    sh_json_write_kv_int(&w, "status", resp.status);
+    sh_json_write_kv_int(&w, "elapsed_ms", (int)elapsed_ms);
 
-    /* Response headers */
+    /* Response headers (Keel already parsed them; the status line is excluded). */
     sh_json_write_key(&w, "headers");
     sh_json_write_object_start(&w);
-
-    const char *line = resp_buf;
-    const char *first_crlf = strstr(line, "\r\n");
-    if (first_crlf) line = first_crlf + 2;
-
-    while (line < header_end) {
-        const char *next = strstr(line, "\r\n");
-        if (!next || next == line) break;
-
-        const char *colon = memchr(line, ':', (size_t)(next - line));
-        if (colon) {
-            size_t key_len = (size_t)(colon - line);
-            char key_buf[256];
-            if (key_len >= sizeof(key_buf)) key_len = sizeof(key_buf) - 1;
-            memcpy(key_buf, line, key_len);
-            key_buf[key_len] = '\0';
-
-            const char *val = colon + 1;
-            while (val < next && *val == ' ') val++;
-            size_t val_len = (size_t)(next - val);
-            char val_buf[4096];
-            if (val_len >= sizeof(val_buf)) val_len = sizeof(val_buf) - 1;
-            memcpy(val_buf, val, val_len);
-            val_buf[val_len] = '\0';
-
-            sh_json_write_kv_string(&w, key_buf, val_buf);
-        }
-        line = next + 2;
+    for (int i = 0; i < resp.num_headers; i++) {
+        if (resp.headers[i].name)
+            sh_json_write_kv_string(&w, resp.headers[i].name,
+                                    resp.headers[i].value ? resp.headers[i].value : "");
     }
-
     sh_json_write_object_end(&w);
 
-    /* Body */
-    sh_json_write_kv_string(&w, "body", resp_body);
-    (void)resp_body_len;
+    /* Body (length-aware: binary-safe, matches the former NUL-terminated
+     * write for every real text/JSON response). */
+    sh_json_write_key(&w, "body");
+    sh_json_write_string_n(&w, resp.body ? resp.body : "", resp.body_len);
 
     sh_json_write_object_end(&w);
-    free(resp_buf);
+    kl_http_client_response_free(&resp);
     return 0;
 }
 
@@ -220,27 +143,42 @@ int hl_agent_status(const char *app_dir, int port, ShJsonBuf *out)
         }
     }
 
-    /* Probe with socket connect */
-    int sock = socket(AF_INET, SOCK_STREAM, 0);
-    int connected = 0;
-    if (sock >= 0) {
-        struct sockaddr_in addr;
-        memset(&addr, 0, sizeof(addr));
-        addr.sin_family = AF_INET;
-        addr.sin_port = htons((uint16_t)port);
-        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-
-        struct timeval tv = { .tv_sec = 1, .tv_usec = 0 };
-        setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
-
-        connected = (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) == 0);
-        close(sock);
+    /* Pure TCP-connect liveness probe through Keel's socket provider (no app
+     * route or middleware invoked): a nonblocking connect + one writability
+     * wait + SO_ERROR, mirroring cap/db_transport.c's connect attempt. */
+    int running = 0;
+    const KlSocketProvider *sp = kl_socket_provider_posix();
+    if (sp && sp->ops && sp->ops->socket && sp->ops->connect &&
+        sp->ops->close && sp->ops->set_nonblocking && sp->ops->get_so_error) {
+        const KlSocketOps *ops = sp->ops;
+        void *sctx = sp->context;
+        KlSockAddr addr;
+        const uint8_t loopback[4] = { 127, 0, 0, 1 };
+        if (kl_sockaddr_from_ipv4(&addr, loopback, (uint16_t)port) == 0) {
+            KlSocketHandle fd = ops->socket(sctx, AF_INET, SOCK_STREAM, 0);
+            if (kl_handle_valid(fd)) {
+                if (ops->set_nonblocking(sctx, fd) == 0) {
+                    int cr = ops->connect(sctx, fd, &addr);
+                    if (cr == 0) {
+                        running = 1;                  /* loopback often connects at once */
+                    } else if (errno == EINPROGRESS) {
+                        struct pollfd pfd = { .fd = (int)fd, .events = POLLOUT, .revents = 0 };
+                        if (poll(&pfd, 1, 1000) > 0) {
+                            int soerr = 0;
+                            if (ops->get_so_error(sctx, fd, &soerr) == 0 && soerr == 0)
+                                running = 1;
+                        }
+                    }
+                }
+                ops->close(sctx, fd);
+            }
+        }
     }
 
     ShJsonWriter w;
     sh_json_writer_init(&w, sh_json_buf_write, out);
     sh_json_write_object_start(&w);
-    sh_json_write_kv_bool(&w, "running", connected != 0);
+    sh_json_write_kv_bool(&w, "running", running != 0);
     sh_json_write_kv_int(&w, "port", port);
     sh_json_write_object_end(&w);
     return 0;

--- a/src/hull/agent/request.c
+++ b/src/hull/agent/request.c
@@ -9,21 +9,15 @@
 
 #include <sh_json.h>
 
-#include <errno.h>       /* EINPROGRESS classification in the connect probe */
 #include <limits.h>      /* PATH_MAX */
-#include <poll.h>        /* poll(): writability wait in the connect probe */
-#include <stdint.h>      /* uint8_t / uint16_t (KlSockAddr construction) */
+#include <stdint.h>      /* uint64_t (kl_monotonic_ms timing) */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/socket.h>  /* AF_INET / SOCK_STREAM ints for the provider socket() op */
 
 #include <keel/allocator.h>    /* kl_allocator_default */
 #include <keel/clock.h>        /* kl_monotonic_ms: request elapsed timing */
-#include <keel/handle.h>       /* KlSocketHandle, kl_handle_valid */
 #include <keel/http_client.h>  /* kl_http_client_request (sync HTTP client) */
-#include <keel/sockaddr.h>     /* kl_sockaddr_from_ipv4 */
-#include <keel/socket.h>       /* kl_socket_provider_posix + ops table */
 
 int hl_agent_request(const char *method, const char *path, int port,
                      const char *body, const char **headers, int nhdrs,
@@ -87,6 +81,11 @@ int hl_agent_request(const char *method, const char *path, int port,
                                     kh, nhdrs, body, body_len, &resp);
     long elapsed_ms = (long)(kl_monotonic_ms() - t0);
     if (rc != 0) {
+        /* Compatibility delta: the former raw-socket path emitted the
+         * connect-specific "cannot connect to 127.0.0.1:<port>". Keel's client
+         * folds connect/send/recv/parse into one rc, so the message is now the
+         * general "request to 127.0.0.1:<port> failed (error N)" - it retains
+         * the 127.0.0.1:<port> context and carries the KlError code. */
         char err[160];
         snprintf(err, sizeof(err),
                  "request to 127.0.0.1:%d failed (error %d)",
@@ -143,37 +142,10 @@ int hl_agent_status(const char *app_dir, int port, ShJsonBuf *out)
         }
     }
 
-    /* Pure TCP-connect liveness probe through Keel's socket provider (no app
-     * route or middleware invoked): a nonblocking connect + one writability
-     * wait + SO_ERROR, mirroring cap/db_transport.c's connect attempt. */
-    int running = 0;
-    const KlSocketProvider *sp = kl_socket_provider_posix();
-    if (sp && sp->ops && sp->ops->socket && sp->ops->connect &&
-        sp->ops->close && sp->ops->set_nonblocking && sp->ops->get_so_error) {
-        const KlSocketOps *ops = sp->ops;
-        void *sctx = sp->context;
-        KlSockAddr addr;
-        const uint8_t loopback[4] = { 127, 0, 0, 1 };
-        if (kl_sockaddr_from_ipv4(&addr, loopback, (uint16_t)port) == 0) {
-            KlSocketHandle fd = ops->socket(sctx, AF_INET, SOCK_STREAM, 0);
-            if (kl_handle_valid(fd)) {
-                if (ops->set_nonblocking(sctx, fd) == 0) {
-                    int cr = ops->connect(sctx, fd, &addr);
-                    if (cr == 0) {
-                        running = 1;                  /* loopback often connects at once */
-                    } else if (errno == EINPROGRESS) {
-                        struct pollfd pfd = { .fd = (int)fd, .events = POLLOUT, .revents = 0 };
-                        if (poll(&pfd, 1, 1000) > 0) {
-                            int soerr = 0;
-                            if (ops->get_so_error(sctx, fd, &soerr) == 0 && soerr == 0)
-                                running = 1;
-                        }
-                    }
-                }
-                ops->close(sctx, fd);
-            }
-        }
-    }
+    /* Pure TCP-connect liveness probe (no app route or middleware invoked),
+     * driven through Keel's socket provider + a private KlEventCtx watcher.
+     * See agent/probe.c. */
+    int running = hl_agent_tcp_probe(port, 1000);
 
     ShJsonWriter w;
     sh_json_writer_init(&w, sh_json_buf_write, out);

--- a/tests/e2e_agent.sh
+++ b/tests/e2e_agent.sh
@@ -205,6 +205,9 @@ rm -rf "$TMPDIR_REQ"
 EXIT_CODE=0
 OUT=$($HULL agent request GET /health -p 39899 2>&1) || EXIT_CODE=$?
 check_contains "request no server error"   "$OUT" '"error"'
+# The failure message retains the 127.0.0.1:<port> context (error-shape delta:
+# the former "cannot connect to ..." is now "request to 127.0.0.1:<port> failed").
+check_contains "request no server host:port" "$OUT" '127.0.0.1:39899'
 check_exit     "request no server exit"    "$EXIT_CODE" "1"
 
 # ── status ────────────────────────────────────────────────────────────

--- a/tests/hull/agent/test_agent_probe.c
+++ b/tests/hull/agent/test_agent_probe.c
@@ -1,0 +1,177 @@
+/*
+ * test_agent_probe.c - deterministic coverage for the `hull agent status`
+ * TCP-connect liveness probe (agent/probe.c).
+ *
+ * White-box: direct-includes probe.c (built with -DHL_AGENT_PROBE_TEST_HOOKS)
+ * to reach hl_agent_tcp_probe and the socket-provider test seam. A fake
+ * provider hands the probe REAL socketpair fds the private KlEventCtx can
+ * watch (one clock domain): a "pending" address is a socketpair whose send
+ * buffer is filled so its fd is never write-ready (deterministic timeout);
+ * "succeed" leaves it writable with get_so_error == 0; "fail" reports
+ * ECONNREFUSED; "immediate" makes connect() return 0; "hardfail" returns a
+ * non-pending error inline. Provider close() calls are counted (close-once).
+ * Two op tables prove both the io_status path and the hosted-errno fallback.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "utest.h"
+#include "../../../src/hull/agent/probe.c"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+
+#include <keel/sockaddr.h>
+
+/* A watchdog so a wedged wait can never hang CI: SIGALRM aborts the test. */
+static void ap_watchdog_fired(int sig) { (void)sig; _exit(77); }
+static void ap_arm_watchdog(void) { signal(SIGALRM, ap_watchdog_fired); alarm(5); }
+static void ap_disarm_watchdog(void) { alarm(0); }
+
+enum { D_IMMEDIATE, D_PENDING, D_SUCCEED, D_FAIL, D_HARDFAIL };
+static int        g_disp;
+static int        g_close_n;          /* provider close() calls (close-once proof) */
+static int        g_a = -1, g_b = -1; /* the mock socketpair */
+static KlIoStatus g_io_status_val;    /* value fk_io_status returns */
+
+static void fk_reset(int disp)
+{
+    g_disp = disp;
+    g_close_n = 0;
+    g_a = g_b = -1;
+    g_io_status_val = KL_IO_OK;
+}
+
+static KlSocketHandle fk_socket(void *c, int d, int t, int p)
+{
+    (void)c; (void)d; (void)t; (void)p;
+    int sv[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) return KL_INVALID_SOCKET;
+    int small = 2048;
+    setsockopt(sv[0], SOL_SOCKET, SO_SNDBUF, &small, sizeof small);
+    setsockopt(sv[1], SOL_SOCKET, SO_RCVBUF, &small, sizeof small);
+    g_a = sv[0]; g_b = sv[1];
+    return (KlSocketHandle)sv[0];
+}
+static int fk_set_nb(void *c, KlSocketHandle fd)
+{ (void)c; int a = (int)fd; int fl = fcntl(a, F_GETFL, 0); return fcntl(a, F_SETFL, fl | O_NONBLOCK); }
+static int fk_set_blocking(void *c, KlSocketHandle fd)
+{ (void)c; int a = (int)fd; int fl = fcntl(a, F_GETFL, 0); return fcntl(a, F_SETFL, fl & ~O_NONBLOCK); }
+static int fk_set_int(void *c, KlSocketHandle fd, int on) { (void)c; (void)fd; (void)on; return 0; }
+static void fk_set_void(void *c, KlSocketHandle fd) { (void)c; (void)fd; }
+static int fk_get_local(void *c, KlSocketHandle fd, KlSockAddr *out)
+{ (void)c; (void)fd; uint8_t ip[4] = {127,0,0,1}; return kl_sockaddr_from_ipv4(out, ip, 0); }
+
+static int fk_connect(void *c, KlSocketHandle fd, const KlSockAddr *addr)
+{
+    (void)c; (void)addr;
+    int s = (int)fd;
+    if (g_disp == D_IMMEDIATE) { errno = 0; return 0; }   /* rc == 0 fast path */
+    if (g_disp == D_PENDING) {
+        char buf[2048];
+        memset(buf, 'x', sizeof buf);
+        while (write(s, buf, sizeof buf) > 0) { }          /* fill SNDBUF: never write-ready */
+    }
+    if (g_disp == D_HARDFAIL) { errno = ECONNREFUSED; g_io_status_val = KL_IO_FATAL; return -1; }
+    errno = EINPROGRESS; g_io_status_val = KL_IO_PENDING;
+    return -1;
+}
+static int fk_get_so_error(void *c, KlSocketHandle fd, int *out)
+{ (void)c; (void)fd; *out = (g_disp == D_FAIL) ? ECONNREFUSED : 0; return 0; }
+static int fk_close(void *c, KlSocketHandle fd)
+{ (void)c; int a = (int)fd; g_close_n++; if (g_b >= 0) { close(g_b); g_b = -1; } return close(a); }
+static KlIoStatus fk_io_status(void *c) { (void)c; return g_io_status_val; }
+
+#define FK_COMMON \
+    .set_nonblocking = fk_set_nb, .set_blocking = fk_set_blocking, \
+    .set_cloexec = fk_set_void, .set_nosigpipe = fk_set_void, \
+    .set_reuseaddr = fk_set_int, .set_reuseport = fk_set_int, \
+    .set_ipv6only = fk_set_int, .set_tcp_nodelay = fk_set_int, .set_cork = fk_set_int, \
+    .socket = fk_socket, .connect = fk_connect, .close = fk_close, \
+    .get_local_addr = fk_get_local, .get_so_error = fk_get_so_error
+
+/* FK_OPS has NO io_status (probe uses the hosted-errno fallback); FK_OPS_IOS
+ * supplies io_status (probe uses it, never errno). */
+static const KlSocketOps FK_OPS     = { FK_COMMON };
+static const KlSocketOps FK_OPS_IOS = { FK_COMMON, .io_status = fk_io_status };
+static const KlSocketProvider FK_PROVIDER =
+    { .ops = &FK_OPS, .context = NULL, .capabilities = KL_SOCK_CAP_NATIVE_FD };
+static const KlSocketProvider FK_PROVIDER_IOS =
+    { .ops = &FK_OPS_IOS, .context = NULL, .capabilities = KL_SOCK_CAP_NATIVE_FD };
+
+/* ── immediate success: connect() rc == 0, no event loop entered ────── */
+UTEST(agent_probe, immediate_success)
+{
+    fk_reset(D_IMMEDIATE);
+    hl_agent_probe_test_provider = &FK_PROVIDER;
+    int r = hl_agent_tcp_probe(39899, 1000);
+    hl_agent_probe_test_provider = NULL;
+    ASSERT_EQ(r, 1);
+    ASSERT_EQ(g_close_n, 1);   /* closed exactly once */
+}
+
+/* ── pending -> succeed via the io_status path ──────────────────────── */
+UTEST(agent_probe, pending_succeed_io_status)
+{
+    fk_reset(D_SUCCEED); ap_arm_watchdog();
+    hl_agent_probe_test_provider = &FK_PROVIDER_IOS;
+    int r = hl_agent_tcp_probe(39899, 1000);
+    hl_agent_probe_test_provider = NULL;
+    ap_disarm_watchdog();
+    ASSERT_EQ(r, 1);
+    ASSERT_EQ(g_close_n, 1);
+}
+
+/* ── pending -> succeed via the hosted-errno fallback (no io_status op) ─ */
+UTEST(agent_probe, pending_succeed_hosted_errno)
+{
+    fk_reset(D_SUCCEED); ap_arm_watchdog();
+    hl_agent_probe_test_provider = &FK_PROVIDER;   /* connect leaves errno = EINPROGRESS */
+    int r = hl_agent_tcp_probe(39899, 1000);
+    hl_agent_probe_test_provider = NULL;
+    ap_disarm_watchdog();
+    ASSERT_EQ(r, 1);
+    ASSERT_EQ(g_close_n, 1);
+}
+
+/* ── pending -> timeout: fd never write-ready, the deadline fires ────── */
+UTEST(agent_probe, pending_timeout)
+{
+    fk_reset(D_PENDING); ap_arm_watchdog();
+    hl_agent_probe_test_provider = &FK_PROVIDER;
+    int r = hl_agent_tcp_probe(39899, 100);   /* 100 ms bound; never writable */
+    hl_agent_probe_test_provider = NULL;
+    ap_disarm_watchdog();
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(g_close_n, 1);
+}
+
+/* ── refusal surfaced by get_so_error after writability ─────────────── */
+UTEST(agent_probe, refusal_via_so_error)
+{
+    fk_reset(D_FAIL); ap_arm_watchdog();
+    hl_agent_probe_test_provider = &FK_PROVIDER_IOS;
+    int r = hl_agent_tcp_probe(39899, 1000);
+    hl_agent_probe_test_provider = NULL;
+    ap_disarm_watchdog();
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(g_close_n, 1);
+}
+
+/* ── hard failure: connect() returns a non-pending error inline ─────── */
+UTEST(agent_probe, immediate_hard_failure)
+{
+    fk_reset(D_HARDFAIL);
+    hl_agent_probe_test_provider = &FK_PROVIDER_IOS;
+    int r = hl_agent_tcp_probe(39899, 1000);
+    hl_agent_probe_test_provider = NULL;
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(g_close_n, 1);   /* no watcher armed, still closed once */
+}
+
+UTEST_MAIN()


### PR DESCRIPTION
Routes the last first-party raw-socket client (`src/hull/agent/request.c`, the
`hull agent request` / `hull agent status` backends) off native Berkeley
sockets onto Keel, completing the Keel-v3 client-transport arc.

## hl_agent_request -> Keel sync HTTP client

Issues its HTTP/1.1 exchange through `kl_http_client_request` (the same blocking
sync client `cap/http.c` uses). Keel owns connect, send, recv, and the
status-line + header parse, so the hand-rolled request builder, recv loop,
status-line scan, and manual CRLF header loop are deleted. The JSON output is
preserved (`status`, `elapsed_ms`, `headers`, `body`); the 5s timeout and 1 MB
response cap carry over via `KlHttpClientConfig`; `elapsed_ms` uses the
monotonic clock; the body write is length-aware (binary-safe, identical to the
former NUL-terminated write for real text/JSON responses).

Compatibility delta (documented in code + covered by e2e): connection failures
changed from the connect-specific `cannot connect to 127.0.0.1:<port>` to the
general `request to 127.0.0.1:<port> failed (error N)` - Keel folds
connect/send/recv/parse into one rc. The message retains the `127.0.0.1:<port>`
context and carries the `KlError` code.

## hl_agent_status -> private KlEventCtx probe

Keeps its pure TCP-connect liveness semantics (no app route or middleware
invoked) but the bounded connect is now driven through Keel's socket provider +
a private `KlEventCtx` `KL_EVENT_WRITE` watcher: nonblocking connect,
classification through the provider `io_status` op with the documented
hosted-errno fallback, and a writability wait bounded by one monotonic deadline.
No raw `poll()` / `errno` event axis remains. The probe lives in
`src/hull/agent/probe.c` (`hl_agent_tcp_probe`) and closes the descriptor
exactly once on every path.

## Build gating

No Makefile behavior change beyond adding `probe.c` to the `HTTP_SERVER=0`
filter: `request.c` is already `HL_ENABLE_HTTP_SERVER`-gated, and `probe.c`
(its sole consumer is `hl_agent_status`) drops with it. At `HTTP_SERVER=0` both
objects are absent and the added Keel references link clean.

## Tests

- `tests/hull/agent/test_agent_probe.c` - deterministic white-box coverage of
  the probe: immediate success, pending-then-succeed via both the `io_status`
  path and the hosted-errno fallback, pending-timeout (fd never write-ready, the
  deadline fires), refusal, and immediate hard-failure - asserting close-once in
  every case. A fake provider hands the probe real socketpair fds the private
  loop can watch; the test-provider hook is absent from the production object.
- `tests/e2e_agent.sh` - unchanged request/status behavior (GET/POST/404,
  `elapsed_ms`, running/not-running, port) plus a new assertion that the
  no-server error retains the `127.0.0.1:<port>` context.

## Local verification

- Default build clean; `test_agent_probe` 6/6; `e2e_agent` 62/62.
- `HL_ENABLE_HTTP_SERVER=0` link-drop clean (both `request.o` and `probe.o`
  absent).
- No raw Berkeley socket syscall remains in either file; prose gates clean.