### PR TITLE
Windows: accept the path form a Git Bash shell hands us, and get e2e running there

### DIFF
--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -814,6 +814,23 @@ jobs:
         run: |
           set -uo pipefail
           export PATH="$PATH:$PWD/cosmo/bin"
+
+          # Put every suite's scratch directory somewhere msys2 and an APE
+          # agree about. 94 of the 99 e2e scripts call `mktemp -d`, which
+          # honours $TMPDIR, so this reaches all of them without touching one
+          # of them. Unset, mktemp lands in msys2's OWN /tmp mount, which msys2
+          # spells to a native program as D:/a/_temp/msys64/tmp/... - the path
+          # e2e-migrate was handed and could not open ("cannot open database
+          # D:/a/_temp/msys64/tmp/tmp.XXXX/app2/data.db"). $RUNNER_TEMP is a
+          # real directory outside that mount, which both sides can name.
+          # Same lesson as #482 one layer out: agree on the temp directory
+          # rather than assume /tmp means the same thing to both.
+          if [ -n "${RUNNER_TEMP:-}" ]; then
+            export TMPDIR="$(cygpath -u "$RUNNER_TEMP" 2>/dev/null || echo "$RUNNER_TEMP")"
+          fi
+          echo "TMPDIR=${TMPDIR:-<unset>}"
+          probe_dir=$(mktemp -d) && echo "mktemp -d -> $probe_dir" && rmdir "$probe_dir"
+
           rc_all=0
           for t in ${{ inputs.probe_e2e }}; do
             echo "===================== $t ====================="

--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -271,6 +271,10 @@ jobs:
       #               git-less build succeeds but stamps HL_VERSION=dev. A
       #               source-build job should stamp the real revision.
       # coreutils, findutils, grep, sed and gawk are all in the MSYS base.
+      #   python    - 17 e2e scripts shell out to python3 to pick a field
+      #               out of hull's JSON. Without it they die at Error 127
+      #               (measured: e2e-jobs, run 34721432268). Only this job
+      #               runs e2e, so the app-build job does not need it.
       - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884  # v2.32.0
         with:
           msystem: MSYS
@@ -281,6 +285,7 @@ jobs:
             vim
             diffutils
             git
+            python
 
       # cosmocc ships as a zip of APEs; SHA-pinned, same acquisition as the
       # sibling cosmocc workflows.
@@ -842,6 +847,31 @@ jobs:
           # receives the POSIX path unchanged.
           export MSYS2_ARG_CONV_EXCL='*'
           echo "MSYS2_ARG_CONV_EXCL=$MSYS2_ARG_CONV_EXCL"
+
+          # What a 10-suite probe measured once both of the above were in place
+          # (run 34721432268), so the next reader starts from the map rather
+          # than from the symptom:
+          #
+          #   ok      e2e-migrate  e2e-templates  e2e-examples  e2e-blob
+          #           e2e-multipart
+          #   FAILED  e2e-cli  e2e-http  e2e-cache  e2e-tools  e2e-jobs
+          #
+          # Four causes, not five:
+          #   e2e-cli, e2e-cache  "verify rc on corruption - got rc=0". The APE
+          #     exit-status shift (jart/cosmopolitan#1521): a POSIX shell reads 0
+          #     for every failure. Not fixable in Hull; these two stay out of the
+          #     tier until their assertions stop reading $?.
+          #   e2e-http  "cc: command not found". The script compiled its echo
+          #     server with a hardcoded cc; this runner has cosmocc and no native
+          #     cc. Fixed at the source: it honours $CC now.
+          #   e2e-jobs  Error 127 on python3. Fixed by installing python above.
+          #   e2e-tools  wamrc has has_cosmo=0, so the install hint legitimately
+          #     differs here, and the reported stub path differs in case from the
+          #     one the shell built. A platform difference, not a break.
+          #
+          # e2e-templates is worth a note: its symptom was "server did not
+          # start", which looks nothing like e2e-migrate's "cannot open
+          # database". Same path-form bug, different mask.
 
 
           rc_all=0

--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -820,37 +820,34 @@ jobs:
           set -uo pipefail
           export PATH="$PATH:$PWD/cosmo/bin"
 
-          # Put every suite's scratch directory somewhere msys2 and an APE
-          # agree about. 94 of the 99 e2e scripts call `mktemp -d`, which
-          # honours $TMPDIR, so this reaches all of them without touching one
-          # of them. Unset, mktemp lands in msys2's OWN /tmp mount, which msys2
-          # spells to a native program as D:/a/_temp/msys64/tmp/... - the path
-          # e2e-migrate was handed and could not open ("cannot open database
-          # D:/a/_temp/msys64/tmp/tmp.XXXX/app2/data.db"). $RUNNER_TEMP is a
-          # real directory outside that mount, which both sides can name.
-          # Same lesson as #482 one layer out: agree on the temp directory
-          # rather than assume /tmp means the same thing to both.
+          # Put every suite's scratch directory on the runner's own temp disk.
+          # 94 of the 99 e2e scripts call `mktemp -d`, which honours $TMPDIR,
+          # so this reaches all of them without touching one of them. Unset,
+          # mktemp lands inside msys2's /tmp mount instead, which is a place
+          # only msys2 names that way. Same lesson as #482 one layer out:
+          # agree on the temp directory rather than assume /tmp means the same
+          # thing to both sides.
+          #
+          # This is hygiene, NOT the fix for the path-form bug. That was a
+          # separate defect on the hull side, fixed by hl_host_normalize_path;
+          # moving the scratch dir changed the prefix and nothing else.
           if [ -n "${RUNNER_TEMP:-}" ]; then
             export TMPDIR="$(cygpath -u "$RUNNER_TEMP" 2>/dev/null || echo "$RUNNER_TEMP")"
           fi
           echo "TMPDIR=${TMPDIR:-<unset>}"
           probe_dir=$(mktemp -d) && echo "mktemp -d -> $probe_dir" && rmdir "$probe_dir"
 
-          # Hand the APE a path IT can parse. msys2 rewrites a POSIX argument to
-          # a native program into the mixed form D:/a/_temp/... (drive letter,
-          # forward slashes). Moving the scratch dir out of msys2's /tmp mount
-          # changed the prefix and nothing else: e2e-migrate still reported
-          # "cannot open database D:/a/_temp/tmp.XXXX/app2/data.db", so the mount
-          # was never the problem and the FORM is the remaining suspect. Cosmo
-          # spells absolute paths /D/a/... and opens /C/... and /c/... happily
-          # (measured). MSYS2_ARG_CONV_EXCL='*' turns the rewriting off so hull
-          # receives the POSIX path unchanged.
-          export MSYS2_ARG_CONV_EXCL='*'
-          echo "MSYS2_ARG_CONV_EXCL=$MSYS2_ARG_CONV_EXCL"
+          # NOTE: this step deliberately does NOT set MSYS2_ARG_CONV_EXCL.
+          # The shell converts a POSIX argument to the mixed form
+          # "D:/a/_temp/..." on its way to the APE, and that is exactly what a
+          # user driving hull from Git Bash gets. Suppressing the conversion
+          # here would only hide whether hull itself copes. It does now:
+          # hl_host_normalize_path rewrites a leading drive letter to the
+          # rooted form SQLite's unix VFS requires. Leaving the conversion ON
+          # is what keeps that fix honest.
 
-          # What a 10-suite probe measured once both of the above were in place
-          # (run 34721432268), so the next reader starts from the map rather
-          # than from the symptom:
+          # What a 10-suite probe measured (run 34721432268), so the next
+          # reader starts from the map rather than from the symptom:
           #
           #   ok      e2e-migrate  e2e-templates  e2e-examples  e2e-blob
           #           e2e-multipart

--- a/.github/workflows/windows-source-build.yml
+++ b/.github/workflows/windows-source-build.yml
@@ -831,6 +831,19 @@ jobs:
           echo "TMPDIR=${TMPDIR:-<unset>}"
           probe_dir=$(mktemp -d) && echo "mktemp -d -> $probe_dir" && rmdir "$probe_dir"
 
+          # Hand the APE a path IT can parse. msys2 rewrites a POSIX argument to
+          # a native program into the mixed form D:/a/_temp/... (drive letter,
+          # forward slashes). Moving the scratch dir out of msys2's /tmp mount
+          # changed the prefix and nothing else: e2e-migrate still reported
+          # "cannot open database D:/a/_temp/tmp.XXXX/app2/data.db", so the mount
+          # was never the problem and the FORM is the remaining suspect. Cosmo
+          # spells absolute paths /D/a/... and opens /C/... and /c/... happily
+          # (measured). MSYS2_ARG_CONV_EXCL='*' turns the rewriting off so hull
+          # receives the POSIX path unchanged.
+          export MSYS2_ARG_CONV_EXCL='*'
+          echo "MSYS2_ARG_CONV_EXCL=$MSYS2_ARG_CONV_EXCL"
+
+
           rc_all=0
           for t in ${{ inputs.probe_e2e }}; do
             echo "===================== $t ====================="

--- a/docs/windows_install.md
+++ b/docs/windows_install.md
@@ -295,6 +295,37 @@ produces there, since both are APEs. It does not affect Linux, macOS, or the
 BSDs. Windows CI that shells out to `hull` from bash should assert artifacts or
 output; a bare `hull ... && ...` chain is not a check.
 
+## Paths from Git Bash and MSYS2
+
+If you drive `hull` from Git Bash, MSYS2 or Cygwin, that shell rewrites a POSIX
+path argument on its way to a native program into the MIXED form
+`D:/work/app/data.db` - drive letter, colon, forward slashes. A Cosmopolitan
+APE is a native program, so that is what `hull` was handed.
+
+Windows itself is happy with that spelling: `open`, `stat` and `mkdir` all
+accept it. The vendored POSIX code inside Hull was not. SQLite's unix VFS
+decides absolute-vs-relative by testing for a leading `/`, so it read
+`D:/work/app/data.db` as RELATIVE, prepended the current directory, and failed
+to open the result. The symptom was a flat contradiction:
+
+```
+hull migrate: cannot open database D:/work/app/data.db
+```
+
+on a database that plainly exists, at a path you can `ls`.
+
+**Hull now rewrites a leading drive letter to the rooted form both layers
+accept** - `D:/work/app/data.db` becomes `/D/work/app/data.db`, which is also
+what cosmo's own `getcwd()` returns. Backslashes are folded in that same case,
+so `D:\work\app\data.db` works too. The rewrite is Windows-only, applies
+only to a SINGLE letter followed by `:` and a separator, and therefore never
+touches a `postgres://` DSN (no real URI scheme is one character) or a POSIX
+path (which never carries a `:` at index 1).
+
+Nothing is required of you. On a Hull released before this fix, the
+workaround is to export `MSYS2_ARG_CONV_EXCL='*'` before invoking `hull`, which
+tells the shell to stop converting arguments at all.
+
 ## What it does
 
 - Resolves the latest official stable release from `artalis-io/hull` (drafts and

--- a/include/hull/shared/host.h
+++ b/include/hull/shared/host.h
@@ -92,6 +92,50 @@ const char *hl_host_exe_suffix(void);
 int hl_host_render_exec(const char *path, char *out, size_t out_sz);
 
 /**
+ * @brief Buffer size a caller needs for @ref hl_host_normalize_path.
+ *
+ * The rewrite grows a path by exactly one byte, so this is one over the
+ * conventional 4096 POSIX limit.
+ */
+#define HL_HOST_PATH_MAX 4097
+
+/**
+ * @brief Rewrite a drive-letter path into the rooted form POSIX code needs.
+ *
+ * An MSYS2 / Git Bash shell rewrites a POSIX argument it passes to a NATIVE
+ * program into the MIXED form "D:/a/app/data.db" - drive letter, colon,
+ * forward slashes. A Cosmopolitan APE is a native program, so this is what
+ * hull is handed. The OS layer coped: open(), stat() and mkdir() all accept
+ * the mixed form (measured, cosmocc 4.0.2 on Windows 11).
+ *
+ * Vendored POSIX code does not. SQLite's unix VFS decides absolute-vs-relative
+ * with a leading '/' (sqlite3.c: a zPath[0] != slash test), so it treated
+ * "D:/a/app/data.db" as RELATIVE, prepended the cwd, and failed to open the
+ * nonexistent result - surfacing as "cannot open database D:/a/app/data.db",
+ * on a path that plainly exists.
+ *
+ * So the rewrite is to the one absolute form BOTH layers accept, which is
+ * also what cosmo's own getcwd() returns:
+ *
+ *   D:/a/app/data.db   ->  /D/a/app/data.db
+ *   D:\a\app\data.db   ->  /D/a/app/data.db
+ *
+ * Only a SINGLE letter followed by ':' and a separator is treated as a drive.
+ * That cannot collide with a URI scheme (no real scheme is one character), so
+ * a "postgres://" DSN passes through untouched, and it cannot collide with a
+ * POSIX path, which never has a ':' at index 1. Backslashes are folded to '/'
+ * only in the drive-letter case, so a POSIX filename that legitimately
+ * contains a backslash is left alone.
+ *
+ * On a non-Windows host this is a verbatim copy: the mixed form is not a path
+ * there, and rewriting it would corrupt a legal (if odd) relative filename.
+ *
+ * @returns 1 if @p out was rewritten, 0 if copied verbatim, -1 on a NULL or
+ *          oversized argument (@p out is emptied when it can be).
+ */
+int hl_host_normalize_path(const char *path, char *out, size_t out_sz);
+
+/**
  * @brief Find @p name as an executable on PATH, honouring host conventions.
  *
  * Splits PATH on the separator the LIST ITSELF uses, not the one the host

--- a/src/hull/cap/db_sqlite.c
+++ b/src/hull/cap/db_sqlite.c
@@ -17,6 +17,8 @@
 
 #include <sqlite3.h>
 #include <stdarg.h>
+#include "hull/shared/host.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -44,6 +46,17 @@ static int sqlite_open(void **ctx, const char *dsn, HlAllocator *alloc)
      * "/var/db", "sqlite://:memory:" -> ":memory:". */
     if (dsn && strncmp(dsn, "sqlite://", 9) == 0)
         dsn += 9;
+
+    /* An MSYS2 / Git Bash shell hands a native program the MIXED path form
+     * "D:/app/data.db". SQLite's unix VFS decides absolute-vs-relative on a
+     * leading '/', so it reads that as relative, prepends the cwd, and cannot
+     * open the result - "cannot open database D:/app/data.db" on a path that
+     * exists. Rewrite to the rooted form ("/D/app/data.db") SQLite and the OS
+     * both accept. No-op off Windows, and on anything without a drive letter -
+     * ":memory:" and "file:" URIs pass through untouched. */
+    char norm[HL_HOST_PATH_MAX];
+    if (dsn && hl_host_normalize_path(dsn, norm, sizeof norm) >= 0)
+        dsn = norm;
 
     int rc = sqlite3_open(dsn, &s->db);
     if (rc != SQLITE_OK) {

--- a/src/hull/shared/cache_dir.c
+++ b/src/hull/shared/cache_dir.c
@@ -6,6 +6,7 @@
  */
 
 #include "hull/shared/cache_dir.h"
+#include "hull/shared/host.h"
 #include "hull/shared/fs_util.h"
 #include <ctype.h>
 #include <errno.h>
@@ -54,6 +55,18 @@ int hl_hull_cache_dir(char *out, size_t out_sz)
      * for the registry-wide path-resolution rules. */
     const char *override = getenv("HULL_CACHE_DIR");
     if (override && *override) {
+        /* A Git Bash / MSYS2 user exports this as "C:/hull-cache", the mixed
+         * form that shell hands a native program. That is absolute, so accept
+         * it by rewriting to the rooted form the rest of this function (and
+         * blob_store, which also tests for a leading '/') requires. No-op off
+         * Windows and on an already-rooted path. */
+        char ovr[HL_HOST_PATH_MAX];
+        if (hl_host_normalize_path(override, ovr, sizeof ovr) < 0) {
+            errno = ENAMETOOLONG;
+            return -1;
+        }
+        override = ovr;
+
         if (override[0] != '/') { errno = EINVAL; return -1; }
         size_t olen = strlen(override);
         /* Strip trailing slashes for canonical form. */

--- a/src/hull/shared/host.c
+++ b/src/hull/shared/host.c
@@ -337,3 +337,42 @@ int hl_host_find_in_path_ex(const char *path_env, const char *name,
     }
     return 0;
 }
+
+/* -- Path form ----------------------------------------------------- */
+
+int hl_host_normalize_path(const char *path, char *out, size_t out_sz)
+{
+    if (!out || out_sz == 0) return -1;
+    out[0] = 0;
+    if (!path) return -1;
+
+    size_t len = strlen(path);
+    if (len + 1 > out_sz) return -1;
+
+    /* A drive letter is exactly ONE alphabetic character, a ':', and a
+     * separator. Anything longer before the ':' is a URI scheme and must be
+     * left alone (a 'postgres://' DSN reaches this function too). */
+    int drive = hl_host_is_windows() &&
+                ((path[0] >= 'A' && path[0] <= 'Z') ||
+                 (path[0] >= 'a' && path[0] <= 'z')) &&
+                path[1] == ':' &&
+                (path[2] == '/' || path[2] == '\\');
+
+    if (!drive) {
+        memcpy(out, path, len + 1);
+        return 0;
+    }
+
+    /* '/' + letter + the rest, which already starts with its own separator:
+     * "D:/a/x" -> "/D" + "/a/x". One byte longer than the input, so the
+     * length check above is re-run against the real output size. */
+    if (len + 2 > out_sz) return -1;
+
+    size_t n = 0;
+    out[n++] = '/';
+    out[n++] = path[0];
+    for (size_t i = 2; i < len; i++)
+        out[n++] = (path[i] == '\\') ? '/' : path[i];
+    out[n] = 0;
+    return 1;
+}

--- a/tests/e2e_http.sh
+++ b/tests/e2e_http.sh
@@ -100,7 +100,7 @@ fi
 SEAL_DEF="-DKEEL_SEAL_REQUEST=1"
 [ -n "${KEEL_DISABLE_SEAL_REQUEST:-}" ] && SEAL_DEF=""
 
-cc -std=c11 -Wall -Wextra -O2 $SEAL_DEF \
+${CC:-cc} -std=c11 -Wall -Wextra -O2 $SEAL_DEF \
     -I"$KEEL_DIR/include" \
     -I"$KEEL_DIR/vendor/sh_seal_arena" \
     -o "$ECHO_BIN" \

--- a/tests/hull/test_host.c
+++ b/tests/hull/test_host.c
@@ -469,4 +469,122 @@ UTEST(host, find_in_path_leaves_out_empty_when_the_buffer_is_too_small)
     ASSERT_STREQ("", small);      /* and must not leave a truncated one */
 }
 
+/* -- Path form (drive letter -> rooted) ---------------------------- */
+
+/*
+ * REGRESSION: an MSYS2 / Git Bash shell rewrites a POSIX argument handed to
+ * a native program into "D:/a/app/data.db". The OS layer accepts that form
+ * (measured: open/stat/mkdir all succeed), but SQLite's unix VFS tests for a
+ * leading '/' to decide absolute-vs-relative, so it prepended the cwd and
+ * failed with "cannot open database D:/a/app/data.db" on a path that exists.
+ * Five e2e suites failed this way on Windows before the rewrite landed.
+ */
+
+UTEST(host, normalize_path_rejects_bad_arguments)
+{
+    char buf[64];
+    ASSERT_EQ(-1, hl_host_normalize_path(NULL, buf, sizeof buf));
+    ASSERT_STREQ("", buf);
+    ASSERT_EQ(-1, hl_host_normalize_path("/tmp/x", NULL, sizeof buf));
+    ASSERT_EQ(-1, hl_host_normalize_path("/tmp/x", buf, 0));
+}
+
+UTEST(host, normalize_path_reports_overflow_rather_than_truncating)
+{
+    char small[4];
+    ASSERT_EQ(-1, hl_host_normalize_path("/a/much/longer/path", small, sizeof small));
+    ASSERT_STREQ("", small);
+}
+
+UTEST(host, normalize_path_passes_posix_paths_through_on_every_host)
+{
+    /* Host-INDEPENDENT: a rooted POSIX path is already the target form, and
+     * a relative one has no drive letter to rewrite. Neither may change on
+     * ANY host - this is the invariant that protects Linux and macOS. */
+    char buf[HL_HOST_PATH_MAX];
+    ASSERT_EQ(0, hl_host_normalize_path("/var/db/data.db", buf, sizeof buf));
+    ASSERT_STREQ("/var/db/data.db", buf);
+    ASSERT_EQ(0, hl_host_normalize_path("data.db", buf, sizeof buf));
+    ASSERT_STREQ("data.db", buf);
+    ASSERT_EQ(0, hl_host_normalize_path("./sub/data.db", buf, sizeof buf));
+    ASSERT_STREQ("./sub/data.db", buf);
+    ASSERT_EQ(0, hl_host_normalize_path("", buf, sizeof buf));
+    ASSERT_STREQ("", buf);
+}
+
+UTEST(host, normalize_path_never_touches_a_uri_scheme)
+{
+    /* A drive letter is ONE character before the ':'. Every real URI scheme
+     * is longer, so a DSN must survive verbatim on every host - otherwise
+     * this helper would corrupt the postgres/mysql connection strings that
+     * flow through the same open path. */
+    char buf[HL_HOST_PATH_MAX];
+    static const char *const dsns[] = {
+        "postgres://user@host/db", "postgresql://h/db", "mysql://h/db",
+        "mariadb://h/db", "sqlite://relative.db", "file:data.db",
+        "duckdb://x.duckdb", ":memory:",
+    };
+    for (size_t i = 0; i < sizeof dsns / sizeof *dsns; i++) {
+        ASSERT_EQ(0, hl_host_normalize_path(dsns[i], buf, sizeof buf));
+        ASSERT_STREQ(dsns[i], buf);
+    }
+}
+
+UTEST(host, normalize_path_rewrites_a_drive_letter_on_windows_only)
+{
+    char buf[HL_HOST_PATH_MAX];
+    int rc = hl_host_normalize_path("D:/a/app/data.db", buf, sizeof buf);
+    if (hl_host_is_windows()) {
+        ASSERT_EQ(1, rc);
+        ASSERT_STREQ("/D/a/app/data.db", buf);
+    } else {
+        /* Off Windows the mixed form is not a path; rewriting it would
+         * corrupt a legal (if odd) relative filename. */
+        ASSERT_EQ(0, rc);
+        ASSERT_STREQ("D:/a/app/data.db", buf);
+    }
+}
+
+UTEST(host, normalize_path_folds_backslashes_in_the_drive_case)
+{
+    char buf[HL_HOST_PATH_MAX];
+    int rc = hl_host_normalize_path("D:\\a\\app\\data.db", buf, sizeof buf);
+    if (hl_host_is_windows()) {
+        ASSERT_EQ(1, rc);
+        ASSERT_STREQ("/D/a/app/data.db", buf);
+    } else {
+        ASSERT_EQ(0, rc);
+    }
+}
+
+UTEST(host, normalize_path_leaves_a_lone_backslash_name_alone)
+{
+    /* Backslashes are folded ONLY in the drive-letter case. A POSIX file may
+     * legitimately contain one, and silently rewriting it would address a
+     * different file. */
+    char buf[HL_HOST_PATH_MAX];
+    const char *odd = "/tmp/we\\ird/name.db";
+    ASSERT_EQ(0, hl_host_normalize_path(odd, buf, sizeof buf));
+    ASSERT_STREQ(odd, buf);
+}
+
+UTEST(host, normalize_path_accepts_either_drive_letter_case)
+{
+    if (!hl_host_is_windows()) return;   /* rewrite is Windows-only */
+    char buf[HL_HOST_PATH_MAX];
+    ASSERT_EQ(1, hl_host_normalize_path("c:/x/y", buf, sizeof buf));
+    ASSERT_STREQ("/c/x/y", buf);
+    ASSERT_EQ(1, hl_host_normalize_path("C:/x/y", buf, sizeof buf));
+    ASSERT_STREQ("/C/x/y", buf);
+}
+
+UTEST(host, normalize_path_ignores_a_drive_letter_without_a_separator)
+{
+    /* "D:foo" is a Win32 drive-RELATIVE path, not an absolute one. Rewriting
+     * it to "/Dfoo" would invent a location, so it is left for the OS. */
+    char buf[HL_HOST_PATH_MAX];
+    ASSERT_EQ(0, hl_host_normalize_path("D:foo", buf, sizeof buf));
+    ASSERT_STREQ("D:foo", buf);
+}
+
 UTEST_MAIN()


### PR DESCRIPTION
Five e2e suites failed on Windows. They turned out to be four unrelated causes, three of which are fixed here.

## The path-form bug (the real one)

An MSYS2 / Git Bash / Cygwin shell rewrites a POSIX path argument on its way to a native program into the mixed form `D:/work/app/data.db`. A Cosmopolitan APE is a native program, so that is what `hull` receives.

I first assumed cosmo could not open that form. **That was wrong, and measuring it is what found the actual bug.** A probe built with cosmocc 4.0.2 on Windows 11 shows `open`, `stat` and `mkdir` all succeed on `C:/...`, on `C:\...`, and on `/C/...`:

```
OK  cosmo /C/ (getcwd)   OK  /c/ lowercase    OK  C:/ mixed
OK  c:/ mixed lower      OK  C:\ backslash    OK  relative
```

The layer that rejects it is **SQLite's unix VFS**, which decides absolute-vs-relative by testing for a leading `/` (three sites in `vendor/sqlite/sqlite3.c`). It read the path as relative, prepended the cwd, and failed to open the nonexistent result — surfacing as `cannot open database D:/work/app/data.db` on a database that plainly exists.

So this was a Hull-side defect, not a cosmo one, and there is no upstream report to file.

`hl_host_normalize_path` rewrites a leading drive letter to the rooted form both layers accept (`/D/work/app/data.db`, which is also what cosmo's `getcwd()` returns) and folds backslashes in that same case. It lives in `shared/host.c`, which already owns every per-host path fact — including the inverse conversion `cap/tool.c` does for busybox.

**What keeps it safe:** a drive letter is exactly ONE character before the `:`. No real URI scheme is one character, so a `postgres://` DSN through the same open path is untouched; and a POSIX path never carries a `:` at index 1. Off Windows the whole function is a verbatim copy, so a legal relative filename spelled `D:/x` is not corrupted. Nine tests pin this, and the host-independent ones (a POSIX path and eight DSNs must survive unchanged) run on every platform.

Applied at the two boundaries that were measurably broken: the SQLite backend open (every `-d` route reaches it) and `HULL_CACHE_DIR`, which tested for a leading `/` and rejected the mixed form outright.

## The two missing commands

- `e2e_http.sh` compiled its echo server with a hardcoded `cc`; the runner has `cosmocc` and no native `cc`, so it died at `Error 127` before asserting anything. It honours `$CC` now.
- `e2e_jobs.sh` died at the same code on `python3`, which is not in the MSYS base. Not one script's quirk: **17 e2e scripts** shell out to `python3` to pick a field out of hull's JSON. Only the source-build job runs e2e, so the app-build job is left alone.

## What is NOT fixed, and why

- `e2e-cli`, `e2e-cache` — `verify rc on corruption - got rc=0`. The APE exit-status shift ([jart/cosmopolitan#1521](https://github.com/jart/cosmopolitan/issues/1521)); a POSIX shell cannot see a failure status. Not fixable here.
- `e2e-tools` — `wamrc` has `has_cosmo = 0`, so hull correctly emits the `make wamrc` hint where the test hardcodes the native `hull tools install wamrc`; and hull reports `/D/a/...` where the shell built `/d/a/...`. Both are platform differences that would need the *test* relaxed, which is a separate call.

## Validation

The probe step deliberately **no longer** sets `MSYS2_ARG_CONV_EXCL`. Suppressing the conversion made the suites pass while hiding whether hull itself copes; leaving it on is what keeps the fix honest.

Measured on Windows: 36/36 in `test_host`, including the Windows branch asserting the rewrite actually happens. e2e went 5/10 → 7/10 (`e2e-http` and `e2e-jobs` FAILED → ok).

The workflow step now records the full four-cause map so the next reader starts from the diagnosis rather than the symptom, and two comments carrying my earlier wrong diagnosis are corrected.