### PR TITLE
fix(lua): embedded modules name themselves in errors too

### DIFF
--- a/src/hull/runtime/lua/internal.h
+++ b/src/hull/runtime/lua/internal.h
@@ -13,6 +13,8 @@
 #ifndef HL_RUNTIME_LUA_INTERNAL_H
 #define HL_RUNTIME_LUA_INTERNAL_H
 
+#include <stdio.h>
+#include <string.h>
 #include <stddef.h>
 #include <stdint.h>
 #include "hull/runtime/lua.h"
@@ -159,5 +161,45 @@ void hl_lua_request_register(lua_State *L);
  * non-streaming routes (body_reader is not a multipart wrapper). */
 void hl_lua_request_install_multipart(lua_State *L, HlLua *lua,
                                        struct KlHttpBodyReader *body_reader);
+
+
+/* ── Chunk names ──────────────────────────────────────────────────
+ *
+ * Mark a chunkname as a FILE name with a leading "@". Lua then renders
+ * errors as "name:line:" instead of [string "name"]:line:, and
+ * luaO_chunkid truncates an over-long name from the FRONT, keeping the
+ * tail - the part that identifies the module. Without the marker the
+ * name is a "string source", rendered in brackets and truncated from
+ * the back, so a long path or a deep module name loses exactly the
+ * identifying part.
+ *
+ * Returns @p buf, or @p name unchanged when the marker would not fit
+ * (which is only ever the previous behaviour).
+ */
+static inline const char *hl_lua_chunkname(char *buf, size_t n,
+                                           const char *name)
+{
+    int len = snprintf(buf, n, "@%s", name);
+    if (len > 0 && (size_t)len < n) return buf;
+    return name;
+}
+
+/* ── Chunk-source namespace test (mod_db.c, mod_fs.c) ─────────────
+ *
+ * Lua's `ar.source` carries the chunkname VERBATIM, including the
+ * leading marker: "@" for a file, "=" for a literal, none for a
+ * string source. (Only `short_src` renders it for display.) Modules
+ * are loaded with an "@" marker so errors read "name:line:" rather
+ * than [string "name"]:line:, so a raw strncmp against "hull." would
+ * no longer match the stdlib - and the callers below use that test to
+ * decide whether _hull_* internal tables may be touched, and whether a
+ * require came from user code. Skip the marker first.
+ */
+static inline int hl_lua_source_is_stdlib(const char *source)
+{
+    if (!source) return 0;
+    if (*source == '@' || *source == '=') source++;
+    return strncmp(source, "hull.", 5) == 0;
+}
 
 #endif /* HL_RUNTIME_LUA_INTERNAL_H */

--- a/src/hull/runtime/lua/mod_db.c
+++ b/src/hull/runtime/lua/mod_db.c
@@ -6,6 +6,7 @@
 #ifdef HL_ENABLE_DB
 
 #include "mod_buffer.h"
+#include "internal.h"   /* hl_lua_source_is_stdlib */
 #include "hull/cap/db.h"
 #include "hull/cap/db_backend.h"
 #include "hull/cap/db_registry.h"
@@ -159,7 +160,7 @@ static int lua_is_stdlib_caller(lua_State *L)
         return 0;
     if (lua_getinfo(L, "S", &ar) == 0)
         return 0;
-    return ar.source && strncmp(ar.source, "hull.", 5) == 0;
+    return hl_lua_source_is_stdlib(ar.source);
 }
 
 /* The default connection, resolved from the registry (there is no separate

--- a/src/hull/runtime/lua/mod_fs.c
+++ b/src/hull/runtime/lua/mod_fs.c
@@ -4,6 +4,7 @@
  */
 
 #include "mod_buffer.h"
+#include "internal.h"   /* hl_lua_source_is_stdlib */
 #include "hull/utils/alloc.h"
 #include "hull/cap/fs.h"
 #include "hull/cap/fs_resolve.h"  /* descriptor-relative virtual-root module read */
@@ -656,7 +657,7 @@ static int hl_lua_require(lua_State *L)
                 int caller_is_user = lua_getstack(L, 1, &ar) &&
                                      lua_getinfo(L, "S", &ar) &&
                                      ar.source &&
-                                     strncmp(ar.source, "hull.", 5) != 0;
+                                     !hl_lua_source_is_stdlib(ar.source);
                 if (caller_is_user)
                     hl_import_tracker_record(&lua->base, spec->name);
             }
@@ -875,11 +876,9 @@ static int hl_lua_require(lua_State *L)
                  * macOS $TMPDIR. Falls back to the bare path if it does not
                  * fit, which is only ever the status quo. */
                 char chunkbuf[HL_MODULE_PATH_MAX + 1];
-                const char *chunkname = path;
-                int cn = snprintf(chunkbuf, sizeof chunkbuf, "@%s", path);
-                if (cn > 0 && (size_t)cn < sizeof chunkbuf)
-                    chunkname = chunkbuf;
-                int load_ok = luaL_loadbuffer(L, buf, nread, chunkname) == LUA_OK;
+                int load_ok = luaL_loadbuffer(
+                    L, buf, nread,
+                    hl_lua_chunkname(chunkbuf, sizeof chunkbuf, path)) == LUA_OK;
 
                 /* Reclaim file buffer - Lua owns the bytecode now */
                 lua->scratch->used = arena_saved;
@@ -958,7 +957,10 @@ int hl_lua_register_stdlib(HlLua *lua)
             if (strchr(e->name, ':')) continue;            /* JS / context */
             if (strncmp(e->name, "static/", 7) == 0) continue;
             if (strncmp(e->name, "templates/", 10) == 0) continue;
-            if (hl_lua_load_cached(L, (const char *)e->data, e->len, e->name) != LUA_OK) {
+            char chunk[HL_MODULE_PATH_MAX + 1];
+            if (hl_lua_load_cached(L, (const char *)e->data, e->len,
+                                   hl_lua_chunkname(chunk, sizeof chunk,
+                                                    e->name)) != LUA_OK) {
                 log_error("[hull:c] failed to load stdlib module '%s': %s",
                           e->name, lua_tostring(L, -1));
                 lua_pop(L, 2); /* pop error + modules table */
@@ -982,7 +984,10 @@ int hl_lua_register_stdlib(HlLua *lua)
                 /* JSON data - store as raw string, decoded on first require() */
                 lua_pushlstring(L, (const char *)e->data, e->len);
             } else {
-                if (hl_lua_load_cached(L, (const char *)e->data, e->len, e->name) != LUA_OK) {
+                char chunk[HL_MODULE_PATH_MAX + 1];
+                if (hl_lua_load_cached(L, (const char *)e->data, e->len,
+                                       hl_lua_chunkname(chunk, sizeof chunk,
+                                                        e->name)) != LUA_OK) {
                     log_error("[hull:c] failed to load app module '%s': %s",
                               e->name, lua_tostring(L, -1));
                     lua_pop(L, 2); /* pop error + modules table */

--- a/tests/hull/runtime/lua/test_lua.c
+++ b/tests/hull/runtime/lua/test_lua.c
@@ -47,6 +47,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include "../../test_tmpdir.h"
+#include "../../../../src/hull/runtime/lua/internal.h"
 
 /* ── Helpers ────────────────────────────────────────────────────────── */
 
@@ -1723,6 +1724,31 @@ UTEST(lua_cap, db_not_available_without_config)
 }
 
 /* ── DB namespace protection tests ──────────────────────────────────── */
+
+UTEST(lua_chunkname, stdlib_namespace_survives_the_file_marker)
+{
+    /* Modules are loaded with an "@" marker so errors render as
+     * "name:line:" rather than [string "name"]:line:. ar.source keeps that
+     * marker verbatim (only short_src strips it), and two gates match
+     * ar.source against "hull.": mod_db.c decides whether _hull_* internal
+     * tables may be touched, and mod_fs.c decides whether a require came
+     * from user code. A raw strncmp would stop matching the moment the
+     * marker appeared, silently revoking every stdlib module's access to
+     * its own tables - so the namespace test skips the marker first. */
+    ASSERT_TRUE(hl_lua_source_is_stdlib("hull.template"));   /* unmarked */
+    ASSERT_TRUE(hl_lua_source_is_stdlib("@hull.template"));  /* file      */
+    ASSERT_TRUE(hl_lua_source_is_stdlib("=hull.template"));  /* literal   */
+
+    /* App code is not in the namespace, marked or not. */
+    ASSERT_FALSE(hl_lua_source_is_stdlib("./routes/users"));
+    ASSERT_FALSE(hl_lua_source_is_stdlib("@./routes/users"));
+    ASSERT_FALSE(hl_lua_source_is_stdlib("@/tmp/app/hull_evil.lua"));
+
+    /* The dot matters: "hull" alone, or a lookalike, is not the namespace. */
+    ASSERT_FALSE(hl_lua_source_is_stdlib("@hullx.template"));
+    ASSERT_FALSE(hl_lua_source_is_stdlib("@hull"));
+    ASSERT_FALSE(hl_lua_source_is_stdlib(NULL));
+}
 
 UTEST(lua_cap, db_namespace_blocks_hull_tables)
 {


### PR DESCRIPTION
#483 marked the **dev-mode** module path as a file chunkname (`"@path"`), so errors read `path:12:` instead of `[string "path"]:12:` with the name truncated off the end. Built binaries did not get that — they load from the embedded VFS, whose chunknames stayed bare. A production app still reported:

```
[string "./routes/users"]:12: attempt to index a nil value
```

and a long module name lost the identifying tail entirely. That is the flavour users actually ship, so it is the one that mattered most.

## The blocker was the gate, not the marker

`ar.source` carries the chunkname **verbatim, including the marker** — only `short_src` renders it for display. Two places match it against `"hull."`:

- `mod_db.c::lua_is_stdlib_caller` — whether `_hull_*` internal tables may be touched
- `mod_fs.c` — whether a `require` came from user code (import tracking)

Marking `hull.template` as `@hull.template` would have made both `strncmp` calls miss, **silently revoking every stdlib module's access to its own tables** — session, outbox, idempotency, rbac. So the namespace test now skips the marker first (`hl_lua_source_is_stdlib`), and both call sites go through it.

All three load sites (dev-mode file, embedded stdlib, embedded app) share one `hl_lua_chunkname` helper, which falls back to the unmarked name if the marker would not fit.

## Cache interaction

The bytecode cache keys on the chunkname as of #483, so the marker change makes old entries unreachable rather than returning bytecode carrying the pre-marker `source`. They age out; nothing ever serves a stale name. This is the second time that key has earned itself.

## Test

`lua_chunkname.stdlib_namespace_survives_the_file_marker` pins the **allow** side of the gate — unmarked, `@`-marked and `=`-marked `hull.` sources all pass; app paths, `hullx.`, bare `hull` and NULL all fail. Worth noting the existing `db_namespace_blocks_*` tests only cover the **deny** side, so nothing in the suite would have caught the revocation described above.