### PR TITLE
test(tar): assert the exec bit separately, and skip it where a host drops it

### DIFF
--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -633,23 +633,14 @@ jobs:
                     test_hex test_arena test_seal_arena test_path_normalize
                     test_mime test_host_match test_module_registry
                     test_module_resolver test_manifest_seal test_time test_env
-                    test_tools_install"
+                    test_tools_install test_tar"
 
           # suite:baseline-failure-count   ("crash" = printed no summary)
           #
-          # test_tar: extract_nested_tree asserts (st.st_mode & S_IXUSR) on a
-          #   file the extractor wrote and chmod'd. Measured on Windows 11 with
-          #   cosmocc 4.0.2: chmod 0755 on a newly created EXTENSIONLESS file
-          #   reads back mode 664, so S_IXUSR is never set (the same name as
-          #   .exe or .com reads 775). The test asserts a chmod'd exec bit is
-          #   observable, and on this host it is not.
-          #
-          #   This is the TEST's assumption, not a product defect - unlike the
-          #   resolver bug that the same measurement exposed, which is fixed and
-          #   is why test_tools_install moved to ENFORCED. A candidate for an
-          #   honest UTEST_SKIP, the way test_fs and test_blob got one for
-          #   symlink privilege and atime.
-          KNOWN="test_tar:1"
+          # Empty. Every suite here is expected to be clean; a suite that is not
+          # belongs in KNOWN with a measured baseline and a stated cause, not
+          # quietly outside the tier.
+          KNOWN=""
 
           # Candidates under investigation, supplied by workflow_dispatch.
           # Built and run but never gating: this is how a suite earns a

--- a/tests/hull/cap/test_tar.c
+++ b/tests/hull/cap/test_tar.c
@@ -301,10 +301,56 @@ UTEST_F(tar_fixture, extract_nested_tree) {
     ASSERT_EQ(hl_tar_extract(buf, off, dest), 0);
 
     snprintf(p, sizeof(p), "%s/zig", dest);
-    ASSERT_EQ(stat(p, &st), 0);
-    ASSERT_TRUE(st.st_mode & S_IXUSR);            /* exec bit preserved */
+    ASSERT_EQ(stat(p, &st), 0);                   /* top-level file created */
     snprintf(p, sizeof(p), "%s/lib/std/foo.zig", dest);
     ASSERT_EQ(stat(p, &st), 0);                   /* deep nested file created */
+    free(buf);
+    /* The exec bit is asserted separately: it is the one property here that a
+     * host can fail to express, and folding it in cost this whole test - the
+     * nested-tree extraction it exists for included - on Windows. */
+}
+
+/* Can a chmod'd exec bit be observed on this host?
+ *
+ * hl_tar_extract applies a member's mode with chmod(). On Windows that grants
+ * no execute ACL for a newly created extensionless file: measured with cosmocc
+ * 4.0.2 on Windows 11, chmod 0755 reads back mode 664 and S_IXUSR is never set
+ * (the same name as .exe or .com reads 775). The extractor is doing the only
+ * thing it can; the host does not carry the bit. Probe rather than assume, so
+ * this also covers any other filesystem that drops it. */
+static int host_preserves_exec_bit(void)
+{
+    char probe[HL_TEST_PATH_MAX];
+    int fd = hl_test_mkstemp(probe, sizeof probe, "hull_execbit_probe", NULL);
+    if (fd < 0) return 1;              /* cannot tell - assert rather than skip */
+    close(fd);
+    if (chmod(probe, 0755) != 0) { unlink(probe); return 1; }
+
+    struct stat pst;
+    int ok = stat(probe, &pst) == 0 && (pst.st_mode & S_IXUSR) != 0;
+    unlink(probe);
+    return ok;
+}
+
+UTEST_F(tar_fixture, extract_preserves_exec_bit) {
+    if (!host_preserves_exec_bit())
+        UTEST_SKIP("host does not carry a chmod'd exec bit; hl_tar_extract "
+                   "applies the mode, the filesystem does not keep it");
+
+    unsigned char *buf = calloc(1, 8192);
+    ASSERT_NE(buf, NULL);
+    size_t off = 0;
+    tar_add_file(buf, &off, "./zig", "BINARY", 6);
+    off += 1024;
+
+    char dest[PATH_MAX], p[PATH_MAX];
+    snprintf(dest, sizeof(dest), "%s/xbit", utest_fixture->tmpdir);
+    ASSERT_EQ(hl_tar_extract(buf, off, dest), 0);
+
+    snprintf(p, sizeof(p), "%s/zig", dest);
+    struct stat st;
+    ASSERT_EQ(stat(p, &st), 0);
+    ASSERT_TRUE(st.st_mode & S_IXUSR);
     free(buf);
 }
 


### PR DESCRIPTION
The last `KNOWN` entry on Windows, removed by fixing the test rather than by baselining it.

`extract_nested_tree` checked two independent things: that a nested tree extracts (structure), and that a member's mode survives (`st_mode & S_IXUSR`). Only the second can fail for a reason that is not Hull's, and folding them together cost the **whole** test on Windows, including the nested-tree extraction it exists for.

## Why the assertion cannot hold there

`hl_tar_extract` applies a member's mode with `chmod()`. On Windows that grants no execute ACL for a newly created extensionless file. Measured with cosmocc 4.0.2 on Windows 11:

```
chmod 0755 on a new extensionless file   -> mode reads back 664, S_IXUSR unset
the same name as .exe or .com            -> mode reads back 775
```

The extractor is doing the only thing it can; the host does not carry the bit.

## Change

The exec-bit assertion moves into its own test that probes the host and skips when a `chmod`'d bit cannot be observed, the way `test_fs` and `test_blob` already skip for symlink privilege and atime. The probe is **behavioural rather than a platform check**, so any other filesystem that drops the bit is covered, and it defaults to asserting when it cannot tell.

A baseline said "one failure is expected here". A skip says "this assertion does not apply on this host" — which is the true statement, and it keeps the structural coverage running on Windows instead of discarding it.

## Result

`test_tar` is clean on Windows and joins `ENFORCED`, now **37 suites**. `KNOWN` is **empty**: every suite in the tier is expected to be clean, and one that is not belongs there with a measured baseline and a stated cause rather than quietly outside the tier.