### PR TITLE
fix: report the tool's name, not the path it was invoked by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,20 @@ toolchain setup, APE filename conventions, Unix package managers, or Makefiles.
   `/app.com`) and Hull's per-project scratch directory (`/.hull/`).
 
 ### Fixed
+- **A Windows toolchain path leaked into `package.sig`.** The compiler and
+  linker vtables took the tool's name by splitting the invocation on `/` only,
+  so a Windows-shaped path stayed whole. `hull build` then printed
+  `compiling with C:\msys64\ucrt64\bin\gcc.exe` and recorded that absolute path
+  as the `cc` field inside `package.sig` - a developer's directory layout baked
+  into a build artifact, and a different recorded value on two machines with
+  the same toolchain. The name is also matched against (`cosmocc`, `tcc` in
+  `build.lua`), and a path matches nothing.
+
+  Both now derive the name once, through a shared `hl_host_tool_name`:
+  basename on either separator, minus a trailing `.com` / `.exe`, so
+  `C:\tools\gcc.exe`, `/usr/bin/gcc` and a bare `gcc` all yield `gcc`. The
+  spawn allowlist's inline copy of that rule (hull#471) now uses the same
+  helper, leaving one implementation rather than two that must agree.
 
 - **`hull doctor` could not find any compiler on Windows.** Its PATH search split
   on `:` and joined with `/`, which shreds the drive letters in a `;`-separated

--- a/include/hull/shared/host.h
+++ b/include/hull/shared/host.h
@@ -108,6 +108,19 @@ int hl_host_render_exec(const char *path, char *out, size_t out_sz);
 int hl_host_find_in_path(const char *name, char *out, size_t out_sz);
 
 /**
+ * @brief Reduce a toolchain invocation to the tool's NAME.
+ *
+ * Basename on EITHER separator, then a trailing ".com" / ".exe" removed, so
+ * `C:\tools\gcc.exe`, `/usr/bin/gcc` and a bare `gcc` all yield "gcc".
+ * Consumers compare against that name (build.lua matches `cosmocc` / `tcc`) or
+ * record it (the `cc` field in package.sig), and neither wants the spelling it
+ * arrived in - least of all an absolute path off a developer's machine.
+ *
+ * @returns 0 on success, -1 on a NULL/oversized argument (@p out is emptied).
+ */
+int hl_host_tool_name(const char *invocation, char *out, size_t out_sz);
+
+/**
  * @brief hl_host_find_in_path over an EXPLICIT search list.
  *
  * Same splitting and extension rules, but @p path_list is supplied by the

--- a/src/hull/cap/tool.c
+++ b/src/hull/cap/tool.c
@@ -13,6 +13,7 @@
  */
 
 #include "hull/cap/tool.h"
+#include "hull/shared/host.h"
 #include "hull/cap/audit.h"
 #include "hull/build_assets.h"
 #include "hull/compiler.h"
@@ -154,39 +155,31 @@ int hl_tool_check_allowlist(const char *binary)
 {
     if (!binary) return -1;
 
-    /* Extract basename. Split on BOTH separators: a cosmo APE reaches Windows,
-     * where a resolved tool path is "C:\tools\gcc.exe" - with '/' alone the
-     * whole string stays the "basename" and never matches. */
-    const char *base = binary;
-    for (const char *c = binary; *c; c++)
-        if (*c == '/' || *c == '\\') base = c + 1;
-
-    /* Drop a host executable suffix before matching. The same tool is `cc` on
-     * POSIX and `cc.exe` on Windows (and hull itself installs as `hull.com`,
-     * the APE convention - see install.ps1 and hl_host_exe_suffix). Without
-     * this every allowlisted tool is denied there, because the match below
-     * accepts only an exact name or a `-<digit>` version suffix.
+    /* Reduce the invocation to a tool NAME before matching: basename on either
+     * separator, minus a trailing ".com" / ".exe". Both halves are load-bearing
+     * on Windows, where a resolved path is "C:\tools\gcc.exe" - splitting on
+     * '/' alone leaves the whole string as the "basename", and the match below
+     * accepts only an exact name or a `-<digit>` version suffix, so every tool
+     * `hull build` spawns there was denied (hull#471).
      *
-     * Narrow by construction: only these two suffixes, only trailing, and only
-     * the SUFFIX is removed - the remaining name still has to be on the list,
-     * so this admits no name that was not already allowed.
+     * The rule is narrow by construction: only those two suffixes, only
+     * trailing, and only the SUFFIX is removed - what remains still has to be
+     * on the list, so no name is admitted that was not already allowed. It is
+     * case-SENSITIVE, matching the comparison it feeds: "CC.EXE" stays denied
+     * exactly as bare "CC" is, a limitation carried over rather than
+     * introduced.
      *
-     * Case-SENSITIVE, like the name match below it. A mixed-case "CC.EXE" is
-     * therefore still denied - exactly as bare "CC" is today, so this is a
-     * limitation carried over, not one introduced. Matching names case-
-     * insensitively would be a real behaviour change (and wrong on POSIX,
-     * where case is significant), so it is deliberately not done here. */
-    char stripped[64];
-    size_t blen = strlen(base);
-    for (const char **sfx = (const char *[]){ ".com", ".exe", NULL }; *sfx; sfx++) {
-        size_t slen = strlen(*sfx);
-        if (blen > slen && blen - slen < sizeof(stripped) &&
-            memcmp(base + blen - slen, *sfx, slen) == 0) {
-            memcpy(stripped, base, blen - slen);
-            stripped[blen - slen] = '\0';
-            base = stripped;
-            break;
-        }
+     * A name too long for the buffer falls back to the raw basename, which
+     * then fails the match - never a truncation, which could match something
+     * else. */
+    char named[64];
+    const char *base;
+    if (hl_host_tool_name(binary, named, sizeof(named)) == 0) {
+        base = named;
+    } else {
+        base = binary;
+        for (const char *c = binary; *c; c++)
+            if (*c == '/' || *c == '\\') base = c + 1;
     }
 
     for (const char **p = allowed_prefixes; *p; p++) {

--- a/src/hull/compiler.c
+++ b/src/hull/compiler.c
@@ -20,14 +20,16 @@
 
 typedef struct {
     char cc[PATH_MAX];
+    /* The tool NAME, derived once at construction (hl_host_tool_name): the
+     * basename with any host executable suffix removed. Held rather than
+     * recomputed so sys_name() can keep returning a borrowed pointer. */
+    char name[64];
 } SysCtx;
 
 static const char *sys_name(HlCompiler *c)
 {
     SysCtx *ctx = (SysCtx *)c->ctx;
-    /* Return just the basename */
-    const char *slash = strrchr(ctx->cc, '/');
-    return slash ? slash + 1 : ctx->cc;
+    return ctx->name;
 }
 
 static int sys_is_available(HlCompiler *c)
@@ -110,6 +112,10 @@ HlCompiler *hl_compiler_system_new(const char *cc_path)
     SysCtx *ctx = (SysCtx *)malloc(sizeof(SysCtx));
     if (!ctx) return NULL;
     snprintf(ctx->cc, sizeof(ctx->cc), "%s", cc_path);
+    /* An over-long name cannot match anything a consumer compares against, so
+     * fall back to the invocation rather than to a truncation that could. */
+    if (hl_host_tool_name(cc_path, ctx->name, sizeof(ctx->name)) != 0)
+        snprintf(ctx->name, sizeof(ctx->name), "%s", cc_path);
     HlCompiler *c = (HlCompiler *)malloc(sizeof(HlCompiler));
     if (!c) { free(ctx); return NULL; }
     c->vtable = &sys_vtable;

--- a/src/hull/linker_system.c
+++ b/src/hull/linker_system.c
@@ -13,6 +13,7 @@
 #include "hull/compiler.h"   /* hl_driver_resolve_native (shared cc resolution) */
 #include "hull/cap/tool.h"
 #include "hull/tools_install.h"
+#include "hull/shared/host.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -24,13 +25,16 @@
 
 typedef struct {
     char cc[PATH_MAX];
+    /* The tool NAME, derived once at construction - see the identical field in
+     * compiler.c::SysCtx and hl_host_tool_name for why the invocation itself
+     * is the wrong thing to report. */
+    char name[64];
 } SysCtx;
 
 static const char *sys_name(HlLinker *l)
 {
     SysCtx *ctx = (SysCtx *)l->ctx;
-    const char *slash = strrchr(ctx->cc, '/');
-    return slash ? slash + 1 : ctx->cc;
+    return ctx->name;
 }
 
 static int sys_is_available(HlLinker *l)
@@ -80,6 +84,8 @@ HlLinker *hl_linker_system_new(const char *cc_path)
     SysCtx *ctx = (SysCtx *)malloc(sizeof(SysCtx));
     if (!ctx) return NULL;
     snprintf(ctx->cc, sizeof(ctx->cc), "%s", cc_path);
+    if (hl_host_tool_name(cc_path, ctx->name, sizeof(ctx->name)) != 0)
+        snprintf(ctx->name, sizeof(ctx->name), "%s", cc_path);
     HlLinker *l = (HlLinker *)malloc(sizeof(HlLinker));
     if (!l) { free(ctx); return NULL; }
     l->vtable = &sys_vtable;

--- a/src/hull/shared/host.c
+++ b/src/hull/shared/host.c
@@ -172,6 +172,59 @@ int hl_host_render_exec(const char *path, char *out, size_t out_sz)
     return 0;
 }
 
+/* ── Tool naming ────────────────────────────────────────────────────
+ *
+ * Reduce a toolchain INVOCATION to the tool's NAME: take the basename, then
+ * drop a host executable suffix. `C:\msys64\ucrt64\bin\gcc.exe`, `/usr/bin/cc`
+ * and a bare `cosmocc` all name the same thing, and every consumer wants that
+ * thing rather than the spelling it arrived in.
+ *
+ * Both separators, because a resolved path on Windows carries backslashes and
+ * splitting on '/' alone leaves the whole string as the "basename". That was a
+ * live defect: hull#471 fixed it for the spawn allowlist, where every tool was
+ * denied; the compiler and linker vtables kept splitting on '/' only, so on
+ * Windows `hull build` printed "compiling with C:\...\cc.exe" and recorded that
+ * absolute path as the `cc` field inside package.sig - a developer's directory
+ * layout baked into a build artifact, and a value that differs per machine for
+ * what is supposed to be the same toolchain.
+ *
+ * The suffix strip is what makes the name host-independent, which is what the
+ * consumers actually compare against: build.lua matches `cosmocc` and `tcc`,
+ * and test_compiler asserts a plain `cc`. Narrow by construction - only
+ * ".com" and ".exe", only trailing, only the suffix removed.
+ *
+ * Case-SENSITIVE, matching the comparisons it feeds. "CC.EXE" keeps its
+ * suffix, exactly as a bare "CC" is not "cc" today; folding case would be a
+ * real behaviour change and wrong on POSIX, where case is significant.
+ *
+ * @returns 0 on success, -1 on a NULL/oversized argument (out is emptied).
+ */
+int hl_host_tool_name(const char *invocation, char *out, size_t out_sz)
+{
+    if (!out || out_sz == 0) return -1;
+    out[0] = '\0';
+    if (!invocation) return -1;
+
+    const char *base = invocation;
+    for (const char *c = invocation; *c; c++)
+        if (*c == '/' || *c == '\\') base = c + 1;
+
+    size_t blen = strlen(base);
+    static const char *const sfx[] = { ".com", ".exe", NULL };
+    for (const char *const *s = sfx; *s; s++) {
+        size_t slen = strlen(*s);
+        if (blen > slen && memcmp(base + blen - slen, *s, slen) == 0) {
+            blen -= slen;
+            break;
+        }
+    }
+
+    if (blen >= out_sz) return -1;   /* a truncated name would match nothing */
+    memcpy(out, base, blen);
+    out[blen] = '\0';
+    return 0;
+}
+
 /* ── PATH search ────────────────────────────────────────────────────
  *
  * The previous (doctor-local) implementation split on ':' and joined with

--- a/tests/hull/compiler/test_compiler.c
+++ b/tests/hull/compiler/test_compiler.c
@@ -76,6 +76,30 @@ UTEST(compiler, system_new_cc)
     hl_compiler_destroy(c);
 }
 
+UTEST(compiler, name_is_the_tool_not_the_invocation)
+{
+    /* The vtable used to take the basename by splitting on '/' only, so a
+     * Windows-shaped invocation stayed whole. That name is not cosmetic: it is
+     * printed ("hull build: compiling with ..."), matched against in build.lua
+     * (`cosmocc`, `tcc`), and RECORDED as the `cc` field inside package.sig -
+     * so a developer's absolute directory layout ended up in a build artifact,
+     * and two machines with the same toolchain recorded different values. */
+    struct { const char *invocation; const char *want; } cases[] = {
+        { "cc",                                  "cc"      },
+        { "/usr/bin/gcc",                        "gcc"     },
+        { "C:\\msys64\\ucrt64\\bin\\gcc.exe",    "gcc"     },
+        { "/C/Users/x/.hull/tools/cosmocc/bin/cosmocc", "cosmocc" },
+        { "cosmocc.exe",                         "cosmocc" },
+        { "gcc-14",                              "gcc-14"  },  /* not a suffix */
+    };
+    for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        HlCompiler *c = hl_compiler_system_new(cases[i].invocation);
+        ASSERT_NE(c, NULL);
+        ASSERT_STREQ(hl_compiler_name(c), cases[i].want);
+        hl_compiler_destroy(c);
+    }
+}
+
 UTEST(compiler, system_new_null_returns_null)
 {
     HlCompiler *c = hl_compiler_system_new(NULL);

--- a/tests/hull/test_host.c
+++ b/tests/hull/test_host.c
@@ -218,6 +218,67 @@ UTEST(host, render_exec_reports_overflow_when_quoting)
 
 /* ── PATH search ───────────────────────────────────────────────────── */
 
+UTEST(host, tool_name_takes_the_basename_on_either_separator)
+{
+    char out[64];
+    /* The defect: splitting on '/' alone leaves a Windows path whole, so the
+     * "name" recorded in package.sig was an absolute path off one machine. */
+    ASSERT_EQ(0, hl_host_tool_name("C:\\msys64\\ucrt64\\bin\\gcc.exe", out, sizeof(out)));
+    ASSERT_STREQ("gcc", out);
+    ASSERT_EQ(0, hl_host_tool_name("/usr/bin/gcc", out, sizeof(out)));
+    ASSERT_STREQ("gcc", out);
+    ASSERT_EQ(0, hl_host_tool_name("/C/Users/x/.hull/tools/cosmocc/bin/cosmocc", out, sizeof(out)));
+    ASSERT_STREQ("cosmocc", out);
+    /* Mixed separators: the LAST one wins, whichever it is. */
+    ASSERT_EQ(0, hl_host_tool_name("C:/tools\\bin/cc", out, sizeof(out)));
+    ASSERT_STREQ("cc", out);
+}
+
+UTEST(host, tool_name_drops_only_a_trailing_exe_or_com)
+{
+    char out[64];
+    ASSERT_EQ(0, hl_host_tool_name("cc.exe", out, sizeof(out)));
+    ASSERT_STREQ("cc", out);
+    ASSERT_EQ(0, hl_host_tool_name("hull.com", out, sizeof(out)));
+    ASSERT_STREQ("hull", out);
+    /* Not an extension, not stripped. */
+    ASSERT_EQ(0, hl_host_tool_name("gcc-14", out, sizeof(out)));
+    ASSERT_STREQ("gcc-14", out);
+    ASSERT_EQ(0, hl_host_tool_name("exe", out, sizeof(out)));
+    ASSERT_STREQ("exe", out);
+    ASSERT_EQ(0, hl_host_tool_name(".exe", out, sizeof(out)));
+    ASSERT_STREQ(".exe", out);      /* nothing would be left; leave it alone */
+    /* Mid-string, not trailing. */
+    ASSERT_EQ(0, hl_host_tool_name("cc.exe.bak", out, sizeof(out)));
+    ASSERT_STREQ("cc.exe.bak", out);
+    /* Case-sensitive, matching the comparisons this feeds. */
+    ASSERT_EQ(0, hl_host_tool_name("CC.EXE", out, sizeof(out)));
+    ASSERT_STREQ("CC.EXE", out);
+}
+
+UTEST(host, tool_name_rejects_rather_than_truncates)
+{
+    /* A truncated name could match a DIFFERENT tool, so an over-long one is
+     * refused and the caller decides what to do. */
+    char small[4];
+    ASSERT_EQ(-1, hl_host_tool_name("/usr/bin/clang", small, sizeof(small)));
+    ASSERT_STREQ("", small);
+
+    char out[64];
+    ASSERT_EQ(-1, hl_host_tool_name(NULL, out, sizeof(out)));
+    ASSERT_STREQ("", out);
+    ASSERT_EQ(-1, hl_host_tool_name("cc", NULL, 16));
+    ASSERT_EQ(-1, hl_host_tool_name("cc", out, 0));
+}
+
+UTEST(host, tool_name_handles_a_trailing_separator)
+{
+    /* Degenerate but must not read past the end: the basename is empty. */
+    char out[64];
+    ASSERT_EQ(0, hl_host_tool_name("/usr/bin/", out, sizeof(out)));
+    ASSERT_STREQ("", out);
+}
+
 UTEST(host, find_in_path_rejects_bad_arguments)
 {
     char out[64];
@@ -333,7 +394,7 @@ UTEST(host, find_in_path_splits_a_win32_shaped_list_on_semicolons)
      * the point, not the miss. */
     char out[512];
     ASSERT_EQ(0, hl_host_find_in_path_ex(
-        "C:\tools;C:\Program Files\LLVM\bin;D:\bin",
+        "C:\\tools;C:\\Program Files\\LLVM\\bin;D:\\bin",
         "hull-definitely-not-a-real-binary-zzz", out, sizeof(out)));
     ASSERT_STREQ("", out);
 }
@@ -346,7 +407,7 @@ UTEST(host, find_in_path_keeps_a_single_win32_component_whole)
      * clean miss is the observable; the point is that it does not split. */
     char out[512];
     ASSERT_EQ(0, hl_host_find_in_path_ex(
-        "C:\tools", "hull-definitely-not-a-real-binary-zzz",
+        "C:\\tools", "hull-definitely-not-a-real-binary-zzz",
         out, sizeof(out)));
     ASSERT_STREQ("", out);
 }


### PR DESCRIPTION
The loose end flagged on #472.

## The bug

The compiler and linker vtables took a tool's name by splitting the invocation
on `/` only, so a Windows-shaped path stayed whole:

```
hull build: compiling with C:\msys64\ucrt64\bin\gcc.exe...
```

and that absolute path was recorded as the `cc` field inside `package.sig` - a
developer's directory layout baked into a build artifact, and a different
recorded value on two machines running the same toolchain. The name is also what
`build.lua` matches against (`cosmocc`, `tcc`), and a path matches nothing.

This was always wrong on Windows, but bare names used to reach it more often
than paths. Resolving a bare name to an absolute path before spawning (#472)
made paths the normal case, which turned a latent bug into a visible one.

## The fix

Both vtables derive the name once at construction through a shared
`hl_host_tool_name()`: basename on **either** separator, minus a trailing
`.com` / `.exe`, so `C:\tools\gcc.exe`, `/usr/bin/gcc` and a bare `gcc` all
yield `gcc`. The suffix strip is what makes the name host-independent, which is
what the consumers compare against.

Narrow by construction (only those two suffixes, only trailing) and
case-sensitive, matching the comparisons it feeds - `CC.EXE` keeps its suffix
exactly as a bare `CC` is not `cc`. The name is stored in the context rather
than recomputed, so `sys_name()` still returns a borrowed pointer, and an
over-long name falls back to the invocation rather than to a truncation that
could name a different tool.

`hl_tool_check_allowlist` had its own inline copy of this rule from #471 and now
calls the same helper, so there is one implementation instead of two that have
to agree.

## Also: two tests that were passing vacuously

Two cases shipped in #472 with single backslashes in their Windows-path
literals, so `\t` became a tab and `\P` / `\L` / `\b` were dropped. Both assert
a clean miss, which held either way - so they passed while testing something
other than what they claim. Repaired here. A `\u` in the new cases is what
surfaced it: that one is an error rather than a warning.

## Results (Windows)

| suite | result |
|---|---|
| `test_host` | 31/31 |
| `test_tool` | 60/60 - the allowlist's 39 accept/deny cases unchanged |
| `test_compiler` | 10/15 - one more test and one more pass than before |

`test_compiler`'s failing set is unchanged: the environment failures documented
in #472, where the resolved `cc` is a native ucrt64 gcc being handed
POSIX-shaped paths by an APE.

## Not addressed

Several sites still take the **dirname** of `hull_exe` by splitting on `/` only
(`tool.c`, `tools_install.c`, `sandbox_tool.c`, `verify_self.c`). They are
correct today because a cosmo APE reports its own path forward-slashed; they
would need the same treatment for a native Windows build, which does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
