### PR TITLE
fix: isolate JS manifest extraction in a child process (#427)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -859,6 +859,21 @@ jobs:
           grep -q "e2e_modular_resolution: ALL PASS" modres.log \
             || { echo "::error::modular resolution e2e did not reach ALL PASS"; exit 1; }
 
+      - name: JS manifest-extraction isolation E2E (#427, must NOT skip)
+        timeout-minutes: 8
+        run: |
+          set -o pipefail
+          # Run the script DIRECTLY, not `make ...`: any bare `make` here trips
+          # the config sentinel and clobbers the embedded hull the build needs.
+          sh tests/e2e_manifest_extract_isolation.sh 2>&1 | tee mextract.log
+          rc=${PIPESTATUS[0]}
+          [ "$rc" -eq 0 ] || { echo "::error::manifest-extraction isolation e2e failed (rc=$rc)"; exit "$rc"; }
+          if grep -qE '\bSKIP\b' mextract.log; then
+            echo "::error::isolation e2e skipped - it must run on this JS-enabled build"; exit 1
+          fi
+          grep -q "e2e_manifest_extract_isolation: ALL PASS" mextract.log \
+            || { echo "::error::isolation e2e did not reach ALL PASS"; exit 1; }
+
       - name: Compute AOT shared-heap E2E (spans + segments, must NOT skip)
         timeout-minutes: 12
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1184,9 +1184,17 @@ ifeq ($(HL_ENABLE_HTTP_SERVER),0)
       $(SRCDIR)/hull/commands/mcp.c, \
       $(CMD_SRCS))
 endif
+# `hull __extract-manifest-js` is the isolated child that reads a .js app's
+# manifest (#427). Without a JS runtime there is nothing for it to run.
+#
+# Two ways to have no JS, and they are NOT the same variable: HL_ENABLE_JS=0
+# drops it wholesale, while RUNTIME=lua leaves HL_ENABLE_JS at its default 1
+# and merely omits -DHL_ENABLE_JS from CFLAGS (see the runtime selection
+# above). Keying on HL_ENABLE_JS alone missed the RUNTIME=lua build.
 ifeq ($(HL_ENABLE_JS),0)
-  # `hull __extract-manifest-js` is the isolated child that reads a .js app's
-  # manifest (#427). Without a JS runtime there is nothing for it to run.
+  CMD_SRCS := $(filter-out $(SRCDIR)/hull/commands/extract_manifest_js.c,$(CMD_SRCS))
+endif
+ifeq ($(RUNTIME),lua)
   CMD_SRCS := $(filter-out $(SRCDIR)/hull/commands/extract_manifest_js.c,$(CMD_SRCS))
 endif
 CMD_OBJS := $(patsubst $(SRCDIR)/hull/commands/%.c,$(BUILDDIR)/cmd_%.o,$(CMD_SRCS))

--- a/Makefile
+++ b/Makefile
@@ -1184,6 +1184,11 @@ ifeq ($(HL_ENABLE_HTTP_SERVER),0)
       $(SRCDIR)/hull/commands/mcp.c, \
       $(CMD_SRCS))
 endif
+ifeq ($(HL_ENABLE_JS),0)
+  # `hull __extract-manifest-js` is the isolated child that reads a .js app's
+  # manifest (#427). Without a JS runtime there is nothing for it to run.
+  CMD_SRCS := $(filter-out $(SRCDIR)/hull/commands/extract_manifest_js.c,$(CMD_SRCS))
+endif
 CMD_OBJS := $(patsubst $(SRCDIR)/hull/commands/%.c,$(BUILDDIR)/cmd_%.o,$(CMD_SRCS))
 
 # Helpers shared by every runtime cache module (arch/endian tag,
@@ -2799,8 +2804,10 @@ $(BUILDDIR)/manifest_js.o: $(SRCDIR)/hull/manifest_js.c $(SRCDIR)/hull/manifest_
 # transient HlJS to read app.manifest({...}) from a .js entry point.
 # Lives outside the manifest_lua/manifest_js split because it ties the
 # JS extractor to a file-on-disk + transient-runtime workflow, not the
-# pre-existing "runtime is already running" extractor flow.
-$(BUILDDIR)/manifest_extract_file.o: $(SRCDIR)/hull/manifest_extract_file.c $(INCDIR)/hull/manifest_extract_file.h | $(BUILDDIR)
+# pre-existing "runtime is already running" extractor flow. Since #427 it
+# also owns the PARENT side of the isolated-child extraction, so it pulls in
+# cap/tool.h (spawn) and release_io.h (self-path).
+$(BUILDDIR)/manifest_extract_file.o: $(SRCDIR)/hull/manifest_extract_file.c $(INCDIR)/hull/manifest_extract_file.h $(INCDIR)/hull/cap/tool.h $(INCDIR)/hull/release_io.h | $(BUILDDIR)
 	$(CC) $(CFLAGS) $(INCLUDES) -c -o $@ $<
 
 # Module registry - canonical sorted table of first-party modules

--- a/include/hull/cap/tool.h
+++ b/include/hull/cap/tool.h
@@ -81,6 +81,33 @@ int hl_tool_spawn(const char *const argv[]);
  */
 int hl_tool_spawn_env(const char *const argv[], const char *const envadd[]);
 
+/** @brief hl_tool_spawn_self(): the child could not be started at all. */
+#define HL_TOOL_SPAWN_NOSTART (-2)
+
+/**
+ * @brief Re-exec the binary that is currently running.
+ *
+ * Unlike hl_tool_spawn(), this does NOT consult the compiler allowlist. That
+ * allowlist bounds which EXTERNAL programs a build may execute; re-running the
+ * process that is already running grants no authority it does not already
+ * have, and the allowlist cannot express it anyway - hull ships under several
+ * names (`hull`, `hull.com` on Windows, `hull-cosmo.exe` in CI), none of which
+ * the exact-or-`-<digit>` match admits. Argument validation still applies.
+ *
+ * Used by JS manifest extraction (issue #427), which runs the transient
+ * QuickJS runtime in a child so a teardown abort cannot kill `hull build`.
+ *
+ * @param argv NULL-terminated argv. argv[0] MUST be a resolved path to this
+ *             binary (from hl_release_io_self_path, else the caller's argv[0]):
+ *             the cosmo path uses posix_spawn, which does no PATH search.
+ * @return The child's exit status; -1 if it started but did not exit normally
+ *         (killed by a signal); #HL_TOOL_SPAWN_NOSTART if it never started.
+ *         The caller MUST distinguish the last two: retrying an aborted run
+ *         in-process reproduces the crash the child exists to contain, while
+ *         refusing to retry one that never started breaks builds for no reason.
+ */
+int hl_tool_spawn_self(const char *const argv[]);
+
 /*
  * Drive an allowlisted compiler @p driver THROUGH a POSIX shell @p shell,
  * running `<shell> [sh] -c 'exec "$0" "$@"' <driver> <args...>` (the "sh"

--- a/include/hull/commands/extract_manifest_js.h
+++ b/include/hull/commands/extract_manifest_js.h
@@ -1,0 +1,20 @@
+/**
+ * @file commands/extract_manifest_js.h
+ * @brief `hull __extract-manifest-js` - INTERNAL, not a user-facing verb.
+ *
+ * The isolated child half of JS manifest extraction (issue #427). Spawned
+ * by hl_manifest_extract_js_from_file(); never typed by a user, never listed
+ * in `hull help` or the shell completions.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#ifndef HL_COMMANDS_EXTRACT_MANIFEST_JS_H
+#define HL_COMMANDS_EXTRACT_MANIFEST_JS_H
+
+#include "hull/commands/dispatch.h"
+
+/** @brief Entry point - invoked by the command dispatcher. */
+int hl_cmd_extract_manifest_js(int argc, char **argv, const HlCommandEnv *env);
+
+#endif /* HL_COMMANDS_EXTRACT_MANIFEST_JS_H */

--- a/include/hull/manifest_extract_file.h
+++ b/include/hull/manifest_extract_file.h
@@ -24,14 +24,31 @@
 
 /**
  * @brief Load a `.js` app, JSON-stringify its declared manifest, and
- *        return a heap-allocated copy.
+ *        return a heap-allocated copy - in an ISOLATED CHILD PROCESS.
  *
- * Spins up a transient HlJS, runs the file (which triggers the app's
- * `app.manifest({...})` call), reads `globalThis.__hull_manifest`, and
- * serializes it via `JSON.stringify`. Tears the runtime down on every
- * exit path.
+ * Runs the extraction by re-execing `hull __extract-manifest-js` and
+ * reading the result back from a temp file. The isolation exists because
+ * a transient QuickJS runtime can abort the WHOLE PROCESS during teardown
+ * on an app that leaves a self-referential pending microtask: the cycle
+ * collector in `JS_FreeRuntime` double-frees the promise resolver and the
+ * allocator raises SIGABRT (issue #427). In-process that kills `hull build`
+ * with no diagnostic; in a child it is contained.
+ *
+ * The child writes its result BEFORE tearing its runtime down, so a
+ * teardown abort still yields a usable manifest and the build SUCCEEDS
+ * rather than merely failing cleanly.
+ *
+ * A child that cannot be launched at all (no resolvable `hull` path, spawn
+ * refused) falls back to running in-process, which is exactly the old
+ * behaviour - isolation is best-effort hardening, never a new way to fail.
+ * A child that DID launch is never retried in-process: that would re-run
+ * the very abort the isolation exists to contain.
  *
  * @param path         Filesystem path to the JS entry point.
+ * @param hull_exe     Path to the running `hull` binary, for the re-exec
+ *                     (the tool VM's `__hull_exe`). NULL is allowed and
+ *                     selects the in-process fallback when the platform
+ *                     cannot resolve its own path (cosmo has no /proc).
  * @param out_json     On success: receives a malloc'd UTF-8 JSON string.
  *                     Caller frees with `free()`. On "no manifest declared"
  *                     receives NULL with no allocation. On error, undefined.
@@ -48,8 +65,48 @@
  * macro themselves before invoking.
  */
 int hl_manifest_extract_js_from_file(const char *path,
+                                       const char *hull_exe,
                                        char **out_json,
                                        size_t *out_json_len,
                                        char **out_err);
+
+/**
+ * @brief The extraction itself, run IN THIS PROCESS.
+ *
+ * Same contract as hl_manifest_extract_js_from_file() minus @p hull_exe.
+ * This is the half that spins up the transient HlJS, and therefore the
+ * half that can abort during QuickJS teardown (issue #427).
+ *
+ * Two callers, both deliberate:
+ *   - `hull __extract-manifest-js` (the isolated child), and
+ *   - hl_manifest_extract_js_from_file()'s fallback when no child could
+ *     be launched.
+ * Everything else must go through hl_manifest_extract_js_from_file().
+ *
+ * @param early_result_path  When non-NULL, the outcome is written there via
+ *        hl_manifest_extract_write_result() BEFORE the JS runtime is torn
+ *        down. That ordering is the whole point: teardown is where QuickJS
+ *        aborts, and by then the manifest is already safely on disk. Pass
+ *        NULL when the caller consumes the return value directly.
+ */
+int hl_manifest_extract_js_in_process(const char *path,
+                                       const char *early_result_path,
+                                       char **out_json,
+                                       size_t *out_json_len,
+                                       char **out_err);
+
+/**
+ * @brief Write one extraction outcome to @p out_path.
+ *
+ * Format is a single header line then the payload verbatim:
+ *   "HULLMANIFEST1 <status>" then a newline then the payload; status is one
+ *   of `ok` / `none` / `err`.
+ * The magic lets the reader tell a real result from a file the child never
+ * finished writing.
+ *
+ * @return 0 on success; -1 on any write failure (the partial file is removed).
+ */
+int hl_manifest_extract_write_result(const char *out_path, const char *status,
+                                     const char *payload, size_t payload_len);
 
 #endif /* HL_MANIFEST_EXTRACT_FILE_H */

--- a/include/hull/manifest_extract_file.h
+++ b/include/hull/manifest_extract_file.h
@@ -100,9 +100,12 @@ int hl_manifest_extract_js_in_process(const char *path,
  *
  * Format is a single header line then the payload verbatim:
  *   "HULLMANIFEST1 <status>" then a newline then the payload; status is one
- *   of `ok` / `none` / `err`.
- * The magic lets the reader tell a real result from a file the child never
- * finished writing.
+ *   of `start` / `ok` / `none` / `err`.
+ * `start` is written by the child on entry, before anything can abort, and is
+ * overwritten by the real result. It is what lets the parent tell a child that
+ * never launched (no file at all) from one that launched and died mid-run -
+ * a distinction the spawn exit status cannot make, since a signal death and a
+ * failed fork are both -1.
  *
  * @return 0 on success; -1 on any write failure (the partial file is removed).
  */

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -1421,6 +1421,13 @@ e2e-validate-parity: $(BUILDDIR)/hull
 e2e-modular-resolution: $(BUILDDIR)/hull
 	sh tests/e2e_modular_resolution.sh
 
+# JS manifest extraction is isolated in a child process (#427): a QuickJS
+# teardown abort must not reach `hull build`. Needs an embedded hull, so CI
+# runs it in the same job as e2e-modular-resolution, after EMBED_PLATFORM=1.
+.PHONY: e2e-manifest-extract-isolation
+e2e-manifest-extract-isolation: $(BUILDDIR)/hull
+	sh tests/e2e_manifest_extract_isolation.sh
+
 .PHONY: e2e-path-parity
 e2e-path-parity: $(BUILDDIR)/hull
 	sh tests/e2e_path_parity.sh

--- a/src/hull/cap/tool.c
+++ b/src/hull/cap/tool.c
@@ -27,7 +27,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>   /* strcasecmp - Windows tool names vary in case */
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -155,33 +154,9 @@ int hl_tool_check_allowlist(const char *binary)
 {
     if (!binary) return -1;
 
-    /* Extract basename. Split on BOTH separators: a cosmo APE reaches Windows,
-     * where an argv[0] or a resolved tool path is "C:\path\hull.com". */
-    const char *base = binary;
-    for (const char *c = binary; *c; c++)
-        if (*c == '/' || *c == '\\') base = c + 1;
-
-    /* Drop a host executable suffix before matching. The same tool is `cc` on
-     * POSIX and `cc.exe` on Windows, and hull itself installs as `hull.com`
-     * (the APE convention - see install.ps1 and hl_host_exe_suffix). Without
-     * this every allowlisted tool is denied on Windows, because the match below
-     * accepts only an exact name or a `-<digit>` version suffix.
-     *
-     * Narrow by construction: only these two suffixes, only trailing, and only
-     * the SUFFIX is removed - the remaining name still has to be on the list,
-     * so this admits no name that was not already allowed. */
-    char stripped[64];
-    size_t blen = strlen(base);
-    for (const char **sfx = (const char *[]){ ".com", ".exe", NULL }; *sfx; sfx++) {
-        size_t slen = strlen(*sfx);
-        if (blen > slen && blen - slen < sizeof(stripped) &&
-            strcasecmp(base + blen - slen, *sfx) == 0) {
-            memcpy(stripped, base, blen - slen);
-            stripped[blen - slen] = '\0';
-            base = stripped;
-            break;
-        }
-    }
+    /* Extract basename */
+    const char *base = strrchr(binary, '/');
+    base = base ? base + 1 : binary;
 
     for (const char **p = allowed_prefixes; *p; p++) {
         size_t plen = strlen(*p);
@@ -708,6 +683,65 @@ static int cosmocc_reroute_read(const char *const argv[],
     return 1;
 }
 #endif  /* __COSMOPOLITAN__ */
+
+/* Re-exec the RUNNING binary. See the header for why this does not consult
+ * the tool allowlist.
+ *
+ * Spawns inline rather than reusing spawn_and_wait / cosmo_spawn_wait because
+ * those collapse "could not start" and "died on a signal" into the same -1,
+ * and the caller must tell them apart: retrying an ABORTED extraction in-process
+ * would reproduce the very crash the child exists to contain (#427), while
+ * refusing to retry one that never started would break builds for no reason.
+ *
+ * On cosmo this takes the posix_spawn path rather than fork()+execvp(): cosmo's
+ * emulated fork is the mechanism Hull already had to route around on Windows
+ * (see cosmo_spawn_wait), and posix_spawn maps to a direct CreateProcess. That
+ * is also why argv[0] must be a real path - posix_spawn does no PATH search. */
+int hl_tool_spawn_self(const char *const argv[])
+{
+    if (!argv || !argv[0] || !*argv[0]) return HL_TOOL_SPAWN_NOSTART;
+    if (hl_tool_validate_args(argv) != 0) {
+        ShJsonWriter w = hl_audit_begin("tool.spawn_self");
+        sh_json_write_kv_string(&w, "argv0", argv[0]);
+        sh_json_write_kv_string(&w, "result", "denied");
+        hl_audit_end(&w);
+        return HL_TOOL_SPAWN_NOSTART;
+    }
+
+    pid_t pid;
+#ifdef __COSMOPOLITAN__
+    {
+        extern char **environ;
+        if (posix_spawn(&pid, argv[0], NULL, NULL,
+                        (char *const *)(uintptr_t)argv, environ) != 0)
+            return HL_TOOL_SPAWN_NOSTART;
+    }
+#else
+    pid = fork();
+    if (pid < 0) return HL_TOOL_SPAWN_NOSTART;
+    if (pid == 0) {
+        /* execvp failure exits 127 - a NORMAL exit, so the caller sees "ran
+         * and returned 127" rather than "never started". That is the right
+         * reading: it did start, it just could not become the target. */
+        execvp(argv[0], (char *const *)(uintptr_t)argv);
+        _exit(127);
+    }
+#endif
+
+    int status;
+    if (waitpid(pid, &status, 0) < 0) return -1;
+    int exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    {
+        ShJsonWriter w = hl_audit_begin("tool.spawn_self");
+        sh_json_write_key(&w, "argv");
+        sh_json_write_array_start(&w);
+        for (int k = 0; argv[k]; k++) sh_json_write_string(&w, argv[k]);
+        sh_json_write_array_end(&w);
+        sh_json_write_kv_int(&w, "exit_code", exit_code);
+        hl_audit_end(&w);
+    }
+    return exit_code;
+}
 
 char *hl_tool_spawn_read(const char *const argv[], size_t *out_len)
 {

--- a/src/hull/cap/tool.c
+++ b/src/hull/cap/tool.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>   /* strcasecmp - Windows tool names vary in case */
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -154,9 +155,33 @@ int hl_tool_check_allowlist(const char *binary)
 {
     if (!binary) return -1;
 
-    /* Extract basename */
-    const char *base = strrchr(binary, '/');
-    base = base ? base + 1 : binary;
+    /* Extract basename. Split on BOTH separators: a cosmo APE reaches Windows,
+     * where an argv[0] or a resolved tool path is "C:\path\hull.com". */
+    const char *base = binary;
+    for (const char *c = binary; *c; c++)
+        if (*c == '/' || *c == '\\') base = c + 1;
+
+    /* Drop a host executable suffix before matching. The same tool is `cc` on
+     * POSIX and `cc.exe` on Windows, and hull itself installs as `hull.com`
+     * (the APE convention - see install.ps1 and hl_host_exe_suffix). Without
+     * this every allowlisted tool is denied on Windows, because the match below
+     * accepts only an exact name or a `-<digit>` version suffix.
+     *
+     * Narrow by construction: only these two suffixes, only trailing, and only
+     * the SUFFIX is removed - the remaining name still has to be on the list,
+     * so this admits no name that was not already allowed. */
+    char stripped[64];
+    size_t blen = strlen(base);
+    for (const char **sfx = (const char *[]){ ".com", ".exe", NULL }; *sfx; sfx++) {
+        size_t slen = strlen(*sfx);
+        if (blen > slen && blen - slen < sizeof(stripped) &&
+            strcasecmp(base + blen - slen, *sfx) == 0) {
+            memcpy(stripped, base, blen - slen);
+            stripped[blen - slen] = '\0';
+            base = stripped;
+            break;
+        }
+    }
 
     for (const char **p = allowed_prefixes; *p; p++) {
         size_t plen = strlen(*p);

--- a/src/hull/commands/dispatch.c
+++ b/src/hull/commands/dispatch.c
@@ -56,6 +56,7 @@
 #include "hull/commands/verify_self.h"
 #include "hull/commands/sbom.h"
 #include "hull/commands/cache.h"
+#include "hull/commands/extract_manifest_js.h"
 #include "hull/commands/help.h"
 
 #include <string.h>
@@ -105,6 +106,12 @@ static const HlCommand commands[] = {
     { "sbom",           hl_cmd_sbom },
     { "cache",          hl_cmd_cache },
     { "help",           hl_cmd_help },
+    /* INTERNAL, not user-facing: the isolated child that reads a .js app's
+     * manifest so a QuickJS teardown abort cannot kill `hull build` (#427).
+     * Deliberately absent from help.c and completions/. */
+#ifdef HL_ENABLE_JS
+    { "__extract-manifest-js", hl_cmd_extract_manifest_js },
+#endif
     { NULL, NULL }  /* sentinel */
 };
 

--- a/src/hull/commands/extract_manifest_js.c
+++ b/src/hull/commands/extract_manifest_js.c
@@ -1,0 +1,55 @@
+/*
+ * extract_manifest_js.c - `hull __extract-manifest-js <app.js> <result-file>`
+ *
+ * INTERNAL. The isolated child half of JS manifest extraction (issue #427).
+ *
+ * Reading `app.manifest({...})` out of a `.js` entry point means running the
+ * app's top level in a transient QuickJS runtime. Tearing that runtime down
+ * can abort the process: on an app that leaves a self-referential pending
+ * microtask, JS_FreeRuntime's cycle collector double-frees the promise
+ * resolver and the allocator raises SIGABRT. In `hull build` that killed the
+ * build outright with no diagnostic. Here it kills only this child.
+ *
+ * The outcome is written to <result-file> BEFORE the runtime is torn down
+ * (hl_manifest_extract_js_in_process's early_result_path), so even an aborted
+ * teardown leaves the parent a complete result and the build succeeds.
+ *
+ * Deliberately silent on stdout: the app's own top-level `console.log` shares
+ * this process's stdout, and mixing the two would corrupt the result. The
+ * file is the only channel.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+#include "hull/commands/extract_manifest_js.h"
+#include "hull/manifest_extract_file.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int hl_cmd_extract_manifest_js(int argc, char **argv, const HlCommandEnv *env)
+{
+    (void)env;
+    if (argc < 4) {
+        fprintf(stderr,
+                "usage: hull __extract-manifest-js <entry.js> <result-file>\n"
+                "  (internal - used by hull build to isolate JS manifest "
+                "extraction)\n");
+        return 2;
+    }
+
+    const char *path        = argv[2];
+    const char *result_path = argv[3];
+
+    char  *json = NULL;
+    char  *err  = NULL;
+    size_t len  = 0;
+
+    /* Writes the result itself, before teardown. Its return value only tells
+     * us the exit code to use; the parent reads the file either way. */
+    int rc = hl_manifest_extract_js_in_process(path, result_path,
+                                               &json, &len, &err);
+    free(json);
+    free(err);
+    return rc == 0 ? 0 : 1;
+}

--- a/src/hull/commands/extract_manifest_js.c
+++ b/src/hull/commands/extract_manifest_js.c
@@ -41,6 +41,21 @@ int hl_cmd_extract_manifest_js(int argc, char **argv, const HlCommandEnv *env)
     const char *path        = argv[2];
     const char *result_path = argv[3];
 
+    /* Claim the result file BEFORE running anything. The parent cannot tell a
+     * child that never launched from one that launched and died: hl_tool_spawn
+     * collapses both to -1 (spawn_and_wait returns WEXITSTATUS or -1, and a
+     * SIGABRT child is !WIFEXITED). This marker is that distinction. Without
+     * it the parent would fall back to IN-PROCESS extraction after an abort,
+     * re-running the very crash the isolation exists to contain.
+     *
+     * It is overwritten by the real result moments later; it only has to
+     * survive the window in which the runtime can abort. */
+    if (hl_manifest_extract_write_result(result_path, "start", NULL, 0) != 0) {
+        fprintf(stderr, "hull __extract-manifest-js: cannot write %s\n",
+                result_path);
+        return 1;
+    }
+
     char  *json = NULL;
     char  *err  = NULL;
     size_t len  = 0;

--- a/src/hull/commands/extract_manifest_js.c
+++ b/src/hull/commands/extract_manifest_js.c
@@ -30,7 +30,11 @@
 int hl_cmd_extract_manifest_js(int argc, char **argv, const HlCommandEnv *env)
 {
     (void)env;
-    if (argc < 4) {
+    /* argv is rebased at the VERB by hl_command_dispatch (it passes
+     * argc - cmd_idx, argv + cmd_idx), so argv[0] is "__extract-manifest-js"
+     * and the two operands are argv[1] / argv[2]. Same convention as every
+     * other handler, which all start their scan at i = 1. */
+    if (argc < 3) {
         fprintf(stderr,
                 "usage: hull __extract-manifest-js <entry.js> <result-file>\n"
                 "  (internal - used by hull build to isolate JS manifest "
@@ -38,8 +42,8 @@ int hl_cmd_extract_manifest_js(int argc, char **argv, const HlCommandEnv *env)
         return 2;
     }
 
-    const char *path        = argv[2];
-    const char *result_path = argv[3];
+    const char *path        = argv[1];
+    const char *result_path = argv[2];
 
     /* Claim the result file BEFORE running anything. The parent cannot tell a
      * child that never launched from one that launched and died: hl_tool_spawn

--- a/src/hull/manifest_extract_file.c
+++ b/src/hull/manifest_extract_file.c
@@ -37,6 +37,7 @@ static char *strdup_safe(const char *s)
 #include "quickjs.h"
 #include "hull/cap/tool.h"         /* hl_tool_spawn, hl_tool_cosmo_tmpdir */
 #include "hull/release_io.h"       /* hl_release_io_self_path */
+#include "log.h"
 
 #include <limits.h>
 #include <stdio.h>
@@ -324,12 +325,18 @@ int hl_manifest_extract_js_from_file(const char *path,
     if (!exe || make_result_path(result_path, sizeof(result_path)) != 0) {
         /* Could not set isolation up at all. Degrade to the historical
          * in-process behaviour rather than inventing a new way to fail. */
+        log_debug("manifest extraction: no isolation available "
+                  "(exe=%s), running in-process", exe ? exe : "unresolved");
         return hl_manifest_extract_js_in_process(path, NULL, out_json,
                                                  out_json_len, out_err);
     }
 
     const char *argv[] = { exe, "__extract-manifest-js", path, result_path,
                            NULL };
+    /* Visible under --verbose. Whether extraction is isolated or fell back is
+     * otherwise unobservable from outside the process, which makes a silent
+     * regression to the in-process path (and its crash) easy to miss. */
+    log_debug("manifest extraction: isolating in child %s", exe);
     int spawn_rc = hl_tool_spawn(argv);
 
     size_t rlen = 0;

--- a/src/hull/manifest_extract_file.c
+++ b/src/hull/manifest_extract_file.c
@@ -35,8 +35,19 @@ static char *strdup_safe(const char *s)
 #include "hull/stdlib_feature.h"   /* hl_platform_vfs_init / _dispose */
 #include "hull/vfs.h"              /* HlVfs */
 #include "quickjs.h"
+#include "hull/cap/tool.h"         /* hl_tool_spawn, hl_tool_cosmo_tmpdir */
+#include "hull/release_io.h"       /* hl_release_io_self_path */
 
-int hl_manifest_extract_js_from_file(const char *path,
+#include <limits.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+int hl_manifest_extract_js_in_process(const char *path,
+                                       const char *early_result_path,
                                        char **out_json,
                                        size_t *out_json_len,
                                        char **out_err)
@@ -46,6 +57,9 @@ int hl_manifest_extract_js_from_file(const char *path,
     if (out_err)      *out_err = NULL;
     if (!path) {
         if (out_err) *out_err = strdup_safe("null path");
+        if (early_result_path)
+            (void)hl_manifest_extract_write_result(early_result_path, "err",
+                                                   "null path", 9);
         return -1;
     }
 
@@ -59,6 +73,9 @@ int hl_manifest_extract_js_from_file(const char *path,
     if (hl_js_init(js, &cfg) != 0) {
         free(js);
         if (out_err) *out_err = strdup_safe("hl_js_init failed");
+        if (early_result_path)
+            (void)hl_manifest_extract_write_result(early_result_path, "err",
+                                                   "hl_js_init failed", 17);
         return -1;
     }
 
@@ -156,6 +173,26 @@ int hl_manifest_extract_js_from_file(const char *path,
     }
 
 cleanup:
+    /* Report BEFORE tearing the runtime down. QuickJS can abort the process
+     * in JS_FreeRuntime's cycle collector (issue #427); by then the manifest
+     * is already on disk, so the parent still gets a complete result and the
+     * build succeeds instead of dying on a teardown bug in code that has
+     * finished doing its job. */
+    if (early_result_path) {
+        if (rc != 0) {
+            const char *m = (out_err && *out_err) ? *out_err
+                                                  : "manifest extraction failed";
+            (void)hl_manifest_extract_write_result(early_result_path, "err",
+                                                   m, strlen(m));
+        } else if (copy) {
+            (void)hl_manifest_extract_write_result(early_result_path, "ok",
+                                                   copy, json_len);
+        } else {
+            (void)hl_manifest_extract_write_result(early_result_path, "none",
+                                                   NULL, 0);
+        }
+    }
+
     hl_js_free(js);
     free(js);
     hl_platform_vfs_dispose(pvfs_owned);
@@ -170,19 +207,213 @@ cleanup:
     return rc;
 }
 
-#else /* HL_ENABLE_JS */
+/* ── Isolated-child half (issue #427) ───────────────────────────────── *
+ *
+ * A transient QuickJS runtime can abort the process in JS_FreeRuntime's
+ * cycle collector when the app left a self-referential pending microtask.
+ * That kills `hull build` outright, so the extraction runs in a re-exec'd
+ * child and the parent only ever reads a file.
+ *
+ * Result-file format - one header line, then the payload verbatim:
+ *
+ *     HULLMANIFEST1 ok\n{"modules":[...]}      manifest captured
+ *     HULLMANIFEST1 none\n                     valid app, no app.manifest()
+ *     HULLMANIFEST1 err\nmessage               extraction failed
+ *
+ * The magic makes a truncated or never-written file detectable, which
+ * matters because the child may die AFTER a successful extraction. The
+ * child writes and closes this file BEFORE tearing its runtime down, so a
+ * teardown abort still leaves a complete, usable result and the build
+ * SUCCEEDS rather than merely failing cleanly.
+ */
+
+#define HL_MEXTRACT_MAGIC "HULLMANIFEST1 "
+
+int hl_manifest_extract_write_result(const char *out_path, const char *status,
+                                     const char *payload, size_t payload_len)
+{
+    if (!out_path || !status) return -1;
+    FILE *f = fopen(out_path, "wb");
+    if (!f) return -1;
+    int ok = (fputs(HL_MEXTRACT_MAGIC, f) >= 0) &&
+             (fputs(status, f) >= 0) &&
+             (fputc('\n', f) != EOF);
+    if (ok && payload && payload_len)
+        ok = (fwrite(payload, 1, payload_len, f) == payload_len);
+    /* fflush before fclose so a write error surfaces here rather than being
+     * swallowed; the parent's magic check is the backstop either way. */
+    if (ok && fflush(f) != 0) ok = 0;
+    if (fclose(f) != 0) ok = 0;
+    if (!ok) { (void)remove(out_path); return -1; }
+    return 0;
+}
+
+/* Slurp a whole file. NULL on any failure (absent, unreadable, OOM). */
+static char *read_all(const char *path, size_t *out_len)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) return NULL;
+    size_t cap = 8192, len = 0;
+    char *buf = malloc(cap);
+    if (!buf) { fclose(f); return NULL; }
+    for (;;) {
+        if (len == cap) {
+            if (cap > SIZE_MAX / 2) { free(buf); fclose(f); return NULL; }
+            cap *= 2;
+            char *nb = realloc(buf, cap);
+            if (!nb) { free(buf); fclose(f); return NULL; }
+            buf = nb;
+        }
+        size_t n = fread(buf + len, 1, cap - len, f);
+        len += n;
+        if (n == 0) break;
+    }
+    int bad = ferror(f);
+    fclose(f);
+    if (bad) { free(buf); return NULL; }
+    char *nb = realloc(buf, len + 1);
+    if (nb) buf = nb;
+    buf[len] = '\0';
+    if (out_len) *out_len = len;
+    return buf;
+}
+
+/* Build a writable temp path for the result file. Prefers the cosmo tmpdir on
+ * Windows (where /tmp is not a path), else $TMPDIR, else /tmp - which the tool
+ * sandbox unveils "rwcx" (sandbox_tool.c). */
+static int make_result_path(char *out, size_t outsz)
+{
+    char dir[512];
+    const char *d;
+    if (hl_tool_cosmo_tmpdir(dir, sizeof(dir)) == 0) {
+        d = dir;
+    } else {
+        d = getenv("TMPDIR");
+        if (!d || !*d) d = "/tmp";
+    }
+    int n = snprintf(out, outsz, "%s/hull-manifest-XXXXXX", d);
+    if (n <= 0 || (size_t)n >= outsz) return -1;
+    int fd = mkstemp(out);
+    if (fd < 0) return -1;
+    close(fd);           /* the child reopens by name; we only wanted the name */
+    return 0;
+}
 
 int hl_manifest_extract_js_from_file(const char *path,
+                                       const char *hull_exe,
                                        char **out_json,
                                        size_t *out_json_len,
                                        char **out_err)
 {
-    (void)path;
+    if (out_json)     *out_json = NULL;
+    if (out_json_len) *out_json_len = 0;
+    if (out_err)      *out_err = NULL;
+    if (!path) {
+        if (out_err) *out_err = strdup_safe("null path");
+        return -1;
+    }
+
+    /* Resolve the binary to re-exec. Prefer the OS's own answer; fall back to
+     * the caller's argv[0], which is the only route on cosmo (no /proc). */
+    char self[PATH_MAX];
+    const char *exe = NULL;
+    if (hl_release_io_self_path(self, sizeof(self)) == 0) exe = self;
+    else if (hull_exe && *hull_exe)                       exe = hull_exe;
+
+    char result_path[600];
+    if (!exe || make_result_path(result_path, sizeof(result_path)) != 0) {
+        /* Could not set isolation up at all. Degrade to the historical
+         * in-process behaviour rather than inventing a new way to fail. */
+        return hl_manifest_extract_js_in_process(path, NULL, out_json,
+                                                 out_json_len, out_err);
+    }
+
+    const char *argv[] = { exe, "__extract-manifest-js", path, result_path,
+                           NULL };
+    int spawn_rc = hl_tool_spawn(argv);
+
+    size_t rlen = 0;
+    char *raw = read_all(result_path, &rlen);
+    (void)remove(result_path);
+
+    const size_t maglen = sizeof(HL_MEXTRACT_MAGIC) - 1;
+    if (!raw || rlen < maglen || memcmp(raw, HL_MEXTRACT_MAGIC, maglen) != 0) {
+        /* No usable result. Distinguish "never ran" from "ran and died": a
+         * child that launched must NOT be retried in-process, since that
+         * re-runs the very abort the isolation exists to contain. */
+        free(raw);
+        if (spawn_rc == -1) {
+            /* Refused by the spawn allowlist, or fork/exec failed outright -
+             * the child never got to run any app code. Safe to fall back. */
+            return hl_manifest_extract_js_in_process(path, NULL, out_json,
+                                                     out_json_len, out_err);
+        }
+        if (out_err) *out_err = strdup_safe(
+            "manifest extraction crashed (the JS runtime died before it "
+            "could report a result)");
+        return -1;
+    }
+
+    char *body = raw + maglen;
+    char *nl   = memchr(body, '\n', rlen - maglen);
+    if (!nl) {
+        free(raw);
+        if (out_err) *out_err = strdup_safe(
+            "manifest extraction produced a truncated result");
+        return -1;
+    }
+    *nl = '\0';
+    const char *status  = body;
+    char       *payload = nl + 1;
+    size_t      plen    = rlen - maglen - (size_t)(payload - body);
+
+    int rc = -1;
+    if (strcmp(status, "ok") == 0) {
+        char *copy = malloc(plen + 1);
+        if (copy) {
+            memcpy(copy, payload, plen);
+            copy[plen] = '\0';
+            if (out_json) *out_json = copy; else free(copy);
+            if (out_json_len) *out_json_len = plen;
+            rc = 0;
+        } else if (out_err) {
+            *out_err = strdup_safe("out of memory");
+        }
+    } else if (strcmp(status, "none") == 0) {
+        rc = 0;                     /* valid app that declares no manifest */
+    } else {
+        if (out_err)
+            *out_err = strdup_safe(plen ? payload : "manifest extraction failed");
+    }
+    free(raw);
+    return rc;
+}
+
+#else /* HL_ENABLE_JS */
+
+int hl_manifest_extract_js_in_process(const char *path,
+                                       const char *early_result_path,
+                                       char **out_json,
+                                       size_t *out_json_len,
+                                       char **out_err)
+{
+    (void)path; (void)early_result_path;
     if (out_json)     *out_json = NULL;
     if (out_json_len) *out_json_len = 0;
     if (out_err)      *out_err = strdup_safe(
         "this hull was built without HL_ENABLE_JS");
     return -1;
+}
+
+int hl_manifest_extract_js_from_file(const char *path,
+                                       const char *hull_exe,
+                                       char **out_json,
+                                       size_t *out_json_len,
+                                       char **out_err)
+{
+    (void)hull_exe;
+    return hl_manifest_extract_js_in_process(path, NULL, out_json,
+                                             out_json_len, out_err);
 }
 
 #endif /* HL_ENABLE_JS */

--- a/src/hull/manifest_extract_file.c
+++ b/src/hull/manifest_extract_file.c
@@ -338,19 +338,26 @@ int hl_manifest_extract_js_from_file(const char *path,
 
     const size_t maglen = sizeof(HL_MEXTRACT_MAGIC) - 1;
     if (!raw || rlen < maglen || memcmp(raw, HL_MEXTRACT_MAGIC, maglen) != 0) {
-        /* No usable result. Distinguish "never ran" from "ran and died": a
-         * child that launched must NOT be retried in-process, since that
-         * re-runs the very abort the isolation exists to contain. */
+        /* No marker at all: the child never reached its first statement.
+         *
+         * Falling back in-process is only safe if nothing ran. spawn_rc cannot
+         * settle that by itself - hl_tool_spawn returns WEXITSTATUS or -1, so a
+         * SIGABRT child and a failed fork are both -1. So:
+         *   spawn_rc >= 0  the child exited NORMALLY without writing a marker,
+         *                  which means the verb was not recognised (an older
+         *                  hull on $PATH, or a JS-less build falling through to
+         *                  the serve path). Nothing ran; fall back.
+         *   spawn_rc == -1 ambiguous - a failed fork or a child killed by a
+         *                  signal. Treat it as "ran": re-running in-process
+         *                  would reproduce the abort we are containing. */
         free(raw);
-        if (spawn_rc == -1) {
-            /* Refused by the spawn allowlist, or fork/exec failed outright -
-             * the child never got to run any app code. Safe to fall back. */
+        if (spawn_rc >= 0) {
             return hl_manifest_extract_js_in_process(path, NULL, out_json,
                                                      out_json_len, out_err);
         }
         if (out_err) *out_err = strdup_safe(
-            "manifest extraction crashed (the JS runtime died before it "
-            "could report a result)");
+            "manifest extraction could not run (the extraction child could "
+            "not be started, or died immediately)");
         return -1;
     }
 
@@ -368,7 +375,14 @@ int hl_manifest_extract_js_from_file(const char *path,
     size_t      plen    = rlen - maglen - (size_t)(payload - body);
 
     int rc = -1;
-    if (strcmp(status, "ok") == 0) {
+    if (strcmp(status, "start") == 0) {
+        /* The child claimed the file and then died without replacing the
+         * marker - the JS runtime aborted mid-extraction. Contained, exactly
+         * as intended: report it and never retry in-process. */
+        if (out_err) *out_err = strdup_safe(
+            "manifest extraction crashed (the JS runtime died before it "
+            "could report a result)");
+    } else if (strcmp(status, "ok") == 0) {
         char *copy = malloc(plen + 1);
         if (copy) {
             memcpy(copy, payload, plen);

--- a/src/hull/manifest_extract_file.c
+++ b/src/hull/manifest_extract_file.c
@@ -13,6 +13,7 @@
 
 #include "hull/manifest_extract_file.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -29,6 +30,33 @@ static char *strdup_safe(const char *s)
     return out;
 }
 
+/* Result-file writer. Deliberately OUTSIDE the HL_ENABLE_JS guard: it is
+ * pure stdio, and hull __extract-manifest-js (its only caller) is compiled
+ * whenever the make-level HL_ENABLE_JS is on - which includes RUNTIME=lua,
+ * where the macro is NOT defined. Guarding it there left the child command
+ * with an undefined reference at link. */
+#define HL_MEXTRACT_MAGIC "HULLMANIFEST1 "
+
+int hl_manifest_extract_write_result(const char *out_path, const char *status,
+                                     const char *payload, size_t payload_len)
+{
+    if (!out_path || !status) return -1;
+    FILE *f = fopen(out_path, "wb");
+    if (!f) return -1;
+    int ok = (fputs(HL_MEXTRACT_MAGIC, f) >= 0) &&
+             (fputs(status, f) >= 0) &&
+             (fputc('\n', f) != EOF);
+    if (ok && payload && payload_len)
+        ok = (fwrite(payload, 1, payload_len, f) == payload_len);
+    /* fflush before fclose so a write error surfaces here rather than being
+     * swallowed; the parent's magic check is the backstop either way. */
+    if (ok && fflush(f) != 0) ok = 0;
+    if (fclose(f) != 0) ok = 0;
+    if (!ok) { (void)remove(out_path); return -1; }
+    return 0;
+}
+
+
 #ifdef HL_ENABLE_JS
 
 #include "hull/runtime/js.h"
@@ -40,7 +68,6 @@ static char *strdup_safe(const char *s)
 #include "log.h"
 
 #include <limits.h>
-#include <stdio.h>
 #include <unistd.h>
 
 #ifndef PATH_MAX
@@ -227,27 +254,6 @@ cleanup:
  * teardown abort still leaves a complete, usable result and the build
  * SUCCEEDS rather than merely failing cleanly.
  */
-
-#define HL_MEXTRACT_MAGIC "HULLMANIFEST1 "
-
-int hl_manifest_extract_write_result(const char *out_path, const char *status,
-                                     const char *payload, size_t payload_len)
-{
-    if (!out_path || !status) return -1;
-    FILE *f = fopen(out_path, "wb");
-    if (!f) return -1;
-    int ok = (fputs(HL_MEXTRACT_MAGIC, f) >= 0) &&
-             (fputs(status, f) >= 0) &&
-             (fputc('\n', f) != EOF);
-    if (ok && payload && payload_len)
-        ok = (fwrite(payload, 1, payload_len, f) == payload_len);
-    /* fflush before fclose so a write error surfaces here rather than being
-     * swallowed; the parent's magic check is the backstop either way. */
-    if (ok && fflush(f) != 0) ok = 0;
-    if (fclose(f) != 0) ok = 0;
-    if (!ok) { (void)remove(out_path); return -1; }
-    return 0;
-}
 
 /* Slurp a whole file. NULL on any failure (absent, unreadable, OOM). */
 static char *read_all(const char *path, size_t *out_len)

--- a/src/hull/manifest_extract_file.c
+++ b/src/hull/manifest_extract_file.c
@@ -337,7 +337,10 @@ int hl_manifest_extract_js_from_file(const char *path,
      * otherwise unobservable from outside the process, which makes a silent
      * regression to the in-process path (and its crash) easy to miss. */
     log_debug("manifest extraction: isolating in child %s", exe);
-    int spawn_rc = hl_tool_spawn(argv);
+    /* spawn_SELF, not spawn: the allowlist bounds external tools and cannot
+     * name this binary anyway (hull ships as `hull`, `hull.com`,
+     * `hull-cosmo.exe`), so routing through it denied the re-exec outright. */
+    int spawn_rc = hl_tool_spawn_self(argv);
 
     size_t rlen = 0;
     char *raw = read_all(result_path, &rlen);
@@ -346,25 +349,28 @@ int hl_manifest_extract_js_from_file(const char *path,
     const size_t maglen = sizeof(HL_MEXTRACT_MAGIC) - 1;
     if (!raw || rlen < maglen || memcmp(raw, HL_MEXTRACT_MAGIC, maglen) != 0) {
         /* No marker at all: the child never reached its first statement.
+         * Falling back in-process is safe only if nothing ran, so the three
+         * cases hl_tool_spawn_self distinguishes matter here:
          *
-         * Falling back in-process is only safe if nothing ran. spawn_rc cannot
-         * settle that by itself - hl_tool_spawn returns WEXITSTATUS or -1, so a
-         * SIGABRT child and a failed fork are both -1. So:
-         *   spawn_rc >= 0  the child exited NORMALLY without writing a marker,
-         *                  which means the verb was not recognised (an older
-         *                  hull on $PATH, or a JS-less build falling through to
-         *                  the serve path). Nothing ran; fall back.
-         *   spawn_rc == -1 ambiguous - a failed fork or a child killed by a
-         *                  signal. Treat it as "ran": re-running in-process
-         *                  would reproduce the abort we are containing. */
+         *   >= 0        exited NORMALLY without writing a marker: the verb was
+         *               not recognised (an older hull on $PATH, or a JS-less
+         *               build falling through to the serve path), or exec
+         *               failed with 127. Nothing of the app ran; fall back.
+         *   NOSTART     never started (spawn refused / failed). Fall back -
+         *               otherwise a spawn that cannot work anywhere would break
+         *               every JS build rather than degrading to the old path.
+         *   -1          started and died on a signal. Do NOT fall back: that
+         *               re-runs the abort this child exists to contain. */
         free(raw);
-        if (spawn_rc >= 0) {
+        if (spawn_rc >= 0 || spawn_rc == HL_TOOL_SPAWN_NOSTART) {
+            log_debug("manifest extraction: child produced no result "
+                      "(status %d), running in-process", spawn_rc);
             return hl_manifest_extract_js_in_process(path, NULL, out_json,
                                                      out_json_len, out_err);
         }
         if (out_err) *out_err = strdup_safe(
-            "manifest extraction could not run (the extraction child could "
-            "not be started, or died immediately)");
+            "manifest extraction crashed (the JS runtime died before it "
+            "could report a result)");
         return -1;
     }
 

--- a/src/hull/runtime/lua/mod_tool.c
+++ b/src/hull/runtime/lua/mod_tool.c
@@ -636,7 +636,16 @@ static int l_tool_extract_manifest_js(lua_State *L)
     size_t json_len = 0;
     char  *err  = NULL;
 
-    int rc = hl_manifest_extract_js_from_file(path, &json, &json_len, &err);
+    /* The extraction runs in a re-exec'd child (#427), so it needs a path to
+     * this binary. hl_release_io_self_path handles Linux/macOS; on cosmo it
+     * cannot, and __hull_exe (argv[0], set by hull_tool) is the only route. */
+    const char *hull_exe = NULL;
+    lua_getglobal(L, "__hull_exe");
+    if (lua_isstring(L, -1)) hull_exe = lua_tostring(L, -1);
+
+    int rc = hl_manifest_extract_js_from_file(path, hull_exe,
+                                              &json, &json_len, &err);
+    lua_pop(L, 1);   /* __hull_exe - popped only after the call, which borrows it */
     if (rc != 0) {
         char buf[256];
         snprintf(buf, sizeof(buf), "tool.extract_manifest_js: %s",

--- a/src/hull/sandbox_tool.c
+++ b/src/hull/sandbox_tool.c
@@ -22,6 +22,7 @@
 #include "hull/sandbox.h"
 #include "hull/cap/tool.h"   /* hl_tool_cosmo_prepare_tmpdir / _tmpdir */
 #include "hull/shared/cache_dir.h"
+#include "hull/release_io.h"  /* hl_release_io_self_path */
 #include "log.h"
 
 #include <limits.h>
@@ -157,6 +158,25 @@ int hl_tool_sandbox_init(HlToolUnveilCtx *ctx,
     /* Platform library + hull binary: read + execute */
     if (platform_dir)
         hl_tool_unveil_add(ctx, platform_dir, "rx");
+
+    /* hull re-execs ITSELF to isolate JS manifest extraction (issue #427), so
+     * the running binary has to stay executable under this sandbox.
+     * platform_dir covers it only when argv[0] carried a slash; the common
+     * `hull build myapp` off $PATH leaves it NULL, and an install prefix like
+     * ~/.local/bin is under none of the roots unveiled above. Resolve the real
+     * path and unveil its DIRECTORY (not $HOME, not "/"). Best-effort: cosmo
+     * has no self-path route, and the extraction falls back to in-process when
+     * the spawn is refused. */
+    {
+        char self[PATH_MAX];
+        if (hl_release_io_self_path(self, sizeof(self)) == 0) {
+            char *slash = strrchr(self, '/');
+            if (slash && slash != self) {   /* skip "/hull": never unveil "/" */
+                *slash = '\0';
+                hl_tool_unveil_add(ctx, self, "rx");
+            }
+        }
+    }
 
     /* Side-loaded tool assets: $HOME/.hull/tools holds tool binaries (wamrc,
      * lld) that get executed AND the libc-musl-<arch> floor bundle

--- a/tests/e2e_manifest_extract_isolation.sh
+++ b/tests/e2e_manifest_extract_isolation.sh
@@ -183,4 +183,25 @@ pass "a JS app with a manifest still builds through the isolated child"
 build_ok "$noapp" "a manifest-less JS app"
 pass "a manifest-less JS app still builds through the isolated child"
 
+# 4. A real `hull build` actually spawns the child.
+#
+# Everything above either drives the child directly or observes the parent
+# OUTCOME, and the parent falls back to in-process extraction when it cannot
+# launch a child. So a bug that stopped the build path from ever reaching the
+# child would leave checks 1-3 green while silently restoring the old crash.
+# That is not hypothetical: the first cut of this feature indexed argv wrong,
+# the child exited on its usage message, and every JS build quietly fell back.
+#
+# The parent logs its decision at debug level, so --verbose makes the choice
+# observable from outside.
+rm -f "$okapp/out"
+"$HULL" build --verbose "$okapp" -o "$okapp/out" --no-verify-platform >"$WORK/v.log" 2>&1 \
+    || fail "verbose build of a valid JS app failed: $(tail -5 "$WORK/v.log")"
+if grep -q "running in-process" "$WORK/v.log"; then
+    fail "a real build fell back to in-process extraction instead of isolating"
+fi
+grep -q "isolating in child" "$WORK/v.log" \
+    || fail "a real build did not report spawning the extraction child"
+pass "a real hull build spawns the isolated extraction child"
+
 echo "e2e_manifest_extract_isolation: ALL PASS"

--- a/tests/e2e_manifest_extract_isolation.sh
+++ b/tests/e2e_manifest_extract_isolation.sh
@@ -148,8 +148,27 @@ if "$HULL" __extract-manifest-js "$badapp/app.js" "$res" >/dev/null 2>&1; then
 fi
 head -1 "$res" | grep -q 'err$' \
     || fail "expected an 'err' status, got: $(head -1 "$res")"
-[ -s "$res" ] || fail "err result carried no message"
+tail -n +2 "$res" | grep -q . \
+    || fail "err result carried no message after the header line"
 pass "child protocol: 'err' reports a failure with a message"
+
+# 2d. The entry marker is transient.
+#
+# The child writes "HULLMANIFEST1 start" before anything can abort, and the
+# parent uses it to tell a child that never launched (no file) from one that
+# launched and died mid-run (bare marker). That distinction is what stops the
+# parent retrying IN-PROCESS after an abort and reproducing the crash - the
+# spawn exit status cannot make it, since a signal death and a failed fork are
+# both -1. The end-to-end consequence is pinned by check 1 above; here we pin
+# the invariant it rests on: a child that completes always REPLACES the marker,
+# so a bare marker unambiguously means "died mid-run".
+rm -f "$WORK/probe.res"
+"$HULL" __extract-manifest-js "$okapp/app.js" "$WORK/probe.res" >/dev/null 2>&1 \
+    || fail "child failed on a re-run of the valid app"
+if head -1 "$WORK/probe.res" | grep -q 'start$'; then
+    fail "child left the start marker in place - the real result never landed"
+fi
+pass "child protocol: the entry marker is replaced by the real result"
 
 # ── 3. The ordinary paths still build ────────────────────────────────────
 build_ok() {

--- a/tests/e2e_manifest_extract_isolation.sh
+++ b/tests/e2e_manifest_extract_isolation.sh
@@ -1,0 +1,167 @@
+#!/bin/sh
+# e2e_manifest_extract_isolation.sh - JS manifest extraction runs in an
+# isolated child process (issue #427).
+#
+# Reading `app.manifest({...})` out of a `.js` entry point means running the
+# app's top level in a transient QuickJS runtime. Tearing that runtime down can
+# SIGABRT: on an app whose top level leaves a self-referential closure cycle in
+# the microtask queue, JS_FreeRuntime's cycle collector double-frees a promise
+# resolver. In-process that killed `hull build` with exit 134 on ~50% of runs.
+#
+# The extraction now runs in a re-exec'd `hull __extract-manifest-js` child that
+# writes its result to a file BEFORE tearing the runtime down, so:
+#   - a teardown abort can no longer reach the parent (never exit 134), and
+#   - a result produced before the abort is still usable.
+#
+# What this pins, in order:
+#   1. the adversarial app fails CLEANLY and repeatably - never on a signal;
+#   2. the child protocol is really in use (ok / none / err all round-trip);
+#   3. the ordinary paths did not regress (manifest app builds, manifest-less
+#      app builds).
+#
+# Check 2 is the one that keeps this honest. The parent falls back to
+# in-process extraction when it cannot launch a child, so checks 1/3 alone
+# would still pass if isolation silently stopped engaging - they would just go
+# back to being flaky. Asserting the result-file protocol directly proves the
+# isolated path exists and works.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+set -eu
+
+HULL="${HULL_BIN:-build/hull}"
+[ -x "$HULL" ] || HULL="./build/hull"
+if [ ! -x "$HULL" ]; then
+    echo "SKIP: no hull binary at $HULL"
+    exit 0
+fi
+HULL=$(cd "$(dirname "$HULL")" && pwd)/$(basename "$HULL")
+
+# Canonicalize the work root: on macOS mktemp lives under /tmp -> /private/tmp
+# and the seatbelt profile is given one path while fs access uses the other.
+WORK=$(cd "$(mktemp -d)" && pwd -P)
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "FAIL: $1"; exit 1; }
+pass() { echo "PASS: $1"; }
+
+# A JS-less hull has no extraction to isolate, and drops the child subcommand
+# entirely. An unregistered verb falls through to the serve path rather than
+# reporting itself, so probe by BEHAVIOUR: run the child on a trivial app and
+# look for the result-file magic. (CI asserts this script reaches ALL PASS, so
+# a skip here cannot quietly stand in for a regression.)
+probe="$WORK/probe"; mkdir -p "$probe"
+echo "export const x = 1;" > "$probe/app.js"
+"$HULL" __extract-manifest-js "$probe/app.js" "$WORK/probe.res" >/dev/null 2>&1 || true
+if [ ! -f "$WORK/probe.res" ] || ! head -c 13 "$WORK/probe.res" | grep -q 'HULLMANIFEST1'; then
+    echo "SKIP: this hull has no JS manifest-extraction child (built HL_ENABLE_JS=0?)"
+    exit 0
+fi
+
+# ── 1. The #427 reproducer: clean failure, never a signal death ──────────
+#
+# Module-local `spin` is the point: a GLOBAL-rooted rescheduler is not a
+# garbage cycle and never tripped the bug (that variant is pinned separately in
+# e2e_modular_resolution.sh). The module stays PENDING, so extraction correctly
+# FAILS - the fix is about HOW it fails, not whether.
+repro="$WORK/repro"; mkdir -p "$repro"
+cat > "$repro/app.js" <<'JS'
+import { app } from "hull:app";
+const p = new Promise(() => {});                 // never resolves
+function spin(){ Promise.resolve().then(spin); } // module-local -> closure cycle
+spin();
+await p;                                          // holds the module PENDING
+app.manifest({ modules: [] });                    // unreachable
+JS
+
+# Ten runs: the pre-fix abort rate was ~50%, so a surviving regression has a
+# ~1-in-1000 chance of slipping through. Each run is also time-boxed, since a
+# hung extractor is a different regression that must not look like a pass.
+N=10
+i=0
+while [ "$i" -lt "$N" ]; do
+    i=$((i + 1))
+    rm -f "$repro/out"
+    "$HULL" build "$repro" -o "$repro/out" --no-verify-platform >"$WORK/r.log" 2>&1 &
+    bp=$!
+    n=0
+    while kill -0 "$bp" 2>/dev/null; do
+        n=$((n + 1))
+        if [ "$n" -ge 60 ]; then
+            kill -9 "$bp" 2>/dev/null || true
+            wait "$bp" 2>/dev/null || true
+            fail "run $i HUNG (bounded-drain or child-wait regressed)"
+        fi
+        sleep 1
+    done
+    if wait "$bp"; then rc=0; else rc=$?; fi
+
+    # The whole point of the issue: 134 = SIGABRT reaching the parent. Any
+    # >=128 status is a signal death and equally disqualifying.
+    [ "$rc" -lt 128 ] || fail "run $i died on a signal (exit $rc) - teardown abort reached the parent"
+    [ "$rc" -ne 0 ]   || fail "run $i unexpectedly SUCCEEDED (a PENDING module must fail extraction)"
+    [ ! -f "$repro/out" ] || fail "run $i produced a binary from a failed extraction"
+done
+pass "self-referential-microtask app fails cleanly $N/$N times (no signal death, no binary)"
+
+# The failure has to be legible, not a bare status.
+grep -qi 'manifest' "$WORK/r.log" \
+    || fail "the failure did not mention manifest extraction: $(cat "$WORK/r.log")"
+pass "the clean failure names manifest extraction"
+
+# ── 2. The child protocol round-trips (proves isolation is really engaged) ──
+res="$WORK/result"
+
+# 2a. "ok" - an app that declares a manifest.
+okapp="$WORK/okapp"; mkdir -p "$okapp"
+cat > "$okapp/app.js" <<'JS'
+import { app } from "hull:app";
+app.manifest({ modules: ["hull/json@1"] });
+JS
+rm -f "$res"
+"$HULL" __extract-manifest-js "$okapp/app.js" "$res" >/dev/null 2>&1 \
+    || fail "child returned non-zero for a valid manifest app"
+[ -f "$res" ] || fail "child wrote no result file"
+head -c 14 "$res" | grep -q '^HULLMANIFEST1' \
+    || fail "result file lacks the HULLMANIFEST1 magic: $(head -c 40 "$res")"
+head -1 "$res" | grep -q 'ok$' \
+    || fail "expected an 'ok' status, got: $(head -1 "$res")"
+tail -n +2 "$res" | grep -q 'hull/json@1' \
+    || fail "the manifest JSON did not survive the child: $(tail -n +2 "$res")"
+pass "child protocol: 'ok' carries the manifest JSON back"
+
+# 2b. "none" - a valid app that simply declares no manifest.
+noapp="$WORK/noapp"; mkdir -p "$noapp"
+printf 'const x = 1;\nexport { x };\n' > "$noapp/app.js"
+rm -f "$res"
+"$HULL" __extract-manifest-js "$noapp/app.js" "$res" >/dev/null 2>&1 \
+    || fail "child returned non-zero for a manifest-less app"
+head -1 "$res" | grep -q 'none$' \
+    || fail "expected a 'none' status, got: $(head -1 "$res")"
+pass "child protocol: 'none' distinguishes a manifest-less app from a failure"
+
+# 2c. "err" - a genuine extraction failure, reported not crashed.
+badapp="$WORK/badapp"; mkdir -p "$badapp"
+printf 'this is not ( valid javascript\n' > "$badapp/app.js"
+rm -f "$res"
+if "$HULL" __extract-manifest-js "$badapp/app.js" "$res" >/dev/null 2>&1; then
+    fail "child returned zero for an unparseable app"
+fi
+head -1 "$res" | grep -q 'err$' \
+    || fail "expected an 'err' status, got: $(head -1 "$res")"
+[ -s "$res" ] || fail "err result carried no message"
+pass "child protocol: 'err' reports a failure with a message"
+
+# ── 3. The ordinary paths still build ────────────────────────────────────
+build_ok() {
+    d="$1"; what="$2"
+    rm -f "$d/out"
+    "$HULL" build "$d" -o "$d/out" --no-verify-platform >"$WORK/b.log" 2>&1 \
+        || fail "$what failed to build: $(tail -5 "$WORK/b.log")"
+    [ -f "$d/out" ] || fail "$what built but produced no binary"
+}
+build_ok "$okapp" "a JS app with a manifest"
+pass "a JS app with a manifest still builds through the isolated child"
+build_ok "$noapp" "a manifest-less JS app"
+pass "a manifest-less JS app still builds through the isolated child"
+
+echo "e2e_manifest_extract_isolation: ALL PASS"

--- a/tests/hull/cap/test_tool.c
+++ b/tests/hull/cap/test_tool.c
@@ -117,6 +117,45 @@ UTEST(tool, allowlist_reject_empty)
     ASSERT_NE(hl_tool_check_allowlist(""), 0);
 }
 
+/* Windows executable suffixes. A cosmo APE reaches Windows, where hull itself
+ * installs as `hull.com` (the APE convention) and system tools are `cc.exe`.
+ * Before this, every allowlisted tool was DENIED there: the match accepts only
+ * an exact name or a `-<digit>` version, so ".com" / ".exe" fell through. The
+ * JS manifest-extraction child (#427) re-execs `hull`, so on Windows it was
+ * refused and extraction silently fell back in-process. */
+UTEST(tool, allowlist_accept_windows_com_suffix)
+{
+    ASSERT_EQ(hl_tool_check_allowlist("hull.com"), 0);
+    ASSERT_EQ(hl_tool_check_allowlist("cosmocc.com"), 0);
+}
+
+UTEST(tool, allowlist_accept_windows_exe_suffix)
+{
+    ASSERT_EQ(hl_tool_check_allowlist("cc.exe"), 0);
+    ASSERT_EQ(hl_tool_check_allowlist("clang-18.exe"), 0);
+}
+
+UTEST(tool, allowlist_accept_windows_backslash_path)
+{
+    ASSERT_EQ(hl_tool_check_allowlist("C:\\Users\\m\\.local\\bin\\hull.com"), 0);
+    ASSERT_EQ(hl_tool_check_allowlist("C:\\tools\\gcc.exe"), 0);
+}
+
+/* Stripping a suffix must not admit a name that was not already allowed:
+ * only the SUFFIX is removed, and what remains still has to be on the list. */
+UTEST(tool, allowlist_suffix_strip_admits_no_new_name)
+{
+    ASSERT_NE(hl_tool_check_allowlist("evil.com"), 0);
+    ASSERT_NE(hl_tool_check_allowlist("sh.exe"), 0);
+    ASSERT_NE(hl_tool_check_allowlist("cc-evil.exe"), 0);
+    ASSERT_NE(hl_tool_check_allowlist("rm.com"), 0);
+    /* not a trailing suffix - must not be stripped from the middle */
+    ASSERT_NE(hl_tool_check_allowlist("cc.exe.evil"), 0);
+    /* the suffix alone is not a name */
+    ASSERT_NE(hl_tool_check_allowlist(".com"), 0);
+    ASSERT_NE(hl_tool_check_allowlist(".exe"), 0);
+}
+
 UTEST(tool, allowlist_reject_cc_evil)
 {
     ASSERT_NE(hl_tool_check_allowlist("cc-evil"), 0);

--- a/tests/hull/cap/test_tool.c
+++ b/tests/hull/cap/test_tool.c
@@ -117,45 +117,6 @@ UTEST(tool, allowlist_reject_empty)
     ASSERT_NE(hl_tool_check_allowlist(""), 0);
 }
 
-/* Windows executable suffixes. A cosmo APE reaches Windows, where hull itself
- * installs as `hull.com` (the APE convention) and system tools are `cc.exe`.
- * Before this, every allowlisted tool was DENIED there: the match accepts only
- * an exact name or a `-<digit>` version, so ".com" / ".exe" fell through. The
- * JS manifest-extraction child (#427) re-execs `hull`, so on Windows it was
- * refused and extraction silently fell back in-process. */
-UTEST(tool, allowlist_accept_windows_com_suffix)
-{
-    ASSERT_EQ(hl_tool_check_allowlist("hull.com"), 0);
-    ASSERT_EQ(hl_tool_check_allowlist("cosmocc.com"), 0);
-}
-
-UTEST(tool, allowlist_accept_windows_exe_suffix)
-{
-    ASSERT_EQ(hl_tool_check_allowlist("cc.exe"), 0);
-    ASSERT_EQ(hl_tool_check_allowlist("clang-18.exe"), 0);
-}
-
-UTEST(tool, allowlist_accept_windows_backslash_path)
-{
-    ASSERT_EQ(hl_tool_check_allowlist("C:\\Users\\m\\.local\\bin\\hull.com"), 0);
-    ASSERT_EQ(hl_tool_check_allowlist("C:\\tools\\gcc.exe"), 0);
-}
-
-/* Stripping a suffix must not admit a name that was not already allowed:
- * only the SUFFIX is removed, and what remains still has to be on the list. */
-UTEST(tool, allowlist_suffix_strip_admits_no_new_name)
-{
-    ASSERT_NE(hl_tool_check_allowlist("evil.com"), 0);
-    ASSERT_NE(hl_tool_check_allowlist("sh.exe"), 0);
-    ASSERT_NE(hl_tool_check_allowlist("cc-evil.exe"), 0);
-    ASSERT_NE(hl_tool_check_allowlist("rm.com"), 0);
-    /* not a trailing suffix - must not be stripped from the middle */
-    ASSERT_NE(hl_tool_check_allowlist("cc.exe.evil"), 0);
-    /* the suffix alone is not a name */
-    ASSERT_NE(hl_tool_check_allowlist(".com"), 0);
-    ASSERT_NE(hl_tool_check_allowlist(".exe"), 0);
-}
-
 UTEST(tool, allowlist_reject_cc_evil)
 {
     ASSERT_NE(hl_tool_check_allowlist("cc-evil"), 0);


### PR DESCRIPTION
Closes #427.

## The bug

Reading `app.manifest({...})` out of a `.js` entry point means running the app's top level in a transient QuickJS runtime. Tearing that runtime down can SIGABRT: on an app whose top level leaves a self-referential closure cycle in the microtask queue, `JS_FreeRuntime`'s cycle collector double-frees a promise resolver. In-process that killed `hull build` with exit 134 on ~50% of runs, naming nothing.

## The fix

Extraction runs in a re-exec'd `hull __extract-manifest-js` child (internal verb; absent from `hull help` and the completions). The parent only ever reads a small result file, so a teardown abort cannot reach it.

## Three departures from the plan in the issue

**1. `fork` + pipe is not usable here.** The issue proposes "run the extraction JS runtime in a forked child; the parent reads the manifest JSON over a pipe". Hull already found that cosmo's emulated `fork` drops the pipe handles a native child's descendants need, and routed around it with `posix_spawn`:

> On cosmo/Windows, `fork()` is EMULATED and its handle inheritance to a native child's descendants doesn't preserve the pipes cosmocc's driver needs [...] (the capture comes back empty). `posix_spawn` maps to a direct CreateProcess, which inherits the standard handles cleanly.
> - `src/hull/cap/tool.c:602`

So this re-execs and passes the result through a **file**, not a pipe, and takes the `posix_spawn` path on cosmo. The file also keeps the result clear of the app's own top-level `console.log`, which shares the child's stdout.

**2. The child reports before teardown, so a good extraction survives an abort.** The result is written and closed *before* `hl_js_free`. Teardown is where QuickJS aborts, and by then the extraction has done its job, so a successful extraction survives an aborted teardown: the parent gets a complete manifest and the build **succeeds** rather than merely failing cleanly. The issue asked only for a clean failure. (The reproducer itself still fails, correctly: its module never settles.)

**3. The re-exec does not go through the tool allowlist.** That allowlist bounds which *external* programs a build may run. Re-running the process already running grants no authority it does not already have, and the allowlist cannot name this binary anyway: hull ships as `hull`, `hull.com`, and `hull-cosmo.exe`, none of which its exact-or-`-<digit>` match admits. `hl_tool_spawn_self()` validates arguments but skips the allowlist.

## Failure model

Isolation is best-effort hardening, never a new way to fail.

| Result file | Spawn status | Meaning | Action |
|---|---|---|---|
| `ok` / `none` / `err` | any | child reported | use it |
| bare `start` marker | any | launched, died mid-run | clean failure, never retried |
| absent | `>= 0` | verb not recognised, or exec failed (127) | fall back in-process |
| absent | `NOSTART` | never started | fall back in-process |
| absent | `-1` | started, killed by a signal | clean failure, never retried |

Two distinctions carry this, and both are load-bearing in **opposite** directions:

- The **`start` marker** separates "never launched" from "launched and died". Without it, a child that aborted before reporting would be retried in-process, reproducing the crash.
- **`HL_TOOL_SPAWN_NOSTART`** separates "could not start" from "died on a signal". The stock spawn helpers collapse both to `-1`, so `hl_tool_spawn_self` spawns inline to keep them apart. Without it, a spawn that fails on some platform would break *every* JS build there instead of degrading to the old in-process path. Given Windows is the platform just stabilised, that direction is not hypothetical.

## Sandbox gap this exposed

`hl_tool_sandbox_init` unveiled hull's own directory only when `argv[0]` carried a slash, so the common `hull build myapp` off `$PATH` left it NULL and an install prefix like `~/.local/bin` matched none of the unveiled roots. It now resolves the real self path and unveils that directory. Without this the re-exec would be denied and every build would silently take the fallback.

## Bugs CI caught in the first cut

- **argv off-by-one.** `hl_command_dispatch` rebases a handler's argv at the verb, so `argv[0]` is the verb. Reading `argv[2]`/`argv[3]` made the child print its usage and exit; every JS build failed.
- **The allowlist denied the re-exec** on Windows (`hull-cosmo.exe`). Fixed by not using the allowlist for a self-exec (departure 3), after an initial attempt that widened the allowlist was reverted as the wrong gate.

## Test

`tests/e2e_manifest_extract_isolation.sh`, in the CI job that already has an embedded hull, must-NOT-skip:

1. runs the #427 reproducer **10x**, asserting no signal death (pre-fix rate ~50%, so a regression has ~1-in-1000 odds of hiding), no binary, a legible message;
2. round-trips the child statuses, including that a completed child always replaces the `start` marker;
3. confirms ordinary JS apps still build;
4. asserts a real `hull build` reports **isolating** rather than falling back.

Check 4 matters most. Checks 1-3 either drive the child directly or observe the parent's outcome, and the parent falls back when it cannot launch a child, so a bug that stopped the build path reaching the child leaves them green while silently restoring the crash. Not hypothetical: the argv bug produced a *normal* child exit with no marker, which reads as "verb not recognised" and falls back. JS builds would have kept working while the isolation did nothing. (`HULL_AUDIT` was the obvious hook and does not work: it is read only in `serve.c`, which `hull build` never reaches. The parent logs its decision at debug level instead.)

## Follow-up noted, deliberately not fixed here

`hl_tool_check_allowlist` has real Windows blind spots: it splits the basename on `/` only, and has no `.exe` / `.com` handling, so `C:\tools\gcc.exe` would be denied. Nothing exercises that today (the Windows E2E passes on main), and a security-surface change does not belong in a bug fix. Worth its own issue.

## Note

Not verified locally: this is a Windows box with no native Hull build path (that needs MSYS2 + cosmocc). The extractor and child TUs pass `gcc -fsyntax-only` clean under the project warning set; `cap/tool.c` needs POSIX headers mingw lacks, so it is validated in CI.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013crBdW6cEF5Q2xuASxeivL



