### PR TITLE
fix(lua): name the file in errors, and key bytecode on the chunkname

### DIFF
--- a/src/hull/agent/validate.c
+++ b/src/hull/agent/validate.c
@@ -110,7 +110,14 @@ static int validate_lua(const char *path, const char *content, size_t len,
         sh_json_write_object_end(&w);
         return 0;
     }
-    int rc = luaL_loadbuffer(L, content, len, path);
+    /* "@" marks a FILE chunkname so a parse error reads "path:line:" and
+     * keeps the file name when the path is long (see mod_fs.c). */
+    char chunkbuf[1024];
+    const char *chunkname = path;
+    int cn = snprintf(chunkbuf, sizeof chunkbuf, "@%s", path);
+    if (cn > 0 && (size_t)cn < sizeof chunkbuf)
+        chunkname = chunkbuf;
+    int rc = luaL_loadbuffer(L, content, len, chunkname);
     int ok = (rc == LUA_OK);
     sh_json_write_kv_bool(&w, "ok", ok);
     if (!ok) {

--- a/src/hull/runtime/lua/bytecode_cache.c
+++ b/src/hull/runtime/lua/bytecode_cache.c
@@ -39,10 +39,27 @@
  * $HOME (NFS / dotfile syncing across architectures). */
 
 /* Cache-key digest = sha256(LUA_VERSION || "|" || arch || "|" ||
- * endian || "|" || source). LUA_VERSION moves on every Lua upgrade
- * (header constant), so stale entries from an old vendor bump never
- * collide. arch/endian tags come from the shared helper. */
-static int compute_key(const char *src, size_t src_len,
+ * endian || "|" || chunkname || "|" || source). LUA_VERSION moves on
+ * every Lua upgrade (header constant), so stale entries from an old
+ * vendor bump never collide. arch/endian tags come from the shared
+ * helper.
+ *
+ * The CHUNKNAME is part of the key (mirroring the JS side, which keys
+ * on the module name) because lua_dump bakes the chunkname into the
+ * bytecode as the proto's `source`: a hit returns the name recorded
+ * when the entry was WRITTEN, and the chunkname passed to
+ * luaL_loadbuffer for a binary chunk does not override it. Keying on
+ * source bytes alone therefore made two modules with byte-identical
+ * source (>= the 256-byte floor below) share one entry, so whichever
+ * lost the race loaded bytecode carrying the OTHER module's name.
+ * That is not just cosmetic: mod_db.c::lua_is_stdlib_caller decides
+ * whether _hull_* internal tables may be touched by testing `ar.source`
+ * for a "hull." prefix, and dumps are written with strip=0 precisely so
+ * that field survives. Including the name keeps one entry per (name,
+ * source) pair, so a rename or a new chunkname is a miss rather than a
+ * stale hit. */
+static int compute_key(const char *chunkname,
+                       const char *src, size_t src_len,
                        char hex_out[HL_BLOB_STORE_ID_BUF_SIZE])
 {
     HlSha256Ctx ctx;
@@ -51,12 +68,15 @@ static int compute_key(const char *src, size_t src_len,
     const char *ver  = LUA_VERSION;
     const char *arch = hl_runtime_cache_arch_tag();
     const char *end  = hl_runtime_cache_endian_tag();
+    const char *name = chunkname ? chunkname : "";
 
     if (hl_cap_crypto_sha256_update(&ctx, ver, strlen(ver))   != 0) return -1;
     if (hl_cap_crypto_sha256_update(&ctx, "|", 1)             != 0) return -1;
     if (hl_cap_crypto_sha256_update(&ctx, arch, strlen(arch)) != 0) return -1;
     if (hl_cap_crypto_sha256_update(&ctx, "|", 1)             != 0) return -1;
     if (hl_cap_crypto_sha256_update(&ctx, end, strlen(end))   != 0) return -1;
+    if (hl_cap_crypto_sha256_update(&ctx, "|", 1)             != 0) return -1;
+    if (hl_cap_crypto_sha256_update(&ctx, name, strlen(name)) != 0) return -1;
     if (hl_cap_crypto_sha256_update(&ctx, "|", 1)             != 0) return -1;
     if (hl_cap_crypto_sha256_update(&ctx, src, src_len)       != 0) return -1;
 
@@ -144,7 +164,7 @@ int hl_lua_load_cached(lua_State *L,
     if (!store) return luaL_loadbuffer(L, src, src_len, chunkname);
 
     char key[HL_BLOB_STORE_ID_BUF_SIZE];
-    if (compute_key(src, src_len, key) != 0) {
+    if (compute_key(chunkname, src, src_len, key) != 0) {
         return luaL_loadbuffer(L, src, src_len, chunkname);
     }
 

--- a/src/hull/runtime/lua/mod_fs.c
+++ b/src/hull/runtime/lua/mod_fs.c
@@ -865,8 +865,21 @@ static int hl_lua_require(lua_State *L)
                     return 1;
                 }
 
-                /* Compile the chunk - copies data into Lua bytecode */
-                int load_ok = luaL_loadbuffer(L, buf, nread, path) == LUA_OK;
+                /* Compile the chunk - copies data into Lua bytecode.
+                 * The leading "@" marks the chunkname as a FILE name. Lua
+                 * then renders errors as "path:line:" and, when the name is
+                 * longer than LUA_IDSIZE, luaO_chunkid truncates from the
+                 * FRONT ("...tail") so the file name survives. A bare name
+                 * is rendered [string "..."] and truncated from the BACK,
+                 * which drops the file name on any long path - e.g. under a
+                 * macOS $TMPDIR. Falls back to the bare path if it does not
+                 * fit, which is only ever the status quo. */
+                char chunkbuf[HL_MODULE_PATH_MAX + 1];
+                const char *chunkname = path;
+                int cn = snprintf(chunkbuf, sizeof chunkbuf, "@%s", path);
+                if (cn > 0 && (size_t)cn < sizeof chunkbuf)
+                    chunkname = chunkbuf;
+                int load_ok = luaL_loadbuffer(L, buf, nread, chunkname) == LUA_OK;
 
                 /* Reclaim file buffer - Lua owns the bytecode now */
                 lua->scratch->used = arena_saved;

--- a/tests/hull/cap/test_blob.c
+++ b/tests/hull/cap/test_blob.c
@@ -561,8 +561,49 @@ UTEST(hl_cap_blob, rejects_invalid_id)
 
 /* ── track_access opt-out ────────────────────────────────────────── */
 
+/*
+ * Does a plain read() bump atime on the filesystem the tests run on?
+ *
+ * hl_cap_blob_get(track_access=0) promises only that HULL does not touch
+ * atime; it cannot stop the KERNEL from doing so. Measured on Windows 11
+ * with cosmocc 4.0.2: utimes() backdates atime by an hour and a following
+ * read() restores it to now. A strictatime Linux mount behaves the same
+ * way. Where that holds, the assertion below says nothing about Hull, so
+ * probe the host instead of assuming, and skip only when the host has
+ * made the check meaningless.
+ */
+static int fs_bumps_atime_on_read(void)
+{
+    char probe[HL_TEST_PATH_MAX];
+    int fd = hl_test_mkstemp(probe, sizeof probe, "hull_atime_probe", NULL);
+    if (fd < 0) return 0;              /* cannot tell - do not skip */
+    if (write(fd, "x", 1) != 1) { close(fd); unlink(probe); return 0; }
+    close(fd);
+
+    struct timeval back[2] = {{ time(NULL) - 3600, 0 },
+                              { time(NULL) - 3600, 0 }};
+    if (utimes(probe, back) != 0) { unlink(probe); return 0; }
+
+    struct stat pst;
+    if (stat(probe, &pst) != 0) { unlink(probe); return 0; }
+    time_t before = pst.st_atime;
+
+    fd = open(probe, O_RDONLY);
+    if (fd >= 0) { char c; ssize_t r = read(fd, &c, 1); (void)r; close(fd); }
+
+    int bumped = 0;
+    if (stat(probe, &pst) == 0)
+        bumped = pst.st_atime > before + 1;
+    unlink(probe);
+    return bumped;
+}
+
 UTEST(hl_cap_blob, track_access_false_preserves_atime)
 {
+    if (fs_bumps_atime_on_read())
+        UTEST_SKIP("filesystem updates atime on read; track_access=0 is a "
+                   "promise about Hull, not about the kernel");
+
     TestEnv e; env_init(&e);
     HlBlob *b = NULL;
     hl_cap_blob_init(&b, &e.fs_cfg, &e.alloc, "blobs", 1, 0);

--- a/tests/hull/cap/test_blob.c
+++ b/tests/hull/cap/test_blob.c
@@ -561,18 +561,33 @@ UTEST(hl_cap_blob, rejects_invalid_id)
 
 /* ── track_access opt-out ────────────────────────────────────────── */
 
+/* Mirrors blob_store.c: O_NOATIME is the Linux-only flag that suppresses
+ * atime updates on read; elsewhere it is 0 and the open is plain. */
+#if defined(__linux__)
+#  ifndef O_NOATIME
+#    define O_NOATIME 01000000
+#  endif
+#else
+#  ifndef O_NOATIME
+#    define O_NOATIME 0
+#  endif
+#endif
+
 /*
- * Does a plain read() bump atime on the filesystem the tests run on?
+ * Can this host suppress the atime update that a read would otherwise cause?
  *
- * hl_cap_blob_get(track_access=0) promises only that HULL does not touch
- * atime; it cannot stop the KERNEL from doing so. Measured on Windows 11
- * with cosmocc 4.0.2: utimes() backdates atime by an hour and a following
- * read() restores it to now. A strictatime Linux mount behaves the same
- * way. Where that holds, the assertion below says nothing about Hull, so
- * probe the host instead of assuming, and skip only when the host has
- * made the check meaningless.
+ * hl_cap_blob_get(track_access=0) opens with O_NOATIME (falling back to a
+ * plain open on EPERM), so the contract holds wherever the kernel honours
+ * that flag - Linux does, including under relatime. Where it does not,
+ * atime moves no matter what Hull asks for, and the assertion below stops
+ * being a statement about Hull: on Windows 11 with cosmocc 4.0.2, O_NOATIME
+ * is 0 and a measured read restores a backdated atime to now.
+ *
+ * So probe the ACTUAL production open, not a naive read - an earlier version
+ * of this used a plain open() and skipped on ordinary relatime Linux, where
+ * O_NOATIME works fine and the test is meaningful.
  */
-static int fs_bumps_atime_on_read(void)
+static int host_cannot_suppress_atime(void)
 {
     char probe[HL_TEST_PATH_MAX];
     int fd = hl_test_mkstemp(probe, sizeof probe, "hull_atime_probe", NULL);
@@ -588,7 +603,8 @@ static int fs_bumps_atime_on_read(void)
     if (stat(probe, &pst) != 0) { unlink(probe); return 0; }
     time_t before = pst.st_atime;
 
-    fd = open(probe, O_RDONLY);
+    fd = open(probe, O_RDONLY | O_NOATIME);
+    if (fd < 0 && errno == EPERM) fd = open(probe, O_RDONLY);
     if (fd >= 0) { char c; ssize_t r = read(fd, &c, 1); (void)r; close(fd); }
 
     int bumped = 0;
@@ -600,9 +616,9 @@ static int fs_bumps_atime_on_read(void)
 
 UTEST(hl_cap_blob, track_access_false_preserves_atime)
 {
-    if (fs_bumps_atime_on_read())
-        UTEST_SKIP("filesystem updates atime on read; track_access=0 is a "
-                   "promise about Hull, not about the kernel");
+    if (host_cannot_suppress_atime())
+        UTEST_SKIP("host does not honour O_NOATIME; atime moves on read "
+                   "whatever Hull asks for");
 
     TestEnv e; env_init(&e);
     HlBlob *b = NULL;

--- a/tests/hull/runtime/lua/test_lua.c
+++ b/tests/hull/runtime/lua/test_lua.c
@@ -1418,19 +1418,12 @@ UTEST(lua_require_fs, syntax_error)
 
     const char *err = lua_tostring(lua_rt.L, -1);
     ASSERT_NE(err, NULL);
-    /* Lua compile errors identify the chunk. The loader passes a bare path as
-     * the chunkname (not "@path"), so Lua renders it as [string "..."] and
-     * luaO_chunkid truncates to LUA_IDSIZE keeping the HEAD - the tail, which
-     * is where "bad.lua" sits, is what gets dropped. A short $TMPDIR (/tmp/...)
-     * fits and keeps the name; a long one (macOS /var/folders/xy/.../T/...)
-     * does not. Accept either, so this asserts the chunk is identified without
-     * depending on how long the host's temp path happens to be. */
-    int names_file = strstr(err, "bad.lua") != NULL;
-    int truncated  = strstr(err, "...") != NULL;
-    if (!names_file && !truncated) {
-        fprintf(stderr, "error did not identify the chunk: %s\n", err);
-    }
-    ASSERT_TRUE(names_file || truncated);
+    /* The loader passes "@path", which marks a FILE chunkname: Lua renders
+     * errors as "path:line:" and luaO_chunkid truncates from the FRONT, so
+     * the file name survives however long the host's temp path is. (With a
+     * bare chunkname Lua renders [string "..."] and truncates from the BACK,
+     * dropping the name - which is what this used to have to tolerate.) */
+    ASSERT_NE(strstr(err, "bad.lua"), NULL);
     lua_pop(lua_rt.L, 1);
 
     cleanup_lua();
@@ -4109,6 +4102,43 @@ static int bc_count_luac(const char *dir)
     }
     closedir(r);
     return n;
+}
+
+UTEST(lua_bytecode_cache, chunkname_in_key)
+{
+    /* The key folds in the chunkname because lua_dump bakes it into the
+     * bytecode as the proto's `source`, and the name handed to
+     * luaL_loadbuffer for a BINARY chunk does not override it. Keyed on
+     * source bytes alone, the same source under two names collapsed to one
+     * entry and the second load reported the first one's name - which
+     * mod_db.c::lua_is_stdlib_caller reads to gate _hull_* access. Mirrors
+     * js_bytecode_cache.module_name_in_key. */
+    char tmp[256];
+    bc_with_tmp_home(tmp, sizeof tmp);
+
+    lua_State *L = luaL_newstate();
+    ASSERT_NE_MSG(L, NULL, "newstate");
+
+    ASSERT_EQ(0, bc_count_luac(tmp));
+    ASSERT_EQ(LUA_OK, hl_lua_load_cached(L, BC_PROBE_SRC,
+                                         strlen(BC_PROBE_SRC), "=name_a"));
+    lua_pop(L, 1);
+    ASSERT_EQ(1, bc_count_luac(tmp));
+
+    ASSERT_EQ(LUA_OK, hl_lua_load_cached(L, BC_PROBE_SRC,
+                                         strlen(BC_PROBE_SRC), "=name_b"));
+    ASSERT_EQ_MSG(2, bc_count_luac(tmp),
+                  "distinct chunknames produce distinct entries");
+
+    /* And the second load reports its OWN name, not the first's. */
+    lua_Debug ar;
+    lua_getinfo(L, ">S", &ar);   /* ">S" consumes the function on the stack */
+    /* ar.source keeps the "=" prefix (only short_src strips it) - and that
+     * raw field is what the _hull_* gate matches "hull." against. */
+    ASSERT_STREQ("=name_b", ar.source);
+
+    lua_close(L);
+    nftw(tmp, bc_rm_entry, 16, FTW_DEPTH | FTW_PHYS);
 }
 
 UTEST(lua_bytecode_cache, miss_then_hit_populates_disk)


### PR DESCRIPTION
Three related fixes: two Lua chunkname problems (one user-facing, one latent in the bytecode cache) and one test that asserted something Hull does not control.

## 1. Errors did not name the file

The module loader compiled with a **bare** path as the chunkname:

```c
luaL_loadbuffer(L, buf, nread, path);
```

Lua treats a name with no `@` or `=` prefix as a *string* source: it renders errors as `[string "..."]:line:` and `luaO_chunkid` truncates to `LUA_IDSIZE` (60) **keeping the head**. The file name sits at the tail, so on any path longer than ~60 characters it is exactly what gets dropped:

```
[string "/var/folders/9k/r7m5x1s93kq0/T/hull_test_ab12"]:1: unexpected symbol
```

An app under a macOS `$TMPDIR`, a deep checkout, or a container path reported syntax errors that named no file at all. Passing `"@path"` marks it a **file** name — errors read `path:1: unexpected symbol` and chunkid truncates from the **front**, so the name always survives.

Applied at the two sites where the chunkname genuinely *is* a filesystem path: the dev-mode module load (`mod_fs.c`) and the `hull check` parse (`agent/validate.c`). Both fall back to the bare path if it does not fit, which is only ever today's behaviour.

**Deliberately not applied to embedded module names.** `mod_db.c::lua_is_stdlib_caller` decides whether `_hull_*` internal tables may be touched by testing `ar.source` for a `"hull."` prefix, and `ar.source` *keeps* the prefix character (only `short_src` strips it). Prefixing the stdlib's `hull.template` would make it `@hull.template` and silently revoke every stdlib module's access to its own tables — session, outbox, idempotency, rbac.

## 2. The Lua bytecode cache ignored the chunkname

The Lua key was `sha256(LUA_VERSION | arch | endian | source)` while the JS side already folded in the module name.

`lua_dump` bakes the chunkname into the bytecode as the proto's `source`, and the name passed to `luaL_loadbuffer` for a **binary** chunk does not override it — a hit returns the name recorded when the entry was *written*. So two modules with byte-identical source (past the 256-byte floor) shared one entry, and whichever lost the race ran under the other's name.

That is not cosmetic: it is the same `ar.source` the `_hull_*` gate above reads, and dumps are written with `strip=0` precisely so the field survives. An app module byte-identical to a stdlib module would inherit `source = "hull.X"` and the gate would let it through.

Now `sha256(LUA_VERSION | arch | endian | chunkname | source)`, matching JS. Covered by `lua_bytecode_cache.chunkname_in_key`, mirroring `js_bytecode_cache.module_name_in_key`.

## 3. The atime test asserted a kernel guarantee

`hl_cap_blob.track_access_false_preserves_atime` asserted that a read with `track_access=0` never advances atime. That is a promise about **Hull**, not about the kernel. Measured on Windows 11 with cosmocc 4.0.2:

```
utimes rc=0
before atime=1789060051   now=1789063651
read 10 bytes
after  atime=1789063651   delta=3600   -> FAIL
```

`utimes()` backdates atime correctly and a plain `read()` restores it. (I had assumed NTFS's `NtfsDisableLastAccessUpdate` default made this a non-issue — measuring said otherwise.) A `strictatime` Linux mount behaves the same way.

The test now probes the host — create, backdate, read, re-stat — and skips only when the filesystem has already made the check meaningless, rather than failing on a difference Hull does not own. On a host that does not bump atime it still enforces the real contract.

## Verification

Every changed file syntax-checks clean under `cosmocc -Wall -Wextra`. A full local build is not available on this Windows box: it stalls in `sqlite3.c` (`during GIMPLE pass: ealias`), the cosmocc large-TU stall reported upstream, so CI is the gate. `main` is green at fd0efd2c.
