### PR TITLE
fix(db): stop sending cosmo users to a command that cannot work

### DIFF
--- a/docs/windows_install.md
+++ b/docs/windows_install.md
@@ -184,6 +184,50 @@ and is not the same configuration CI exercises.
 This path is exercised in CI by `.github/workflows/windows-source-build.yml`,
 whose header carries the full evidence and history.
 
+## What works on Windows, and what does not
+
+Windows runs the Cosmopolitan APE build. A fat APE cannot force-load a native
+static archive, so every subsystem that ships as a **composable feature** is
+unavailable there. Everything the cosmo base compiles in works normally.
+
+| Capability | Windows | Why |
+|---|---|---|
+| Lua and JS runtimes, `fs`, `crypto`, `http`, `time`, `env` | yes | in the cosmo base |
+| SQLite (`db`, migrations, session/outbox/idempotency/rbac/search) | yes | cosmo compiles SQLite in |
+| WASM compute (`compute.*`) | yes, interpreted | cosmo keeps WASM in-base |
+| Terminal UI (`hull.tui`) | yes | `HL_ENABLE_TUI` defaults to 1 on cosmo |
+| `hull build` of an APE app | yes | needs `cosmocc`; see below |
+| PostgreSQL (`postgres://`) | **no** | native-only feature |
+| MySQL / MariaDB (`mysql://`, `mariadb://`) | **no** | native-only feature |
+| DuckDB (`duckdb://`) | **no** | native-only feature |
+| GPU compute (`gpu.*`) | **no** | native-only feature |
+| AOT-compiled compute | **no** | `wamrc` is not published for cosmo |
+| Kernel sandbox (pledge/unveil) | **no** | see below |
+
+If an app needs a network database or GPU, run it on a native build
+(`hull-linux-x86_64`, `hull-linux-aarch64`, `hull-darwin-arm64`), where
+`hull feature install <name>` and `hull build --with=<name>` work. Building
+Hull from source on Windows with `HL_ENABLE_POSTGRES=1` or `HL_ENABLE_MYSQL=1`
+also works, because those backends are pure C with no vendored engine; DuckDB
+and GPU are not viable that way.
+
+### Compute runs interpreted
+
+`wamrc`, the WAMR AOT compiler, is not published for cosmo (it needs LLVM, which
+is too large to bundle into a fat APE). `compute.call` is correct on Windows but
+runs through the interpreter, so compute-heavy workloads are slower than on a
+native host with `hull tools install wamrc`. Building `wamrc` from source with
+`make wamrc` is the alternative.
+
+### There is no kernel sandbox on Windows
+
+Cosmopolitan's `pledge()` and `unveil()` return 0 and do nothing on Windows
+(measured with cosmocc 4.0.2 on Windows 11: `pledge("stdio", NULL)` returns 0
+and a following `socket()` still succeeds). Startup logs one warning saying so.
+Hull's capability layer, the manifest allowlists for `fs`, `env` and `hosts`,
+still applies in full, and it is the only enforcement boundary on this host.
+Treat a Windows deployment as capability-sandboxed but not kernel-sandboxed.
+
 ## Exit codes on Windows (read this before scripting `hull`)
 
 **On Windows, a POSIX-style shell cannot tell whether `hull` succeeded.** In

--- a/src/hull/cap/db_select.c
+++ b/src/hull/cap/db_select.c
@@ -74,15 +74,55 @@ static const HlDbBackend *const BACKENDS[] = {
  * DuckDB additionally resolves when composed as a build feature: the feature
  * loop above (hl_db_feature_backends) matches duckdb:// before this table, so
  * this hint fires only for a base app with neither the compile flag nor the
- * feature, and points at the feature path. See docs/features_and_flavors.md. */
+ * feature, and points at the feature path. See docs/features_and_flavors.md.
+ *
+ * The feature route does not exist on a cosmo build. Features ship as native
+ * static archives and a fat APE cannot force-load one, so FEATURES[] carries no
+ * cosmo column and `hull feature install` refuses with "not published for
+ * cosmo". Pointing a cosmo user at that command sends them to something that
+ * cannot succeed, so these hints name the routes that do work there: a native
+ * hull, a source build with the compile flag, or SQLite. */
+#if defined(__COSMOPOLITAN__)
+static const char HINT_PG[] =
+    "postgres:// is not available on this build. Features are native static "
+    "archives and a fat APE cannot load one, so they are not published for "
+    "cosmo. Use a native hull (linux-x86_64, linux-aarch64, darwin-arm64) "
+    "with 'hull feature install postgres' then 'hull build --with=postgres', "
+    "or build from source with HL_ENABLE_POSTGRES=1. A SQLite DSN works on "
+    "this build.";
+static const char HINT_MY[] =
+    "mysql:// is not available on this build. Features are native static "
+    "archives and a fat APE cannot load one, so they are not published for "
+    "cosmo. Use a native hull (linux-x86_64, linux-aarch64, darwin-arm64) "
+    "with 'hull feature install mysql' then 'hull build --with=mysql', or "
+    "build from source with HL_ENABLE_MYSQL=1. A SQLite DSN works on this "
+    "build.";
+static const char HINT_DD[] =
+    "duckdb:// is not available on this build. Features are native static "
+    "archives and a fat APE cannot load one, so they are not published for "
+    "cosmo. Use a native hull (linux-x86_64, linux-aarch64, darwin-arm64) "
+    "with 'hull feature install duckdb' then 'hull build --with=duckdb'. "
+    "A SQLite DSN works on this build.";
+#else
+static const char HINT_PG[] =
+    "postgres:// needs the Postgres feature: run 'hull feature install "
+    "postgres', then build the app with 'hull build --with=postgres'";
+static const char HINT_MY[] =
+    "mysql:// needs the MySQL feature: run 'hull feature install mysql', "
+    "then build the app with 'hull build --with=mysql'";
+static const char HINT_DD[] =
+    "duckdb:// needs the DuckDB feature: run 'hull feature install duckdb', "
+    "then build the app with 'hull build --with=duckdb'";
+#endif
+
 static const struct { const char *scheme; const char *msg; } RESERVED[] = {
-    { "postgres",   "postgres:// needs the Postgres feature: run 'hull feature install postgres', then build the app with 'hull build --with=postgres'" },
-    { "postgresql", "postgresql:// needs the Postgres feature: run 'hull feature install postgres', then build the app with 'hull build --with=postgres'" },
+    { "postgres",   HINT_PG },
+    { "postgresql", HINT_PG },
     { "sqlite",     "sqlite:// requires a build with HL_ENABLE_SQLITE" },
     { "file",       "file: URIs require a build with HL_ENABLE_SQLITE" },
-    { "duckdb",     "duckdb:// needs the DuckDB feature: run 'hull feature install duckdb', then build the app with 'hull build --with=duckdb'" },
-    { "mysql",      "mysql:// needs the MySQL feature: run 'hull feature install mysql', then build the app with 'hull build --with=mysql'" },
-    { "mariadb",    "mariadb:// needs the MySQL feature: run 'hull feature install mysql', then build the app with 'hull build --with=mysql'" },
+    { "duckdb",     HINT_DD },
+    { "mysql",      HINT_MY },
+    { "mariadb",    HINT_MY },
 };
 
 static int scheme_in(const char *const *list, const char *scheme)

--- a/src/hull/cap/db_select.c
+++ b/src/hull/cap/db_select.c
@@ -84,21 +84,24 @@ static const HlDbBackend *const BACKENDS[] = {
  * hull, a source build with the compile flag, or SQLite. */
 #if defined(__COSMOPOLITAN__)
 static const char HINT_PG[] =
-    "postgres:// is not available on this build. Features are native static "
+    "postgres:// needs the Postgres feature, which is not available on this "
+    "build. Features are native static "
     "archives and a fat APE cannot load one, so they are not published for "
     "cosmo. Use a native hull (linux-x86_64, linux-aarch64, darwin-arm64) "
     "with 'hull feature install postgres' then 'hull build --with=postgres', "
     "or build from source with HL_ENABLE_POSTGRES=1. A SQLite DSN works on "
     "this build.";
 static const char HINT_MY[] =
-    "mysql:// is not available on this build. Features are native static "
+    "mysql:// needs the MySQL feature, which is not available on this build. "
+    "Features are native static "
     "archives and a fat APE cannot load one, so they are not published for "
     "cosmo. Use a native hull (linux-x86_64, linux-aarch64, darwin-arm64) "
     "with 'hull feature install mysql' then 'hull build --with=mysql', or "
     "build from source with HL_ENABLE_MYSQL=1. A SQLite DSN works on this "
     "build.";
 static const char HINT_DD[] =
-    "duckdb:// is not available on this build. Features are native static "
+    "duckdb:// needs the DuckDB feature, which is not available on this "
+    "build. Features are native static "
     "archives and a fat APE cannot load one, so they are not published for "
     "cosmo. Use a native hull (linux-x86_64, linux-aarch64, darwin-arm64) "
     "with 'hull feature install duckdb' then 'hull build --with=duckdb'. "

--- a/tests/hull/cap/test_db_select.c
+++ b/tests/hull/cap/test_db_select.c
@@ -53,6 +53,14 @@ UTEST(db_select, postgres_scheme)
 #else
     ASSERT_FALSE(b); ASSERT_TRUE(err);
     ASSERT_TRUE(strstr(err, "feature install postgres") != NULL);
+#  if defined(__COSMOPOLITAN__)
+    /* A cosmo build cannot load a native feature archive, so `hull feature
+     * install` refuses for every feature. The hint must not read as though
+     * running it would fix this, and must name a route that works. */
+    ASSERT_TRUE(strstr(err, "not available on this build") != NULL);
+    ASSERT_TRUE(strstr(err, "native hull") != NULL);
+    ASSERT_TRUE(strstr(err, "SQLite") != NULL);
+#  endif
 #endif
 }
 
@@ -70,6 +78,10 @@ UTEST(db_select, mysql_scheme)
 #else
     ASSERT_FALSE(b); ASSERT_TRUE(err);
     ASSERT_TRUE(strstr(err, "feature install mysql") != NULL);
+#  if defined(__COSMOPOLITAN__)
+    ASSERT_TRUE(strstr(err, "not available on this build") != NULL);
+    ASSERT_TRUE(strstr(err, "native hull") != NULL);
+#  endif
     b = hl_db_backend_select("mariadb://u@h/db", &err);
     ASSERT_FALSE(b); ASSERT_TRUE(strstr(err, "feature install mysql") != NULL);
 #endif


### PR DESCRIPTION
A Windows user whose app uses a `postgres://` DSN was told:

```
postgres:// needs the Postgres feature: run 'hull feature install postgres',
then build the app with 'hull build --with=postgres'
```

Running that prints:

```
hull feature: 'postgres' is not available for cosmo
(features are native-only; not published for cosmo)
```

and the trail ends there.

## Why the route does not exist

Features ship as **native static archives**, and a fat APE cannot force-load one. `FEATURES[]` has no cosmo column at all — `has_linux_x86_64`, `has_linux_aarch64`, `has_darwin_arm64` are the only three. So this is not a missing build artifact that someone could publish; the table has nowhere to express one. The hint named a route that cannot be made to exist by running anything.

## Change

On cosmo, the reserved-scheme hints for `postgres`/`postgresql`, `mysql`/`mariadb` and `duckdb` now state the capability is unavailable on this build, say why in one clause, and name the routes that **do** work:

- a native hull (`linux-x86_64`, `linux-aarch64`, `darwin-arm64`) with `hull feature install` + `hull build --with=`
- a source build with `HL_ENABLE_POSTGRES=1` / `HL_ENABLE_MYSQL=1` — both are pure C with no vendored engine, so this genuinely works on Windows; DuckDB and GPU are not viable that way
- SQLite, which the cosmo base compiles in

Native builds keep the existing wording. Written as string arrays rather than multi-line macros so the text needs no backslash continuations.

## Docs

`docs/windows_install.md` said **nothing** about any of this (grep for feature/postgres/mysql/duckdb/gpu/wamrc/sandbox returned empty). It now carries the capability matrix:

- works: Lua/JS runtimes, `fs`/`crypto`/`http`/`time`/`env`, SQLite and everything built on it, WASM compute, `hull.tui`, `hull build`
- native-only: postgres, mysql, duckdb, gpu
- compute runs **interpreted**, because `wamrc` needs LLVM and is not published for cosmo
- **no kernel sandbox**: `pledge`/`unveil` are no-ops on Windows, so the capability layer and manifest allowlists are the only boundary

## Test

`test_db_select` pins the cosmo contract: the hint must not read as though `hull feature install` would fix it, and must name a working route. Guarded by `__COSMOPOLITAN__`, so native CI keeps asserting the existing wording.