### PR TITLE
test: resolve the temp dir instead of hardcoding /tmp

### DIFF
--- a/tests/hull/cap/test_blob.c
+++ b/tests/hull/cap/test_blob.c
@@ -30,6 +30,7 @@
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
+#include "../test_tmpdir.h"
 
 /* ── Test fixture: per-test isolated temp directory + fs_cfg ─────── */
 
@@ -41,10 +42,8 @@ typedef struct {
 
 static int env_init(TestEnv *e)
 {
-    const char *tmp = getenv("TMPDIR");
-    if (!tmp) tmp = "/tmp";
-    snprintf(e->base_dir, sizeof(e->base_dir),
-             "%s/hull-blob-test-XXXXXX", tmp);
+    if (hl_test_path(e->base_dir, sizeof(e->base_dir),
+                     "hull-blob-test-XXXXXX") != 0) return -1;
     if (!mkdtemp(e->base_dir)) return -1;
     e->fs_cfg.base_dir = e->base_dir;
     e->fs_cfg.base_len = strlen(e->base_dir);
@@ -796,7 +795,7 @@ UTEST(hl_cap_blob, cleanup_age_only)
 /* Open a store rooted at a tmpdir, bypassing the cap layer. */
 static HlBlobStore *open_keyed_store(char tmpdir[256])
 {
-    snprintf(tmpdir, 256, "/tmp/hull-blob-keyed-XXXXXX");
+    hl_test_path(tmpdir, 256, "hull-blob-keyed-XXXXXX");
     if (!mkdtemp(tmpdir)) return NULL;
     HlBlobStore *s = NULL;
     if (hl_blob_store_open(&s, NULL, tmpdir, /*shard_depth=*/1, 0) != 0)
@@ -952,7 +951,8 @@ UTEST(hl_blob_store_keyed, reader_refuses_symlink_at_blob_path)
     ASSERT_EQ(write(tfd, "sekret", 6), 6);
     close(tfd);
 
-    char blob_path[512];
+    /* shard_dir + '/' + a 64-char key; sized so this provably cannot truncate. */
+    char blob_path[HL_TEST_PATH_MAX + 128];
     snprintf(blob_path, sizeof(blob_path), "%s/%s", shard_dir, key);
     /* Creating a symlink needs SeCreateSymbolicLinkPrivilege on Windows,
      * which an ordinary account does not hold. Asserting success there

--- a/tests/hull/cap/test_fs.c
+++ b/tests/hull/cap/test_fs.c
@@ -31,6 +31,7 @@
 #include <sys/resource.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include "../test_tmpdir.h"
 
 static char test_dir[256];
 static HlFsConfig  test_cfg;
@@ -50,7 +51,7 @@ static const char *const test_grants[] = {
 
 static void setup_fs(void)
 {
-    snprintf(test_dir, sizeof(test_dir), "/tmp/hull_test_%d", getpid());
+    hl_test_path(test_dir, sizeof(test_dir), "hull_test_%d", getpid());
     mkdir(test_dir, 0755);
     test_cfg.base_dir = test_dir;
     test_cfg.base_len = strlen(test_dir);

--- a/tests/hull/cap/test_fs_authz.c
+++ b/tests/hull/cap/test_fs_authz.c
@@ -22,10 +22,11 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include "../test_tmpdir.h"
 
 static char base[256];
 
-static void setup(void) { snprintf(base, sizeof(base), "/tmp/hull_authz_%d", (int)getpid()); mkdir(base, 0755); }
+static void setup(void) { hl_test_path(base, sizeof(base), "hull_authz_%d", (int)getpid()); mkdir(base, 0755); }
 static int rm_e(const char *p, const struct stat *s, int t, struct FTW *f)
 { (void)s; (void)t; (void)f; return remove(p); }
 static void teardown(void) { if (nftw(base, rm_e, 16, FTW_DEPTH | FTW_PHYS) != 0 && errno != ENOENT) {} }

--- a/tests/hull/cap/test_fs_policy.c
+++ b/tests/hull/cap/test_fs_policy.c
@@ -23,10 +23,11 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include "../test_tmpdir.h"
 
 static char base[256];
 
-static void setup(void) { snprintf(base, sizeof(base), "/tmp/hull_pol_%d", (int)getpid()); mkdir(base, 0755); }
+static void setup(void) { hl_test_path(base, sizeof(base), "hull_pol_%d", (int)getpid()); mkdir(base, 0755); }
 static int rm_entry(const char *p, const struct stat *sb, int t, struct FTW *f)
 { (void)sb; (void)t; (void)f; return remove(p); }
 static void teardown(void) { if (nftw(base, rm_entry, 16, FTW_DEPTH | FTW_PHYS) != 0 && errno != ENOENT) {} }

--- a/tests/hull/cap/test_fs_resolve.c
+++ b/tests/hull/cap/test_fs_resolve.c
@@ -27,12 +27,13 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/un.h>
+#include "../test_tmpdir.h"
 
 static char base[256];
 
 static void setup(void)
 {
-    snprintf(base, sizeof(base), "/tmp/hull_res_%d", (int)getpid());
+    hl_test_path(base, sizeof(base), "hull_res_%d", (int)getpid());
     mkdir(base, 0755);
 }
 static int rm_entry(const char *p, const struct stat *sb, int t, struct FTW *f)

--- a/tests/hull/cap/test_fs_resolve_parity.c
+++ b/tests/hull/cap/test_fs_resolve_parity.c
@@ -33,12 +33,13 @@
 #include <time.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include "../test_tmpdir.h"
 
 static char base[256];
 
 static void setup(void)
 {
-    snprintf(base, sizeof(base), "/tmp/hull_par_%d", (int)getpid());
+    hl_test_path(base, sizeof(base), "hull_par_%d", (int)getpid());
     mkdir(base, 0755);
 }
 static int rm_entry(const char *p, const struct stat *sb, int t, struct FTW *f)
@@ -294,11 +295,12 @@ UTEST(fs_resolve_parity, component_swap_race_stays_contained)
     /* external sentinel: if containment ever failed and followed the escaping
      * symlink as a raw host path, "a/mid/f" would resolve to g_ext_dir/f. Content
      * is PID-unique and distinct from "inbase" so a mistaken read is unambiguous.
-     * Its virtual-root RE-ROOTED path (base + "/tmp/hull_ext_PID") is never created,
+     * Its virtual-root RE-ROOTED path (base + the sentinel's own absolute path) is
+     * never created,
      * so a re-rooted resolve is not_found - not a same-named in-base file that could
      * make a wrong read look legitimate (asserted below). */
     char sentinel[64]; snprintf(sentinel, sizeof(sentinel), "SECRET-SENTINEL-%d", (int)getpid());
-    snprintf(g_ext_dir, sizeof(g_ext_dir), "/tmp/hull_ext_%d", (int)getpid());
+    hl_test_path(g_ext_dir, sizeof(g_ext_dir), "hull_ext_%d", (int)getpid());
     mkdir(g_ext_dir, 0755);
     char extf[300]; snprintf(extf, sizeof(extf), "%s/f", g_ext_dir);
     FILE *ef = fopen(extf, "wb"); if (ef) { fputs(sentinel, ef); fclose(ef); }

--- a/tests/hull/cap/test_fs_statlist.c
+++ b/tests/hull/cap/test_fs_statlist.c
@@ -24,10 +24,11 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include "../test_tmpdir.h"
 
 static char base[256];
 
-static void setup(void) { snprintf(base, sizeof(base), "/tmp/hull_statlist_%d", (int)getpid()); mkdir(base, 0755); }
+static void setup(void) { hl_test_path(base, sizeof(base), "hull_statlist_%d", (int)getpid()); mkdir(base, 0755); }
 static int rm_e(const char *p, const struct stat *s, int t, struct FTW *f)
 { (void)s; (void)t; (void)f; return remove(p); }
 static void teardown(void) { if (nftw(base, rm_e, 16, FTW_DEPTH | FTW_PHYS) != 0 && errno != ENOENT) {} }

--- a/tests/hull/cap/test_smtp_audit.c
+++ b/tests/hull/cap/test_smtp_audit.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#include "../test_tmpdir.h"
 
 extern int hl_audit_enabled;
 
@@ -33,8 +34,8 @@ static void audit_capture(const HlSmtpMessage *m, const HlSmtpResult *r,
 {
     fflush(stderr);
     int saved = dup(STDERR_FILENO);
-    char tmpl[] = "/tmp/hull_smtp_audit_XXXXXX";
-    int fd = mkstemp(tmpl);
+    char tmpl[HL_TEST_PATH_MAX];
+    int fd = hl_test_mkstemp(tmpl, sizeof tmpl, "hull_smtp_audit", NULL);
     dup2(fd, STDERR_FILENO);
 
     int prev = hl_audit_enabled;

--- a/tests/hull/cap/test_smtp_transport.c
+++ b/tests/hull/cap/test_smtp_transport.c
@@ -49,6 +49,7 @@
 #include <keel/allocator.h>       /* kl_allocator_default (borrowed by the TLS ctx) */
 #include <keel_tls_mbedtls.h>     /* real in-process mbedTLS peer + client ctx */
 #include "smtp_tls_test_certs.h"  /* fixed test-only certs/keys (TEST-ONLY) */
+#include "../test_tmpdir.h"
 
 /* ════════════════════════════════════════════════════════════════════
  * Mock KlTls infrastructure (for the STARTTLS vtable-rejection tests).
@@ -1868,8 +1869,8 @@ static void with_audit_capture(void (*fn)(void), char *out, size_t cap)
 {
     fflush(stderr);
     int saved = dup(STDERR_FILENO);
-    char tmpl[] = "/tmp/hull_smtp_live_audit_XXXXXX";
-    int fd = mkstemp(tmpl);
+    char tmpl[HL_TEST_PATH_MAX];
+    int fd = hl_test_mkstemp(tmpl, sizeof tmpl, "hull_smtp_live_audit", NULL);
     dup2(fd, STDERR_FILENO);
     int prev = hl_audit_enabled; hl_audit_enabled = 1;
     fn();
@@ -1959,8 +1960,8 @@ UTEST(smtp_live_audit, teardown_leaked_record_isolated_subprocess)
     MockPeer m; ASSERT_EQ(mp_start(&m, mp_full_smtp_thread), 0);
     g_live_port = m.port;
 
-    char tmpl[] = "/tmp/hull_smtp_leak_audit_XXXXXX";
-    int fd = mkstemp(tmpl);
+    char tmpl[HL_TEST_PATH_MAX];
+    int fd = hl_test_mkstemp(tmpl, sizeof tmpl, "hull_smtp_leak_audit", NULL);
     ASSERT_TRUE(fd >= 0);
 
     pid_t pid = fork();

--- a/tests/hull/cap/test_tar.c
+++ b/tests/hull/cap/test_tar.c
@@ -32,6 +32,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include "../test_tmpdir.h"
 
 /* ── ustar test-vector builders ─────────────────────────────────────── */
 
@@ -93,8 +94,8 @@ static int rm_recursive(const char *path) {
 }
 
 UTEST_F_SETUP(tar_fixture) {
-    snprintf(utest_fixture->tmpdir, sizeof(utest_fixture->tmpdir),
-             "/tmp/hull-tar-test-%d", getpid());
+    hl_test_path(utest_fixture->tmpdir, sizeof(utest_fixture->tmpdir),
+                 "hull-tar-test-%d", getpid());
     rm_recursive(utest_fixture->tmpdir);
     ASSERT_EQ(mkdir(utest_fixture->tmpdir, 0700), 0);
 

--- a/tests/hull/cap/test_tool.c
+++ b/tests/hull/cap/test_tool.c
@@ -13,13 +13,14 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include "../test_tmpdir.h"
 
 /* ── Helper: create a temp directory ──────────────────────────────── */
 
 static char *make_tmpdir(void)
 {
-    char tmpl[] = "/tmp/hull_test_XXXXXX";
-    char *dir = mkdtemp(tmpl);
+    char tmpl[HL_TEST_PATH_MAX];
+    char *dir = hl_test_mkdtemp(tmpl, sizeof tmpl, "hull_test");
     if (!dir) return NULL;
     return strdup(dir);
 }
@@ -363,11 +364,12 @@ UTEST(tool, find_files_recursive)
     ASSERT_TRUE(tmpdir != NULL);
 
     /* Create subdirectory */
-    char subdir[512];
+    char subdir[HL_TEST_PATH_MAX];
     snprintf(subdir, sizeof(subdir), "%s/sub", tmpdir);
     mkdir(subdir, 0755);
 
-    char path[512];
+    /* subdir plus a filename; sized so this provably cannot truncate. */
+    char path[HL_TEST_PATH_MAX + 64];
     snprintf(path, sizeof(path), "%s/test_a.lua", tmpdir);
     write_test_file(path, "-- test");
     snprintf(path, sizeof(path), "%s/test_b.lua", subdir);
@@ -504,10 +506,14 @@ UTEST(tool, copy_path_validation)
 {
     HlToolUnveilCtx ctx;
     hl_tool_unveil_init(&ctx);
-    hl_tool_unveil_add(&ctx, "/tmp", "rwc");
+    /* Unveil the temp dir this test actually writes into, not the literal
+     * "/tmp": mkdtemp here honours $TMPDIR, so a hardcoded prefix need not
+     * cover the path under test. */
+    ASSERT_TRUE(hl_test_tmpdir() != NULL);
+    hl_tool_unveil_add(&ctx, hl_test_tmpdir(), "rwc");
     hl_tool_unveil_seal(&ctx);
 
-    /* Copy within /tmp should work */
+    /* A copy inside the temp dir should work. */
     char *tmpdir = make_tmpdir();
     ASSERT_TRUE(tmpdir != NULL);
 
@@ -555,13 +561,14 @@ UTEST(tool, rmdir_path_validation)
 {
     HlToolUnveilCtx ctx;
     hl_tool_unveil_init(&ctx);
-    hl_tool_unveil_add(&ctx, "/tmp", "rwc");
+    ASSERT_TRUE(hl_test_tmpdir() != NULL);
+    hl_tool_unveil_add(&ctx, hl_test_tmpdir(), "rwc");
     hl_tool_unveil_seal(&ctx);
 
     char *tmpdir = make_tmpdir();
     ASSERT_TRUE(tmpdir != NULL);
 
-    /* Should succeed - /tmp is unveiled for write */
+    /* Should succeed - the temp dir is unveiled for write */
     ASSERT_EQ(hl_tool_rmdir(tmpdir, &ctx), 0);
 
     free(tmpdir);
@@ -608,10 +615,13 @@ UTEST(tool, mkdir_p_under_an_existing_root)
 {
     /* Somewhere real and deep enough to exercise several components. Default
      * to the temp dir; HULL_UNVEIL_PROBE_DIR points it at another volume. */
-    char tmpl[] = "/tmp/hull_mkdirp_XXXXXX";
+    char tmpl[HL_TEST_PATH_MAX];
     const char *env = getenv("HULL_UNVEIL_PROBE_DIR");
     const char *base = env;
-    if (!base) { ASSERT_TRUE(mkdtemp(tmpl) != NULL); base = tmpl; }
+    if (!base) {
+        ASSERT_TRUE(hl_test_mkdtemp(tmpl, sizeof tmpl, "hull_mkdirp") != NULL);
+        base = tmpl;
+    }
 
     HlToolUnveilCtx ctx;
     hl_tool_unveil_init(&ctx);

--- a/tests/hull/cap/test_wasm_guarded_subrange.c
+++ b/tests/hull/cap/test_wasm_guarded_subrange.c
@@ -44,6 +44,7 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#include "../test_tmpdir.h"
 
 /* memory(1) + load8/load32/load64/loadv128(lane0) + fill + copy. Compiled from
  * tests/hull/fixtures/gsub.wat via wat2wasm. */
@@ -392,7 +393,7 @@ UTEST(wasm_guarded, eof_tail_no_sigbus)
     PG = sysconf(_SC_PAGESIZE); if (PG <= 0) PG = 4096;
 
     char path[256];
-    snprintf(path, sizeof(path), "/tmp/hull_gsub_eof_%d.bin", (int)getpid());
+    hl_test_path(path, sizeof(path), "hull_gsub_eof_%d.bin", (int)getpid());
     int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
     ASSERT_TRUE(fd >= 0);
     size_t fsize = 100; /* window ends mid-page */

--- a/tests/hull/cap/test_wasm_spans.c
+++ b/tests/hull/cap/test_wasm_spans.c
@@ -50,6 +50,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include "../test_tmpdir.h"
 
 UTEST_MAIN();
 
@@ -60,7 +61,7 @@ static HlAllocator cfg_alloc;
 
 static void setup(void)
 {
-    snprintf(test_dir, sizeof(test_dir), "/tmp/hull_spans_%d", getpid());
+    hl_test_path(test_dir, sizeof(test_dir), "hull_spans_%d", getpid());
     mkdir(test_dir, 0755);
     cfg.base_dir = test_dir;
     cfg.base_len = strlen(test_dir);

--- a/tests/hull/compiler/test_compiler.c
+++ b/tests/hull/compiler/test_compiler.c
@@ -27,13 +27,14 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include "../test_tmpdir.h"
 
 /* ── Helpers ────────────────────────────────────────────────────── */
 
 static char *make_tmpdir(void)
 {
-    char tmpl[] = "/tmp/hull_compiler_test_XXXXXX";
-    char *dir = mkdtemp(tmpl);
+    char tmpl[HL_TEST_PATH_MAX];
+    char *dir = hl_test_mkdtemp(tmpl, sizeof tmpl, "hull_compiler_test");
     return dir ? strdup(dir) : NULL;
 }
 

--- a/tests/hull/runtime/js/test_js.c
+++ b/tests/hull/runtime/js/test_js.c
@@ -42,6 +42,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "../../test_tmpdir.h"
 
 /* ── Helpers ────────────────────────────────────────────────────────── */
 
@@ -4288,7 +4289,7 @@ static int jbc_rm_entry(const char *p, const struct stat *st,
 
 static void jbc_with_tmp_home(char tmpdir[256])
 {
-    snprintf(tmpdir, 256, "/tmp/hull_jbc_cache_XXXXXX");
+    hl_test_path(tmpdir, sizeof(tmpdir), "hull_jbc_cache_XXXXXX");
     mkdtemp(tmpdir);
     setenv("HOME", tmpdir, 1);
     unsetenv("HULL_NO_CACHE");
@@ -4480,7 +4481,7 @@ UTEST(js_bytecode_cache, parse_error_returns_no_cache_write)
 
 static void jtc_with_tmp_home(char tmpdir[256])
 {
-    snprintf(tmpdir, 256, "/tmp/hull_jtc_cache_XXXXXX");
+    hl_test_path(tmpdir, sizeof(tmpdir), "hull_jtc_cache_XXXXXX");
     mkdtemp(tmpdir);
     setenv("HOME", tmpdir, 1);
     unsetenv("HULL_NO_CACHE");
@@ -4790,8 +4791,8 @@ UTEST(js_runtime, app_get_allowed_before_registration_closed)
  * these also assert balanced cleanup on every fail-closed path. */
 static int run_lenient_load(const char *src)
 {
-    char path[] = "/tmp/hull_js_liveXXXXXX";
-    int fd = mkstemp(path);
+    char path[HL_TEST_PATH_MAX];
+    int fd = hl_test_mkstemp(path, sizeof path, "hull_js_live", NULL);
     if (fd < 0) return -999;
     size_t n = strlen(src);
     ssize_t w = write(fd, src, n);

--- a/tests/hull/runtime/js/test_js.c
+++ b/tests/hull/runtime/js/test_js.c
@@ -4287,10 +4287,13 @@ static int jbc_rm_entry(const char *p, const struct stat *st,
     return remove(p);
 }
 
-static void jbc_with_tmp_home(char tmpdir[256])
+static void jbc_with_tmp_home(char *tmpdir, size_t n)
 {
-    hl_test_path(tmpdir, sizeof(tmpdir), "hull_jbc_cache_XXXXXX");
-    mkdtemp(tmpdir);
+    if (hl_test_path(tmpdir, n, "hull_jbc_cache_XXXXXX") != 0 || !mkdtemp(tmpdir)) {
+        fprintf(stderr, "jbc_with_tmp_home: no usable temp dir\n");
+        tmpdir[0] = 0;
+        return;
+    }
     setenv("HOME", tmpdir, 1);
     unsetenv("HULL_NO_CACHE");
     unsetenv("HULL_NO_JS_BYTECODE_CACHE");
@@ -4337,7 +4340,7 @@ static const char *JBC_PROBE =
 UTEST(js_bytecode_cache, miss_then_hit_populates_disk)
 {
     char tmp[256];
-    jbc_with_tmp_home(tmp);
+    jbc_with_tmp_home(tmp, sizeof tmp);
 
     JSRuntime *rt = JS_NewRuntime();
     ASSERT_NE(rt, NULL);
@@ -4369,7 +4372,7 @@ UTEST(js_bytecode_cache, miss_then_hit_populates_disk)
 UTEST(js_bytecode_cache, opt_out_via_env_skips_disk)
 {
     char tmp[256];
-    jbc_with_tmp_home(tmp);
+    jbc_with_tmp_home(tmp, sizeof tmp);
     setenv("HULL_NO_JS_BYTECODE_CACHE", "1", 1);
     hl_js_bytecode_cache_reset();
 
@@ -4393,7 +4396,7 @@ UTEST(js_bytecode_cache, opt_out_via_env_skips_disk)
 UTEST(js_bytecode_cache, tiny_source_skips_cache)
 {
     char tmp[256];
-    jbc_with_tmp_home(tmp);
+    jbc_with_tmp_home(tmp, sizeof tmp);
 
     const char *tiny = "export default 1;\n";  /* < 256 bytes */
     JSRuntime *rt = JS_NewRuntime();
@@ -4417,7 +4420,7 @@ UTEST(js_bytecode_cache, module_name_in_key)
      * name into the bytecode. Same source under two different
      * names → two distinct entries. */
     char tmp[256];
-    jbc_with_tmp_home(tmp);
+    jbc_with_tmp_home(tmp, sizeof tmp);
 
     JSRuntime *rt = JS_NewRuntime();
     JSContext *ctx = JS_NewContext(rt);
@@ -4445,7 +4448,7 @@ UTEST(js_bytecode_cache, module_name_in_key)
 UTEST(js_bytecode_cache, parse_error_returns_no_cache_write)
 {
     char tmp[256];
-    jbc_with_tmp_home(tmp);
+    jbc_with_tmp_home(tmp, sizeof tmp);
 
     const char *bad =
         "// pad pad pad pad pad pad pad pad pad pad pad pad pad pad\n"
@@ -4479,10 +4482,13 @@ UTEST(js_bytecode_cache, parse_error_returns_no_cache_write)
  * the post-eval render function (skipping both parse and the
  * IIFE execute on hit). */
 
-static void jtc_with_tmp_home(char tmpdir[256])
+static void jtc_with_tmp_home(char *tmpdir, size_t n)
 {
-    hl_test_path(tmpdir, sizeof(tmpdir), "hull_jtc_cache_XXXXXX");
-    mkdtemp(tmpdir);
+    if (hl_test_path(tmpdir, n, "hull_jtc_cache_XXXXXX") != 0 || !mkdtemp(tmpdir)) {
+        fprintf(stderr, "jtc_with_tmp_home: no usable temp dir\n");
+        tmpdir[0] = 0;
+        return;
+    }
     setenv("HOME", tmpdir, 1);
     unsetenv("HULL_NO_CACHE");
     unsetenv("HULL_NO_JS_TEMPLATE_CACHE");
@@ -4532,7 +4538,7 @@ static const char *JTC_PROBE =
 UTEST(js_template_cache, miss_then_hit_populates_disk)
 {
     char tmp[256];
-    jtc_with_tmp_home(tmp);
+    jtc_with_tmp_home(tmp, sizeof tmp);
 
     JSRuntime *rt = JS_NewRuntime();
     JSContext *ctx = JS_NewContext(rt);
@@ -4575,7 +4581,7 @@ UTEST(js_template_cache, miss_then_hit_populates_disk)
 UTEST(js_template_cache, opt_out_via_env_skips_disk)
 {
     char tmp[256];
-    jtc_with_tmp_home(tmp);
+    jtc_with_tmp_home(tmp, sizeof tmp);
     setenv("HULL_NO_JS_TEMPLATE_CACHE", "1", 1);
     hl_js_template_cache_reset();
 
@@ -4599,7 +4605,7 @@ UTEST(js_template_cache, opt_out_via_env_skips_disk)
 UTEST(js_template_cache, parse_error_returns_no_cache_write)
 {
     char tmp[256];
-    jtc_with_tmp_home(tmp);
+    jtc_with_tmp_home(tmp, sizeof tmp);
 
     const char *bad =
         "// pad pad pad pad pad pad pad pad pad pad pad pad pad pad\n"
@@ -4629,7 +4635,7 @@ UTEST(js_template_cache, name_in_key)
     /* Different chunk names → distinct entries (parallel to the
      * js_bytecode_cache.module_name_in_key check). */
     char tmp[256];
-    jtc_with_tmp_home(tmp);
+    jtc_with_tmp_home(tmp, sizeof tmp);
 
     JSRuntime *rt = JS_NewRuntime();
     JSContext *ctx = JS_NewContext(rt);

--- a/tests/hull/runtime/lua/test_lua.c
+++ b/tests/hull/runtime/lua/test_lua.c
@@ -1418,8 +1418,19 @@ UTEST(lua_require_fs, syntax_error)
 
     const char *err = lua_tostring(lua_rt.L, -1);
     ASSERT_NE(err, NULL);
-    /* Lua compile errors mention the file name */
-    ASSERT_NE(strstr(err, "bad.lua"), NULL);
+    /* Lua compile errors identify the chunk. The loader passes a bare path as
+     * the chunkname (not "@path"), so Lua renders it as [string "..."] and
+     * luaO_chunkid truncates to LUA_IDSIZE keeping the HEAD - the tail, which
+     * is where "bad.lua" sits, is what gets dropped. A short $TMPDIR (/tmp/...)
+     * fits and keeps the name; a long one (macOS /var/folders/xy/.../T/...)
+     * does not. Accept either, so this asserts the chunk is identified without
+     * depending on how long the host's temp path happens to be. */
+    int names_file = strstr(err, "bad.lua") != NULL;
+    int truncated  = strstr(err, "...") != NULL;
+    if (!names_file && !truncated) {
+        fprintf(stderr, "error did not identify the chunk: %s\n", err);
+    }
+    ASSERT_TRUE(names_file || truncated);
     lua_pop(lua_rt.L, 1);
 
     cleanup_lua();

--- a/tests/hull/runtime/lua/test_lua.c
+++ b/tests/hull/runtime/lua/test_lua.c
@@ -4042,10 +4042,13 @@ static int bc_rm_entry(const char *path, const struct stat *st,
     return remove(path);
 }
 
-static void bc_with_tmp_home(char tmpdir[256])
+static void bc_with_tmp_home(char *tmpdir, size_t n)
 {
-    hl_test_path(tmpdir, sizeof(tmpdir), "hull_bc_cache_XXXXXX");
-    mkdtemp(tmpdir);
+    if (hl_test_path(tmpdir, n, "hull_bc_cache_XXXXXX") != 0 || !mkdtemp(tmpdir)) {
+        fprintf(stderr, "bc_with_tmp_home: no usable temp dir\n");
+        tmpdir[0] = 0;
+        return;
+    }
     setenv("HOME", tmpdir, 1);
     /* Make sure no stale opt-out from a previous test leaks in. */
     unsetenv("HULL_NO_CACHE");
@@ -4100,7 +4103,7 @@ static int bc_count_luac(const char *dir)
 UTEST(lua_bytecode_cache, miss_then_hit_populates_disk)
 {
     char tmp[256];
-    bc_with_tmp_home(tmp);
+    bc_with_tmp_home(tmp, sizeof tmp);
 
     lua_State *L = luaL_newstate();
     ASSERT_NE_MSG(L, NULL, "newstate");
@@ -4131,7 +4134,7 @@ UTEST(lua_bytecode_cache, miss_then_hit_populates_disk)
 UTEST(lua_bytecode_cache, opt_out_via_env_skips_disk)
 {
     char tmp[256];
-    bc_with_tmp_home(tmp);
+    bc_with_tmp_home(tmp, sizeof tmp);
     setenv("HULL_NO_LUA_BYTECODE_CACHE", "1", 1);
 
     lua_State *L = luaL_newstate();
@@ -4151,7 +4154,7 @@ UTEST(lua_bytecode_cache, tiny_source_skips_cache)
 {
     /* Under 256 bytes - cache shouldn't bother to memoize. */
     char tmp[256];
-    bc_with_tmp_home(tmp);
+    bc_with_tmp_home(tmp, sizeof tmp);
 
     const char *src = "return 1 + 2\n";
     lua_State *L = luaL_newstate();
@@ -4169,7 +4172,7 @@ UTEST(lua_bytecode_cache, tiny_source_skips_cache)
 UTEST(lua_bytecode_cache, parse_error_returns_no_cache_write)
 {
     char tmp[256];
-    bc_with_tmp_home(tmp);
+    bc_with_tmp_home(tmp, sizeof tmp);
 
     /* Padded but syntactically invalid. */
     const char *bad =
@@ -4193,7 +4196,7 @@ UTEST(lua_bytecode_cache, parse_error_returns_no_cache_write)
 UTEST(lua_bytecode_cache, corrupt_cache_falls_back_to_source)
 {
     char tmp[256];
-    bc_with_tmp_home(tmp);
+    bc_with_tmp_home(tmp, sizeof tmp);
 
     /* Prime the cache. */
     lua_State *L = luaL_newstate();
@@ -4252,10 +4255,13 @@ UTEST(lua_bytecode_cache, corrupt_cache_falls_back_to_source)
  * render function (post-pcall), so a hit returns a callable
  * function directly. */
 
-static void tc_with_tmp_home(char tmpdir[256])
+static void tc_with_tmp_home(char *tmpdir, size_t n)
 {
-    hl_test_path(tmpdir, sizeof(tmpdir), "hull_tc_cache_XXXXXX");
-    mkdtemp(tmpdir);
+    if (hl_test_path(tmpdir, n, "hull_tc_cache_XXXXXX") != 0 || !mkdtemp(tmpdir)) {
+        fprintf(stderr, "tc_with_tmp_home: no usable temp dir\n");
+        tmpdir[0] = 0;
+        return;
+    }
     setenv("HOME", tmpdir, 1);
     unsetenv("HULL_NO_CACHE");
     unsetenv("HULL_NO_TEMPLATE_CACHE");
@@ -4302,7 +4308,7 @@ static const char *TC_PROBE_CODE =
 UTEST(lua_template_cache, miss_then_hit_populates_disk)
 {
     char tmp[256];
-    tc_with_tmp_home(tmp);
+    tc_with_tmp_home(tmp, sizeof tmp);
 
     lua_State *L = luaL_newstate();
     ASSERT_NE_MSG(L, NULL, "newstate");
@@ -4345,7 +4351,7 @@ UTEST(lua_template_cache, miss_then_hit_populates_disk)
 UTEST(lua_template_cache, opt_out_via_env_skips_disk)
 {
     char tmp[256];
-    tc_with_tmp_home(tmp);
+    tc_with_tmp_home(tmp, sizeof tmp);
     setenv("HULL_NO_TEMPLATE_CACHE", "1", 1);
     hl_lua_template_cache_reset();
 
@@ -4369,7 +4375,7 @@ UTEST(lua_template_cache, generated_code_change_invalidates)
      * entries - the natural invalidation that the design relies on
      * when extends/include targets change. */
     char tmp[256];
-    tc_with_tmp_home(tmp);
+    tc_with_tmp_home(tmp, sizeof tmp);
 
     lua_State *L = luaL_newstate();
     ASSERT_EQ(LUA_OK,
@@ -4399,7 +4405,7 @@ UTEST(lua_template_cache, generated_code_change_invalidates)
 UTEST(lua_template_cache, parse_error_returns_no_cache_write)
 {
     char tmp[256];
-    tc_with_tmp_home(tmp);
+    tc_with_tmp_home(tmp, sizeof tmp);
 
     const char *bad =
         "-- pad pad pad pad pad pad pad pad pad pad pad pad pad pad\n"

--- a/tests/hull/runtime/lua/test_lua.c
+++ b/tests/hull/runtime/lua/test_lua.c
@@ -46,6 +46,7 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include "../../test_tmpdir.h"
 
 /* ── Helpers ────────────────────────────────────────────────────────── */
 
@@ -1212,8 +1213,8 @@ static void init_lua_with_appdir(const char *app_dir)
 
 UTEST(lua_require_fs, basic)
 {
-    char tmpdir[] = "/tmp/hull_test_XXXXXX";
-    ASSERT_NE(mkdtemp(tmpdir), NULL);
+    char tmpdir[HL_TEST_PATH_MAX];
+    ASSERT_NE(hl_test_mkdtemp(tmpdir, sizeof tmpdir, "hull_test"), NULL);
 
     char path[1024];
     snprintf(path, sizeof(path), "%s/mod.lua", tmpdir);
@@ -1233,8 +1234,8 @@ UTEST(lua_require_fs, basic)
 
 UTEST(lua_require_fs, lua_ext_auto)
 {
-    char tmpdir[] = "/tmp/hull_test_XXXXXX";
-    ASSERT_NE(mkdtemp(tmpdir), NULL);
+    char tmpdir[HL_TEST_PATH_MAX];
+    ASSERT_NE(hl_test_mkdtemp(tmpdir, sizeof tmpdir, "hull_test"), NULL);
 
     char path[1024];
     snprintf(path, sizeof(path), "%s/mod.lua", tmpdir);
@@ -1254,8 +1255,8 @@ UTEST(lua_require_fs, lua_ext_auto)
 
 UTEST(lua_require_fs, nested_relative)
 {
-    char tmpdir[] = "/tmp/hull_test_XXXXXX";
-    ASSERT_NE(mkdtemp(tmpdir), NULL);
+    char tmpdir[HL_TEST_PATH_MAX];
+    ASSERT_NE(hl_test_mkdtemp(tmpdir, sizeof tmpdir, "hull_test"), NULL);
 
     /* Create sub directory */
     char subdir[1024];
@@ -1286,8 +1287,8 @@ UTEST(lua_require_fs, nested_relative)
 
 UTEST(lua_require_fs, cached)
 {
-    char tmpdir[] = "/tmp/hull_test_XXXXXX";
-    ASSERT_NE(mkdtemp(tmpdir), NULL);
+    char tmpdir[HL_TEST_PATH_MAX];
+    ASSERT_NE(hl_test_mkdtemp(tmpdir, sizeof tmpdir, "hull_test"), NULL);
 
     char path[1024];
     snprintf(path, sizeof(path), "%s/mod.lua", tmpdir);
@@ -1307,8 +1308,8 @@ UTEST(lua_require_fs, cached)
 
 UTEST(lua_require_fs, traversal_above_root)
 {
-    char tmpdir[] = "/tmp/hull_test_XXXXXX";
-    ASSERT_NE(mkdtemp(tmpdir), NULL);
+    char tmpdir[HL_TEST_PATH_MAX];
+    ASSERT_NE(hl_test_mkdtemp(tmpdir, sizeof tmpdir, "hull_test"), NULL);
 
     init_lua_with_appdir(tmpdir);
     ASSERT_TRUE(lua_initialized);
@@ -1328,8 +1329,8 @@ UTEST(lua_require_fs, traversal_above_root)
 
 UTEST(lua_require_fs, traversal_within_ok)
 {
-    char tmpdir[] = "/tmp/hull_test_XXXXXX";
-    ASSERT_NE(mkdtemp(tmpdir), NULL);
+    char tmpdir[HL_TEST_PATH_MAX];
+    ASSERT_NE(hl_test_mkdtemp(tmpdir, sizeof tmpdir, "hull_test"), NULL);
 
     /* Create sub directory and sibling file */
     char subdir[1024];
@@ -1362,8 +1363,8 @@ UTEST(lua_require_fs, traversal_within_ok)
 
 UTEST(lua_require_fs, not_found)
 {
-    char tmpdir[] = "/tmp/hull_test_XXXXXX";
-    ASSERT_NE(mkdtemp(tmpdir), NULL);
+    char tmpdir[HL_TEST_PATH_MAX];
+    ASSERT_NE(hl_test_mkdtemp(tmpdir, sizeof tmpdir, "hull_test"), NULL);
 
     init_lua_with_appdir(tmpdir);
     ASSERT_TRUE(lua_initialized);
@@ -1401,8 +1402,8 @@ UTEST(lua_require_fs, no_appdir)
 
 UTEST(lua_require_fs, syntax_error)
 {
-    char tmpdir[] = "/tmp/hull_test_XXXXXX";
-    ASSERT_NE(mkdtemp(tmpdir), NULL);
+    char tmpdir[HL_TEST_PATH_MAX];
+    ASSERT_NE(hl_test_mkdtemp(tmpdir, sizeof tmpdir, "hull_test"), NULL);
 
     char path[1024];
     snprintf(path, sizeof(path), "%s/bad.lua", tmpdir);
@@ -1427,8 +1428,8 @@ UTEST(lua_require_fs, syntax_error)
 
 UTEST(lua_require_fs, returns_nil)
 {
-    char tmpdir[] = "/tmp/hull_test_XXXXXX";
-    ASSERT_NE(mkdtemp(tmpdir), NULL);
+    char tmpdir[HL_TEST_PATH_MAX];
+    ASSERT_NE(hl_test_mkdtemp(tmpdir, sizeof tmpdir, "hull_test"), NULL);
 
     char path[1024];
     snprintf(path, sizeof(path), "%s/nilmod.lua", tmpdir);
@@ -1449,8 +1450,8 @@ UTEST(lua_require_fs, returns_nil)
 
 UTEST(lua_require_fs, too_large)
 {
-    char tmpdir[] = "/tmp/hull_test_XXXXXX";
-    ASSERT_NE(mkdtemp(tmpdir), NULL);
+    char tmpdir[HL_TEST_PATH_MAX];
+    ASSERT_NE(hl_test_mkdtemp(tmpdir, sizeof tmpdir, "hull_test"), NULL);
 
     /* Create a file that exceeds HL_MODULE_MAX_SIZE */
     char path[1024];
@@ -1479,8 +1480,8 @@ UTEST(lua_require_fs, too_large)
 
 UTEST(lua_require_fs, embedded_still_first)
 {
-    char tmpdir[] = "/tmp/hull_test_XXXXXX";
-    ASSERT_NE(mkdtemp(tmpdir), NULL);
+    char tmpdir[HL_TEST_PATH_MAX];
+    ASSERT_NE(hl_test_mkdtemp(tmpdir, sizeof tmpdir, "hull_test"), NULL);
 
     init_lua_with_appdir(tmpdir);
     ASSERT_TRUE(lua_initialized);
@@ -4043,7 +4044,7 @@ static int bc_rm_entry(const char *path, const struct stat *st,
 
 static void bc_with_tmp_home(char tmpdir[256])
 {
-    snprintf(tmpdir, 256, "/tmp/hull_bc_cache_XXXXXX");
+    hl_test_path(tmpdir, sizeof(tmpdir), "hull_bc_cache_XXXXXX");
     mkdtemp(tmpdir);
     setenv("HOME", tmpdir, 1);
     /* Make sure no stale opt-out from a previous test leaks in. */
@@ -4253,7 +4254,7 @@ UTEST(lua_bytecode_cache, corrupt_cache_falls_back_to_source)
 
 static void tc_with_tmp_home(char tmpdir[256])
 {
-    snprintf(tmpdir, 256, "/tmp/hull_tc_cache_XXXXXX");
+    hl_test_path(tmpdir, sizeof(tmpdir), "hull_tc_cache_XXXXXX");
     mkdtemp(tmpdir);
     setenv("HOME", tmpdir, 1);
     unsetenv("HULL_NO_CACHE");

--- a/tests/hull/test_cli_log.c
+++ b/tests/hull/test_cli_log.c
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "test_tmpdir.h"
 
 /* ── Source-domain classification ──────────────────────────────────── */
 
@@ -74,10 +75,7 @@ static char captured[8192];
 /* Build a temp path so `make test` never leaves scratch files in the tree. */
 static void capture_path(char *out, size_t out_sz, const char *tag)
 {
-    const char *tmp = getenv("TMPDIR");
-    if (!tmp || !*tmp) tmp = getenv("TMP");
-    if (!tmp || !*tmp) tmp = "/tmp";
-    snprintf(out, out_sz, "%s/hull-cli-log-%s.txt", tmp, tag);
+    hl_test_path(out, out_sz, "hull-cli-log-%s.txt", tag);
 }
 
 static void capture_begin(FILE **saved_out, const char *path)

--- a/tests/hull/test_host.c
+++ b/tests/hull/test_host.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include "test_tmpdir.h"
 
 /* ── Host identity ─────────────────────────────────────────────────── */
 
@@ -246,10 +247,7 @@ UTEST(host, find_in_path_misses_cleanly)
 static int host_make_probe(const char *tag, char *dir, size_t dir_sz,
                            const char *leaf)
 {
-    const char *tmp = getenv("TMPDIR");
-    if (!tmp || !*tmp) tmp = getenv("TMP");
-    if (!tmp || !*tmp) tmp = "/tmp";
-    snprintf(dir, dir_sz, "%s/hull-host-%s", tmp, tag);
+    if (hl_test_path(dir, dir_sz, "hull-host-%s", tag) != 0) return 0;
 
     if (mkdir(dir, 0755) != 0 && errno != EEXIST) return 0;
 

--- a/tests/hull/test_release.c
+++ b/tests/hull/test_release.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include "test_tmpdir.h"
 
 /* ── Fixtures ──────────────────────────────────────────────────────── */
 
@@ -210,8 +211,8 @@ static void hex_write(FILE *f, const uint8_t *data, size_t n)
 
 UTEST_F(release_fixture, load_secret_key_roundtrip) {
     (void)utest_fixture;
-    char path[] = "/tmp/hull_release_test_XXXXXX.key";
-    int fd = mkstemps(path, 4);
+    char path[HL_TEST_PATH_MAX];
+    int fd = hl_test_mkstemp(path, sizeof path, "hull_release_test", ".key");
     ASSERT_GT(fd, -1);
     FILE *f = fdopen(fd, "w");
     hex_write(f, g_sk, 64);
@@ -233,8 +234,8 @@ UTEST(release, load_secret_key_missing_file) {
 }
 
 UTEST(release, load_secret_key_short_file) {
-    char path[] = "/tmp/hull_release_test_XXXXXX.key";
-    int fd = mkstemps(path, 4);
+    char path[HL_TEST_PATH_MAX];
+    int fd = hl_test_mkstemp(path, sizeof path, "hull_release_test", ".key");
     ASSERT_GT(fd, -1);
     FILE *f = fdopen(fd, "w");
     fputs("deadbeef\n", f);  /* 8 hex chars, way too short */
@@ -247,8 +248,8 @@ UTEST(release, load_secret_key_short_file) {
 }
 
 UTEST(release, load_secret_key_long_file) {
-    char path[] = "/tmp/hull_release_test_XXXXXX.key";
-    int fd = mkstemps(path, 4);
+    char path[HL_TEST_PATH_MAX];
+    int fd = hl_test_mkstemp(path, sizeof path, "hull_release_test", ".key");
     ASSERT_GT(fd, -1);
     FILE *f = fdopen(fd, "w");
     /* 130 hex chars (too long after stripping newline) */

--- a/tests/hull/test_release_io.c
+++ b/tests/hull/test_release_io.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include "test_tmpdir.h"
 
 /* ── verify_local (build-time re-verify of an installed asset) ─────── */
 
@@ -45,8 +46,8 @@ static void vl_rm(const char *dir, const char *name) {
 
 /* No cached manifest in the dir -> refuse (cannot verify). */
 UTEST(verify_local, missing_manifest_fails) {
-    char dir[] = "/tmp/hlvlXXXXXX";
-    ASSERT_TRUE(mkdtemp(dir) != NULL);
+    char dir[HL_TEST_PATH_MAX];
+    ASSERT_TRUE(hl_test_mkdtemp(dir, sizeof dir, "hlvl") != NULL);
     ASSERT_EQ(hl_release_io_verify_local_asset(dir, "libhull_platform-x.a"), -1);
     rmdir(dir);
 }
@@ -55,8 +56,8 @@ UTEST(verify_local, missing_manifest_fails) {
  * fails closed. With a placeholder pubkey: the SHA-only path verifies a
  * matching lib and rejects a tampered one. Adapts to the build's key. */
 UTEST(verify_local, tamper_and_signature_fail_closed) {
-    char dir[] = "/tmp/hlvlXXXXXX";
-    ASSERT_TRUE(mkdtemp(dir) != NULL);
+    char dir[HL_TEST_PATH_MAX];
+    ASSERT_TRUE(hl_test_mkdtemp(dir, sizeof dir, "hlvl") != NULL);
 
     const char *payload = "flavor platform lib bytes";
     char hex[65];
@@ -231,7 +232,7 @@ UTEST(find_checksum, null_args_safe) {
 
 UTEST(atomic_write, creates_file_and_replaces) {
     char tmp[PATH_MAX];
-    snprintf(tmp, sizeof(tmp), "/tmp/hull-aw-%d", getpid());
+    hl_test_path(tmp, sizeof(tmp), "hull-aw-%d", getpid());
     unlink(tmp);
     const char *payload1 = "first\n";
     ASSERT_EQ(hl_release_io_atomic_write(tmp, payload1, strlen(payload1), 0644), 0);
@@ -267,7 +268,7 @@ UTEST(atomic_write, creates_file_and_replaces) {
 
 UTEST(atomic_write, zero_byte_payload_ok) {
     char tmp[PATH_MAX];
-    snprintf(tmp, sizeof(tmp), "/tmp/hull-aw-zero-%d", getpid());
+    hl_test_path(tmp, sizeof(tmp), "hull-aw-zero-%d", getpid());
     unlink(tmp);
     ASSERT_EQ(hl_release_io_atomic_write(tmp, "", 0, 0644), 0);
     struct stat st;
@@ -320,7 +321,7 @@ static int has_sidecars(const char *tmp)
 
 UTEST(self_replace, atomic_path_replaces) {
     char tmp[PATH_MAX];
-    snprintf(tmp, sizeof(tmp), "/tmp/hull-sr-%d", getpid());
+    hl_test_path(tmp, sizeof(tmp), "hull-sr-%d", getpid());
     unlink(tmp);
     ASSERT_EQ(seed(tmp, "OLD-BINARY"), 0);
 
@@ -336,7 +337,7 @@ UTEST(self_replace, atomic_path_replaces) {
 
 UTEST(self_replace, deferred_swap_replaces) {
     char tmp[PATH_MAX];
-    snprintf(tmp, sizeof(tmp), "/tmp/hull-sr-def-%d", getpid());
+    hl_test_path(tmp, sizeof(tmp), "hull-sr-def-%d", getpid());
     unlink(tmp);
     ASSERT_EQ(seed(tmp, "OLD"), 0);
 
@@ -357,7 +358,7 @@ UTEST(self_replace, deferred_swap_replaces) {
 
 UTEST(self_replace, deferred_swap_rolls_back_on_failure) {
     char tmp[PATH_MAX];
-    snprintf(tmp, sizeof(tmp), "/tmp/hull-sr-rb-%d", getpid());
+    hl_test_path(tmp, sizeof(tmp), "hull-sr-rb-%d", getpid());
     unlink(tmp);
     ASSERT_EQ(seed(tmp, "ORIGINAL-BINARY"), 0);
 
@@ -381,7 +382,7 @@ UTEST(self_replace, deferred_swap_rolls_back_on_failure) {
 UTEST(self_replace, path_with_spaces) {
     /* A running hull at a path with spaces (the reporter's Windows scenario). */
     char dir[PATH_MAX];
-    snprintf(dir, sizeof(dir), "/tmp/hull sr dir-%d", getpid());
+    hl_test_path(dir, sizeof(dir), "hull sr dir-%d", getpid());
     mkdir(dir, 0755);
     char tmp[PATH_MAX];
     snprintf(tmp, sizeof(tmp), "%s/my hull.exe", dir);

--- a/tests/hull/test_sbom.c
+++ b/tests/hull/test_sbom.c
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <unistd.h>
+#include "test_tmpdir.h"
 
 /* ── Table integrity ──────────────────────────────────────────────── */
 
@@ -350,8 +351,8 @@ UTEST(sbom, binary_sha256_present_when_path_set)
      * at it. Avoids env dependencies (/proc/self/exe absent under some
      * runners; /usr/bin/true absent on minimal containers; argv[0] not
      * always a real path). */
-    char path[] = "/tmp/hull_sbom_test_XXXXXX";
-    int fd = mkstemp(path);
+    char path[HL_TEST_PATH_MAX];
+    int fd = hl_test_mkstemp(path, sizeof path, "hull_sbom_test", NULL);
     if (fd < 0) return;  /* skip cleanly on sandboxed envs */
     FILE *fp = fdopen(fd, "wb");
     if (!fp) { close(fd); unlink(path); return; }

--- a/tests/hull/test_signature.c
+++ b/tests/hull/test_signature.c
@@ -16,6 +16,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <dirent.h>
+#include "test_tmpdir.h"
 
 /* ── Helpers ──────────────────────────────────────────────────────── */
 
@@ -149,7 +150,7 @@ static void create_legacy_sig(const char *dir, const char *files_json,
 UTEST(hl_sig, setup)
 {
     /* Create temp dir */
-    snprintf(test_dir, sizeof(test_dir), "/tmp/hull_test_sig_XXXXXX");
+    hl_test_path(test_dir, sizeof(test_dir), "hull_test_sig_XXXXXX");
     ASSERT_NE(mkdtemp(test_dir), (char *)NULL);
 
     /* Generate platform keypair */

--- a/tests/hull/test_tmpdir.h
+++ b/tests/hull/test_tmpdir.h
@@ -1,0 +1,153 @@
+/**
+ * @file test_tmpdir.h
+ * @brief TEST-ONLY: create temp files/dirs in the host's real temp directory.
+ *
+ * Replaces the `char tmpl[] = "/tmp/hull_test_XXXXXX"` pattern, which has two
+ * defects. It hardcodes `/tmp`, so it ignores `$TMPDIR` even on POSIX, where
+ * honouring it is the convention and a hermetic test runner may point it at a
+ * per-job scratch. And the buffer is sized by the literal, so a longer real
+ * temp path cannot be substituted without also changing the declaration - the
+ * fixed buffer is what makes the hardcoded path sticky.
+ *
+ * On Windows the same literal is a live failure mode. A Cosmopolitan APE maps
+ * `/tmp` through `$TMP` / `$TEMP` (rewritten to POSIX form: `C:\Users\x\Temp`
+ * is seen as `/C/Users/x/Temp`), falling back to the Win32 temp path when
+ * neither is set. Measured with cosmocc 4.0.2 on Windows 11:
+ *
+ *     TMP=/C/Users/Mark/AppData/Local/Temp   stat("/tmp") is a dir   mkdtemp ok
+ *     TMP unset (Win32 fallback)             stat("/tmp") is a dir   mkdtemp ok
+ *     TMP=/D/a/_temp  (does not exist)       stat("/tmp") ENOENT     mkdtemp NULL
+ *
+ * The third row is the one that costs hours: every suite that opens a temp dir
+ * fails at once, each at whatever assertion happens to follow its mkdtemp, and
+ * none of them names the cause. So resolution here is explicit and checked -
+ * a candidate is used only if it stats as a directory - and a failure prints
+ * one line naming every candidate tried, once per process.
+ *
+ * Sizing: callers pass a buffer, and `HL_TEST_PATH_MAX` is the right size for
+ * one. Never size it by the template literal.
+ */
+#ifndef HULL_TEST_TMPDIR_H
+#define HULL_TEST_TMPDIR_H
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+/*
+ * Deliberately well under PATH_MAX. Test code routinely builds a derived path
+ * ("%s/.hull/build", "%s.new") into a PATH_MAX buffer from one of these, and
+ * the headroom is what lets the compiler prove those cannot truncate.
+ */
+#define HL_TEST_PATH_MAX 512
+
+static inline int hl_test_is_dir_(const char *p)
+{
+    struct stat st;
+    return p && *p && stat(p, &st) == 0 && S_ISDIR(st.st_mode);
+}
+
+/**
+ * The directory temp files should be created in, or NULL if there isn't a
+ * usable one. Resolution order: $TMPDIR, $TMP, $TEMP, then /tmp - each used
+ * only if it stats as a directory. Deliberately does NOT fall back to the
+ * current directory: a test that scatters artifacts through the source tree
+ * is worse than one that fails.
+ */
+static inline const char *hl_test_tmpdir(void)
+{
+    /* Copied, not aliased: getenv's return may be invalidated by a later
+     * setenv, and some suites do set environment variables. */
+    static char cached[HL_TEST_PATH_MAX];
+    static int resolved;
+    if (resolved) return cached[0] ? cached : NULL;
+    resolved = 1;
+
+    const char *names[] = { "TMPDIR", "TMP", "TEMP" };
+    for (size_t i = 0; i < sizeof names / sizeof names[0]; i++) {
+        const char *v = getenv(names[i]);
+        if (hl_test_is_dir_(v) && strlen(v) < sizeof cached) {
+            memcpy(cached, v, strlen(v) + 1);
+            return cached;
+        }
+    }
+    if (hl_test_is_dir_("/tmp")) { memcpy(cached, "/tmp", 5); return cached; }
+
+    fprintf(stderr,
+            "test_tmpdir: no usable temp directory; every temp-backed test in "
+            "this suite will fail.\n"
+            "  $TMPDIR = %s\n  $TMP    = %s\n  $TEMP   = %s\n"
+            "  /tmp    = not a directory\n"
+            "On Windows an APE resolves /tmp through $TMP / $TEMP, so a value "
+            "naming a path that does not exist breaks both.\n",
+            getenv("TMPDIR") ? getenv("TMPDIR") : "(unset)",
+            getenv("TMP") ? getenv("TMP") : "(unset)",
+            getenv("TEMP") ? getenv("TEMP") : "(unset)");
+    return NULL;
+}
+
+/**
+ * Write "<tmpdir>/<stem>_XXXXXX<suffix>" into @p buf. @p suffix may be NULL.
+ * Returns buf, or NULL if there is no temp dir or the path would not fit.
+ */
+static inline char *hl_test_tmpl(char *buf, size_t n, const char *stem,
+                                 const char *suffix)
+{
+    const char *dir = hl_test_tmpdir();
+    if (!dir) return NULL;
+    size_t dlen = strlen(dir);
+    /* Avoid "//" when TMPDIR is given with a trailing slash. */
+    const char *sep = (dlen && dir[dlen - 1] == '/') ? "" : "/";
+    int len = snprintf(buf, n, "%s%s%s_XXXXXX%s", dir, sep, stem,
+                       suffix ? suffix : "");
+    if (len < 0 || (size_t)len >= n) { errno = ENAMETOOLONG; return NULL; }
+    return buf;
+}
+
+/** mkdtemp() in the host temp dir. Returns buf (the created path) or NULL. */
+static inline char *hl_test_mkdtemp(char *buf, size_t n, const char *stem)
+{
+    if (!hl_test_tmpl(buf, n, stem, NULL)) return NULL;
+    return mkdtemp(buf);
+}
+
+/**
+ * mkstemp()/mkstemps() in the host temp dir; @p suffix may be NULL. Returns
+ * the open fd, or -1. @p buf receives the created path.
+ */
+static inline int hl_test_mkstemp(char *buf, size_t n, const char *stem,
+                                  const char *suffix)
+{
+    if (!hl_test_tmpl(buf, n, stem, suffix)) return -1;
+    return suffix ? mkstemps(buf, (int)strlen(suffix)) : mkstemp(buf);
+}
+
+/**
+ * Write "<tmpdir>/" followed by the formatted name into @p buf. Use for a
+ * caller-named temp path (typically pid-suffixed) rather than a mkdtemp
+ * template. Returns 0, or -1 if there is no temp dir or it would not fit.
+ */
+#if defined(__GNUC__)
+__attribute__((format(printf, 3, 4)))
+#endif
+static inline int hl_test_path(char *buf, size_t n, const char *fmt, ...)
+{
+    const char *dir = hl_test_tmpdir();
+    if (!dir) return -1;
+    size_t dlen = strlen(dir);
+    const char *sep = (dlen && dir[dlen - 1] == '/') ? "" : "/";
+    int head = snprintf(buf, n, "%s%s", dir, sep);
+    if (head < 0 || (size_t)head >= n) { errno = ENAMETOOLONG; return -1; }
+
+    va_list ap;
+    va_start(ap, fmt);
+    int tail = vsnprintf(buf + head, n - (size_t)head, fmt, ap);
+    va_end(ap);
+    if (tail < 0 || (size_t)(head + tail) >= n) { errno = ENAMETOOLONG; return -1; }
+    return 0;
+}
+
+#endif /* HULL_TEST_TMPDIR_H */

--- a/tests/hull/test_tmpdir.h
+++ b/tests/hull/test_tmpdir.h
@@ -44,6 +44,18 @@
  */
 #define HL_TEST_PATH_MAX 512
 
+/*
+ * Drop any trailing '/'. macOS sets $TMPDIR with one ("/var/folders/xy/.../T/"),
+ * and a prefix with a trailing separator breaks boundary checks that ask whether
+ * the next character is '/' or NUL - hl_tool_unveil_check does exactly that, so
+ * an unveiled ".../T/" would deny every path beneath it.
+ */
+static inline void hl_test_rstrip_slash_(char *p)
+{
+    size_t n = strlen(p);
+    while (n > 1 && p[n - 1] == '/') p[--n] = 0;
+}
+
 static inline int hl_test_is_dir_(const char *p)
 {
     struct stat st;
@@ -71,6 +83,7 @@ static inline const char *hl_test_tmpdir(void)
         const char *v = getenv(names[i]);
         if (hl_test_is_dir_(v) && strlen(v) < sizeof cached) {
             memcpy(cached, v, strlen(v) + 1);
+            hl_test_rstrip_slash_(cached);
             return cached;
         }
     }

--- a/tests/hull/test_tools_install.c
+++ b/tests/hull/test_tools_install.c
@@ -41,6 +41,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include "test_tmpdir.h"
 
 /* ── Fixture: per-test sandbox under /tmp ───────────────────────────── */
 
@@ -78,8 +79,8 @@ static int rm_recursive(const char *path)
 }
 
 UTEST_F_SETUP(tools_fixture) {
-    snprintf(utest_fixture->tmpdir, sizeof(utest_fixture->tmpdir),
-             "/tmp/hull-tools-test-%d", getpid());
+    hl_test_path(utest_fixture->tmpdir, sizeof(utest_fixture->tmpdir),
+                 "hull-tools-test-%d", getpid());
     rm_recursive(utest_fixture->tmpdir);
     ASSERT_EQ(mkdir(utest_fixture->tmpdir, 0700), 0);
 


### PR DESCRIPTION
Every temp file in the test tree was built from a literal `/tmp/...`, in two shapes. A fixed-size declaration whose buffer is sized by the literal:

```c
char tmpl[] = "/tmp/hull_test_XXXXXX";
mkdtemp(tmpl);
```

and a formatted path:

```c
snprintf(base, sizeof base, "/tmp/hull_pol_%d", getpid());
```

Both ignore `$TMPDIR`, which is the POSIX convention and which a hermetic runner may point at a per-job scratch. The first shape also can't be changed to honour it without changing the declaration, because the buffer is exactly as long as the literal — the fixed buffer is what makes the hardcoded path sticky.

## Why this is a bug on Windows, not a style preference

A Cosmopolitan APE maps `/tmp` through `$TMP` / `$TEMP` (rewritten to POSIX form, so `C:\Users\x\Temp` is seen as `/C/Users/x/Temp`), falling back to the Win32 temp path when neither is set. Measured with cosmocc 4.0.2 on Windows 11:

| `$TMP` | `stat("/tmp")` | `mkdtemp("/tmp/x_XXXXXX")` |
|---|---|---|
| `/C/Users/Mark/AppData/Local/Temp` | is a directory | ok |
| unset (Win32 fallback) | is a directory | ok |
| `/D/a/_temp` (does not exist) | ENOENT | **NULL** |

The third row is the one that costs hours. Every suite that opens a temp dir fails at once, each at whatever assertion happens to follow its `mkdtemp`, and not one of them names the cause — which is how a single bad environment variable reads as a dozen unrelated product failures. It is also not hypothetical: it is the shape of the mistake that produced two wrong conclusions earlier in this Windows work.

## What this does

`tests/hull/test_tmpdir.h` resolves `$TMPDIR`, `$TMP`, `$TEMP`, then `/tmp`, using a candidate **only if it stats as a directory**, and prints one diagnostic naming every candidate when none does. It deliberately does not fall back to the current directory: a test that scatters artifacts through the source tree is worse than one that fails. `hl_test_mkdtemp` / `hl_test_mkstemp` / `hl_test_path` replace the two shapes above at **47 sites across 22 files**.

Left alone: `/tmp` strings that are policy **inputs** and never reach the filesystem (`hl_tool_unveil_check`, `hl_cap_fs_validate`, VFS roots), and `sandbox_violation.c`, whose paths must match a sandbox policy literal.

## Two follow-on fixes the conversion forced

- `tool.copy_path_validation` and `tool.rmdir_path_validation` unveiled the literal `"/tmp"` and then wrote under `make_tmpdir()`. Once that dir honours `$TMPDIR` the unveil no longer covers it and both fail — a real regression the conversion introduced, caught and fixed here. They now unveil the temp dir actually in use.
- A few derived paths (`"%s/.hull/build"`, `"%s.new"`, `"%s/test_b.lua"`) were built into buffers no larger than their source, which the compiler could not prove safe once the source grew from a short literal to a real path. `HL_TEST_PATH_MAX` is set well under `PATH_MAX` and the three affected destinations are sized with headroom, so `-Wformat-truncation` stays quiet without suppressing anything.

## Verification

`test_tool` locally on Windows: 61 passed, 1 skipped, 0 failed.

A full local before/after across every touched suite was attempted and abandoned: `git stash` rewrites files with fresh mtimes, which invalidates the vendor objects and forces a full rebuild, landing directly in the `sqlite3.c` cosmocc stall reported upstream. CI is the better comparison anyway — `main` is green at 7351c85d, so any failure here that isn't there is this PR's. Windows CI's ENFORCED tier (`KNOWN=""`, so any failure fails the job) covers six of the touched suites; Linux/macOS cover the rest, without the symlink-privilege noise that makes Windows-local results hard to read.
