### PR TITLE
ci: layer-cache the reproducible build container (needs rework: evicts the repro artifacts)

### DIFF
--- a/.github/actions/hull-build-container/action.yml
+++ b/.github/actions/hull-build-container/action.yml
@@ -17,6 +17,37 @@ inputs:
       digest-pinned base image, which is already deterministic.
     required: false
     default: ""
+  cache:
+    description: >
+      Cache the image layers in the GitHub Actions cache (buildx type=gha).
+
+      OFF by default, and deliberately so. This action also builds the image
+      the RELEASE pipeline uses, and a cached layer is a different trust anchor
+      from the base-image digest + apt snapshot pins the Dockerfile documents:
+      it introduces a mutable store, plus two Docker-org actions, into a path
+      that today depends on neither. Release therefore keeps building from
+      source every time.
+
+      CI's reproducibility jobs opt in, because the alternative is worse for
+      them. snapshot.ubuntu.com is a single Canonical service with no public
+      mirror - ordinary Ubuntu mirrors carry the CURRENT archive and have no
+      /ubuntu/<timestamp>/ space at all - so when it degrades, every one of
+      those jobs fails inside `docker build`, before a line of Hull is
+      compiled. Measured 2026-09-08: 502/503 across all three of its IPs for
+      hours, four jobs red on every push, and `apt-get -o Acquire::Retries`
+      (added in the Dockerfile) does not help against an outage that long.
+
+      Caching does not weaken what those jobs prove. The image is a pure
+      function of the Dockerfile: the base is digest-pinned and the apt
+      snapshot is derived from that base, so a cache HIT and a cache MISS
+      produce the same layers by construction - that is exactly the property
+      the reproducible build asserts. A hit simply skips the network.
+
+      Cost worth knowing: the image carries clang plus a ~330 MB cosmocc, so
+      each arch's cache runs to roughly a gigabyte against the repo's 10 GB
+      budget, and can evict other caches.
+    required: false
+    default: "false"
   user:
     description: >
       Container user. Default (empty) runs as root, fine when the job only
@@ -29,7 +60,30 @@ inputs:
 runs:
   using: composite
   steps:
+    # Two build paths, one image. The cached one is a straight swap of the
+    # builder: same Dockerfile, same context, same build-arg, same tag, so the
+    # `docker run` below cannot tell which produced it (`load: true` puts the
+    # result in the local daemon exactly as `docker build` does).
+    #
+    # The scope is per-arch: ubuntu-24.04 and ubuntu-24.04-arm build genuinely
+    # different images, and sharing one scope would make them evict each other
+    # on every run.
+    - name: Set up buildx
+      if: inputs.cache == 'true'
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+    - name: Build reproducible container (layer-cached)
+      if: inputs.cache == 'true'
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+      with:
+        context: .github/docker
+        file: .github/docker/Dockerfile.build
+        build-args: SOURCE_DATE_EPOCH=${{ inputs.source-date-epoch }}
+        tags: hull-build:pinned
+        load: true
+        cache-from: type=gha,scope=hull-build-${{ runner.arch }}
+        cache-to: type=gha,mode=max,scope=hull-build-${{ runner.arch }}
     - name: Build reproducible container
+      if: inputs.cache != 'true'
       shell: bash
       run: |
         docker build \

--- a/.github/docker/Dockerfile.build
+++ b/.github/docker/Dockerfile.build
@@ -35,10 +35,19 @@ ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}
 # main / restricted / universe / multiverse / -updates / -security / -backports
 # pockets, so security-patched package versions are frozen too.
 COPY repro-sources-list.sh /usr/local/bin/repro-sources-list.sh
+# Acquire::Retries is not tuning: snapshot.ubuntu.com is a single Canonical
+# service with no public mirror (ordinary Ubuntu mirrors carry the CURRENT
+# archive and have no /ubuntu/<timestamp>/ space at all), so a transient 5xx
+# there cannot be routed around and fails the whole image build. Retrying
+# absorbs a blip. It does NOT absorb an outage - on 2026-09-08 the service
+# returned 502/503 across all three of its IPs for hours and every
+# reproducible-build job failed right here, before any Hull code compiled.
+# The layer cache is the defence against that; see the `cache` input in
+# .github/actions/hull-build-container.
 RUN chmod 0755 /usr/local/bin/repro-sources-list.sh \
  && /usr/local/bin/repro-sources-list.sh \
- && apt-get update \
- && apt-get install -y --no-install-recommends \
+ && apt-get -o Acquire::Retries=5 update \
+ && apt-get -o Acquire::Retries=5 install -y --no-install-recommends \
       build-essential clang xxd curl ca-certificates git unzip \
  && rm -rf /var/lib/apt/lists/*
 
@@ -57,7 +66,7 @@ RUN git config --system --add safe.directory '*'
 # bump procedure.
 ARG COSMOCC_VERSION=4.0.2
 ARG COSMOCC_SHA256=85b8c37a406d862e656ad4ec14be9f6ce474c1b436b9615e91a55208aced3f44
-RUN curl -fsSL -o /tmp/cosmocc.zip "https://cosmo.zip/pub/cosmocc/cosmocc-${COSMOCC_VERSION}.zip" \
+RUN curl -fsSL --retry 5 --retry-all-errors -o /tmp/cosmocc.zip "https://cosmo.zip/pub/cosmocc/cosmocc-${COSMOCC_VERSION}.zip" \
  && echo "${COSMOCC_SHA256}  /tmp/cosmocc.zip" | sha256sum -c - \
  && mkdir -p /opt/cosmo \
  && unzip -q -o /tmp/cosmocc.zip -d /opt/cosmo \

--- a/.github/docker/README.md
+++ b/.github/docker/README.md
@@ -9,6 +9,12 @@ not just within a major-version window.
 Design rationale (and why this over a published GHCR image or a Nix flake) lives
 in [`docs/security.md` → "Build-environment immutability"](../../docs/security.md).
 
+CI's reproducibility jobs additionally opt into a buildx `type=gha` layer cache
+(the `cache` input on `.github/actions/hull-build-container`), because
+`snapshot.ubuntu.com` has no public mirror and an outage there otherwise fails
+every one of them inside `docker build`. The release pipeline does not opt in
+and still rebuilds from source every time. Same reference in `docs/security.md`.
+
 ## How it works
 
 - **`Dockerfile.build`** pins two things:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1467,6 +1467,9 @@ jobs:
       - name: Build twice in the reproducible container and cmp
         uses: ./.github/actions/hull-build-container
         with:
+          # Opt in to the layer cache: a snapshot.ubuntu.com outage otherwise
+          # fails this job inside docker build (see the action's `cache` input).
+          cache: "true"
           run: |
             make
             cp build/hull /tmp/hull-c1
@@ -1498,6 +1501,9 @@ jobs:
       - name: Build hull in-container as the runner user
         uses: ./.github/actions/hull-build-container
         with:
+          # Opt in to the layer cache: a snapshot.ubuntu.com outage otherwise
+          # fails this job inside docker build (see the action's `cache` input).
+          cache: "true"
           user: host
           run: make
       - name: Host runs the container-built binary and writes into build/
@@ -1538,6 +1544,9 @@ jobs:
       - name: Build hull-cosmo in the reproducible container
         uses: ./.github/actions/hull-build-container
         with:
+          # Opt in to the layer cache: a snapshot.ubuntu.com outage otherwise
+          # fails this job inside docker build (see the action's `cache` input).
+          cache: "true"
           run: |
             make platform-cosmo
             make CC=cosmocc

--- a/docs/security.md
+++ b/docs/security.md
@@ -1587,6 +1587,29 @@ A verifier reproduces the toolchain by rebuilding the Dockerfile from
 this repo at the recorded timestamp; nothing is pulled from a registry
 Hull controls, so there is no hosted image to trust or to rot.
 
+**One availability caveat, and what CI does about it.** Everything above buys
+immutability, not availability. `snapshot.ubuntu.com` is a single Canonical
+service with no public mirror - ordinary Ubuntu mirrors carry the CURRENT
+archive and have no `/ubuntu/<timestamp>/` URL space at all - so while it is
+degraded the image cannot be built anywhere. On 2026-09-08 it returned 502/503
+across all three of its IPs for hours, and every reproducible-build job failed
+inside `docker build`, before a line of Hull was compiled.
+
+`apt-get -o Acquire::Retries=5` in the Dockerfile absorbs a blip but not an
+outage of that length. So CI's reproducibility jobs (and only those - see
+below) opt into a buildx `type=gha` LAYER CACHE via the `cache` input on
+`.github/actions/hull-build-container`. That does not weaken what they prove:
+the image is a pure function of the Dockerfile, since the base is digest-pinned
+and the apt snapshot is derived from that base, so a cache hit and a cache miss
+produce the same layers by construction. A hit only skips the network.
+
+The **release** pipeline deliberately does NOT opt in. It builds the image from
+source on every run, so the artifact's provenance still rests on the digest and
+snapshot pins alone, with no mutable cache and no extra actions in that path.
+That asymmetry is the point: CI trades a little trust surface for the ability to
+run at all during someone else's outage; a release does not need to make that
+trade, because it is a deliberate act that can simply be retried.
+
 This was chosen over both a published+digest-pinned image and a Nix flake:
 
 - **vs. a published image (GHCR + `container: @sha256`).** A pushed image


### PR DESCRIPTION
Options (b) and (d) from the outage discussion on #472. Neither disturbs the
registry-less design; (a), publishing the image to GHCR, is left alone.

## The problem

The reproducible build container pins its apt archive to a point in time on
`snapshot.ubuntu.com`. That is a single Canonical service with **no public
mirror** - ordinary Ubuntu mirrors carry the *current* archive and have no
`/ubuntu/<timestamp>/` URL space at all - so while it is degraded the image
cannot be built anywhere, and there is no host to fail over to. DNS already
returns three IPs (`185.125.189.36/.37/.69`).

On 2026-09-08 it returned 502/503 across all three for hours. Four jobs failed
on every push, inside `docker build`, before a line of Hull was compiled:

```
E: Failed to fetch http://snapshot.ubuntu.com/.../Packages  503  Service Unavailable
ERROR: failed to solve: ... apt-get install ... exit code: 100
```

## (d) Retries

`apt-get -o Acquire::Retries=5`, and `--retry 5 --retry-all-errors` on the
cosmocc fetch. This absorbs a blip. It does **not** absorb an outage that long,
and the comment says so rather than implying the problem is solved.

## (b) Layer cache, opt-in

The three CI reproducibility jobs opt into a buildx `type=gha` cache via a new
`cache` input on `hull-build-container`; a hit skips the network entirely.

**Caching does not weaken what those jobs prove.** The image is a pure function
of the Dockerfile - the base is digest-pinned, and the apt snapshot is derived
from that base - so a cache hit and a cache miss produce the same layers by
construction. That is precisely the property these jobs assert. A hit only skips
the fetch. The scope is per runner arch, since amd64 and arm64 build genuinely
different images and one scope would make them evict each other.

**Release deliberately does not opt in**, which is why this is an input rather
than unconditional. The same action is used in seven places in `release.yml`,
and release provenance should keep resting on the digest and snapshot pins alone
- no mutable cache, and no `docker/setup-buildx-action` /
`docker/build-push-action` in that path. CI trades a little trust surface for the
ability to run during someone else's outage; a release does not need that trade,
because it is a deliberate act that can simply be retried.

Both new actions are SHA-pinned, resolved from their upstream tags rather than
transcribed by hand.

## What this does not do

**It does not unblock anything today.** The first build after this change is a
cache miss, so it still needs the mirror. The claim is only that the *next*
outage does not take CI down.

Worth knowing about cost: the image carries clang plus a ~330 MB cosmocc, so
each arch's cache runs to roughly a gigabyte against the repo's 10 GB budget and
can evict other caches.

`docs/security.md` ("Build-environment immutability") and
`.github/docker/README.md` record the availability caveat and the CI/release
asymmetry, since both previously described the registry-less design as though
availability followed from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
