### PR TITLE
feat(cosmo): compile the PostgreSQL and MySQL backends into the cosmo base

### DIFF
--- a/mk/flags.mk
+++ b/mk/flags.mk
@@ -51,6 +51,28 @@ HL_ENABLE_POSTGRES ?= 0
 HL_ENABLE_MYSQL    ?= 0
 HL_ENABLE_DUCKDB   ?= 0
 endif
+# Cosmo compiles the composable subsystems IN, the same reasoning as
+# HL_ENABLE_TUI: a fat APE cannot force-load a native feature archive, and
+# FEATURES[] has no cosmo column at all (has_linux_x86_64, has_linux_aarch64,
+# has_darwin_arm64 are the only three), so `hull feature install postgres`
+# refuses with "not published for cosmo". Left at 0, postgres:// and mysql://
+# are unreachable on EVERY cosmo host, Windows included, with no route that
+# could be made to work.
+#
+# These two are the pair that can be compiled in. Both are pure C wire clients
+# with no vendored engine - cap/pgwire.c and cap/mysqlwire.c, ~1800 lines with
+# their vtables - and they reuse the mbedTLS and cap/crypto the cosmo base
+# already carries for sslmode and SCRAM / caching_sha2 auth. DuckDB (a vendored
+# C++ engine) and GPU (wgpu-native) genuinely cannot follow: they stay
+# native-only.
+#
+# Placed AFTER the HL_ENABLE_DB=0 block above so that pin still wins: ?= only
+# assigns when unset.
+ifeq ($(COSMO),1)
+HL_ENABLE_POSTGRES ?= 1
+HL_ENABLE_MYSQL    ?= 1
+endif
+
 HL_ENABLE_SQLITE   ?= 1
 HL_ENABLE_POSTGRES ?= 0
 HL_ENABLE_MYSQL    ?= 0


### PR DESCRIPTION
`postgres://` and `mysql://` were unreachable on every cosmo host, Windows included — and not because nobody had published the artefact.

Features ship as **native static archives**, a fat APE cannot force-load one, and `FEATURES[]` has no cosmo column at all (`has_linux_x86_64`, `has_linux_aarch64`, `has_darwin_arm64` are the only three). So `hull feature install postgres` refuses with *"not available for cosmo (features are native-only)"*. There was no route a user could take to make it work. #486 fixed the misleading hint; this fixes the capability.

## Why these two can be compiled in

Cosmo already answers this for every other composable subsystem by compiling it in. `HL_ENABLE_TUI` is `0` native and `1` on cosmo for exactly this reason, and WASM and SQLite are in-base there too. These two backends can follow:

- both are **pure C wire clients with no vendored engine** — `cap/pgwire.c` and `cap/mysqlwire.c`, ~1800 lines including their vtables
- they reuse the mbedTLS and `cap/crypto` the cosmo base **already carries**, for `sslmode` and for SCRAM / `caching_sha2` auth

**DuckDB and GPU cannot follow** and stay native-only: one is a vendored C++ engine, the other needs wgpu-native. That asymmetry is the real story, rather than "four capabilities are missing on Windows".

## Implementation

Mirrors the TUI precedent in `mk/flags.mk`, placed **after** the `HL_ENABLE_DB=0` block so that pin still wins (`?=` only assigns when unset).

Verified by dry run before any build:

| build | macros |
|---|---|
| cosmo | `-DHL_ENABLE_POSTGRES -DHL_ENABLE_MYSQL -DHL_ENABLE_SQLITE -DHL_ENABLE_TUI` |
| native | `-DHL_ENABLE_SQLITE` (unchanged) |
| cosmo + `HL_ENABLE_DB=0` | neither pg nor mysql macro |

## What reviewers should weigh

This changes the **shipped `hull-cosmo` artefact**: it gains both backends. The docs put each at roughly 48 KB of pure C, and CI's Cosmopolitan (APE) job is the real check on build and size. If the size is judged not worth it, the alternative is to keep them off and say so explicitly in `docs/windows_install.md`, which currently lists them as simply unavailable.