### PR TITLE
test(compiler): skip the cc-dependent cases when there is no system cc

### DIFF
--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -561,29 +561,30 @@ jobs:
       # than it is). ENFORCED is clean on BOTH a Windows 11 desktop and the
       # Actions runner, which is what makes it safe to enforce.
       #
-      # The KNOWN baselines are the RUNNER's numbers, because this step only
-      # ever runs in CI. They are NOT the same as a developer box's, and the
-      # difference is instructive rather than noise:
+      # KNOWN IS EMPTY, and that is the goal state - every suite is enforced at
+      # zero. Two of them got there by fixing the platform, one by fixing a
+      # test that was asserting an environment:
       #
-      #                     runner (windows-latest)   dev box (Win 11 + ucrt64)
-      #   test_compiler     14 ran, 5 failed          15 ran, 4 failed
-
-      # test_fs was here too (3 on the runner, 4 on a dev box) until the
-      # windowed-mmap fixes: Windows maps views at the 64 KiB ALLOCATION
-      # GRANULARITY rather than the page size, and refuses a view past
-      # end-of-file, so three mmap_window_* cases could never pass; a
-      # fourth ignored symlink()'s return value and asserted against a
-      # path that was never a symlink. It is ENFORCED now.
+      #   test_fs      sat at 3 (runner) / 4 (dev box) until the windowed-mmap
+      #                fixes: Windows maps views at the 64 KiB ALLOCATION
+      #                GRANULARITY rather than the page size and refuses a view
+      #                past end-of-file, so three mmap_window_* cases could
+      #                never pass. A fourth ignored symlink()'s return value and
+      #                asserted against a path that was never a symlink.
       #
-      # test_compiler's failures are ENTIRELY system-compiler cases, and the
-      # two hosts do not even run the same number of them: the runner has no
-      # native cc/gcc/clang at all (doctor reports all three null - only
-      # cosmocc is present), while a dev box usually has ucrt64 gcc. So the
-      # failing SET differs too, not just the count - only
-      # system_is_available_cc is common to both. This is the same environment
-      # sensitivity #472 recorded when it saw 10/15. Expect this count to move
-      # if the runner image gains a compiler; the ratchet will say so.
+      #   test_compiler sat at 5 (runner) / 4 (dev box) - and the two hosts did
+      #                not even run the same number of cases. Not a defect in
+      #                the compiler abstraction: five cases asserted "cc should
+      #                be available in CI and dev environments", which is false
+      #                on a runner carrying only cosmocc. With no cc to find
+      #                they had nothing to assert, so they skip now. The
+      #                compile_* cases already self-guarded, which is why they
+      #                always passed here.
       #
+      # The tier machinery stays. It is the right landing place for the next
+      # suite that fails for a reason worth RECORDING rather than hiding, and
+      # it ratchets in both directions - a baseline cannot quietly become
+      # permanent, and an improvement is reported rather than absorbed.
       #
       # Same flags as the build above. They must match EXACTLY: the Makefile's
       # config fingerprint purge deletes build/test_* on a flag flip, so a
@@ -596,9 +597,9 @@ jobs:
 
           ENFORCED="test_host test_tool test_vfs test_static test_cacert
                     test_dispatch test_csp test_parse_size test_signature
-                    test_release test_fs"
+                    test_release test_fs test_compiler"
           # suite:baseline-failure-count   ("crash" = printed no summary)
-          KNOWN="test_compiler:5"
+          KNOWN=""
 
           targets=""
           for s in $ENFORCED; do targets="$targets build/$s"; done

--- a/tests/hull/compiler/test_compiler.c
+++ b/tests/hull/compiler/test_compiler.c
@@ -82,8 +82,30 @@ UTEST(compiler, system_new_null_returns_null)
     ASSERT_EQ(c, NULL);
 }
 
+/* Is a SYSTEM C compiler present at all?
+ *
+ * The cases below were written assuming "cc should be available in CI and dev
+ * environments". That is not true everywhere: the Windows runner carries only
+ * cosmocc, which is not a system compiler, so `hull build` there goes through
+ * the cosmo driver instead. With no cc to find, these tests have nothing to
+ * assert - and reporting a FAILURE for it describes a defect that does not
+ * exist, which is how test_compiler ended up carrying a baseline of five
+ * permanent failures on Windows.
+ *
+ * Skip honestly instead. On a host that does have a cc they run exactly as
+ * before. */
+static int have_system_cc(void)
+{
+    HlCompiler *c = hl_compiler_system_new("cc");
+    if (!c) return 0;
+    int ok = hl_compiler_is_available(c);
+    hl_compiler_destroy(c);
+    return ok == 1;
+}
+
 UTEST(compiler, system_is_available_cc)
 {
+    if (!have_system_cc()) UTEST_SKIP("no system C compiler on this host");
     HlCompiler *c = hl_compiler_system_new("cc");
     ASSERT_NE(c, NULL);
     /* cc should be available in CI and dev environments */
@@ -185,6 +207,7 @@ UTEST(compiler, compile_with_include_dir)
 
 UTEST(compiler, select_null_returns_compiler)
 {
+    if (!have_system_cc()) UTEST_SKIP("no system C compiler on this host");
     HlCompiler *c = hl_compiler_select(NULL);
     /* At least one compiler should be available in CI */
     ASSERT_NE(c, NULL);
@@ -194,6 +217,7 @@ UTEST(compiler, select_null_returns_compiler)
 
 UTEST(compiler, select_explicit_cc)
 {
+    if (!have_system_cc()) UTEST_SKIP("no system C compiler on this host");
     HlCompiler *c = hl_compiler_select("cc");
     ASSERT_NE(c, NULL);
     ASSERT_STREQ(hl_compiler_name(c), "cc");
@@ -208,6 +232,7 @@ UTEST(compiler, select_fake_returns_null)
 
 UTEST(compiler, select_system_forces_system)
 {
+    if (!have_system_cc()) UTEST_SKIP("no system C compiler on this host");
     HlCompiler *c = hl_compiler_select("system");
     /* system compilers should always be available in CI */
     ASSERT_NE(c, NULL);
@@ -265,6 +290,7 @@ UTEST(compiler, compile_app_registry_pattern)
 
 UTEST(compiler, default_compiler_resolves)
 {
+    if (!have_system_cc()) UTEST_SKIP("no system C compiler on this host");
     /* Auto-select must resolve an available compiler (the system cc). */
     HlCompiler *c = hl_compiler_select(NULL);
     ASSERT_NE(c, NULL);


### PR DESCRIPTION
Five `test_compiler` cases assert *"cc should be available in CI and dev environments"*. That is not true everywhere: the Windows runner carries only cosmocc, which is not a system compiler, so `hull build` goes through the cosmo driver instead.

With no `cc` to find, those tests have nothing to assert - and reporting a **failure** for it describes a defect that does not exist. That is the whole reason `test_compiler` carries a baseline of five permanent failures on Windows in #475's KNOWN tier: not a bug in the compiler abstraction, just tests asserting an environment.

They now skip when no system cc is present, and run exactly as before on a host that has one:

```
[  SKIPPED ] compiler.default_compiler_resolves
[  SKIPPED ] compiler.select_explicit_cc
[  SKIPPED ] compiler.select_null_returns_compiler
[  SKIPPED ] compiler.select_system_forces_system
[  SKIPPED ] compiler.system_is_available_cc
```

Verified on Windows with `cc` removed from PATH, which reproduces the runner's condition. The `compile_*` cases already self-guard with an early return when `hl_compiler_select` yields nothing - which is why they pass on the runner - and are untouched.

## Also promotes it, verified on the runner

With the cases skipping instead of failing, `test_compiler` returns **0** against #475's baseline of 5 - and the ratchet fires on *improvement* by design. Merging the skips alone would break the nightly, exactly as a stale `test_fs` baseline would have.

So this also moves `test_compiler` to ENFORCED and leaves `KNOWN` **empty** - the goal state, every Windows suite enforced at zero.

I did not take that on inference. A developer box cannot answer it: locally `test_compiler` still reports 3 failures, because here cosmocc is on PATH, `hl_compiler_select` returns it, and the in-test compile fails - while on the runner `select` yields nothing and the `compile_*` cases early-return. Dispatched the Windows workflow against this branch first:

```
ENFORCED: test_host test_tool test_vfs test_static test_cacert test_dispatch
          test_csp test_parse_size test_signature test_release test_fs
          test_compiler                                      <- all ok
KNOWN:    (empty)
```

The tier machinery stays rather than being deleted. It is the right landing place for the next suite that fails for a reason worth *recording* rather than hiding, and it ratchets both ways - so a baseline cannot quietly become permanent, and an improvement is reported rather than absorbed.
