### PR TITLE
fix(blob): a future mtime is not stale, and stop a test racing a worker thread

### DIFF
--- a/src/hull/shared/blob_store.c
+++ b/src/hull/shared/blob_store.c
@@ -173,6 +173,20 @@ static void sweep_stale_tmps(const char *root, uint64_t max_age_sec)
 
         struct stat st;
         if (stat(path, &st) < 0) continue;
+
+        /* A future mtime is never stale. (now - st_mtime) is signed, and
+         * casting a NEGATIVE difference to uint64_t wraps to a huge value
+         * that clears any max_age - so a temp file whose mtime sits even
+         * one second ahead of time(NULL) was unlinked as ancient. That is
+         * the opposite of what this sweep is for: the file it deletes in
+         * that case is the freshest one, potentially a concurrent writer's
+         * in-flight blob.
+         *
+         * mtime can lead the clock after an NTP step, or where the
+         * filesystem and time(NULL) resolve slightly differently - which is
+         * how this surfaced: an intermittent CI failure where the sweep ate
+         * the file the test had just created. */
+        if (st.st_mtime > now) continue;
         if ((uint64_t)(now - st.st_mtime) >= max_age_sec) unlink(path);
     }
     closedir(d);

--- a/tests/hull/cap/test_blob.c
+++ b/tests/hull/cap/test_blob.c
@@ -170,6 +170,45 @@ UTEST(hl_cap_blob, init_sweeps_stale_tmps)
     env_free(&e);
 }
 
+/* A temp file whose mtime LEADS the clock must survive the sweep.
+ *
+ * (now - st_mtime) is signed; casting a negative difference to uint64_t wraps
+ * to a huge value that clears any max_age, so the sweep used to unlink the
+ * freshest file rather than the oldest - potentially a concurrent writer's
+ * in-flight blob. mtime can lead time(NULL) after an NTP step or where the
+ * filesystem and the clock resolve differently, which is how this first showed
+ * up: an intermittent CI failure where init_sweeps_stale_tmps lost the file it
+ * had just created. Planted here rather than waited for. */
+UTEST(hl_cap_blob, sweep_keeps_a_tmp_whose_mtime_leads_the_clock)
+{
+    TestEnv e;
+    ASSERT_EQ(env_init(&e), 0);
+
+    HlBlob *b = NULL;
+    ASSERT_EQ(hl_cap_blob_init(&b, &e.fs_cfg, &e.alloc, "blobs", 1, 60), 0);
+    hl_cap_blob_free(b);
+
+    char future[512];
+    snprintf(future, sizeof(future), "%s/blobs/tmp/.blob-future.tmp", e.base_dir);
+    int fd = open(future, O_WRONLY | O_CREAT, 0644);
+    ASSERT_TRUE(fd >= 0);
+    write(fd, "z", 1);
+    close(fd);
+
+    /* Two minutes ahead - well past the 60s max_age, so a wrapped comparison
+     * deletes it while a correct one leaves it alone. */
+    struct timeval tv[2] = {{ time(NULL) + 120, 0 }, { time(NULL) + 120, 0 }};
+    ASSERT_EQ(utimes(future, tv), 0);
+
+    ASSERT_EQ(hl_cap_blob_init(&b, &e.fs_cfg, &e.alloc, "blobs", 1, 60), 0);
+    hl_cap_blob_free(b);
+
+    struct stat st;
+    ASSERT_EQ(stat(future, &st), 0);   /* survives: a future mtime is not stale */
+
+    env_free(&e);
+}
+
 /* ── put / get round-trip ────────────────────────────────────────── */
 
 UTEST(hl_cap_blob, put_get_roundtrip)
@@ -915,7 +954,13 @@ UTEST(hl_blob_store_keyed, reader_refuses_symlink_at_blob_path)
 
     char blob_path[512];
     snprintf(blob_path, sizeof(blob_path), "%s/%s", shard_dir, key);
-    ASSERT_EQ(symlink(target_file, blob_path), 0);
+    /* Creating a symlink needs SeCreateSymbolicLinkPrivilege on Windows,
+     * which an ordinary account does not hold. Asserting success there
+     * fails for a reason that has nothing to do with the O_NOFOLLOW
+     * refusal under test; skip honestly instead, the same way
+     * hl_cap_fs.validate_rejects_symlink_escape does. */
+    if (symlink(target_file, blob_path) != 0)
+        UTEST_SKIP("symlink() unavailable (needs privilege on this host)");
 
     /* reader_open MUST refuse - O_NOFOLLOW returns ELOOP/EMLINK. */
     HlBlobStoreReader *r = NULL;

--- a/tests/hull/cap/test_smtp_backend_poll.c
+++ b/tests/hull/cap/test_smtp_backend_poll.c
@@ -93,7 +93,19 @@ UTEST(smtp_backend_poll, real_worker_terminal_then_done_dropped_release_once)
     }
     ASSERT_TRUE(got);
     ASSERT_EQ(r.rc, 0);                                 /* worker ran the transport */
-    ASSERT_EQ(hl_smtp_admission_inflight(&adm), 0);     /* lease released on the worker side */
+
+    /* The lease is released by submit_on_terminal, which runs AFTER the
+     * terminal is published (see the hook comment in cap/smtp_submit.c) -
+     * so observing the terminal does NOT imply the slot is back yet. This
+     * used to assert inflight==0 the instant `got` turned true and flaked
+     * on loaded runners, landing on "Actual : 1 vs 0". Wait for it the
+     * same bounded way the terminal itself is waited for. */
+    int released = 0;
+    for (int i = 0; i < 2000; i++) {
+        if (hl_smtp_admission_inflight(&adm) == 0) { released = 1; break; }
+        usleep(1000);
+    }
+    ASSERT_TRUE(released);                              /* lease released on the worker side */
 
     /* Simulate shutdown pass 1 for this op (mark non-resumable), like
      * request_cancel_all would - so the dropped/held done never resumes. */


### PR DESCRIPTION
Two intermittent CI failures from this week's Windows work. **One of them is a real bug, not a flaky test.**

## 1. The blob sweep deletes the freshest file - product bug

`hl_cap_blob.init_sweeps_stale_tmps` failed on an aarch64 run. The assertion that failed was not the staleness check - it was:

```
Expected : (stat(fresh, &st)) == (0)
  Actual : -1 vs 0
```

The sweep had deleted the file the test had just created. Cause:

```c
if ((uint64_t)(now - st.st_mtime) >= max_age_sec) unlink(path);
```

`(now - st_mtime)` is signed. Casting a **negative** difference to `uint64_t` wraps to a huge value that clears any `max_age`, so a temp file whose mtime sits even one second **ahead** of `time(NULL)` is unlinked as ancient - the freshest file rather than the oldest, the exact inverse of the sweep's purpose.

mtime can lead the clock after an NTP step, or where the filesystem and `time(NULL)` resolve slightly differently. In production this can delete a **concurrent writer's in-flight blob**, which is precisely what the tmp sweep exists to avoid.

A future mtime is never stale, so it is skipped. The regression test plants an mtime two minutes ahead rather than waiting for the condition to recur - well past the 60s `max_age`, so a wrapped comparison deletes it and a correct one leaves it alone.

## 2. A test racing a worker thread - test bug

`smtp_backend_poll.real_worker_terminal_then_done_dropped_release_once` flaked **twice in one afternoon on two different PRs**, both on macOS, both on:

```
Expected : (hl_smtp_admission_inflight(&adm)) == (0)
  Actual : 1 vs 0
```

Not a timeout - the run took 17ms. The test waits for the worker to publish the terminal, then asserts the admission slot is already back. It is not, and it is not meant to be: `submit_on_terminal` releases the lease **after** terminal publication, which that hook's own comment in `cap/smtp_submit.c` states plainly. The window is by design; the test's assumption of ordering was wrong.

It now waits for the release the same bounded way it waits for the terminal. The assertion still fails if the lease is never returned - it just no longer depends on winning a race.

## Also

`hl_blob_store_keyed.reader_refuses_symlink_at_blob_path` asserted `symlink()` succeeds, which needs a privilege an ordinary Windows account lacks, so it failed for a reason unrelated to the `O_NOFOLLOW` refusal under test. Same honest skip `hl_cap_fs.validate_rejects_symlink_escape` got in #477.

## Testing

Windows 11 + MSYS2 + cosmocc: `test_smtp_backend_poll` 2/2, `test_blob` 31 ran / 1 failed. The remaining failure is `track_access_false_preserves_atime`, a genuine Windows atime behavioural difference that predates this and wants its own look - `test_blob` is not in the enforced Windows tier, so CI does not see it either way.

Worth noting the pattern: two "flaky tests" were one real correctness bug and one incorrect assumption about thread ordering. Neither was random.