### PR TITLE
Windows: windowed mmap must use the 64 KiB allocation granularity and not map past EOF

### DIFF
--- a/include/hull/cap/fs.h
+++ b/include/hull/cap/fs.h
@@ -306,6 +306,15 @@ typedef struct HlMappedBuffer {
  */
 #define HL_FS_MMAP_MAX_WINDOW_BYTES ((uint64_t)1 << 30)
 
+/* The alignment a windowed mmap offset must satisfy on this host.
+ *
+ * NOT always the page size. Windows maps views at multiples of the
+ * ALLOCATION GRANULARITY (64 KiB); an offset that is merely page-aligned
+ * is rejected with EINVAL even though sysconf(_SC_PAGESIZE) reports 4096.
+ * Exposed so callers and tests derive the same value instead of each
+ * assuming the page size. */
+uint64_t hl_cap_fs_mmap_granularity(void);
+
 /**
  * @brief Pure, filesystem-free geometry for a page-aligned windowed mmap.
  *

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -1111,7 +1111,12 @@ fuzz/fuzz_span_sdk: fuzz/fuzz_span_sdk.c
 # resolver (cap/fs_resolve.c) and the authorization policy (cap/fs_policy.c, since
 # read/write/mmap select through it); link that small chain so the fuzzer resolves
 # without dragging in Keel.
-fuzz/fuzz_span_window: fuzz/fuzz_span_window.c $(SRCDIR)/hull/cap/fs.c $(SRCDIR)/hull/cap/fs_resolve.c $(SRCDIR)/hull/cap/fs_policy.c $(SRCDIR)/hull/cap/audit.c $(SRCDIR)/hull/utils/alloc.c $(SH_JSON_DIR)/sh_json.c $(SH_ARENA_DIR)/sh_arena.c
+#
+# shared/host.c joined the chain when the windowed mmap started asking
+# hl_host_is_windows() for the mapping granularity (Windows maps views at the
+# 64 KiB allocation granularity, not the page size). It is a libc-only leaf, so
+# it costs the fuzzer nothing and keeps the "no Keel" property intact.
+fuzz/fuzz_span_window: fuzz/fuzz_span_window.c $(SRCDIR)/hull/cap/fs.c $(SRCDIR)/hull/cap/fs_resolve.c $(SRCDIR)/hull/cap/fs_policy.c $(SRCDIR)/hull/cap/audit.c $(SRCDIR)/hull/utils/alloc.c $(SRCDIR)/hull/shared/host.c $(SH_JSON_DIR)/sh_json.c $(SH_ARENA_DIR)/sh_arena.c
 	$(CC) $(FUZZ_CFLAGS) -Ivendor/keel/include -o $@ $^
 
 # hull.source.lua parser: adversarial bytes -> lua.parse() over a bounded lua_State.

--- a/src/hull/cap/fs.c
+++ b/src/hull/cap/fs.c
@@ -8,6 +8,7 @@
  */
 
 #include "hull/cap/fs.h"
+#include "hull/shared/host.h"
 #include "hull/cap/fs_resolve.h"
 #include "hull/utils/alloc.h"
 #include "hull/cap/audit.h"
@@ -728,6 +729,21 @@ int hl_cap_fs_mmap_window_geometry(uint64_t offset, uint64_t length,
     return 0;
 }
 
+uint64_t hl_cap_fs_mmap_granularity(void)
+{
+    long pg = sysconf(_SC_PAGESIZE);
+    uint64_t gran = (pg > 0) ? (uint64_t)pg : 4096u;
+    /* Windows MapViewOfFile takes the file offset in multiples of the
+     * allocation granularity, which is 64 KiB and independent of the 4 KiB
+     * page size sysconf reports. Measured on Windows 11 + cosmocc 4.0.2:
+     *   mmap(off=4096)  -> EINVAL
+     *   mmap(off=16384) -> EINVAL
+     * A larger granularity is always a valid page alignment too, so this
+     * only ever widens the mapping. */
+    if (hl_host_is_windows() && gran < 65536u) gran = 65536u;
+    return gran;
+}
+
 HlMappedBuffer *hl_cap_fs_mmap_window(const HlFsConfig *cfg, const char *path,
                                       uint64_t offset, uint64_t length,
                                       HlAllocator *alloc, const char **err_msg)
@@ -751,11 +767,10 @@ HlMappedBuffer *hl_cap_fs_mmap_window(const HlFsConfig *cfg, const char *path,
         goto audit;
     }
 
-    long pg = sysconf(_SC_PAGESIZE);
-    if (pg <= 0) pg = 4096;
+    uint64_t gran = hl_cap_fs_mmap_granularity();
 
     if (hl_cap_fs_mmap_window_geometry(offset, length, (uint64_t)st.st_size,
-                                       (uint64_t)pg, &map_off, &map_len, &slop,
+                                       gran, &map_off, &map_len, &slop,
                                        &eff_len, err_msg) != 0) {
         close(fd);
         goto audit;
@@ -773,6 +788,23 @@ HlMappedBuffer *hl_cap_fs_mmap_window(const HlFsConfig *cfg, const char *path,
         if (err_msg) *err_msg = "window_too_large";
         goto audit;
     }
+
+    /* The geometry helper rounds map_len UP to a whole granule. Windows
+     * refuses a view that extends past end-of-file (measured: mapping
+     * 40960 bytes of a 40000-byte file fails, win32 error 8), so clamp to
+     * what the file actually holds. Safe everywhere: mmap does not require
+     * a page-multiple length, and the bytes past EOF were never readable
+     * anyway. The window itself still fits - slop + eff_len never exceeds
+     * file_size - map_off.
+     *
+     * Windows-only ON PURPOSE. The rounded tail past EOF is unusable
+     * everywhere (SIGBUS on POSIX), so clamping would arguably be more
+     * correct in general - but map_len is what the WASM span layer reserves
+     * in guest address space and asserts on (tests/hull/cap/test_wasm_spans.c),
+     * and that path is compiled out on the host this was fixed on. Not
+     * changing memory geometry that cannot be re-validated here. */
+    if (hl_host_is_windows() && map_len > (uint64_t)st.st_size - map_off)
+        map_len = (uint64_t)st.st_size - map_off;
 
     void *base = mmap(NULL, (size_t)map_len, PROT_READ, MAP_PRIVATE, fd,
                       (off_t)map_off);

--- a/tests/hull/cap/test_fs.c
+++ b/tests/hull/cap/test_fs.c
@@ -23,6 +23,7 @@
 #include "hull/utils/alloc.h"
 #include <errno.h>
 #include <fcntl.h>
+#include <sys/mman.h>
 #include <ftw.h>
 #include <string.h>
 #include <stdio.h>
@@ -253,7 +254,17 @@ UTEST(hl_cap_fs, validate_rejects_symlink_escape)
     /* Create a symlink inside test_dir pointing to /tmp */
     char link_path[512];
     snprintf(link_path, sizeof(link_path), "%s/escape", test_dir);
-    symlink("/tmp", link_path);
+
+    /* Creating a symlink needs SeCreateSymbolicLinkPrivilege on Windows,
+     * which an ordinary account does not hold. The return value was
+     * ignored here, so on such a host no symlink existed and the assertion
+     * below ran against a plain missing path - it passed or failed for
+     * reasons having nothing to do with symlink escape, i.e. the test was
+     * silently covering nothing. Skip honestly instead. */
+    if (symlink("/tmp", link_path) != 0) {
+        teardown_fs();
+        UTEST_SKIP("symlink() unavailable (needs privilege on this host)");
+    }
 
     /* Accessing via symlink should be rejected */
     ASSERT_EQ(hl_cap_fs_validate(&test_cfg, "escape/some_file", NULL), -1);
@@ -555,9 +566,12 @@ static int write_pattern(const char *name, size_t n)
 static void assert_window_invariants(int *utest_result, HlMappedBuffer *buf,
                                      uint64_t offset, size_t eff_len)
 {
-    long pg = sysconf(_SC_PAGESIZE);
-    if (pg <= 0) pg = 4096;
-    uint64_t pagemask = (uint64_t)pg - 1;
+    /* The mapping is aligned to the mmap GRANULARITY, which is not the page
+     * size everywhere: Windows maps views at 64 KiB boundaries while
+     * sysconf(_SC_PAGESIZE) still reports 4096. Ask the same source the
+     * implementation does, or these invariants encode a Linux assumption. */
+    uint64_t gran = hl_cap_fs_mmap_granularity();
+    uint64_t pagemask = gran - 1;
 
     ASSERT_NE(buf, NULL);
     ASSERT_EQ(buf->foffset, offset);


### PR DESCRIPTION
Tier 2 of the Windows work. `test_fs` goes **33/37 -> 37/37** on Windows: three real platform gaps, and one test that was quietly covering nothing.

## Measured before changing anything

On Windows 11 + cosmocc 4.0.2, against a 40000-byte file. `sysconf(_SC_PAGESIZE)` reports **4096** throughout:

```
off=0     len=40000   ok
off=0     len=40960   FAIL  errno 14, win32 error 8
off=4096  len=4096    FAIL  errno 87 (EINVAL)
off=16384 len=8192    FAIL  errno 87 (EINVAL)
```

Two independent constraints, neither predicted by the page size.

## 1. Alignment: 64 KiB, not the page size

Windows maps views at multiples of the **allocation granularity** (64 KiB). `hl_cap_fs_mmap_window` aligned `map_off` using `sysconf(_SC_PAGESIZE)`, so a window at offset 20000 asked for `map_off=16384` and was rejected outright.

Added `hl_cap_fs_mmap_granularity()` and align to that. A coarser granularity is always a valid page alignment too, so this only ever widens the mapping - and POSIX is unchanged, because there the value *is* the page size.

It is published in the header rather than kept private for a reason: the test's own `assert_window_invariants` recomputed the alignment from `_SC_PAGESIZE` and so encoded the same wrong assumption. Both sides now ask one source instead of each guessing.

## 2. Length: a view cannot extend past EOF

The geometry helper rounds `map_len` **up** to a whole granule, and Windows refuses a view past end-of-file. So a 1000-byte window at offset 4000 of a 5000-byte file asked to map 8192 bytes and failed. Clamped to what the file actually holds.

**The clamp is Windows-only on purpose.** The rounded tail is unusable everywhere (SIGBUS on POSIX), so clamping is arguably more correct in general - but `map_len` is what the WASM span layer reserves in guest address space and asserts on (`test_wasm_spans.c`), and that path is compiled out on the host this was fixed on. I am not changing memory geometry I cannot re-validate; happy to widen it if someone runs the span suite on Linux.

## 3. A test that asserted nothing

`validate_rejects_symlink_escape` ignored `symlink()`'s return value. Creating a symlink needs `SeCreateSymbolicLinkPrivilege` on Windows, which an ordinary account lacks - so no symlink existed, and the assertion ran against a plain missing path, passing or failing for reasons unrelated to symlink escape.

It now skips honestly when the platform cannot create one. **This is not a traversal hole** - the check itself was never exercised here, which is the point: it reported coverage it did not have.

## Testing

Windows 11 + MSYS2 + cosmocc 4.0.2:

* `test_fs` **37 ran, 0 failed** (was 4 failed); the symlink case skips with a reason
* every suite #475 enforces: 0 failures
* `test_compiler`'s 5 are the pre-existing system-compiler cases baselined in #475

Once this lands, `test_fs` can move from #475's KNOWN tier to ENFORCED - its baseline there is `test_fs:3` on the runner, and this should take it to 0. Worth confirming against a nightly rather than assuming, since the runner and a dev box already disagree by one on that suite.

Independent of #475 (CI/docs) and #476 (doctor / cosmo detection / tool sandbox).
