### PR TITLE
chore: pin line endings in the repository, not in each clone

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,47 @@
+# Line endings are a property of the REPOSITORY, not of whoever cloned it.
+#
+# Without this file, each checkout inherits core.autocrlf from the machine.
+# Git for Windows sets it to `true` at SYSTEM level, so a Windows working tree
+# gets CRLF while Linux and macOS get LF. Committing normalises back to LF, so
+# the history has stayed clean by luck rather than by rule: one contributor with
+# core.autocrlf=false on Windows commits CRLF and the tree is permanently mixed.
+#
+# It is not only a tidiness question. Three things here read bytes off DISK and
+# care what they are:
+#   - scripts/wamr_apply_patches.sh pins patches/wamr/*.patch by sha256 of the
+#     working-tree file. A CRLF checkout cannot match a recorded LF hash, so the
+#     WASM build fails on Windows with "stale patch" for a reason that has
+#     nothing to do with the patch.
+#   - site/install.sh is minisign-signed (site/install.sh.minisig). A signature
+#     over LF content does not verify against a CRLF checkout.
+#   - The reproducible-build jobs compare artefacts across platforms.
+#
+# `text=auto` lets Git decide text vs binary by content; `eol=lf` then checks
+# text out as LF on every platform, Windows included. MSYS2, Git Bash, VS Code,
+# PowerShell and MSVC all read LF without complaint.
+* text=auto eol=lf
+
+# ── Byte-exact files ────────────────────────────────────────────────────────
+# `binary` is shorthand for `-text -diff`: never normalised, never line-diffed.
+# Content detection would catch most of these, but declaring them is the point -
+# a corrupted fixture is discovered late and looks like a code bug.
+*.wasm    binary
+*.aot     binary
+*.woff2   binary
+*.bin     binary
+*.der     binary
+*.pdf     binary
+*.png     binary
+*.jpg     binary
+*.jpeg    binary
+*.gif     binary
+*.webp    binary
+*.ico     binary
+*.minisig binary
+*.tar     binary
+*.gz      binary
+*.zip     binary
+
+# Fuzzer seed corpora: extensionless, byte-exact inputs. Normalising one changes
+# what it exercises without changing anything a reviewer would notice.
+fuzz/corpus_*/** binary


### PR DESCRIPTION
There was no `.gitattributes`, so every checkout inherited `core.autocrlf` from the machine. Git for Windows sets it to `true` at **system** level, so a Windows working tree gets CRLF while Linux and macOS get LF. Committing normalises back to LF, which is why history has stayed clean so far: **by luck rather than by rule**. One contributor with `core.autocrlf=false` on Windows commits CRLF and the tree is mixed permanently.

## It is not only tidiness

Three things in this repo read bytes off **disk** and care what they are:

- **`scripts/wamr_apply_patches.sh` pins `patches/wamr/*.patch` by `sha256` of the working-tree file.** A CRLF checkout cannot match a recorded LF hash, so a WASM-enabled build fails on Windows with `stale patch` for a reason that has nothing to do with the patch. This is a live second wall behind the dirty-submodule one that blocks `HL_ENABLE_WASM=1` on Windows.
- **`site/install.sh` is minisign-signed** (`site/install.sh.minisig`). A signature over LF content does not verify against a CRLF checkout.
- The reproducible-build jobs compare artefacts across platforms.

Verified after the change, on Windows:

```
recorded: 423beeae0e94454381ce0d805e9985c5cd94e14e511981c629af186676411698
on-disk : 423beeae0e94454381ce0d805e9985c5cd94e14e511981c629af186676411698
```

## What it does

`* text=auto eol=lf` makes the repository the authority: content normalises to LF on the way in, and checks out as LF everywhere including Windows. MSYS2, Git Bash, VS Code, PowerShell and MSVC all read LF without complaint.

Byte-exact files are declared `binary` rather than left to content detection, because a corrupted fixture surfaces late and reads like a code bug: media and archive types, `*.minisig`, `*.der`, and the extensionless **fuzzer seed corpora** under `fuzz/corpus_*/`.

## No committed content changes

The repository already stores pure LF, verified by hashing tracked text files out of `HEAD` rather than the working tree. This commit only stops that depending on who cloned it. The diff is one new file, 47 lines.

One trap worth recording: `git add --renormalize .` is the **wrong** tool here. My working tree already held CRLF copies of the corpora from the old `autocrlf=true` checkout, so re-staging them once they are declared `binary` would have committed the polluted bytes verbatim. The correct move is to let Git re-materialise the working tree from the unchanged repository content under the new rules, after which `git status` is clean and every sampled corpus matches the repo byte-for-byte.