### PR TITLE
Windows source build: resumable fat builds, working toolchain resolution, and lint gates that stop deleting your build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2533,6 +2533,12 @@ jobs:
       - name: Fat-cosmo pair-repair gate
         run: make check-cosmo-fat-repair
 
+      # `make -n` must describe a build, not perform part of one: three
+      # parse-time $(shell) hooks delete artifacts, and parsing is not
+      # suppressed by -n. Temp dir, no compiler, under a second.
+      - name: Dry-run inertness gate
+        run: make check-dry-run-inert
+
   htmx-browser:
     needs: [classify]
     if: needs.classify.outputs.run_web == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2527,6 +2527,12 @@ jobs:
       - name: Site-consistency self-test (negative)
         run: make check-site-consistency-selftest
 
+      # scripts/cosmo_fat_repair.sh runs from a parse-time $(shell) and deletes
+      # build artifacts, so what it will and will not delete has to be pinned.
+      # Synthetic trees, no compiler, under a second.
+      - name: Fat-cosmo pair-repair gate
+        run: make check-cosmo-fat-repair
+
   htmx-browser:
     needs: [classify]
     if: needs.classify.outputs.run_web == 'true'

--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -424,6 +424,16 @@ jobs:
           # a retry costs a fraction of a build, and at ~30% per build three
           # attempts leave roughly 3% residual failure.
           #
+          # "Resumes from the objects already built" is only true because the
+          # Makefile now repairs the tree first. Killing a wedged cc1 lands
+          # mid-cosmocc, which compiles each TU twice: `foo.o` can exist while
+          # `.aarch64/foo.o` does not, and only the first is a make target, so
+          # every later make skipped the pair as up to date and the retry died
+          # at the fat link naming the archive rather than the cause - stuck
+          # until `make clean`. A parse-time repair (scripts/cosmo_fat_repair.sh)
+          # now deletes a half-written pair so the ordinary rules rebuild both
+          # halves, which is what makes retrying work at all here.
+          #
           # A retry is applied ONLY to a stall. A genuine compile error fails
           # immediately - retrying that would just hide it.
           stall_limit=${HULL_STALL_LIMIT_SECS:-300}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,41 @@ toolchain setup, APE filename conventions, Unix package managers, or Makefiles.
 - **`hull doctor --tui` no longer reserves a row for embedded tcc.** `doctor.c`
   has emitted no `tcc_embedded` field since tcc was retired, so the row was
   unreachable.
+- **No toolchain on PATH was findable on Windows.** `hl_host_find_in_path` -
+  the resolver introduced to fix exactly this - inferred the list separator
+  from the host and split on `;`. But a Cosmopolitan APE, the only Hull build
+  that runs on Windows, is handed a POSIX-shaped PATH by its own runtime
+  (measured on Windows 11: `/C/Users/...:/C/Program Files (x86)/...`), and an
+  MSYS2 or Git-Bash shell exports the same shape, so the whole list collapsed
+  into one nonsense component and every probe reported "not found" however much
+  was installed. The separator is now taken from the list (`;` when one is
+  present, or a single drive-prefixed entry; `:` otherwise) and each hit is
+  composed with its own component's separator, so a POSIX-shaped entry stays
+  POSIX-shaped. On a POSIX host both rules are exact no-ops. Measured on this
+  machine: `hull doctor` went from reporting no compilers to resolving the
+  `cc.exe` that had been on PATH all along.
+- **`hull doctor` and `hull tools list` could disagree about the same tool.**
+  `hl_tools_lookup_path`'s PATH step kept a second, private walker that split
+  on `:` and joined with `/` - the copy hull#459 replaced in doctor, left
+  behind here - so the two surfaces used different rules and neither tried the
+  `.exe` / `.com` forms. It now delegates to the shared resolver, leaving one
+  PATH walker in the tree.
+- **`hull build --compiler=<name>` failed on Windows for a compiler that was
+  installed.** Selection spawned the bare name and left the search to exec,
+  which does not search the PATH Windows hands an APE. A bare name is now
+  resolved by Hull first (`hl_driver_resolve_name`), falling through to the
+  bare name on a miss so exec still gets its turn and POSIX behaviour is
+  unchanged. The same resolution now applies to `--linker=<name>` and to the
+  automatic cc / gcc / clang / cosmocc probes.
+- **cosmocc could not be driven from a shell whose `$HOME` differed from the
+  install's.** cosmocc ships a `#!/bin/sh` driver that Windows cannot execute
+  directly, so Hull routes it through the busybox in the same bundle - but
+  looked for that busybox only under `$HOME`. Under MSYS2 `$HOME` is
+  `/home/<user>` (`C:\msys64\home\<user>`) while `hull tools install cosmocc`
+  from PowerShell installs under `C:\Users\<user>`, so a perfectly good busybox
+  sitting next to the resolved cosmocc was missed and no compile could start.
+  It is now looked for beside the driver first, with the `$HOME` locations as
+  fallbacks.
 
 ## [0.14.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,18 @@ toolchain setup, APE filename conventions, Unix package managers, or Makefiles.
   and labelled `[build-eval]` under `--verbose`. The window's existing bounds -
   the kernel sandbox, stripped dynamic-code loaders, no-op capability stubs,
   top-level only, once per process - are now documented at the call site.
+- **An interrupted cosmocc build could not be resumed, only `make clean`ed.**
+  cosmocc compiles every translation unit twice - `foo.o` beside
+  `.aarch64/foo.o` - and pairs the archives that collect them the same way, but
+  only the first of each pair is ever named as a make target. A build stopped
+  part-way (Ctrl-C, or the Windows source-build watchdog killing a wedged cc1)
+  therefore left a half-written pair that every later `make` skipped as up to
+  date, and the build died at the fat link on a message that named the archive
+  rather than the cause (`linker input missing concomitant
+  vendor/keel/.aarch64/libkeel.a file`). A parse-time repair now removes a
+  half-written pair so the ordinary rules rebuild both halves. This is also what
+  makes the Windows source build's retry-after-stall work: it resumes from the
+  objects already built, and one of those was the pair its own kill had broken.
 
 ## [0.14.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,47 @@ toolchain setup, APE filename conventions, Unix package managers, or Makefiles.
   self-test skips its matching probe for the same reason (that probe is
   observable only through the LTO configuration).
 
+### Security
+
+- **Hull announced a kernel sandbox on Windows that was not there.** A
+  Cosmopolitan APE is the only Hull build that reaches Windows, and
+  `sb_supported()` returned true for every cosmo host unconditionally - so
+  startup logged `[sandbox] phase 1 pledge applied (exec/proc/fork blocked)`
+  and `[sandbox] applied (... pledge: stdio rpath wpath cpath flock fattr
+  inet)`, which a reader can only take as "this process is confined". It was
+  not. Cosmopolitan's `pledge()`/`unveil()` enforce only where the host gives
+  them a mechanism (seccomp-bpf plus Landlock on Linux, the native syscalls on
+  OpenBSD); everywhere else both return 0 and do nothing. Measured with cosmocc
+  4.0.2 on Windows 11: `pledge("stdio", NULL)` returns 0 and a following
+  `socket(AF_INET, SOCK_STREAM, 0)` succeeds, though `stdio` grants no `inet`.
+  The same false claim covered a cosmo APE on macOS and the BSDs, where the
+  cosmo branch is selected ahead of the `__APPLE__` one and Seatbelt is never
+  reached.
+
+  `sb_supported()` is now true only on the hosts that enforce, and any other
+  host emits one warning naming what is and is not protecting it:
+
+  ```
+  [sandbox] NO kernel sandbox on this host: syscall and filesystem
+  confinement, and W^X, are not enforced. Hull's capability layer
+  (manifest fs / env / hosts) is the only boundary.
+  ```
+
+  Startup is **not** refused there. W^X normally fails closed without a kernel
+  sandbox, but that rule exists for a backend that is incomplete - Linux
+  without Landlock, which still refuses unless `--allow-degraded-sandbox`. On a
+  host with no backend at all there is no partial sandbox to opt into and no
+  setting that would produce one, so demanding a flag on every run would add
+  friction without offering an actionable decision. Behaviour on Linux, macOS
+  (native) and OpenBSD is unchanged.
+
+- **`hull doctor` reports the sandbox.** A new `Sandbox` section says whether
+  pledge/unveil are enforcing on THIS host, or that the capability layer is the
+  only boundary - the fallback state, not a failure, so the exit status is
+  unaffected. `--json` carries `kernel_sandbox`. Whether a backend exists is a
+  host fact rather than a build one for the cosmo binary, so it could not be
+  read off the build before.
+
 ## [0.14.0] - 2026-08-27
 
 Windows stabilization. A produced Cosmopolitan APE web app now serves on Windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,29 @@ toolchain setup, APE filename conventions, Unix package managers, or Makefiles.
   configuration, mirroring what it already did for CFI, and the negative
   self-test skips its matching probe for the same reason (that probe is
   observable only through the LTO configuration).
+- **`make platform-cosmo` built a corrupt aarch64 platform archive on Windows.**
+  Keel picks per-platform translation units (`socket_posix.c` vs
+  `socket_winsock.c`, `platform_posix.c` vs `platform_win.c`, and four more) and
+  its `clean` removes the set for the configuration it was *parsed* with. Hull
+  invoked that clean without passing `CC`, so on Windows - where Keel sets
+  `WINDOWS := 1` from `uname` - it deleted the Windows objects and left every
+  POSIX object a cosmo build had made. Measured under MSYS2:
+  `make -n clean` names 17 win objects and 0 posix; `make -n clean
+  CC=x86_64-unknown-cosmo-cc` names the 6 posix ones.
+
+  The aarch64 pass then found `platform_posix.o`, `socket_posix.o`,
+  `udp_cmsg.o` and three siblings already present and up to date, and archived
+  those **x86_64** objects into the aarch64 library. Every `hull build` against
+  it then died in the app link with `ld.bfd: i386:x86-64 architecture of input
+  file ... is incompatible with aarch64 output` - naming binutils rather than
+  the stale object. Each keel clean is now given the same `CC`/`AR` as the build
+  whose objects it removes, and asserts that no object survived it; `make clean`
+  passes its own `CC` through for the same reason. On Linux both configurations
+  select the same POSIX set, so this worked there by coincidence.
+
+  The sweep also covers `.aarch64/` residue under `integrations/`, which Keel's
+  own clean does not reach (it sweeps `src/`, `src/protocols/*/` and
+  `vendor/llhttp/`) - found by the new assertion on its first run.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,17 @@ toolchain setup, APE filename conventions, Unix package managers, or Makefiles.
   half-written pair so the ordinary rules rebuild both halves. This is also what
   makes the Windows source build's retry-after-stall work: it resumes from the
   objects already built, and one of those was the pair its own kill had broken.
+- **`hull build`'s no-compiler hint pointed at a flag that no longer exists.** It
+  advised "rebuild hull with `HL_ENABLE_TCC=1`", which was removed with the rest
+  of the tcc toolchain, so following it could only fail. The hint now names a
+  route that exists on the running binary, as doctor's do: a cosmo hull (the
+  build that reaches Windows) is told to run `hull doctor --fix` or
+  `hull tools install cosmocc`, since it can only link with cosmocc and Hull
+  installs that itself; a native build is told to install gcc or clang or point
+  at one with `--compiler=<path>`.
+- **`hull doctor --tui` no longer reserves a row for embedded tcc.** `doctor.c`
+  has emitted no `tcc_embedded` field since tcc was retired, so the row was
+  unreachable.
 
 ## [0.14.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,34 @@ toolchain setup, APE filename conventions, Unix package managers, or Makefiles.
   sitting next to the resolved cosmocc was missed and no compile could start.
   It is now looked for beside the driver first, with the `$HOME` locations as
   fallbacks.
+- **Running a lint gate deleted your build.** The build-fingerprint purge and
+  the fat-cosmo pair repair are parse-time `$(shell)` hooks, so they fire on
+  *any* `make` invocation whose configuration differs from the last build - and
+  a gate is normally run without the flags the tree was built with. Measured:
+  after `make CC=cosmocc HL_OPT=-O0 HL_ENABLE_WASM=0`, a plain
+  `make check-keel-flags` removed 429 objects and `build/hull`. `make -n` did
+  the same, because `-n` does not suppress parsing. Both hooks are now skipped
+  when the tree must not change: under `-n`, and for goals that build nothing
+  (`lint`, `help`, and every `check-%` except `check-hardening`, which depends
+  on `build/hull` and so genuinely does build). New gate
+  `make check-dry-run-inert` pins it, exercising the MAKEFLAGS detection - the
+  fragile part, where a naive `findstring n` reads `--no-print-directory` as a
+  dry run - in a temp directory where nothing can be lost.
+- **`check-keel-flags` reported six failures on any machine that had built
+  Hull.** It dry-ran `make -n vendor/keel/libkeel.a` and read the compile
+  lines, but that archive's only prerequisites are Hull's mbedTLS objects, so
+  once it exists make answers "up to date", never enters Keel's sub-make and
+  emits no compile lines at all. The gate then reported "no Keel compile lines
+  found (recipe changed?)", which reads as a regression in the thing being
+  gated rather than as the gate mis-firing. It now asks with `-B` what the
+  commands *would* be, which is the actual question.
+- **`check-keel-flags` asserted LTO propagation on toolchains that cannot do
+  LTO.** Hull's own `HL_LTO_CFLAG` comes from a compiler probe and stays empty
+  when neither `-flto=thin` nor `-flto` works, so there was no flag to
+  propagate and the gate was testing the probe. It now skips that
+  configuration, mirroring what it already did for CFI, and the negative
+  self-test skips its matching probe for the same reason (that probe is
+  observable only through the LTO configuration).
 
 ## [0.14.0] - 2026-08-27
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1473,6 +1473,22 @@ Two-phase sandbox in `sandbox.c`:
 
 Violation = SIGABRT on OpenBSD, SIGKILL on Linux/Cosmo, EPERM on macOS. `--no-sandbox` flag disables kernel enforcement for debugging.
 
+**A cosmo APE only gets a kernel sandbox on Linux and OpenBSD.** Cosmopolitan's
+`pledge()`/`unveil()` enforce where the host gives them a mechanism (seccomp-bpf
++ Landlock on Linux, the native syscalls on OpenBSD); on Windows, macOS and the
+other BSDs both calls return 0 and do nothing. Measured with cosmocc 4.0.2 on
+Windows 11: `pledge("stdio", NULL)` returns 0 and a following
+`socket(AF_INET, SOCK_STREAM, 0)` succeeds, though `stdio` grants no `inet`.
+`sb_supported()` therefore reports true only for those two hosts, and anywhere
+else startup logs one WARN - `[sandbox] NO kernel sandbox on this host` - naming
+the capability layer as the only boundary. W^X is not enforced there either;
+this does NOT refuse startup, because there is no partial sandbox to opt into
+and no setting that would produce one (an INCOMPLETE backend, such as Linux
+without Landlock, is the opposite case and still fails closed unless
+`--allow-degraded-sandbox`). Note the cosmo branch is selected before the
+`__APPLE__` one, so an APE on macOS does not reach Seatbelt - giving it one is a
+tracked follow-up, and would add protection rather than only honesty.
+
 ### Capability Enforcement Invariants
 
 - **SQL injection impossible:** All DB access uses `sqlite3_bind_*` parameterized binding. SQL is always a literal string.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1417,6 +1417,18 @@ make CC=cosmocc
 - Sets `COSMO_FAT=1` only when `CC=cosmocc`: creates `.aarch64/libkeel.a` counterpart
 - Uses plain `ar` (not `cosmoar`. Cosmoar fails with recursive `.aarch64/` lookups)
 
+**Interrupted fat builds repair themselves.** Only the x86_64 half of each pair
+(`foo.o`, `libkeel.a`) is ever named as a make target - nothing names the
+`.aarch64/` counterpart - so make cannot tell that half a pair is missing. A
+build stopped part-way therefore used to leave an orphan that every later `make`
+skipped as up to date, dying at the fat link on `linker input missing
+concomitant .aarch64/libkeel.a` until someone ran `make clean`. When `CC` is
+exactly `cosmocc`, a parse-time hook runs `scripts/cosmo_fat_repair.sh` over
+`build/` and `vendor/keel/` (plus the two paired archives, named explicitly -
+`build/libhull_platform.a` is deliberately single-arch even under cosmocc) and
+deletes any orphan so the ordinary rules rebuild both halves. In steady state it
+is a no-op. Its blast radius is gated by `make check-cosmo-fat-repair`.
+
 **hull build with cosmo:**
 - `build.lua` detects `is_cosmo = cc:find("cosmocc")`
 - Searches for both arch-specific archives in `build/` or hull binary directory

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1131,8 +1131,16 @@ per-host fact a user-facing string depends on: `hl_host_is_windows()` (compile-
 time on a native build; an environment probe on a cosmo APE, which is the only
 build that reaches Windows), `hl_host_exe_suffix()` (`".com"` on Windows, `""`
 elsewhere), `hl_host_render_exec()` (`./app` vs `.\app.com`), and
-`hl_host_find_in_path()` (splits PATH on the HOST separator - `;` on Windows -
-and tries the `.exe`/`.com` forms there). Exposed to the tool VM as
+`hl_host_find_in_path()` (splits PATH on the separator the LIST itself uses,
+not the host's - on Windows a Cosmopolitan APE is handed a POSIX-shaped
+`/C/a:/C/b`, an MSYS2 shell exports the same, and a native shell gives Win32
+`C:\a;C:\b` - joins each hit with that component's own separator, and tries the
+`.exe`/`.com` forms on Windows). It is the ONE PATH walker: a second private
+copy in `tools_install.c` was why `hull doctor` and `hull tools list` could
+disagree about the same tool on the same box. `hl_driver_resolve_name()`
+(`compiler.c`) resolves a bare toolchain name through it before spawning,
+because an APE's own exec does not search the PATH Windows hands it. Exposed to
+the tool VM as
 `tool.host_os()` / `tool.exe_suffix()` / `tool.render_exec()`. Every "now run
 it" string routes through `render_exec` rather than hard-coding `./x`: neither
 PowerShell nor a POSIX shell searches the current directory, so a bare relative

--- a/Makefile
+++ b/Makefile
@@ -2652,22 +2652,71 @@ endif
 # Multi-arch cosmo platform: build x86_64 and aarch64 archives
 COSMO_STAGE := .cosmo_staging
 
+# Keel's object SET is configuration-dependent, so its `clean` must be given the
+# same CC as the build whose objects it is removing. Keel picks per-platform TUs
+# (socket_posix.c vs socket_winsock.c, platform_posix.c vs platform_win.c, and
+# four more), and `clean` deletes $(CORE_OBJ) - the set for the configuration it
+# was PARSED with, not the set on disk.
+#
+# Unconfigured, that silently cleans the wrong half on Windows. Measured under
+# MSYS2, where Keel sets WINDOWS := 1 from uname:
+#
+#   make -n clean                          -> names 17 win objects, 0 posix
+#   make -n clean CC=x86_64-unknown-cosmo-cc -> names the 6 posix objects
+#
+# A cosmo build produces the POSIX set, so an unconfigured clean between the two
+# arch passes below removed nothing it had made. The aarch64 pass then found
+# platform_posix.o, socket_posix.o, udp_cmsg.o and three siblings already
+# present and up to date, archived those x86_64 objects into the aarch64 lib,
+# and every `hull build` against it died in the app link with
+#
+#   ld.bfd: i386:x86-64 architecture of input file
+#           `.aarch64/libhull_platform.a(udp_cmsg.o)' is incompatible with
+#           aarch64 output
+#
+# naming binutils rather than the stale object. On Linux both configurations
+# select the same POSIX set, so this worked there by coincidence; passing CC
+# makes it correct by construction on every host.
+#
+# The assertion after each clean is the cheap invariant that would have caught
+# it: a clean that leaves a .o behind has cleaned the wrong set.
+define keel-clean
+	$(MAKE) -C $(KEEL_DIR) clean CC=$(1) AR=$(2)
+	@# Keel's clean sweeps .aarch64/ under src/, src/protocols/*/ and
+	@# vendor/llhttp/ but not under integrations/, so a previous FAT build
+	@# leaves integrations/*/*/.aarch64/*.o behind. Those are inert for the
+	@# single-arch passes here, but they are still residue from another
+	@# configuration and the assertion below is not worth weakening to
+	@# tolerate them. Sweep every .aarch64 dir rather than naming Keel's
+	@# layout, so this keeps working if Keel grows another one.
+	@find $(KEEL_DIR) -type d -name .aarch64 -exec rm -rf {} + 2>/dev/null || true
+	@leftover=$$(find $(KEEL_DIR) -name '*.o' 2>/dev/null | head -5); \
+	if [ -n "$$leftover" ]; then \
+	    echo "ERROR: keel objects survived a clean configured for CC=$(1):"; \
+	    echo "$$leftover" | sed 's/^/  /'; \
+	    echo "  A later arch pass would archive these as if they were its own."; \
+	    exit 1; \
+	fi
+endef
+
 platform-cosmo:
 	@rm -rf $(COSMO_STAGE) && mkdir -p $(COSMO_STAGE)
 	@echo "=== Building x86_64-cosmo platform ==="
 	$(MAKE) clean
-	$(MAKE) -C $(KEEL_DIR) clean
+	$(call keel-clean,x86_64-unknown-cosmo-cc,x86_64-unknown-cosmo-ar)
 	$(MAKE) platform CC=x86_64-unknown-cosmo-cc AR=x86_64-unknown-cosmo-ar
 	cp $(BUILDDIR)/libhull_platform.a $(COSMO_STAGE)/libhull_platform.x86_64-cosmo.a
 	cp $(BUILDDIR)/platform_canary_hash $(COSMO_STAGE)/platform_canary_hash.x86_64-cosmo
 	@echo "=== Building aarch64-cosmo platform ==="
 	$(MAKE) clean
-	$(MAKE) -C $(KEEL_DIR) clean
+	@# x86_64 on purpose, not a copy-paste slip: what is on disk here is what
+	@# the pass above built, and a clean must match the objects it removes.
+	$(call keel-clean,x86_64-unknown-cosmo-cc,x86_64-unknown-cosmo-ar)
 	$(MAKE) platform CC=aarch64-unknown-cosmo-cc AR=aarch64-unknown-cosmo-ar
 	cp $(BUILDDIR)/libhull_platform.a $(COSMO_STAGE)/libhull_platform.aarch64-cosmo.a
 	cp $(BUILDDIR)/platform_canary_hash $(COSMO_STAGE)/platform_canary_hash.aarch64-cosmo
 	$(MAKE) clean
-	$(MAKE) -C $(KEEL_DIR) clean
+	$(call keel-clean,aarch64-unknown-cosmo-cc,aarch64-unknown-cosmo-ar)
 	mkdir -p $(BUILDDIR)
 	cp $(COSMO_STAGE)/* $(BUILDDIR)/
 	echo "cosmocc" > $(BUILDDIR)/platform_cc
@@ -3619,7 +3668,12 @@ docs-api-check:
 clean:
 	rm -rf $(BUILDDIR)
 	rm -f fuzz/fuzz_sh_json fuzz/fuzz_path_normalize fuzz/fuzz_mime_sniff fuzz/fuzz_host_match fuzz/fuzz_pgwire fuzz/fuzz_pg_dsn fuzz/fuzz_pg_rewrite fuzz/fuzz_mysqlwire fuzz/fuzz_mysql_dsn
-	@$(MAKE) -s -C $(KEEL_DIR) clean 2>/dev/null || true
+	@# Hand Keel the SAME CC this clean was invoked with. Keel selects
+	@# per-platform TUs (socket_posix.c vs socket_winsock.c, and five more) and
+	@# its clean removes the set for the configuration it was PARSED with - so
+	@# unconfigured on Windows it deletes the win objects and leaves every posix
+	@# object a cosmo build made. See the keel-clean note in platform-cosmo.
+	@$(MAKE) -s -C $(KEEL_DIR) clean CC=$(CC) AR=$(AR) 2>/dev/null || true
 
 # ── Header-dependency replay ────────────────────────────────────────
 #

--- a/Makefile
+++ b/Makefile
@@ -2130,9 +2130,44 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
     printf '%s\n' '$(BUILD_FINGERPRINT)' > $(BUILD_CONFIG_FILE); \
 })
 
+# ── Fat-cosmo object-pair repair ────────────────────────────────────
+#
+# cosmocc writes every object TWICE - `foo.o` and `.aarch64/foo.o` - but only
+# the first is a make target, so an interrupted build leaves a half-written
+# pair that make skips as up to date and the fat link then dies on, naming the
+# archive rather than the cause. It stays dead until `make clean`. That is the
+# exact state the Windows source build inherits whenever its watchdog kills a
+# wedged cc1, which is what stops its retry-after-stall mitigation from
+# working there (.github/workflows/windows-source-build.yml, HANG). The
+# failing messages and the full rationale are in the script.
+#
+# Parse-time on purpose, like the fingerprint purge above: the damage has to be
+# undone before make decides anything is up to date, and it decides that as it
+# walks. One consequence worth stating - `make -n` repairs too, so a dry run
+# over a corrupt tree describes the build that would actually happen.
+#
+# Two trees, because a fat build writes objects into exactly two: $(BUILDDIR)
+# (Hull's own objects plus every vendored one - mbedTLS, QuickJS, Lua, SQLite,
+# WAMR all land there) and Keel's, the one sub-make with its own object
+# directory. Pruning objects alone is not enough: make re-enters Keel's
+# sub-make only when libkeel.a is out of date, so a surviving half-paired
+# archive means the pruned objects are never rebuilt. The two paired ARCHIVES
+# are therefore named explicitly rather than swept - build/libhull_platform.a
+# is deliberately single-arch even under cosmocc, so a blanket `*.a` sweep
+# would delete it on every invocation and never converge.
+#
+# Gated on $(CC) being exactly `cosmocc`, the same test Keel uses to set
+# COSMO_FAT, so a single-arch cosmo build (x86_64-unknown-cosmo-cc) - where no
+# counterpart is ever expected and every object would look like an orphan - is
+# never touched. In steady state this is a no-op: a build that ran to
+# completion leaves no orphan.
+ifeq ($(CC),cosmocc)
+$(shell sh scripts/cosmo_fat_repair.sh $(BUILDDIR) $(KEEL_DIR) $(KEEL_LIB) $(BUILDDIR)/libhull.a >/dev/null)
+endif
+
 # ── Targets ─────────────────────────────────────────────────────────
 
-.PHONY: all clean test debug msan tsan tsan-shared-heap fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-valkey e2e-feature-valkey e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-stream-meta e2e-compute-async-trap e2e-sync-spans e2e-compute-aot-shared-heap e2e-compute-memory64 e2e-compute-headers e2e-spans-example e2e-spans-multi e2e-spans-hugefile e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-linker-zig e2e-cross-build e2e-musl e2e-musl-cross floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-test-harness e2e-jobs e2e-hypermedia-photos-upload e2e-jwt-asym e2e-path-parity hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-mapped-span bench-gpu bench-bytecode-cache wamrc wamrc-configure coverage lint-lua lint-js lint check-sdk-headers check-sdk-headers-selftest check-wamr-msan-annotation check-docs-integrity check-docs-integrity-selftest check-no-emdash check-no-emdash-selftest check-no-milestone-narration check-no-milestone-narration-selftest check-keel-flags check-keel-flags-selftest check-site-consistency check-site-consistency-selftest platform platform-cosmo hardening check-hardening
+.PHONY: all clean test debug msan tsan tsan-shared-heap fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-valkey e2e-feature-valkey e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-stream-meta e2e-compute-async-trap e2e-sync-spans e2e-compute-aot-shared-heap e2e-compute-memory64 e2e-compute-headers e2e-spans-example e2e-spans-multi e2e-spans-hugefile e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-linker-zig e2e-cross-build e2e-musl e2e-musl-cross floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-test-harness e2e-jobs e2e-hypermedia-photos-upload e2e-jwt-asym e2e-path-parity hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-mapped-span bench-gpu bench-bytecode-cache wamrc wamrc-configure coverage lint-lua lint-js lint check-sdk-headers check-sdk-headers-selftest check-wamr-msan-annotation check-docs-integrity check-docs-integrity-selftest check-no-emdash check-no-emdash-selftest check-no-milestone-narration check-no-milestone-narration-selftest check-keel-flags check-keel-flags-selftest check-site-consistency check-site-consistency-selftest check-cosmo-fat-repair platform platform-cosmo hardening check-hardening
 
 all: $(BUILDDIR)/hull
 
@@ -3437,7 +3472,16 @@ check-site-consistency:
 check-site-consistency-selftest:
 	sh tests/check_site_consistency_selftest.sh
 
-lint: lint-lua lint-js check-sdk-headers check-docs-integrity check-no-emdash check-no-milestone-narration check-site-consistency check-keel-flags
+# Fat-cosmo pair-repair gate: scripts/cosmo_fat_repair.sh runs from a
+# parse-time $(shell) and DELETES build artifacts, so its blast radius has to
+# be pinned down. Over-reach means an artifact that legitimately has no aarch64
+# counterpart is deleted and rebuilt on every invocation and the build never
+# converges; a stray line on stdout is a syntax error in the middle of the
+# makefile. Synthetic trees, no compiler, under a second. See the script header.
+check-cosmo-fat-repair:
+	sh tests/check_cosmo_fat_repair.sh
+
+lint: lint-lua lint-js check-sdk-headers check-docs-integrity check-no-emdash check-no-milestone-narration check-site-consistency check-keel-flags check-cosmo-fat-repair
 
 # ── API documentation (two-tier: source comments + generated HTML) ──
 #

--- a/Makefile
+++ b/Makefile
@@ -2079,6 +2079,54 @@ BUILD_FINGERPRINT := \
   APP_BASE_TLSLESS=$(HL_APP_BASE_TLSLESS)|\
   CC=$(CC)
 
+# ── Dry-run detection ───────────────────────────────────────────────
+#
+# `make -n` must DESCRIBE the build, never perform part of it. Two parse-time
+# $(shell ...) hooks below delete build artifacts (the fingerprint purge and
+# the fat-cosmo pair repair), and $(shell) runs during PARSING - which -n does
+# not suppress. So a dry run mutated the tree.
+#
+# That is not theoretical. tests/check_keel_flag_propagation.sh advertises
+# itself as "dry run, no artifacts" and shells `make -n <vars> libkeel.a` with
+# variables that differ from whatever the developer last built with. The
+# fingerprint mismatch fired the purge: running the LINT gate deleted 273
+# objects and build/hull out of a working tree.
+#
+# GNU make collects single-letter options into the FIRST word of MAKEFLAGS,
+# WITHOUT a leading dash (`-Bn` arrives as `Bn`); long options arrive as
+# separate dash-prefixed words. So a first word that carries no dash is the
+# short-option set, and an `n` in it means -n. No other make short option
+# contains an `n`, and checking for the dash keeps `--no-print-directory` -
+# which does contain one - from reading as a dry run.
+HL_MAKE_SHORT_OPTS := $(firstword $(MAKEFLAGS))
+ifeq ($(findstring -,$(HL_MAKE_SHORT_OPTS)),)
+HL_DRY_RUN := $(findstring n,$(HL_MAKE_SHORT_OPTS))
+endif
+
+# Goals that BUILD NOTHING must not fire it either. The purge exists to stop a
+# stale object from another configuration reaching a binary; a lint gate
+# produces no binary, so there is nothing to protect - and firing it there is
+# actively destructive, because a gate is normally run WITHOUT the flags the
+# tree was built with. `make lint` after `make CC=cosmocc HL_OPT=-O0
+# HL_ENABLE_WASM=0 ...` differs in every fingerprint field, so it deleted that
+# entire build: 429 objects and build/hull, measured, from running a gate.
+#
+# `check-%` covers every gate by construction, so a new one needs no edit here.
+# check-hardening is the single exception: it depends on $(BUILDDIR)/hull and
+# therefore really does build, and skipping the purge for it could let it
+# inspect a binary carrying stale objects.
+HL_INERT_GOALS := $(filter-out check-hardening,\
+                    $(filter lint lint-lua lint-js help check-%,$(MAKECMDGOALS)))
+ifneq ($(MAKECMDGOALS),)
+ifeq ($(filter-out $(HL_INERT_GOALS),$(MAKECMDGOALS)),)
+HL_NO_BUILD := 1
+endif
+endif
+
+# Either reason is enough: this is what the parse-time hooks below are guarded
+# on. Non-empty = leave the tree exactly as found.
+HL_TREE_MUST_NOT_CHANGE := $(HL_DRY_RUN)$(HL_NO_BUILD)
+
 BUILD_CONFIG_FILE := $(BUILDDIR)/.build-config
 
 # Parse-time: ensure builddir exists, then compare fingerprint. On
@@ -2099,6 +2147,8 @@ else
 PLATFORM_LIB_PURGE := $(BUILDDIR)/libhull_platform.a
 endif
 
+# Guarded: a dry run or a build-nothing goal leaves the tree alone (above).
+ifeq ($(HL_TREE_MUST_NOT_CHANGE),)
 $(shell mkdir -p $(BUILDDIR))
 $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)" || { \
     rm -f $(BUILDDIR)/cap_*.o $(BUILDDIR)/cmd_*.o $(BUILDDIR)/js_*.o $(BUILDDIR)/lua_rt_*.o \
@@ -2129,6 +2179,7 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
           $(BUILDDIR)/test_* 2>/dev/null; \
     printf '%s\n' '$(BUILD_FINGERPRINT)' > $(BUILD_CONFIG_FILE); \
 })
+endif
 
 # ── Fat-cosmo object-pair repair ────────────────────────────────────
 #
@@ -2143,8 +2194,9 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
 #
 # Parse-time on purpose, like the fingerprint purge above: the damage has to be
 # undone before make decides anything is up to date, and it decides that as it
-# walks. One consequence worth stating - `make -n` repairs too, so a dry run
-# over a corrupt tree describes the build that would actually happen.
+# walks. Skipped under `-n` for the same reason the purge is: a dry run
+# describes a build, it does not perform part of one. Nothing is built under
+# -n, so not repairing there costs nothing.
 #
 # Two trees, because a fat build writes objects into exactly two: $(BUILDDIR)
 # (Hull's own objects plus every vendored one - mbedTLS, QuickJS, Lua, SQLite,
@@ -2162,12 +2214,14 @@ $(shell test "$$(cat $(BUILD_CONFIG_FILE) 2>/dev/null)" = "$(BUILD_FINGERPRINT)"
 # never touched. In steady state this is a no-op: a build that ran to
 # completion leaves no orphan.
 ifeq ($(CC),cosmocc)
+ifeq ($(HL_TREE_MUST_NOT_CHANGE),)
 $(shell sh scripts/cosmo_fat_repair.sh $(BUILDDIR) $(KEEL_DIR) $(KEEL_LIB) $(BUILDDIR)/libhull.a >/dev/null)
+endif
 endif
 
 # ── Targets ─────────────────────────────────────────────────────────
 
-.PHONY: all clean test debug msan tsan tsan-shared-heap fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-valkey e2e-feature-valkey e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-stream-meta e2e-compute-async-trap e2e-sync-spans e2e-compute-aot-shared-heap e2e-compute-memory64 e2e-compute-headers e2e-spans-example e2e-spans-multi e2e-spans-hugefile e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-linker-zig e2e-cross-build e2e-musl e2e-musl-cross floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-test-harness e2e-jobs e2e-hypermedia-photos-upload e2e-jwt-asym e2e-path-parity hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-mapped-span bench-gpu bench-bytecode-cache wamrc wamrc-configure coverage lint-lua lint-js lint check-sdk-headers check-sdk-headers-selftest check-wamr-msan-annotation check-docs-integrity check-docs-integrity-selftest check-no-emdash check-no-emdash-selftest check-no-milestone-narration check-no-milestone-narration-selftest check-keel-flags check-keel-flags-selftest check-site-consistency check-site-consistency-selftest check-cosmo-fat-repair platform platform-cosmo hardening check-hardening
+.PHONY: all clean test debug msan tsan tsan-shared-heap fuzz fuzz-run e2e e2e-build e2e-postgres e2e-mysql e2e-valkey e2e-feature-valkey e2e-http e2e-sandbox e2e-examples e2e-cli e2e-migrate e2e-templates e2e-agent e2e-context e2e-mcp e2e-agent-api e2e-compute e2e-stream-meta e2e-compute-async-trap e2e-sync-spans e2e-compute-aot-shared-heap e2e-compute-memory64 e2e-compute-headers e2e-spans-example e2e-spans-multi e2e-spans-hugefile e2e-compute-dev e2e-aot-cache e2e-cache e2e-cache-concurrent e2e-cache-cosmo e2e-named-connections e2e-dynamic-connections e2e-compiler-free e2e-linker e2e-linker-zig e2e-cross-build e2e-musl e2e-musl-cross floor-musl e2e-build-flavor e2e-install e2e-ca-bundle e2e-update e2e-tools e2e-multipart e2e-attachment e2e-blob e2e-test-harness e2e-jobs e2e-hypermedia-photos-upload e2e-jwt-asym e2e-path-parity hull-test-examples self-build check analyze cppcheck bench bench-template bench-wasm bench-mapped-span bench-gpu bench-bytecode-cache wamrc wamrc-configure coverage lint-lua lint-js lint check-sdk-headers check-sdk-headers-selftest check-wamr-msan-annotation check-docs-integrity check-docs-integrity-selftest check-no-emdash check-no-emdash-selftest check-no-milestone-narration check-no-milestone-narration-selftest check-keel-flags check-keel-flags-selftest check-site-consistency check-site-consistency-selftest check-cosmo-fat-repair check-dry-run-inert platform platform-cosmo hardening check-hardening
 
 all: $(BUILDDIR)/hull
 
@@ -3481,7 +3535,16 @@ check-site-consistency-selftest:
 check-cosmo-fat-repair:
 	sh tests/check_cosmo_fat_repair.sh
 
-lint: lint-lua lint-js check-sdk-headers check-docs-integrity check-no-emdash check-no-milestone-narration check-site-consistency check-keel-flags check-cosmo-fat-repair
+# Dry-run inertness gate: `make -n` must DESCRIBE a build, never perform part
+# of one. Three parse-time $(shell) hooks delete build artifacts, and parsing
+# is not suppressed by -n - which is how the keel-flags gate, advertising
+# itself as a dry run, came to delete 273 objects and build/hull out of a
+# working tree. Exercises the MAKEFLAGS detection in a temp dir where nothing
+# can be lost. See the script header.
+check-dry-run-inert:
+	sh tests/check_dry_run_is_inert.sh
+
+lint: lint-lua lint-js check-sdk-headers check-docs-integrity check-no-emdash check-no-milestone-narration check-site-consistency check-keel-flags check-cosmo-fat-repair check-dry-run-inert
 
 # ── API documentation (two-tier: source comments + generated HTML) ──
 #

--- a/docs/security.md
+++ b/docs/security.md
@@ -191,7 +191,7 @@ This is the primary threat model. Hull exists to make it possible to trust apps 
 
 **Attack: Declare minimal manifest but access more at runtime**
 
-- **Prevention:** Manifest is signed in `package.sig`. At runtime, pledge/unveil enforce the declared capabilities at the kernel level. Accessing undeclared paths triggers SIGKILL (Linux/Cosmo).
+- **Prevention:** Manifest is signed in `package.sig`. At runtime, pledge/unveil enforce the declared capabilities at the kernel level. Accessing undeclared paths triggers SIGKILL (Linux, and a cosmo APE ON Linux/OpenBSD - see "Cosmopolitan APE" below for the hosts where a cosmo build has no kernel sandbox at all).
 - **Remaining risk:** On macOS, Seatbelt returns EPERM (operation denied) rather than SIGKILL. The app continues running after a violation. The forbidden operation simply fails. On Linux/Cosmo, the process is killed on violation. The practical security is equivalent (the operation is denied either way), but the failure mode differs.
 
 **Attack: Call `app.manifest()` again at runtime to escalate capabilities**
@@ -538,18 +538,58 @@ but it is not equivalent to the full Linux sandbox and is logged as degraded.
 
 ### Cosmopolitan APE (cosmocc)
 
-| Mechanism | Implementation | Violation |
-|-----------|---------------|-----------|
-| Syscall filter | Native pledge() in cosmocc libc | SIGKILL |
-| Filesystem restriction | Native unveil() | ENOENT |
-| Static binary | No dynamic linking | N/A |
+| Mechanism | Implementation | Where it enforces | Violation |
+|-----------|---------------|-------------------|-----------|
+| Syscall filter | Native pledge() in cosmocc libc | Linux, OpenBSD | SIGKILL |
+| Filesystem restriction | Native unveil() | Linux, OpenBSD | ENOENT |
+| Static binary | No dynamic linking | every host | N/A |
 
-**Additional protections:**
-- Works on Linux, FreeBSD, OpenBSD, Windows (via NT security)
+**The kernel sandbox is Linux/OpenBSD only.** Cosmopolitan's `pledge()` and
+`unveil()` enforce where the host gives them a mechanism: seccomp-bpf plus
+Landlock on Linux, the native syscalls on OpenBSD. On **Windows, macOS and the
+other BSDs the same APE gets no kernel confinement at all** - both calls return
+0 and do nothing. Measured with cosmocc 4.0.2 on Windows 11:
+`pledge("stdio", NULL)` returns 0, and a subsequent
+`socket(AF_INET, SOCK_STREAM, 0)` SUCCEEDS even though the `stdio` promise
+grants no `inet`.
+
+Hull reports that rather than assuming it. `sb_supported()`
+(`src/hull/sandbox.c`) is true for a cosmo build only on Linux and OpenBSD; on
+any other host startup emits one warning,
+
+```
+[sandbox] NO kernel sandbox on this host: syscall and filesystem confinement,
+and W^X, are not enforced. Hull's capability layer (manifest fs / env / hosts)
+is the only boundary.
+```
+
+and the process continues. W^X is not enforced there, and that does not refuse
+startup: there is no partial sandbox to opt into on such a host and no setting
+that would produce one, so demanding a flag on every run would add friction
+without offering an actionable decision. A backend that EXISTS but is
+incomplete is the opposite case and still fails closed - Linux without Landlock
+refuses unless `--allow-degraded-sandbox`.
+
+On those hosts the **C capability layer is the boundary**: the manifest's
+fs/env/hosts gates, checked in C before every operation, exactly as on any
+platform with no kernel backend. That is a real boundary against the app's own
+code, but unlike pledge/unveil it is not a boundary against native code that
+escapes the runtime.
+
+Note also that the cosmo branch is selected ahead of the `__APPLE__` one, so an
+APE running on macOS never reaches the Seatbelt profile a native macOS build
+would apply. Wiring Seatbelt into the cosmo path is a tracked follow-up; it
+would add protection, not merely honesty.
+
+**Additional protections (every host):**
 - No dynamic linking → no LD_PRELOAD attacks
 - No DLL injection
 - No dynamic linker attacks
-- W^X enforcement by Cosmopolitan runtime (APE loader uses fixed code segments; `MAP_JIT` and equivalent OS-specific JIT APIs are unavailable to the guest)
+- No JIT surface: the APE loader uses fixed code segments, and `MAP_JIT` and the
+  equivalent OS-specific JIT APIs are unavailable to the guest. This is a
+  property of the loader and the runtime, not a kernel-enforced W^X guarantee -
+  on Linux/OpenBSD the pledge promise set enforces W^X as well, and elsewhere it
+  is unenforced.
 
 ### macOS (gcc/clang)
 

--- a/include/hull/cap/tool.h
+++ b/include/hull/cap/tool.h
@@ -128,15 +128,20 @@ int hl_tool_spawn_driver_shell(const char *shell, const char *driver,
 
 /*
  * Resolve the bundled busybox shell used to drive cosmocc on Windows (the
- * cosmo/Windows build path). Returns 0 and writes the path to @p out when a
- * cosmocc-bundle busybox is present AND this is a cosmo hull on Windows; returns
+ * cosmo/Windows build path). @p driver is the cosmocc invocation about to be
+ * spawned: busybox.exe is looked for BESIDE it first (the bundle ships them as
+ * siblings), which is what makes this work wherever the bundle lives and
+ * whatever $HOME says, before falling back to the $HOME/$USERPROFILE bundle
+ * locations. Pass NULL to search only those. Returns 0 and writes the path to
+ * @p out when a cosmocc-bundle busybox is present AND this is a cosmo hull on
+ * Windows; returns
  * -1 otherwise (always -1 on a native build / on a POSIX host, where cosmocc's
  * #!/bin/sh driver runs directly). Used by the transparent cosmocc reroute in
  * the spawn layer (hl_tool_spawn_env / _read), which covers every cosmocc call
  * site - the compiler vtable, tool.spawn, and the -dumpmachine / --version
  * probes - so the build tool needs no per-call-site change.
  */
-int hl_tool_cosmo_shell(char *out, size_t outsz);
+int hl_tool_cosmo_shell(const char *driver, char *out, size_t outsz);
 
 /*
  * On a cosmo hull on Windows, point TMPDIR/TMP/TEMP at one real directory that

--- a/include/hull/compiler.h
+++ b/include/hull/compiler.h
@@ -81,4 +81,20 @@ HlCompiler *hl_compiler_select(const char *explicit_cc);
  */
 int hl_driver_resolve_native(char *out, size_t outsz);
 
+/*
+ * Resolve a toolchain driver NAME to something spawnable, without probing it.
+ *
+ * A name carrying a separator is a path already and is copied verbatim. A bare
+ * name is looked up on PATH by Hull itself (hl_host_find_in_path) rather than
+ * left for exec's own search, which cannot be relied on for this on Windows: a
+ * Cosmopolitan APE is handed a POSIX-shaped PATH there and its exec does not
+ * search it, so `--compiler=cosmocc` failed on a box whose `hull doctor`
+ * listed that exact cosmocc. A miss copies the bare name through, so exec
+ * still gets its turn and POSIX behaviour is unchanged.
+ *
+ * Returns 0 on success (out holds the invocation), -1 on a bad argument or if
+ * the result does not fit.
+ */
+int hl_driver_resolve_name(const char *name, char *out, size_t outsz);
+
 #endif /* HL_COMPILER_H */

--- a/include/hull/sandbox.h
+++ b/include/hull/sandbox.h
@@ -158,4 +158,17 @@ int hl_tool_sandbox_init(HlToolUnveilCtx *ctx,
                          const char *output_dir,
                          const char *platform_dir);
 
+
+/*
+ * Does THIS host have a kernel sandbox backend behind pledge()/unveil()?
+ *
+ * Not a compile-time fact for a Cosmopolitan build: the same APE runs on hosts
+ * that enforce (Linux, OpenBSD) and hosts where both calls return 0 and do
+ * nothing (Windows, macOS, the other BSDs). Exposed so `hull doctor` can report
+ * the state BEFORE an app is run, rather than leaving it to a warning at
+ * startup. Returns 1 when a backend is present, 0 when the C capability layer
+ * is the only boundary.
+ */
+int hl_sandbox_kernel_available(void);
+
 #endif /* HL_SANDBOX_H */

--- a/include/hull/shared/host.h
+++ b/include/hull/shared/host.h
@@ -94,9 +94,14 @@ int hl_host_render_exec(const char *path, char *out, size_t out_sz);
 /**
  * @brief Find @p name as an executable on PATH, honouring host conventions.
  *
- * Splits PATH on hl_host_path_list_sep() and, on Windows, also tries the
- * ".exe" / ".com" / ".bat" / ".cmd" forms (the PATHEXT entries that matter for
- * a toolchain probe). Writes the resolved absolute-ish path to @p out.
+ * Splits PATH on the separator the LIST ITSELF uses, not the one the host
+ * nominally prefers: on Windows both a Win32 `C:\a;C:\b` and a POSIX-shaped
+ * `/C/a:/C/b` occur, and the second is what a Cosmopolitan APE - the only Hull
+ * build that runs there - is actually handed. Each hit is composed with the
+ * separator its own PATH component uses, so a POSIX-shaped entry stays
+ * POSIX-shaped. On Windows the ".exe" / ".com" / ".bat" / ".cmd" forms are
+ * tried too (the PATHEXT entries that matter for a toolchain probe). Writes
+ * the resolved absolute-ish path to @p out.
  *
  * @returns 1 when found, 0 otherwise.
  */

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -665,16 +665,16 @@ $(CAP_TOOL_NONE_OBJ): $(SRCDIR)/hull/cap/tool.c | $(BUILDDIR)
 
 # TOOLS_INSTALL_OBJ (pure-libc registry + hl_tools_lookup_path) is needed for
 # tool-resolution symbols referenced by the compiler backend.
-$(BUILDDIR)/test_tool: $(TESTDIR)/hull/cap/test_tool.c $(CAP_TOOL_NONE_OBJ) $(COMPILER_OBJ) $(TOOLS_INSTALL_OBJ) $(FS_UTIL_OBJ) $(BUILD_ASSET_OBJ) $(BUILDDIR)/cap_audit.o $(SH_JSON_OBJ) $(SH_ARENA_OBJ) | $(BUILDDIR)
-	$(CC) $(filter-out -DHL_ENABLE_LUA -DHL_ENABLE_JS,$(CFLAGS)) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(CAP_TOOL_NONE_OBJ) $(COMPILER_OBJ) $(TOOLS_INSTALL_OBJ) $(FS_UTIL_OBJ) $(BUILD_ASSET_OBJ) $(BUILDDIR)/cap_audit.o $(SH_JSON_OBJ) $(SH_ARENA_OBJ)
+$(BUILDDIR)/test_tool: $(TESTDIR)/hull/cap/test_tool.c $(CAP_TOOL_NONE_OBJ) $(COMPILER_OBJ) $(TOOLS_INSTALL_OBJ) $(FS_UTIL_OBJ) $(HOST_OBJ) $(BUILD_ASSET_OBJ) $(BUILDDIR)/cap_audit.o $(SH_JSON_OBJ) $(SH_ARENA_OBJ) | $(BUILDDIR)
+	$(CC) $(filter-out -DHL_ENABLE_LUA -DHL_ENABLE_JS,$(CFLAGS)) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(CAP_TOOL_NONE_OBJ) $(COMPILER_OBJ) $(TOOLS_INSTALL_OBJ) $(FS_UTIL_OBJ) $(HOST_OBJ) $(BUILD_ASSET_OBJ) $(BUILDDIR)/cap_audit.o $(SH_JSON_OBJ) $(SH_ARENA_OBJ)
 
 # Compiler vtable tests
 COMPILER_TEST_DEPS := $(TEST_CAP_OBJS) $(ALLOC_OBJ) $(ASYNC_OBJ) $(COMPRESS_OBJ) $(MINIZ_OBJ) $(WORKER_DB_OBJ) $(WORKER_WASM_OBJ) $(WORKER_GPU_OBJ) $(VFS_OBJ) $(PATH_NORM_OBJ) $(THREAD_AFFINITY_OBJ) $(CACERT_OBJ) $(TLS_CLIENT_OBJ) $(WAMR_OBJS) $(MBEDTLS_OBJS) $(SH_SEAL_ARENA_OBJ) $(KEEL_LIB) $(SQLITE_OBJ) $(LOG_OBJ) $(LOG_LOCK_OBJ) $(SH_ARENA_OBJ) $(SH_JSON_OBJ) $(TWEETNACL_OBJ) $(STB_OBJ)
 
-$(BUILDDIR)/test_compiler: $(TESTDIR)/hull/compiler/test_compiler.c $(COMPILER_OBJ) $(TOOLS_INSTALL_OBJ) $(FS_UTIL_OBJ) $(CAP_TOOL_NONE_OBJ) $(BUILD_ASSET_OBJ) $(BUILDDIR)/cap_audit.o $(SH_JSON_OBJ) $(SH_ARENA_OBJ) | $(BUILDDIR)
+$(BUILDDIR)/test_compiler: $(TESTDIR)/hull/compiler/test_compiler.c $(COMPILER_OBJ) $(TOOLS_INSTALL_OBJ) $(FS_UTIL_OBJ) $(HOST_OBJ) $(CAP_TOOL_NONE_OBJ) $(BUILD_ASSET_OBJ) $(BUILDDIR)/cap_audit.o $(SH_JSON_OBJ) $(SH_ARENA_OBJ) | $(BUILDDIR)
 	$(CC) $(filter-out -DHL_ENABLE_LUA -DHL_ENABLE_JS,$(CFLAGS)) $(INCLUDES) -I$(VENDDIR) -o $@ \
 		$(TESTDIR)/hull/compiler/test_compiler.c \
-		$(COMPILER_OBJ) $(TOOLS_INSTALL_OBJ) $(FS_UTIL_OBJ) \
+		$(COMPILER_OBJ) $(TOOLS_INSTALL_OBJ) $(FS_UTIL_OBJ) $(HOST_OBJ) \
 		$(CAP_TOOL_NONE_OBJ) $(BUILD_ASSET_OBJ) \
 		$(BUILDDIR)/cap_audit.o $(SH_JSON_OBJ) $(SH_ARENA_OBJ) -lm
 
@@ -713,8 +713,8 @@ $(BUILDDIR)/test_release: $(TESTDIR)/hull/test_release.c $(RELEASE_OBJ) $(TEST_C
 		$(RELEASE_OBJ) $(TEST_COMMON_LIBS)
 
 # Tool registry + path helpers - standalone module, no runtime deps.
-$(BUILDDIR)/test_tools_install: $(TESTDIR)/hull/test_tools_install.c $(TOOLS_INSTALL_OBJ) $(FS_UTIL_OBJ) | $(BUILDDIR)
-	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(TOOLS_INSTALL_OBJ) $(FS_UTIL_OBJ)
+$(BUILDDIR)/test_tools_install: $(TESTDIR)/hull/test_tools_install.c $(TOOLS_INSTALL_OBJ) $(FS_UTIL_OBJ) $(HOST_OBJ) | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(TOOLS_INSTALL_OBJ) $(FS_UTIL_OBJ) $(HOST_OBJ)
 
 # release_io/sbom/verify_self now hash via the cap layer's self-contained
 # SHA-256 (hl_cap_crypto_sha256) instead of mbedtls_sha256, so these focused

--- a/scripts/cosmo_fat_repair.sh
+++ b/scripts/cosmo_fat_repair.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# scripts/cosmo_fat_repair.sh - restore the fat-cosmo pair invariant.
+#
+# cosmocc builds every translation unit TWICE and writes `foo.o` beside
+# `.aarch64/foo.o`; the archives that collect them are paired the same way
+# (`libkeel.a` + `.aarch64/libkeel.a`). Only the first of each pair is a make
+# target. Nothing in Hull's Makefile - or in Keel's - ever NAMES an
+# `.aarch64/` counterpart, so make cannot know one is missing, and an
+# interrupted build leaves a half-written pair that every later `make` skips as
+# up to date. The build then dies at the fat link with a message that names the
+# archive rather than the cause:
+#
+#   aarch64-unknown-cosmo-ar: src/.aarch64/socket_posix.o: No such file
+#   cosmocc: fatal error: vendor/keel/libkeel.a: linker input missing
+#            concomitant vendor/keel/.aarch64/libkeel.a file
+#
+# and it stays dead until someone runs `make clean`.
+#
+# That is not hypothetical. It is the state the Windows source build inherits
+# every time its watchdog kills a wedged cc1 (the HANG section in
+# .github/workflows/windows-source-build.yml), which is what stops that job's
+# retry-after-stall from working: the retry resumes from the objects already
+# built, and one of them is now half a pair. Ctrl-C reproduces it on any host.
+#
+# The repair is the invariant make cannot express: an x86_64 artifact with no
+# aarch64 counterpart is unusable in a fat link, so delete it and let the
+# ordinary rules rebuild both halves. The reverse case needs nothing - a
+# missing x86_64 artifact IS a make target, so it rebuilds on its own.
+#
+# Usage: cosmo_fat_repair.sh <dir|file>...
+#
+#   <dir>   scan recursively for `*.o` whose `.aarch64/` sibling is missing.
+#   <file>  check that one path (used for the two paired ARCHIVES, which
+#           cannot be found by scanning: build/libhull_platform.a is
+#           deliberately single-arch even under cosmocc, so a blanket `*.a`
+#           sweep would delete it on every invocation and never stop).
+#
+# Reports to STDERR and never to stdout: the caller is a parse-time $(shell),
+# whose stdout becomes makefile text. Always exits 0 - a tree we could not
+# inspect is not a reason to refuse to build.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -u
+
+# Remove $1 if its `.aarch64/` sibling does not exist. A path with no
+# counterpart is reported, once, on the way out.
+repair_one() {
+    _p=$1
+    [ -f "$_p" ] || return 0
+    _d=${_p%/*}
+    _b=${_p##*/}
+    [ "$_d" = "$_p" ] && _d=.
+    [ -f "$_d/.aarch64/$_b" ] && return 0
+    rm -f "$_p" || return 0
+    echo "cosmo-fat-repair: removed half-built $_p (no .aarch64 counterpart)" >&2
+}
+
+for arg in "$@"; do
+    if [ -d "$arg" ]; then
+        # Objects only. `-name '*.o'` deliberately does not match the `.o.d`
+        # depfiles written alongside them; an orphaned depfile is harmless
+        # (make regenerates it with the object).
+        find "$arg" -name '*.o' ! -path '*/.aarch64/*' 2>/dev/null | while IFS= read -r obj; do
+            repair_one "$obj"
+        done
+    elif [ -e "$arg" ]; then
+        repair_one "$arg"
+    fi
+done
+
+exit 0

--- a/src/hull/cap/tool.c
+++ b/src/hull/cap/tool.c
@@ -490,7 +490,7 @@ static char *spawn_read_argv(const char *const argv[], size_t *out_len)
 
 /* ── cosmo/Windows: drive cosmocc through the bundled busybox ───────── */
 
-int hl_tool_cosmo_shell(char *out, size_t outsz)
+int hl_tool_cosmo_shell(const char *driver, char *out, size_t outsz)
 {
     if (!out || outsz == 0) return -1;
 #ifdef __COSMOPOLITAN__
@@ -499,6 +499,37 @@ int hl_tool_cosmo_shell(char *out, size_t outsz)
      * always-present env (no cosmo-API include needed). */
     if (!getenv("SystemRoot") && !getenv("SYSTEMROOT") && !getenv("windir"))
         return -1;
+
+    /* FIRST: busybox.exe beside the driver we were actually given. The cosmocc
+     * bundle ships bin/cosmocc and bin/busybox.exe as siblings, so this holds
+     * wherever the bundle lives, whatever $HOME says, and however the driver
+     * was resolved (PATH, --compiler=<path>, ~/.hull/tools).
+     *
+     * The $HOME probes below cannot cover that. Under MSYS2 - the shell a
+     * Windows source build runs in - $HOME is /home/<user>, i.e.
+     * C:\msys64\home\<user>, while `hull tools install cosmocc` from
+     * PowerShell put the bundle under C:\Users\<user>. So a HOME-only search
+     * missed a perfectly good busybox sitting right next to the cosmocc it had
+     * just resolved, and cosmocc's #!/bin/sh driver could not be run at all. */
+    if (driver && *driver) {
+        char dir[512];
+        int n = snprintf(dir, sizeof(dir), "%s", driver);
+        if (n > 0 && (size_t)n < sizeof(dir)) {
+            char *cut = NULL;
+            for (char *c = dir; *c; c++)
+                if (*c == '/' || *c == '\\') cut = c;
+            if (cut) {
+                *cut = '\0';
+                char p[512];
+                n = snprintf(p, sizeof(p), "%s/busybox.exe", dir);
+                if (n > 0 && (size_t)n < sizeof(p) && access(p, X_OK) == 0) {
+                    n = snprintf(out, outsz, "%s", p);
+                    return (n > 0 && (size_t)n < outsz) ? 0 : -1;
+                }
+            }
+        }
+    }
+
     const char *home = getenv("HOME");
     if (!home || !*home) home = getenv("USERPROFILE");
     if (!home || !*home) return -1;
@@ -518,7 +549,7 @@ int hl_tool_cosmo_shell(char *out, size_t outsz)
     }
     return -1;
 #else
-    (void)out; (void)outsz;
+    (void)driver; (void)out; (void)outsz;
     return -1;
 #endif
 }
@@ -686,7 +717,7 @@ static int cosmocc_reroute_exec(const char *const argv[],
 {
     if (!argv_is_cosmocc(argv)) return 0;
     char shell[512];
-    if (hl_tool_cosmo_shell(shell, sizeof(shell)) != 0) return 0;
+    if (hl_tool_cosmo_shell(argv[0], shell, sizeof(shell)) != 0) return 0;
     cosmo_prepare(shell);
     char td[512];
     const char *tmpdir = (hl_tool_cosmo_tmpdir(td, sizeof(td)) == 0) ? td : NULL;
@@ -704,7 +735,7 @@ static int cosmocc_reroute_read(const char *const argv[],
 {
     if (!argv_is_cosmocc(argv)) return 0;
     char shell[512];
-    if (hl_tool_cosmo_shell(shell, sizeof(shell)) != 0) return 0;
+    if (hl_tool_cosmo_shell(argv[0], shell, sizeof(shell)) != 0) return 0;
     cosmo_prepare(shell);
     char td[512];
     const char *tmpdir = (hl_tool_cosmo_tmpdir(td, sizeof(td)) == 0) ? td : NULL;

--- a/src/hull/commands/doctor.c
+++ b/src/hull/commands/doctor.c
@@ -44,6 +44,7 @@
 #include "hull/shared/host.h"
 #include "hull/tool.h"
 #include "hull/tools_install.h"
+#include "hull/sandbox.h"
 #ifdef HL_ENABLE_HTTP_CLIENT
 #include "hull/commands/tools.h"
 #endif
@@ -622,6 +623,28 @@ static void print_human(FILE *f, CompilerInfo *ci, int nci,
     }
     fprintf(f, "\n");
 
+    /* ── Sandbox ── */
+    /* Whether a kernel backend exists is a HOST fact for the build that
+     * reaches Windows, not a compile-time one: the same APE enforces on Linux
+     * and OpenBSD and enforces nothing on Windows, macOS or a BSD. Reporting it
+     * here means a user learns it from `hull doctor` rather than from a warning
+     * the first time they run an app. Absence is the FALLBACK state, not a
+     * failure - the capability layer is a real boundary, just a different one -
+     * so it gets the fallback glyph, and doctor's exit status is unaffected. */
+    fprintf(f, "Sandbox\n");
+    if (hl_sandbox_kernel_available()) {
+        print_row(f, "kernel", GLYPH_OK,
+                  "pledge/unveil enforcing (syscall + filesystem confinement)");
+    } else {
+        print_row(f, "kernel", GLYPH_FALL,
+                  "none on this host - capability layer only");
+        fprintf(f, "                the manifest's fs / env / hosts gates are "
+                   "checked in C on every call;\n");
+        fprintf(f, "                syscall + filesystem confinement and W^X "
+                   "are NOT enforced here.\n");
+    }
+    fprintf(f, "\n");
+
     /* ── Module subsystems ── */
     /* Summarises which capability bits the *build* satisfies, then walks
      * the registry to flag any modules that can never be admitted in
@@ -865,6 +888,12 @@ static void print_json(FILE *f, CompilerInfo *ci, int nci,
         sh_json_write_kv_bool  (&w, "aot_ready",      aot_ready != 0);
         sh_json_write_object_end(&w);
     }
+
+    /* A HOST fact, not a build one, for the cosmo build: the same APE
+     * enforces on Linux/OpenBSD and enforces nothing on Windows, macOS or a
+     * BSD. Machine-readable so an agent can tell the two apart. */
+    sh_json_write_kv_bool(&w, "kernel_sandbox",
+                          hl_sandbox_kernel_available() != 0);
 
     /* Module-subsystem capability bits - mirrors build_provided_caps()
      * in module_resolver.c. */

--- a/src/hull/compiler.c
+++ b/src/hull/compiler.c
@@ -6,6 +6,7 @@
 
 #include "hull/compiler.h"
 #include "hull/cap/tool.h"
+#include "hull/shared/host.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -118,6 +119,29 @@ HlCompiler *hl_compiler_system_new(const char *cc_path)
 
 /* ── Native driver resolution (shared with the linker) ──────────── */
 
+int hl_driver_resolve_name(const char *name, char *out, size_t outsz)
+{
+    if (!name || !*name || !out || outsz == 0) return -1;
+
+    /* Already a path: the caller named a specific file, so use it verbatim. */
+    if (!strchr(name, '/') && !strchr(name, '\\')) {
+        /* A bare name goes through Hull's OWN PATH search rather than being
+         * left for exec to find. On Windows that is the difference between
+         * working and not: a Cosmopolitan APE is handed a POSIX-shaped PATH
+         * and its exec does not search it, so `--compiler=cosmocc` failed with
+         * "not found in PATH" on a box where `hull doctor` listed that very
+         * cosmocc - the two surfaces disagreeing about one toolchain.
+         *
+         * A miss falls through to the bare name, so POSIX behaviour is
+         * unchanged: exec still gets its turn, and this can only turn a
+         * failure into a success. */
+        if (hl_host_find_in_path(name, out, outsz) == 1) return 0;
+    }
+
+    int n = snprintf(out, outsz, "%s", name);
+    return (n > 0 && (size_t)n < outsz) ? 0 : -1;
+}
+
 /* Is `path` a runnable toolchain driver? Probe `<path> --version`. */
 static int driver_ok(const char *path)
 {
@@ -166,7 +190,10 @@ int hl_driver_resolve_native(char *out, size_t outsz)
         if (driver_ok("/opt/cosmo/bin/cosmocc")) {
             snprintf(out, outsz, "/opt/cosmo/bin/cosmocc"); return 0;
         }
-        if (driver_ok("cosmocc")) { snprintf(out, outsz, "cosmocc"); return 0; }
+        if (hl_driver_resolve_name("cosmocc", path, sizeof(path)) == 0 &&
+            driver_ok(path)) {
+            snprintf(out, outsz, "%s", path); return 0;
+        }
         /* Fall through to cc/gcc/clang. They won't produce a working APE
          * against cosmo .a's, but letting them resolve gives a clearer
          * link-time error than a silent "no compiler found." */
@@ -174,8 +201,11 @@ int hl_driver_resolve_native(char *out, size_t outsz)
 #endif
 
     static const char *candidates[] = { "cc", "gcc", "clang", NULL };
-    for (const char **p = candidates; *p; p++)
-        if (driver_ok(*p)) { snprintf(out, outsz, "%s", *p); return 0; }
+    for (const char **p = candidates; *p; p++) {
+        char cand[PATH_MAX];
+        if (hl_driver_resolve_name(*p, cand, sizeof(cand)) != 0) continue;
+        if (driver_ok(cand)) { snprintf(out, outsz, "%s", cand); return 0; }
+    }
 
     return -1;
 }
@@ -190,6 +220,12 @@ HlCompiler *hl_compiler_select(const char *explicit_cc)
 
     /* Explicit named compiler (a path or a PATH name). */
     if (explicit_cc && !is_system) {
+        /* Resolve a bare name to an absolute path first (see
+         * hl_driver_resolve_name): exec's own PATH search cannot be relied on
+         * for this on Windows. */
+        char resolved[PATH_MAX];
+        if (hl_driver_resolve_name(explicit_cc, resolved, sizeof resolved) == 0)
+            explicit_cc = resolved;
         HlCompiler *c = hl_compiler_system_new(explicit_cc);
         if (c && hl_compiler_is_available(c)) return c;
         if (c) hl_compiler_destroy(c);

--- a/src/hull/linker_system.c
+++ b/src/hull/linker_system.c
@@ -180,6 +180,11 @@ HlLinker *hl_linker_select(const char *explicit_linker, const char *hull_exe)
 
     int is_system = (explicit_linker && strcmp(explicit_linker, "system") == 0);
     if (explicit_linker && !is_system) {
+        /* Same bare-name resolution the compiler side does - see
+         * hl_driver_resolve_name; exec's PATH search is not dependable here. */
+        char resolved[PATH_MAX];
+        if (hl_driver_resolve_name(explicit_linker, resolved, sizeof resolved) == 0)
+            explicit_linker = resolved;
         HlLinker *l = hl_linker_system_new(explicit_linker);
         if (l && hl_linker_is_available(l)) return l;
         if (l) hl_linker_destroy(l);

--- a/src/hull/sandbox.c
+++ b/src/hull/sandbox.c
@@ -120,11 +120,39 @@ static int sandbox_resolve_manifest_path(const char *app_dir,
 
 #if defined(__COSMOPOLITAN__)
 
+#include <cosmo.h>   /* IsLinux() / IsOpenbsd() - see sb_supported() below */
+
 /* Cosmopolitan libc provides pledge() and unveil() natively. */
 extern int pledge(const char *promises, const char *execpromises);
 extern int unveil(const char *path, const char *permissions);
 
-static int sb_supported(void) { return 1; }
+/* ...but they only ENFORCE where the host gives them something to enforce
+ * with: seccomp-bpf + Landlock on Linux, the native syscalls on OpenBSD.
+ * Everywhere else - Windows above all, the platform this build exists to
+ * reach - both calls return 0 and do nothing.
+ *
+ * Returning 1 unconditionally therefore made Hull ANNOUNCE a sandbox it did
+ * not have. Measured on Windows 11 with cosmocc 4.0.2: pledge("stdio", NULL)
+ * returns 0, and a socket(AF_INET, SOCK_STREAM, 0) immediately afterwards
+ * SUCCEEDS - `stdio` grants no `inet`, so under a pledge that is enforcing,
+ * that call is denied. The startup log nonetheless read
+ *
+ *   [sandbox] phase 1 pledge applied (exec/proc/fork blocked)
+ *   [sandbox] applied (unveil: 0 read, 0 write; pledge: stdio ... inet)
+ *
+ * which a reader can only take as "this process is confined". It is not. The
+ * same is true of a cosmo APE on macOS or a BSD: the cosmo branch is selected
+ * before the __APPLE__ one, so a Seatbelt profile is never reached there
+ * either.
+ *
+ * Two things follow from getting this right, beyond the log being true. The
+ * "kernel sandbox not available on this platform" path - which already exists
+ * for exactly this case - becomes the one taken; and a manifest asking for W^X
+ * enforcement FAILS CLOSED there, instead of being accepted with nothing
+ * behind it. The C capability layer is untouched and remains the enforcement
+ * boundary on such hosts, as it is on any platform without a kernel backend.
+ */
+static int sb_supported(void) { return IsLinux() || IsOpenbsd(); }
 
 #elif defined(__OpenBSD__)
 
@@ -560,6 +588,8 @@ static int sb_supported(void) { return 0; }
 
 #endif /* platform dispatch */
 
+int hl_sandbox_kernel_available(void) { return sb_supported(); }
+
 /* ── Phase 1: pre-load pledge ──────────────────────────────────────── */
 
 /* Whether any of stdin/stdout/stderr is a controlling terminal, probed once
@@ -583,7 +613,9 @@ int hl_sandbox_apply_pledge(void)
                       isatty(STDERR_FILENO)) ? 1 : 0;
 
     if (!sb_supported()) {
-        log_info("[sandbox] kernel sandbox not available on this platform");
+        /* Terse here on purpose: this is a step note, and phase 2 carries the
+         * one loud verdict about what is - and is not - enforcing. */
+        log_info("[sandbox] phase 1 skipped (no kernel sandbox on this host)");
         return 0;
     }
 
@@ -670,16 +702,25 @@ int hl_sandbox_apply(const HlSandboxPolicy *policy, const char *app_dir,
                       "but W^X is enforced - fail-closed.");
             return -1;
         }
-        if (!sb_supported()) {
-            log_error("[sandbox] W^X enforcement requested but no kernel "
-                      "sandbox is available on this platform - fail-closed. "
-                      "Use --no-sandbox to opt out (development only).");
-            return -1;
-        }
+        /* A host with NO kernel backend at all is handled below, not here.
+         * Refusing to start would demand a flag on every run while offering
+         * no decision the user could act on: there is no partial sandbox to
+         * accept, and no setting that would produce one. A backend that
+         * exists but is INCOMPLETE is the opposite case and still fails
+         * closed - see the Landlock check further down. */
     }
 
     if (!sb_supported()) {
-        log_info("[sandbox] kernel sandbox not available on this platform");
+        /* Loud, and once. Everything this process does from here is bounded by
+         * Hull's capability layer alone - the manifest's fs/env/hosts gates
+         * checked in C - with nothing underneath it. Saying "applied" here,
+         * which is what this code used to do on every cosmo host, told the
+         * reader the opposite of the truth. */
+        log_warn("[sandbox] NO kernel sandbox on this host: syscall and "
+                 "filesystem confinement%s are not enforced. Hull's "
+                 "capability layer (manifest fs / env / hosts) is the only "
+                 "boundary. See docs/security.md.",
+                 policy->wx_enforced ? ", and W^X," : "");
         return 0;
     }
 

--- a/src/hull/shared/host.c
+++ b/src/hull/shared/host.c
@@ -188,6 +188,66 @@ int hl_host_render_exec(const char *path, char *out, size_t out_sz)
  * PATH_MAX buffers (component + leaf + candidate) was worth collapsing. An
  * over-long join is rejected rather than truncated - a truncated path could
  * name a different, existing file. */
+/* Does `s` begin with a Windows drive prefix (`C:\` or `C:/`)? */
+static int looks_like_drive_prefix(const char *s)
+{
+    if (!s || !s[0] || s[1] != ':') return 0;
+    if (!((s[0] >= 'A' && s[0] <= 'Z') || (s[0] >= 'a' && s[0] <= 'z'))) return 0;
+    return s[2] == '\\' || s[2] == '/';
+}
+
+/* Which character separates entries in THIS search list?
+ *
+ * Not a property of the host, which is what an earlier revision assumed. On
+ * Windows both shapes occur, and the host does not tell you which you were
+ * handed:
+ *
+ *   Win32   C:\tools;C:\Program Files\LLVM\bin      (';', backslashes)
+ *   POSIX   /C/tools:/C/Program Files/LLVM/bin      (':', forward slashes)
+ *
+ * The POSIX shape is not an edge case there - it is what the ONLY Hull build
+ * that runs on Windows actually sees. A Cosmopolitan APE is handed a
+ * POSIX-ified PATH by its own runtime (measured on Windows 11:
+ * `/C/Users/...:/C/Program Files (x86)/...`), and an MSYS2 or Git-Bash shell
+ * exports the same shape. Splitting that on ';' yields ONE nonsense component,
+ * so every probe missed whatever was installed - the exact failure this
+ * resolver was written to end.
+ *
+ * Detect from the string:
+ *   - any ';' means Win32. A ';' cannot appear inside a Windows path
+ *     component, and a POSIX list would not carry one either.
+ *   - otherwise a leading drive prefix means a SINGLE Win32 component, where
+ *     the ':' belongs to the drive letter and must not split. Returning ';'
+ *     for it leaves the string whole, which is the right answer.
+ *   - otherwise ':'.
+ *
+ * On a POSIX host neither Windows shape can arise, so this is a no-op there. */
+static char detect_list_sep(const char *path_env)
+{
+    if (strchr(path_env, ';'))          return ';';
+    if (looks_like_drive_prefix(path_env)) return ';';
+    return ':';
+}
+
+/* Which separator should join this PATH component to the leaf?
+ *
+ * The component's own, so the composed path reads the way whoever set PATH
+ * wrote it: `C:\tools\gcc.exe` from a native Windows PATH, `/c/msys64/usr/bin/
+ * gcc` from the POSIX-shaped PATH an MSYS2 shell exports inside a Windows
+ * process. Windows file APIs accept either separator, so this is presentation
+ * rather than function - but these paths are printed (hull doctor, hull tools
+ * list) and a mixed `/c/msys64/usr/bin\gcc` reads like a bug. A component with
+ * no separator at all (a bare `C:`, or a relative directory) has no convention
+ * to preserve, so the host's own is used. */
+static char component_sep(const char *dir, size_t dlen)
+{
+    for (size_t i = 0; i < dlen; i++) {
+        if (dir[i] == '\\') return '\\';
+        if (dir[i] == '/')  return '/';
+    }
+    return hl_host_dir_sep();
+}
+
 static int try_candidate(const char *dir, size_t dlen, char sep,
                          const char *name, const char *ext,
                          char *out, size_t out_sz)
@@ -231,9 +291,7 @@ int hl_host_find_in_path_ex(const char *path_env, const char *name,
     if (!path_env || !*path_env) return 0;
 
     int  win      = hl_host_is_windows();
-    char list_sep = win ? ';' : ':';
-    /* Windows accepts either separator in a path; '\' is conventional. */
-    char dir_sep  = win ? '\\' : '/';
+    char list_sep = detect_list_sep(path_env);
 
     /* The PATHEXT forms worth probing for a toolchain binary. An entry with
      * an explicit extension already (e.g. "busybox.exe") still tries the bare
@@ -270,7 +328,8 @@ int hl_host_find_in_path_ex(const char *path_env, const char *name,
          * a file in the process's cwd could shadow a real toolchain binary. */
         if (dlen > 0) {
             for (const char **e = exts; *e; e++)
-                if (try_candidate(d, dlen, dir_sep, name, *e, out, out_sz))
+                if (try_candidate(d, dlen, component_sep(d, dlen),
+                                  name, *e, out, out_sz))
                     return 1;
         }
 

--- a/src/hull/tools_install.c
+++ b/src/hull/tools_install.c
@@ -22,6 +22,7 @@
 
 #include "hull/tools_install.h"
 #include "hull/shared/fs_util.h"
+#include "hull/shared/host.h"
 
 #include <dirent.h>
 #include <errno.h>
@@ -332,41 +333,25 @@ static int strip_basename(const char *path, char *out, size_t out_sz)
 }
 
 /* Walk PATH and return the first directory containing an executable
- * `name`. Output buffer holds the full path on success. */
+ * `name`. Output buffer holds the full path on success.
+ *
+ * Delegates to the shared host resolver rather than walking PATH here. The
+ * local walker this replaces split on ':' and joined with '/', which cannot
+ * work on Windows: PATH is ';'-separated with `C:\...` components, so the ':'
+ * split shredded every drive letter and this step found nothing no matter what
+ * was installed - and it never probed the `.exe` / `.com` forms, so even a
+ * correctly-split `wamrc.exe` would have been missed. That is the same defect
+ * hull#459 fixed in doctor's copy; this second copy was left behind, which is
+ * why `hull doctor` and `hull tools list` could disagree about the very same
+ * tool on the very same box.
+ *
+ * POSIX behaviour is unchanged: hl_host_find_in_path splits on ':', joins with
+ * '/', and probes the bare name only. Note the return convention flips - the
+ * shared resolver returns 1 for found - so this wrapper keeps the 0/-1 shape
+ * hl_tools_lookup_path is written against. */
 static int find_on_path(const char *name, char *out, size_t out_sz)
 {
-    const char *path = getenv("PATH");
-    if (!path || !*path) return -1;
-
-    const char *p = path;
-    while (*p) {
-        const char *colon = strchr(p, ':');
-        size_t seg_len = colon ? (size_t)(colon - p) : strlen(p);
-
-        /* Empty segment ('::' or leading ':') means current directory
-         * - POSIX-ism; skip for safety. */
-        if (seg_len > 0) {
-            /* Compose "<seg>/<name>" in a stack buffer first so we
-             * can `access()` it without trampling the caller's out. */
-            char cand[PATH_MAX];
-            if (seg_len + 1 + strlen(name) + 1 <= sizeof(cand)) {
-                memcpy(cand, p, seg_len);
-                cand[seg_len] = '/';
-                size_t nlen = strlen(name);
-                memcpy(cand + seg_len + 1, name, nlen);
-                cand[seg_len + 1 + nlen] = '\0';
-                if (access(cand, X_OK) == 0) {
-                    int n = snprintf(out, out_sz, "%s", cand);
-                    if (n < 0 || (size_t)n >= out_sz) return -1;
-                    return 0;
-                }
-            }
-        }
-
-        if (!colon) break;
-        p = colon + 1;
-    }
-    return -1;
+    return hl_host_find_in_path(name, out, out_sz) == 1 ? 0 : -1;
 }
 
 int hl_tools_lookup_path(const char *name, const char *hull_exe,

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -2065,7 +2065,21 @@ local function main()
         or is_cosmo
     if will_compile and not tool.compiler then
         tool.stderr("hull build: no C compiler available\n")
-        tool.stderr("hint: install gcc or clang, or rebuild hull with HL_ENABLE_TCC=1\n")
+        -- Name a route that exists on THIS hull, the way doctor does. A cosmo
+        -- build can only link with cosmocc - native cc/gcc/clang would emit
+        -- ELF/Mach-O against cosmo-format archives - and Hull installs that
+        -- itself through the signed `hull tools install` path, so sending a
+        -- Windows user to a Unix package manager is the wrong advice there.
+        -- The previous hint named HL_ENABLE_TCC=1, a build flag that exists
+        -- nowhere in the tree: tcc was retired as a Hull-provided toolchain,
+        -- so following it could only fail.
+        if is_cosmo then
+            tool.stderr("hint: run `hull doctor --fix` (installs cosmocc), "
+                        .. "or `hull tools install cosmocc`\n")
+        else
+            tool.stderr("hint: install gcc or clang, "
+                        .. "or point at one with --compiler=<path>\n")
+        end
         tool.rmdir(tmpdir)
         tool.exit(1)
     end

--- a/stdlib/cli/lua/hull/doctor_tui.lua
+++ b/stdlib/cli/lua/hull/doctor_tui.lua
@@ -133,10 +133,6 @@ local function render(t, d, last_action, palette)
         row(t, 3, y, name, on and true or false, on and "enabled" or "disabled", palette)
         y = y + 1
     end
-    if d.tcc_embedded ~= nil then
-        row(t, 3, y, "tcc", d.tcc_embedded, d.tcc_embedded and "embedded" or "not embedded", palette)
-        y = y + 1
-    end
     y = y + 1
 
     t:style({ bold = true }); t:print(1, y, "Compute"); t:style({})

--- a/tests/check_cosmo_fat_repair.sh
+++ b/tests/check_cosmo_fat_repair.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+# tests/check_cosmo_fat_repair.sh - behaviour gate for scripts/cosmo_fat_repair.sh.
+#
+# The repair runs from a parse-time $(shell) in the Makefile and DELETES build
+# artifacts, so two properties are load-bearing and neither is visible from
+# reading a build log:
+#
+#   1. It removes exactly the half-written pairs and nothing else. Over-reach
+#      means an artifact that legitimately has no aarch64 counterpart (the
+#      single-arch build/libhull_platform.a) gets deleted and rebuilt on every
+#      single invocation, which never converges.
+#   2. It writes NOTHING to stdout. The caller's stdout becomes makefile text,
+#      so one stray line is a syntax error in the middle of the build.
+#
+# Synthetic trees only: no cosmocc, no compiler, runs in under a second on any
+# host. See the script header for what the repair is for.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -u
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+REPAIR="$SCRIPT_DIR/scripts/cosmo_fat_repair.sh"
+
+fails=0
+pass() { printf '  ok    %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1"; fails=$((fails + 1)); }
+
+check() { # check <description> <condition-result>
+    if [ "$2" -eq 0 ]; then pass "$1"; else fail "$1"; fi
+}
+
+tmp=$(mktemp -d) || { echo "cannot mktemp"; exit 1; }
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+# ── Fixture ─────────────────────────────────────────────────────────
+#   paired.o        + .aarch64/paired.o      -> kept
+#   orphan.o        (no counterpart)         -> removed
+#   nested/deep.o   (no counterpart)         -> removed (recursive)
+#   nested/kept.o   + nested/.aarch64/kept.o -> kept
+#   orphan.o.d                               -> kept (depfile, not an object)
+#   stray.txt                                -> kept (not an object)
+#   .aarch64/lonely.o                        -> kept (never the scan's target)
+mkdir -p "$tmp/build/.aarch64" "$tmp/build/nested/.aarch64"
+: > "$tmp/build/paired.o";              : > "$tmp/build/.aarch64/paired.o"
+: > "$tmp/build/orphan.o";              : > "$tmp/build/orphan.o.d"
+: > "$tmp/build/stray.txt"
+: > "$tmp/build/.aarch64/lonely.o"
+: > "$tmp/build/nested/deep.o"
+: > "$tmp/build/nested/kept.o";         : > "$tmp/build/nested/.aarch64/kept.o"
+
+# Paired + unpaired archives, named explicitly (they are never swept).
+: > "$tmp/build/libhull.a";             : > "$tmp/build/.aarch64/libhull.a"
+mkdir -p "$tmp/keel"
+: > "$tmp/keel/libkeel.a"   # no counterpart -> removed
+# The single-arch platform archive: passed to NOTHING, and living in a scanned
+# directory. It must survive, or every build deletes and rebuilds it forever.
+: > "$tmp/build/libhull_platform.a"
+
+out=$(sh "$REPAIR" "$tmp/build" "$tmp/keel" "$tmp/keel/libkeel.a" \
+        "$tmp/build/libhull.a" "$tmp/does/not/exist" 2>"$tmp/stderr")
+rc=$?
+
+echo "== cosmo_fat_repair =="
+
+check "exits 0" "$rc"
+[ -z "$out" ]; check "writes nothing to stdout (the caller is a \$(shell))" $?
+
+[ ! -e "$tmp/build/orphan.o" ];            check "removes an unpaired object" $?
+[ ! -e "$tmp/build/nested/deep.o" ];       check "recurses into subdirectories" $?
+[ ! -e "$tmp/keel/libkeel.a" ];            check "removes an unpaired named archive" $?
+
+[ -e "$tmp/build/paired.o" ];              check "keeps a paired object" $?
+[ -e "$tmp/build/nested/kept.o" ];         check "keeps a paired nested object" $?
+[ -e "$tmp/build/libhull.a" ];             check "keeps a paired named archive" $?
+[ -e "$tmp/build/libhull_platform.a" ];    check "keeps the single-arch platform archive" $?
+[ -e "$tmp/build/orphan.o.d" ];            check "keeps an orphaned depfile" $?
+[ -e "$tmp/build/stray.txt" ];             check "keeps a non-object file" $?
+[ -e "$tmp/build/.aarch64/lonely.o" ];     check "never removes an aarch64 object" $?
+
+grep -q 'orphan\.o' "$tmp/stderr"; check "names what it removed, on stderr" $?
+
+# Idempotence: a second pass over the repaired tree must be silent and must not
+# touch what survived. A repair that keeps finding work is a rebuild loop.
+out2=$(sh "$REPAIR" "$tmp/build" "$tmp/keel" "$tmp/build/libhull.a" 2>"$tmp/stderr2")
+[ -z "$out2" ] && [ ! -s "$tmp/stderr2" ]; check "is silent on an already-repaired tree" $?
+[ -e "$tmp/build/paired.o" ] && [ -e "$tmp/build/libhull_platform.a" ]
+check "leaves the survivors alone on a second pass" $?
+
+# No arguments at all is a clean no-op, not a usage error: $(KEEL_LIB) is empty
+# in the pure-compute flavor, so the Makefile can legitimately pass fewer paths.
+sh "$REPAIR" >/dev/null 2>&1; check "no arguments is a clean no-op" $?
+
+if [ "$fails" -ne 0 ]; then
+    echo "cosmo_fat_repair: $fails check(s) failed"
+    exit 1
+fi
+echo "cosmo_fat_repair: all checks passed"

--- a/tests/check_dry_run_is_inert.sh
+++ b/tests/check_dry_run_is_inert.sh
@@ -1,0 +1,134 @@
+#!/bin/sh
+# tests/check_dry_run_is_inert.sh - `make -n` must describe, never delete.
+#
+# WHY THIS EXISTS. Two parse-time $(shell ...) hooks in the Makefile DELETE
+# build artifacts: the build-fingerprint purge (drop every Hull .o when the
+# configuration changed) and the fat-cosmo pair repair. $(shell) runs while
+# make PARSES, and -n does not suppress parsing - so a dry run performed part
+# of a build.
+#
+# That cost a working tree. tests/check_keel_flag_propagation.sh calls itself
+# "dry run, no artifacts" and shells `make -n <vars> vendor/keel/libkeel.a`
+# with variables that differ from whatever the developer last built with. The
+# fingerprint mismatch fired the purge, so running the LINT gate deleted 273
+# objects and build/hull.
+#
+# WHAT IS ACTUALLY FRAGILE is the detection, not the wiring: GNU make reports
+# -n through MAKEFLAGS in a shape that is easy to get subtly wrong (short
+# options collected into the first word WITHOUT a dash, long options as
+# separate dash-prefixed words - so a naive `findstring n` reads
+# --no-print-directory as a dry run). So the detection block is lifted OUT of
+# the real Makefile and exercised directly, against a marker file in a temp
+# directory where a regression can destroy nothing.
+#
+# The wiring is then checked two ways. On a tree with no build objects - a
+# fresh checkout, which is what CI lints - the real Makefile is dry-run with a
+# deliberately mismatched fingerprint and must leave a planted marker alone.
+# On a tree that HAS objects the same run would delete them if the guard were
+# broken, so that case is asserted structurally instead, and says so.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -eu
+cd "$(dirname "$0")/.."
+
+MAKE="${MAKE:-make}"
+FAILED=0
+pass() { printf '  ok    %s\n' "$1"; }
+bad()  { printf '  FAIL  %s\n' "$1"; FAILED=$((FAILED + 1)); }
+skip() { printf '  skip  %s\n' "$1"; }
+
+echo "check-dry-run-inert: asserting a dry run deletes nothing"
+
+# ── 1. The detection idiom, in isolation ────────────────────────────
+#
+# Lifted from the Makefile rather than restated, so a change to the idiom is
+# covered instead of shadowed by a stale copy.
+tmp=$(mktemp -d) || { echo "cannot mktemp" >&2; exit 1; }
+trap 'rm -rf "$tmp"' EXIT INT TERM
+
+sed -n '/^HL_MAKE_SHORT_OPTS :=/,/^HL_TREE_MUST_NOT_CHANGE :=/p' Makefile > "$tmp/detect.mk"
+if ! grep -q 'HL_TREE_MUST_NOT_CHANGE :=' "$tmp/detect.mk"; then
+    bad "cannot find the HL_TREE_MUST_NOT_CHANGE detection block in Makefile"
+    echo "check-dry-run-inert: 1 failure(s)" >&2
+    exit 1
+fi
+pass "detection block extracted from Makefile"
+
+{
+    cat "$tmp/detect.mk"
+    printf 'ifeq ($(HL_TREE_MUST_NOT_CHANGE),)\n'
+    printf '$(shell rm -f %s/marker)\n' "$tmp"
+    printf 'endif\n'
+    printf 'probe check-anything lint check-hardening:\n\t@echo goal\n'
+} > "$tmp/Makefile"
+
+# $1 = description, $2 = expected marker state after the run (gone|kept),
+# rest = make flags.
+detect_case() {
+    desc=$1; want=$2; shift 2
+    : > "$tmp/marker"
+    ( cd "$tmp" && $MAKE "$@" >/dev/null 2>&1 ) || true
+    if [ -e "$tmp/marker" ]; then got=kept; else got=gone; fi
+    if [ "$got" = "$want" ]; then pass "$desc"; else bad "$desc (marker $got, wanted $want)"; fi
+}
+
+detect_case "a real build runs the hook"                 gone probe
+detect_case "-n does not"                                kept -n probe
+detect_case "-Bn does not"                               kept -Bn probe
+detect_case "-n with a variable does not"                kept -n FOO=bar probe
+# The trap for a naive `findstring n`: a long option that contains an 'n' but
+# is not -n. This must still be treated as a real build.
+detect_case "--no-print-directory is not a dry run"      gone --no-print-directory probe
+
+# The second reason to stay inert: a goal that builds nothing. A gate is
+# normally run WITHOUT the flags the tree was built with, so letting the purge
+# fire there deletes the build it was asked only to inspect.
+detect_case "a check-* goal builds nothing, so stays inert" kept check-anything
+detect_case "lint builds nothing either"                     kept lint
+# check-hardening is the exception: it depends on build/hull, so it DOES build
+# and must keep the purge.
+detect_case "check-hardening does build, so acts"           gone check-hardening
+
+# ── 2. The wiring, in the real Makefile ─────────────────────────────
+objs=$(ls build/*.o 2>/dev/null | wc -l | tr -d ' ')
+if [ "${objs:-0}" -eq 0 ]; then
+    # Safe to exercise for real: there is nothing a broken guard could destroy.
+    mkdir -p build
+    saved=""
+    if [ -f build/.build-config ]; then
+        saved=$(cat build/.build-config)
+    fi
+    printf 'a-configuration-this-tree-was-never-built-with\n' > build/.build-config
+    : > build/cap_zzdryrunprobe.o
+    $MAKE -n HL_OPT=-O0 HL_ENABLE_LTO=1 probe-nonexistent-target >/dev/null 2>&1 || true
+    if [ -e build/cap_zzdryrunprobe.o ]; then
+        pass "the real Makefile's purge does not fire under -n"
+    else
+        bad "the real Makefile's purge DELETED a build object under -n"
+    fi
+    rm -f build/cap_zzdryrunprobe.o
+    if [ -n "$saved" ]; then
+        printf '%s\n' "$saved" > build/.build-config
+    else
+        rm -f build/.build-config
+    fi
+else
+    # Running the real check here would delete this tree's objects if the guard
+    # were broken - the very damage being gated. Assert the shape instead.
+    hooks=$(grep -c '^\$(shell ' Makefile || true)
+    guarded=$(awk '/^ifeq \(\$\(HL_TREE_MUST_NOT_CHANGE\),\)/{g=1} /^endif$/{g=0} /^\$\(shell /{if(g)c++} END{print c+0}' Makefile)
+    if [ "$hooks" -gt 0 ] && [ "$hooks" = "$guarded" ]; then
+        pass "all $hooks parse-time \$(shell) hooks sit inside the inertness guard"
+    else
+        bad "$((hooks - guarded)) of $hooks parse-time \$(shell) hooks are OUTSIDE the guard"
+    fi
+    skip "live purge check ($objs build objects present; a regression would delete them)"
+fi
+
+if [ "$FAILED" -eq 0 ]; then
+    echo "check-dry-run-inert: OK"
+    exit 0
+fi
+echo "check-dry-run-inert: $FAILED failure(s)" >&2
+exit 1

--- a/tests/check_keel_flag_propagation.sh
+++ b/tests/check_keel_flag_propagation.sh
@@ -39,9 +39,19 @@ if [ ! -f vendor/keel/Makefile ]; then
 fi
 
 # Keel's compile lines for one configuration. $1 = extra make variables.
+#
+# -B (always-make) is load-bearing, not belt and braces. Without it the gate
+# only works on a tree where vendor/keel/libkeel.a has never been built: the
+# archive's only prerequisites are Hull's mbedTLS objects, so once it exists
+# make answers "'vendor/keel/libkeel.a' is up to date", never enters the
+# sub-make, and emits no compile lines at all. The gate then reported six
+# failures - "no Keel compile lines found (recipe changed?)" - on every
+# developer machine that had built Hull, which reads as a regression in the
+# thing being gated rather than as the gate mis-firing. -B makes it ask what
+# the commands WOULD be, which is the actual question.
 keel_lines() {
     # shellcheck disable=SC2086
-    $MAKE -n $1 vendor/keel/libkeel.a 2>/dev/null | grep -- ' -c -o ' || true
+    $MAKE -Bn $1 vendor/keel/libkeel.a 2>/dev/null | grep -- ' -c -o ' || true
 }
 
 core_flags()   { printf '%s\n' "$1" | grep -- ' -c -o src/'; }
@@ -107,8 +117,24 @@ check_config "default"          "HL_OPT=-O2 HL_ENABLE_LTO=0 HL_ENABLE_CFI=0" ' -
 # 2. The defect #461 is about. Before the fix this was -O2 in both halves.
 check_config "HL_OPT=-O0"       "HL_OPT=-O0 HL_ENABLE_LTO=0 HL_ENABLE_CFI=0" ' -O0 '  ' -flto'
 
-# 3. LTO. Before the fix KEEL_EXTRA_CFLAGS was passed and ignored.
-check_config "HL_ENABLE_LTO=1"  "HL_OPT=-O2 HL_ENABLE_LTO=1 HL_ENABLE_CFI=0" ' -flto' ''
+# 3. LTO, only where the toolchain can actually do it - same reasoning as the
+#    CFI case below. Hull's HL_LTO_CFLAG comes from a probe (-flto=thin, then
+#    -flto) and stays EMPTY when the compiler can do neither, so on such a
+#    toolchain there is no flag to propagate and asserting one tests the probe
+#    rather than propagation. Mirror the probe, not the flag name.
+lto_probe=no
+for lto_f in -flto=thin -flto; do
+    if printf 'int main(void){return 0;}\n' | \
+       ${CC:-cc} -Werror "$lto_f" -x c -c -o /dev/null - 2>/dev/null; then
+        lto_probe=yes
+        break
+    fi
+done
+if [ "$lto_probe" = yes ]; then
+    check_config "HL_ENABLE_LTO=1"  "HL_OPT=-O2 HL_ENABLE_LTO=1 HL_ENABLE_CFI=0" ' -flto' ''
+else
+    printf '  skip  LTO: %s cannot do -flto (no flag to propagate)\n' "${CC:-cc}"
+fi
 
 # 4. Both together, since they travel by different mechanisms (KEEL_OPT vs
 #    KEEL_EXTRA_CFLAGS) and could regress independently.

--- a/tests/check_keel_flag_propagation_selftest.sh
+++ b/tests/check_keel_flag_propagation_selftest.sh
@@ -64,7 +64,8 @@ fi
 trap cleanup EXIT INT TERM
 
 # 1. Baseline: the real tree must pass, or the probes below prove nothing.
-if $GATE >/dev/null 2>&1; then
+#    Keep the output: probe B's applicability is read out of it below.
+if base_out=$($GATE 2>&1); then
     pass "baseline: propagation is intact"
 else
     bad "baseline: gate already failing on an unmodified tree"
@@ -83,15 +84,26 @@ fi
 cleanup
 
 # 3. Probe B - the asymmetric shape: hook reaches CFLAGS, not VENDOR_CFLAGS.
-sed 's/^override VENDOR_CFLAGS += \$(KEEL_EXTRA_CFLAGS)$/# probe B: hook removed from the vendored half/' \
-    "$KEEL_MK" > "$KEEL_MK.probe" && mv "$KEEL_MK.probe" "$KEEL_MK"
-out=$($GATE 2>&1) && rc=0 || rc=$?
-if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q 'vendor'; then
-    pass "probe B (vendored half unhooked) -> gate BITES"
+#
+#    Observable ONLY through the LTO configuration. Probe B removes the
+#    KEEL_EXTRA_CFLAGS hook, while -O0/-O2 travel by KEEL_OPT instead - so
+#    with no LTO flag in play the vendored half has nothing to lose and there
+#    is no bite to demonstrate. The gate already decides that (it skips LTO
+#    when the compiler cannot do it), so read its verdict rather than
+#    re-probing here, which keeps the two from drifting apart.
+if printf '%s' "$base_out" | grep -q 'skip  LTO'; then
+    printf '  skip  probe B: gate skips LTO on this toolchain, so it cannot bite\n'
 else
-    bad "probe B (vendored half unhooked) -> gate did NOT bite (rc=$rc)"
+    sed 's/^override VENDOR_CFLAGS += \$(KEEL_EXTRA_CFLAGS)$/# probe B: hook removed from the vendored half/' \
+        "$KEEL_MK" > "$KEEL_MK.probe" && mv "$KEEL_MK.probe" "$KEEL_MK"
+    out=$($GATE 2>&1) && rc=0 || rc=$?
+    if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q 'vendor'; then
+        pass "probe B (vendored half unhooked) -> gate BITES"
+    else
+        bad "probe B (vendored half unhooked) -> gate did NOT bite (rc=$rc)"
+    fi
+    cleanup
 fi
-cleanup
 
 # 4. Restored: clean again, so the probes left nothing behind.
 if $GATE >/dev/null 2>&1; then

--- a/tests/e2e_sandbox.sh
+++ b/tests/e2e_sandbox.sh
@@ -114,11 +114,24 @@ elif [ "$UNAME_S" = "OpenBSD" ]; then
     SANDBOX_TYPE="pledge"
 fi
 # Cosmopolitan binaries report Linux on Linux, so check if hull was built
-# with cosmocc by looking for the APE magic or platform_cc marker
+# with cosmocc by looking for the APE magic or platform_cc marker.
+#
+# A cosmo build only ENFORCES where Cosmopolitan's pledge/unveil have a
+# mechanism to enforce with - Linux and OpenBSD. The same APE on Windows or a
+# BSD reports "no kernel sandbox on this host" and runs on the capability layer
+# alone (see sb_supported() in src/hull/sandbox.c), so expecting a sandbox
+# there would assert a protection that deliberately is not claimed. The
+# UNAME_S test above has already set the expectation for the hosts that do
+# enforce, so this only needs to avoid overriding it on the ones that do not.
 if [ -f "$BUILDDIR/platform_cc" ]; then
     PLATFORM_CC=$(cat "$BUILDDIR/platform_cc" 2>/dev/null)
     case "$PLATFORM_CC" in
-        *cosmocc*) SANDBOX_EXPECTED=1; SANDBOX_TYPE="pledge" ;;
+        *cosmocc*)
+            case "$UNAME_S" in
+                Linux|OpenBSD) SANDBOX_EXPECTED=1; SANDBOX_TYPE="pledge" ;;
+                *)             SANDBOX_EXPECTED=0; SANDBOX_TYPE="" ;;
+            esac
+            ;;
     esac
 fi
 
@@ -168,7 +181,7 @@ if wait_for_server 19880; then
             check_contains "sandbox dns promise (hosts declared)" "$LOG" "dns"
         fi
     else
-        check_contains "sandbox not available log" "$LOG" "kernel sandbox not available"
+        check_contains "sandbox not available log" "$LOG" "NO kernel sandbox on this host"
     fi
 else
     stop_server
@@ -211,7 +224,7 @@ if wait_for_server 19881; then
             check_not_contains "no dns without manifest" "$LOG2" " dns"
         fi
     else
-        check_contains "sandbox not available log" "$LOG2" "kernel sandbox not available"
+        check_contains "sandbox not available log" "$LOG2" "NO kernel sandbox on this host"
     fi
 else
     stop_server
@@ -308,7 +321,7 @@ if wait_for_server 19883; then
             check_contains "JS sandbox dns promise (hosts declared)" "$LOG4" "dns"
         fi
     else
-        check_contains "JS sandbox not available log" "$LOG4" "kernel sandbox not available"
+        check_contains "JS sandbox not available log" "$LOG4" "NO kernel sandbox on this host"
     fi
 else
     stop_server
@@ -350,7 +363,7 @@ if wait_for_server 19884; then
             fail "phase 1 should appear before phase 2 (got $P1_LINE vs $P2_LINE)"
         fi
     else
-        check_contains "phase 1 not available log" "$LOG5" "kernel sandbox not available"
+        check_contains "phase 1 not available log" "$LOG5" "NO kernel sandbox on this host"
     fi
 else
     stop_server

--- a/tests/hull/test_host.c
+++ b/tests/hull/test_host.c
@@ -27,6 +27,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 /* ── Host identity ─────────────────────────────────────────────────── */
 
@@ -233,6 +236,41 @@ UTEST(host, find_in_path_misses_cleanly)
     ASSERT_STREQ("", out);             /* miss clears the buffer */
 }
 
+/* Create a temp directory holding an executable probe file. Returns 1 on
+ * success, 0 if the environment will not allow it (the caller then skips).
+ *
+ * Deliberately POSIX calls rather than system("mkdir -p") / system("chmod +x"):
+ * a Cosmopolitan APE on Windows has no /bin/sh, so every shelling-out test
+ * SKIPPED there - on the one platform whose PATH handling these tests exist to
+ * pin. mkdir/fopen/chmod work on every host Hull runs on. */
+static int host_make_probe(const char *tag, char *dir, size_t dir_sz,
+                           const char *leaf)
+{
+    const char *tmp = getenv("TMPDIR");
+    if (!tmp || !*tmp) tmp = getenv("TMP");
+    if (!tmp || !*tmp) tmp = "/tmp";
+    snprintf(dir, dir_sz, "%s/hull-host-%s", tmp, tag);
+
+    if (mkdir(dir, 0755) != 0 && errno != EEXIST) return 0;
+
+    char exe[700];
+    snprintf(exe, sizeof(exe), "%s/%s", dir, leaf);
+    FILE *f = fopen(exe, "w");
+    if (!f) return 0;
+    fputs("#!/bin/sh\nexit 0\n", f);
+    fclose(f);
+    return chmod(exe, 0755) == 0;
+}
+
+/* Best-effort teardown for host_make_probe. */
+static void host_drop_probe(const char *dir, const char *leaf)
+{
+    char exe[700];
+    snprintf(exe, sizeof(exe), "%s/%s", dir, leaf);
+    (void)unlink(exe);
+    (void)rmdir(dir);
+}
+
 UTEST(host, find_in_path_finds_a_real_executable)
 {
     /* Use a directory we control, joined with the HOST separator, so the test
@@ -241,23 +279,8 @@ UTEST(host, find_in_path_finds_a_real_executable)
      * everything on Windows. hl_host_find_in_path_ex takes the search list
      * explicitly, so no environment mutation is needed. */
     char dir[512];
-    const char *tmp = getenv("TMPDIR");
-    if (!tmp || !*tmp) tmp = getenv("TMP");
-    if (!tmp || !*tmp) tmp = "/tmp";
-    snprintf(dir, sizeof(dir), "%s/hull-host-test", tmp);
-
-    char cmd[1200];
-    snprintf(cmd, sizeof(cmd), "mkdir -p '%s'", dir);
-    if (system(cmd) != 0) { UTEST_SKIP("cannot create a temp directory"); }
-
-    char exe[700];
-    snprintf(exe, sizeof(exe), "%s/hulltestprobe", dir);
-    FILE *f = fopen(exe, "w");
-    if (!f) { UTEST_SKIP("cannot write a temp file"); }
-    fputs("#!/bin/sh\nexit 0\n", f);
-    fclose(f);
-    snprintf(cmd, sizeof(cmd), "chmod +x '%s'", exe);
-    if (system(cmd) != 0) { UTEST_SKIP("cannot chmod a temp file"); }
+    if (!host_make_probe("test", dir, sizeof(dir), "hulltestprobe"))
+        UTEST_SKIP("cannot create a temp probe");
 
     char list[2048];
     snprintf(list, sizeof(list), "%s%c%s", dir, hl_host_path_list_sep(),
@@ -266,12 +289,66 @@ UTEST(host, find_in_path_finds_a_real_executable)
     char out[700];
     int found = hl_host_find_in_path_ex(list, "hulltestprobe",
                                         out, sizeof(out));
-
-    snprintf(cmd, sizeof(cmd), "rm -rf '%s'", dir);
-    if (system(cmd) != 0) { /* best-effort cleanup */ }
+    host_drop_probe(dir, "hulltestprobe");
 
     ASSERT_EQ(1, found);
     ASSERT_TRUE(strstr(out, "hulltestprobe") != NULL);
+}
+
+UTEST(host, find_in_path_splits_a_posix_shaped_list_on_any_host)
+{
+    /* THE WINDOWS BUG, in one assertion. A Cosmopolitan APE on Windows is
+     * handed a POSIX-shaped PATH by its own runtime - measured on Windows 11:
+     *
+     *   PATH=/C/Users/.../ft_gcc:/C/Program Files (x86)/.../bin:...
+     *
+     * Inferring ';' from the host collapsed that entire list into one nonsense
+     * component, so `hull doctor` reported every compiler missing however many
+     * were installed. The separator has to come from the list, not the host,
+     * which is what makes this pass on Windows as well as POSIX. */
+    char dir[512];
+    if (!host_make_probe("posixlist", dir, sizeof(dir), "hullprobeposix"))
+        UTEST_SKIP("cannot create a temp probe");
+
+    /* Colon-separated, forward slashes, and a component with a space in it -
+     * the exact shape measured above. */
+    char list[2048];
+    snprintf(list, sizeof(list), "/C/Program Files (x86)/nowhere:%s", dir);
+
+    char out[700];
+    int found = hl_host_find_in_path_ex(list, "hullprobeposix",
+                                        out, sizeof(out));
+
+    host_drop_probe(dir, "hullprobeposix");
+    ASSERT_EQ(1, found);
+    /* Composed with the COMPONENT's separator, so it stays POSIX-shaped. */
+    ASSERT_TRUE(strstr(out, "hull-host-posixlist/hullprobeposix") != NULL);
+}
+
+UTEST(host, find_in_path_splits_a_win32_shaped_list_on_semicolons)
+{
+    /* The mirror: a genuine Win32 list must still split on ';', and its ':'
+     * drive letters must survive. Nothing here exists, so the assertion is
+     * about not crashing and not reporting a bogus hit - the components are
+     * the point, not the miss. */
+    char out[512];
+    ASSERT_EQ(0, hl_host_find_in_path_ex(
+        "C:\tools;C:\Program Files\LLVM\bin;D:\bin",
+        "hull-definitely-not-a-real-binary-zzz", out, sizeof(out)));
+    ASSERT_STREQ("", out);
+}
+
+UTEST(host, find_in_path_keeps_a_single_win32_component_whole)
+{
+    /* A one-entry Win32 PATH carries no ';' but does carry the drive letter's
+     * ':'. Splitting on ':' there would shred `C:\tools` into `C` and
+     * `\tools`, so a lone drive-prefixed entry must be left whole. Again a
+     * clean miss is the observable; the point is that it does not split. */
+    char out[512];
+    ASSERT_EQ(0, hl_host_find_in_path_ex(
+        "C:\tools", "hull-definitely-not-a-real-binary-zzz",
+        out, sizeof(out)));
+    ASSERT_STREQ("", out);
 }
 
 UTEST(host, find_in_path_skips_empty_components)
@@ -319,23 +396,8 @@ UTEST(host, find_in_path_has_no_fixed_length_cap)
      * this function exists to fix. Bury a findable directory past 32 KB of
      * padding and require it to still resolve. */
     char dir[512];
-    const char *tmp = getenv("TMPDIR");
-    if (!tmp || !*tmp) tmp = getenv("TMP");
-    if (!tmp || !*tmp) tmp = "/tmp";
-    snprintf(dir, sizeof(dir), "%s/hull-host-longpath", tmp);
-
-    char cmd[1200];
-    snprintf(cmd, sizeof(cmd), "mkdir -p '%s'", dir);
-    if (system(cmd) != 0) { UTEST_SKIP("cannot create a temp directory"); }
-
-    char exe[700];
-    snprintf(exe, sizeof(exe), "%s/hulllongprobe", dir);
-    FILE *f = fopen(exe, "w");
-    if (!f) { UTEST_SKIP("cannot write a temp file"); }
-    fputs("#!/bin/sh\nexit 0\n", f);
-    fclose(f);
-    snprintf(cmd, sizeof(cmd), "chmod +x '%s'", exe);
-    if (system(cmd) != 0) { UTEST_SKIP("cannot chmod a temp file"); }
+    if (!host_make_probe("longpath", dir, sizeof(dir), "hulllongprobe"))
+        UTEST_SKIP("cannot create a temp probe");
 
     size_t cap = 40000;
     char *list = (char *)malloc(cap);
@@ -354,8 +416,7 @@ UTEST(host, find_in_path_has_no_fixed_length_cap)
     int found = hl_host_find_in_path_ex(list, "hulllongprobe", out, sizeof(out));
 
     free(list);
-    snprintf(cmd, sizeof(cmd), "rm -rf '%s'", dir);
-    if (system(cmd) != 0) { /* best-effort cleanup */ }
+    host_drop_probe(dir, "hulllongprobe");
 
     ASSERT_EQ(1, found);
     ASSERT_TRUE(strstr(out, "hulllongprobe") != NULL);
@@ -372,7 +433,7 @@ UTEST(host, find_in_path_never_probes_the_current_directory)
     if (!f) { UTEST_SKIP("cannot write into the working directory"); }
     fputs("#!/bin/sh\nexit 0\n", f);
     fclose(f);
-    if (system("chmod +x hullcwdprobe") != 0) { /* best effort */ }
+    (void)chmod("hullcwdprobe", 0755);
 
     char sep = hl_host_path_list_sep();
     char list[32];
@@ -395,23 +456,8 @@ UTEST(host, find_in_path_leaves_out_empty_when_the_buffer_is_too_small)
      * that ignores the return value (or logs the buffer on a miss) gets a
      * truncated path, which names a DIFFERENT file than the one found. */
     char dir[512];
-    const char *tmp = getenv("TMPDIR");
-    if (!tmp || !*tmp) tmp = getenv("TMP");
-    if (!tmp || !*tmp) tmp = "/tmp";
-    snprintf(dir, sizeof(dir), "%s/hull-host-small", tmp);
-
-    char cmd[1200];
-    snprintf(cmd, sizeof(cmd), "mkdir -p '%s'", dir);
-    if (system(cmd) != 0) { UTEST_SKIP("cannot create a temp directory"); }
-
-    char exe[700];
-    snprintf(exe, sizeof(exe), "%s/hullsmallprobe", dir);
-    FILE *f = fopen(exe, "w");
-    if (!f) { UTEST_SKIP("cannot write a temp file"); }
-    fputs("#!/bin/sh\nexit 0\n", f);
-    fclose(f);
-    snprintf(cmd, sizeof(cmd), "chmod +x '%s'", exe);
-    if (system(cmd) != 0) { UTEST_SKIP("cannot chmod a temp file"); }
+    if (!host_make_probe("small", dir, sizeof(dir), "hullsmallprobe"))
+        UTEST_SKIP("cannot create a temp probe");
 
     /* Deliberately far too small to hold the resolved path. */
     char small[8];
@@ -419,8 +465,7 @@ UTEST(host, find_in_path_leaves_out_empty_when_the_buffer_is_too_small)
     int found = hl_host_find_in_path_ex(dir, "hullsmallprobe",
                                         small, sizeof(small));
 
-    snprintf(cmd, sizeof(cmd), "rm -rf '%s'", dir);
-    if (system(cmd) != 0) { /* best-effort cleanup */ }
+    host_drop_probe(dir, "hullsmallprobe");
 
     ASSERT_EQ(0, found);          /* cannot report a path that does not fit */
     ASSERT_STREQ("", small);      /* and must not leave a truncated one */

--- a/tests/hull/test_tools_install.c
+++ b/tests/hull/test_tools_install.c
@@ -31,6 +31,7 @@
 
 #include "utest.h"
 #include "hull/tools_install.h"
+#include "hull/shared/host.h"
 
 #include <errno.h>
 #include <ftw.h>
@@ -667,6 +668,43 @@ UTEST_F(tools_fixture, status_sibling_source) {
     ASSERT_TRUE(st.resolved);
     ASSERT_EQ(st.source, HL_TOOL_SRC_SIBLING);
     ASSERT_STREQ(st.path, tool_path);
+}
+
+UTEST_F(tools_fixture, lookup_finds_a_tool_on_a_host_shaped_path) {
+    /* Step 3 of hl_tools_lookup_path walked PATH with a private ':'-splitting,
+     * '/'-joining loop, which on Windows - where PATH is ';'-separated with
+     * `C:\...` components - collapsed the whole list into one nonsense
+     * component and found nothing however much was installed. Building the
+     * search list with the HOST separator makes this test fail on that walker
+     * and pass on the shared resolver, on either host.
+     *
+     * The fixture points HOME at a fresh tmpdir, so the managed-install step
+     * cannot answer first and this really does exercise the PATH step. */
+    char bin[PATH_MAX], tool[PATH_MAX];
+    snprintf(bin,  sizeof(bin),  "%s/pathdir", utest_fixture->tmpdir);
+    ASSERT_EQ(mkdir(bin, 0755), 0);
+    snprintf(tool, sizeof(tool), "%s/wamrc", bin);
+    ASSERT_EQ(touch_exec(tool), 0);
+
+    const char *prev = getenv("PATH");
+    char saved[4096];
+    snprintf(saved, sizeof(saved), "%s", prev ? prev : "");
+
+    char list[PATH_MAX * 2];
+    snprintf(list, sizeof(list), "%s%c%s/nowhere",
+             bin, hl_host_path_list_sep(), utest_fixture->tmpdir);
+    setenv("PATH", list, 1);
+
+    char out[PATH_MAX];
+    int rc = hl_tools_lookup_path("wamrc", NULL, out, sizeof(out));
+
+    if (*saved) setenv("PATH", saved, 1); else unsetenv("PATH");
+
+    ASSERT_EQ(rc, 0);
+    /* The join keeps the COMPONENT's own separator, so a POSIX-shaped entry
+     * stays POSIX-shaped on every host - these paths get printed (hull doctor,
+     * hull tools list) and a mixed `.../pathdir\wamrc` reads like a bug. */
+    ASSERT_TRUE(strstr(out, "pathdir/wamrc") != NULL);
 }
 
 UTEST_MAIN()


### PR DESCRIPTION
Everything here was found by building Hull from source on Windows (MSYS2 +
SHA-pinned cosmocc) and then actually using the result, in the order the
failures appeared. Six defects, several of which were hiding the next.

## 1. An interrupted cosmocc build could not be resumed, only `make clean`ed

cosmocc compiles every TU twice - `foo.o` beside `.aarch64/foo.o` - and pairs
the archives that collect them the same way, but only the first of each pair is
ever a make target. A build stopped part-way left a half-written pair that every
later `make` skipped as up to date, then died at the fat link on a message
naming the archive rather than the cause:

```
aarch64-unknown-cosmo-ar: src/.aarch64/socket_posix.o: No such file
cosmocc: fatal error: vendor/keel/libkeel.a: linker input missing
         concomitant vendor/keel/.aarch64/libkeel.a file
```

This is also the state `windows-source-build.yml` inherits every time its
watchdog kills a wedged cc1 (#462), which is what stopped its retry-after-stall
from working. A parse-time repair now removes a half-written pair so the
ordinary rules rebuild both halves; `make check-cosmo-fat-repair` pins the blast
radius. (Commit 6 turned out to explain *why* those orphans existed.)

## 2. `hull build`'s no-compiler hint pointed at a flag that no longer exists

It advised `HL_ENABLE_TCC=1`, removed with the rest of the tcc toolchain. It now
names a route that exists on the running binary, as doctor's hints do. Also
drops doctor_tui's unreachable tcc row.

## 3. No toolchain on PATH was findable on Windows

`hl_host_find_in_path` - the resolver introduced precisely to fix Windows PATH
handling - never worked there. It inferred the separator from the host and split
on `;`, but a Cosmopolitan APE is handed a POSIX-shaped PATH by its own runtime:

```
PATH=/C/Users/.../ft_gcc:/C/Program Files (x86)/.../bin:...
```

Four linked defects, fixed together: the separator now comes from the **list**
and each hit is composed with its own component's separator; `hl_tools_lookup_path`
kept a **second, private** PATH walker (the copy #459 replaced in doctor, left
behind) so doctor and `hull tools list` could disagree about the same tool;
`--compiler=<name>` spawned a bare name and left the search to exec, which does
not search the PATH Windows hands an APE; and cosmocc's `#!/bin/sh` driver is
routed through the busybox in its own bundle, which was looked for only under
`$HOME` (wrong under MSYS2, where `$HOME` is `C:\msys64\home\<user>`).

Measured: `hull doctor` went from reporting every compiler missing to resolving
the `cc.exe` on PATH all along. `test_host` also stopped shelling out - four of
its probe tests SKIPPED on Windows because a cosmo APE has no `/bin/sh`, which
is why this survived #459. Now 27/27 there, no skips.

## 4. Running a lint gate deleted the build it was asked to inspect

`check-keel-flags` reported six failures on any machine that had built Hull
(`libkeel.a` was "up to date", so `make -n` emitted no compile lines; `-B` asks
the actual question). Worse: the fingerprint purge and the fat-cosmo repair are
parse-time `$(shell)` hooks, so they fire on **any** make invocation whose
configuration differs from the last build. Measured: after
`make CC=cosmocc HL_OPT=-O0 HL_ENABLE_WASM=0`, a plain `make check-keel-flags`
removed **429 objects and `build/hull`**.

Both hooks are now skipped when the tree must not change - under `-n`, and for
goals that build nothing (`lint`, `help`, every `check-%` except
`check-hardening`, which depends on `build/hull`). New gate
`make check-dry-run-inert` pins it in a temp directory where nothing can be
lost. The gate also stopped asserting LTO propagation on toolchains that cannot
do LTO, mirroring what it already did for CFI.

## 5. Hull announced a kernel sandbox on Windows that was not there

`sb_supported()` returned true for every cosmo host, so startup logged
`[sandbox] applied (... pledge: stdio rpath wpath cpath flock fattr inet)`.
Cosmopolitan's pledge/unveil enforce only where the host gives them a mechanism.
Measured with cosmocc 4.0.2 on Windows 11, since the docs are silent:

```
pledge("stdio") -> 0 (errno=0)
socket() after pledge("stdio") -> 3 (errno=0)  ALLOWED
```

`stdio` grants no `inet`. The same false claim covered a cosmo APE on macOS and
the BSDs, where the cosmo branch is selected ahead of the `__APPLE__` one.

Startup is **not** refused there, which is the one judgement call in this PR.
W^X normally fails closed without a kernel sandbox, but that rule exists for an
*incomplete* backend (Linux without Landlock, which still refuses unless
`--allow-degraded-sandbox`). With no backend at all there is nothing to opt into,
so the process starts and says once, at WARN, what is and is not protecting it.
`hull doctor` gained a Sandbox section (fallback glyph, exit status unaffected)
and `kernel_sandbox` in `--json`. `docs/security.md` claimed the sandbox "works
on ... Windows (via NT security)"; corrected with the measurement.

## 6. `make platform-cosmo` built a corrupt aarch64 archive on Windows

Found by finally testing the whole chain. Keel selects per-platform TUs and its
`clean` removes the set for the configuration it was *parsed* with; Hull invoked
it without `CC`, so on Windows it deleted the win objects and left every POSIX
object a cosmo build had made:

```
make -n clean                             -> 17 win objects, 0 posix
make -n clean CC=x86_64-unknown-cosmo-cc  -> the 6 posix objects
```

The aarch64 pass then archived those **x86_64** objects, and every `hull build`
died with `ld.bfd: i386:x86-64 architecture ... is incompatible with aarch64
output`. Each clean now gets the CC/AR of the build whose objects it removes,
and asserts nothing survived - which on its first run found a second gap
(`.aarch64/` residue under `integrations/`, which Keel's clean does not reach).

**This is the root cause of #1**: those six orphans were POSIX objects a
Windows-configured clean could never remove.

## Verification

Built and exercised on Windows 11 (MSYS2, cosmocc 4.0.2) throughout. The full
chain now works, which was not possible before commit 6:

`make platform-cosmo` → `make EMBED_PLATFORM=cosmo` → `hull new` → `hull build`
→ **`app.com`** (debug sidecars relocated, `.\app.com` launch hint) → runs and
serves HTTP 200 on `/` and `/health`.

Also: `windows-source-build` dispatched against this branch passes on attempt 1
in 2.5 min; `test_host` 27/27 (was 21 + 4 skipped); `test_tools_install` 37/40
(same three pre-existing environmental failures); `test_tool` 60/60; build with
non-default flags then run the gates - 429 objects and `build/hull` still there,
where that sequence previously left 161 and no binary.

Both new PATH rules are exact no-ops on POSIX, and Linux/native-macOS/OpenBSD
sandbox behaviour is unchanged.

One honest note on `test_compiler` (Windows only, 9/14 before and after): three
**resolution** cases that failed now pass, and three **compile** cases that used
to short-circuit on "no compiler" now reach a real compile and fail on this box,
where the resolved `cc` is a native ucrt64 gcc being handed POSIX-shaped paths by
an APE. That trade is `compiler.c`'s documented intent, and CI runs that suite on
Linux/macOS where the resolved cc is the right one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
