### PR TITLE
ci+docs: retry the Windows wedge, and draft the upstream cosmocc report (#462)

### DIFF
--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -79,9 +79,19 @@ name: Windows source build (cosmocc, -O0)
 # clause has now been exercised: see HANG below.
 #
 # HANG - OPEN, INTERMITTENT, NOT UNDERSTOOD.
-#   The build wedges roughly 1 run in 4: the compiler stops emitting output
-#   entirely and accumulates no CPU. Three signatures captured so far, and they
-#   do NOT all share a cause:
+#   MEASURED (#462, probe runs 34112570526 and 34114442514): cosmocc's cc1
+#   blocks indefinitely at ~0 CPU on about 12% of compiles of a LARGE
+#   translation unit. That is a cosmocc-on-Windows bug, not a Hull one. It
+#   needs neither parallelism (-j1 wedges too) nor MSYS2's temp directory
+#   (relocating it changed nothing, 4/10 vs 2/10, p=0.63). Established over 250
+#   solo compiles of vendor/sqlite/sqlite3.c with nothing else running;
+#   vendor/quickjs/quickjs.c wedges identically, and this file's own -O0 note
+#   below recorded the same thing about quickjs.c long before it was measured.
+#
+#   The build step therefore RETRIES a stall (up to 3 attempts), which is a
+#   mitigation for someone else's bug rather than cover for one of ours.
+#
+#   Historical signatures, kept because they show how the picture changed:
 #
 #     a) miniz at -O2 (run 34035825889) - CAUSED by HL_OPT never reaching the
 #        Keel sub-make. Deterministic. Fixed properly in hull#461: Keel now
@@ -399,62 +409,100 @@ jobs:
           # hardcoded -O2 before it existed). See the HL_OPT block in Makefile.
           echo "using MAKE_BIN=${MAKE_BIN:-<unset>} AR=${AR:-<unset>}"
 
-          # WATCHDOG. This build wedges intermittently (~1 run in 4) with the
-          # compiler at ~0 CPU and no further output - see the HANG section in
-          # the header, and issue #462. Left to the job timeout, a hang costs
-          # 45 minutes and yields nothing but "cancelled" - which is how two
-          # hangs already went by without leaving any evidence.
+          # WATCHDOG + RETRY.
           #
-          # So: run make in the background and watch its output file. A healthy
-          # build emits a line every fraction of a second and finishes in ~3
-          # minutes, so several minutes of TOTAL silence is unambiguous. On a
-          # stall, dump the tail plus a process snapshot with command lines and
-          # CPU deltas (the one measurement that separates "blocked" from
-          # "spinning") and fail fast instead of burning the runner.
+          # The wedge is a TOOLCHAIN bug, not a Hull one, and it is now measured
+          # (#462): cosmocc's cc1 blocks indefinitely at ~0 CPU compiling large
+          # translation units on Windows, about 12% of the time PER large-TU
+          # compile. Established by 250 solo compiles of vendor/sqlite/sqlite3.c
+          # with nothing else running - so it needs neither concurrency (-j1
+          # still wedges) nor MSYS2's temp directory (relocating it changed
+          # nothing). vendor/quickjs/quickjs.c wedges the same way.
+          #
+          # Retrying is therefore the honest mitigation rather than papering
+          # over our own defect: make resumes from the objects already built, so
+          # a retry costs a fraction of a build, and at ~30% per build three
+          # attempts leave roughly 3% residual failure.
+          #
+          # A retry is applied ONLY to a stall. A genuine compile error fails
+          # immediately - retrying that would just hide it.
           stall_limit=${HULL_STALL_LIMIT_SECS:-300}
           poll=15
+          attempts=${HULL_BUILD_ATTEMPTS:-3}
           log=build-output.log
 
-          "$MAKE_BIN" CC=cosmocc AR="$AR" HL_OPT=-O0 HL_ENABLE_WASM=0 -j2 > "$log" 2>&1 &
-          mk=$!
+          # Kill anything the wedge left holding files, or the next attempt
+          # inherits a stuck cc1 still sitting on its output.
+          kill_stragglers() {
+            powershell.exe -NoProfile -Command \
+              "Get-Process cc1,cc1plus,cosmocc,'*cosmo-gcc' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue" \
+              >/dev/null 2>&1 || true
+          }
 
-          last_size=0
-          stalled=0
-          while kill -0 "$mk" 2>/dev/null; do
-            sleep "$poll"
-            size=$(wc -c < "$log" 2>/dev/null || echo 0)
-            if [ "$size" -eq "$last_size" ]; then
-              stalled=$((stalled + poll))
-            else
-              stalled=0
-              last_size=$size
-            fi
-            if [ "$stalled" -ge "$stall_limit" ]; then
-              echo ""
-              echo "=========================================================="
-              echo "BUILD STALLED: no output for ${stalled}s (limit ${stall_limit}s)"
-              echo "=========================================================="
-              echo "--- last 25 lines of build output ---"
-              tail -25 "$log" || true
-              echo ""
-              # PowerShell is the only thing here that can see a Windows
-              # process's command line and cumulative CPU.
-              powershell.exe -NoProfile -ExecutionPolicy Bypass \
-                -File "$(cygpath -w .github/scripts/dump-stuck-build.ps1)" \
-                -IntervalSeconds 5 || true
-              kill "$mk" 2>/dev/null || true
-              exit 1
-            fi
+          build_once() {
+            : > "$log"
+            "$MAKE_BIN" CC=cosmocc AR="$AR" HL_OPT=-O0 HL_ENABLE_WASM=0 -j2 > "$log" 2>&1 &
+            mk=$!
+            last_size=0
+            stalled=0
+            while kill -0 "$mk" 2>/dev/null; do
+              sleep "$poll"
+              size=$(wc -c < "$log" 2>/dev/null || echo 0)
+              if [ "$size" -eq "$last_size" ]; then
+                stalled=$((stalled + poll))
+              else
+                stalled=0
+                last_size=$size
+              fi
+              if [ "$stalled" -ge "$stall_limit" ]; then
+                echo ""
+                echo "=========================================================="
+                echo "BUILD STALLED: no output for ${stalled}s (limit ${stall_limit}s)"
+                echo "=========================================================="
+                echo "--- last 25 lines of build output ---"
+                tail -25 "$log" || true
+                echo ""
+                # PowerShell is the only thing here that can see a Windows
+                # process's command line and cumulative CPU. dcpu ~0 on the
+                # stuck compiler is the signature of this wedge; a non-zero
+                # delta would mean something else is going on and the retry
+                # below is the wrong response.
+                powershell.exe -NoProfile -ExecutionPolicy Bypass \
+                  -File "$(cygpath -w .github/scripts/dump-stuck-build.ps1)" \
+                  -IntervalSeconds 5 || true
+                kill "$mk" 2>/dev/null || true
+                kill_stragglers
+                return 2
+              fi
+            done
+            rc=0
+            wait "$mk" || rc=$?
+            [ "$rc" -eq 0 ] || return 1
+            return 0
+          }
+
+          attempt=1
+          while : ; do
+            echo "--- build attempt $attempt of $attempts ---"
+            set +e
+            build_once
+            outcome=$?
+            set -e
+            case "$outcome" in
+              0) echo "build ok on attempt $attempt"; break ;;
+              1) echo "FAIL compile error (not a stall) - not retrying"; tail -25 "$log"; exit 1 ;;
+              2) if [ "$attempt" -ge "$attempts" ]; then
+                   echo "FAIL wedged on all $attempts attempts (see #462)"
+                   exit 1
+                 fi
+                 echo "wedged; retrying (make resumes from existing objects)"
+                 attempt=$((attempt + 1))
+                 ;;
+            esac
           done
 
-          # `wait` reports the child's status; set -e must not pre-empt it.
-          set +e
-          wait "$mk"; rc=$?
-          set -e
           cat "$log"
-          [ "$rc" -eq 0 ] || { echo "FAIL make exited $rc"; exit 1; }
-
-          # Never trust the exit status alone - assert the artifact.
+          # Never trust the exit status alone here - assert the artifact.
           test -f build/hull || { echo "FAIL build/hull was not produced"; exit 1; }
           ls -la build/hull
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,7 @@ specific signature, parameter list, or return value.
 | [`release_acceptance_v0.14.0.md`](release_acceptance_v0.14.0.md) | Durable v0.14.0 acceptance record: release tag/commit, published binary SHA-256s, environment assertions, and each smoke result (self-contained after the Actions artifacts expire). |
 | [`windows_install.md`](windows_install.md) | User-facing Windows install guide: `install.ps1` quick start, options, verification, uninstall, and the one-time v0.13.0 -> v0.14.0 upgrade. |
 | [`windows_install_design.md`](windows_install_design.md) | Windows-native install/upgrade/verify/remove UX design: the explicit trust model, the user-local install dir + PATH convention, the `install.ps1` CLI contract, Winget/Scoop shape, and the Authenticode-on-APE experiment plan. |
+| [`cosmocc_windows_wedge_upstream_report.md`](cosmocc_windows_wedge_upstream_report.md) | Draft upstream report for the intermittent cosmocc-on-Windows `cc1` hang: reproducer, the ~12% per-large-TU rate, the CPU-delta evidence that it is blocked rather than spinning, and the hypotheses ruled out by measurement (temp dir, parallelism, one bad file, arch). Hull-side tracking in issue #462. |
 | [`sbom.md`](sbom.md) | The SBOM subsystem (human / JSON / CycloneDX / SPDX formats). |
 | [`compiler_free_build.md`](compiler_free_build.md) | The object-emitter path: `hull build` needs only a linker (no C compiler). |
 | [`toolchain_free_build.md`](toolchain_free_build.md) | Linker-as-tool + cross-compilation (`--linker=zig`), the musl static-link floors. |

--- a/docs/cosmocc_windows_wedge_upstream_report.md
+++ b/docs/cosmocc_windows_wedge_upstream_report.md
@@ -1,0 +1,111 @@
+# cosmocc on Windows: cc1 blocks indefinitely on large translation units
+
+Draft of an upstream report for [jart/cosmopolitan](https://github.com/jart/cosmopolitan),
+kept in-tree so the measurements have a home and the numbers do not have to be
+re-derived. Tracked on the Hull side as
+[hull#462](https://github.com/artalis-io/hull/issues/462).
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+---
+
+## Summary
+
+Compiling a large C translation unit with `cosmocc` on Windows intermittently
+hangs. `cc1` stops making progress and sits at **~0% CPU indefinitely** while
+holding an open temporary output file. It is not an ICE, not an error, and not
+a slow compile: the process simply blocks and never returns.
+
+Measured rate: **about 12% per compile of a large TU.**
+
+## Environment
+
+| | |
+|---|---|
+| cosmocc | 4.0.2 (`cosmocc-4.0.2.zip`, SHA-256 `85b8c37a406d862e656ad4ec14be9f6ce474c1b436b9615e91a55208aced3f44`) |
+| Host | GitHub Actions `windows-latest` (Windows Server 2025, image `windows-2025-vs2026`) |
+| Shell | MSYS2 (`msys2/setup-msys2`, `msystem: MSYS`), GNU Make 4.4.1 from MSYS2 |
+| Optimization | `-O0` (the hang also motivated using `-O0`; it is not optimization-dependent) |
+
+## Reproducer
+
+The Hull tree vendors the SQLite amalgamation. Compiling that one file, alone,
+is enough:
+
+```sh
+cosmocc -std=c11 -O0 -w -DSQLITE_THREADSAFE=1 -DSQLITE_ENABLE_FTS5 \
+        -Ivendor/sqlite -c -o build/sqlite3.o vendor/sqlite/sqlite3.c
+```
+
+Roughly 1 invocation in 8 never returns. Any sufficiently large TU seems to do
+it: `vendor/quickjs/quickjs.c` hangs the same way.
+
+## Evidence
+
+A watchdog fires after 120s of no output and samples every build process twice,
+5 seconds apart, reporting cumulative CPU and the delta between samples:
+
+```
+WEDGED after 120s of silence
+pid=5744 ppid=7140 cc1  cpu=3.42s  dcpu=0.01s  rss=219.4MB
+    cmd: ...\libexec\gcc\aarch64-linux-cosmo\14.1.0\cc1 -quiet -nostdinc
+         -I vendor/sqlite -imultiarch aarch64-linux-cosmo ...
+         vendor/sqlite/sqlite3.c -quiet -dumpdir build/.aarch64/
+         -dumpbase sqlite3.c ... -O0 -std=c11 -fportcosmo ...
+         -o D:\a\_temp\msys64\tmp\ccfs5cmy.s
+pid=7140 ppid=5396 aarch64-linux-cosmo-gcc  cpu=0.09s  dcpu=0s
+pid=8512 ppid=500  make.exe                 cpu=0.66s  dcpu=0.04s
+```
+
+`dcpu=0.01s` over a 5-second window is the key measurement: **`cc1` is blocked,
+not spinning.** It has accumulated only 3-7s of CPU and then stops, consistently
+at roughly the same point.
+
+## What has been ruled out
+
+Each of these was tested rather than reasoned about, on the same runner image,
+with both arms in a single dispatch:
+
+| Hypothesis | Test | Result |
+|---|---|---|
+| Optimizer or codegen blow-up | CPU delta while wedged | **No.** `dcpu ~ 0`; a blow-up would burn CPU. |
+| MSYS2 temp directory | 10 runs with `TMPDIR`/`TMP`/`TEMP` relocated off the MSYS2 tree, vs 10 without | **No.** 2/10 vs 4/10, Fisher exact two-tailed p=0.63. Relocating did not eliminate it. |
+| Parallel-make contention | 10 full builds at `-j1` | **No.** Still 2/10. |
+| Needs a big build around it | 250 compiles of `sqlite3.c` alone, nothing else running | **No.** 10/10 jobs wedged. |
+| One bad source file | which TU each wedge was on | **No.** `sqlite3.c` and `quickjs.c` both. |
+| Architecture-specific | arch of the stuck `cc1` | **No.** Both `x86_64-linux-cosmo` and `aarch64-linux-cosmo`. |
+
+## Rate measurement
+
+250 solo compiles across 10 parallel jobs, each looping until it wedged:
+
+```
+first wedge at iteration: 1, 1, 2, 2, 3, 8, 11, 13, 19, 23
+mean 8.3 iterations
+```
+
+A geometric distribution with p = 0.12 has mean 1/p = 8.3, so the observed
+mean matches a constant ~12% per-compile probability closely.
+
+At the whole-build level (one `sqlite3.c` plus one `quickjs.c` compile, `-j2`)
+this shows up as roughly 30% of builds hanging: 6/20 observed.
+
+## What would help
+
+Anything that narrows where `cc1` is blocking would be more useful than more
+sampling from outside. Specifically:
+
+- whether the temporary `.s` output path is implicated (the block is observed
+  while `cc1` holds it open);
+- whether this is known behaviour of the Windows port of the GCC used by
+  cosmocc 4.0.2, or specific to the cosmo build of it;
+- whether a newer cosmocc changes the rate.
+
+Happy to run further arms on request: the probe harness takes an arm name and
+returns 10 to 250 samples within about half an hour.
+
+## Workaround in use
+
+Retrying the build on a stall. `make` resumes from the objects already
+completed, so a retry costs a fraction of a build, and three attempts leave
+roughly 3% residual failure. This is a mitigation, not a fix.

--- a/docs/windows_install.md
+++ b/docs/windows_install.md
@@ -167,12 +167,19 @@ and is not the same configuration CI exercises.
 
 > **This build wedges intermittently, roughly 1 run in 3.** The compiler stops
 > emitting output and sits at ~0 CPU indefinitely. It is not a hang in *your*
-> setup and not something the flags above avoid: it is an open defect, tracked
-> in [#462](https://github.com/artalis-io/hull/issues/462), and it has been seen
-> on three different translation units. If a build goes silent for several
-> minutes, interrupt it and re-run. `make` resumes from the objects already
-> built, so a retry is cheap. CI catches this with a watchdog that fails after
-> five minutes of silence rather than waiting out the job timeout.
+> setup, and no flag above avoids it: it is a **cosmocc bug on Windows**, not a
+> Hull one, tracked in [#462](https://github.com/artalis-io/hull/issues/462).
+>
+> Measured: `cc1` blocks on about **12% of compiles of a large translation
+> unit** (established over 250 solo compiles of `vendor/sqlite/sqlite3.c`;
+> `vendor/quickjs/quickjs.c` does the same). It needs neither parallelism
+> (`-j1` wedges too) nor any particular temp directory (relocating it changed
+> nothing).
+>
+> **If a build goes silent for several minutes, interrupt it and re-run.**
+> `make` resumes from the objects already built, so a retry costs a fraction of
+> a build, and the odds of wedging twice in a row are small. CI does exactly
+> this automatically, retrying a stall up to three times.
 
 This path is exercised in CI by `.github/workflows/windows-source-build.yml`,
 whose header carries the full evidence and history.


### PR DESCRIPTION
#462 is now **measured**, and the cause is outside Hull.

## What the probes established

Two dispatches, both arms in the same run on the same image ([34112570526](https://github.com/artalis-io/hull/actions/runs/34112570526), [34114442514](https://github.com/artalis-io/hull/actions/runs/34114442514)):

| Hypothesis | Test | Result |
|---|---|---|
| Optimizer/codegen blow-up | CPU delta while wedged | **No** — `dcpu ~ 0`, blocked not spinning |
| MSYS2 temp directory | 10 relocated vs 10 not | **No** — 2/10 vs 4/10, Fisher p=0.63, and it did not eliminate the wedge |
| Parallel-make contention | 10 full builds at `-j1` | **No** — still 2/10 |
| Needs a big build around it | 250 solo compiles of `sqlite3.c` | **No** — 10/10 jobs wedged with nothing else running |
| One bad source file | TU from each stuck `cc1`'s argv | **No** — `quickjs.c` wedges identically |
| Architecture-specific | arch of the stuck `cc1` | **No** — x86_64 and aarch64 both |

**Rate: ~12% per large-TU compile.** First wedge at iterations 1, 1, 2, 2, 3, 8, 11, 13, 19, 23 — mean 8.3, matching a geometric distribution at p=0.12.

Worth noting this file's own `-O0` comment recorded cosmocc hanging on `quickjs.c` **before** any of it was measured. The measurement confirms a pre-existing observation rather than discovering something new.

## Retry-on-stall

Since the bug is in the toolchain, retrying is a mitigation rather than cover for one of our own defects — which is why it was the wrong move earlier and is the right one now.

- Retries a **stall** up to 3 attempts. `make` resumes from completed objects, so a retry costs a fraction of a build; at ~30% per build, three attempts leave roughly 3% residual.
- A **genuine compile error is not retried** — that would hide it.
- Stragglers are killed between attempts so a stuck `cc1` cannot hold its output across the next one.

Verified against a stubbed `build_once` covering all three outcomes: wedge-then-success retries and succeeds; compile error fails immediately; wedging every time exhausts attempts and fails.

## Docs

The user-facing warning now names cosmocc as the cause, gives the 12% figure, and says the odds of wedging twice running are small — instead of leaving a reader to wonder whether their setup is broken.

## Upstream draft

`docs/cosmocc_windows_wedge_upstream_report.md` holds the report for [jart/cosmopolitan](https://github.com/jart/cosmopolitan), kept in-tree so the measurements outlive CI log retention. It leads with what was ruled out **by measurement**, states the rate with its derivation, and offers to run further arms since the probe harness makes 10-250 samples cheap.

Every figure was re-derived from the run data before committing rather than copied from my own earlier prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013crBdW6cEF5Q2xuASxeivL