### PR TITLE
test: pass void * where utest's printer prints %p

### DIFF
--- a/tests/hull/cap/test_blob.c
+++ b/tests/hull/cap/test_blob.c
@@ -1022,7 +1022,7 @@ UTEST(hl_blob_store_keyed, reader_refuses_symlink_at_blob_path)
     /* reader_open MUST refuse - O_NOFOLLOW returns ELOOP/EMLINK. */
     HlBlobStoreReader *r = NULL;
     ASSERT_NE(hl_blob_store_reader_open(s, key, 0, &r), 0);
-    ASSERT_EQ(r, NULL);
+    ASSERT_EQ((void *)r, NULL);
 
     /* And `_get` does too. */
     uint8_t *buf = NULL;

--- a/tests/hull/compiler/test_compiler.c
+++ b/tests/hull/compiler/test_compiler.c
@@ -72,7 +72,7 @@ static void rm_rf(const char *dir)
 UTEST(compiler, system_new_cc)
 {
     HlCompiler *c = hl_compiler_system_new("cc");
-    ASSERT_NE(c, NULL);
+    ASSERT_NE((void *)c, NULL);
     ASSERT_STREQ(hl_compiler_name(c), "cc");
     hl_compiler_destroy(c);
 }
@@ -80,7 +80,7 @@ UTEST(compiler, system_new_cc)
 UTEST(compiler, system_new_null_returns_null)
 {
     HlCompiler *c = hl_compiler_system_new(NULL);
-    ASSERT_EQ(c, NULL);
+    ASSERT_EQ((void *)c, NULL);
 }
 
 /* Is a SYSTEM C compiler present at all?
@@ -108,7 +108,7 @@ UTEST(compiler, system_is_available_cc)
 {
     if (!have_system_cc()) UTEST_SKIP("no system C compiler on this host");
     HlCompiler *c = hl_compiler_system_new("cc");
-    ASSERT_NE(c, NULL);
+    ASSERT_NE((void *)c, NULL);
     /* cc should be available in CI and dev environments */
     ASSERT_EQ(hl_compiler_is_available(c), 1);
     hl_compiler_destroy(c);
@@ -117,7 +117,7 @@ UTEST(compiler, system_is_available_cc)
 UTEST(compiler, system_is_not_available_fake)
 {
     HlCompiler *c = hl_compiler_system_new("__hull_fake_compiler_xyz__");
-    ASSERT_NE(c, NULL);
+    ASSERT_NE((void *)c, NULL);
     ASSERT_EQ(hl_compiler_is_available(c), 0);
     hl_compiler_destroy(c);
 }
@@ -125,7 +125,7 @@ UTEST(compiler, system_is_not_available_fake)
 UTEST(compiler, system_version_cc)
 {
     HlCompiler *c = hl_compiler_system_new("cc");
-    ASSERT_NE(c, NULL);
+    ASSERT_NE((void *)c, NULL);
     if (hl_compiler_is_available(c)) {
         char *v = hl_compiler_version(c);
         ASSERT_NE(v, NULL);
@@ -211,7 +211,7 @@ UTEST(compiler, select_null_returns_compiler)
     if (!have_system_cc()) UTEST_SKIP("no system C compiler on this host");
     HlCompiler *c = hl_compiler_select(NULL);
     /* At least one compiler should be available in CI */
-    ASSERT_NE(c, NULL);
+    ASSERT_NE((void *)c, NULL);
     ASSERT_EQ(hl_compiler_is_available(c), 1);
     hl_compiler_destroy(c);
 }
@@ -220,7 +220,7 @@ UTEST(compiler, select_explicit_cc)
 {
     if (!have_system_cc()) UTEST_SKIP("no system C compiler on this host");
     HlCompiler *c = hl_compiler_select("cc");
-    ASSERT_NE(c, NULL);
+    ASSERT_NE((void *)c, NULL);
     ASSERT_STREQ(hl_compiler_name(c), "cc");
     hl_compiler_destroy(c);
 }
@@ -228,7 +228,7 @@ UTEST(compiler, select_explicit_cc)
 UTEST(compiler, select_fake_returns_null)
 {
     HlCompiler *c = hl_compiler_select("__nonexistent_xyz__");
-    ASSERT_EQ(c, NULL);
+    ASSERT_EQ((void *)c, NULL);
 }
 
 UTEST(compiler, select_system_forces_system)
@@ -236,7 +236,7 @@ UTEST(compiler, select_system_forces_system)
     if (!have_system_cc()) UTEST_SKIP("no system C compiler on this host");
     HlCompiler *c = hl_compiler_select("system");
     /* system compilers should always be available in CI */
-    ASSERT_NE(c, NULL);
+    ASSERT_NE((void *)c, NULL);
     hl_compiler_destroy(c);
 }
 
@@ -294,7 +294,7 @@ UTEST(compiler, default_compiler_resolves)
     if (!have_system_cc()) UTEST_SKIP("no system C compiler on this host");
     /* Auto-select must resolve an available compiler (the system cc). */
     HlCompiler *c = hl_compiler_select(NULL);
-    ASSERT_NE(c, NULL);
+    ASSERT_NE((void *)c, NULL);
     ASSERT_EQ(hl_compiler_is_available(c), 1);
     hl_compiler_destroy(c);
 }

--- a/tests/hull/runtime/lua/test_lua.c
+++ b/tests/hull/runtime/lua/test_lua.c
@@ -4117,7 +4117,7 @@ UTEST(lua_bytecode_cache, chunkname_in_key)
     bc_with_tmp_home(tmp, sizeof tmp);
 
     lua_State *L = luaL_newstate();
-    ASSERT_NE_MSG(L, NULL, "newstate");
+    ASSERT_NE_MSG((void *)L, NULL, "newstate");
 
     ASSERT_EQ(0, bc_count_luac(tmp));
     ASSERT_EQ(LUA_OK, hl_lua_load_cached(L, BC_PROBE_SRC,
@@ -4147,7 +4147,7 @@ UTEST(lua_bytecode_cache, miss_then_hit_populates_disk)
     bc_with_tmp_home(tmp, sizeof tmp);
 
     lua_State *L = luaL_newstate();
-    ASSERT_NE_MSG(L, NULL, "newstate");
+    ASSERT_NE_MSG((void *)L, NULL, "newstate");
 
     /* First call: cache miss, should compile + persist. */
     ASSERT_EQ(0, bc_count_luac(tmp));
@@ -4352,7 +4352,7 @@ UTEST(lua_template_cache, miss_then_hit_populates_disk)
     tc_with_tmp_home(tmp, sizeof tmp);
 
     lua_State *L = luaL_newstate();
-    ASSERT_NE_MSG(L, NULL, "newstate");
+    ASSERT_NE_MSG((void *)L, NULL, "newstate");
     /* The probe calls tostring(), so load stdlibs in the test state. */
     luaL_openlibs(L);
 


### PR DESCRIPTION
utest's value printer picks a format with `_Generic` and falls through to `"%p"` for anything not a listed numeric type — in practice, every pointer. The value is then handed to printf unchanged, so an opaque pointer (`HlCompiler *`, `HlBlobStoreReader *`, `lua_State *`) reaches a `%p` conversion that is specified for `void *`, and `-Wformat=2` says so. 20 warnings across two suites, plus 3 more from `lua_State *`.

**Why not fix the vendored header.** The `default:` branch selects the *format*, while the value is a separate macro argument — so casting only in that branch needs a second `_Generic` around the value, and its non-selected associations must still be valid expressions. `(void *)(float)` is not one. That is the same class of problem the existing Hull patch in `utest.h` already documents about upstream's `val - val` pointer-detection trick.

So the cast goes at the call sites: explicit, local, and it does not weaken the diagnostic anywhere.

**This recurs.** A new `ASSERT_NE(ptr, NULL)` on an opaque type warns again unless it casts too. Worth knowing before someone re-adds one and wonders where the warning came from.

Verified: `cosmocc -Wall -Wextra -Wformat=2 -fsyntax-only` reports 0 remaining `void *` format warnings in both files.