### PR TITLE
fix(lua): db.async error must raise from inside lua_resume (#321)

### DIFF
--- a/src/hull/runtime/lua/mod_db.c
+++ b/src/hull/runtime/lua/mod_db.c
@@ -592,18 +592,43 @@ static int lua_db_quote_identifier(lua_State *L)
 
 /* ── db.async.query / db.async.exec ─────────────────────────────────── */
 
+/* Continuation for db.async.query / .exec. Runs INSIDE lua_resume (Lua calls
+ * it when the yielded coroutine is resumed), so a raise here is a proper
+ * coroutine error - catchable by pcall, otherwise a 500 - rather than a
+ * longjmp out of the resume that leaves the connection suspended (#321).
+ *
+ * The op arrives as the yield's KContext and is still alive: both resume paths
+ * in shared/async.c call cont->resume BEFORE free_driver. Mirrors
+ * lua_compute_async_k (#320) and the JS side's promise reject (#319).
+ *
+ * On success lua_push_worker_db_result has already pushed the single result
+ * value; return it unchanged. */
+static int lua_db_async_k(lua_State *L, int status, lua_KContext kctx)
+{
+    (void)status;
+    HlWorkerDbOp *op = (HlWorkerDbOp *)kctx;
+    if (op && op->error)
+        return luaL_error(L, "db.async: %s", op->error_msg);
+    return 1;
+}
+
 /* push_result callback: convert HlWorkerDbOp result to Lua value.
- * On error, raises a Lua error (longjmps out of the resume continuation,
- * which propagates as a regular pcall failure in user code). Successful
- * exec returns { changes, last_id }; query returns rows array directly. */
+ * On error it pushes a NIL PLACEHOLDER and leaves the raising to
+ * lua_db_async_k - see there for why. Successful exec returns
+ * { changes, last_id }; query returns rows array directly. */
 static void lua_push_worker_db_result(lua_State *L, void *driver)
 {
     HlWorkerDbOp *op = (HlWorkerDbOp *)driver;
 
     if (op->error) {
-        /* luaL_error longjmps - caller's resume completes with an error */
-        luaL_error(L, "db.async: %s", op->error_msg);
-        return; /* unreachable */
+        /* Push a placeholder and let lua_db_async_k raise. Raising HERE would
+         * longjmp out of hl_async_on_resume, which runs BEFORE lua_resume - the
+         * error would escape the resume entirely and strand the suspended
+         * connection (issue #321: the request hangs at HTTP 000 instead of
+         * failing). The continuation raises from INSIDE lua_resume, where it
+         * becomes a proper coroutine error a pcall can catch. */
+        lua_pushnil(L);
+        return;
     }
 
     if (op->kind == HL_WORK_DB_WAIT_NOTIFY) {
@@ -792,7 +817,7 @@ static int lua_db_async_common(lua_State *L, HlWorkerDbKind kind)
         return luaL_error(L, "db.async: failed to suspend connection");
     }
 
-    return lua_yieldk(L, 0, 0, NULL);
+    return lua_yieldk(L, 0, (lua_KContext)op, lua_db_async_k);
 }
 
 static int lua_db_async_query(lua_State *L)

--- a/tests/e2e_compute_async_trap.sh
+++ b/tests/e2e_compute_async_trap.sh
@@ -16,8 +16,14 @@
 #   - uncaught -> a clean 500 (not a 000 hang, not a swallowed 200)
 #   - pcall / try-catch -> the handler recovers and responds 200
 #
-# Also asserts the SHARED js/async.c fix generalises beyond compute: a db.async
-# error (a throwing consumer, like compute/gpu) now rejects too (cross-consumer).
+# Also asserts the fix generalises beyond compute, in BOTH runtimes: a db.async
+# error surfaces rather than hanging or being swallowed (cross-consumer). JS got
+# that from the one shared js/async.c reject; Lua needed the same continuation
+# treatment per module, which #321 did for db.async.
+#
+# (gpu.async needs no such fix and never did, despite what #321 assumed: its
+# push_result callbacks return a { result } / { error } TABLE rather than
+# raising, so nothing can longjmp out of the resume there.)
 #
 # Persistent-instance async additionally depends on the busy-owner fix (#316,
 # landing via #313). On a base without #316 the first persistent async call is
@@ -139,17 +145,17 @@ run_rt() {
     else
         fail "${runtime} persistent async trap hung (000)"
     fi
-    # Cross-consumer proof for the SHARED js/async.c reject fix: db.async (another
-    # throwing consumer) error is catchable too. JS-only: the JS fix is shared
-    # across all consumers, so one fix covers compute+db+gpu. The Lua side is
-    # per-module (the #317 continuation only landed for compute); Lua db.async /
-    # gpu.async still hang on error -- tracked as #321, not #319.
-    if [ "$runtime" = "js" ]; then
-        case "$dberr" in
-            *'"ok":false'*) pass "${runtime} db.async error is catchable (cross-consumer)" ;;
-            *) fail "${runtime} db.async error catchable (got: $dberr)" ;;
-        esac
-    fi
+    # Cross-consumer proof: a db.async error is catchable too, in BOTH runtimes.
+    # JS got this from the shared js/async.c reject (#319 - one fix covers every
+    # consumer). Lua is per-module: #317/#320 gave compute.async its lua_yieldk
+    # continuation, and #321 gave db.async the same, which is what un-gated this
+    # assertion for Lua. Before that the Lua leg HUNG here (HTTP 000, empty
+    # body), so an empty $dberr is the specific regression this catches.
+    case "$dberr" in
+        *'"ok":false'*) pass "${runtime} db.async error is catchable (cross-consumer)" ;;
+        "")             fail "${runtime} db.async error HUNG (empty body - the #321 raise escaped lua_resume)" ;;
+        *)              fail "${runtime} db.async error catchable (got: $dberr)" ;;
+    esac
 }
 
 run_rt "lua" "lua"


### PR DESCRIPTION
Closes #321.

## The bug

A Lua `db.async.query` / `.exec` that failed **hung** the request at HTTP 000 instead of erroring.

`lua_push_worker_db_result` raised via `luaL_error`, but that callback runs in `hl_async_on_resume` **before** `lua_resume`. The longjmp escaped the resume entirely and left the connection suspended forever. A `pcall` around the call could not recover, because the error never reached the coroutine at all.

```lua
app.get("/dberr", function(req, res)
  local ok = pcall(function()
    return require("hull.db").default().async.query("SELECT * FROM no_such_table")
  end)
  res:json({ ok = ok })   -- never reached; request hangs (000)
end)
```

## The fix

The same treatment `compute.async` got in #317/#320: `push_result` pushes a nil placeholder, and a `lua_yieldk` continuation raises from **inside** `lua_resume`, where it is an ordinary coroutine error a `pcall` can catch.

The op is passed as the yield's `KContext` and is still alive there: both resume paths in `shared/async.c` call `cont->resume` **before** `free_driver`. I verified that invariant rather than inheriting it from the compute template, since the whole fix rests on it.

## Correction to the issue: gpu.async was never affected

#321 lists `gpu.async.dispatch` / `.pipeline` as sharing the bug. They do not, and did not.

Both `lua_push_worker_gpu_result` and `lua_push_worker_gpu_pipeline_result` build a `{ result }` / `{ error }` **table** and never raise, so nothing can longjmp out of the resume. The `luaL_error` calls in `mod_gpu.c` are all in the synchronous setup path before the yield, which is fine.

This was a misreading when the issue was filed, not something fixed in between: those callbacks date from the March `modules.c` split and their error path has not been touched since (the only commits to the file since the issue are a Keel migration and an em-dash sweep). Left alone, and noted in the test header so the next reader does not re-derive it.

## The audit the issue asked for

> `http.fetch` async and `worker.dispatch` async use return-value conventions (not `luaL_error`) and are unaffected - audit each when fixing.

Done, and slightly wider than asked, because grepping for the yield form turns up more sites than the issue lists:

| site | verdict |
|---|---|
| `db.async.query` / `.exec` | **affected** - fixed here |
| `gpu.async.dispatch` / `.pipeline` | safe: returns `{result}`/`{error}` |
| `worker.dispatch` | safe: returns `{error=...}` |
| `http.fetch` | safe: pushes nil / a response table |
| `smtp.send` | safe: returns `{ok, error}` |
| `tui.poll` | safe: pushes an event or nil |
| `hull.sleep` | safe: no driver to fail |

`smtp.send` and `tui.poll` are worth naming: they use the same bare `lua_yieldk(L, 0, 0, NULL)` form and so *look* like candidates. They are safe because their callbacks cannot raise, not because they yield differently. Neither appears in #321.

## Test

No new file: `tests/e2e_compute_async_trap.sh` already drove the Lua `/dberr` route and only gated the **assertion** to JS, precisely because the Lua leg hung. That gate is now removed, so both runtimes assert it.

The failure branch is specific rather than generic: an empty body is called out as the hang this fixes, so a regression reports "db.async error HUNG (empty body - the #321 raise escaped lua_resume)" instead of a vague mismatch.

`mod_db.c` compiles clean locally under the project warning set.
