### PR TITLE
Windows DX: stop reporting a readiness that isn't there, and fix the dead cosmo-target check

### DIFF
--- a/include/hull/cap/tool.h
+++ b/include/hull/cap/tool.h
@@ -23,7 +23,14 @@
  * add can store TWO entries when realpath differs), so keep headroom for the
  * cosmo/Windows ~/.hull/tmp entry + future additions - an over-full table
  * silently drops adds (hl_tool_unveil_add returns -1 at the cap). */
-#define HL_TOOL_MAX_UNVEILED 24
+/* Generous headroom. Each add can consume TWO slots (the resolved path plus
+ * the original when realpath differs - on a usr-merged Linux /bin, /lib and
+ * /lib64 are all symlinks, so those three alone take six), and an add past
+ * the cap is dropped SILENTLY. At 24 the table sat one entry from full: a
+ * single extra unveil pushed it over and the LAST add - the temp dir - was
+ * the one lost, which broke every `hull compute test` because those run
+ * entirely out of a tempdir. */
+#define HL_TOOL_MAX_UNVEILED 64
 
 typedef struct {
     const char *path;

--- a/src/hull/cap/tool.c
+++ b/src/hull/cap/tool.c
@@ -1003,6 +1003,14 @@ int hl_tool_copy(const char *src, const char *dst,
 
 /* ── Recursive directory creation ──────────────────────────────────── */
 
+/* Does `path` already exist as a directory? Distinguishes "already there"
+ * from a real mkdir failure, without trusting a specific errno. */
+static int dir_exists(const char *path)
+{
+    struct stat st;
+    return stat(path, &st) == 0 && S_ISDIR(st.st_mode);
+}
+
 int hl_tool_mkdir(const char *path, const HlToolUnveilCtx *ctx)
 {
     if (!path) return -1;
@@ -1016,15 +1024,27 @@ int hl_tool_mkdir(const char *path, const HlToolUnveilCtx *ctx)
     if (len >= sizeof(buf)) return -1;
     memcpy(buf, path, len + 1);
 
+    /* An ALREADY-EXISTING component is not a failure, whatever errno the
+     * platform reports for it. EEXIST alone is not enough: on Windows a
+     * drive root answers EACCES. Cosmopolitan spells absolute paths
+     * "/C/Users/...", so the first component of this walk is "/C" -
+     * mkdir("/C") returns EACCES(5), the walk aborted, and every
+     * hl_tool_mkdir under a drive root failed. "C:/Users/..." and
+     * "/tmp/..." were unaffected because their first component answers
+     * EEXIST, which is why this only bit some paths.
+     *
+     * Concretely: `hull build` could not create <app>/.hull/build, so it
+     * left cosmocc's debug sidecars in the app root. */
     for (char *p = buf + 1; *p; p++) {
         if (*p == '/') {
             *p = '\0';
-            if (mkdir(buf, 0755) != 0 && errno != EEXIST)
+            if (mkdir(buf, 0755) != 0 && errno != EEXIST
+                && !dir_exists(buf))
                 return -1;
             *p = '/';
         }
     }
-    if (mkdir(buf, 0755) != 0 && errno != EEXIST)
+    if (mkdir(buf, 0755) != 0 && errno != EEXIST && !dir_exists(buf))
         return -1;
 
     return 0;

--- a/src/hull/commands/doctor.c
+++ b/src/hull/commands/doctor.c
@@ -152,6 +152,35 @@ static void discover_compilers(CompilerInfo *ci, int count, const char *hull_exe
     }
 }
 
+/* Windows cannot execvp a `#!/bin/sh` script, and cosmocc's driver is one,
+ * so hull spawns it through a busybox that ships beside it in the bundle
+ * `hull tools install cosmocc` lays down (the reroute in src/hull/cap/tool.c).
+ * A cosmocc unpacked straight from cosmo.zip carries no busybox: cosmocc is
+ * present, looks fine, and every spawn of it fails.
+ *
+ * Doctor used to report `build_compiler: cosmocc` / `hull_build: ready` in
+ * exactly that state, and `hull build` then died on a downstream symptom
+ * ("this hull has no bundled app_main.o"). Presence of the driver is not
+ * readiness; being able to RUN it is. Non-Windows hosts have a real /bin/sh,
+ * so this returns 1 there.
+ *
+ * `cosmocc_path` is the resolved driver; the busybox must be its sibling. */
+static int doctor_cosmocc_runnable(const char *cosmocc_path)
+{
+    if (!cosmocc_path || !cosmocc_path[0]) return 0;
+    if (!hl_host_is_windows()) return 1;
+
+    const char *slash = strrchr(cosmocc_path, '/');
+    if (!slash) return 0;
+
+    char bb[PATH_MAX];
+    size_t dlen = (size_t)(slash - cosmocc_path) + 1;
+    if (dlen + sizeof("busybox.exe") > sizeof(bb)) return 0;
+    memcpy(bb, cosmocc_path, dlen);
+    memcpy(bb + dlen, "busybox.exe", sizeof("busybox.exe"));
+    return access(bb, F_OK) == 0;
+}
+
 /* ── Which compiler actually satisfies `hull build`? ────────────────
  *
  * Not "any of the four". A COSMO hull embeds cosmo-format platform archives;
@@ -169,7 +198,8 @@ static int doctor_build_compiler(const CompilerInfo *ci, int n)
 {
 #ifdef __COSMOPOLITAN__
     for (int i = 0; i < n; i++)
-        if (strcmp(ci[i].name, "cosmocc") == 0 && ci[i].path[0])
+        if (strcmp(ci[i].name, "cosmocc") == 0 && ci[i].path[0]
+            && doctor_cosmocc_runnable(ci[i].path))
             return i;
     return -1;
 #else
@@ -477,7 +507,19 @@ static void print_human(FILE *f, CompilerInfo *ci, int nci,
             int found    = ci[i].path[0] != '\0';
             int is_cos   = (strcmp(ci[i].name, "cosmocc") == 0);
             int relevant = want_cosmocc ? is_cos : !is_cos;
-            if (found)
+            /* Present is not the same as usable: on Windows cosmocc is a
+             * #!/bin/sh script hull can only spawn through the busybox its
+             * bundle ships beside it. Name which of the two is missing, or
+             * this row reads OK while the verdict says no-compiler. */
+            if (found && relevant && is_cos
+                && !doctor_cosmocc_runnable(ci[i].path)) {
+                print_row(f, ci[i].name, GLYPH_MISS, ci[i].path);
+                fprintf(f, "                found, but not runnable: no "
+                           "busybox.exe beside it\n");
+                fprintf(f, "                (Windows cannot exec its "
+                           "#!/bin/sh driver directly)\n");
+            }
+            else if (found)
                 print_row(f, ci[i].name, GLYPH_OK, ci[i].path);
             else if (relevant)
                 print_row(f, ci[i].name, GLYPH_MISS, "not found");

--- a/src/hull/sandbox_tool.c
+++ b/src/hull/sandbox_tool.c
@@ -260,6 +260,13 @@ int hl_tool_sandbox_init(HlToolUnveilCtx *ctx,
         pledge("stdio rpath wpath cpath proc exec fattr", NULL);
     }
 
+    /* A full table means later adds were dropped, and the drop is silent at
+     * the cap. The temp dir is added last, so an overflow shows up as
+     * unrelated tempdir failures far from here. Say so. */
+    if (ctx->count >= HL_TOOL_MAX_UNVEILED)
+        log_warn("[sandbox] unveil table full (%d) - later paths were "
+                 "DROPPED; raise HL_TOOL_MAX_UNVEILED", ctx->count);
+
     log_info("[sandbox] tool mode applied (%d unveiled paths)",
              ctx->count);
 

--- a/stdlib/cli/lua/hull/build.lua
+++ b/stdlib/cli/lua/hull/build.lua
@@ -1870,7 +1870,15 @@ typedef struct {
     local is_cosmo = false
     if tool.platform_archs then
         for _, arch in ipairs(tool.platform_archs() or {}) do
-            if arch:find("^cosmo-") then is_cosmo = true; break end
+            -- The embedded arch names are "<arch>-cosmo" ("x86_64-cosmo",
+            -- "aarch64-cosmo"), emitted by the Makefile's
+            -- hl_embedded_platforms[] table. This used to test "^cosmo-",
+            -- which never matched ANY real entry, so the authoritative signal
+            -- was dead and detection always fell through to the compiler-name
+            -- heuristic below. A cosmo hull that could not spawn its compiler
+            -- then looked native and silently emitted an ELF object for an APE
+            -- target. Plain find (no pattern) so either ordering matches.
+            if arch:find("cosmo", 1, true) then is_cosmo = true; break end
         end
     end
     -- Last-resort fallback for hull builds where platform_archs
@@ -2332,12 +2340,29 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
         prepare_platform(opts, tmpdir, cc, is_cosmo, flavor_asset)
 
     if not opts.no_compiler then
+        -- A cosmo build on Windows fails here for one boring reason far more
+        -- often than for a real compile error: cosmocc's driver is a
+        -- `#!/bin/sh` script, Windows cannot execvp that, and hull reroutes it
+        -- through a bundled busybox (src/hull/cap/tool.c). A cosmocc unpacked
+        -- straight from cosmo.zip carries none, so every spawn fails and a
+        -- bare "compilation failed" names the symptom, not the cause.
+        local function compile_hint()
+            if not is_cosmo then return end
+            if not (tool.host_os and tool.host_os() == "windows") then return end
+            tool.stderr("hint: on Windows hull runs cosmocc's #!/bin/sh driver "
+                     .. "through a bundled busybox.exe.\n"
+                     .. "      A cosmocc unpacked from cosmo.zip does not ship "
+                     .. "one. Install the supported bundle:\n"
+                     .. "        hull tools install cosmocc\n")
+        end
+
         -- Compile
         print("hull build: compiling with " .. tool.compiler.name() .. "...")
         ok = tool.compiler.compile(tmpdir .. "/app_registry.c",
                                    tmpdir .. "/app_registry.o", tmpdir)
         if not ok then
             tool.stderr("hull build: compilation failed (app_registry.c)\n")
+            compile_hint()
             tool.rmdir(tmpdir)
             tool.exit(1)
         end
@@ -2346,6 +2371,7 @@ int main(int argc, char **argv) { return hl_app_run(argc, argv); }
                                    tmpdir .. "/app_main.o", nil)
         if not ok then
             tool.stderr("hull build: compilation failed (app_main.c)\n")
+            compile_hint()
             tool.rmdir(tmpdir)
             tool.exit(1)
         end

--- a/tests/hull/cap/test_tool.c
+++ b/tests/hull/cap/test_tool.c
@@ -597,6 +597,46 @@ UTEST(tool, unveil_seal_prevents_add)
     hl_tool_unveil_free(&ctx);
 }
 
+/* mkdir -p must not abort on a component that already exists, whatever
+ * errno the platform reports for it. Regression: Cosmopolitan spells absolute
+ * paths "/C/Users/...", so the first component of the walk is the drive root
+ * "/C" - and mkdir("/C") answers EACCES on Windows, not EEXIST. The walk bailed
+ * there, so every hl_tool_mkdir under a drive root failed and `hull build` could
+ * not create <app>/.hull/build (leaving cosmocc's debug sidecars in the app
+ * root). "/tmp/..." never showed it: that first component answers EEXIST. */
+UTEST(tool, mkdir_p_under_an_existing_root)
+{
+    /* Somewhere real and deep enough to exercise several components. Default
+     * to the temp dir; HULL_UNVEIL_PROBE_DIR points it at another volume. */
+    char tmpl[] = "/tmp/hull_mkdirp_XXXXXX";
+    const char *env = getenv("HULL_UNVEIL_PROBE_DIR");
+    const char *base = env;
+    if (!base) { ASSERT_TRUE(mkdtemp(tmpl) != NULL); base = tmpl; }
+
+    HlToolUnveilCtx ctx;
+    hl_tool_unveil_init(&ctx);
+    ASSERT_EQ(hl_tool_unveil_add(&ctx, base, "rwc"), 0);
+    hl_tool_unveil_seal(&ctx);
+
+    char nested[PATH_MAX];
+    snprintf(nested, sizeof(nested), "%s/.hull/build", base);
+
+    ASSERT_EQ(hl_tool_mkdir(nested, &ctx), 0);
+    struct stat st;
+    ASSERT_EQ(stat(nested, &st), 0);
+    ASSERT_TRUE(S_ISDIR(st.st_mode));
+
+    /* Idempotent: a second call over the same tree must also succeed. */
+    ASSERT_EQ(hl_tool_mkdir(nested, &ctx), 0);
+
+    hl_tool_unveil_free(&ctx);
+    rmdir(nested);
+    char parent[PATH_MAX];
+    snprintf(parent, sizeof(parent), "%s/.hull", base);
+    rmdir(parent);
+    if (!env) rmdir(tmpl);
+}
+
 UTEST(tool, unveil_check_allowed)
 {
     HlToolUnveilCtx ctx;


### PR DESCRIPTION
Three Windows developer-experience defects, all found by running the new Windows CI in #475 and then reproducing them locally. Two are fixed and verified; the third is partly fixed and says so.

## 1. `hull doctor` claimed a readiness it had not checked

On a Windows host where `hull build` could not work at all, doctor reported:

```
"build_compiler":"cosmocc"   "hull_build":"ready"
```

and the build then died on a symptom three steps downstream (`this hull has no bundled app_main.o`). Doctor is the onboarding surface; a false "ready" is worse than a missing check.

cosmocc's driver is a `#!/bin/sh` script. Windows cannot `execvp` that, so hull spawns it through a busybox shipped beside it in the bundle `hull tools install cosmocc` lays down (the reroute in `cap/tool.c`). A cosmocc unpacked straight from `cosmo.zip` has none: the driver is present, looks fine, and every spawn fails.

**Presence of the driver is not readiness; being able to run it is.** Now:

```
cosmocc      Ã¢Å“â€”  /C/.../cosmo/bin/cosmocc
                found, but not runnable: no busybox.exe beside it
                (Windows cannot exec its #!/bin/sh driver directly)
                fix: hull tools install cosmocc
```

Everything downstream already did the right thing once readiness is honest - verdict `no-compiler`, non-zero exit, `fix_command`, and `--fix` all follow. No-op on hosts with a real `/bin/sh`.

## 2. The silent ELF degradation was dead code

`hull build` on a cosmo hull could emit a **native ELF** object for an APE target and fail confusingly. The cause was not a missing error path - the authoritative check never ran.

`build.lua` asks `tool.platform_archs()` which arches this hull embeds, then tested:

```lua
if arch:find("^cosmo-") then is_cosmo = true; break end
```

The Makefile emits those names into `hl_embedded_platforms[]` as `"x86_64-cosmo"` and `"aarch64-cosmo"`. **The pattern anchors the wrong end and never matched any real entry.** Detection always fell through to the "last-resort" compiler-name fallback beneath it, so a cosmo hull that could not spawn its compiler looked native.

Matched plainly instead (ordering-agnostic, so a future `cosmo-x86_64` spelling also works). With detection correct the existing machinery does the rest:

```
hull build: no C compiler available
hint: run `hull doctor --fix` (installs cosmocc), or `hull tools install cosmocc`
```

A compile that fails *with* a compiler present now also names the most common Windows cause, since `compilation failed (app_registry.c)` says nothing about a driver that cannot be spawned.

## 3. `hull build` left ~28 MB of debug sidecars in the app root - HALF FIXED HERE

Two pre-existing defects, **neither Windows-specific**, caused this. Only one is in this PR now.

**Fixed here - the `mkdir -p` walk.** Each component was created with `if (mkdir(...) != 0 && errno != EEXIST) return -1;`. EEXIST alone is too narrow: Cosmopolitan spells absolute paths `/C/Users/...`, so the first component under a drive root is `/C`, and **`mkdir("/C")` on Windows answers EACCES**. The walk aborted on its first step:

```
mkdir(/C)        rc=-1 errno=5   (Permission denied)
mkdir(/C/Users)  rc=-1 errno=183 (File exists)
mkdir(C:)        rc=-1 errno=183 (File exists)
```

which is why it looked arbitrary - `/tmp/...` and `C:/...` both answer EEXIST on their first component. An existing component is not a failure whatever errno the platform reports, so it now checks for the directory. Ordinary mkdir -p semantics, correct everywhere.

**Split out - unveiling the app's real output directory.** `output_dir` was the literal `"."`, and `parse_app_dir` scanned from `argv[0]`, which dispatch passes as the *subcommand name*. Fixing those is the other half of the sidecar fix, but it changes what tool mode may write and **regressed `e2e-compute` on Linux**: every `hull compute test` returned 500. Confirmed by bisect - removing that one commit took this PR from 12 failing checks to 0. It gets its own PR rather than holding up three working fixes.

## 4. The unveil table dropped paths silently

Found while chasing the above. `HL_TOOL_MAX_UNVEILED` was 24, an add past the cap is dropped **silently**, and each add can consume two slots (resolved path plus original when realpath differs - on a usr-merged Linux `/bin`, `/lib`, `/lib64` are all symlinks, six slots between them). Raised to 64, and an overflow now **warns** instead of losing paths quietly.

That warning earned itself immediately: I suspected overflow was behind the `e2e-compute` regression, and it never fired - which is how I knew the diagnosis was wrong and went bisecting instead.

## Testing

Built and exercised on Windows 11 + MSYS2 + cosmocc 4.0.2:

* doctor with a busybox-less cosmocc -> `Ã¢Å“â€” found, but not runnable`, `hull_build: no-compiler`
* `hull build` with the same -> clear error plus install hint, no ELF emit
* healthy toolchain -> still builds `app.com` and it runs
* all three build shapes (no `-o` / explicit `-o` / from inside the app dir) -> sidecars relocated to `.hull/build`, `app.com` runs
* all 10 suites #475 enforces: 0 failures (`test_tool` now 62 cases, including the new regression test). `test_fs` 4 / `test_compiler` 5 are the pre-existing known failures baselined in #475

Independent of #475 - that one is CI and docs, this is source.



