### PR TITLE
fix(tool): unveil where hull build actually writes, and keep the two unveil lists in step

### DIFF
--- a/src/hull/sandbox_tool.c
+++ b/src/hull/sandbox_tool.c
@@ -140,7 +140,15 @@ int hl_tool_sandbox_init(HlToolUnveilCtx *ctx,
     hl_tool_unveil_add(ctx, "/Library", "r");
 #endif
 
-    /* Output directory: write/create */
+    /* The invocation directory: `hull new` / `hull init` create their
+     * scaffold relative to it. Unconditional, so `output_dir` is free to
+     * carry where `hull build` actually writes rather than doubling as
+     * this. */
+    hl_tool_unveil_add(ctx, ".", "rwc");
+
+    /* Output directory: write/create. app_dir above is READ-ONLY, so a
+     * build writing into the app tree (app.com, and the .hull/build the
+     * post-link tidy-up moves debug sidecars into) depends on this. */
     if (output_dir)
         hl_tool_unveil_add(ctx, output_dir, "rwc");
 

--- a/src/hull/sandbox_tool.c
+++ b/src/hull/sandbox_tool.c
@@ -90,6 +90,14 @@ static int sb_supported(void) { return 0; }
 
 /* ── Tool-mode sandbox ─────────────────────────────────────────────── */
 
+/* Does this path name a directory that exists? Unveiling one that does not
+ * grants nothing and, on the kernel path, is a failed call. */
+static int dir_exists_p(const char *path)
+{
+    struct stat st;
+    return path && stat(path, &st) == 0 && S_ISDIR(st.st_mode);
+}
+
 int hl_tool_sandbox_init(HlToolUnveilCtx *ctx,
                          const char *app_dir,
                          const char *output_dir,
@@ -99,8 +107,9 @@ int hl_tool_sandbox_init(HlToolUnveilCtx *ctx,
 
     hl_tool_unveil_init(ctx);
 
-    /* App sources: read-only */
-    if (app_dir)
+    /* App sources: read-only, and only when the path is a real directory
+     * (see the output_dir note below). */
+    if (app_dir && dir_exists_p(app_dir))
         hl_tool_unveil_add(ctx, app_dir, "r");
 
     /* Temp directory: read/write/create (build artifacts) */
@@ -148,8 +157,13 @@ int hl_tool_sandbox_init(HlToolUnveilCtx *ctx,
 
     /* Output directory: write/create. app_dir above is READ-ONLY, so a
      * build writing into the app tree (app.com, and the .hull/build the
-     * post-link tidy-up moves debug sidecars into) depends on this. */
-    if (output_dir)
+     * post-link tidy-up moves debug sidecars into) depends on this.
+     *
+     * Only when it EXISTS. parse_app_dir returns the first positional
+     * argument, which for a non-build subcommand is a word like "test"
+     * rather than a directory - unveiling that grants nothing and, on
+     * Linux, is a failed unveil against a path that is not there. */
+    if (output_dir && dir_exists_p(output_dir))
         hl_tool_unveil_add(ctx, output_dir, "rwc");
 
     /* Hull runtime cache root - `hull build` writes AOT artifacts
@@ -246,7 +260,15 @@ int hl_tool_sandbox_init(HlToolUnveilCtx *ctx,
         unveil("/opt", "rx");
         unveil("/Library", "r");
 #endif
-        if (output_dir)   unveil(output_dir, "rwc");
+        /* Mirror of the userspace grant above. These two lists must stay in
+         * step: the ctx is what hl_tool_* check, the kernel unveil is what
+         * actually stops a write. Adding "." to only the first is how
+         * moving output_dir off "." quietly removed the CWD's kernel
+         * grant on Linux, while Windows - which has no kernel sandbox -
+         * looked fine. */
+        unveil(".", "rwc");
+        if (output_dir && dir_exists_p(output_dir))
+            unveil(output_dir, "rwc");
         if (platform_dir) unveil(platform_dir, "rx");
         {
             char cache_path[PATH_MAX];

--- a/src/hull/tool.c
+++ b/src/hull/tool.c
@@ -144,7 +144,14 @@ static const char *parse_linker_option(int argc, char **argv)
  */
 static const char *parse_app_dir(int argc, char **argv)
 {
-    for (int i = 0; i < argc; i++) {
+    /* From i=1: argv[0] is the SUBCOMMAND ("build"), which
+     * hl_command_dispatch passes through as argv[0] of the handler.
+     * Scanning from 0 returned "build" as the app dir, so the
+     * read-only app unveil pointed at a relative path that does not
+     * exist. It went unnoticed because the temp dir and the
+     * invocation dir are unveiled separately, and apps normally live
+     * under one of them. */
+    for (int i = 1; i < argc; i++) {
         if (!argv[i]) continue;
         if (argv[i][0] != '-')
             return argv[i];
@@ -164,6 +171,48 @@ static const char *parse_app_dir(int argc, char **argv)
         }
     }
     return ".";
+}
+
+/*
+ * Extract the output DIRECTORY from argv: dirname of `-o` / `--output`, else
+ * the app dir (a bare `hull build <dir>` writes <dir>/app).
+ *
+ * The tool sandbox unveils app_dir READ-ONLY, so writes under it depend
+ * entirely on the output dir being unveiled "rwc". That used to be the literal
+ * ".", i.e. whatever directory hull happened to be INVOKED from - so
+ * `hull build /path/to/app` from anywhere else could not create
+ * <app>/.hull/build, and the post-link tidy-up that moves cosmocc's debug
+ * sidecars (app.com.dbg, app.aarch64.elf) out of the app root silently
+ * degraded to "leaving debug artifacts in place". Building from INSIDE the app
+ * dir worked, which is why it went unnoticed. Not Windows-specific.
+ *
+ * Writes into `buf` and returns it, or NULL when the caller should fall back.
+ */
+static const char *parse_output_dir(int argc, char **argv, char *buf, size_t bufsz)
+{
+    const char *out = NULL;
+    for (int i = 1; i < argc; i++) {   /* i=1: skip the subcommand */
+        if (!argv[i]) continue;
+        if (strncmp(argv[i], "--output=", 9) == 0) { out = argv[i] + 9; continue; }
+        if ((strcmp(argv[i], "--output") == 0 || strcmp(argv[i], "-o") == 0)
+            && i + 1 < argc && argv[i + 1]) {
+            out = argv[++i];
+        }
+    }
+    if (!out) return NULL;                 /* caller falls back to app_dir */
+
+    /* dirname(out); a bare filename means the current directory. */
+    const char *slash = strrchr(out, '/');
+    const char *bslash = strrchr(out, '\\');
+    if (bslash > slash) slash = bslash;
+    if (!slash) return NULL;
+
+    size_t len = (size_t)(slash - out);
+    if (len == 0) len = 1;                 /* "/x" -> "/" */
+    if (len >= bufsz) return NULL;
+    memcpy(buf, out, len);
+    buf[len] = '\0';
+    return buf;
 }
 
 int hull_tool(const char *module, int argc, char **argv, const char *hull_exe)
@@ -203,7 +252,17 @@ int hull_tool(const char *module, int argc, char **argv, const char *hull_exe)
         }
     }
 
-    hl_tool_sandbox_init(&unveil_ctx, app_dir, ".", platform_dir);
+    /* Where `hull build` actually writes. This used to be the literal ".",
+     * i.e. the invocation directory, which is only the app dir when you
+     * happen to build from inside it - see parse_output_dir. The
+     * invocation dir is unveiled unconditionally inside
+     * hl_tool_sandbox_init now, so nothing is lost by naming the real
+     * one here. (It must be passed IN: the context is sealed on return,
+     * and hl_tool_unveil_add then silently drops adds.) */
+    char out_buf[4096];
+    const char *output_dir = parse_output_dir(argc, argv, out_buf, sizeof(out_buf));
+    hl_tool_sandbox_init(&unveil_ctx, app_dir,
+                         output_dir ? output_dir : app_dir, platform_dir);
 
     /* Init unsandboxed Lua VM with tool unveil context */
     HlLuaConfig cfg = HL_LUA_CONFIG_DEFAULT;


### PR DESCRIPTION
Completes the sidecar fix. `hull build <dir>` run from anywhere other than inside the app tree left cosmocc's debug artefacts (`app.com.dbg`, `app.aarch64.elf` - about 28 MB) sitting in the app root beside the shippable binary, the opposite of the documented *one obvious shippable executable in the app root*.

The `mkdir -p` half landed in #476. This is the other half, and it is the change that regressed `e2e-compute` on Linux the first time round.

## Two defects fixed here

**1. `output_dir` was the literal `"."`** - whatever directory hull was *invoked from*. `app_dir` is unveiled read-only, so every write under the app tree depended on it. Building from inside the app dir worked, which is why it went unnoticed. Also `parse_app_dir` scanned from `argv[0]`, which dispatch passes as the **subcommand name**, so `hull build /path/app` unveiled an app_dir of `"build"`.

**2. The kernel and userspace unveil lists drifted** - and this is what broke Linux.

`hl_tool_sandbox_init` maintains two parallel lists: the `HlToolUnveilCtx` that `hl_tool_*` consult, and the `unveil()` calls that actually stop a write. The first attempt added the invocation directory to the ctx only:

```c
hl_tool_unveil_add(ctx, ".", "rwc");        /* added */
...
if (output_dir) unveil(output_dir, "rwc");   /* untouched */
```

So once `output_dir` stopped being `"."`, the CWD kept its userspace grant and silently lost its **kernel** one. Every check inside hull still said yes; the kernel said no. Result: `hull compute test` writing into a tempdir failed, and every one returned 500.

**Windows has no kernel sandbox**, so this looked correct locally no matter how carefully it was tested - the failing path does not exist on the machine the fix was written on. That is the second time in this series where the only instrument that can see a defect is Linux CI.

Now mirrored into the kernel list, with a comment saying the two must stay in step, because nothing else in the file says so and the failure mode is this quiet.

**Also:** both `app_dir` and `output_dir` are guarded on actually being a directory. `parse_app_dir` returns the first positional argument, which for a non-build subcommand is a word - `hull compute test scoring` yields `"test"`. Unveiling a path that is not there grants nothing, and on the kernel path it is a failed `unveil()`.

## Testing

Windows 11 + MSYS2 + cosmocc: build clean, `test_tool` 62/62, `test_fs` 37/37, and the payoff intact - `hull build <dir>` from outside the app tree leaves `app.com` alone in the app root with sidecars under `.hull/build`.

Local checks cannot confirm this fix, only that it does not break what Windows can see. **`e2e-compute` on Linux is the real check**, and it is the one that failed last time.

## Note for review

This **widens the tool sandbox**: the app's output directory becomes writable (`rwc`) where only the invocation directory was. Required for the documented behaviour, and the compiler subprocess already wrote there, but it is a deliberate change - and given it has already caused one Linux regression, worth a careful read.