### PR TITLE
fix: the spawn allowlist denied every tool on Windows

### DIFF
--- a/src/hull/cap/tool.c
+++ b/src/hull/cap/tool.c
@@ -154,9 +154,40 @@ int hl_tool_check_allowlist(const char *binary)
 {
     if (!binary) return -1;
 
-    /* Extract basename */
-    const char *base = strrchr(binary, '/');
-    base = base ? base + 1 : binary;
+    /* Extract basename. Split on BOTH separators: a cosmo APE reaches Windows,
+     * where a resolved tool path is "C:\tools\gcc.exe" - with '/' alone the
+     * whole string stays the "basename" and never matches. */
+    const char *base = binary;
+    for (const char *c = binary; *c; c++)
+        if (*c == '/' || *c == '\\') base = c + 1;
+
+    /* Drop a host executable suffix before matching. The same tool is `cc` on
+     * POSIX and `cc.exe` on Windows (and hull itself installs as `hull.com`,
+     * the APE convention - see install.ps1 and hl_host_exe_suffix). Without
+     * this every allowlisted tool is denied there, because the match below
+     * accepts only an exact name or a `-<digit>` version suffix.
+     *
+     * Narrow by construction: only these two suffixes, only trailing, and only
+     * the SUFFIX is removed - the remaining name still has to be on the list,
+     * so this admits no name that was not already allowed.
+     *
+     * Case-SENSITIVE, like the name match below it. A mixed-case "CC.EXE" is
+     * therefore still denied - exactly as bare "CC" is today, so this is a
+     * limitation carried over, not one introduced. Matching names case-
+     * insensitively would be a real behaviour change (and wrong on POSIX,
+     * where case is significant), so it is deliberately not done here. */
+    char stripped[64];
+    size_t blen = strlen(base);
+    for (const char **sfx = (const char *[]){ ".com", ".exe", NULL }; *sfx; sfx++) {
+        size_t slen = strlen(*sfx);
+        if (blen > slen && blen - slen < sizeof(stripped) &&
+            memcmp(base + blen - slen, *sfx, slen) == 0) {
+            memcpy(stripped, base, blen - slen);
+            stripped[blen - slen] = '\0';
+            base = stripped;
+            break;
+        }
+    }
 
     for (const char **p = allowed_prefixes; *p; p++) {
         size_t plen = strlen(*p);

--- a/tests/hull/cap/test_tool.c
+++ b/tests/hull/cap/test_tool.c
@@ -117,6 +117,66 @@ UTEST(tool, allowlist_reject_empty)
     ASSERT_NE(hl_tool_check_allowlist(""), 0);
 }
 
+/* Windows executable names. A cosmo APE reaches Windows, where the tools
+ * `hull build` spawns are `cc.exe` / `gcc.exe` and paths are backslash-
+ * separated. Two blind spots made every one of them DENIED there: the basename
+ * was split on '/' only, so "C:\tools\gcc.exe" stayed whole and matched
+ * nothing; and the match accepts only an exact name or a `-<digit>` version, so
+ * a clean "cc.exe" fell through as well. */
+UTEST(tool, allowlist_accept_windows_com_suffix)
+{
+    ASSERT_EQ(hl_tool_check_allowlist("hull.com"), 0);
+    ASSERT_EQ(hl_tool_check_allowlist("cosmocc.com"), 0);
+}
+
+UTEST(tool, allowlist_accept_windows_exe_suffix)
+{
+    ASSERT_EQ(hl_tool_check_allowlist("cc.exe"), 0);
+    ASSERT_EQ(hl_tool_check_allowlist("clang-18.exe"), 0);
+}
+
+UTEST(tool, allowlist_accept_windows_backslash_path)
+{
+    ASSERT_EQ(hl_tool_check_allowlist("C:\\Users\\m\\.local\\bin\\hull.com"), 0);
+    ASSERT_EQ(hl_tool_check_allowlist("C:\\tools\\gcc.exe"), 0);
+}
+
+/* Stripping a suffix must not admit a name that was not already allowed:
+ * only the SUFFIX is removed, and what remains still has to be on the list. */
+UTEST(tool, allowlist_suffix_strip_admits_no_new_name)
+{
+    ASSERT_NE(hl_tool_check_allowlist("evil.com"), 0);
+    ASSERT_NE(hl_tool_check_allowlist("sh.exe"), 0);
+    ASSERT_NE(hl_tool_check_allowlist("cc-evil.exe"), 0);
+    ASSERT_NE(hl_tool_check_allowlist("rm.com"), 0);
+    /* not a trailing suffix - must not be stripped from the middle */
+    ASSERT_NE(hl_tool_check_allowlist("cc.exe.evil"), 0);
+    /* the suffix alone is not a name */
+    ASSERT_NE(hl_tool_check_allowlist(".com"), 0);
+    ASSERT_NE(hl_tool_check_allowlist(".exe"), 0);
+}
+
+/* The boundary this fix does NOT cross. `hull-cosmo.exe` is a real name the CI
+ * runs, and it stays denied: stripping ".exe" leaves "hull-cosmo", which the
+ * exact-or-`-<digit>` match rejects. That is deliberate - loosening it would
+ * admit any `hull-*`. Re-execing hull does not need the allowlist at all and
+ * goes through hl_tool_spawn_self instead (#427). */
+UTEST(tool, allowlist_still_rejects_suffixed_variant_names)
+{
+    ASSERT_NE(hl_tool_check_allowlist("hull-cosmo.exe"), 0);
+    ASSERT_NE(hl_tool_check_allowlist("gcc-wrapper.exe"), 0);
+}
+
+/* The suffix strip is case-SENSITIVE, like the name match it feeds. "CC.EXE"
+ * is therefore denied - exactly as bare "CC" is, so this is a limitation
+ * carried over rather than introduced. Matching names case-insensitively would
+ * be a real behaviour change, and wrong on POSIX where case is significant. */
+UTEST(tool, allowlist_suffix_strip_is_case_sensitive)
+{
+    ASSERT_NE(hl_tool_check_allowlist("CC.EXE"), 0);
+    ASSERT_NE(hl_tool_check_allowlist("cc.EXE"), 0);
+}
+
 UTEST(tool, allowlist_reject_cc_evil)
 {
     ASSERT_NE(hl_tool_check_allowlist("cc-evil"), 0);


### PR DESCRIPTION
Fixes the latent Windows blind spot noted in #469's description and deliberately left out of it.

## The bug

`hl_tool_check_allowlist` took the basename by splitting on `/` only, then required an exact name or a `-<digit>` version suffix. On Windows neither holds, and two blind spots compound:

- `C:\tools\gcc.exe` has no `/`, so the **whole string** stayed the "basename" and matched nothing.
- Even a clean `cc.exe` fell through, because `.exe` is neither `""` nor `-<digit>`.

So every tool `hull build` spawns on a cosmo APE under Windows was denied.

## The fix

Split the basename on both separators, and drop a trailing `.com` / `.exe` before matching.

Narrow by construction: only those two suffixes, only trailing, and only the **suffix** is removed. What remains still has to be on the list, so no name is admitted that was not already allowed.

## Two judgment calls worth reviewing

**Case sensitivity.** The strip is case-**sensitive**, matching the name comparison it feeds. `CC.EXE` stays denied, exactly as bare `CC` is today, so that is a limitation carried over rather than introduced. Case-insensitive *name* matching would be a real behaviour change and wrong on POSIX, so it is out of scope.

An earlier draft used `strcasecmp` for the suffix alone. That was worse than it looked: it stripped `.EXE` and then failed on `CC`, reaching the same answer by a more confusing route. Uniformly case-sensitive is simpler and drops the `<strings.h>` dependency.

**The boundary is pinned.** `hull-cosmo.exe` (a real name CI runs) stays **denied**: stripping `.exe` leaves `hull-cosmo`, which the exact-or-version match rejects. That is deliberate, since loosening it would admit any `hull-*`. Re-execing hull does not need the allowlist at all and goes through `hl_tool_spawn_self` instead (#427).

## Why this is a separate PR

Found while fixing #427, where re-execing hull was refused on Windows. I reverted it out of that PR: the real fix there was that re-execing the running binary needs no allowlist, so carrying a security-surface change in a bug fix would have been scope creep. It remains a genuine latent bug for **system** tools, which is what this fixes on its own terms.

## Verification

By execution, not inspection. The matcher was extracted into a harness and run over **39 cases** before committing - 20 accept, 19 deny:

- 14 pre-existing POSIX names (`cc`, `gcc`, `clang-18`, `/usr/bin/cc`, `ld.lld`, `zig`, …) to show nothing regressed
- the new Windows forms, including full backslash paths
- denials for `evil.com`, `sh.exe`, `rm.com`, `cc-evil.exe`, the non-trailing `cc.exe.evil`, bare `.com` / `.exe`
- the suffixed variants `hull-cosmo.exe` / `gcc-wrapper.exe`
- the case-sensitivity boundary `CC.EXE` / `cc.EXE`

Those cases are now in `test_tool`.

## Note

Not built locally: this is a Windows box without a native Hull build path, and `cap/tool.c` needs POSIX headers mingw lacks. The matcher itself was compiled and executed standalone under the project warning set; the full build and unit suite run in CI.
