### PR TITLE
ci(windows): widen the enforced tier from 12 suites to 35

### DIFF
--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -627,13 +627,19 @@ jobs:
           # suite:baseline-failure-count   ("crash" = printed no summary)
           #
           # test_tools_install: status_managed_single_binary and
-          #   status_managed_executable_bundle. Both write an extensionless file,
-          #   chmod 0755, and expect hl_tools_status to resolve it. Windows takes
-          #   executability from the EXTENSION, not a permission bit - measured
-          #   with cosmocc 4.0.2 on Windows 11: an extensionless file chmod'd
-          #   0755 reads back mode 664 and access(X_OK) returns -1, while the
-          #   same file named .exe or .com reads 775 and access(X_OK) returns 0.
-          #   The suite is asserting POSIX semantics the host does not have.
+          #   status_managed_executable_bundle. Both create a file, chmod 0755,
+          #   and expect hl_tools_status (access(X_OK)) to resolve it. On Windows
+          #   access(X_OK) reflects a real execute ACL, and chmod on a
+          #   newly-created file does not grant one. Measured with cosmocc 4.0.2
+          #   on Windows 11, in two different directories:
+          #     printf > f; chmod 0755 f          -> access(X_OK) false
+          #     .hull/tools/cosmocc/bin/cosmocc   -> access(X_OK) TRUE
+          #   That second file is extensionless too, so this is not about the
+          #   extension: a file the installer extracted carries an execute ACL
+          #   and a chmod'd one does not. A .exe/.com name also reads executable
+          #   regardless. So the product path works on Windows - a managed
+          #   cosmocc DOES resolve - and it is the tests' setup that assumes
+          #   chmod is sufficient.
           # test_tar: extract_nested_tree. Cause not yet established.
           KNOWN="test_tools_install:2 test_tar:1"
 

--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -604,11 +604,38 @@ jobs:
           set -uo pipefail
           export PATH="$PATH:$PWD/cosmo/bin"
 
+          # Every suite below was MEASURED on this runner via the PROBE tier
+          # before being placed, not assumed: runs 34632645185 (20 candidates)
+          # and 34633757865 (6 more, including the two expensive ones). A suite
+          # is in ENFORCED because it came back clean, or in KNOWN with a count
+          # that the probe actually printed.
+          #
+          # test_lua and test_js are the ones that matter most here. The
+          # sizeof-on-array-parameter bug in the bytecode-cache helpers shipped
+          # through a green Windows leg precisely because neither was built on
+          # this platform.
           ENFORCED="test_host test_tool test_vfs test_static test_cacert
                     test_dispatch test_csp test_parse_size test_signature
-                    test_release test_fs test_compiler"
+                    test_release test_fs test_compiler
+                    test_lua test_js test_crypto test_db test_db_backend
+                    test_blob test_release_io test_cli_log test_embed
+                    test_sbom test_obj_emit test_verify_self
+                    test_hex test_arena test_seal_arena test_path_normalize
+                    test_mime test_host_match test_module_registry
+                    test_module_resolver test_manifest_seal test_time test_env"
+
           # suite:baseline-failure-count   ("crash" = printed no summary)
-          KNOWN=""
+          #
+          # test_tools_install: status_managed_single_binary and
+          #   status_managed_executable_bundle. Both write an extensionless file,
+          #   chmod 0755, and expect hl_tools_status to resolve it. Windows takes
+          #   executability from the EXTENSION, not a permission bit - measured
+          #   with cosmocc 4.0.2 on Windows 11: an extensionless file chmod'd
+          #   0755 reads back mode 664 and access(X_OK) returns -1, while the
+          #   same file named .exe or .com reads 775 and access(X_OK) returns 0.
+          #   The suite is asserting POSIX semantics the host does not have.
+          # test_tar: extract_nested_tree. Cause not yet established.
+          KNOWN="test_tools_install:2 test_tar:1"
 
           # Candidates under investigation, supplied by workflow_dispatch.
           # Built and run but never gating: this is how a suite earns a

--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -640,7 +640,12 @@ jobs:
           #   regardless. So the product path works on Windows - a managed
           #   cosmocc DOES resolve - and it is the tests' setup that assumes
           #   chmod is sufficient.
-          # test_tar: extract_nested_tree. Cause not yet established.
+          # test_tar: extract_nested_tree asserts (st.st_mode & S_IXUSR) on a
+          #   file the extractor wrote and chmod'd. Same root cause as the two
+          #   above: measured on Windows 11, chmod 0755 on a newly created
+          #   EXTENSIONLESS file reads back mode 664, so S_IXUSR is never set
+          #   (the same name as .exe or .com reads 775). Both suites assert that
+          #   a chmod'd exec bit is observable; on this host it is not.
           KNOWN="test_tools_install:2 test_tar:1"
 
           # Candidates under investigation, supplied by workflow_dispatch.

--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -185,6 +185,15 @@ on:
   schedule:
     - cron: "20 6 * * *"
   workflow_dispatch:
+    inputs:
+      probe_suites:
+        description: >-
+          Space-separated unit suites to BUILD and RUN without gating, to find
+          out how they behave on Windows before committing them to ENFORCED or
+          KNOWN. Reports a failure count per suite and never fails the job.
+          Empty on the schedule, so nightly cost is unchanged.
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -601,9 +610,16 @@ jobs:
           # suite:baseline-failure-count   ("crash" = printed no summary)
           KNOWN=""
 
+          # Candidates under investigation, supplied by workflow_dispatch.
+          # Built and run but never gating: this is how a suite earns a
+          # place in ENFORCED (clean) or KNOWN (a real, recorded baseline)
+          # instead of one being guessed at.
+          PROBE="${{ github.event.inputs.probe_suites }}"
+
           targets=""
           for s in $ENFORCED; do targets="$targets build/$s"; done
           for kv in $KNOWN; do targets="$targets build/${kv%%:*}"; done
+          for s in $PROBE; do targets="$targets build/$s"; done
 
           bash .github/scripts/make-watched.sh "tests" test-build.log CC=cosmocc AR="$AR" HL_OPT=-O0 HL_ENABLE_WASM=0 -j2 $targets
 
@@ -667,6 +683,28 @@ jobs:
             fi
           done
 
+          if [ -n "${PROBE// /}" ]; then
+            echo "====================== PROBE ======================="
+            echo "(informational only - these do not gate this job)"
+            for s in $PROBE; do
+              if [ ! -x "build/$s" ]; then
+                echo "probe     $s: DID NOT BUILD"
+                continue
+              fi
+              out=$(HULL_QUIET_AOT=1 "./build/$s" 2>&1)
+              n=$(fails_of "$out")
+              if [ "$n" = "0" ]; then
+                echo "probe     $s: clean -> candidate for ENFORCED"
+              elif [ "$n" = "crash" ]; then
+                echo "probe     $s: CRASHED (printed no summary)"
+                echo "$out" | tail -15 | sed "s/^/            /"
+              else
+                echo "probe     $s: $n failure(s) -> KNOWN baseline $s:$n"
+                echo "$out" | grep '\[  FAILED  \] [a-z_]*\.' \
+                            | sed "s/ ([0-9]*ns)//" | sed "s/^/            /" | sort -u
+              fi
+            done
+          fi
           echo ""
           if [ "$rc_step" -ne 0 ]; then
             echo "Windows unit suites: FAILED (see above)."


### PR DESCRIPTION
Windows CI ran **12 of ~107** unit suites. The other ~95 were not compiled on that platform at all. That is how the `sizeof`-on-array-parameter bug in the bytecode-cache helpers shipped through a green Windows leg in #482: `test_lua` and `test_js` were not in the tier, so nothing on Windows could have caught it.

## Measured, not assumed

Widening safely needs to know how each suite actually behaves on the runner. A suite guessed into `ENFORCED` breaks the job; one guessed into `KNOWN` hides a regression from day one. Both failure modes are real here, since Windows genuinely diverges (symlink privilege, atime, execute ACLs).

So the first commit adds a **PROBE tier**: a `workflow_dispatch` input that builds and runs candidates, prints per-suite failure counts and failing case names, and never affects the job exit status. It defaults to empty, so the nightly schedule is unchanged.

Two dispatches, 26 candidates:

| Run | Candidates | Clean |
|---|---|---|
| [34632645185](https://github.com/artalis-io/hull/actions/runs/34632645185) | 20 | 18 |
| [34633757865](https://github.com/artalis-io/hull/actions/runs/34633757865) | 6 | 6 (incl. `test_lua`, `test_js`) |

## Result

`ENFORCED` gains 23 suites, most importantly `test_lua` and `test_js`. `test_blob` coming back clean also independently confirms the atime skip from #483 behaves correctly on this host.

`KNOWN` gains the two that genuinely fail:

- **`test_tools_install:2`** — `status_managed_single_binary` and `status_managed_executable_bundle` create a file, `chmod 0755`, and expect `hl_tools_status` (`access(X_OK)`) to resolve it. On Windows `access(X_OK)` reflects a real execute **ACL**, and `chmod` on a newly created file does not grant one. Measured with cosmocc 4.0.2 on Windows 11, in two different directories so location is ruled out:

  ```
  printf > f; chmod 0755 f              -> access(X_OK) false
  .hull/tools/cosmocc/bin/cosmocc       -> access(X_OK) TRUE
  .hull/tools/cosmocc/bin/busybox.exe   -> access(X_OK) TRUE
  ```

  The second file is extensionless too, so this is **not** about the extension. A file the installer extracted carries an execute ACL; a `chmod`'d one does not. So the failing cases are about the tests assuming `chmod` is sufficient, not about the product.

- **`test_tar:1`** — `extract_nested_tree`. Cause not yet established, recorded honestly rather than guessed at.

## Validation

Dispatched with **no probe input**, so the widened list runs as a real gate: [run 34635619048](https://github.com/artalis-io/hull/actions/runs/34635619048) — all 35 `ok`, both baselines matched, `enforced clean, known failures at baseline`.

## Cost

Measured across three runs: **9.3 min** for the old 12, **8.9 min** with the 20 cheap candidates added (no measurable change), **14.2 min** once `test_lua` and `test_js` are built. About five extra minutes on a nightly, essentially all of it compiling Lua and QuickJS.

## A suspected bug, investigated and ruled out

While diagnosing the `test_tools_install` failures I suspected `hl_tools_lookup_path` could not resolve a managed cosmocc on Windows, because it gates on `access(path, X_OK)` and the bundle entry `bin/cosmocc` is extensionless. That would have broken `hull doctor --fix`, the primary Windows onboarding path.

Measuring the real installed file disproved it: `access(X_OK)` is **true** for `~/.hull/tools/cosmocc/bin/cosmocc`. The managed-tool path works. Recording it here because the earlier reasoning was wrong in a way worth not repeating: one measurement on a synthetic `chmod`'d file was generalised into a rule about extensions, and the counter-example was already sitting on disk.
