### PR TITLE
fix(tools): resolve a managed tool the installer itself wrote on Windows

### DIFF
--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -622,44 +622,24 @@ jobs:
                     test_sbom test_obj_emit test_verify_self
                     test_hex test_arena test_seal_arena test_path_normalize
                     test_mime test_host_match test_module_registry
-                    test_module_resolver test_manifest_seal test_time test_env"
+                    test_module_resolver test_manifest_seal test_time test_env
+                    test_tools_install"
 
           # suite:baseline-failure-count   ("crash" = printed no summary)
           #
-          # test_tools_install: status_managed_single_binary and
-          #   status_managed_executable_bundle. Both create a file, chmod 0755,
-          #   and expect hl_tools_status (access(X_OK)) to resolve it. On Windows
-          #   access(X_OK) reflects a real execute ACL, and chmod on a
-          #   newly-created file does not grant one. Measured with cosmocc 4.0.2
-          #   on Windows 11, in two different directories:
-          #     printf > f; chmod 0755 f          -> access(X_OK) false
-          #     .hull/tools/cosmocc/bin/cosmocc   -> access(X_OK) TRUE
-          #   That second file is extensionless too, so this is not about the
-          #   extension: a file the installer extracted carries an execute ACL
-          #   and a chmod'd one does not. A .exe/.com name also reads executable
-          #   regardless. So the product path works on Windows - a managed
-          #   cosmocc DOES resolve - and it is the tests' setup that assumes
-          #   chmod is sufficient.
-          # NOT every entry below is benign. The two status_managed_* cases
-          # and test_tar are tests asserting something this host cannot do.
-          # extracted_bundle_resolves_like_doctor_resolves is different: it is a
-          # REAL Windows bug, landed failing on purpose so it is gated while the
-          # fix is designed. hl_tar_extract sets modes with chmod, Windows grants
-          # no execute ACL from that, so hl_tools_lookup_path's access(entry,
-          # X_OK) probe misses and the resolver returns the install DIRECTORY
-          # instead of bin/cosmocc. doctor_cosmocc_runnable then looks for
-          # busybox beside that path, gets ~/.hull/tools rather than
-          # ~/.hull/tools/cosmocc/bin, and reports the toolchain unusable - so
-          # `hull tools install cosmocc` succeeds and `hull doctor` still says
-          # not ready. When that is fixed this baseline drops back to 2.
-          #
           # test_tar: extract_nested_tree asserts (st.st_mode & S_IXUSR) on a
-          #   file the extractor wrote and chmod'd. Same root cause as the two
-          #   above: measured on Windows 11, chmod 0755 on a newly created
-          #   EXTENSIONLESS file reads back mode 664, so S_IXUSR is never set
-          #   (the same name as .exe or .com reads 775). Both suites assert that
-          #   a chmod'd exec bit is observable; on this host it is not.
-          KNOWN="test_tools_install:3 test_tar:1"
+          #   file the extractor wrote and chmod'd. Measured on Windows 11 with
+          #   cosmocc 4.0.2: chmod 0755 on a newly created EXTENSIONLESS file
+          #   reads back mode 664, so S_IXUSR is never set (the same name as
+          #   .exe or .com reads 775). The test asserts a chmod'd exec bit is
+          #   observable, and on this host it is not.
+          #
+          #   This is the TEST's assumption, not a product defect - unlike the
+          #   resolver bug that the same measurement exposed, which is fixed and
+          #   is why test_tools_install moved to ENFORCED. A candidate for an
+          #   honest UTEST_SKIP, the way test_fs and test_blob got one for
+          #   symlink privilege and atime.
+          KNOWN="test_tar:1"
 
           # Candidates under investigation, supplied by workflow_dispatch.
           # Built and run but never gating: this is how a suite earns a

--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -640,13 +640,26 @@ jobs:
           #   regardless. So the product path works on Windows - a managed
           #   cosmocc DOES resolve - and it is the tests' setup that assumes
           #   chmod is sufficient.
+          # NOT every entry below is benign. The two status_managed_* cases
+          # and test_tar are tests asserting something this host cannot do.
+          # extracted_bundle_resolves_like_doctor_resolves is different: it is a
+          # REAL Windows bug, landed failing on purpose so it is gated while the
+          # fix is designed. hl_tar_extract sets modes with chmod, Windows grants
+          # no execute ACL from that, so hl_tools_lookup_path's access(entry,
+          # X_OK) probe misses and the resolver returns the install DIRECTORY
+          # instead of bin/cosmocc. doctor_cosmocc_runnable then looks for
+          # busybox beside that path, gets ~/.hull/tools rather than
+          # ~/.hull/tools/cosmocc/bin, and reports the toolchain unusable - so
+          # `hull tools install cosmocc` succeeds and `hull doctor` still says
+          # not ready. When that is fixed this baseline drops back to 2.
+          #
           # test_tar: extract_nested_tree asserts (st.st_mode & S_IXUSR) on a
           #   file the extractor wrote and chmod'd. Same root cause as the two
           #   above: measured on Windows 11, chmod 0755 on a newly created
           #   EXTENSIONLESS file reads back mode 664, so S_IXUSR is never set
           #   (the same name as .exe or .com reads 775). Both suites assert that
           #   a chmod'd exec bit is observable; on this host it is not.
-          KNOWN="test_tools_install:2 test_tar:1"
+          KNOWN="test_tools_install:3 test_tar:1"
 
           # Candidates under investigation, supplied by workflow_dispatch.
           # Built and run but never gating: this is how a suite earns a

--- a/include/hull/tools_install.h
+++ b/include/hull/tools_install.h
@@ -66,6 +66,14 @@ typedef struct {
      * (the floor) point it at a sentinel file (crt1.o) that is never exec-looked
      * up. NULL for a single-binary tool. */
     const char *bundle_entry;
+    /* 1 when bundle_entry names an EXECUTABLE driver (zig, cosmocc), 0 when it
+     * is a data sentinel that only proves the bundle is present (crt1.o,
+     * libhull_platform.a). The resolver used to infer this from the filesystem
+     * by probing access(X_OK), which is wrong on a host where that probe cannot
+     * succeed for a file the installer itself just wrote - see
+     * hl_tools_lookup_path. Declaring the intent keeps the data-only fallback
+     * (resolve to the DIRECTORY) exact while letting a real driver resolve. */
+    int         bundle_entry_exec;
     /* Asset-name shape for a bundle. 0 (default): the ARCH is baked into the
      * name and the bundle is published for exactly one platform, so the asset is
      * `hull-<name>.tar` (the libc-musl-<arch> floor). 1: the name is arch-free

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -713,8 +713,12 @@ $(BUILDDIR)/test_release: $(TESTDIR)/hull/test_release.c $(RELEASE_OBJ) $(TEST_C
 		$(RELEASE_OBJ) $(TEST_COMMON_LIBS)
 
 # Tool registry + path helpers - standalone module, no runtime deps.
-$(BUILDDIR)/test_tools_install: $(TESTDIR)/hull/test_tools_install.c $(TOOLS_INSTALL_OBJ) $(FS_UTIL_OBJ) $(HOST_OBJ) | $(BUILDDIR)
-	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(TOOLS_INSTALL_OBJ) $(FS_UTIL_OBJ) $(HOST_OBJ)
+# cap_tar.o: extracted_bundle_resolves_like_doctor_resolves installs through the
+# REAL extractor (hl_tar_extract) rather than faking a layout with chmod, so the
+# install -> resolve seam is covered the way `hull tools install` + `hull doctor`
+# actually exercise it.
+$(BUILDDIR)/test_tools_install: $(TESTDIR)/hull/test_tools_install.c $(TOOLS_INSTALL_OBJ) $(FS_UTIL_OBJ) $(HOST_OBJ) $(BUILDDIR)/cap_tar.o | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(INCLUDES) -I$(VENDDIR) -o $@ $< $(TOOLS_INSTALL_OBJ) $(FS_UTIL_OBJ) $(HOST_OBJ) $(BUILDDIR)/cap_tar.o
 
 # release_io/sbom/verify_self now hash via the cap layer's self-contained
 # SHA-256 (hl_cap_crypto_sha256) instead of mbedtls_sha256, so these focused

--- a/src/hull/tools_install.c
+++ b/src/hull/tools_install.c
@@ -138,6 +138,7 @@ static const HlToolSpec REGISTRY[] = {
         .has_darwin_arm64     = 1,
         .is_bundle            = 1,
         .bundle_entry         = "zig",   /* the zig driver binary */
+        .bundle_entry_exec    = 1,
         .bundle_per_platform  = 1,
     },
     /* The trimmed Cosmopolitan cosmocc toolchain (+ a busybox-w64 ride-along at
@@ -162,6 +163,7 @@ static const HlToolSpec REGISTRY[] = {
         .has_cosmo            = 1,
         .is_bundle            = 1,
         .bundle_entry         = "bin/cosmocc",
+        .bundle_entry_exec    = 1,
     },
     { 0 }  /* sentinel */
 };
@@ -354,6 +356,53 @@ static int find_on_path(const char *name, char *out, size_t out_sz)
     return hl_host_find_in_path(name, out, out_sz) == 1 ? 0 : -1;
 }
 
+/* Is a bundle's entry usable as the thing the resolver should return?
+ *
+ * access(X_OK) is the right probe wherever it means something. It is what keeps
+ * a data-only bundle - crt1.o for the musl floors, libhull_platform.a for the
+ * platform ones - from being mistaken for a toolchain, and build.lua depends on
+ * those resolving to their DIRECTORY instead.
+ *
+ * Windows has no POSIX exec bit. access(X_OK) there reflects an execute ACL,
+ * and hl_tar_extract sets modes with chmod(), which does not grant one. So a
+ * bundle this very installer just laid down fails its own X_OK probe: the entry
+ * misses, the resolver falls through to the install directory, and every
+ * consumer expecting a driver path gets a directory instead. hull doctor then
+ * looks for busybox beside "the driver", finds ~/.hull/tools rather than
+ * ~/.hull/tools/cosmocc/bin, and reports the toolchain unusable - so
+ * `hull tools install cosmocc` succeeds and `hull doctor` still says not ready.
+ *
+ * Where the SPEC declares the entry an executable, trust the spec on that host
+ * and accept a regular file. POSIX behaviour is unchanged: there, a driver that
+ * is not executable is genuinely broken and must not resolve. */
+/* The same X_OK problem as bundle_entry_usable, for the single-binary shape.
+ * A non-bundle tool IS its executable, so there is no data-only case to keep
+ * apart here - on a host where the installer cannot make what it wrote pass
+ * X_OK, a regular file at the canonical install path is the tool.
+ *
+ * Latent rather than live today: every single-binary tool in the registry
+ * (wamrc) is has_cosmo = 0, so none can be installed on Windows in the first
+ * place. Fixed alongside the bundle path so the two do not drift, and so a
+ * future cosmo-published single-binary tool does not reintroduce it. */
+static int single_binary_usable(const char *path)
+{
+    if (access(path, X_OK) == 0) return 1;
+    if (!hl_host_is_windows())   return 0;
+
+    struct stat st;
+    return stat(path, &st) == 0 && S_ISREG(st.st_mode);
+}
+
+static int bundle_entry_usable(const HlToolSpec *spec, const char *path)
+{
+    if (access(path, X_OK) == 0) return 1;
+    if (!spec->bundle_entry_exec) return 0;
+    if (!hl_host_is_windows())    return 0;
+
+    struct stat st;
+    return stat(path, &st) == 0 && S_ISREG(st.st_mode);
+}
+
 int hl_tools_lookup_path(const char *name, const char *hull_exe,
                          char *out, size_t out_sz)
 {
@@ -373,7 +422,8 @@ int hl_tools_lookup_path(const char *name, const char *hull_exe,
         if (hl_tools_install_path(name, bdir, sizeof(bdir)) == 0) {
             char be[PATH_MAX];
             int n = snprintf(be, sizeof(be), "%s/%s", bdir, bspec->bundle_entry);
-            if (n > 0 && (size_t)n < sizeof(be) && access(be, X_OK) == 0) {
+            if (n > 0 && (size_t)n < sizeof(be) &&
+                bundle_entry_usable(bspec, be)) {
                 int m = snprintf(out, out_sz, "%s", be);
                 if (m < 0 || (size_t)m >= out_sz) return -1;
                 return 0;
@@ -387,7 +437,7 @@ int hl_tools_lookup_path(const char *name, const char *hull_exe,
      *    identically across helpers. */
     char cand[PATH_MAX];
     if (hl_tools_install_path(name, cand, sizeof(cand)) == 0 &&
-        access(cand, X_OK) == 0) {
+        single_binary_usable(cand)) {
         int n = snprintf(out, out_sz, "%s", cand);
         if (n < 0 || (size_t)n >= out_sz) return -1;
         return 0;

--- a/tests/hull/test_tools_install.c
+++ b/tests/hull/test_tools_install.c
@@ -32,6 +32,7 @@
 #include "utest.h"
 #include "hull/tools_install.h"
 #include "hull/shared/host.h"
+#include "hull/cap/tar.h"
 
 #include <errno.h>
 #include <ftw.h>
@@ -606,6 +607,76 @@ UTEST_F(tools_fixture, status_managed_single_binary) {
     ASSERT_EQ(st.source, HL_TOOL_SRC_MANAGED);
     ASSERT_STREQ(st.path, target);
     ASSERT_EQ(st.size_bytes, 4096ULL);
+}
+
+/* ── install -> resolve, through the REAL extractor ──────────────────────
+ *
+ * Everything else in this file fakes an install with write_data(), i.e. create
+ * + chmod. That is not how a tool arrives: `hull tools install <bundle>` lands
+ * it with hl_tar_extract, and `hull doctor` then resolves it through
+ * hl_tools_status -> hl_tools_lookup_path, whose bundle probe is a single
+ * access(entry, X_OK).
+ *
+ * Nothing covered that seam end to end on any platform. discover_compilers in
+ * doctor.c falls back to hl_tools_status specifically so "a PATH-only probe
+ * would [not] report a hull-installed cosmocc as missing", and CI never
+ * exercises that branch because it puts cosmocc on PATH.
+ *
+ * It matters most where the two halves can disagree. On Windows access(X_OK)
+ * reflects an execute ACL rather than a permission bit, and hl_tar_extract sets
+ * modes with chmod(), so "extracted" and "executable" are not obviously the
+ * same thing there. This test asserts they are: install the way the installer
+ * installs, then resolve the way doctor resolves.
+ */
+static void tools_put_header(unsigned char *b, const char *name, size_t size,
+                             unsigned mode)
+{
+    memset(b, 0, 512);
+    strncpy((char *)b, name, 99);
+    snprintf((char *)(b + 100), 8, "%07o", mode);
+    snprintf((char *)(b + 124), 12, "%011o", (unsigned)size);
+    memset(b + 148, ' ', 8);
+    b[156] = '0';
+}
+
+UTEST_F(tools_fixture, extracted_bundle_resolves_like_doctor_resolves) {
+    /* A cosmocc-shaped bundle: the entry the registry names, plus one sibling
+     * so the directory is not degenerate. */
+    unsigned char *tar = calloc(1, 8192);
+    ASSERT_NE(tar, NULL);
+    size_t off = 0;
+    tools_put_header(tar + off, "bin/cosmocc", 6, 0755);
+    off += 512;
+    memcpy(tar + off, "DRIVER", 6);
+    off += 512;
+    tools_put_header(tar + off, "lib/x.a", 4, 0644);
+    off += 512;
+    memcpy(tar + off, "DATA", 4);
+    off += 512;
+    off += 1024;   /* two zero blocks: end of archive */
+
+    char root[PATH_MAX];
+    ASSERT_EQ(hl_tools_install_path("cosmocc", root, sizeof(root)), 0);
+    ASSERT_EQ(hl_tar_extract(tar, off, root), 0);
+    free(tar);
+
+    /* The file landed. */
+    char entry[PATH_MAX];
+    snprintf(entry, sizeof(entry), "%s/bin/cosmocc", root);
+    struct stat st;
+    ASSERT_EQ(stat(entry, &st), 0);
+
+    /* And doctor's resolver finds it. This is the assertion that matters: if a
+     * host cannot make an extracted file executable, `hull tools install
+     * cosmocc` succeeds and `hull doctor` still reports cosmocc missing, which
+     * would break `hull doctor --fix` - the primary Windows onboarding path. */
+    HlToolStatus ts;
+    ASSERT_EQ(hl_tools_status("cosmocc", NULL, &ts), 0);
+    ASSERT_TRUE(ts.managed);
+    ASSERT_TRUE_MSG(ts.resolved,
+        "extracted bundle entry did not resolve; hull tools install would "
+        "succeed while hull doctor still reports the tool missing");
+    ASSERT_STREQ(ts.path, entry);
 }
 
 UTEST_F(tools_fixture, status_managed_executable_bundle) {


### PR DESCRIPTION
On Windows, `hull tools install cosmocc` succeeded and `hull doctor` still reported the toolchain missing — breaking `hull doctor --fix`, the primary Windows onboarding path, which exists precisely to install it.

## Cause

`hl_tools_lookup_path` decided whether a bundle's entry was the thing to return by probing `access(entry, X_OK)`. That probe cannot succeed on Windows for a file this installer just wrote: there is no POSIX exec bit, `access(X_OK)` reflects an execute ACL, and `hl_tar_extract` sets modes with `chmod()`, which grants none.

The failure was not clean. The entry probe missed, the resolver fell through to "the install directory is searchable", and returned **the directory**. `doctor_cosmocc_runnable` then stripped the last component looking for busybox beside the driver, got `~/.hull/tools` instead of `~/.hull/tools/cosmocc/bin`, found none, and declared the toolchain unusable.

## Why not simply relax `X_OK`

That probe is what keeps a data-only bundle — `crt1.o` for the musl floors, `libhull_platform.a` for the platform ones — from being taken for a toolchain, and `build.lua` relies on those resolving to their **directory**. `status_managed_data_only_bundle` pins exactly that behaviour.

The filesystem cannot answer "is this meant to be an executable" on a host that cannot express it, so the **spec** answers instead: `HlToolSpec` gains `bundle_entry_exec`, set on `zig` and `cosmocc`, left `0` on the data-only floors. The resolver trusts that declaration on Windows and accepts a regular file. POSIX behaviour is unchanged — there, a driver that is not executable is genuinely broken and must not resolve.

The single-binary path had the same flaw and is fixed alongside so the two do not drift. That one is latent rather than live: every non-bundle tool in the registry (`wamrc`) is `has_cosmo = 0`, so none can be installed on Windows today.

## The test that found it

Every existing test in the file fakes an install with `write_data()` — create + `chmod`. That is not how a tool arrives. `extracted_bundle_resolves_like_doctor_resolves` installs through the **real** extractor and resolves the way doctor resolves, covering a seam nothing touched on any platform: `discover_compilers` falls back to `hl_tools_status` specifically so "a PATH-only probe would [not] report a hull-installed cosmocc as missing", and CI never exercised that branch because every job puts cosmocc on `PATH`.

## Evidence, on the CI runner rather than one laptop

| Windows run | Result |
|---|---|
| [34684605351](https://github.com/artalis-io/hull/actions/runs/34684605351) — before the fix | `known test_tools_install: 3 (baseline 3)` |
| [34684777161](https://github.com/artalis-io/hull/actions/runs/34684777161) — after | `ok test_tools_install` |

The suite is now clean on Windows and **promoted out of `KNOWN` into `ENFORCED`** (36 suites). `KNOWN` keeps only `test_tar:1`, whose comment now says plainly that it is the test's assumption — it asserts a `chmod`'d exec bit is observable — rather than a product defect, a distinction this fix made concrete.