### PR TITLE
chore(keel): upgrade to v3.0.0

### DIFF
--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -302,10 +302,20 @@ jobs:
           # again it should say so here, in one line, instead of wedging for 45
           # minutes on a -O2 TU.
           echo "--- Keel receives the opt level directly ---"
+          # Keel v3.0.0 builds objects under build/<backend>/, so the -o target is
+          # build/<backend>/src/*.o and build/<backend>/vendor/llhttp/*.o; the
+          # pre-v3.0.0 src/*.o shape is still accepted. Hull compiles FLAT to
+          # build/*.o, so the extra directory level is what separates them.
+          # The `|| true` matters: under `set -euo pipefail` a grep matching
+          # nothing kills the assignment, and this probe died silently at exactly
+          # that point after the upgrade - printing its header and exiting 1
+          # without ever reaching the FAIL message that explains what to do.
           keel_opt=$("$MAKE_BIN" -n HL_OPT=-O0 vendor/keel/libkeel.a 2>/dev/null \
-                     | grep -- ' -c -o src/' | grep -oE ' -O[0-9]' | sort -u | tr -d ' ' | tr '\n' ' ')
+                     | grep -E -- ' -c -o (build/[^/]+/)?src/' \
+                     | grep -oE ' -O[0-9]' | sort -u | tr -d ' ' | tr '\n' ' ' || true)
           keel_vendor_opt=$("$MAKE_BIN" -n HL_OPT=-O0 vendor/keel/libkeel.a 2>/dev/null \
-                     | grep -- ' -c -o vendor/' | grep -oE ' -O[0-9]' | sort -u | tr -d ' ' | tr '\n' ' ')
+                     | grep -E -- ' -c -o (build/[^/]+/)?vendor/' \
+                     | grep -oE ' -O[0-9]' | sort -u | tr -d ' ' | tr '\n' ' ' || true)
           echo "  keel core TUs   : ${keel_opt:-<none>}"
           echo "  keel vendored   : ${keel_vendor_opt:-<none>}"
           if [ "$(echo $keel_opt)" = "-O0" ] && [ "$(echo $keel_vendor_opt)" = "-O0" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,21 @@ toolchain setup, APE filename conventions, Unix package managers, or Makefiles.
 
 ### Changed
 
+- **Keel upgraded to v3.0.0** (from the `3.0.0-rc.3`+3 pin). Hull inherits the
+  release's headline server fix without any code change: an early final response
+  is no longer destroyed by its own teardown. Previously a 413 / 431 / 415 / 500
+  - or an auth rejection on a `multipart` route, which is a documented Hull
+  pattern - left the request body unread, and closing a socket with unread
+  received data makes TCP send RST, discarding the response the client should
+  have seen. Keel now flushes the response, half-closes its send side, and drains
+  inbound bytes asynchronously, bounded by `reject_drain_max_bytes` (64 KiB) and
+  `reject_drain_timeout_ms` (500 ms); Hull leaves both at their defaults. Also
+  picked up: `kl_async_complete` sends the response when `on_resume` leaves the
+  connection processing, a connection pool no longer claims its old capacity
+  after being freed, and several IOCP correctness fixes that matter on Windows.
+  No API Hull uses changed - the only public removals are `max_align_t` from a
+  header (so MSVC consumers can compile it) and the prerelease version macros.
+
 - **`hull build` names the produced binary for the host that must run it.** The
   default output is now `app.com` on Windows (`app` on Linux/macOS, unchanged).
   Windows will not execute an extensionless file, so the APE previously written

--- a/tests/check_keel_flag_propagation.sh
+++ b/tests/check_keel_flag_propagation.sh
@@ -16,9 +16,15 @@
 # HOW. `make -n` through Hull's own recipe, then read Keel's inner compile
 # lines. Dry run, no artifacts, ~seconds - cheap enough to sit in the lint job.
 #
-# Keel's TUs are identified by their -o target: Keel compiles to `src/*.o` and
-# `vendor/llhttp/*.o` relative to vendor/keel, whereas Hull compiles everything
-# to `build/*.o`. Both groups are checked separately and deliberately: Keel
+# Keel's TUs are identified by their -o target. Keel v3.0.0 moved objects under
+# `build/<backend>/` so switching BACKEND= cannot mix incompatible objects into
+# one archive, making the target `build/<backend>/src/*.o` and
+# `build/<backend>/vendor/llhttp/*.o` relative to vendor/keel; the pre-v3.0.0
+# `src/*.o` / `vendor/llhttp/*.o` shape is still accepted so this gate keeps
+# working across a bisect. Hull compiles everything FLAT to `build/*.o`, so the
+# extra directory level is what tells the two apart - matching `build/` alone
+# would sweep in every Hull TU and make the assertions meaningless.
+# Both groups are checked separately and deliberately: Keel
 # splits CFLAGS (core) from VENDOR_CFLAGS (llhttp, the miniz adapter), and the
 # vendored half is exactly where the Windows wedge was observed, so a hook that
 # reached only one of them would look fine here and still be broken.
@@ -54,8 +60,8 @@ keel_lines() {
     $MAKE -Bn $1 vendor/keel/libkeel.a 2>/dev/null | grep -- ' -c -o ' || true
 }
 
-core_flags()   { printf '%s\n' "$1" | grep -- ' -c -o src/'; }
-vendor_flags() { printf '%s\n' "$1" | grep -- ' -c -o vendor/llhttp/'; }
+core_flags()   { printf '%s\n' "$1" | grep -E -- ' -c -o (build/[^/]+/)?src/'; }
+vendor_flags() { printf '%s\n' "$1" | grep -E -- ' -c -o (build/[^/]+/)?vendor/llhttp/'; }
 
 # $1 label, $2 make vars, $3 pattern that must appear, $4 pattern that must NOT
 # appear (empty to skip the negative assertion).


### PR DESCRIPTION
Moves `vendor/keel` from the `3.0.0-rc.3`+3 pin (`82affaa`) to the **v3.0.0** tag (`179392a`). A clean fast-forward of 29 commits; nothing in Hull pinned a prerelease, so the submodule pointer is the only required change.

## What Hull inherits, with no code change

**An early final response is no longer destroyed by its own teardown.** A 413 / 431 / 415 / 500 — or an auth rejection on a `multipart` route, which is a documented Hull pattern — left the request body unread, and closing a socket with unread received data makes TCP send RST, discarding data the peer had already buffered. The client saw a reset instead of the response explaining why. Keel now flushes the response, half-closes its send side, and drains inbound bytes asynchronously, bounded by `reject_drain_max_bytes` (64 KiB) and `reject_drain_timeout_ms` (500 ms).

Also picked up: `kl_async_complete` sends the response when `on_resume` leaves the connection processing; a freed connection pool no longer claims its old capacity; and several IOCP correctness fixes (watcher re-arm ordering, `kl_watcher_mod` honouring the interest mask) that matter on Windows.

## A config subtlety worth recording

Hull builds `KlHttpServerConfig` with a designated initializer, so both new fields are `0`. That is the **default-selecting** value, not the disabling one:

```c
if (s->config.reject_drain_max_bytes == 0 && s->config.reject_drain_timeout_ms == 0) {
    s->config.reject_drain_max_bytes = KL_HTTP_SERVER_DEFAULT_REJECT_DRAIN_BYTES;
    s->config.reject_drain_timeout_ms = KL_HTTP_SERVER_DEFAULT_REJECT_DRAIN_MS;
}
```

So Hull gets the fix. Worth stating explicitly because Keel's public header says the opposite — "set bytes to 0 and timeout to 0 to disable" — and its own inline comment says a third thing, "0 for EITHER disables". The code is authoritative; the header is being reported upstream.

## Integration points, checked rather than assumed

| Concern | Finding |
|---|---|
| `build: isolate objects per backend` | `OBJDIR` → `build/<backend>/`, but `LIB = libkeel.a` stays top-level, so `KEEL_LIB` is unaffected |
| Cosmo fat pairing | `.aarch64/libkeel.a` still produced; `cosmo_fat_repair.sh`'s `$_d/.aarch64/$_b` probe works at any depth |
| Public API removals | only `max_align_t` from a header (an MSVC fix) and the prerelease version macros |
| `KlSocketOps` gains `.shutdown` | source-compatible with Hull's designated-initializer test providers — unset fields zero-init, NULL selects the built-in |

## Verification

CI, not local. Building Keel on this Windows box stalls compiling `llhttp.c` — the same cosmocc large-TU wedge reported upstream as [jart/cosmopolitan#1522](https://github.com/jart/cosmopolitan/issues/1522) that also stalls `sqlite3.c`. The Linux/macOS/Cosmo jobs build and run the full suite, and I will dispatch the Windows workflow against this branch as well.