### PR TITLE
ci(windows): enforce test_fs once the mmap-window gaps are fixed

### DIFF
--- a/.github/scripts/make-watched.sh
+++ b/.github/scripts/make-watched.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Run ONE make invocation under a stall watchdog, retrying ONLY a stall.
+#
+# WHY THIS EXISTS. cosmocc's cc1 blocks indefinitely at ~0 CPU on roughly 12%
+# of large-translation-unit compiles on Windows (hull#462). That is a
+# cosmocc-on-Windows bug, not a Hull one, and it is why every make invocation
+# in windows-source-build.yml needs a watchdog rather than just a job timeout:
+# a wedge otherwise burns the full cap and reports nothing useful.
+#
+# WHY A SCRIPT AND NOT INLINE BASH. This logic was inline in the "Build hull
+# from source" step. Once a second and third make invocation existed (the unit
+# tests, and the multi-arch platform build for the app-build job), copies would
+# have drifted - and the retry rule here is subtle enough that a drifted copy
+# is worse than none. One implementation, three callers.
+#
+# THE RETRY RULE, which is the whole point: a retry is applied ONLY to a stall.
+# A genuine compile error fails immediately, because retrying a real error just
+# hides it behind a slower red. Retrying a stall is cheap because make resumes
+# from the objects already built (see the cosmo_fat_repair note in the
+# workflow header for why a half-built fat pair does not poison the resume).
+#
+# Usage:  make-watched.sh <label> <logfile> <make-arg>...
+#
+# Env:
+#   MAKE_BIN               required - the MSYS-native make (see workflow header)
+#   HULL_STALL_LIMIT_SECS  no log output for this long = stall (default 300)
+#   HULL_BUILD_ATTEMPTS    total attempts before giving up (default 3)
+#
+# Exit: 0 success; 1 genuine failure, or wedged on every attempt.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -uo pipefail
+
+label=${1:?usage: make-watched.sh <label> <logfile> <make-args...>}
+log=${2:?usage: make-watched.sh <label> <logfile> <make-args...>}
+shift 2
+
+: "${MAKE_BIN:?make-watched.sh: MAKE_BIN must be set to the MSYS-native make}"
+stall_limit=${HULL_STALL_LIMIT_SECS:-300}
+attempts=${HULL_BUILD_ATTEMPTS:-3}
+poll=15
+
+# Kill anything a wedge left holding files, or the next attempt inherits a
+# stuck cc1 still sitting on its output.
+kill_stragglers() {
+  powershell.exe -NoProfile -Command \
+    "Get-Process cc1,cc1plus,cosmocc,'*cosmo-gcc' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue" \
+    >/dev/null 2>&1 || true
+}
+
+# 0 = ok, 1 = genuine failure, 2 = stalled.
+run_once() {
+  : > "$log"
+  "$MAKE_BIN" "$@" > "$log" 2>&1 &
+  local mk=$! last_size=0 stalled=0 size rc
+
+  while kill -0 "$mk" 2>/dev/null; do
+    sleep "$poll"
+    size=$(wc -c < "$log" 2>/dev/null || echo 0)
+    if [ "$size" -eq "$last_size" ]; then
+      stalled=$((stalled + poll))
+    else
+      stalled=0
+      last_size=$size
+    fi
+    if [ "$stalled" -ge "$stall_limit" ]; then
+      echo ""
+      echo "=========================================================="
+      echo "STALLED [$label]: no output for ${stalled}s (limit ${stall_limit}s)"
+      echo "=========================================================="
+      echo "--- last 25 lines ---"
+      tail -25 "$log" || true
+      echo ""
+      # PowerShell is the only thing here that can see a Windows process's
+      # command line and cumulative CPU. dcpu ~0 on the stuck compiler is the
+      # signature of this wedge; a non-zero delta would mean something else is
+      # going on and retrying is the wrong response.
+      powershell.exe -NoProfile -ExecutionPolicy Bypass \
+        -File "$(cygpath -w .github/scripts/dump-stuck-build.ps1)" \
+        -IntervalSeconds 5 || true
+      kill "$mk" 2>/dev/null || true
+      kill_stragglers
+      return 2
+    fi
+  done
+
+  rc=0
+  wait "$mk" || rc=$?
+  [ "$rc" -eq 0 ] || return 1
+  return 0
+}
+
+attempt=1
+while : ; do
+  echo "--- [$label] attempt $attempt of $attempts ---"
+  run_once "$@"
+  case $? in
+    0) echo "[$label] ok on attempt $attempt"; cat "$log"; exit 0 ;;
+    1) echo "[$label] FAIL genuine error (not a stall) - not retrying"
+       tail -25 "$log"; exit 1 ;;
+    2) if [ "$attempt" -ge "$attempts" ]; then
+         echo "[$label] FAIL wedged on all $attempts attempts (see hull#462)"
+         exit 1
+       fi
+       echo "[$label] wedged; retrying (make resumes from existing objects)"
+       attempt=$((attempt + 1))
+       ;;
+  esac
+done

--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -774,33 +774,47 @@ jobs:
           bash .github/scripts/make-watched.sh "platform-cosmo" platform-cosmo.log platform-cosmo CC=cosmocc AR="$AR" HL_OPT=-O0 HL_ENABLE_WASM=0 -j2
           ls -la build/libhull_platform.x86_64-cosmo.a build/libhull_platform.aarch64-cosmo.a
 
-      # KNOWN DEFECT, worked around here on purpose - do not "simplify" this.
+      # TRANSIENT GUARD - observed once, NOT reproduced. Do not "simplify" it,
+      # and do not upgrade the wording to a known defect without new evidence.
       #
-      # The FIRST `EMBED_PLATFORM=cosmo` build after `platform-cosmo` links
-      # against objects it never compiled and dies with:
+      # Seen once on Windows 11 + MSYS2 + cosmocc 4.0.2 (2026-09-09): the first
+      # `EMBED_PLATFORM=cosmo` build after `platform-cosmo` died at the link
+      # with
       #
       #   cosmocc: fatal error: build/cap_audit.o: no such file
       #
-      # Reproduced on Windows 11 + MSYS2 + cosmocc on 2026-09-09: of the
-      # objects on the link line, exactly the first three (cap_audit.o,
-      # cap_blob.o, cap_body.o) are never compiled - the run emits 425 compile
-      # recipes starting at cap_crypto.o - and the link then fails naming the
-      # first of them. Running the IDENTICAL command again succeeds.
+      # having compiled 425 objects. Re-running the IDENTICAL command
+      # succeeded. Captured, so the failure itself is not in doubt.
       #
-      # What is established: `platform-cosmo` leaves build/.build-config
-      # holding a DEFAULT fingerprint (CC=cc, WASM=1, EMBED_PLATFORM=empty)
-      # rather than the flags it was invoked with, because its trailing
-      # `$(MAKE) clean` rm -rf's the build dir and the archives are copied back
-      # afterwards. The next build therefore trips the fingerprint purge
-      # (Makefile "Build-flag fingerprint"), and comes out of it having skipped
-      # those three. The second run's fingerprint matches, no purge fires, and
-      # it builds only what is missing. Why exactly three, and why those, is
-      # NOT established - hence "defect", not "explained".
+      # It did NOT reproduce in two controlled attempts:
       #
-      # This is a Hull build-system bug, not a cosmocc one, and it is separate
-      # from the #462 wedge. It is retried here ONLY on its exact signature so
-      # a genuine compile error still fails on the first pass. Delete this
-      # block once the purge/skip interaction is fixed.
+      #   1. Synthetic precondition - build/ holding only the two arch archives
+      #      plus a planted default-fingerprint .build-config, then the same
+      #      embed command. The fingerprint purge fired exactly once, every
+      #      object built, link succeeded.
+      #   2. The full original sequence - `make platform-cosmo` then the same
+      #      embed command, nothing else. Both returned 0 and produced hull.
+      #
+      # Two guesses that looked obvious and are WRONG, recorded so the next
+      # person does not re-derive them:
+      #
+      #   * "platform-cosmo leaves a stale default fingerprint behind." It
+      #     leaves NO .build-config at all - its trailing `$(MAKE) clean`
+      #     rm -rf's the build dir and only the archives are copied back. The
+      #     next build sees an absent file, purges (a no-op on an empty tree)
+      #     and writes its own.
+      #   * "cap_audit.o / cap_blob.o / cap_body.o are never compiled - the log
+      #     starts at cap_crypto.o." Their recipe lines are missing from the
+      #     log in SUCCESSFUL runs too, while the objects are present on disk
+      #     with .aarch64 counterparts and mtimes one second AHEAD of
+      #     cap_crypto.o. That absence is a logging artifact, not a signal.
+      #
+      # So the cause is unknown and may well be transient (a killed compile
+      # from the #462 wedge, or a Windows file-lock) rather than a Makefile
+      # defect. The retry below is a SAFETY NET for a nightly job, not a fix:
+      # it fires only on this exact signature, so a genuine compile error still
+      # fails on the first pass. If it ever fires in CI, the log is the new
+      # evidence this needs - capture it rather than just re-running.
       - name: Build hull with the platform embedded
         shell: msys2 {0}
         run: |
@@ -815,9 +829,10 @@ jobs:
             if grep -q "no such file" hull-embed.log; then
               echo ""
               echo "=================================================================="
-              echo "KNOWN DEFECT: first embed build after platform-cosmo skipped"
-              echo "objects the fingerprint purge removed. Re-running once; see the"
-              echo "comment above this step. This is NOT the #462 cosmocc wedge."
+              echo "TRANSIENT: an object on the link line was missing. Cause is"
+              echo "UNKNOWN and did not reproduce in two controlled attempts - see"
+              echo "the comment above this step. Re-running once; PLEASE CAPTURE"
+              echo "this log, it is the evidence the investigation needs."
               echo "=================================================================="
               grep -n "no such file" hull-embed.log | head -3
               embed_build "hull-embed-2nd-pass"

--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -551,29 +551,30 @@ jobs:
       #              so and asks for the baseline to be lowered, so this tier
       #              cannot rot into a list nobody reads.
       #
-      # Measured on Windows 11 + MSYS2 + cosmocc, 2026-09-09, with TMP/TEMP
-      # set (see the guard below - without them, suites that mkdtemp under
-      # /tmp fail in bulk and the picture looks far worse than it is):
+      # Measured with TMP/TEMP set (see the guard below - without them, suites
+      # that mkdtemp under /tmp fail in bulk and the picture looks far worse
+      # than it is). ENFORCED is clean on BOTH a Windows 11 desktop and the
+      # Actions runner, which is what makes it safe to enforce.
       #
-      #   test_host 31/31   test_tool 60/61   test_vfs 22/22   test_static 23/23
-      #   test_cacert 6/6   test_dispatch 5/5 test_csp 7/7     test_parse_size 9/9
-      #   test_signature 20/20   test_release 20/20      <- all ENFORCED
-      #   test_compiler 11/15 (4 failed)   test_fs 33/37 (4 failed)  <- KNOWN
+      # The KNOWN baselines are the RUNNER's numbers, because this step only
+      # ever runs in CI. They are NOT the same as a developer box's, and the
+      # difference is instructive rather than noise:
       #
-      # The two KNOWN suites fail for reasons that are understood:
+      #                     runner (windows-latest)   dev box (Win 11 + ucrt64)
+      #   test_compiler     14 ran, 5 failed          15 ran, 4 failed
+      #   test_fs           37 ran, 3 failed          37 ran, 4 failed
       #
-      #   test_compiler: system_is_available_cc, compile_hello,
-      #     compile_with_include_dir, compile_app_registry_pattern - all four
-      #     exercise the SYSTEM compiler, and on Windows the resolved `cc` is a
-      #     native ucrt64 gcc being handed POSIX-shaped paths by an APE. This
-      #     is the same environment difference #472 recorded (it saw 10/15).
-      #     Expect the count to MOVE on a runner whose PATH differs.
-      #   test_fs: validate_rejects_symlink_escape plus three mmap_window_*
-      #     cases - Windows symlink semantics and mmap windowing, i.e. real
-      #     platform gaps rather than anything this workflow introduced.
+      # test_compiler's failures are ENTIRELY system-compiler cases, and the
+      # two hosts do not even run the same number of them: the runner has no
+      # native cc/gcc/clang at all (doctor reports all three null - only
+      # cosmocc is present), while a dev box usually has ucrt64 gcc. So the
+      # failing SET differs too, not just the count - only
+      # system_is_available_cc is common to both. This is the same environment
+      # sensitivity #472 recorded when it saw 10/15. Expect this count to move
+      # if the runner image gains a compiler; the ratchet will say so.
       #
-      # Baselines came from a developer box, so the first nightly may need them
-      # adjusted to the runner - the failure message says exactly how.
+      # test_fs is Windows symlink semantics plus the mmap_window_* cases -
+      # real platform gaps, not anything this workflow introduced.
       #
       # Same flags as the build above. They must match EXACTLY: the Makefile's
       # config fingerprint purge deletes build/test_* on a flag flip, so a
@@ -588,7 +589,7 @@ jobs:
                     test_dispatch test_csp test_parse_size test_signature
                     test_release"
           # suite:baseline-failure-count   ("crash" = printed no summary)
-          KNOWN="test_compiler:4 test_fs:4"
+          KNOWN="test_compiler:5 test_fs:3"
 
           targets=""
           for s in $ENFORCED; do targets="$targets build/$s"; done
@@ -646,6 +647,13 @@ jobs:
               echo "IMPROVED  $s: $n failures, baseline $base"
               echo "          -> lower this suite's baseline in KNOWN above."
               rc_step=1
+            fi
+            # A bare count is not actionable. The first CI run proved it:
+            # test_fs reported "3, baseline 4" with no way to see which three.
+            if [ "$n" != "$base" ]; then
+              echo "          cases failing now:"
+              echo "$out" | grep '\[  FAILED  \] [a-z_]*\.' | sed 's/ ([0-9]*ns)//' \
+                          | sed 's/^/            /' | sort -u
             fi
           done
 
@@ -888,7 +896,24 @@ jobs:
           sed -i 's/^          //' "$work/app.lua"
           echo "--- app.lua ---"; cat "$work/app.lua"
 
-          ./build/hull build "$work" --no-verify-platform 2>&1 | tee hull-app-build.log
+          # DIAGNOSTICS. The first CI run of this step failed here while the
+          # identical build succeeds on a Windows 11 desktop, so print what
+          # hull actually sees before asking it to build. Cheap, and the run
+          # that fails is the only place the answer exists.
+          echo "--- toolchain as this shell sees it ---"
+          echo "cosmocc: $(command -v cosmocc || echo '(not on PATH)')"
+          for d in x86_64-unknown-cosmo-cc aarch64-unknown-cosmo-cc; do
+            p=$(command -v "$d" 2>/dev/null || true)
+            # A tar that cannot create symlinks leaves these as ~10-byte text
+            # files holding the link target, which still lets `cosmocc` work
+            # but breaks the per-arch drivers. Observed locally, so check.
+            echo "$d: ${p:-(absent)} $( [ -n "$p" ] && echo "size=$(stat -c%s "$p" 2>/dev/null)" )"
+          done
+          echo "--- what hull reports about itself ---"
+          ./build/hull doctor --json | tr ',' '\n' \
+            | grep -E '"(platform|platform_embedded|build_compiler|hull_build)"' || true
+
+          ./build/hull build "$work" --no-verify-platform --verbose 2>&1 | tee hull-app-build.log
           echo "--- hull build exit (informational only, see comment): ${PIPESTATUS[0]} ---"
 
           # On Windows the artifact is app.com: Windows will not execute an

--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -567,7 +567,13 @@ jobs:
       #
       #                     runner (windows-latest)   dev box (Win 11 + ucrt64)
       #   test_compiler     14 ran, 5 failed          15 ran, 4 failed
-      #   test_fs           37 ran, 3 failed          37 ran, 4 failed
+
+      # test_fs was here too (3 on the runner, 4 on a dev box) until the
+      # windowed-mmap fixes: Windows maps views at the 64 KiB ALLOCATION
+      # GRANULARITY rather than the page size, and refuses a view past
+      # end-of-file, so three mmap_window_* cases could never pass; a
+      # fourth ignored symlink()'s return value and asserted against a
+      # path that was never a symlink. It is ENFORCED now.
       #
       # test_compiler's failures are ENTIRELY system-compiler cases, and the
       # two hosts do not even run the same number of them: the runner has no
@@ -578,8 +584,6 @@ jobs:
       # sensitivity #472 recorded when it saw 10/15. Expect this count to move
       # if the runner image gains a compiler; the ratchet will say so.
       #
-      # test_fs is Windows symlink semantics plus the mmap_window_* cases -
-      # real platform gaps, not anything this workflow introduced.
       #
       # Same flags as the build above. They must match EXACTLY: the Makefile's
       # config fingerprint purge deletes build/test_* on a flag flip, so a
@@ -592,9 +596,9 @@ jobs:
 
           ENFORCED="test_host test_tool test_vfs test_static test_cacert
                     test_dispatch test_csp test_parse_size test_signature
-                    test_release"
+                    test_release test_fs"
           # suite:baseline-failure-count   ("crash" = printed no summary)
-          KNOWN="test_compiler:5 test_fs:3"
+          KNOWN="test_compiler:5"
 
           targets=""
           for s in $ENFORCED; do targets="$targets build/$s"; done

--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -193,6 +193,11 @@ env:
   # Same pin as cosmocc-bbox-probe.yml / cosmocc-windows-e2e.yml. Keep in step.
   COSMOCC_VERSION: 4.0.2
   COSMOCC_SHA256: 85b8c37a406d862e656ad4ec14be9f6ce474c1b436b9615e91a55208aced3f44
+  # busybox-w64: cosmocc's driver is a #!/bin/sh script that Windows cannot
+  # execvp, so `hull build` reroutes it through busybox. Same pin as
+  # release.yml's bundle producer.
+  BUSYBOX_URL: https://frippery.org/files/busybox/busybox64u.exe
+  BUSYBOX_SHA256: 6e263d154d8548d1eb936f65d1d8312c80df31c45974e48d6335e4dcc0f4f34c
 
 jobs:
   windows-source-build:
@@ -734,7 +739,29 @@ jobs:
             diffutils
             git
 
-      - name: Fetch + verify cosmocc
+      # cosmocc, PLUS the busybox ride-along that `hull build` needs.
+      #
+      # WHY BUSYBOX. cosmocc's driver is a `#!/bin/sh` script, and Windows
+      # cannot execvp that - so Hull drives it through a bundled busybox
+      # (src/hull/cap/tool.c, the cosmocc->busybox reroute). `hull tools install
+      # cosmocc` ships one at bin/busybox.exe for exactly this reason; the raw
+      # cosmo.zip does not carry it.
+      #
+      # Without it hull cannot spawn cosmocc at all, decides no compiler is
+      # available, and silently takes the compiler-free emit path - which for a
+      # cosmo hull produces an ELF x86_64 app_registry.o and then dies on
+      # "this hull has no bundled app_main.o". That is precisely how this job
+      # failed on its first two runs, while the same build succeeded on a
+      # developer box whose PATH pointed at an installed Hull bundle. Verified
+      # by adding only busybox.exe to an otherwise-identical raw tree: the
+      # build then produces a runnable app.com.
+      #
+      # NOTE the sibling build job does NOT need this - it only runs
+      # `make CC=cosmocc` from an MSYS2 shell that already has /bin/sh. The
+      # dependency is specific to hull SPAWNING cosmocc itself.
+      #
+      # Same pin as release.yml's bundle producer.
+      - name: Fetch + verify cosmocc (+ busybox, required to spawn it)
         shell: pwsh
         run: |
           curl.exe -fsSL --retry 3 -o cosmocc.zip "https://cosmo.zip/pub/cosmocc/cosmocc-$env:COSMOCC_VERSION.zip"
@@ -742,7 +769,10 @@ jobs:
           if ($h -ne $env:COSMOCC_SHA256) { throw "cosmocc sha mismatch: got $h" }
           New-Item -ItemType Directory -Force -Path cosmo | Out-Null
           tar.exe -xpf cosmocc.zip -C cosmo
-          Write-Host "cosmocc extracted"
+          curl.exe -fsSL --retry 3 -L -o cosmo/bin/busybox.exe "$env:BUSYBOX_URL"
+          $b = (Get-FileHash cosmo/bin/busybox.exe -Algorithm SHA256).Hash.ToLower()
+          if ($b -ne $env:BUSYBOX_SHA256) { throw "busybox sha mismatch: got $b" }
+          Write-Host "cosmocc extracted; busybox.exe verified"
 
       # The sibling job's full probe explains WHY an MSYS-native make is
       # required and asserts it. That reasoning is not repeated here; this only
@@ -896,19 +926,14 @@ jobs:
           sed -i 's/^          //' "$work/app.lua"
           echo "--- app.lua ---"; cat "$work/app.lua"
 
-          # DIAGNOSTICS. The first CI run of this step failed here while the
-          # identical build succeeds on a Windows 11 desktop, so print what
-          # hull actually sees before asking it to build. Cheap, and the run
-          # that fails is the only place the answer exists.
+          # Diagnostics: print what hull can actually reach before asking it to
+          # build. busybox is the load-bearing one - without it hull cannot
+          # spawn cosmocc's #!/bin/sh driver and silently emits a native object
+          # instead, which is how this job failed twice before.
           echo "--- toolchain as this shell sees it ---"
           echo "cosmocc: $(command -v cosmocc || echo '(not on PATH)')"
-          for d in x86_64-unknown-cosmo-cc aarch64-unknown-cosmo-cc; do
-            p=$(command -v "$d" 2>/dev/null || true)
-            # A tar that cannot create symlinks leaves these as ~10-byte text
-            # files holding the link target, which still lets `cosmocc` work
-            # but breaks the per-arch drivers. Observed locally, so check.
-            echo "$d: ${p:-(absent)} $( [ -n "$p" ] && echo "size=$(stat -c%s "$p" 2>/dev/null)" )"
-          done
+          bb=$(dirname "$(command -v cosmocc)")/busybox.exe
+          echo "busybox: $( [ -f "$bb" ] && echo "$bb" || echo '(MISSING - hull cannot spawn cosmocc)')"
           echo "--- what hull reports about itself ---"
           ./build/hull doctor --json | tr ',' '\n' \
             | grep -E '"(platform|platform_embedded|build_compiler|hull_build)"' || true

--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -1,4 +1,4 @@
-name: Windows source build (cosmocc, -O0)
+name: Windows source build + unit tests + app build (cosmocc, -O0)
 
 # Proves Hull can be BUILT FROM SOURCE on Windows with the SHA-pinned cosmocc
 # toolchain, under MSYS2 - no WSL and no Visual Studio.
@@ -40,6 +40,27 @@ name: Windows source build (cosmocc, -O0)
 # problem they addressed and are both UNNECESSARY under MSYS2, which provides
 # /bin/sh natively and passes a POSIX $0. The probe asserts both properties
 # rather than assuming them.)
+#
+# WHAT THIS FILE COVERS, and what it deliberately does not.
+#
+#   job windows-source-build
+#     1. compiles hull from source with cosmocc under MSYS2
+#     2. asserts the produced binary is Windows-AWARE (host_os, exe_suffix,
+#        build_compiler_required, a usable HTTPS trust store)
+#     3. runs the HOST-SENSITIVE unit suites - see that step for why a subset
+#        and not `make test`
+#   job windows-app-build
+#     4. builds the multi-arch cosmo platform archives, links a hull with them
+#        embedded, then `hull new` + `hull build` + checks the produced app.com
+#
+# Steps 3 and 4 were added after a coverage audit found that NO job in the repo
+# ran a single Hull unit test on a Windows runner, and that the only Windows
+# `hull build` coverage (cosmocc-windows-e2e.yml) used a hull compiled on
+# LINUX. Both gaps are now closed here; see each step for the reasoning.
+#
+# Still NOT covered here, on purpose: optimized-build correctness (this job is
+# -O0, see below), the WASM surface (HL_ENABLE_WASM=0, see below), and the full
+# 108-binary unit suite (cost + wedge exposure, see the unit-test step).
 #
 # WHAT THIS IS NOT: it does not produce a shippable artifact. Every released
 # `hull-cosmo` is built on Linux (release.yml `build-cosmo`, runs-on
@@ -409,7 +430,7 @@ jobs:
           # hardcoded -O2 before it existed). See the HL_OPT block in Makefile.
           echo "using MAKE_BIN=${MAKE_BIN:-<unset>} AR=${AR:-<unset>}"
 
-          # WATCHDOG + RETRY.
+          # WATCHDOG + RETRY -> .github/scripts/make-watched.sh
           #
           # The wedge is a TOOLCHAIN bug, not a Hull one, and it is now measured
           # (#462): cosmocc's cc1 blocks indefinitely at ~0 CPU compiling large
@@ -436,82 +457,13 @@ jobs:
           #
           # A retry is applied ONLY to a stall. A genuine compile error fails
           # immediately - retrying that would just hide it.
-          stall_limit=${HULL_STALL_LIMIT_SECS:-300}
-          poll=15
-          attempts=${HULL_BUILD_ATTEMPTS:-3}
-          log=build-output.log
+          #
+          # The logic lives in a script because the unit-test step below is a
+          # second caller and the multi-arch platform build in the app-build
+          # job is a third. The retry rule is subtle enough that a drifted
+          # copy would be worse than no copy.
+          bash .github/scripts/make-watched.sh "hull" build-output.log CC=cosmocc AR="$AR" HL_OPT=-O0 HL_ENABLE_WASM=0 -j2
 
-          # Kill anything the wedge left holding files, or the next attempt
-          # inherits a stuck cc1 still sitting on its output.
-          kill_stragglers() {
-            powershell.exe -NoProfile -Command \
-              "Get-Process cc1,cc1plus,cosmocc,'*cosmo-gcc' -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue" \
-              >/dev/null 2>&1 || true
-          }
-
-          build_once() {
-            : > "$log"
-            "$MAKE_BIN" CC=cosmocc AR="$AR" HL_OPT=-O0 HL_ENABLE_WASM=0 -j2 > "$log" 2>&1 &
-            mk=$!
-            last_size=0
-            stalled=0
-            while kill -0 "$mk" 2>/dev/null; do
-              sleep "$poll"
-              size=$(wc -c < "$log" 2>/dev/null || echo 0)
-              if [ "$size" -eq "$last_size" ]; then
-                stalled=$((stalled + poll))
-              else
-                stalled=0
-                last_size=$size
-              fi
-              if [ "$stalled" -ge "$stall_limit" ]; then
-                echo ""
-                echo "=========================================================="
-                echo "BUILD STALLED: no output for ${stalled}s (limit ${stall_limit}s)"
-                echo "=========================================================="
-                echo "--- last 25 lines of build output ---"
-                tail -25 "$log" || true
-                echo ""
-                # PowerShell is the only thing here that can see a Windows
-                # process's command line and cumulative CPU. dcpu ~0 on the
-                # stuck compiler is the signature of this wedge; a non-zero
-                # delta would mean something else is going on and the retry
-                # below is the wrong response.
-                powershell.exe -NoProfile -ExecutionPolicy Bypass \
-                  -File "$(cygpath -w .github/scripts/dump-stuck-build.ps1)" \
-                  -IntervalSeconds 5 || true
-                kill "$mk" 2>/dev/null || true
-                kill_stragglers
-                return 2
-              fi
-            done
-            rc=0
-            wait "$mk" || rc=$?
-            [ "$rc" -eq 0 ] || return 1
-            return 0
-          }
-
-          attempt=1
-          while : ; do
-            echo "--- build attempt $attempt of $attempts ---"
-            set +e
-            build_once
-            outcome=$?
-            set -e
-            case "$outcome" in
-              0) echo "build ok on attempt $attempt"; break ;;
-              1) echo "FAIL compile error (not a stall) - not retrying"; tail -25 "$log"; exit 1 ;;
-              2) if [ "$attempt" -ge "$attempts" ]; then
-                   echo "FAIL wedged on all $attempts attempts (see #462)"
-                   exit 1
-                 fi
-                 echo "wedged; retrying (make resumes from existing objects)"
-                 attempt=$((attempt + 1))
-                 ;;
-            esac
-          done
-
-          cat "$log"
           # Never trust the exit status alone here - assert the artifact.
           test -f build/hull || { echo "FAIL build/hull was not produced"; exit 1; }
           ls -la build/hull
@@ -548,6 +500,174 @@ jobs:
             *) echo "  FAIL doctor reports no usable HTTPS trust store"; exit 1 ;;
           esac
 
+      # UNIT TESTS ON WINDOWS.
+      #
+      # Until this step existed, NO job in the repo ran a single Hull unit test
+      # on a Windows runner - the suite ran on Linux and macOS only, so every
+      # host-specific path was covered by nothing. The three most recent Windows
+      # fixes (#471 spawn allowlist, #472 toolchain resolution, and the
+      # tool-name basename fix) were all in code this step exercises, and all
+      # three were found by hand rather than by CI.
+      #
+      # WHY A SUBSET AND NOT `make test`. The full suite is 108 binaries, each a
+      # fat APE link - far past this job's budget, and it multiplies exposure to
+      # the #462 wedge, which fires per large-TU compile. The suites below are
+      # the ones whose behaviour is HOST-DEPENDENT plus the cheap
+      # always-relevant ones; their portable logic is already covered on Linux
+      # and macOS in ci.yml.
+      #
+      # WHY THE OUTPUT IS PARSED AND NOT JUST THE EXIT CODE.
+      #
+      # On Windows a cosmocc APE does not report its exit code: it reports the
+      # code SHIFTED LEFT BY 8, i.e. a raw wait status. Isolated with a two-line
+      # program on 2026-09-09, so this is the toolchain and not anything Hull
+      # does:
+      #
+      #   int main(void){ return 1; }  -> PowerShell 256,  MSYS2 bash 0
+      #   int main(void){ return 4; }  -> PowerShell 1024, MSYS2 bash 0
+      #
+      # PowerShell shows the shifted value; a POSIX shell keeps the low byte,
+      # which for any code < 256 is 0. So under the msys2 shell this step runs
+      # in, EVERY failing binary looks like a success. Only a signal death
+      # surfaces (SIGILL shows as 4).
+      #
+      # That is not theoretical here: build/test_release prints
+      # "[  PASSED  ] 19 tests." then "[  FAILED  ] 1 tests" and still exits 0.
+      # An exit-code-only gate would score every failure below as a pass.
+      #
+      # So gate on utest's printed summary - the same "assert the artifact, not
+      # the status" rule the build step above already follows. The exit code is
+      # still checked, but only as a secondary signal.
+      #
+      # TWO TIERS, because Windows is not green yet and pretending otherwise
+      # would paint the nightly red forever:
+      #
+      #   ENFORCED - measured clean on Windows 11 + MSYS2 + cosmocc
+      #              (2026-09-09). Any failure fails the job.
+      #   KNOWN    - suites with REAL pre-existing Windows failures, recorded
+      #              with the count measured that day. They do not fail the job
+      #              at baseline, but the count is RATCHETED: more than baseline
+      #              fails. Fewer means somebody fixed something - the step says
+      #              so and asks for the baseline to be lowered, so this tier
+      #              cannot rot into a list nobody reads.
+      #
+      # Measured on Windows 11 + MSYS2 + cosmocc, 2026-09-09, with TMP/TEMP
+      # set (see the guard below - without them, suites that mkdtemp under
+      # /tmp fail in bulk and the picture looks far worse than it is):
+      #
+      #   test_host 31/31   test_tool 60/61   test_vfs 22/22   test_static 23/23
+      #   test_cacert 6/6   test_dispatch 5/5 test_csp 7/7     test_parse_size 9/9
+      #   test_signature 20/20   test_release 20/20      <- all ENFORCED
+      #   test_compiler 11/15 (4 failed)   test_fs 33/37 (4 failed)  <- KNOWN
+      #
+      # The two KNOWN suites fail for reasons that are understood:
+      #
+      #   test_compiler: system_is_available_cc, compile_hello,
+      #     compile_with_include_dir, compile_app_registry_pattern - all four
+      #     exercise the SYSTEM compiler, and on Windows the resolved `cc` is a
+      #     native ucrt64 gcc being handed POSIX-shaped paths by an APE. This
+      #     is the same environment difference #472 recorded (it saw 10/15).
+      #     Expect the count to MOVE on a runner whose PATH differs.
+      #   test_fs: validate_rejects_symlink_escape plus three mmap_window_*
+      #     cases - Windows symlink semantics and mmap windowing, i.e. real
+      #     platform gaps rather than anything this workflow introduced.
+      #
+      # Baselines came from a developer box, so the first nightly may need them
+      # adjusted to the runner - the failure message says exactly how.
+      #
+      # Same flags as the build above. They must match EXACTLY: the Makefile's
+      # config fingerprint purge deletes build/test_* on a flag flip, so a
+      # differing HL_ENABLE_WASM here would discard the binaries just built.
+      - name: Run the host-sensitive unit suites
+        shell: msys2 {0}
+        run: |
+          set -uo pipefail
+          export PATH="$PATH:$PWD/cosmo/bin"
+
+          ENFORCED="test_host test_tool test_vfs test_static test_cacert
+                    test_dispatch test_csp test_parse_size test_signature
+                    test_release"
+          # suite:baseline-failure-count   ("crash" = printed no summary)
+          KNOWN="test_compiler:4 test_fs:4"
+
+          targets=""
+          for s in $ENFORCED; do targets="$targets build/$s"; done
+          for kv in $KNOWN; do targets="$targets build/${kv%%:*}"; done
+
+          bash .github/scripts/make-watched.sh "tests" test-build.log CC=cosmocc AR="$AR" HL_OPT=-O0 HL_ENABLE_WASM=0 -j2 $targets
+
+          # Several suites mkdtemp under /tmp, which for an APE resolves via
+          # TMP/TEMP rather than a real /tmp. The msys2 shell action sets both.
+          if [ -z "${TMP:-}" ] && [ -z "${TEMP:-}" ]; then
+            echo "FAIL neither TMP nor TEMP is set; APE mkdtemp under /tmp will fail"
+            exit 1
+          fi
+          echo "TMP=${TMP:-<unset>} TEMP=${TEMP:-<unset>}"
+
+          fails_of() {
+            printf '%s' "$1" | grep -qE '^\[==========\] [0-9]+ test cases ran\.' || { echo crash; return; }
+            n=$(printf '%s' "$1" | sed -n 's/^\[  FAILED  \] \([0-9][0-9]*\) tests.*/\1/p' | head -1)
+            echo "${n:-0}"
+          }
+
+          rc_step=0
+
+          echo "===================== ENFORCED ====================="
+          for s in $ENFORCED; do
+            test -x "build/$s" || { echo "FAIL $s was not built"; exit 1; }
+            out=$(HULL_QUIET_AOT=1 "./build/$s" 2>&1)
+            n=$(fails_of "$out")
+            if [ "$n" = "0" ]; then
+              echo "ok        $s"
+            else
+              echo "FAIL      $s: $n failure(s) - this suite must be clean"
+              echo "$out" | tail -25
+              rc_step=1
+            fi
+          done
+
+          echo "====================== KNOWN ======================="
+          for kv in $KNOWN; do
+            s=${kv%%:*}; base=${kv##*:}
+            test -x "build/$s" || { echo "FAIL $s was not built"; exit 1; }
+            out=$(HULL_QUIET_AOT=1 "./build/$s" 2>&1)
+            n=$(fails_of "$out")
+            if [ "$n" = "$base" ]; then
+              echo "known     $s: $n (baseline $base)"
+            elif [ "$n" = "crash" ] || [ "$base" = "crash" ]; then
+              echo "CHANGED   $s: now '$n', baseline '$base'"
+              echo "$out" | tail -20
+              rc_step=1
+            elif [ "$n" -gt "$base" ]; then
+              echo "REGRESSED $s: $n failures, baseline $base"
+              echo "$out" | tail -25
+              rc_step=1
+            else
+              echo "IMPROVED  $s: $n failures, baseline $base"
+              echo "          -> lower this suite's baseline in KNOWN above."
+              rc_step=1
+            fi
+          done
+
+          echo ""
+          if [ "$rc_step" -ne 0 ]; then
+            echo "Windows unit suites: FAILED (see above)."
+            echo "If the runner simply differs from the box these baselines came"
+            echo "from, update the KNOWN counts in this step and say so."
+          else
+            echo "Windows unit suites: enforced clean, known failures at baseline."
+          fi
+          exit "$rc_step"
+
+      - name: Upload the unit-test build log on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: hull-windows-test-build-log
+          path: test-build.log
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Upload the produced APE (diagnostic only, never released)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         if: always()
@@ -556,3 +676,234 @@ jobs:
           path: build/hull
           if-no-files-found: warn
           retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # APP BUILD: does a hull COMPILED ON WINDOWS actually build and run an app?
+  #
+  # WHAT THIS ADDS OVER cosmocc-windows-e2e.yml. That workflow already proves
+  # `hull build` works on Windows - but with a hull binary compiled on LINUX
+  # (its build job is runs-on: ubuntu-24.04, EMBED_PLATFORM=cosmo) and only
+  # CONSUMED on the Windows runner. So the two cover different halves:
+  #
+  #   cosmocc-windows-e2e : Linux-built hull   -> hull build on Windows  (was covered)
+  #   this job            : Windows-built hull -> hull build on Windows  (was NOT)
+  #
+  # The gap matters because the Windows-specific defects Hull has actually hit
+  # (#471 spawn allowlist, #472 driver resolution) live in the path a hull takes
+  # when it drives a compiler - so a hull produced BY the Windows toolchain
+  # driving that same toolchain is its own case, not a corollary of either.
+  #
+  # WHY A SEPARATE JOB rather than more steps on the build job. This needs
+  # `make platform-cosmo` (two full clean builds, one per arch) plus an
+  # EMBED_PLATFORM link - three builds where the sibling job does one. At the
+  # #462 wedge rate that is roughly triple the exposure, and folding it in
+  # would mean a wedge here turns the fast build+test signal red even though
+  # both had already passed. Separate job, separate timeout, independent
+  # verdict.
+  #
+  # NOT REQUIRED, same as its sibling: nightly only.
+  # ---------------------------------------------------------------------------
+  windows-app-build:
+    name: hull built on Windows builds + runs an app (cosmocc, HL_ENABLE_WASM=0)
+    runs-on: windows-latest
+    # Three builds, not one, plus up to 3 stall retries each. The watchdog is
+    # what should stop a hang; this is the backstop behind it.
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: recursive
+
+      - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884  # v2.32.0
+        with:
+          msystem: MSYS
+          update: false
+          install: >-
+            make
+            binutils
+            vim
+            diffutils
+            git
+
+      - name: Fetch + verify cosmocc
+        shell: pwsh
+        run: |
+          curl.exe -fsSL --retry 3 -o cosmocc.zip "https://cosmo.zip/pub/cosmocc/cosmocc-$env:COSMOCC_VERSION.zip"
+          $h = (Get-FileHash cosmocc.zip -Algorithm SHA256).Hash.ToLower()
+          if ($h -ne $env:COSMOCC_SHA256) { throw "cosmocc sha mismatch: got $h" }
+          New-Item -ItemType Directory -Force -Path cosmo | Out-Null
+          tar.exe -xpf cosmocc.zip -C cosmo
+          Write-Host "cosmocc extracted"
+
+      # The sibling job's full probe explains WHY an MSYS-native make is
+      # required and asserts it. That reasoning is not repeated here; this only
+      # resolves the two tools and refuses cosmocc's bundled APE make, which is
+      # the one substitution that silently produces a broken build.
+      - name: Resolve make + ar
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+          MAKE_BIN=$(command -v make || true)
+          [ -n "$MAKE_BIN" ] || { echo "FAIL no make on PATH"; exit 1; }
+          case "$MAKE_BIN" in
+            */cosmo/bin/*) echo "FAIL make resolved to cosmocc's bundled APE make"; exit 1 ;;
+          esac
+          ar_name=""
+          for cand in ar x86_64-unknown-cosmo-ar aarch64-unknown-cosmo-ar cosmoar; do
+            command -v "$cand" >/dev/null 2>&1 && { ar_name=$cand; break; }
+          done
+          [ -n "$ar_name" ] || { echo "FAIL no ar found"; exit 1; }
+          echo "make: $MAKE_BIN ($("$MAKE_BIN" --version | head -1))"
+          echo "ar  : $ar_name"
+          echo "MAKE_BIN=$MAKE_BIN" >> "$GITHUB_ENV"
+          echo "AR=$ar_name" >> "$GITHUB_ENV"
+
+      # `hull build` on cosmo needs BOTH arch archives side by side -
+      # libhull_platform.{x86_64,aarch64}-cosmo.a - because cosmocc links a fat
+      # APE from an x86_64 image plus its .aarch64/ counterpart. build.lua
+      # searches the build dir for exactly that pair, so a single-arch
+      # `make platform` would not do: it is deliberately single-arch even under
+      # cosmocc. platform-cosmo runs `make clean` between the two arches, which
+      # is why the hull link below comes after it and not before.
+      - name: Build the multi-arch cosmo platform archives
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+          export PATH="$PATH:$PWD/cosmo/bin"
+          bash .github/scripts/make-watched.sh "platform-cosmo" platform-cosmo.log platform-cosmo CC=cosmocc AR="$AR" HL_OPT=-O0 HL_ENABLE_WASM=0 -j2
+          ls -la build/libhull_platform.x86_64-cosmo.a build/libhull_platform.aarch64-cosmo.a
+
+      # KNOWN DEFECT, worked around here on purpose - do not "simplify" this.
+      #
+      # The FIRST `EMBED_PLATFORM=cosmo` build after `platform-cosmo` links
+      # against objects it never compiled and dies with:
+      #
+      #   cosmocc: fatal error: build/cap_audit.o: no such file
+      #
+      # Reproduced on Windows 11 + MSYS2 + cosmocc on 2026-09-09: of the
+      # objects on the link line, exactly the first three (cap_audit.o,
+      # cap_blob.o, cap_body.o) are never compiled - the run emits 425 compile
+      # recipes starting at cap_crypto.o - and the link then fails naming the
+      # first of them. Running the IDENTICAL command again succeeds.
+      #
+      # What is established: `platform-cosmo` leaves build/.build-config
+      # holding a DEFAULT fingerprint (CC=cc, WASM=1, EMBED_PLATFORM=empty)
+      # rather than the flags it was invoked with, because its trailing
+      # `$(MAKE) clean` rm -rf's the build dir and the archives are copied back
+      # afterwards. The next build therefore trips the fingerprint purge
+      # (Makefile "Build-flag fingerprint"), and comes out of it having skipped
+      # those three. The second run's fingerprint matches, no purge fires, and
+      # it builds only what is missing. Why exactly three, and why those, is
+      # NOT established - hence "defect", not "explained".
+      #
+      # This is a Hull build-system bug, not a cosmocc one, and it is separate
+      # from the #462 wedge. It is retried here ONLY on its exact signature so
+      # a genuine compile error still fails on the first pass. Delete this
+      # block once the purge/skip interaction is fixed.
+      - name: Build hull with the platform embedded
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+          export PATH="$PATH:$PWD/cosmo/bin"
+
+          embed_build() {
+            bash .github/scripts/make-watched.sh "$1" hull-embed.log               CC=cosmocc AR="$AR" HL_OPT=-O0 HL_ENABLE_WASM=0 EMBED_PLATFORM=cosmo -j2
+          }
+
+          if ! embed_build "hull-embed"; then
+            if grep -q "no such file" hull-embed.log; then
+              echo ""
+              echo "=================================================================="
+              echo "KNOWN DEFECT: first embed build after platform-cosmo skipped"
+              echo "objects the fingerprint purge removed. Re-running once; see the"
+              echo "comment above this step. This is NOT the #462 cosmocc wedge."
+              echo "=================================================================="
+              grep -n "no such file" hull-embed.log | head -3
+              embed_build "hull-embed-2nd-pass"
+            else
+              echo "FAIL embed build failed for a reason other than the known defect"
+              exit 1
+            fi
+          fi
+
+          test -f build/hull || { echo "FAIL build/hull was not produced"; exit 1; }
+          ls -la build/hull
+          ./build/hull version
+          # Assert the embed actually took. A hull that silently lost its
+          # platform archives would fail later at `hull build` with a confusing
+          # "not found", and doctor is the surface that knows. Expect
+          # multi-arch, since this embedded BOTH cosmo archives.
+          ./build/hull doctor --json > doctor.json || true
+          grep -o '"platform_library"[^,]*' doctor.json || cat doctor.json
+
+      # THE PAYOFF: a hull COMPILED on Windows builds an app, and that app RUNS.
+      #
+      # Shape of this check, all three parts learned by running it (2026-09-09):
+      #
+      #   * `--no-verify-platform` is REQUIRED. A locally built hull carries no
+      #     embedded platform manifest, and without the flag `hull build` stops
+      #     with "this hull has no embedded platform manifest". The sibling
+      #     cosmocc-windows-e2e.yml passes it for the same reason.
+      #   * The app is an `app.main` CLI printing a marker, NOT `hull new`'s web
+      #     scaffold. A server does not exit, so it cannot be asserted on in a
+      #     step; a marker on stdout can.
+      #   * The verdict is the MARKER, never the exit status. A cosmocc APE on
+      #     Windows reports its exit code shifted left by 8 (a raw wait status),
+      #     so a POSIX shell sees 0 for every failure - isolated with a two-line
+      #     C program, see the unit-test step for the measurements. This is a
+      #     TOOLCHAIN limitation, not a Hull defect, and it is not something
+      #     Hull can work around: `hull build` on an app whose manifest fails to
+      #     extract correctly calls exit(1), prints "the build cannot continue"
+      #     and writes no artifact - and the shell still sees 0. Any script
+      #     doing `hull build && ...` on Windows proceeds after a failed build.
+      #     Assert the artifact and its output instead.
+      - name: hull new + hull build + run the produced APE
+        shell: msys2 {0}
+        run: |
+          set -uo pipefail
+          export PATH="$PATH:$PWD/cosmo/bin"
+
+          work=$(mktemp -d)/demo
+          mkdir -p "$work"
+          cat > "$work/app.lua" <<'LUA'
+          app.manifest({ modules = {} })
+          app.main(function(ctx) ctx.stdout:write("APP-MARKER-OK\n"); return 0 end)
+          LUA
+          sed -i 's/^          //' "$work/app.lua"
+          echo "--- app.lua ---"; cat "$work/app.lua"
+
+          ./build/hull build "$work" --no-verify-platform 2>&1 | tee hull-app-build.log
+          echo "--- hull build exit (informational only, see comment): ${PIPESTATUS[0]} ---"
+
+          # On Windows the artifact is app.com: Windows will not execute an
+          # extensionless file, which is what hl_host_exe_suffix() encodes.
+          app="$work/app.com"
+          if [ ! -f "$app" ]; then
+            echo "FAIL expected $app to exist"
+            ls -la "$work"
+            exit 1
+          fi
+          ls -la "$app"
+
+          out=$("$app" 2>&1) || true
+          echo "--- app output ---"
+          echo "$out"
+          if printf '%s' "$out" | grep -q 'APP-MARKER-OK'; then
+            echo "APP BUILD OK: a Windows-compiled hull produced an APE that runs"
+          else
+            echo "FAIL the produced app did not print its marker"
+            exit 1
+          fi
+
+      - name: Upload the app-build logs on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: hull-windows-app-build-logs
+          path: |
+            platform-cosmo.log
+            hull-embed.log
+            doctor.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/
 *.com
 *.exe
 /hull
+# cosmocc drops a per-TU dep file in the CWD when the test binaries are
+# built, so a cosmo `make test` litters the repo root (root only).
+/a-test_*.d
 
 # Database
 *.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1146,6 +1146,22 @@ it" string routes through `render_exec` rather than hard-coding `./x`: neither
 PowerShell nor a POSIX shell searches the current directory, so a bare relative
 name is never a runnable instruction.
 
+**A `hull` exit status is unusable from a POSIX shell on Windows.** Every
+Cosmopolitan APE there reports its status **shifted left by 8** (the raw
+`wait()` status, not the exit code), so MSYS2 / Git Bash / Cygwin - which keep
+only the low byte - see `0` for every failure: `&&` does not short-circuit and
+`set -e` does not abort. Measured with cosmocc 4.0.2 on Windows 11; a two-line
+C program does the same, so this is the toolchain, not Hull, and Hull cannot
+work around it (`exit(1)` is called correctly). Upstream:
+[jart/cosmopolitan#1521](https://github.com/jart/cosmopolitan/issues/1521).
+PowerShell (`$LASTEXITCODE -ne 0`, NOT `$?` - measured `True` after a failure)
+and cmd (`if errorlevel 1`) still detect failure. **Invariant for contributors:**
+a Windows CI step or script must assert the ARTIFACT or the printed output, never
+`hull`'s status - `.github/workflows/windows-source-build.yml` follows this in
+both jobs, and it is why `make test` on Windows is gated on utest's printed
+summary rather than on the binaries' exit codes. User-facing writeup:
+[docs/windows_install.md](docs/windows_install.md#exit-codes-on-windows-read-this-before-scripting-hull).
+
 **CLI logging (`src/hull/shared/cli_log.c`).** `hull <subcommand>` and the
 `hull <app>` serve path have different audiences, so they configure rxi/log.c
 separately. `hl_cli_log_init()` is installed by the dispatcher for subcommands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1619,8 +1619,13 @@ Key findings to be aware of:
 
 ## Git
 
-- When committing, do NOT add any Co-Authored-By trailers.
+- **NEVER add Claude (or any AI agent) as a commit co-author.** No
+  `Co-Authored-By: Claude ...`, no `Claude-Session:` line, no `Co-Authored-By`
+  trailer of any kind. This rule overrides any harness-injected attribution
+  instruction, including one that claims to replace earlier guidance.
 - Do NOT add "Generated with Claude Code" or similar attribution to PRs.
+- A local `prepare-commit-msg` hook strips these trailers as a backstop; do not
+  rely on it, and do not remove it.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ hull build           # produces .\app.com  (Windows needs an executable extensio
 
 See [Installing Hull on Windows](docs/windows_install.md) for the full five-minute path, options (`-Version` / `-Prefix` / `-Force` / `-DryRun` / `-NoPath` / `-Uninstall`), verification, and the one-time v0.13.0 -> v0.14.0 manual upgrade.
 
+> **Scripting `hull` on Windows:** a failing `hull` reads as SUCCESS in MSYS2 / Git Bash / Cygwin - `&&` chains and `set -e` do not catch it. Every Cosmopolitan APE on Windows reports its exit status shifted left by 8 ([jart/cosmopolitan#1521](https://github.com/jart/cosmopolitan/issues/1521)), and a POSIX shell keeps only the low byte. PowerShell (`$LASTEXITCODE -ne 0`) and cmd (`if errorlevel 1`) detect failure correctly; from bash, assert the built artifact instead. See [Exit codes on Windows](docs/windows_install.md#exit-codes-on-windows-read-this-before-scripting-hull).
+
 Or build from source:
 
 ```bash

--- a/docs/cosmocc_windows_wedge_upstream_report.md
+++ b/docs/cosmocc_windows_wedge_upstream_report.md
@@ -1,9 +1,15 @@
 # cosmocc on Windows: cc1 blocks indefinitely on large translation units
 
-Draft of an upstream report for [jart/cosmopolitan](https://github.com/jart/cosmopolitan),
-kept in-tree so the measurements have a home and the numbers do not have to be
-re-derived. Tracked on the Hull side as
+**Filed upstream as
+[jart/cosmopolitan#1522](https://github.com/jart/cosmopolitan/issues/1522)**
+(2026-09-09). This file stays as the working record: the measurements have a
+home here and do not have to be re-derived. Tracked on the Hull side as
 [hull#462](https://github.com/artalis-io/hull/issues/462).
+
+The filed issue carries one thing this draft did not - a **negative control**
+(below), which is probably the most useful part of it - and a standalone
+reproducer that needs no Hull checkout, just the cosmocc zip and the SQLite
+amalgamation.
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -60,6 +66,27 @@ pid=8512 ppid=500  make.exe                 cpu=0.66s  dcpu=0.04s
 `dcpu=0.01s` over a 5-second window is the key measurement: **`cc1` is blocked,
 not spinning.** It has accumulated only 3-7s of CPU and then stops, consistently
 at roughly the same point.
+
+## Negative control: it does NOT reproduce on a Windows 11 desktop
+
+Everything above was measured on GitHub Actions. Running the same reproducer -
+same cosmocc 4.0.2, same `-O0`, same MSYS2 shell, the SQLite amalgamation as
+the TU - on a **Windows 11 Pro 26200 desktop** gave **0 wedges in 40
+consecutive compiles**, every one finishing in 4-5s.
+
+That is not just "did not reproduce". If p were 0.12, the chance of 40 clean
+compiles is `0.88^40 = 0.6%`; zero events in 40 puts a 95% upper bound of
+`3/40 = 7.5%` on the rate for that host. The two hosts are statistically
+incompatible.
+
+So the trigger is not "cosmocc compiling a large TU on Windows". Something
+about the Actions image differs - its ephemeral `D:\` work volume, real-time
+scanning on the temp path `cc1` writes its `.s` into, or that image's MSYS2
+installation. Note the temp-directory arm below moved `TMPDIR`/`TMP`/`TEMP`
+*within* the image, which does not rule out the volume or the scanner.
+
+This also means the retry mitigation is aimed at CI specifically, and a
+developer building on a Windows desktop may never see the wedge at all.
 
 ## What has been ruled out
 

--- a/docs/windows_install.md
+++ b/docs/windows_install.md
@@ -184,6 +184,73 @@ and is not the same configuration CI exercises.
 This path is exercised in CI by `.github/workflows/windows-source-build.yml`,
 whose header carries the full evidence and history.
 
+## Exit codes on Windows (read this before scripting `hull`)
+
+**On Windows, a POSIX-style shell cannot tell whether `hull` succeeded.** In
+MSYS2, Git Bash and Cygwin, a *failing* `hull` command reports success: `&&`
+runs the next command anyway and `set -e` does not abort.
+
+```sh
+# In Git Bash / MSYS2 on Windows. `hull build` FAILS here, and yet:
+hull build ./app && echo "shipped"      # prints "shipped"
+set -e; hull build ./app; echo "reached"  # prints "reached"
+```
+
+This is not a Hull bug and Hull cannot work around it. Every Cosmopolitan APE
+on Windows - which is what `hull.com` and the apps it builds are - reports its
+exit status **shifted left by 8**, i.e. the raw `wait()`-style status rather
+than the exit code. A two-line C program built with `cosmocc` does the same
+thing. Tracked upstream as
+[jart/cosmopolitan#1521](https://github.com/jart/cosmopolitan/issues/1521).
+
+| `hull` intends | PowerShell `$LASTEXITCODE` | cmd `ERRORLEVEL` | MSYS2 / Git Bash `$?` |
+|---|---|---|---|
+| `0` (success) | `0` | `0` | `0` |
+| `1` (failure) | `256` | `256` | **`0`** |
+| `2` (failure) | `512` | `512` | **`0`** |
+
+Success is reported correctly everywhere, which is exactly why this is easy to
+miss: a green run behaves normally and only failures are swallowed. The value
+is always `code << 8`, whose low byte is `0` for any code below 256 - so a
+shell that keeps only the low byte sees `0`.
+
+### What to do
+
+**PowerShell** - works, if you test `$LASTEXITCODE` rather than `$?`:
+
+```powershell
+hull build .\app
+if ($LASTEXITCODE -ne 0) { throw "hull build failed" }
+```
+
+Do **not** use `$?` here. Measured on Windows 11 with cosmocc 4.0.2: after a
+failing `hull`, `$LASTEXITCODE` is `256` but `$?` is still `True`.
+
+**cmd.exe** - works, `if errorlevel 1` triggers correctly:
+
+```bat
+hull build .\app
+if errorlevel 1 (echo hull build failed & exit /b 1)
+```
+
+**MSYS2 / Git Bash / Cygwin** - the status is unusable. Check for the
+**artifact** instead, which is what Hull's own CI does:
+
+```sh
+hull build ./app
+test -f ./app/app.com || { echo "hull build failed"; exit 1; }
+```
+
+For commands that produce no file, check the output instead - for example
+`hull doctor --json` and test a field, rather than trusting the status.
+
+### Scope
+
+This affects every `hull` subcommand on Windows, and every app `hull build`
+produces there, since both are APEs. It does not affect Linux, macOS, or the
+BSDs. Windows CI that shells out to `hull` from bash should assert artifacts or
+output; a bare `hull ... && ...` chain is not a check.
+
 ## What it does
 
 - Resolves the latest official stable release from `artalis-io/hull` (drafts and


### PR DESCRIPTION
Stacked and **not mergeable yet** - opened so it is ready rather than remembered.

Moves `test_fs` from #475's KNOWN tier to ENFORCED, and drops the baseline that quietly permitted 3 failures.

## Order this has to land in

1. #477 - the windowed-mmap fixes (64 KiB allocation granularity, no view past EOF, and the symlink test that asserted nothing)
2. #475 - the workflow this edits
3. this

Landing it before #477 turns the nightly red: the branch would enforce a suite whose fix is not present.

Base is `ci/windows-test-and-app-build` (#475's branch) rather than `main`, so the diff here is the single commit rather than all of #475.

## Verified

Ran the modified step's own logic against binaries built from #477:

```
===================== ENFORCED =====================
ok  test_host  test_tool  test_vfs  test_static  test_cacert
ok  test_dispatch  test_csp  test_parse_size  test_signature
ok  test_release  test_fs
====================== KNOWN =======================
known  test_compiler: 5 (baseline 5)
Windows unit suites: enforced clean, known failures at baseline.   (exit 0)
```

## One thing to actually check rather than assume

That verification is a **developer box**. The runner and a dev box already disagreed by one on this suite (3 failures vs 4), so the first nightly after this lands is worth reading. If the runner still shows a failure, the ratchet names the case - which is what it is for.