### PR TITLE
EXPERIMENT (do not merge): are the LTO/CFI builds broken on main?

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1346,6 +1346,14 @@ jobs:
           # that stb is fully unlinked.
           - name: image-less (no image codecs)
             flags: HL_ENABLE_IMAGE=0
+          # EXPERIMENT (do not merge): does the LTO configuration fail on main,
+          # i.e. WITHOUT the Keel flag-propagation change in #463? Neither
+          # configuration has ever been built in CI, so "my change broke it"
+          # and "it was already broken" look identical from #463 alone.
+          - name: LTO
+            flags: HL_ENABLE_LTO=1
+          - name: LTO + CFI (clang)
+            flags: CC=clang HL_ENABLE_CFI=1
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:


### PR DESCRIPTION
**Do not merge. Diagnostic only — will be closed once it answers the question.**

#463 added `LTO` and `LTO + CFI (clang)` to the flavors matrix and both failed. Neither configuration had ever been built in CI, so from #463 alone two explanations are indistinguishable:

- the Keel flag-propagation change broke them, or
- they were already broken and #463 merely became the first thing to look.

This branch is `main` **plus only the two matrix entries** — no submodule bump, no `KEEL_OPT` wiring, no propagation gate. Verified: one file changed, `vendor/keel` still pinned at `54ad7508`, `KEEL_OPT` absent from `mk/vendor/keel.mk`.

If both fail here, the defects are pre-existing and belong in their own issue rather than in #463.

The two errors from #463, for comparison:

**LTO (gcc):** `491 × undefined reference to kl_*`, with `AR=/usr/bin/llvm-ar-18` archiving gcc `-flto` bitcode. `HL_LTO_AR` (`Makefile:485`) probes only for `llvm-ar*`; there is no `gcc-ar` in the list.

**LTO + CFI (clang):**
```
/usr/bin/ld: relocation R_X86_64_8 against hidden symbol
             `__typeid__ZTSFiPvPKcmE_align' can not be used when making a PIE object
```
CFI's typeid symbols need `lld`; `fuse-ld` appears nowhere in the build system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013crBdW6cEF5Q2xuASxeivL